### PR TITLE
feat(starlark): expose host os/arch via heph.core namespace

### DIFF
--- a/src/htplatform.rs
+++ b/src/htplatform.rs
@@ -1,0 +1,75 @@
+//! Host platform identification with a unified naming convention.
+//!
+//! Every ecosystem names operating systems and architectures differently
+//! (Rust: `macos`/`x86_64`/`aarch64`; Go/OCI/Docker: `darwin`/`amd64`/`arm64`).
+//! This module exposes the host's os/arch in both the canonical Go/OCI
+//! convention (the common-denominator naming) and the raw Rust convention,
+//! so callers do not each reinvent the mapping.
+
+/// Host operating system in canonical (Go/OCI) naming, e.g. `linux`, `darwin`.
+pub fn os() -> &'static str {
+    rust_os_to_canonical(std::env::consts::OS)
+}
+
+/// Host architecture in canonical (Go/OCI) naming, e.g. `amd64`, `arm64`.
+pub fn arch() -> &'static str {
+    rust_arch_to_canonical(std::env::consts::ARCH)
+}
+
+/// Host operating system as Rust reports it (`std::env::consts::OS`).
+pub fn os_raw() -> &'static str {
+    std::env::consts::OS
+}
+
+/// Host architecture as Rust reports it (`std::env::consts::ARCH`).
+pub fn arch_raw() -> &'static str {
+    std::env::consts::ARCH
+}
+
+/// Map a Rust os name to the canonical (Go/OCI) convention. Unknown names pass through.
+pub fn rust_os_to_canonical(os: &str) -> &str {
+    match os {
+        "macos" => "darwin",
+        other => other,
+    }
+}
+
+/// Map a Rust arch name to the canonical (Go/OCI) convention. Unknown names pass through.
+pub fn rust_arch_to_canonical(arch: &str) -> &str {
+    match arch {
+        "x86_64" => "amd64",
+        "aarch64" => "arm64",
+        "x86" => "386",
+        "arm" => "arm",
+        other => other,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_arch_mapping() {
+        assert_eq!(rust_arch_to_canonical("x86_64"), "amd64");
+        assert_eq!(rust_arch_to_canonical("aarch64"), "arm64");
+        assert_eq!(rust_arch_to_canonical("x86"), "386");
+        assert_eq!(rust_arch_to_canonical("arm"), "arm");
+        assert_eq!(rust_arch_to_canonical("riscv64"), "riscv64");
+    }
+
+    #[test]
+    fn test_os_mapping() {
+        assert_eq!(rust_os_to_canonical("macos"), "darwin");
+        assert_eq!(rust_os_to_canonical("linux"), "linux");
+        assert_eq!(rust_os_to_canonical("windows"), "windows");
+    }
+
+    #[test]
+    fn test_host_values_non_empty() {
+        assert!(!os().is_empty());
+        assert!(!arch().is_empty());
+        assert!(!os_raw().is_empty());
+        assert!(!arch_raw().is_empty());
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -38,6 +38,7 @@ pub mod hmemoizer;
 pub mod htaddr;
 pub mod htmatcher;
 pub mod htpkg;
+pub mod htplatform;
 pub mod htvalue;
 pub mod log;
 pub mod pluginbuildfile;

--- a/src/pluginbuildfile/run_file.rs
+++ b/src/pluginbuildfile/run_file.rs
@@ -21,14 +21,16 @@ use std::collections::{HashMap, HashSet};
 use std::path::{Path, PathBuf};
 use std::sync::{Arc, Mutex, OnceLock};
 
-/// Build the Starlark globals: the static `starlark_module` builtins plus a
-/// dynamic `heph.<provider>.<fn>` namespace for every function the providers
-/// expose. Built once per buildfile-provider lifetime (the registry is fixed
-/// after the engine injects it).
+/// Build the Starlark globals: the static `starlark_module` builtins, the static
+/// `heph.core` host/platform namespace, plus a dynamic `heph.<provider>.<fn>`
+/// namespace for every function the providers expose. Built once per
+/// buildfile-provider lifetime (the registry is fixed after the engine injects it).
 fn build_globals(registry: &ProviderFunctionRegistry) -> Globals {
     let mut builder = GlobalsBuilder::standard();
     builder = builder.with(starlark_module);
     builder.with_namespace("heph", |hb| {
+        // Static `heph.core` host/platform builtins.
+        hb.namespace("core", heph_core_module);
         // One `heph.<provider>` namespace per provider; each function becomes a
         // native callable bridging into its async `ProviderFn`.
         for (provider, fns) in registry.providers() {
@@ -527,11 +529,35 @@ fn starlark_module(builder: &mut GlobalsBuilder) {
 
         Ok(starlark::values::none::NoneType)
     }
+}
 
-    fn get_pkg<'v>(eval: &mut Evaluator<'v, '_, '_>) -> starlark::Result<String> {
+#[starlark_module]
+fn heph_core_module(builder: &mut GlobalsBuilder) {
+    /// Host operating system in canonical (Go/OCI) naming, e.g. `linux`, `darwin`.
+    fn os() -> starlark::Result<String> {
+        Ok(crate::htplatform::os().to_string())
+    }
+
+    /// Host architecture in canonical (Go/OCI) naming, e.g. `amd64`, `arm64`.
+    fn arch() -> starlark::Result<String> {
+        Ok(crate::htplatform::arch().to_string())
+    }
+
+    /// Host operating system as Rust reports it, e.g. `linux`, `macos`.
+    fn os_raw() -> starlark::Result<String> {
+        Ok(crate::htplatform::os_raw().to_string())
+    }
+
+    /// Host architecture as Rust reports it, e.g. `x86_64`, `aarch64`.
+    fn arch_raw() -> starlark::Result<String> {
+        Ok(crate::htplatform::arch_raw().to_string())
+    }
+
+    /// The package currently being evaluated.
+    fn pkg<'v>(eval: &mut Evaluator<'v, '_, '_>) -> starlark::Result<String> {
         let extra = eval
             .extra
-            .expect("evaluator extra must be set before calling get_pkg()")
+            .expect("evaluator extra must be set before calling heph.core.pkg()")
             .downcast_ref::<Extra>()
             .expect("evaluator extra must be of type Extra");
         Ok(extra.pkg.to_string())
@@ -1644,13 +1670,13 @@ target(name = "t", driver = "d", deps = coerce("single"))
     }
 
     #[test]
-    fn test_get_pkg_returns_current_pkg() {
+    fn test_heph_core_pkg_returns_current_pkg() {
         let tmp_dir = tempdir().unwrap();
         let pkg = tmp_dir.path().join("some").join("pkg");
         fs::create_dir_all(&pkg).unwrap();
         fs::write(
             pkg.join("BUILD"),
-            r#"target(name = "t", driver = "d", here = get_pkg())"#,
+            r#"target(name = "t", driver = "d", here = heph.core.pkg())"#,
         )
         .unwrap();
         let provider = make_provider(&tmp_dir);
@@ -1663,21 +1689,21 @@ target(name = "t", driver = "d", deps = coerce("single"))
     }
 
     #[test]
-    fn test_get_pkg_in_loaded_file_reports_loader_pkg() {
-        // load("//lib", ...) evaluates lib's BUILD under pkg "lib" — get_pkg() there
-        // returns "lib", not the caller's package.
+    fn test_heph_core_pkg_in_loaded_file_reports_loader_pkg() {
+        // load("//lib", ...) evaluates lib's BUILD under pkg "lib" — heph.core.pkg()
+        // there returns "lib", not the caller's package.
         let tmp_dir = tempdir().unwrap();
         let root = tmp_dir.path();
         let lib = root.join("lib");
         fs::create_dir_all(&lib).unwrap();
-        fs::write(lib.join("BUILD"), r#"WHERE = get_pkg()"#).unwrap();
+        fs::write(lib.join("BUILD"), r#"WHERE = heph.core.pkg()"#).unwrap();
         let app = root.join("app");
         fs::create_dir_all(&app).unwrap();
         fs::write(
             app.join("BUILD"),
             r#"
 load("//lib", "WHERE")
-target(name = "t", driver = "d", loaded_from = WHERE, here = get_pkg())
+target(name = "t", driver = "d", loaded_from = WHERE, here = heph.core.pkg())
 "#,
         )
         .unwrap();
@@ -1760,6 +1786,29 @@ target(
             }
             other => panic!("expected dict, got {other:?}"),
         }
+    }
+
+    #[test]
+    fn test_heph_core_host_builtins() {
+        let content = r#"
+target(
+    name = "t",
+    driver = "d",
+    os = heph.core.os(),
+    arch = heph.core.arch(),
+    os_raw = heph.core.os_raw(),
+    arch_raw = heph.core.arch_raw(),
+)
+"#;
+        let config = run_target_config(content);
+        let expect = |key: &str, want: &str| match config.get(key) {
+            Some(htvalue::Value::String(s)) => assert_eq!(s, want, "for {key}"),
+            other => panic!("expected {key} string, got {other:?}"),
+        };
+        expect("os", crate::htplatform::os());
+        expect("arch", crate::htplatform::arch());
+        expect("os_raw", std::env::consts::OS);
+        expect("arch_raw", std::env::consts::ARCH);
     }
 
     #[test]

--- a/src/plugingo/factors.rs
+++ b/src/plugingo/factors.rs
@@ -42,28 +42,13 @@ impl Factors {
 }
 
 pub fn current_goos() -> String {
-    rust_os_to_go(std::env::consts::OS).to_string()
-}
-
-fn rust_os_to_go(os: &str) -> &str {
-    match os {
-        "macos" => "darwin",
-        other => other,
-    }
+    // Go's GOOS naming matches the canonical (Go/OCI) convention.
+    crate::htplatform::os().to_string()
 }
 
 pub fn current_goarch() -> String {
-    rust_arch_to_go(std::env::consts::ARCH).to_string()
-}
-
-fn rust_arch_to_go(arch: &str) -> &str {
-    match arch {
-        "x86_64" => "amd64",
-        "aarch64" => "arm64",
-        "x86" => "386",
-        "arm" => "arm",
-        other => other,
-    }
+    // Go's GOARCH naming matches the canonical (Go/OCI) convention.
+    crate::htplatform::arch().to_string()
 }
 
 #[cfg(test)]
@@ -118,21 +103,5 @@ mod tests {
             build_tags: vec!["foo".into(), "bar".into()],
         };
         assert_eq!(f.go_list_flags(), vec!["-tags", "foo,bar"]);
-    }
-
-    #[test]
-    fn test_arch_mapping() {
-        assert_eq!(rust_arch_to_go("x86_64"), "amd64");
-        assert_eq!(rust_arch_to_go("aarch64"), "arm64");
-        assert_eq!(rust_arch_to_go("x86"), "386");
-        assert_eq!(rust_arch_to_go("arm"), "arm");
-        assert_eq!(rust_arch_to_go("riscv64"), "riscv64");
-    }
-
-    #[test]
-    fn test_os_mapping() {
-        assert_eq!(rust_os_to_go("macos"), "darwin");
-        assert_eq!(rust_os_to_go("linux"), "linux");
-        assert_eq!(rust_os_to_go("windows"), "windows");
     }
 }


### PR DESCRIPTION
## Context

BUILD files (Starlark) had no way to read the host platform. Every ecosystem names os/arch differently — Rust: `macos`/`x86_64`/`aarch64`; Go/OCI/Docker: `darwin`/`amd64`/`arm64`. Consumers need one unified, predictable answer.

## What

New `heph.core` namespace exposing host platform in **both** the canonical (Go/OCI) and raw (Rust) conventions:

| Function | Returns | Example (arm64 mac) |
|---|---|---|
| `heph.core.os()` | canonical os | `darwin` |
| `heph.core.arch()` | canonical arch | `arm64` |
| `heph.core.os_raw()` | raw `std::env::consts::OS` | `macos` |
| `heph.core.arch_raw()` | raw `std::env::consts::ARCH` | `aarch64` |
| `heph.core.pkg()` | current package | `foo/bar` |

Canonical mapping: `macos→darwin`, `x86_64→amd64`, `aarch64→arm64`, `x86→386`; passthrough otherwise.

## Changes

- **`src/htplatform.rs`** (new) — single source of truth for the os/arch convention mapping.
- **`src/plugingo/factors.rs`** — `current_goos/goarch` delegate to `htplatform` (removed duplicate private Rust→Go mappers).
- **`src/pluginbuildfile/run_file.rs`** — `heph_core_module` + namespace wiring; removed top-level `get_pkg` (now `heph.core.pkg()`).

## Tests

`htplatform` 3/3, `factors` 4/4, `run_file` core 3/3. clippy `-D warnings` clean, fmt applied.

🤖 Generated with [Claude Code](https://claude.com/claude-code)