### PR TITLE
Implement addr Matcher with MatchYes/MatchNo/MatchShrug (HEP-8)

### DIFF
--- a/src/htmatcher/matcher.rs
+++ b/src/htmatcher/matcher.rs
@@ -1,6 +1,13 @@
 use crate::htaddr::Addr;
 use crate::htpkg::PkgBuf;
 
+#[derive(Debug, PartialEq, Eq, Clone, Copy)]
+pub enum MatchResult {
+    MatchYes,
+    MatchNo,
+    MatchShrug,
+}
+
 #[derive(Debug, PartialEq, Eq, Clone)]
 pub enum Matcher {
     Addr(Addr),
@@ -10,4 +17,217 @@ pub enum Matcher {
     Or(Vec<Matcher>),
     And(Vec<Matcher>),
     Not(Box<Matcher>),
+}
+
+impl Matcher {
+    pub fn matches(&self, addr: &Addr) -> MatchResult {
+        match self {
+            Matcher::Addr(a) => {
+                if a == addr {
+                    MatchResult::MatchYes
+                } else {
+                    MatchResult::MatchNo
+                }
+            }
+            Matcher::Label(_) => MatchResult::MatchShrug,
+            Matcher::Package(pkg) => {
+                if &addr.package == pkg {
+                    MatchResult::MatchYes
+                } else {
+                    MatchResult::MatchNo
+                }
+            }
+            Matcher::PackagePrefix(prefix) => {
+                if addr.package.has_prefix(prefix) {
+                    MatchResult::MatchYes
+                } else {
+                    MatchResult::MatchNo
+                }
+            }
+            Matcher::Or(matchers) => {
+                let mut shrug = false;
+                for m in matchers {
+                    match m.matches(addr) {
+                        MatchResult::MatchYes => return MatchResult::MatchYes,
+                        MatchResult::MatchShrug => shrug = true,
+                        MatchResult::MatchNo => {}
+                    }
+                }
+                if shrug {
+                    MatchResult::MatchShrug
+                } else {
+                    MatchResult::MatchNo
+                }
+            }
+            Matcher::And(matchers) => {
+                let mut shrug = false;
+                for m in matchers {
+                    match m.matches(addr) {
+                        MatchResult::MatchNo => return MatchResult::MatchNo,
+                        MatchResult::MatchShrug => shrug = true,
+                        MatchResult::MatchYes => {}
+                    }
+                }
+                if shrug {
+                    MatchResult::MatchShrug
+                } else {
+                    MatchResult::MatchYes
+                }
+            }
+            Matcher::Not(m) => match m.matches(addr) {
+                MatchResult::MatchYes => MatchResult::MatchNo,
+                MatchResult::MatchNo => MatchResult::MatchYes,
+                MatchResult::MatchShrug => MatchResult::MatchShrug,
+            },
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::collections::HashMap;
+
+    fn addr(pkg: &str, name: &str) -> Addr {
+        Addr {
+            package: PkgBuf::from(pkg),
+            name: name.to_string(),
+            args: HashMap::new(),
+        }
+    }
+
+    #[test]
+    fn addr_exact_match() {
+        let a = addr("foo/bar", "baz");
+        assert_eq!(Matcher::Addr(a.clone()).matches(&a), MatchResult::MatchYes);
+    }
+
+    #[test]
+    fn addr_no_match() {
+        let a = addr("foo/bar", "baz");
+        let b = addr("foo/bar", "qux");
+        assert_eq!(Matcher::Addr(a).matches(&b), MatchResult::MatchNo);
+    }
+
+    #[test]
+    fn label_always_shrugs() {
+        let a = addr("foo/bar", "baz");
+        let label = addr("", "my_label");
+        assert_eq!(Matcher::Label(label).matches(&a), MatchResult::MatchShrug);
+    }
+
+    #[test]
+    fn package_match() {
+        let a = addr("foo/bar", "baz");
+        assert_eq!(
+            Matcher::Package(PkgBuf::from("foo/bar")).matches(&a),
+            MatchResult::MatchYes
+        );
+        assert_eq!(
+            Matcher::Package(PkgBuf::from("foo")).matches(&a),
+            MatchResult::MatchNo
+        );
+    }
+
+    #[test]
+    fn package_prefix_match() {
+        let a = addr("foo/bar/baz", "t");
+        assert_eq!(
+            Matcher::PackagePrefix(PkgBuf::from("foo/bar")).matches(&a),
+            MatchResult::MatchYes
+        );
+        assert_eq!(
+            Matcher::PackagePrefix(PkgBuf::from("foo/ba")).matches(&a),
+            MatchResult::MatchNo
+        );
+        assert_eq!(
+            Matcher::PackagePrefix(PkgBuf::from("")).matches(&a),
+            MatchResult::MatchYes
+        );
+    }
+
+    #[test]
+    fn or_yes_if_any_yes() {
+        let a = addr("foo/bar", "t");
+        let m = Matcher::Or(vec![
+            Matcher::Package(PkgBuf::from("other")),
+            Matcher::Package(PkgBuf::from("foo/bar")),
+        ]);
+        assert_eq!(m.matches(&a), MatchResult::MatchYes);
+    }
+
+    #[test]
+    fn or_no_if_all_no() {
+        let a = addr("foo/bar", "t");
+        let m = Matcher::Or(vec![
+            Matcher::Package(PkgBuf::from("a")),
+            Matcher::Package(PkgBuf::from("b")),
+        ]);
+        assert_eq!(m.matches(&a), MatchResult::MatchNo);
+    }
+
+    #[test]
+    fn or_shrug_if_no_yes_but_some_shrug() {
+        let a = addr("foo/bar", "t");
+        let label = addr("", "lbl");
+        let m = Matcher::Or(vec![
+            Matcher::Package(PkgBuf::from("other")),
+            Matcher::Label(label),
+        ]);
+        assert_eq!(m.matches(&a), MatchResult::MatchShrug);
+    }
+
+    #[test]
+    fn and_yes_if_all_yes() {
+        let a = addr("foo/bar", "t");
+        let m = Matcher::And(vec![
+            Matcher::Package(PkgBuf::from("foo/bar")),
+            Matcher::PackagePrefix(PkgBuf::from("foo")),
+        ]);
+        assert_eq!(m.matches(&a), MatchResult::MatchYes);
+    }
+
+    #[test]
+    fn and_no_if_any_no() {
+        let a = addr("foo/bar", "t");
+        let m = Matcher::And(vec![
+            Matcher::Package(PkgBuf::from("foo/bar")),
+            Matcher::Package(PkgBuf::from("other")),
+        ]);
+        assert_eq!(m.matches(&a), MatchResult::MatchNo);
+    }
+
+    #[test]
+    fn and_shrug_if_no_no_but_some_shrug() {
+        let a = addr("foo/bar", "t");
+        let label = addr("", "lbl");
+        let m = Matcher::And(vec![
+            Matcher::Package(PkgBuf::from("foo/bar")),
+            Matcher::Label(label),
+        ]);
+        assert_eq!(m.matches(&a), MatchResult::MatchShrug);
+    }
+
+    #[test]
+    fn not_flips() {
+        let a = addr("foo/bar", "t");
+        assert_eq!(
+            Matcher::Not(Box::new(Matcher::Package(PkgBuf::from("foo/bar")))).matches(&a),
+            MatchResult::MatchNo
+        );
+        assert_eq!(
+            Matcher::Not(Box::new(Matcher::Package(PkgBuf::from("other")))).matches(&a),
+            MatchResult::MatchYes
+        );
+    }
+
+    #[test]
+    fn not_shrug_stays_shrug() {
+        let a = addr("foo/bar", "t");
+        let label = addr("", "lbl");
+        assert_eq!(
+            Matcher::Not(Box::new(Matcher::Label(label))).matches(&a),
+            MatchResult::MatchShrug
+        );
+    }
 }

--- a/src/htmatcher/matcher.rs
+++ b/src/htmatcher/matcher.rs
@@ -20,7 +20,7 @@ pub enum Matcher {
 }
 
 impl Matcher {
-    pub fn matches(&self, addr: &Addr) -> MatchResult {
+    pub fn matches_addr(&self, addr: &Addr) -> MatchResult {
         match self {
             Matcher::Addr(a) => {
                 if a == addr {
@@ -47,7 +47,7 @@ impl Matcher {
             Matcher::Or(matchers) => {
                 let mut shrug = false;
                 for m in matchers {
-                    match m.matches(addr) {
+                    match m.matches_addr(addr) {
                         MatchResult::MatchYes => return MatchResult::MatchYes,
                         MatchResult::MatchShrug => shrug = true,
                         MatchResult::MatchNo => {}
@@ -62,7 +62,7 @@ impl Matcher {
             Matcher::And(matchers) => {
                 let mut shrug = false;
                 for m in matchers {
-                    match m.matches(addr) {
+                    match m.matches_addr(addr) {
                         MatchResult::MatchNo => return MatchResult::MatchNo,
                         MatchResult::MatchShrug => shrug = true,
                         MatchResult::MatchYes => {}
@@ -74,7 +74,7 @@ impl Matcher {
                     MatchResult::MatchYes
                 }
             }
-            Matcher::Not(m) => match m.matches(addr) {
+            Matcher::Not(m) => match m.matches_addr(addr) {
                 MatchResult::MatchYes => MatchResult::MatchNo,
                 MatchResult::MatchNo => MatchResult::MatchYes,
                 MatchResult::MatchShrug => MatchResult::MatchShrug,
@@ -99,32 +99,32 @@ mod tests {
     #[test]
     fn addr_exact_match() {
         let a = addr("foo/bar", "baz");
-        assert_eq!(Matcher::Addr(a.clone()).matches(&a), MatchResult::MatchYes);
+        assert_eq!(Matcher::Addr(a.clone()).matches_addr(&a), MatchResult::MatchYes);
     }
 
     #[test]
     fn addr_no_match() {
         let a = addr("foo/bar", "baz");
         let b = addr("foo/bar", "qux");
-        assert_eq!(Matcher::Addr(a).matches(&b), MatchResult::MatchNo);
+        assert_eq!(Matcher::Addr(a).matches_addr(&b), MatchResult::MatchNo);
     }
 
     #[test]
     fn label_always_shrugs() {
         let a = addr("foo/bar", "baz");
         let label = addr("", "my_label");
-        assert_eq!(Matcher::Label(label).matches(&a), MatchResult::MatchShrug);
+        assert_eq!(Matcher::Label(label).matches_addr(&a), MatchResult::MatchShrug);
     }
 
     #[test]
     fn package_match() {
         let a = addr("foo/bar", "baz");
         assert_eq!(
-            Matcher::Package(PkgBuf::from("foo/bar")).matches(&a),
+            Matcher::Package(PkgBuf::from("foo/bar")).matches_addr(&a),
             MatchResult::MatchYes
         );
         assert_eq!(
-            Matcher::Package(PkgBuf::from("foo")).matches(&a),
+            Matcher::Package(PkgBuf::from("foo")).matches_addr(&a),
             MatchResult::MatchNo
         );
     }
@@ -133,15 +133,15 @@ mod tests {
     fn package_prefix_match() {
         let a = addr("foo/bar/baz", "t");
         assert_eq!(
-            Matcher::PackagePrefix(PkgBuf::from("foo/bar")).matches(&a),
+            Matcher::PackagePrefix(PkgBuf::from("foo/bar")).matches_addr(&a),
             MatchResult::MatchYes
         );
         assert_eq!(
-            Matcher::PackagePrefix(PkgBuf::from("foo/ba")).matches(&a),
+            Matcher::PackagePrefix(PkgBuf::from("foo/ba")).matches_addr(&a),
             MatchResult::MatchNo
         );
         assert_eq!(
-            Matcher::PackagePrefix(PkgBuf::from("")).matches(&a),
+            Matcher::PackagePrefix(PkgBuf::from("")).matches_addr(&a),
             MatchResult::MatchYes
         );
     }
@@ -153,7 +153,7 @@ mod tests {
             Matcher::Package(PkgBuf::from("other")),
             Matcher::Package(PkgBuf::from("foo/bar")),
         ]);
-        assert_eq!(m.matches(&a), MatchResult::MatchYes);
+        assert_eq!(m.matches_addr(&a), MatchResult::MatchYes);
     }
 
     #[test]
@@ -163,7 +163,7 @@ mod tests {
             Matcher::Package(PkgBuf::from("a")),
             Matcher::Package(PkgBuf::from("b")),
         ]);
-        assert_eq!(m.matches(&a), MatchResult::MatchNo);
+        assert_eq!(m.matches_addr(&a), MatchResult::MatchNo);
     }
 
     #[test]
@@ -174,7 +174,7 @@ mod tests {
             Matcher::Package(PkgBuf::from("other")),
             Matcher::Label(label),
         ]);
-        assert_eq!(m.matches(&a), MatchResult::MatchShrug);
+        assert_eq!(m.matches_addr(&a), MatchResult::MatchShrug);
     }
 
     #[test]
@@ -184,7 +184,7 @@ mod tests {
             Matcher::Package(PkgBuf::from("foo/bar")),
             Matcher::PackagePrefix(PkgBuf::from("foo")),
         ]);
-        assert_eq!(m.matches(&a), MatchResult::MatchYes);
+        assert_eq!(m.matches_addr(&a), MatchResult::MatchYes);
     }
 
     #[test]
@@ -194,7 +194,7 @@ mod tests {
             Matcher::Package(PkgBuf::from("foo/bar")),
             Matcher::Package(PkgBuf::from("other")),
         ]);
-        assert_eq!(m.matches(&a), MatchResult::MatchNo);
+        assert_eq!(m.matches_addr(&a), MatchResult::MatchNo);
     }
 
     #[test]
@@ -205,18 +205,18 @@ mod tests {
             Matcher::Package(PkgBuf::from("foo/bar")),
             Matcher::Label(label),
         ]);
-        assert_eq!(m.matches(&a), MatchResult::MatchShrug);
+        assert_eq!(m.matches_addr(&a), MatchResult::MatchShrug);
     }
 
     #[test]
     fn not_flips() {
         let a = addr("foo/bar", "t");
         assert_eq!(
-            Matcher::Not(Box::new(Matcher::Package(PkgBuf::from("foo/bar")))).matches(&a),
+            Matcher::Not(Box::new(Matcher::Package(PkgBuf::from("foo/bar")))).matches_addr(&a),
             MatchResult::MatchNo
         );
         assert_eq!(
-            Matcher::Not(Box::new(Matcher::Package(PkgBuf::from("other")))).matches(&a),
+            Matcher::Not(Box::new(Matcher::Package(PkgBuf::from("other")))).matches_addr(&a),
             MatchResult::MatchYes
         );
     }
@@ -226,7 +226,7 @@ mod tests {
         let a = addr("foo/bar", "t");
         let label = addr("", "lbl");
         assert_eq!(
-            Matcher::Not(Box::new(Matcher::Label(label))).matches(&a),
+            Matcher::Not(Box::new(Matcher::Label(label))).matches_addr(&a),
             MatchResult::MatchShrug
         );
     }

--- a/src/htmatcher/mod.rs
+++ b/src/htmatcher/mod.rs
@@ -1,6 +1,6 @@
 mod matcher;
 mod parse;
 
-pub use matcher::Matcher;
+pub use matcher::{MatchResult, Matcher};
 pub use parse::parse;
 


### PR DESCRIPTION
## Summary

- Adds `MatchResult` enum with `MatchYes`, `MatchNo`, `MatchShrug` variants
- Implements `Matcher::matches(&Addr) -> MatchResult` for all matcher variants
- `Label` always returns `MatchShrug` (can't decide from addr alone)
- `Or`/`And`/`Not` compose results with short-circuit logic
- 13 new unit tests covering all variants and edge cases

Closes HEP-8

🤖 Generated with [Claude Code](https://claude.com/claude-code)