### PR TITLE
gen-gitignore: target-annotated lines + scoped rebuild

### DIFF
--- a/src/commands/mod.rs
+++ b/src/commands/mod.rs
@@ -8,6 +8,7 @@ pub mod query;
 pub mod run;
 pub mod tool;
 mod utils;
+pub mod validate;
 pub mod version;
 
 pub use global::GlobalOptions;
@@ -27,6 +28,9 @@ pub enum Commands {
     /// Query targets
     #[command(visible_alias = "q")]
     Query(query::Args),
+    /// Validate all targets (link graph + check codegen outputs)
+    #[command(visible_alias = "v")]
+    Validate(validate::ValidateArgs),
     /// Prints version
     Version(version::Args),
     /// Garbage collect the local cache
@@ -44,6 +48,7 @@ impl Commands {
             Commands::Run(args) => run::execute(args, sink, global),
             Commands::Inspect(args) => args.execute(sink, global),
             Commands::Query(args) => query::execute(args, sink, global),
+            Commands::Validate(args) => validate::execute(args, sink, global),
             Commands::Version(args) => version::execute(args),
             Commands::Gc(args) => gc::execute(args, sink, global),
             Commands::Tool(args) => args.execute(sink, global),

--- a/src/commands/tool/gen_gitignore.rs
+++ b/src/commands/tool/gen_gitignore.rs
@@ -6,14 +6,29 @@ use async_trait::async_trait;
 
 use crate::commands::GlobalOptions;
 use crate::commands::bootstrap;
-use crate::engine::{Engine, get_root, gitignore};
+use crate::engine::{Engine, get_cwp, get_root, gitignore};
+use crate::htmatcher::Matcher;
+use crate::htpkg::{self, PkgBuf};
 use crate::tui::{self, App, AppContext, BufferedStdout, LogSink};
 
 #[derive(clap::Args, Clone)]
-pub struct Args {}
+#[command(override_usage = "heph gen-gitignore\n       heph gen-gitignore <PACKAGE_MATCHER>")]
+pub struct Args {
+    /// Package matcher (e.g. //pkg/...); omit to regenerate the whole section.
+    /// When given, only the lines emitted by targets under that matcher are
+    /// rebuilt — a smaller graph walk, so a faster run.
+    #[arg(value_name = "PACKAGE_MATCHER")]
+    pub matcher: Option<String>,
+}
 
 struct GenGitignoreApp {
     engine: Arc<Engine>,
+    /// Targets to scan for codegen-copy outputs. Whole-workspace selector, or
+    /// the user's package matcher when scoped.
+    matcher: Matcher,
+    /// True when the user passed a matcher: rebuild only the matching slice of
+    /// the section and preserve every other line.
+    scoped: bool,
     root: PathBuf,
     fail_fast: bool,
 }
@@ -39,8 +54,8 @@ impl App for GenGitignoreApp {
 
         let out = BufferedStdout::new(&ctx);
         let res: anyhow::Result<()> = async {
-            let entries = Arc::clone(&self.engine)
-                .codegen_copy_gitignore_patterns(rs.clone())
+            let fresh = Arc::clone(&self.engine)
+                .codegen_copy_gitignore_patterns(rs.clone(), &self.matcher)
                 .await?;
 
             let path = self.root.join(".gitignore");
@@ -50,6 +65,14 @@ impl App for GenGitignoreApp {
                 Err(e) => {
                     return Err(e).with_context(|| format!("reading {}", path.display()));
                 }
+            };
+            // Scoped: graft the freshly-scanned slice over the existing section,
+            // keeping every line emitted by a target outside the matcher.
+            // Whole-workspace: replace the section wholesale.
+            let entries = if self.scoped {
+                gitignore::merge_section(&existing, fresh, &self.matcher)
+            } else {
+                fresh
             };
             let updated = gitignore::render(&existing, &entries);
             if updated == existing {
@@ -77,11 +100,19 @@ pub fn execute(args: &Args, sink: LogSink, global: &GlobalOptions) -> anyhow::Re
     bootstrap::block_on(execute_async(args.clone(), sink, global.clone()))?
 }
 
-async fn execute_async(_args: Args, sink: LogSink, global: GlobalOptions) -> anyhow::Result<()> {
+async fn execute_async(args: Args, sink: LogSink, global: GlobalOptions) -> anyhow::Result<()> {
     let root = get_root()?;
+    // Scoped runs walk only the matched packages; whole-workspace runs use the
+    // codegen-tree selector that reaches every codegen target.
+    let (matcher, scoped) = match args.matcher {
+        Some(s) => (htpkg::parse(&s, &get_cwp()?)?, true),
+        None => (Matcher::TreeOutputTo(PkgBuf::from("")), false),
+    };
     let (engine, shutdown) = bootstrap::new_engine()?;
     let app = GenGitignoreApp {
         engine,
+        matcher,
+        scoped,
         root,
         fail_fast: global.fail_fast,
     };

--- a/src/commands/validate.rs
+++ b/src/commands/validate.rs
@@ -116,7 +116,10 @@ impl App for ValidateApp {
                     return Ok::<bool, anyhow::Error>(false);
                 }
                 let entries = Arc::clone(&engine)
-                    .codegen_copy_gitignore_patterns(rs.clone())
+                    .codegen_copy_gitignore_patterns(
+                        rs.clone(),
+                        &Matcher::TreeOutputTo(PkgBuf::from("")),
+                    )
                     .await?;
                 let path = root.join(".gitignore");
                 let existing = match std::fs::read_to_string(&path) {

--- a/src/commands/validate.rs
+++ b/src/commands/validate.rs
@@ -1,0 +1,190 @@
+use std::path::PathBuf;
+use std::sync::Arc;
+
+use anyhow::Context;
+use async_trait::async_trait;
+use enclose::enclose;
+use futures::TryStreamExt;
+
+use crate::commands::GlobalOptions;
+use crate::commands::bootstrap;
+use crate::engine::error::TargetNotFoundError;
+use crate::engine::{Engine, get_cwp, get_root, gitignore};
+use crate::hmemoizer::downcast_chain_ref;
+use crate::htaddr::Addr;
+use crate::htmatcher::Matcher;
+use crate::htpkg::{self, PkgBuf};
+use crate::tui::{self, App, AppContext, BufferedStdout, LogSink};
+
+#[derive(clap::Args, Clone)]
+#[command(override_usage = "heph validate\n       heph validate <PACKAGE_MATCHER>")]
+pub struct ValidateArgs {
+    /// Package matcher (e.g. //pkg/...); omit to validate the whole workspace
+    #[arg(value_name = "PACKAGE_MATCHER")]
+    pub matcher: Option<String>,
+}
+
+struct ValidateApp {
+    engine: Arc<Engine>,
+    /// Targets to validate — whole workspace or the user-scoped matcher.
+    matcher: Matcher,
+    /// True when the user passed a matcher; the gitignore check is then skipped.
+    scoped: bool,
+    root: PathBuf,
+    fail_fast: bool,
+}
+
+#[async_trait]
+impl App for ValidateApp {
+    type Output = ();
+    type TuiView = crate::tui::TuiProgressView;
+    type CiView = crate::tui::CiProgressView;
+
+    fn tui_view(&self) -> Self::TuiView {
+        crate::tui::TuiProgressView::new("Validating targets".to_string())
+    }
+
+    fn ci_view(&self) -> Self::CiView {
+        crate::tui::CiProgressView::new("Validating targets".to_string())
+    }
+
+    async fn run(self, ctx: AppContext) -> anyhow::Result<()> {
+        let ValidateApp {
+            engine,
+            matcher,
+            scoped,
+            root,
+            fail_fast,
+        } = self;
+        let rs = engine.new_state_with_events(fail_fast, ctx.event_sender());
+
+        // Overlap detection scopes to the user matcher when scoped, else uses the
+        // codegen-tree selector (same one the gitignore enumeration uses).
+        let overlap_matcher = if scoped {
+            matcher.clone()
+        } else {
+            Matcher::TreeOutputTo(PkgBuf::from(""))
+        };
+
+        let out = BufferedStdout::new(&ctx);
+        let res: anyhow::Result<()> = async {
+            // 1. Link every in-scope target: parse + resolve its runtime inputs.
+            //    No execution — proves the graph is well-formed.
+            let link_fut = enclose!((engine, rs, matcher) async move {
+                let addrs: Vec<Addr> = Arc::clone(&engine)
+                    .query(rs.clone(), &matcher)
+                    .try_collect()
+                    .await?;
+                let futs = addrs.iter().map(|addr| {
+                    enclose!((engine, rs, addr) async move {
+                        let def = match Arc::clone(&engine).get_def(rs.clone(), &addr).await {
+                            Ok(def) => def,
+                            // A provider may `list` an addr it cannot `get`
+                            // standalone — e.g. go per-platform variants that only
+                            // resolve as in-context deps. The query resolver skips
+                            // these the same way. A NotFound for a *different* addr
+                            // is a real missing dependency and still propagates
+                            // (get_def surfaces it while expanding inputs).
+                            Err(e)
+                                if downcast_chain_ref::<TargetNotFoundError>(&e)
+                                    .is_some_and(|nf| nf.addr == addr) =>
+                            {
+                                return Ok(());
+                            }
+                            Err(e) => return Err(e),
+                        };
+                        Arc::clone(&engine)
+                            .link(rs.clone(), Arc::clone(&def.target_def))
+                            .await?;
+                        Ok::<(), anyhow::Error>(())
+                    })
+                });
+                crate::engine::fanout::join_all_failable(futs, fail_fast).await?;
+                Ok::<(), anyhow::Error>(())
+            });
+
+            // 2. Detect overlapping `codegen = copy` outputs.
+            let overlap_fut = enclose!((engine, rs) async move {
+                Arc::clone(&engine)
+                    .codegen_copy_overlaps(rs.clone(), &overlap_matcher)
+                    .await
+            });
+
+            // 3. Verify `.gitignore` is up to date (whole-workspace runs only).
+            let gitignore_fut = enclose!((engine, rs) async move {
+                if scoped {
+                    return Ok::<bool, anyhow::Error>(false);
+                }
+                let entries = Arc::clone(&engine)
+                    .codegen_copy_gitignore_patterns(rs.clone())
+                    .await?;
+                let path = root.join(".gitignore");
+                let existing = match std::fs::read_to_string(&path) {
+                    Ok(s) => s,
+                    Err(e) if e.kind() == std::io::ErrorKind::NotFound => String::new(),
+                    Err(e) => return Err(e).with_context(|| format!("reading {}", path.display())),
+                };
+                let want = gitignore::render(&existing, &entries);
+                Ok(want != existing) // true = stale
+            });
+
+            let ((), overlaps, stale) = tokio::try_join!(link_fut, overlap_fut, gitignore_fut)?;
+
+            let mut problems: Vec<String> = Vec::new();
+            for o in &overlaps {
+                let addrs = o
+                    .addrs
+                    .iter()
+                    .map(|a| a.format())
+                    .collect::<Vec<_>>()
+                    .join(", ");
+                problems.push(format!(
+                    "codegen=copy output `{}` is produced by multiple targets: {}",
+                    o.path, addrs
+                ));
+            }
+            if stale {
+                problems.push("`.gitignore` is out of date — run `heph gen-gitignore`".to_string());
+            }
+            if !problems.is_empty() {
+                anyhow::bail!("validation failed:\n  {}", problems.join("\n  "));
+            }
+
+            // Success prints nothing; only the scoped-skip warning is emitted.
+            if scoped {
+                out.println("warning: skipped .gitignore freshness check (validation is scoped)");
+            }
+            Ok(())
+        }
+        .await;
+        out.close().await;
+
+        crate::commands::errors::finalize!(ctx, rs, res)
+    }
+}
+
+pub fn execute(args: &ValidateArgs, sink: LogSink, global: &GlobalOptions) -> anyhow::Result<()> {
+    bootstrap::block_on(execute_async(args.clone(), sink, global.clone()))?
+}
+
+async fn execute_async(
+    args: ValidateArgs,
+    sink: LogSink,
+    global: GlobalOptions,
+) -> anyhow::Result<()> {
+    let root = get_root()?;
+    let (matcher, scoped) = match args.matcher {
+        Some(s) => (htpkg::parse(&s, &get_cwp()?)?, true),
+        None => (Matcher::PackagePrefix(PkgBuf::from("")), false),
+    };
+    let (engine, shutdown) = bootstrap::new_engine()?;
+    let app = ValidateApp {
+        engine,
+        matcher,
+        scoped,
+        root,
+        fail_fast: global.fail_fast,
+    };
+    let interactive = tui::should_use_tui(global.no_tui);
+    tui::run_app(app, sink, interactive, shutdown).await
+}

--- a/src/commands/validate.rs
+++ b/src/commands/validate.rs
@@ -135,15 +135,12 @@ impl App for ValidateApp {
 
             let mut problems: Vec<String> = Vec::new();
             for o in &overlaps {
-                let addrs = o
-                    .addrs
-                    .iter()
-                    .map(|a| a.format())
-                    .collect::<Vec<_>>()
-                    .join(", ");
                 problems.push(format!(
-                    "codegen=copy output `{}` is produced by multiple targets: {}",
-                    o.path, addrs
+                    "codegen=copy outputs overlap: `{}` ({}) and `{}` ({})",
+                    o.a.path,
+                    o.a.addr.format(),
+                    o.b.path,
+                    o.b.addr.format()
                 ));
             }
             if stale {

--- a/src/engine/gitignore.rs
+++ b/src/engine/gitignore.rs
@@ -14,8 +14,8 @@ use futures::TryStreamExt;
 use crate::engine::Engine;
 use crate::engine::driver::targetdef::path::{CodegenMode, Content};
 use crate::engine::request_state::RequestState;
-use crate::htmatcher::Matcher;
-use crate::htpkg::PkgBuf;
+use crate::htaddr::{Addr, parse_addr};
+use crate::htmatcher::{MatchResult, Matcher};
 
 /// Markers delimiting the heph-managed region. Lines between them (inclusive)
 /// are owned by heph and rewritten on every run; everything outside is
@@ -24,37 +24,148 @@ pub const BEGIN_MARKER: &str =
     "# BEGIN heph-generated (managed by `heph gen-gitignore` — do not edit)";
 pub const END_MARKER: &str = "# END heph-generated";
 
+/// Separator between a gitignore pattern and the trailing `# //pkg:target`
+/// comment naming the emitting target. The space-hash-space form keeps the
+/// comment valid gitignore syntax and round-trips through [`parse_entry`].
+const COMMENT_SEP: &str = " # ";
+
+/// One managed `.gitignore` line: a root-anchored pattern plus the target that
+/// emits it. The target is rendered as a trailing `# //pkg:target` comment so a
+/// scoped rebuild can tell which lines it owns without re-scanning the graph.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct GitignoreEntry {
+    pub pattern: String,
+    /// The target whose `codegen = copy` output produces `pattern`. `None` only
+    /// for lines parsed from an existing section that lack the comment (legacy
+    /// or hand-edited) — kept verbatim so a scoped rebuild never drops them.
+    pub addr: Option<Addr>,
+}
+
+impl GitignoreEntry {
+    /// Render as a single gitignore line: `pattern # //pkg:target`, or just the
+    /// bare pattern when the emitting target is unknown.
+    fn to_line(&self) -> String {
+        match &self.addr {
+            Some(addr) => format!("{}{COMMENT_SEP}{}", self.pattern, addr.format()),
+            None => self.pattern.clone(),
+        }
+    }
+
+    /// Sort key: by pattern first, then by emitting target so lines are
+    /// deterministic and dedupe-comparable.
+    fn sort_key(&self) -> (&str, String) {
+        (
+            self.pattern.as_str(),
+            self.addr.as_ref().map(Addr::format).unwrap_or_default(),
+        )
+    }
+}
+
+/// Sort, then drop exact `(pattern, addr)` duplicates so the rendered section is
+/// deterministic. Two *different* targets emitting the same path stay as two
+/// distinct lines (that collision is a `validate` error, not a gitignore one).
+fn normalize(mut entries: Vec<GitignoreEntry>) -> Vec<GitignoreEntry> {
+    entries.sort_by(|a, b| a.sort_key().cmp(&b.sort_key()));
+    entries.dedup();
+    entries
+}
+
 impl Engine {
-    /// Enumerate the root-anchored `.gitignore` patterns for every
-    /// `codegen = copy` output in the workspace. Sorted and deduplicated so the
-    /// result is deterministic and directly diffable against an existing file.
+    /// Enumerate the root-anchored `.gitignore` entries for every
+    /// `codegen = copy` output produced by a target matching `matcher`. Sorted
+    /// and deduplicated so the result is deterministic and directly diffable
+    /// against an existing file.
+    ///
+    /// Whole-workspace callers pass [`Matcher::TreeOutputTo`] with an empty
+    /// package (reaches every codegen target); scoped callers pass the user's
+    /// package matcher so only that slice of the dependency graph is walked.
     pub async fn codegen_copy_gitignore_patterns(
         self: Arc<Self>,
         rs: Arc<RequestState>,
-    ) -> anyhow::Result<Vec<String>> {
-        // Empty-package `TreeOutputTo` selects every target whose codegen tree
-        // lands anywhere in the workspace (any codegen mode). The per-path
-        // `CodegenMode::Copy` filter keeps only the copied outputs — those are
-        // the ones written into the tree and thus need gitignoring.
-        let matcher = Matcher::TreeOutputTo(PkgBuf::from(""));
-
-        let mut entries: Vec<String> = Vec::new();
-        let stream = Arc::clone(&self).query(rs.clone(), &matcher);
+        matcher: &Matcher,
+    ) -> anyhow::Result<Vec<GitignoreEntry>> {
+        let mut entries: Vec<GitignoreEntry> = Vec::new();
+        let stream = Arc::clone(&self).query(rs.clone(), matcher);
         tokio::pin!(stream);
         while let Some(addr) = stream.try_next().await? {
             let def = Arc::clone(&self).get_def(rs.clone(), &addr).await?;
             for output in &def.target_def.outputs {
                 for path in &output.paths {
                     if path.codegen_tree == CodegenMode::Copy {
-                        entries.push(content_to_pattern(&path.content));
+                        entries.push(GitignoreEntry {
+                            pattern: content_to_pattern(&path.content),
+                            addr: Some(addr.clone()),
+                        });
                     }
                 }
             }
         }
-        entries.sort();
-        entries.dedup();
-        Ok(entries)
+        Ok(normalize(entries))
     }
+}
+
+/// Parse a single managed-section line into a [`GitignoreEntry`]. Splits on the
+/// `# //pkg:target` comment and parses the target; a line without a parseable
+/// comment becomes an entry with `addr = None` (preserved verbatim on rebuild).
+fn parse_entry(line: &str) -> GitignoreEntry {
+    if let Some((pattern, comment)) = line.split_once(COMMENT_SEP)
+        && let Ok(addr) = parse_addr(comment.trim())
+    {
+        return GitignoreEntry {
+            pattern: pattern.to_string(),
+            addr: Some(addr),
+        };
+    }
+    GitignoreEntry {
+        pattern: line.to_string(),
+        addr: None,
+    }
+}
+
+/// Extract the entries currently inside the heph-managed marker section of
+/// `existing`. Returns an empty vec when no section is present. Marker lines and
+/// blank lines are skipped; every other line is parsed via [`parse_entry`].
+#[expect(
+    clippy::string_slice,
+    reason = "slice indices come from `find` on ASCII markers — always char-aligned"
+)]
+pub fn parse_section(existing: &str) -> Vec<GitignoreEntry> {
+    let (Some(start), Some(end)) = (existing.find(BEGIN_MARKER), existing.find(END_MARKER)) else {
+        return Vec::new();
+    };
+    if end < start {
+        return Vec::new();
+    }
+    existing[start..end]
+        .lines()
+        .map(str::trim)
+        .filter(|l| !l.is_empty() && !l.starts_with(BEGIN_MARKER))
+        .map(parse_entry)
+        .collect()
+}
+
+/// Merge a scoped rebuild into the existing section. Existing entries whose
+/// emitting target matches `matcher` are dropped (regenerated by `fresh`);
+/// everything else — other packages' entries and un-attributed legacy lines —
+/// is preserved. The union is sorted and deduplicated.
+///
+/// Only valid for decisive package matchers (`Package` / `PackagePrefix`), which
+/// resolve `matches_addr` without a def. The whole-workspace path must *not* go
+/// through here — it replaces the section wholesale instead.
+pub fn merge_section(
+    existing: &str,
+    fresh: Vec<GitignoreEntry>,
+    matcher: &Matcher,
+) -> Vec<GitignoreEntry> {
+    let mut merged: Vec<GitignoreEntry> = parse_section(existing)
+        .into_iter()
+        .filter(|e| match &e.addr {
+            Some(addr) => matcher.matches_addr(addr) != MatchResult::MatchYes,
+            None => true,
+        })
+        .collect();
+    merged.extend(fresh);
+    normalize(merged)
 }
 
 /// Convert an output path into a root-anchored `.gitignore` pattern. Output
@@ -78,12 +189,12 @@ pub(crate) fn content_to_pattern(content: &Content) -> String {
     clippy::string_slice,
     reason = "slice indices come from `find` on ASCII markers — always char-aligned"
 )]
-pub fn render(existing: &str, entries: &[String]) -> String {
+pub fn render(existing: &str, entries: &[GitignoreEntry]) -> String {
     let mut section = String::new();
     section.push_str(BEGIN_MARKER);
     section.push('\n');
     for e in entries {
-        section.push_str(e);
+        section.push_str(&e.to_line());
         section.push('\n');
     }
     section.push_str(END_MARKER);
@@ -116,6 +227,23 @@ pub fn render(existing: &str, entries: &[String]) -> String {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::htpkg::PkgBuf;
+
+    /// Bare entry (no emitting target) — renders as just the pattern.
+    fn bare(pattern: &str) -> GitignoreEntry {
+        GitignoreEntry {
+            pattern: pattern.to_string(),
+            addr: None,
+        }
+    }
+
+    /// Entry attributed to `addr` (e.g. `//pkg:target`).
+    fn attributed(pattern: &str, addr: &str) -> GitignoreEntry {
+        GitignoreEntry {
+            pattern: pattern.to_string(),
+            addr: Some(parse_addr(addr).expect("valid addr")),
+        }
+    }
 
     #[test]
     fn content_to_pattern_anchors_paths() {
@@ -135,13 +263,22 @@ mod tests {
 
     #[test]
     fn render_appends_section_to_empty_file() {
-        let out = render("", &["/a".into(), "/b".into()]);
+        let out = render("", &[bare("/a"), bare("/b")]);
         assert_eq!(out, format!("{BEGIN_MARKER}\n/a\n/b\n{END_MARKER}\n"));
     }
 
     #[test]
+    fn render_emits_target_comment() {
+        let out = render("", &[attributed("/foo/gen.go", "//foo:gen")]);
+        assert_eq!(
+            out,
+            format!("{BEGIN_MARKER}\n/foo/gen.go # //foo:gen\n{END_MARKER}\n")
+        );
+    }
+
+    #[test]
     fn render_appends_after_existing_content_with_blank_line() {
-        let out = render("node_modules\n", &["/gen/".into()]);
+        let out = render("node_modules\n", &[bare("/gen/")]);
         assert_eq!(
             out,
             format!("node_modules\n\n{BEGIN_MARKER}\n/gen/\n{END_MARKER}\n")
@@ -150,7 +287,7 @@ mod tests {
 
     #[test]
     fn render_inserts_newline_when_existing_lacks_trailing() {
-        let out = render("node_modules", &["/gen/".into()]);
+        let out = render("node_modules", &[bare("/gen/")]);
         assert_eq!(
             out,
             format!("node_modules\n\n{BEGIN_MARKER}\n/gen/\n{END_MARKER}\n")
@@ -160,7 +297,7 @@ mod tests {
     #[test]
     fn render_replaces_existing_section_preserving_surroundings() {
         let existing = format!("top\n{BEGIN_MARKER}\n/old\n{END_MARKER}\nbottom\n");
-        let out = render(&existing, &["/new".into()]);
+        let out = render(&existing, &[bare("/new")]);
         assert_eq!(
             out,
             format!("top\n{BEGIN_MARKER}\n/new\n{END_MARKER}\nbottom\n")
@@ -170,7 +307,7 @@ mod tests {
     #[test]
     fn render_shrinks_section_when_entries_removed() {
         let existing = format!("{BEGIN_MARKER}\n/a\n/b\n/c\n{END_MARKER}\n");
-        let out = render(&existing, &["/a".into()]);
+        let out = render(&existing, &[bare("/a")]);
         assert_eq!(out, format!("{BEGIN_MARKER}\n/a\n{END_MARKER}\n"));
     }
 
@@ -183,8 +320,76 @@ mod tests {
 
     #[test]
     fn render_is_idempotent() {
-        let first = render("keep\n", &["/a".into(), "/b".into()]);
-        let second = render(&first, &["/a".into(), "/b".into()]);
+        let first = render("keep\n", &[bare("/a"), bare("/b")]);
+        let second = render(&first, &[bare("/a"), bare("/b")]);
         assert_eq!(first, second);
+    }
+
+    #[test]
+    fn parse_section_round_trips_attributed_lines() {
+        let rendered = render(
+            "",
+            &[
+                attributed("/foo/a.go", "//foo:gen"),
+                attributed("/bar/b.go", "//bar:gen"),
+            ],
+        );
+        let parsed = parse_section(&rendered);
+        assert_eq!(
+            parsed,
+            vec![
+                attributed("/foo/a.go", "//foo:gen"),
+                attributed("/bar/b.go", "//bar:gen"),
+            ]
+        );
+    }
+
+    #[test]
+    fn parse_section_keeps_bare_lines_unattributed() {
+        let existing = format!("{BEGIN_MARKER}\n/legacy\n{END_MARKER}\n");
+        assert_eq!(parse_section(&existing), vec![bare("/legacy")]);
+    }
+
+    #[test]
+    fn parse_section_empty_without_markers() {
+        assert!(parse_section("node_modules\n").is_empty());
+    }
+
+    #[test]
+    fn merge_section_replaces_only_in_scope_targets() {
+        // Existing section: one foo entry, one bar entry. A scoped rebuild of
+        // `//foo/...` drops foo's line and substitutes the freshly-scanned one,
+        // leaving bar's untouched.
+        let existing = render(
+            "",
+            &[
+                attributed("/foo/old.go", "//foo:gen"),
+                attributed("/bar/keep.go", "//bar:gen"),
+            ],
+        );
+        let fresh = vec![attributed("/foo/new.go", "//foo:gen")];
+        let matcher = Matcher::PackagePrefix(PkgBuf::from("foo"));
+
+        let merged = merge_section(&existing, fresh, &matcher);
+        assert_eq!(
+            merged,
+            vec![
+                attributed("/bar/keep.go", "//bar:gen"),
+                attributed("/foo/new.go", "//foo:gen"),
+            ]
+        );
+    }
+
+    #[test]
+    fn merge_section_preserves_unattributed_lines() {
+        let existing = format!("{BEGIN_MARKER}\n/legacy\n{END_MARKER}\n");
+        let fresh = vec![attributed("/foo/new.go", "//foo:gen")];
+        let matcher = Matcher::PackagePrefix(PkgBuf::from("foo"));
+
+        let merged = merge_section(&existing, fresh, &matcher);
+        assert_eq!(
+            merged,
+            vec![attributed("/foo/new.go", "//foo:gen"), bare("/legacy")]
+        );
     }
 }

--- a/src/engine/gitignore.rs
+++ b/src/engine/gitignore.rs
@@ -60,7 +60,10 @@ impl Engine {
 /// Convert an output path into a root-anchored `.gitignore` pattern. Output
 /// paths are already workspace-root-relative (package-rooted), so a leading
 /// `/` anchors them precisely.
-fn content_to_pattern(content: &Content) -> String {
+///
+/// Reused by `validate` as the canonical, normalized output-path key for
+/// detecting overlapping `codegen = copy` outputs across targets.
+pub(crate) fn content_to_pattern(content: &Content) -> String {
     match content {
         Content::FilePath(p) => format!("/{}", p.trim_start_matches('/')),
         Content::DirPath(p) => format!("/{}/", p.trim_start_matches('/').trim_end_matches('/')),

--- a/src/engine/mod.rs
+++ b/src/engine/mod.rs
@@ -51,3 +51,4 @@ mod link;
 mod matcher_spec;
 mod meta;
 pub mod sandbox_cleaner;
+pub mod validate;

--- a/src/engine/validate.rs
+++ b/src/engine/validate.rs
@@ -1,16 +1,17 @@
 //! Workspace validation helpers.
 //!
-//! `codegen_copy_overlaps` detects when two *different* targets declare a
-//! `codegen = copy` output on the *same* tree path — those outputs would clobber
-//! each other when materialized into the source tree, so they must be rejected.
+//! `codegen_copy_overlaps` detects when two *different* targets declare
+//! `codegen = copy` outputs that collide in the source tree — they would clobber
+//! each other when materialized, so they must be rejected.
 //!
-//! The overlap key is the normalized, root-anchored output path produced by
-//! [`crate::engine::gitignore::content_to_pattern`]. This matches identical
-//! *declared* paths; it does not resolve glob-vs-file fuzzy overlap (a `*.go`
-//! glob and a concrete `foo.go` are treated as distinct keys), mirroring the
-//! precision of the gitignore enumeration that shares this normalization.
+//! Outputs are normalized to root-anchored paths via
+//! [`crate::engine::gitignore::content_to_pattern`] (directories carry a trailing
+//! `/`). Two outputs overlap when they are the *same* path, or when one is a
+//! directory that *contains* the other (e.g. `/gen/` vs `/gen/a.go`). Glob
+//! patterns are compared as their literal strings, so a glob lying inside a
+//! declared directory is caught, but glob-vs-concrete-file fuzzy matching is not
+//! resolved.
 
-use std::collections::HashMap;
 use std::sync::Arc;
 
 use enclose::enclose;
@@ -25,13 +26,43 @@ use crate::hmemoizer::downcast_chain_ref;
 use crate::htaddr::Addr;
 use crate::htmatcher::Matcher;
 
-/// A single overlap: one normalized output path produced by two or more targets.
+/// One `codegen = copy` output: its normalized, root-anchored path and the
+/// target that emits it.
+#[derive(Debug, Clone)]
+pub struct CodegenOutput {
+    pub path: String,
+    pub addr: Addr,
+}
+
+/// A single collision between two `codegen = copy` outputs from *different*
+/// targets — either the same path, or a directory containing the other.
 #[derive(Debug, Clone)]
 pub struct CodegenOverlap {
-    /// Normalized, root-anchored output path (the collision key).
-    pub path: String,
-    /// The (≥2) distinct targets producing it, sorted by formatted address.
-    pub addrs: Vec<Addr>,
+    pub a: CodegenOutput,
+    pub b: CodegenOutput,
+}
+
+/// Split a normalized path into its `/`-separated components, ignoring a trailing
+/// slash. Used as a sort key so a directory and its descendants stay adjacent
+/// (component order, unlike raw byte order, never lets a sibling slip between).
+fn path_components(p: &str) -> std::str::Split<'_, char> {
+    p.trim_end_matches('/').split('/')
+}
+
+/// True when `ancestor` is a strict parent directory of `descendant` — both
+/// already trailing-slash-trimmed. `descendant` must continue past `ancestor`
+/// at a `/` boundary, so `/a` is an ancestor of `/a/b` but not of `/ab`.
+fn is_ancestor(ancestor: &str, descendant: &str) -> bool {
+    descendant.starts_with(ancestor) && descendant.as_bytes().get(ancestor.len()) == Some(&b'/')
+}
+
+/// True when two normalized output paths collide in the tree: the same path
+/// (trailing slash ignored, so a file and a same-named directory still clash),
+/// or one is an ancestor directory of the other (`/gen/` vs `/gen/a.go`).
+fn paths_overlap(a: &str, b: &str) -> bool {
+    let a = a.trim_end_matches('/');
+    let b = b.trim_end_matches('/');
+    a == b || is_ancestor(a, b) || is_ancestor(b, a)
 }
 
 impl Engine {
@@ -90,27 +121,49 @@ impl Engine {
         });
         let per_target = crate::engine::fanout::join_all_failable(futs, fail_fast).await?;
 
-        // Group addrs by output path. A path declared twice by the *same* target
-        // is not a conflict, so dedupe per path (Addr interning makes `==` cheap).
-        let mut by_path: HashMap<String, Vec<Addr>> = HashMap::new();
-        for (addr, paths) in per_target {
-            for path in paths {
-                let entry = by_path.entry(path).or_default();
-                if !entry.iter().any(|a| a == &addr) {
-                    entry.push(addr.clone());
+        // Flatten to (path, addr) outputs, then sort by path *components* (ties by
+        // addr) so every group of overlapping outputs is contiguous: equal paths
+        // sit together and a directory's descendants sort immediately after it.
+        // Component order (not raw string order) is what guarantees contiguity —
+        // it keeps `/a` next to `/a/x` instead of letting a sibling like `/a-b`
+        // (where `-` < `/`) slip between them. Dedupe identical (path, addr) — a
+        // target listing the same output twice is not a self-conflict.
+        let mut outs: Vec<CodegenOutput> = per_target
+            .into_iter()
+            .flat_map(|(addr, paths)| {
+                paths.into_iter().map(move |path| CodegenOutput {
+                    path,
+                    addr: addr.clone(),
+                })
+            })
+            .collect();
+        outs.sort_by(|a, b| {
+            path_components(&a.path)
+                .cmp(path_components(&b.path))
+                .then_with(|| a.addr.format().cmp(&b.addr.format()))
+        });
+        outs.dedup_by(|a, b| a.path == b.path && a.addr == b.addr);
+
+        // Sorted scan: for each output, the only outputs that can overlap it are
+        // the contiguous run that follows (equal paths, then — if it is a
+        // directory — its contained children). The first non-overlapping entry
+        // ends the run, since everything beyond sorts lexicographically clear of
+        // it. Cross-target only: a target owning a dir *and* a file under it is
+        // fine.
+        let mut overlaps: Vec<CodegenOverlap> = Vec::new();
+        for (i, a) in outs.iter().enumerate() {
+            for b in outs.iter().skip(i + 1) {
+                if !paths_overlap(&a.path, &b.path) {
+                    break;
+                }
+                if a.addr != b.addr {
+                    overlaps.push(CodegenOverlap {
+                        a: a.clone(),
+                        b: b.clone(),
+                    });
                 }
             }
         }
-
-        let mut overlaps: Vec<CodegenOverlap> = by_path
-            .into_iter()
-            .filter(|(_, addrs)| addrs.len() > 1)
-            .map(|(path, mut addrs)| {
-                addrs.sort_by_key(|a| a.format());
-                CodegenOverlap { path, addrs }
-            })
-            .collect();
-        overlaps.sort_by(|a, b| a.path.cmp(&b.path));
         Ok(overlaps)
     }
 }
@@ -167,6 +220,15 @@ mod tests {
         Matcher::TreeOutputTo(PkgBuf::from(""))
     }
 
+    /// True if `overlaps` contains the collision between the two given outputs,
+    /// in either order.
+    fn has_pair(overlaps: &[CodegenOverlap], p1: &str, a1: &str, p2: &str, a2: &str) -> bool {
+        let want = |x: &CodegenOutput, p: &str, a: &str| x.path == p && x.addr.format() == a;
+        overlaps.iter().any(|o| {
+            (want(&o.a, p1, a1) && want(&o.b, p2, a2)) || (want(&o.a, p2, a2) && want(&o.b, p1, a1))
+        })
+    }
+
     #[tokio::test]
     async fn detects_overlapping_copy_outputs() -> anyhow::Result<()> {
         // Two targets in the same package both emitting `gen.go` as copy.
@@ -180,14 +242,71 @@ mod tests {
             .codegen_copy_overlaps(rs, &all())
             .await?;
 
-        assert_eq!(
-            overlaps.len(),
-            1,
-            "exactly one overlapping path: {overlaps:?}"
+        assert_eq!(overlaps.len(), 1, "one collision: {overlaps:?}");
+        assert!(
+            has_pair(&overlaps, "/a/gen.go", "//a:t1", "/a/gen.go", "//a:t2"),
+            "{overlaps:?}"
         );
-        assert_eq!(overlaps[0].path, "/a/gen.go");
-        let addrs: Vec<String> = overlaps[0].addrs.iter().map(|a| a.format()).collect();
-        assert_eq!(addrs, vec!["//a:t1".to_string(), "//a:t2".to_string()]);
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn directory_output_overlaps_file_inside_it() -> anyhow::Result<()> {
+        // One target emits the directory `gen/`, another a file inside it.
+        let (engine, _root) = engine_with(vec![
+            codegen_target("//a:dir", &["gen/"], "copy"),
+            codegen_target("//a:file", &["gen/sub/x.go"], "copy"),
+        ])?;
+        let rs = engine.new_state();
+
+        let overlaps = Arc::clone(&engine)
+            .codegen_copy_overlaps(rs, &all())
+            .await?;
+
+        assert_eq!(overlaps.len(), 1, "one collision: {overlaps:?}");
+        assert!(
+            has_pair(
+                &overlaps,
+                "/a/gen/",
+                "//a:dir",
+                "/a/gen/sub/x.go",
+                "//a:file"
+            ),
+            "{overlaps:?}"
+        );
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn sibling_paths_with_shared_prefix_do_not_overlap() -> anyhow::Result<()> {
+        // `gen/` must not be treated as a parent of the sibling `gen-extra.go`
+        // just because the strings share a prefix.
+        let (engine, _root) = engine_with(vec![
+            codegen_target("//a:dir", &["gen/"], "copy"),
+            codegen_target("//a:sib", &["gen-extra.go"], "copy"),
+        ])?;
+        let rs = engine.new_state();
+
+        let overlaps = Arc::clone(&engine)
+            .codegen_copy_overlaps(rs, &all())
+            .await?;
+
+        assert!(overlaps.is_empty(), "siblings do not overlap: {overlaps:?}");
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn same_target_dir_and_file_within_is_not_a_conflict() -> anyhow::Result<()> {
+        // A single target owning a directory and a file inside it is fine.
+        let (engine, _root) =
+            engine_with(vec![codegen_target("//a:t", &["gen/", "gen/x.go"], "copy")])?;
+        let rs = engine.new_state();
+
+        let overlaps = Arc::clone(&engine)
+            .codegen_copy_overlaps(rs, &all())
+            .await?;
+
+        assert!(overlaps.is_empty(), "same-target nesting ok: {overlaps:?}");
         Ok(())
     }
 

--- a/src/engine/validate.rs
+++ b/src/engine/validate.rs
@@ -1,0 +1,358 @@
+//! Workspace validation helpers.
+//!
+//! `codegen_copy_overlaps` detects when two *different* targets declare a
+//! `codegen = copy` output on the *same* tree path — those outputs would clobber
+//! each other when materialized into the source tree, so they must be rejected.
+//!
+//! The overlap key is the normalized, root-anchored output path produced by
+//! [`crate::engine::gitignore::content_to_pattern`]. This matches identical
+//! *declared* paths; it does not resolve glob-vs-file fuzzy overlap (a `*.go`
+//! glob and a concrete `foo.go` are treated as distinct keys), mirroring the
+//! precision of the gitignore enumeration that shares this normalization.
+
+use std::collections::HashMap;
+use std::sync::Arc;
+
+use enclose::enclose;
+use futures::TryStreamExt;
+
+use crate::engine::Engine;
+use crate::engine::driver::targetdef::path::CodegenMode;
+use crate::engine::error::TargetNotFoundError;
+use crate::engine::gitignore::content_to_pattern;
+use crate::engine::request_state::RequestState;
+use crate::hmemoizer::downcast_chain_ref;
+use crate::htaddr::Addr;
+use crate::htmatcher::Matcher;
+
+/// A single overlap: one normalized output path produced by two or more targets.
+#[derive(Debug, Clone)]
+pub struct CodegenOverlap {
+    /// Normalized, root-anchored output path (the collision key).
+    pub path: String,
+    /// The (≥2) distinct targets producing it, sorted by formatted address.
+    pub addrs: Vec<Addr>,
+}
+
+impl Engine {
+    /// Find `codegen = copy` outputs that collide across targets.
+    ///
+    /// `matcher` scopes which targets are inspected — whole-workspace callers
+    /// pass [`Matcher::TreeOutputTo`] with an empty package (the selector the
+    /// gitignore enumeration uses to reach every codegen target); scoped callers
+    /// pass the user's matcher. Each target's def is fetched concurrently via the
+    /// per-request memoizer, so this shares parse work with any other walk in the
+    /// same request.
+    pub async fn codegen_copy_overlaps(
+        self: Arc<Self>,
+        rs: Arc<RequestState>,
+        matcher: &Matcher,
+    ) -> anyhow::Result<Vec<CodegenOverlap>> {
+        // Drain the addr stream first, then fan the def fetches out in parallel.
+        let addrs: Vec<Addr> = {
+            let stream = Arc::clone(&self).query(rs.clone(), matcher);
+            tokio::pin!(stream);
+            let mut v = Vec::new();
+            while let Some(addr) = stream.try_next().await? {
+                v.push(addr);
+            }
+            v
+        };
+
+        let fail_fast = rs.fail_fast();
+        let futs = addrs.iter().map(|addr| {
+            enclose!((self => engine, rs, addr) async move {
+                // A provider may `list` an addr it cannot `get` standalone (e.g. go
+                // per-platform variants resolved only as in-context deps). Such a
+                // target produces no real tree output here, so skip it on a
+                // self-addr NotFound — matching the query resolver. Any other
+                // failure (parse error, missing dep) propagates.
+                let def = match engine.get_def(rs, &addr).await {
+                    Ok(def) => def,
+                    Err(e)
+                        if downcast_chain_ref::<TargetNotFoundError>(&e)
+                            .is_some_and(|nf| nf.addr == addr) =>
+                    {
+                        return Ok((addr, Vec::new()));
+                    }
+                    Err(e) => return Err(e),
+                };
+                let paths: Vec<String> = def
+                    .target_def
+                    .outputs
+                    .iter()
+                    .flat_map(|output| output.paths.iter())
+                    .filter(|p| p.codegen_tree == CodegenMode::Copy)
+                    .map(|p| content_to_pattern(&p.content))
+                    .collect();
+                Ok::<(Addr, Vec<String>), anyhow::Error>((addr, paths))
+            })
+        });
+        let per_target = crate::engine::fanout::join_all_failable(futs, fail_fast).await?;
+
+        // Group addrs by output path. A path declared twice by the *same* target
+        // is not a conflict, so dedupe per path (Addr interning makes `==` cheap).
+        let mut by_path: HashMap<String, Vec<Addr>> = HashMap::new();
+        for (addr, paths) in per_target {
+            for path in paths {
+                let entry = by_path.entry(path).or_default();
+                if !entry.iter().any(|a| a == &addr) {
+                    entry.push(addr.clone());
+                }
+            }
+        }
+
+        let mut overlaps: Vec<CodegenOverlap> = by_path
+            .into_iter()
+            .filter(|(_, addrs)| addrs.len() > 1)
+            .map(|(path, mut addrs)| {
+                addrs.sort_by_key(|a| a.format());
+                CodegenOverlap { path, addrs }
+            })
+            .collect();
+        overlaps.sort_by(|a, b| a.path.cmp(&b.path));
+        Ok(overlaps)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::engine::Config;
+    use crate::htpkg::PkgBuf;
+    use crate::pluginstatictarget;
+    use std::collections::HashMap;
+
+    /// Build a static target declaring an `out` default-group with the given
+    /// paths and codegen mode.
+    fn codegen_target(addr: &str, outs: &[&str], codegen: &str) -> pluginstatictarget::Target {
+        let mut out = HashMap::new();
+        out.insert(
+            String::new(),
+            outs.iter().map(|o| (*o).to_string()).collect(),
+        );
+        pluginstatictarget::Target {
+            addr: addr.to_string(),
+            driver: "exec".to_string(),
+            run: Some("true".to_string()),
+            out,
+            codegen: Some(codegen.to_string()),
+            deps: HashMap::new(),
+            labels: vec![],
+        }
+    }
+
+    fn engine_with(
+        targets: Vec<pluginstatictarget::Target>,
+    ) -> anyhow::Result<(Arc<Engine>, tempfile::TempDir)> {
+        let root = tempfile::tempdir()?;
+        let mut engine = Engine::new(Config {
+            root: root.path().to_path_buf(),
+            home_dir: std::path::PathBuf::new(),
+            parallelism: None,
+            ..Default::default()
+        })?;
+        // exec driver parses specs into defs (with codegen-stamped outputs); the
+        // fs provider/driver resolves any synthesized inputs; the static provider
+        // supplies the specs and the `list_packages` query needs.
+        engine.register_managed_driver(Box::new(crate::pluginexec::Driver::new_exec()))?;
+        engine.register_provider(|_| Box::new(crate::pluginfs::Provider))?;
+        engine.register_driver(Box::new(crate::pluginfs::Driver))?;
+        let provider = pluginstatictarget::Provider::new(targets)?;
+        engine.register_provider(move |_| Box::new(provider))?;
+        Ok((Arc::new(engine), root))
+    }
+
+    fn all() -> Matcher {
+        Matcher::TreeOutputTo(PkgBuf::from(""))
+    }
+
+    #[tokio::test]
+    async fn detects_overlapping_copy_outputs() -> anyhow::Result<()> {
+        // Two targets in the same package both emitting `gen.go` as copy.
+        let (engine, _root) = engine_with(vec![
+            codegen_target("//a:t1", &["gen.go"], "copy"),
+            codegen_target("//a:t2", &["gen.go"], "copy"),
+        ])?;
+        let rs = engine.new_state();
+
+        let overlaps = Arc::clone(&engine)
+            .codegen_copy_overlaps(rs, &all())
+            .await?;
+
+        assert_eq!(
+            overlaps.len(),
+            1,
+            "exactly one overlapping path: {overlaps:?}"
+        );
+        assert_eq!(overlaps[0].path, "/a/gen.go");
+        let addrs: Vec<String> = overlaps[0].addrs.iter().map(|a| a.format()).collect();
+        assert_eq!(addrs, vec!["//a:t1".to_string(), "//a:t2".to_string()]);
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn distinct_copy_outputs_do_not_overlap() -> anyhow::Result<()> {
+        let (engine, _root) = engine_with(vec![
+            codegen_target("//a:t1", &["a.go"], "copy"),
+            codegen_target("//a:t2", &["b.go"], "copy"),
+        ])?;
+        let rs = engine.new_state();
+
+        let overlaps = Arc::clone(&engine)
+            .codegen_copy_overlaps(rs, &all())
+            .await?;
+
+        assert!(overlaps.is_empty(), "no overlap expected: {overlaps:?}");
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn same_target_duplicate_path_is_not_a_conflict() -> anyhow::Result<()> {
+        // One target listing the same copy output twice is not a self-conflict.
+        let (engine, _root) = engine_with(vec![codegen_target(
+            "//a:t1",
+            &["dup.go", "dup.go"],
+            "copy",
+        )])?;
+        let rs = engine.new_state();
+
+        let overlaps = Arc::clone(&engine)
+            .codegen_copy_overlaps(rs, &all())
+            .await?;
+
+        assert!(
+            overlaps.is_empty(),
+            "self-dup is not a conflict: {overlaps:?}"
+        );
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn non_copy_outputs_are_ignored() -> anyhow::Result<()> {
+        // Same path but not `codegen = copy` -> not a tree collision.
+        let (engine, _root) = engine_with(vec![
+            codegen_target("//a:t1", &["gen.go"], "in_place"),
+            codegen_target("//a:t2", &["gen.go"], "in_place"),
+        ])?;
+        let rs = engine.new_state();
+
+        let overlaps = Arc::clone(&engine)
+            .codegen_copy_overlaps(rs, &all())
+            .await?;
+
+        assert!(
+            overlaps.is_empty(),
+            "non-copy outputs ignored: {overlaps:?}"
+        );
+        Ok(())
+    }
+
+    /// A provider that *lists* an addr but returns `NotFound` from `get` —
+    /// mimicking the go provider's per-platform variants that resolve only as
+    /// in-context deps. `codegen_copy_overlaps` must skip such a target rather
+    /// than surface its `get_def` failure as a validation error.
+    struct GhostProvider;
+
+    impl crate::engine::provider::Provider for GhostProvider {
+        fn config(
+            &self,
+            _req: crate::engine::provider::ConfigRequest,
+        ) -> anyhow::Result<crate::engine::provider::ConfigResponse> {
+            Ok(crate::engine::provider::ConfigResponse {
+                name: "ghost".to_string(),
+            })
+        }
+        fn list<'a>(
+            &'a self,
+            req: crate::engine::provider::ListRequest,
+            _ctoken: &'a (dyn crate::hasync::Cancellable + Send + Sync),
+        ) -> futures::future::BoxFuture<
+            'a,
+            anyhow::Result<
+                Box<
+                    dyn Iterator<Item = anyhow::Result<crate::engine::provider::ListResponse>>
+                        + Send,
+                >,
+            >,
+        > {
+            let pkg = req.package.clone();
+            Box::pin(async move {
+                let items: Vec<anyhow::Result<crate::engine::provider::ListResponse>> =
+                    if pkg.as_str() == "virt" {
+                        vec![Ok(crate::engine::provider::ListResponse {
+                            addr: Addr::new(pkg, "ghost".to_string(), Default::default()),
+                        })]
+                    } else {
+                        vec![]
+                    };
+                Ok(Box::new(items.into_iter()) as Box<dyn Iterator<Item = _> + Send>)
+            })
+        }
+        fn list_packages<'a>(
+            &'a self,
+            _req: crate::engine::provider::ListPackagesRequest,
+            _ctoken: &'a (dyn crate::hasync::Cancellable + Send + Sync),
+        ) -> futures::future::BoxFuture<
+            'a,
+            anyhow::Result<
+                Box<
+                    dyn Iterator<
+                            Item = anyhow::Result<crate::engine::provider::ListPackageResponse>,
+                        > + Send,
+                >,
+            >,
+        > {
+            Box::pin(async {
+                let items: Vec<anyhow::Result<crate::engine::provider::ListPackageResponse>> =
+                    vec![Ok(crate::engine::provider::ListPackageResponse {
+                        pkg: PkgBuf::from("virt"),
+                    })];
+                Ok(Box::new(items.into_iter()) as Box<dyn Iterator<Item = _> + Send>)
+            })
+        }
+        fn get<'a>(
+            &'a self,
+            _req: crate::engine::provider::GetRequest,
+            _ctoken: &'a (dyn crate::hasync::Cancellable + Send + Sync),
+        ) -> futures::future::BoxFuture<
+            'a,
+            Result<crate::engine::provider::GetResponse, crate::engine::provider::GetError>,
+        > {
+            // Listed but unresolvable standalone.
+            Box::pin(async { Err(crate::engine::provider::GetError::NotFound) })
+        }
+        fn probe<'a>(
+            &'a self,
+            _req: crate::engine::provider::ProbeRequest,
+            _ctoken: &'a (dyn crate::hasync::Cancellable + Send + Sync),
+        ) -> futures::future::BoxFuture<'a, anyhow::Result<crate::engine::provider::ProbeResponse>>
+        {
+            Box::pin(async { Ok(crate::engine::provider::ProbeResponse { states: vec![] }) })
+        }
+    }
+
+    #[tokio::test]
+    async fn listed_but_unresolvable_target_is_skipped() -> anyhow::Result<()> {
+        let root = tempfile::tempdir()?;
+        let mut engine = Engine::new(Config {
+            root: root.path().to_path_buf(),
+            home_dir: std::path::PathBuf::new(),
+            parallelism: None,
+            ..Default::default()
+        })?;
+        engine.register_provider(|_| Box::new(GhostProvider))?;
+        let engine = Arc::new(engine);
+        let rs = engine.new_state();
+
+        // `PackagePrefix` yields the listed addr straight to the overlap fanout
+        // (no spec resolution), so the per-target `get_def` NotFound is what the
+        // skip must absorb. Result: no error, no overlaps.
+        let overlaps = Arc::clone(&engine)
+            .codegen_copy_overlaps(rs, &Matcher::PackagePrefix(PkgBuf::from("virt")))
+            .await?;
+
+        assert!(overlaps.is_empty(), "ghost target skipped: {overlaps:?}");
+        Ok(())
+    }
+}


### PR DESCRIPTION
## What

`gen-gitignore` now emits the emitting target as a trailing comment on each managed line, and accepts an optional `PACKAGE_MATCHER` to rebuild only part of the section.

Each managed `.gitignore` line goes from:
```
/the/path
```
to:
```
/the/path # //some:target
```

## Why

The comment records which target owns each line. That lets a scoped run rebuild only a slice of the file without walking the whole dependency graph.

```
heph gen-gitignore                  # whole workspace (unchanged)
heph gen-gitignore //some/pkg/...   # rebuild only that slice — smaller graph walk, faster
```

A scoped run re-scans only the matched packages, then grafts the result over the existing section: existing lines whose target matches the matcher are regenerated; everything else (other packages' lines, unattributed legacy lines) is preserved.

## Changes

- `src/engine/gitignore.rs` — `GitignoreEntry { pattern, addr }`; `render` emits the comment; new `parse_section` + `merge_section`; `codegen_copy_gitignore_patterns` now takes a matcher.
- `src/commands/tool/gen_gitignore.rs` — optional `PACKAGE_MATCHER` arg; scoped merge vs. whole-section replace.
- `src/commands/validate.rs` — passes the whole-workspace selector explicitly.

## Notes

- Scoped runs don't clean up lines for targets *outside* the matcher; a full (no-arg) run does. Expected tradeoff for the smaller walk.
- First whole-workspace run after merge rewrites all lines into the annotated format.

## Tests

14 gitignore + 7 validate tests pass; clippy clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)