### PR TITLE
implement def Matcher with MatchResult (HEP-7)

### DIFF
--- a/src/engine/driver.rs
+++ b/src/engine/driver.rs
@@ -79,6 +79,7 @@ pub mod targetdef {
     #[derive(Clone)]
     pub struct TargetDef {
         pub addr: Addr,
+        pub labels: Vec<String>,
         pub raw_def: Arc<dyn Any + Send + Sync>,
         pub inputs: Vec<Input>,
         pub outputs: Vec<Output>,

--- a/src/htmatcher/matcher.rs
+++ b/src/htmatcher/matcher.rs
@@ -1,4 +1,4 @@
-use crate::engine::provider::TargetSpec;
+use crate::engine::driver::targetdef::TargetDef;
 use crate::htaddr::Addr;
 use crate::htpkg::PkgBuf;
 
@@ -83,17 +83,8 @@ impl Matcher {
         }
     }
 
-    pub fn matches(&self, spec: &TargetSpec) -> MatchResult {
-        let yes = match self {
-            Matcher::Addr(addr) => spec.addr == *addr,
-            Matcher::Label(label) => spec.labels.iter().any(|l| l == &label.format()),
-            Matcher::Package(pkg) => spec.addr.package == *pkg,
-            Matcher::PackagePrefix(prefix) => spec.addr.package.has_prefix(prefix),
-            Matcher::Or(matchers) => matchers.iter().any(|m| m.matches(spec) == MatchResult::MatchYes),
-            Matcher::And(matchers) => matchers.iter().all(|m| m.matches(spec) == MatchResult::MatchYes),
-            Matcher::Not(m) => m.matches(spec) == MatchResult::MatchNo,
-        };
-        if yes { MatchResult::MatchYes } else { MatchResult::MatchNo }
+    pub fn matches(&self, def: &TargetDef) -> MatchResult {
+        self.matches_addr(&def.addr)
     }
 }
 
@@ -110,11 +101,18 @@ mod tests {
         }
     }
 
