### PR TITLE
docs(cli): expand command and flag help text

### DIFF
--- a/src/commands/gendocs.rs
+++ b/src/commands/gendocs.rs
@@ -40,7 +40,10 @@ fn render_command(cmd: &clap::Command, parent_path: &str, out: &mut String) {
 
     out.push_str(&format!("## `{path}`\n\n"));
 
-    if let Some(about) = cmd.get_about() {
+    // Prefer the long description (multi-paragraph doc comment incl. examples)
+    // so the reference carries the same detail as `--help`; fall back to the
+    // one-line about for commands without one.
+    if let Some(about) = cmd.get_long_about().or_else(|| cmd.get_about()) {
         out.push_str(&format!("{about}\n\n"));
     }
 
@@ -240,6 +243,45 @@ mod tests {
         );
         assert!(table.contains("`off`"), "row missing default: {table}");
         assert!(table.contains("Force it"), "row missing help: {table}");
+    }
+
+    #[test]
+    fn long_about_preferred_over_short() {
+        let mut out = String::new();
+        let cmd = clap::Command::new("run")
+            .about("short")
+            .long_about("long body\n\nExamples:\n  heph run //pkg:bin");
+        render_command(&cmd, BIN, &mut out);
+
+        assert!(
+            out.contains("long body") && out.contains("heph run //pkg:bin"),
+            "long_about (with examples) not rendered:\n{out}"
+        );
+        assert!(
+            !out.contains("short\n"),
+            "short about leaked when long_about present:\n{out}"
+        );
+    }
+
+    #[test]
+    fn falls_back_to_short_about_when_no_long() {
+        let mut out = String::new();
+        let cmd = clap::Command::new("ver").about("Prints version");
+        render_command(&cmd, BIN, &mut out);
+
+        assert!(
+            out.contains("Prints version"),
+            "short about not rendered as fallback:\n{out}"
+        );
+    }
+
+    #[test]
+    fn real_cli_examples_reach_markdown() {
+        let md = render_markdown(&cli_command());
+        assert!(
+            md.contains("heph run //cmd/server:bin"),
+            "run command examples missing from reference:\n{md}"
+        );
     }
 
     #[test]

--- a/src/commands/inspect/def.rs
+++ b/src/commands/inspect/def.rs
@@ -14,9 +14,9 @@ use crate::tui::{self, App, AppContext, LogSink};
 
 #[derive(clap::Args, Clone)]
 pub struct Args {
-    /// Target address
+    /// Target address (e.g. //pkg:name)
     pub addr: String,
-    /// Skip applying transitive deps
+    /// Show the direct def only, without applying transitive deps
     #[arg(long)]
     pub no_transitive: bool,
 }

--- a/src/commands/inspect/deps.rs
+++ b/src/commands/inspect/deps.rs
@@ -11,9 +11,9 @@ use crate::tui::{self, App, AppContext, LogSink};
 
 #[derive(clap::Args, Clone)]
 pub struct Args {
-    /// Target address
+    /// Target address (e.g. //pkg:name)
     pub addr: String,
-    /// Explore deps interactively
+    /// Explore the dependency tree in an interactive TUI (requires a terminal)
     #[arg(short = 'i', long = "interactive")]
     pub interactive: bool,
 }

--- a/src/commands/inspect/hashin.rs
+++ b/src/commands/inspect/hashin.rs
@@ -11,7 +11,7 @@ use crate::tui::{self, App, AppContext, LogSink};
 
 #[derive(clap::Args, Clone)]
 pub struct Args {
-    /// Target address
+    /// Target address (e.g. //pkg:name)
     pub addr: String,
 }
 

--- a/src/commands/inspect/hashout.rs
+++ b/src/commands/inspect/hashout.rs
@@ -11,7 +11,7 @@ use crate::tui::{self, App, AppContext, LogSink};
 
 #[derive(clap::Args, Clone)]
 pub struct Args {
-    /// Target address
+    /// Target address (e.g. //pkg:name)
     pub addr: String,
 }
 

--- a/src/commands/inspect/mod.rs
+++ b/src/commands/inspect/mod.rs
@@ -21,19 +21,71 @@ pub struct InspectArgs {
 
 #[derive(Subcommand)]
 pub enum InspectCommands {
-    /// List packages
+    /// List packages matching a matcher
+    ///
+    /// Walks providers to discover packages and prints those matching the given
+    /// matcher, one per line. With no argument, lists every package in the
+    /// workspace.
+    ///
+    /// Examples:
+    ///
+    /// `heph inspect packages`
+    ///
+    /// `heph inspect packages //cmd/...`
     Packages(packages::Args),
-    /// Prints targets hashin
+    /// Print a target's input hash
+    ///
+    /// Computes and prints the content hash of all the target's declared
+    /// inputs — the key heph uses to decide a cache hit. Does not run the
+    /// target.
+    ///
+    /// Example: `heph inspect hashin //cmd/server:bin`
     Hashin(hashin::Args),
-    /// Prints targets hashout
+    /// Print a target's output hashes
+    ///
+    /// Runs the target (or reads its cached result) and prints the content hash
+    /// of each output artifact, one per line.
+    ///
+    /// Example: `heph inspect hashout //cmd/server:bin`
     Hashout(hashout::Args),
-    /// Prints target spec
+    /// Print a target's spec, as supplied by its provider
+    ///
+    /// Prints the raw spec — the unresolved definition a provider returns
+    /// before a driver parses it — as pretty JSON.
+    ///
+    /// Example: `heph inspect spec //cmd/server:bin`
     Spec(spec::Args),
-    /// Prints target def
+    /// Print a target's resolved def (inputs, outputs, sandbox)
+    ///
+    /// Parses the target's spec into a def and prints it as pretty JSON,
+    /// including declared inputs, outputs, and sandbox configuration. By
+    /// default transitive deps are applied; pass --no-transitive for the
+    /// direct def only.
+    ///
+    /// Examples:
+    ///
+    /// `heph inspect def //cmd/server:bin`
+    ///
+    /// `heph inspect def //cmd/server:bin --no-transitive`
     Def(def::Args),
-    /// Prints target deps
+    /// Print a target's input dependencies
+    ///
+    /// Resolves the target's def and prints the ref of each declared input,
+    /// one per line. Pass -i/--interactive to browse the dependency tree in a
+    /// TUI.
+    ///
+    /// Examples:
+    ///
+    /// `heph inspect deps //cmd/server:bin`
+    ///
+    /// `heph inspect deps //cmd/server:bin -i`
     Deps(deps::Args),
     /// List provider-exposed functions (`heph.<provider>.<fn>`)
+    ///
+    /// Prints every function registered by a provider for use in BUILD files,
+    /// in `heph.<provider>.<function>` form, one per line.
+    ///
+    /// Example: `heph inspect functions`
     Functions(functions::Args),
 }
 

--- a/src/commands/inspect/packages.rs
+++ b/src/commands/inspect/packages.rs
@@ -11,7 +11,7 @@ use crate::tui::{self, App, AppContext, BufferedStdout, LogSink};
 
 #[derive(clap::Args, Clone)]
 pub struct Args {
-    /// Packages matcher
+    /// Package matcher (defaults to all packages)
     pub matcher: Option<String>,
 }
 

--- a/src/commands/inspect/spec.rs
+++ b/src/commands/inspect/spec.rs
@@ -11,7 +11,7 @@ use crate::tui::{self, App, AppContext, LogSink};
 
 #[derive(clap::Args, Clone)]
 pub struct Args {
-    /// Target address
+    /// Target address (e.g. //pkg:name)
     pub addr: String,
 }
 

--- a/src/commands/mod.rs
+++ b/src/commands/mod.rs
@@ -17,18 +17,64 @@ use crate::tui::LogSink;
 
 #[derive(Subcommand)]
 pub enum Commands {
-    /// Run a command
+    /// Build and run targets
+    ///
+    /// Resolves the matched target(s), builds their dependency graph, and runs
+    /// them — reusing cached results when inputs are unchanged. A single
+    /// argument is a target address; two arguments are a label followed by a
+    /// package matcher, selecting every target carrying that label.
+    ///
+    /// Examples:
+    ///
+    /// `heph run //cmd/server:bin` — run a single target
+    ///
+    /// `heph run test //...` — run every target labelled `test`
+    ///
+    /// `heph run //cmd/server:bin --shell` — open a shell in the target sandbox
+    ///
+    /// `heph run build //... -e //vendor/...` — run, excluding a subtree
     #[command(visible_alias = "r")]
     Run(run::RunArgs),
-    /// Inspect
+    /// Inspect targets, packages, hashes, and deps
+    ///
+    /// Read-only introspection of the build graph. Subcommands print a target's
+    /// spec, resolved def, input/output hashes, or dependencies, and list
+    /// packages or provider functions. Nothing is executed unless a provider
+    /// must run a target to answer the query.
+    ///
+    /// Examples:
+    ///
+    /// `heph inspect packages //...`
+    ///
+    /// `heph inspect deps //cmd/server:bin`
+    ///
+    /// `heph inspect hashin //cmd/server:bin`
     #[command(arg_required_else_help = true, visible_alias = "i")]
     Inspect(inspect::InspectArgs),
     /// Query targets
+    ///
+    /// Prints the address of every target matched by the argument(s), one per
+    /// line. Accepts the same address / label+matcher forms as `run`, plus
+    /// `-e` to exclude addresses. Useful for scripting and for previewing what
+    /// a matcher selects before running it.
+    ///
+    /// Examples:
+    ///
+    /// `heph query //...`
+    ///
+    /// `heph query test //cmd/...`
+    ///
+    /// `heph query //... -e //vendor/...`
     #[command(visible_alias = "q")]
     Query(query::Args),
     /// Prints version
+    ///
+    /// Prints the heph version string and exits.
     Version(version::Args),
     /// Developer tools
+    ///
+    /// Maintenance and housekeeping subcommands that operate on the workspace
+    /// or the local cache rather than on individual targets.
     Tool(tool::ToolArgs),
     /// Generate markdown CLI reference
     #[command(name = "gen-docs", hide = true)]

--- a/src/commands/run.rs
+++ b/src/commands/run.rs
@@ -20,10 +20,10 @@ pub struct RunArgs {
     /// Package matcher (only if first argument is a Label)
     #[arg(value_name = "PACKAGE_MATCHER")]
     pub arg2: Option<String>,
-    /// Force execution
+    /// Force execution, ignoring any cached result
     #[arg(long = "force")]
     pub force: bool,
-    /// Interactive shell
+    /// Drop into an interactive shell in the target's sandbox instead of running it
     #[arg(long = "shell", num_args = 0..=1, require_equals = true, default_missing_value = "", value_name = "TARGET",)]
     pub shell: Option<String>,
     /// Print output artifacts to stdout

--- a/src/commands/tool/mod.rs
+++ b/src/commands/tool/mod.rs
@@ -16,8 +16,20 @@ pub struct ToolArgs {
 #[derive(Subcommand)]
 pub enum ToolCommands {
     /// Garbage collect the local cache
+    ///
+    /// Sweeps the local cache (.heph3/cache) and removes artifacts no longer
+    /// reachable from any current target, reclaiming disk space. Resolves every
+    /// cached target's spec, so providers may run.
+    ///
+    /// Example: `heph tool gc`
     Gc(gc::GcArgs),
     /// Manage the heph-generated section of the root .gitignore
+    ///
+    /// Computes the ignore patterns for codegen-copy outputs and writes them
+    /// into a managed block in the workspace root .gitignore, leaving the rest
+    /// of the file untouched. Idempotent: a no-op when already up to date.
+    ///
+    /// Example: `heph tool gen-gitignore`
     #[command(name = "gen-gitignore")]
     GenGitignore(gen_gitignore::Args),
 }


### PR DESCRIPTION
## What

Adds longer descriptions and usage examples to **every** CLI command, and tightens vague arg/flag help.

### Command docs (clap `long_about`)
Each command now carries a multi-paragraph doc comment with examples, surfaced on `heph <cmd> --help`:
- `run`, `query`, `inspect`, `tool`, `version`
- `inspect packages|hashin|hashout|spec|def|deps|functions`
- `tool gc|gen-gitignore`

### Tightened arg/flag help
- `run --force` → "ignoring any cached result"; `run --shell` now explains the sandbox shell
- `inspect` subcommand summaries reworded from "Prints targets X" to proper one-liners
- `addr` positionals get `(e.g. //pkg:name)`; `packages` matcher notes the all-packages default
- `def --no-transitive` / `deps --interactive` descriptions clarified

### gen-docs
`render_command` now renders `long_about` (fallback to `about`) so the generated markdown reference carries the same detail as `--help`. New tests cover the long-over-short preference, the short fallback, and that real CLI examples reach the markdown.

## Test
- `cargo test -p heph --lib gendocs` — 9 passed
- `cargo fmt`, `cargo clippy -p heph` — clean
- Verified `--help` and `gen-docs` output by hand

🤖 Generated with [Claude Code](https://claude.com/claude-code)