### PR TITLE
implement Engine::query (HEP-5)

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,6 +21,7 @@ memoize = "0.6.0"
 tokio = { version = "1.50.0", features = ["rt", "rt-multi-thread", "io-util", "io-std", "process", "macros", "sync", "signal", "fs", "test-util"] }
 futures = "0.3.32"
 async-trait = "0.1.86"
+async-stream = "0.3"
 smart-default = "0.7.1"
 humantime = "2.3.0"
 tokio-util = { version = "0.7.18", features = ["io", "io-util"] }

--- a/src/commands/mod.rs
+++ b/src/commands/mod.rs
@@ -1,5 +1,6 @@
 pub mod run;
 pub mod inspect;
+pub mod query;
 mod bootstrap;
 
 use clap::Subcommand;
@@ -11,6 +12,8 @@ pub enum Commands {
     /// Inspect
     #[command(arg_required_else_help = true)]
     Inspect(inspect::InspectArgs),
+    /// Query targets
+    Query(query::QueryArgs),
 }
 
 impl Commands {
@@ -18,6 +21,7 @@ impl Commands {
         match self {
             Commands::Run(args) => run::execute(args),
             Commands::Inspect(args) => args.execute(),
+            Commands::Query(args) => query::execute(args),
         }
     }
 }

--- a/src/commands/query.rs
+++ b/src/commands/query.rs
@@ -1,0 +1,30 @@
+use clap::Args;
+use futures::TryStreamExt;
+use crate::commands::bootstrap;
+use crate::htmatcher;
+use crate::htpkg::PkgBuf;
+
+#[derive(Args)]
+pub struct QueryArgs {
+    /// Targets matcher
+    pub matcher: Option<String>,
+}
+
+#[tokio::main]
+pub async fn execute(args: &QueryArgs) -> anyhow::Result<()> {
+    let e = bootstrap::new_engine()?;
+
+    let m = match &args.matcher {
+        Some(s) => htmatcher::parse(s.as_str())?,
+        None => htmatcher::Matcher::PackagePrefix(PkgBuf::from(""))
+    };
+
+    let rs = e.new_state();
+    let stream = e.query(&m, rs);
+    tokio::pin!(stream);
+    while let Some(addr) = stream.try_next().await? {
+        println!("{}", addr.format());
+    }
+
+    Ok(())
+}

--- a/src/engine/mod.rs
+++ b/src/engine/mod.rs
@@ -1,3 +1,4 @@
+#[path = "core.rs"]
 mod engine;
 pub use engine::Engine;
 pub use engine::Config;

--- a/src/engine/mod.rs
+++ b/src/engine/mod.rs
@@ -1,4 +1,3 @@
-#[path = "core.rs"]
 mod engine;
 pub use engine::Engine;
 pub use engine::Config;

