### PR TITLE
implement addr Matcher with MatchYes/No/Shrug

### DIFF
--- a/src/htmatcher/matcher.rs
+++ b/src/htmatcher/matcher.rs
@@ -10,3 +10,74 @@ pub enum Matcher {
     And(Vec<Matcher>),
     Not(Box<Matcher>),
 }
+
+#[derive(Debug, PartialEq, Eq, Clone)]
+pub enum MatchResult {
+    Yes,
+    No,
+    Shrug,
+}
+
+impl Matcher {
+    pub fn match_addr(&self, addr: &Addr) -> MatchResult {
+        match self {
+            Matcher::Addr(a) => {
+                if a == addr {
+                    MatchResult::Yes
+                } else {
+                    MatchResult::No
+                }
+            }
+            Matcher::Package(pkg) => {
+                if &addr.package == pkg {
+                    MatchResult::Yes
+                } else {
+                    MatchResult::No
+                }
+            }
+            Matcher::PackagePrefix(prefix) => {
+                if addr.package.starts_with(prefix.as_str()) {
+                    MatchResult::Yes
+                } else {
+                    MatchResult::No
+                }
+            }
+            Matcher::Label(_) => MatchResult::Shrug,
+            Matcher::Or(matchers) => {
+                let mut has_shrug = false;
+                for m in matchers {
+                    match m.match_addr(addr) {
+                        MatchResult::Yes => return MatchResult::Yes,
+                        MatchResult::Shrug => has_shrug = true,
+                        MatchResult::No => {}
+                    }
+                }
+                if has_shrug {
+                    MatchResult::Shrug
+                } else {
+                    MatchResult::No
+                }
+            }
+            Matcher::And(matchers) => {
+                let mut has_shrug = false;
+                for m in matchers {
+                    match m.match_addr(addr) {
+                        MatchResult::No => return MatchResult::No,
+                        MatchResult::Shrug => has_shrug = true,
+                        MatchResult::Yes => {}
+                    }
+                }
+                if has_shrug {
+                    MatchResult::Shrug
+                } else {
+                    MatchResult::Yes
+                }
+            }
+            Matcher::Not(m) => match m.match_addr(addr) {
+                MatchResult::Yes => MatchResult::No,
+                MatchResult::No => MatchResult::Yes,
+                MatchResult::Shrug => MatchResult::Shrug,
+            },
+        }
+    }
+}

--- a/src/htmatcher/mod.rs
+++ b/src/htmatcher/mod.rs
@@ -1,6 +1,6 @@
 mod matcher;
 mod parse;
 
-pub use matcher::Matcher;
+pub use matcher::{MatchResult, Matcher};
 pub use parse::parse;
 


### PR DESCRIPTION
## Summary
- Adds `MatchResult` enum with `Yes`, `No`, `Shrug` variants
- Implements `Matcher::match_addr(&Addr) -> MatchResult` for all matcher variants
- `Label` returns `Shrug` since label info can't be resolved from addr alone; boolean combinators propagate shrug correctly

Closes HEP-8

## Test plan
- [ ] `Matcher::Addr` returns Yes on exact match, No otherwise
- [ ] `Matcher::Package` / `PackagePrefix` return Yes/No based on addr.package
- [ ] `Matcher::Label` returns Shrug
- [ ] `Matcher::And` / `Or` / `Not` compose results correctly including Shrug propagation

🤖 Generated with [Claude Code](https://claude.ai/claude-code)