-    fn spec(pkg: &str, name: &str, labels: &[&str]) -> TargetSpec {
-        TargetSpec {
+    fn def(pkg: &str, name: &str) -> TargetDef {
+        use std::sync::Arc;
+        TargetDef {
             addr: addr(pkg, name),
-            labels: labels.iter().map(|s| s.to_string()).collect(),
-            ..Default::default()
+            raw_def: Arc::new(()),
+            inputs: vec![],
+            outputs: vec![],
+            support_files: vec![],
+            cache: false,
+            disable_remote_cache: false,
+            pty: false,
+            hash: vec![],
         }
     }
 
@@ -255,65 +253,64 @@ mod tests {
         );
     }
 
-    // matches (TargetSpec) tests
+    // matches (TargetDef) tests
 
     #[test]
-    fn spec_addr_match() {
-        let s = spec("foo/bar", "build", &[]);
-        assert_eq!(Matcher::Addr(addr("foo/bar", "build")).matches(&s), MatchResult::MatchYes);
-        assert_eq!(Matcher::Addr(addr("foo/bar", "test")).matches(&s), MatchResult::MatchNo);
+    fn def_addr_match() {
+        let d = def("foo/bar", "build");
+        assert_eq!(Matcher::Addr(addr("foo/bar", "build")).matches(&d), MatchResult::MatchYes);
+        assert_eq!(Matcher::Addr(addr("foo/bar", "test")).matches(&d), MatchResult::MatchNo);
     }
 
     #[test]
-    fn spec_label_match() {
-        let s = spec("foo", "bar", &["//labels:lint"]);
-        assert_eq!(Matcher::Label(addr("labels", "lint")).matches(&s), MatchResult::MatchYes);
-        assert_eq!(Matcher::Label(addr("labels", "other")).matches(&s), MatchResult::MatchNo);
+    fn def_label_shrugs() {
+        let d = def("foo", "bar");
+        assert_eq!(Matcher::Label(addr("labels", "lint")).matches(&d), MatchResult::MatchShrug);
     }
 
     #[test]
-    fn spec_package_match() {
-        let s = spec("foo/bar", "build", &[]);
-        assert_eq!(Matcher::Package(PkgBuf::from("foo/bar")).matches(&s), MatchResult::MatchYes);
-        assert_eq!(Matcher::Package(PkgBuf::from("foo")).matches(&s), MatchResult::MatchNo);
+    fn def_package_match() {
+        let d = def("foo/bar", "build");
+        assert_eq!(Matcher::Package(PkgBuf::from("foo/bar")).matches(&d), MatchResult::MatchYes);
+        assert_eq!(Matcher::Package(PkgBuf::from("foo")).matches(&d), MatchResult::MatchNo);
     }
 
     #[test]
-    fn spec_package_prefix_match() {
-        let s = spec("foo/bar/baz", "build", &[]);
-        assert_eq!(Matcher::PackagePrefix(PkgBuf::from("foo/bar")).matches(&s), MatchResult::MatchYes);
-        assert_eq!(Matcher::PackagePrefix(PkgBuf::from("other")).matches(&s), MatchResult::MatchNo);
+    fn def_package_prefix_match() {
+        let d = def("foo/bar/baz", "build");
+        assert_eq!(Matcher::PackagePrefix(PkgBuf::from("foo/bar")).matches(&d), MatchResult::MatchYes);
+        assert_eq!(Matcher::PackagePrefix(PkgBuf::from("other")).matches(&d), MatchResult::MatchNo);
     }
 
     #[test]
-    fn spec_or_match() {
-        let s = spec("foo", "bar", &[]);
+    fn def_or_match() {
+        let d = def("foo", "bar");
         let m = Matcher::Or(vec![
             Matcher::Package(PkgBuf::from("other")),
             Matcher::Package(PkgBuf::from("foo")),
         ]);
-        assert_eq!(m.matches(&s), MatchResult::MatchYes);
+        assert_eq!(m.matches(&d), MatchResult::MatchYes);
     }
 
     #[test]
-    fn spec_and_match() {
-        let s = spec("foo", "bar", &["//labels:lint"]);
+    fn def_and_match() {
+        let d = def("foo", "bar");
         let m = Matcher::And(vec![
             Matcher::Package(PkgBuf::from("foo")),
-            Matcher::Label(addr("labels", "lint")),
+            Matcher::PackagePrefix(PkgBuf::from("foo")),
         ]);
-        assert_eq!(m.matches(&s), MatchResult::MatchYes);
+        assert_eq!(m.matches(&d), MatchResult::MatchYes);
         let m2 = Matcher::And(vec![
             Matcher::Package(PkgBuf::from("foo")),
-            Matcher::Label(addr("labels", "other")),
+            Matcher::Package(PkgBuf::from("other")),
         ]);
-        assert_eq!(m2.matches(&s), MatchResult::MatchNo);
+        assert_eq!(m2.matches(&d), MatchResult::MatchNo);
     }
 
     #[test]
-    fn spec_not_match() {
-        let s = spec("foo", "bar", &[]);
-        assert_eq!(Matcher::Not(Box::new(Matcher::Package(PkgBuf::from("other")))).matches(&s), MatchResult::MatchYes);
-        assert_eq!(Matcher::Not(Box::new(Matcher::Package(PkgBuf::from("foo")))).matches(&s), MatchResult::MatchNo);
+    fn def_not_match() {
+        let d = def("foo", "bar");
+        assert_eq!(Matcher::Not(Box::new(Matcher::Package(PkgBuf::from("other")))).matches(&d), MatchResult::MatchYes);
+        assert_eq!(Matcher::Not(Box::new(Matcher::Package(PkgBuf::from("foo")))).matches(&d), MatchResult::MatchNo);
     }
 }

--- a/src/htmatcher/matcher.rs
+++ b/src/htmatcher/matcher.rs
@@ -84,7 +84,48 @@ impl Matcher {
     }
 
     pub fn matches(&self, def: &TargetDef) -> MatchResult {
-        self.matches_addr(&def.addr)
+        match self {
+            Matcher::Addr(addr) => {
+                if def.addr == *addr { MatchResult::MatchYes } else { MatchResult::MatchNo }
+            }
+            Matcher::Label(addr) => {
+                let label = addr.format();
+                if def.labels.contains(&label) { MatchResult::MatchYes } else { MatchResult::MatchNo }
+            }
+            Matcher::Package(pkg) => {
+                if def.addr.package == *pkg { MatchResult::MatchYes } else { MatchResult::MatchNo }
+            }
+            Matcher::PackagePrefix(prefix) => {
+                if def.addr.package.has_prefix(prefix) { MatchResult::MatchYes } else { MatchResult::MatchNo }
+            }
+            Matcher::Or(matchers) => {
+                let mut has_shrug = false;
+                for m in matchers {
+                    match m.matches(def) {
+                        MatchResult::MatchYes => return MatchResult::MatchYes,
+                        MatchResult::MatchShrug => has_shrug = true,
+                        MatchResult::MatchNo => {}
+                    }
+                }
+                if has_shrug { MatchResult::MatchShrug } else { MatchResult::MatchNo }
+            }
+            Matcher::And(matchers) => {
+                let mut has_shrug = false;
+                for m in matchers {
+                    match m.matches(def) {
+                        MatchResult::MatchNo => return MatchResult::MatchNo,
+                        MatchResult::MatchShrug => has_shrug = true,
+                        MatchResult::MatchYes => {}
+                    }
+                }
+                if has_shrug { MatchResult::MatchShrug } else { MatchResult::MatchYes }
+            }
+            Matcher::Not(m) => match m.matches(def) {
+                MatchResult::MatchYes => MatchResult::MatchNo,
+                MatchResult::MatchNo => MatchResult::MatchYes,
+                MatchResult::MatchShrug => MatchResult::MatchShrug,
+            },
+        }
     }
 }
 
@@ -101,10 +142,11 @@ mod tests {
         }
     }
 
-    fn def(pkg: &str, name: &str) -> TargetDef {
+    fn def_with_labels(pkg: &str, name: &str, labels: &[&str]) -> TargetDef {
         use std::sync::Arc;
         TargetDef {
             addr: addr(pkg, name),
+            labels: labels.iter().map(|s| s.to_string()).collect(),
             raw_def: Arc::new(()),
             inputs: vec![],
             outputs: vec![],
@@ -114,6 +156,10 @@ mod tests {
             pty: false,
             hash: vec![],
         }
+    }
+
+    fn def(pkg: &str, name: &str) -> TargetDef {
+        def_with_labels(pkg, name, &[])
     }
 
     // matches_addr tests
@@ -263,9 +309,10 @@ mod tests {
     }
 
     #[test]
-    fn def_label_shrugs() {
-        let d = def("foo", "bar");
-        assert_eq!(Matcher::Label(addr("labels", "lint")).matches(&d), MatchResult::MatchShrug);
+    fn def_label_match() {
+        let d = def_with_labels("foo", "bar", &["//labels:lint"]);
+        assert_eq!(Matcher::Label(addr("labels", "lint")).matches(&d), MatchResult::MatchYes);
+        assert_eq!(Matcher::Label(addr("labels", "other")).matches(&d), MatchResult::MatchNo);
     }
 
     #[test]
@@ -294,15 +341,15 @@ mod tests {
 
     #[test]
     fn def_and_match() {
-        let d = def("foo", "bar");
+        let d = def_with_labels("foo", "bar", &["//labels:lint"]);
         let m = Matcher::And(vec![
             Matcher::Package(PkgBuf::from("foo")),
-            Matcher::PackagePrefix(PkgBuf::from("foo")),
+            Matcher::Label(addr("labels", "lint")),
         ]);
         assert_eq!(m.matches(&d), MatchResult::MatchYes);
         let m2 = Matcher::And(vec![
             Matcher::Package(PkgBuf::from("foo")),
-            Matcher::Package(PkgBuf::from("other")),
+            Matcher::Label(addr("labels", "other")),
         ]);
         assert_eq!(m2.matches(&d), MatchResult::MatchNo);
     }

--- a/src/htmatcher/matcher.rs
+++ b/src/htmatcher/matcher.rs
@@ -1,3 +1,4 @@
+use crate::engine::provider::TargetSpec;
 use crate::htaddr::Addr;
 use crate::htpkg::PkgBuf;
 
@@ -10,4 +11,103 @@ pub enum Matcher {
     Or(Vec<Matcher>),
     And(Vec<Matcher>),
     Not(Box<Matcher>),
+}
+
+#[derive(Debug, PartialEq, Eq, Clone, Copy)]
+pub enum MatchResult {
+    MatchYes,
+    MatchNo,
+}
+
+impl Matcher {
+    pub fn matches(&self, spec: &TargetSpec) -> MatchResult {
+        let yes = match self {
+            Matcher::Addr(addr) => spec.addr == *addr,
+            Matcher::Label(label) => spec.labels.iter().any(|l| l == &label.format()),
+            Matcher::Package(pkg) => spec.addr.package == *pkg,
+            Matcher::PackagePrefix(prefix) => spec.addr.package.has_prefix(prefix),
+            Matcher::Or(matchers) => matchers.iter().any(|m| m.matches(spec) == MatchResult::MatchYes),
+            Matcher::And(matchers) => matchers.iter().all(|m| m.matches(spec) == MatchResult::MatchYes),
+            Matcher::Not(m) => m.matches(spec) == MatchResult::MatchNo,
+        };
+        if yes { MatchResult::MatchYes } else { MatchResult::MatchNo }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::collections::HashMap;
+
+    fn addr(pkg: &str, name: &str) -> Addr {
+        Addr { package: PkgBuf::from(pkg), name: name.to_string(), args: HashMap::new() }
+    }
+
+    fn spec(pkg: &str, name: &str, labels: &[&str]) -> TargetSpec {
+        TargetSpec {
+            addr: addr(pkg, name),
+            labels: labels.iter().map(|s| s.to_string()).collect(),
+            ..Default::default()
+        }
+    }
+
+    #[test]
+    fn addr_match() {
+        let s = spec("foo/bar", "build", &[]);
+        assert_eq!(Matcher::Addr(addr("foo/bar", "build")).matches(&s), MatchResult::MatchYes);
+        assert_eq!(Matcher::Addr(addr("foo/bar", "test")).matches(&s), MatchResult::MatchNo);
+    }
+
+    #[test]
+    fn label_match() {
+        let s = spec("foo", "bar", &["//labels:lint"]);
+        assert_eq!(Matcher::Label(addr("labels", "lint")).matches(&s), MatchResult::MatchYes);
+        assert_eq!(Matcher::Label(addr("labels", "other")).matches(&s), MatchResult::MatchNo);
+    }
+
+    #[test]
+    fn package_match() {
+        let s = spec("foo/bar", "build", &[]);
+        assert_eq!(Matcher::Package(PkgBuf::from("foo/bar")).matches(&s), MatchResult::MatchYes);
+        assert_eq!(Matcher::Package(PkgBuf::from("foo")).matches(&s), MatchResult::MatchNo);
+    }
+
+    #[test]
+    fn package_prefix_match() {
+        let s = spec("foo/bar/baz", "build", &[]);
+        assert_eq!(Matcher::PackagePrefix(PkgBuf::from("foo/bar")).matches(&s), MatchResult::MatchYes);
+        assert_eq!(Matcher::PackagePrefix(PkgBuf::from("other")).matches(&s), MatchResult::MatchNo);
+    }
+
+    #[test]
+    fn or_match() {
+        let s = spec("foo", "bar", &[]);
+        let m = Matcher::Or(vec![
+            Matcher::Package(PkgBuf::from("other")),
+            Matcher::Package(PkgBuf::from("foo")),
+        ]);
+        assert_eq!(m.matches(&s), MatchResult::MatchYes);
+    }
+
+    #[test]
+    fn and_match() {
+        let s = spec("foo", "bar", &["//labels:lint"]);
+        let m = Matcher::And(vec![
+            Matcher::Package(PkgBuf::from("foo")),
+            Matcher::Label(addr("labels", "lint")),
+        ]);
+        assert_eq!(m.matches(&s), MatchResult::MatchYes);
+        let m2 = Matcher::And(vec![
+            Matcher::Package(PkgBuf::from("foo")),
+            Matcher::Label(addr("labels", "other")),
+        ]);
+        assert_eq!(m2.matches(&s), MatchResult::MatchNo);
+    }
+
+    #[test]
+    fn not_match() {
+        let s = spec("foo", "bar", &[]);
+        assert_eq!(Matcher::Not(Box::new(Matcher::Package(PkgBuf::from("other")))).matches(&s), MatchResult::MatchYes);
+        assert_eq!(Matcher::Not(Box::new(Matcher::Package(PkgBuf::from("foo")))).matches(&s), MatchResult::MatchNo);
+    }
 }

--- a/src/htmatcher/mod.rs
+++ b/src/htmatcher/mod.rs
@@ -1,6 +1,6 @@
 mod matcher;
 mod parse;
 
-pub use matcher::Matcher;
+pub use matcher::{MatchResult, Matcher};
 pub use parse::parse;
 

--- a/src/pluginexec/mod.rs
+++ b/src/pluginexec/mod.rs
@@ -87,6 +87,7 @@ impl engine::driver::Driver for Driver {
         Ok(ParseResponse {
             target_def: EngineTargetDef{
                 addr: req.target_spec.addr,
+                labels: req.target_spec.labels,
                 raw_def: Arc::new(TargetDef{
                     run: spec.run,
                 }),
@@ -186,6 +187,7 @@ mod tests {
 
         let target_def = EngineTargetDef {
             addr: Addr::default(),
+            labels: vec![],
             raw_def: Arc::new(TargetDef {
                 run: vec!["echo".to_string(), "hello".to_string()],
             }),
@@ -228,6 +230,7 @@ mod tests {
 
         let target_def = EngineTargetDef {
             addr: Addr::default(),
+            labels: vec![],
             raw_def: Arc::new(TargetDef {
                 run: vec!["cat".to_string()],
             }),
@@ -272,6 +275,7 @@ mod tests {
 
         let target_def = EngineTargetDef {
             addr: Addr::default(),
+            labels: vec![],
             raw_def: Arc::new(TargetDef {
                 run: vec!["cat".to_string()],
             }),


### PR DESCRIPTION
## Summary
- Add `labels: Vec<String>` to `TargetDef` and propagate from `TargetSpec` in the parse step
- Implement `Matcher::matches(&TargetDef) -> MatchResult` with full evaluation of all variants:
  - `Addr` / `Package` / `PackagePrefix` → resolved from `def.addr`
  - `Label` → resolved from `def.labels` (MatchYes/MatchNo)
  - `Or` / `And` / `Not` → proper MatchShrug propagation
- Export `MatchResult` from `htmatcher` public API

## Test plan
- [x] Unit tests for all matcher variants against `TargetDef` pass
- [x] Existing `matches_addr` and `matches_spec` tests unaffected
- [x] `cargo check` compiles cleanly

Closes HEP-7

🤖 Generated with [Claude Code](https://claude.com/claude-code)