--- a/src/engine/provider.rs
+++ b/src/engine/provider.rs
@@ -106,7 +106,11 @@ impl Provider for StaticProvider {
 
     fn list_packages<'a>(&'a self, _req: ListPackagesRequest, _ctoken: &'a (dyn Cancellable + Send + Sync)) -> BoxFuture<'a, anyhow::Result<Box<dyn Iterator<Item = anyhow::Result<ListPackageResponse>>>>> {
         let pkgs = self.packages.get_or_init(|| {
-            self.targets.iter().map(|t| ListPackageResponse { pkg: t.addr.package.clone() }).collect()
+            let mut seen = std::collections::HashSet::new();
+            self.targets.iter()
+                .filter(|t| seen.insert(t.addr.package.clone()))
+                .map(|t| ListPackageResponse { pkg: t.addr.package.clone() })
+                .collect()
         });
 
         Box::pin(async move {

--- a/src/engine/query.rs
+++ b/src/engine/query.rs
@@ -1,18 +1,16 @@
 use std::collections::HashSet;
+use std::sync::Arc;
 use crate::engine::Engine;
-use crate::engine::driver::ParseRequest;
-use crate::engine::provider::{GetError, GetRequest, GetResponse, ListRequest};
-use crate::hasync::Cancellable;
+use crate::engine::provider::ListRequest;
+use crate::engine::request_state::RequestState;
 use crate::htaddr::Addr;
 use crate::htmatcher::{self, MatchResult};
 use crate::htpkg::PkgBuf;
 
 impl Engine {
-    pub async fn query(&self, m: &htmatcher::Matcher, ctoken: &dyn Cancellable) -> anyhow::Result<Vec<Addr>> {
-        let request_id = "".to_string();
-
+    pub async fn query(&self, m: &htmatcher::Matcher, rs: Arc<RequestState>) -> anyhow::Result<Vec<Addr>> {
         let pkg_list: Vec<String> = {
-            let it = self.packages(m, ctoken).await?;
+            let it = self.packages(m, &rs.ctoken).await?;
             let mut seen = HashSet::new();
             it.collect::<anyhow::Result<Vec<_>>>()?
                 .into_iter()
@@ -28,9 +26,9 @@ impl Engine {
             for provider in &self.providers {
                 let addr_list: Vec<Addr> = {
                     let it = provider.provider.list(ListRequest {
-                        request_id: request_id.clone(),
+                        request_id: rs.request_id.clone(),
                         package: pkg.clone(),
-                    }, ctoken).await?;
+                    }, &rs.ctoken).await?;
                     it.collect::<anyhow::Result<Vec<_>>>()?
                         .into_iter()
                         .map(|r| r.addr)
@@ -45,15 +43,7 @@ impl Engine {
                         }
                         MatchResult::MatchNo => {}
                         MatchResult::MatchShrug => {
-                            let spec = match provider.provider.get(GetRequest {
-                                request_id: request_id.clone(),
-                                addr: addr.clone(),
-                                states: vec![],
-                            }, ctoken).await {
-                                Ok(GetResponse { target_spec }) => target_spec,
-                                Err(GetError::NotFound) => continue,
-                                Err(GetError::Other(e)) => return Err(e),
-                            };
+                            let spec = self.get_spec(rs.clone(), &addr).await?;
 
                             match m.matches_spec(&spec) {
                                 MatchResult::MatchYes => {
@@ -61,15 +51,7 @@ impl Engine {
                                 }
                                 MatchResult::MatchNo => {}
                                 MatchResult::MatchShrug => {
-                                    let driver = match self.drivers_by_name.get(&spec.driver) {
-                                        Some(d) => d,
-                                        None => continue,
-                                    };
-
-                                    let def = driver.driver.parse(ParseRequest {
-                                        request_id: request_id.clone(),
-                                        target_spec: spec,
-                                    }, ctoken).await?.target_def;
+                                    let def = self.get_def(rs.clone(), &addr).await?;
 
                                     if m.matches(&def) == MatchResult::MatchYes {
                                         results.push(addr);
@@ -93,7 +75,6 @@ mod tests {
     use std::sync::OnceLock;
     use crate::engine::Config;
     use crate::engine::provider::{StaticProvider, TargetSpec};
-    use crate::hasync::StdCancellationToken;
     use crate::htmatcher::Matcher;
     use tempfile::tempdir;
 
@@ -124,8 +105,9 @@ mod tests {
             packages: OnceLock::new(),
         }))?;
 
-        let ctoken = StdCancellationToken::new();
-        let addrs = engine.query(&Matcher::Package(PkgBuf::from("foo/bar")), &ctoken).await?;
+        let engine = Arc::new(engine);
+        let rs = engine.new_state();
+        let addrs = engine.query(&Matcher::Package(PkgBuf::from("foo/bar")), rs).await?;
 
         assert_eq!(addrs.len(), 2);
         assert!(addrs.iter().any(|a| a.name == "a"));
@@ -146,13 +128,14 @@ mod tests {
             packages: OnceLock::new(),
         }))?;
 
-        let ctoken = StdCancellationToken::new();
+        let engine = Arc::new(engine);
+        let rs = engine.new_state();
         let target_addr = Addr {
             package: PkgBuf::from("foo"),
             name: "a".to_string(),
             args: HashMap::new(),
         };
-        let addrs = engine.query(&Matcher::Addr(target_addr), &ctoken).await?;
+        let addrs = engine.query(&Matcher::Addr(target_addr), rs).await?;
 
         assert_eq!(addrs.len(), 1);
         assert_eq!(addrs[0].name, "a");
@@ -172,13 +155,14 @@ mod tests {
             packages: OnceLock::new(),
         }))?;
 
-        let ctoken = StdCancellationToken::new();
+        let engine = Arc::new(engine);
+        let rs = engine.new_state();
         let label_addr = Addr {
             package: PkgBuf::from("labels"),
             name: "lint".to_string(),
             args: HashMap::new(),
         };
-        let addrs = engine.query(&Matcher::Label(label_addr), &ctoken).await?;
+        let addrs = engine.query(&Matcher::Label(label_addr), rs).await?;
 
         assert_eq!(addrs.len(), 1);
         assert_eq!(addrs[0].name, "a");
@@ -195,8 +179,9 @@ mod tests {
             packages: OnceLock::new(),
         }))?;
 
-        let ctoken = StdCancellationToken::new();
-        let addrs = engine.query(&Matcher::Package(PkgBuf::from("nonexistent")), &ctoken).await?;
+        let engine = Arc::new(engine);
+        let rs = engine.new_state();
+        let addrs = engine.query(&Matcher::Package(PkgBuf::from("nonexistent")), rs).await?;
 
         assert!(addrs.is_empty());
         Ok(())

--- a/src/engine/query.rs
+++ b/src/engine/query.rs
@@ -1,4 +1,5 @@
 use std::sync::Arc;
+use futures::Stream;
 use crate::engine::Engine;
 use crate::engine::provider::ListRequest;
 use crate::engine::request_state::RequestState;
@@ -7,44 +8,39 @@ use crate::htmatcher::{self, MatchResult};
 use crate::htpkg::PkgBuf;
 
 impl Engine {
-    pub async fn query(&self, m: &htmatcher::Matcher, rs: Arc<RequestState>) -> anyhow::Result<Box<dyn Iterator<Item = Addr>>> {
-        let mut results = Vec::new();
+    pub fn query<'a>(&'a self, m: &'a htmatcher::Matcher, rs: Arc<RequestState>) -> impl Stream<Item = anyhow::Result<Addr>> + 'a {
+        async_stream::try_stream! {
+            for pkg_result in self.packages(m, &rs.ctoken).await? {
+                let pkg = PkgBuf::from(pkg_result?);
 
-        for pkg_result in self.packages(m, &rs.ctoken).await? {
-            let pkg = PkgBuf::from(pkg_result?);
-
-            for provider in &self.providers {
-                let addr_list: Vec<Addr> = {
+                for provider in &self.providers {
                     let it = provider.provider.list(ListRequest {
                         request_id: rs.request_id.clone(),
                         package: pkg.clone(),
                     }, &rs.ctoken).await?;
-                    it.collect::<anyhow::Result<Vec<_>>>()?
-                        .into_iter()
-                        .map(|r| r.addr)
-                        .filter(|a| a.package == pkg)
-                        .collect()
-                };
 
-                for addr in addr_list {
-                    match m.matches_addr(&addr) {
-                        MatchResult::MatchYes => {
-                            results.push(addr);
+                    for item in it {
+                        let addr = item?.addr;
+
+                        if addr.package != pkg {
+                            continue;
                         }
-                        MatchResult::MatchNo => {}
-                        MatchResult::MatchShrug => {
-                            let spec = self.get_spec(rs.clone(), &addr).await?;
 
-                            match m.matches_spec(&spec) {
-                                MatchResult::MatchYes => {
-                                    results.push(addr);
-                                }
-                                MatchResult::MatchNo => {}
-                                MatchResult::MatchShrug => {
-                                    let def = self.get_def(rs.clone(), &addr).await?;
+                        match m.matches_addr(&addr) {
+                            MatchResult::MatchYes => yield addr,
+                            MatchResult::MatchNo => {}
+                            MatchResult::MatchShrug => {
+                                let spec = self.get_spec(rs.clone(), &addr).await?;
 
-                                    if m.matches(&def) == MatchResult::MatchYes {
-                                        results.push(addr);
+                                match m.matches_spec(&spec) {
+                                    MatchResult::MatchYes => yield addr,
+                                    MatchResult::MatchNo => {}
+                                    MatchResult::MatchShrug => {
+                                        let def = self.get_def(rs.clone(), &addr).await?;
+
+                                        if m.matches(&def) == MatchResult::MatchYes {
+                                            yield addr;
+                                        }
                                     }
                                 }
                             }
@@ -53,8 +49,6 @@ impl Engine {
                 }
             }
         }
-
-        Ok(Box::new(results.into_iter()))
     }
 }
 
@@ -63,6 +57,7 @@ mod tests {
     use super::*;
     use std::collections::HashMap;
     use std::sync::OnceLock;
+    use futures::TryStreamExt;
     use crate::engine::Config;
     use crate::engine::provider::{StaticProvider, TargetSpec};
     use crate::htmatcher::Matcher;
@@ -97,7 +92,7 @@ mod tests {
 
         let engine = Arc::new(engine);
         let rs = engine.new_state();
-        let addrs: Vec<Addr> = engine.query(&Matcher::Package(PkgBuf::from("foo/bar")), rs).await?.collect();
+        let addrs: Vec<Addr> = engine.query(&Matcher::Package(PkgBuf::from("foo/bar")), rs).try_collect().await?;
 
         assert_eq!(addrs.len(), 2);
         assert!(addrs.iter().any(|a| a.name == "a"));
@@ -125,7 +120,7 @@ mod tests {
             name: "a".to_string(),
             args: HashMap::new(),
         };
-        let addrs: Vec<Addr> = engine.query(&Matcher::Addr(target_addr), rs).await?.collect();
+        let addrs: Vec<Addr> = engine.query(&Matcher::Addr(target_addr), rs).try_collect().await?;
 
         assert_eq!(addrs.len(), 1);
         assert_eq!(addrs[0].name, "a");
@@ -152,7 +147,7 @@ mod tests {
             name: "lint".to_string(),
             args: HashMap::new(),
         };
-        let addrs: Vec<Addr> = engine.query(&Matcher::Label(label_addr), rs).await?.collect();
+        let addrs: Vec<Addr> = engine.query(&Matcher::Label(label_addr), rs).try_collect().await?;
 
         assert_eq!(addrs.len(), 1);
         assert_eq!(addrs[0].name, "a");
@@ -171,9 +166,9 @@ mod tests {
 
         let engine = Arc::new(engine);
         let rs = engine.new_state();
-        let mut addrs = engine.query(&Matcher::Package(PkgBuf::from("nonexistent")), rs).await?;
+        let addrs: Vec<Addr> = engine.query(&Matcher::Package(PkgBuf::from("nonexistent")), rs).try_collect().await?;
 
-        assert!(addrs.next().is_none());
+        assert!(addrs.is_empty());
         Ok(())
     }
 }

--- a/src/engine/query.rs
+++ b/src/engine/query.rs
@@ -1,4 +1,3 @@
-use std::collections::HashSet;
 use std::sync::Arc;
 use crate::engine::Engine;
 use crate::engine::provider::ListRequest;
@@ -10,14 +9,9 @@ use crate::htpkg::PkgBuf;
 impl Engine {
     pub async fn query(&self, m: &htmatcher::Matcher, rs: Arc<RequestState>) -> anyhow::Result<Vec<Addr>> {
         let mut results = Vec::new();
-        let mut seen = HashSet::new();
 
         for pkg_result in self.packages(m, &rs.ctoken).await? {
-            let pkg_str = pkg_result?;
-            if !seen.insert(pkg_str.clone()) {
-                continue;
-            }
-            let pkg = PkgBuf::from(pkg_str);
+            let pkg = PkgBuf::from(pkg_result?);
 
             for provider in &self.providers {
                 let addr_list: Vec<Addr> = {

--- a/src/engine/query.rs
+++ b/src/engine/query.rs
@@ -7,7 +7,7 @@ use crate::htmatcher::{self, MatchResult};
 use crate::htpkg::PkgBuf;
 
 impl Engine {
-    pub async fn query(&self, m: &htmatcher::Matcher, rs: Arc<RequestState>) -> anyhow::Result<Vec<Addr>> {
+    pub async fn query(&self, m: &htmatcher::Matcher, rs: Arc<RequestState>) -> anyhow::Result<Box<dyn Iterator<Item = Addr>>> {
         let mut results = Vec::new();
 
         for pkg_result in self.packages(m, &rs.ctoken).await? {
@@ -54,7 +54,7 @@ impl Engine {
             }
         }
 
-        Ok(results)
+        Ok(Box::new(results.into_iter()))
     }
 }
 
@@ -97,7 +97,7 @@ mod tests {
 
         let engine = Arc::new(engine);
         let rs = engine.new_state();
-        let addrs = engine.query(&Matcher::Package(PkgBuf::from("foo/bar")), rs).await?;
+        let addrs: Vec<Addr> = engine.query(&Matcher::Package(PkgBuf::from("foo/bar")), rs).await?.collect();
 
         assert_eq!(addrs.len(), 2);
         assert!(addrs.iter().any(|a| a.name == "a"));
@@ -125,7 +125,7 @@ mod tests {
             name: "a".to_string(),
             args: HashMap::new(),
         };
-        let addrs = engine.query(&Matcher::Addr(target_addr), rs).await?;
+        let addrs: Vec<Addr> = engine.query(&Matcher::Addr(target_addr), rs).await?.collect();
 
         assert_eq!(addrs.len(), 1);
         assert_eq!(addrs[0].name, "a");
@@ -152,7 +152,7 @@ mod tests {
             name: "lint".to_string(),
             args: HashMap::new(),
         };
-        let addrs = engine.query(&Matcher::Label(label_addr), rs).await?;
+        let addrs: Vec<Addr> = engine.query(&Matcher::Label(label_addr), rs).await?.collect();
 
         assert_eq!(addrs.len(), 1);
         assert_eq!(addrs[0].name, "a");
@@ -171,9 +171,9 @@ mod tests {
 
         let engine = Arc::new(engine);
         let rs = engine.new_state();
-        let addrs = engine.query(&Matcher::Package(PkgBuf::from("nonexistent")), rs).await?;
+        let mut addrs = engine.query(&Matcher::Package(PkgBuf::from("nonexistent")), rs).await?;
 
-        assert!(addrs.is_empty());
+        assert!(addrs.next().is_none());
         Ok(())
     }
 }

--- a/src/engine/query.rs
+++ b/src/engine/query.rs
@@ -9,18 +9,14 @@ use crate::htpkg::PkgBuf;
 
 impl Engine {
     pub async fn query(&self, m: &htmatcher::Matcher, rs: Arc<RequestState>) -> anyhow::Result<Vec<Addr>> {
-        let pkg_list: Vec<String> = {
-            let it = self.packages(m, &rs.ctoken).await?;
-            let mut seen = HashSet::new();
-            it.collect::<anyhow::Result<Vec<_>>>()?
-                .into_iter()
-                .filter(|p| seen.insert(p.clone()))
-                .collect()
-        };
-
         let mut results = Vec::new();
+        let mut seen = HashSet::new();
 
-        for pkg_str in pkg_list {
+        for pkg_result in self.packages(m, &rs.ctoken).await? {
+            let pkg_str = pkg_result?;
+            if !seen.insert(pkg_str.clone()) {
+                continue;
+            }
             let pkg = PkgBuf::from(pkg_str);
 
             for provider in &self.providers {

--- a/src/engine/query.rs
+++ b/src/engine/query.rs
@@ -1,10 +1,204 @@
+use std::collections::HashSet;
 use crate::engine::Engine;
+use crate::engine::driver::ParseRequest;
+use crate::engine::provider::{GetError, GetRequest, GetResponse, ListRequest};
 use crate::hasync::Cancellable;
 use crate::htaddr::Addr;
-use crate::htmatcher;
+use crate::htmatcher::{self, MatchResult};
+use crate::htpkg::PkgBuf;
 
 impl Engine {
-    pub async fn query(&self, _m: &htmatcher::Matcher, _ctoken: &dyn Cancellable) -> anyhow::Result<Vec<Addr>> {
-        Ok(vec![])
+    pub async fn query(&self, m: &htmatcher::Matcher, ctoken: &dyn Cancellable) -> anyhow::Result<Vec<Addr>> {
+        let request_id = "".to_string();
+
+        let pkg_list: Vec<String> = {
+            let it = self.packages(m, ctoken).await?;
+            let mut seen = HashSet::new();
+            it.collect::<anyhow::Result<Vec<_>>>()?
+                .into_iter()
+                .filter(|p| seen.insert(p.clone()))
+                .collect()
+        };
+
+        let mut results = Vec::new();
+
+        for pkg_str in pkg_list {
+            let pkg = PkgBuf::from(pkg_str);
+
+            for provider in &self.providers {
+                let addr_list: Vec<Addr> = {
+                    let it = provider.provider.list(ListRequest {
+                        request_id: request_id.clone(),
+                        package: pkg.clone(),
+                    }, ctoken).await?;
+                    it.collect::<anyhow::Result<Vec<_>>>()?
+                        .into_iter()
+                        .map(|r| r.addr)
+                        .filter(|a| a.package == pkg)
+                        .collect()
+                };
+
+                for addr in addr_list {
+                    match m.matches_addr(&addr) {
+                        MatchResult::MatchYes => {
+                            results.push(addr);
+                        }
+                        MatchResult::MatchNo => {}
+                        MatchResult::MatchShrug => {
+                            let spec = match provider.provider.get(GetRequest {
+                                request_id: request_id.clone(),
+                                addr: addr.clone(),
+                                states: vec![],
+                            }, ctoken).await {
+                                Ok(GetResponse { target_spec }) => target_spec,
+                                Err(GetError::NotFound) => continue,
+                                Err(GetError::Other(e)) => return Err(e),
+                            };
+
+                            match m.matches_spec(&spec) {
+                                MatchResult::MatchYes => {
+                                    results.push(addr);
+                                }
+                                MatchResult::MatchNo => {}
+                                MatchResult::MatchShrug => {
+                                    let driver = match self.drivers_by_name.get(&spec.driver) {
+                                        Some(d) => d,
+                                        None => continue,
+                                    };
+
+                                    let def = driver.driver.parse(ParseRequest {
+                                        request_id: request_id.clone(),
+                                        target_spec: spec,
+                                    }, ctoken).await?.target_def;
+
+                                    if m.matches(&def) == MatchResult::MatchYes {
+                                        results.push(addr);
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        }
+
+        Ok(results)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::collections::HashMap;
+    use std::sync::OnceLock;
+    use crate::engine::Config;
+    use crate::engine::provider::{StaticProvider, TargetSpec};
+    use crate::hasync::StdCancellationToken;
+    use crate::htmatcher::Matcher;
+    use tempfile::tempdir;
+
+    fn make_spec(pkg: &str, name: &str, labels: &[&str]) -> TargetSpec {
+        TargetSpec {
+            addr: Addr {
+                package: PkgBuf::from(pkg),
+                name: name.to_string(),
+                args: HashMap::new(),
+            },
+            driver: "exec".to_string(),
+            labels: labels.iter().map(|s| s.to_string()).collect(),
+            ..Default::default()
+        }
+    }
+
+    #[tokio::test]
+    async fn query_by_package() -> anyhow::Result<()> {
+        let root = tempdir()?;
+        let mut engine = Engine::new(Config { root: root.path().to_path_buf() })?;
+
+        engine.register_provider(|_| Box::new(StaticProvider {
+            targets: vec![
+                make_spec("foo/bar", "a", &[]),
+                make_spec("foo/bar", "b", &[]),
+                make_spec("other", "c", &[]),
+            ],
+            packages: OnceLock::new(),
+        }))?;
+
+        let ctoken = StdCancellationToken::new();
+        let addrs = engine.query(&Matcher::Package(PkgBuf::from("foo/bar")), &ctoken).await?;
+
+        assert_eq!(addrs.len(), 2);
+        assert!(addrs.iter().any(|a| a.name == "a"));
+        assert!(addrs.iter().any(|a| a.name == "b"));
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn query_by_addr() -> anyhow::Result<()> {
+        let root = tempdir()?;
+        let mut engine = Engine::new(Config { root: root.path().to_path_buf() })?;
+
+        engine.register_provider(|_| Box::new(StaticProvider {
+            targets: vec![
+                make_spec("foo", "a", &[]),
+                make_spec("foo", "b", &[]),
+            ],
+            packages: OnceLock::new(),
+        }))?;
+
+        let ctoken = StdCancellationToken::new();
+        let target_addr = Addr {
+            package: PkgBuf::from("foo"),
+            name: "a".to_string(),
+            args: HashMap::new(),
+        };
+        let addrs = engine.query(&Matcher::Addr(target_addr), &ctoken).await?;
+
+        assert_eq!(addrs.len(), 1);
+        assert_eq!(addrs[0].name, "a");
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn query_by_label_calls_get_spec() -> anyhow::Result<()> {
+        let root = tempdir()?;
+        let mut engine = Engine::new(Config { root: root.path().to_path_buf() })?;
+
+        engine.register_provider(|_| Box::new(StaticProvider {
+            targets: vec![
+                make_spec("foo", "a", &["//labels:lint"]),
+                make_spec("foo", "b", &[]),
+            ],
+            packages: OnceLock::new(),
+        }))?;
+
+        let ctoken = StdCancellationToken::new();
+        let label_addr = Addr {
+            package: PkgBuf::from("labels"),
+            name: "lint".to_string(),
+            args: HashMap::new(),
+        };
+        let addrs = engine.query(&Matcher::Label(label_addr), &ctoken).await?;
+
+        assert_eq!(addrs.len(), 1);
+        assert_eq!(addrs[0].name, "a");
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn query_empty_when_no_match() -> anyhow::Result<()> {
+        let root = tempdir()?;
+        let mut engine = Engine::new(Config { root: root.path().to_path_buf() })?;
+
+        engine.register_provider(|_| Box::new(StaticProvider {
+            targets: vec![make_spec("foo", "a", &[])],
+            packages: OnceLock::new(),
+        }))?;
+
+        let ctoken = StdCancellationToken::new();
+        let addrs = engine.query(&Matcher::Package(PkgBuf::from("nonexistent")), &ctoken).await?;
+
+        assert!(addrs.is_empty());
+        Ok(())
     }
 }


### PR DESCRIPTION
## Summary
- Implements `Engine::query` to search targets across providers matching a `Matcher`
- Uses 3-step matching cascade: `matches_addr` → `matches_spec` (get_spec) → `matches` on `TargetDef` (get_def), calling each only when previous returns `MatchShrug`
- Deduplicates packages and filters list results to the requested package

## Test plan
- [ ] `query_by_package` — returns targets in matching package only
- [ ] `query_by_addr` — returns exact address match
- [ ] `query_by_label_calls_get_spec` — Label matcher triggers get_spec path
- [ ] `query_empty_when_no_match` — no results for unknown package

Closes HEP-5

🤖 Generated with [Claude Code](https://claude.com/claude-code)