### PR TITLE
feat(cli): tab completion for target addresses

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -450,6 +450,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "clap_complete"
+version = "4.6.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e0a7a9bfdb35811f9e59832f0f05975114d2251b415fb534108e6f34060fd772"
+dependencies = [
+ "clap",
+ "clap_lex",
+ "is_executable",
+ "shlex",
+]
+
+[[package]]
 name = "clap_derive"
 version = "4.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1338,6 +1350,7 @@ dependencies = [
  "borsh",
  "chrono",
  "clap",
+ "clap_complete",
  "crossbeam-channel",
  "crossterm",
  "derivative",
@@ -1630,6 +1643,15 @@ dependencies = [
  "hermit-abi",
  "libc",
  "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "is_executable"
+version = "1.0.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "baabb8b4867b26294d818bf3f651a454b6901431711abb96e296245888d6e8c4"
+dependencies = [
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -4209,7 +4231,7 @@ version = "0.52.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "282be5f36a8ce781fad8c8ae18fa3f9beff57ec1b52cb3de0789201425d9a33d"
 dependencies = [
- "windows-targets",
+ "windows-targets 0.52.6",
 ]
 
 [[package]]
@@ -4218,7 +4240,16 @@ version = "0.59.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1e38bc4d79ed67fd075bcc251a1c39b32a1776bbe92e5bef1f0bf1f8c531853b"
 dependencies = [
- "windows-targets",
+ "windows-targets 0.52.6",
+]
+
+[[package]]
+name = "windows-sys"
+version = "0.60.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f2f500e4d28234f72040990ec9d39e3a6b950f9f22d3dba18416c35882612bcb"
+dependencies = [
+ "windows-targets 0.53.5",
 ]
 
 [[package]]
@@ -4236,14 +4267,31 @@ version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9b724f72796e036ab90c1021d4780d4d3d648aca59e491e6b98e725b84e99973"
 dependencies = [
- "windows_aarch64_gnullvm",
- "windows_aarch64_msvc",
- "windows_i686_gnu",
- "windows_i686_gnullvm",
- "windows_i686_msvc",
- "windows_x86_64_gnu",
- "windows_x86_64_gnullvm",
- "windows_x86_64_msvc",
+ "windows_aarch64_gnullvm 0.52.6",
+ "windows_aarch64_msvc 0.52.6",
+ "windows_i686_gnu 0.52.6",
+ "windows_i686_gnullvm 0.52.6",
+ "windows_i686_msvc 0.52.6",
+ "windows_x86_64_gnu 0.52.6",
+ "windows_x86_64_gnullvm 0.52.6",
+ "windows_x86_64_msvc 0.52.6",
+]
+
+[[package]]
+name = "windows-targets"
+version = "0.53.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4945f9f551b88e0d65f3db0bc25c33b8acea4d9e41163edf90dcd0b19f9069f3"
+dependencies = [
+ "windows-link",
+ "windows_aarch64_gnullvm 0.53.1",
+ "windows_aarch64_msvc 0.53.1",
+ "windows_i686_gnu 0.53.1",
+ "windows_i686_gnullvm 0.53.1",
+ "windows_i686_msvc 0.53.1",
+ "windows_x86_64_gnu 0.53.1",
+ "windows_x86_64_gnullvm 0.53.1",
+ "windows_x86_64_msvc 0.53.1",
 ]
 
 [[package]]
@@ -4253,10 +4301,22 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32a4622180e7a0ec044bb555404c800bc9fd9ec262ec147edd5989ccd0c02cd3"
 
 [[package]]
+name = "windows_aarch64_gnullvm"
+version = "0.53.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a9d8416fa8b42f5c947f8482c43e7d89e73a173cead56d044f6a56104a6d1b53"
+
+[[package]]
 name = "windows_aarch64_msvc"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "09ec2a7bb152e2252b53fa7803150007879548bc709c039df7627cabbd05d469"
+
+[[package]]
+name = "windows_aarch64_msvc"
+version = "0.53.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b9d782e804c2f632e395708e99a94275910eb9100b2114651e04744e9b125006"
 
 [[package]]
 name = "windows_i686_gnu"
@@ -4265,10 +4325,22 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8e9b5ad5ab802e97eb8e295ac6720e509ee4c243f69d781394014ebfe8bbfa0b"
 
 [[package]]
+name = "windows_i686_gnu"
+version = "0.53.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "960e6da069d81e09becb0ca57a65220ddff016ff2d6af6a223cf372a506593a3"
+
+[[package]]
 name = "windows_i686_gnullvm"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0eee52d38c090b3caa76c563b86c3a4bd71ef1a819287c19d586d7334ae8ed66"
+
+[[package]]
+name = "windows_i686_gnullvm"
+version = "0.53.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fa7359d10048f68ab8b09fa71c3daccfb0e9b559aed648a8f95469c27057180c"
 
 [[package]]
 name = "windows_i686_msvc"
@@ -4277,10 +4349,22 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "240948bc05c5e7c6dabba28bf89d89ffce3e303022809e73deaefe4f6ec56c66"
 
 [[package]]
+name = "windows_i686_msvc"
+version = "0.53.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e7ac75179f18232fe9c285163565a57ef8d3c89254a30685b57d83a38d326c2"
+
+[[package]]
 name = "windows_x86_64_gnu"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "147a5c80aabfbf0c7d901cb5895d1de30ef2907eb21fbbab29ca94c5b08b1a78"
+
+[[package]]
+name = "windows_x86_64_gnu"
+version = "0.53.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9c3842cdd74a865a8066ab39c8a7a473c0778a3f29370b5fd6b4b9aa7df4a499"
 
 [[package]]
 name = "windows_x86_64_gnullvm"
@@ -4289,10 +4373,22 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "24d5b23dc417412679681396f2b49f3de8c1473deb516bd34410872eff51ed0d"
 
 [[package]]
+name = "windows_x86_64_gnullvm"
+version = "0.53.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0ffa179e2d07eee8ad8f57493436566c7cc30ac536a3379fdf008f47f6bb7ae1"
+
+[[package]]
 name = "windows_x86_64_msvc"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "589f6da84c646204747d1270a2a5661ea66ed1cced2631d546fdfb155959f9ec"
+
+[[package]]
+name = "windows_x86_64_msvc"
+version = "0.53.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d6bbff5f0aada427a1e5a6da5f1f98158182f26556f345ac9e04d36d0ebed650"
 
 [[package]]
 name = "winnow"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -88,6 +88,7 @@ serde_yaml = "0.9"
 borsh = { version = "1.5.7", features = ["derive"] }
 chrono = { version = "0.4", features = ["serde"] }
 clap = { version = "4.6.0", features = ["derive"] }
+clap_complete = { version = "4.6", features = ["unstable-dynamic"] }
 tracing = "0.1"
 tracing-subscriber = { version = "0.3", features = ["env-filter"] }
 tracing-log = "0.2"

--- a/src/commands/completion.rs
+++ b/src/commands/completion.rs
@@ -7,6 +7,7 @@ use futures::TryStreamExt;
 use crate::commands::bootstrap;
 use crate::engine::request_state::RequestState;
 use crate::engine::{Engine, get_cwp};
+use crate::htaddr::parse_addr_with_base;
 use crate::htmatcher::Matcher;
 use crate::htpkg::PkgBuf;
 
@@ -42,7 +43,10 @@ fn candidates(partial: &str) -> anyhow::Result<Vec<String>> {
 /// Core completion logic, factored out so it can be unit-tested against an
 /// in-memory engine without a real working directory or shell.
 ///
-/// `base` is the current package, used to resolve the relative `:name` form.
+/// `base` is the current package, used to resolve the relative forms.
+/// Candidates are emitted in the same style the user is typing, mirroring the
+/// address forms `parse_addr_with_base` accepts: absolute `//pkg:name`,
+/// `:name`, `./sub:name`, `../sib:name`, and bare `name` (a target in `base`).
 async fn addr_candidates(
     engine: &Arc<Engine>,
     base: &PkgBuf,
@@ -50,51 +54,127 @@ async fn addr_candidates(
 ) -> anyhow::Result<Vec<String>> {
     let rs = engine.new_state();
 
-    // Relative ":name" — complete targets in the current package, preserving
-    // the relative form the user is typing.
+    // Absolute "//pkg" / "//pkg:name".
+    if let Some(body) = partial.strip_prefix("//") {
+        if let Some((pkg_part, name_prefix)) = body.rsplit_once(':') {
+            // Targets in that exact package. Matching on `Package` yields
+            // `MatchYes` without a def eval, so this costs one BUILD eval.
+            let pkg = PkgBuf::from(pkg_part);
+            let names = targets_in(engine, &rs, &pkg).await?;
+            return Ok(filter_map_dedup(names, name_prefix, |n| {
+                format!("//{pkg}:{n}")
+            }));
+        }
+        // "//pkg" prefix — keep packages whose path starts with what's typed.
+        // A plain string prefix (not `PackagePrefix`, which narrows
+        // component-wise) is what the user expects mid-word: typing `go` must
+        // also surface a sibling `group`, not just the `go` subtree. clap does
+        // not post-filter `ArgValueCompleter` candidates, so we filter here.
+        // The trailing colon cues the shell into completing target names next.
+        let pkgs = all_packages(engine, &rs).await?;
+        return Ok(filter_map_dedup(pkgs, body, |p| format!("//{p}:")));
+    }
+
+    // Relative ":name" — a target in the current package.
     if let Some(name_prefix) = partial.strip_prefix(':') {
         let names = targets_in(engine, &rs, base).await?;
-        return Ok(dedup(
-            names
-                .into_iter()
-                .filter(|n| n.starts_with(name_prefix))
-                .map(|n| format!(":{n}")),
-        ));
+        return Ok(filter_map_dedup(names, name_prefix, |n| format!(":{n}")));
     }
 
-    // Absolute address; the leading "//" may be only partially typed.
-    let body = partial.strip_prefix("//").unwrap_or(partial);
-
-    if let Some((pkg_part, name_prefix)) = body.rsplit_once(':') {
-        // "//pkg:name" — list targets in that exact package. Matching on
-        // `Package` yields `MatchYes` without a def eval, so this only costs
-        // one BUILD evaluation.
-        let pkg = PkgBuf::from(pkg_part);
-        let names = targets_in(engine, &rs, &pkg).await?;
-        return Ok(dedup(
-            names
-                .into_iter()
-                .filter(|n| n.starts_with(name_prefix))
-                .map(|n| format!("//{pkg}:{n}")),
-        ));
-    }
-
-    // "//pkg" prefix — list every package and keep those whose path starts
-    // with what's typed. A plain string prefix (not `PackagePrefix`, which
-    // narrows component-wise) is what the user expects mid-word: typing `go`
-    // must also surface a sibling `group`, not just the `go` subtree. clap
-    // does not post-filter `ArgValueCompleter` candidates, so we filter here.
-    // The trailing colon cues the shell into the next round of target names.
-    let m = Matcher::PackagePrefix(PkgBuf::from(""));
-    let pkgs = engine.packages(&m, &rs).await?;
-    let mut out = Vec::new();
-    for p in pkgs {
-        let p = p?;
-        if p.starts_with(body) {
-            out.push(format!("//{p}:"));
+    // Relative "./sub" / "../sib" path forms.
+    if partial.starts_with("./") || partial.starts_with("../") {
+        if let Some((prefix, name_prefix)) = partial.split_once(':') {
+            // Package fully typed — complete the target name. Resolve the
+            // relative package through the real parser, then re-emit with the
+            // exact prefix the user typed.
+            let Ok(probe) = parse_addr_with_base(&format!("{prefix}:__heph_probe__"), base) else {
+                return Ok(Vec::new());
+            };
+            let pkg = probe.package.clone();
+            let names = targets_in(engine, &rs, &pkg).await?;
+            return Ok(filter_map_dedup(names, name_prefix, |n| {
+                format!("{prefix}:{n}")
+            }));
         }
+        // Still typing the package path — render each package relative to
+        // `base` and keep the ones that round-trip back to the same package.
+        let pkgs = all_packages(engine, &rs).await?;
+        let mut out = Vec::new();
+        for p in pkgs {
+            let p = PkgBuf::from(p);
+            if let Some(rel) = render_relative_pkg(base, &p)
+                && rel.starts_with(partial)
+                && round_trips(&rel, base, &p)
+            {
+                out.push(format!("{rel}:"));
+            }
+        }
+        return Ok(dedup(out));
     }
-    Ok(dedup(out))
+
+    // Bare "name" — a target in the current package. A path separator with
+    // none of the markers above is not a valid relative form, so skip it.
+    if !partial.contains('/') {
+        let names = targets_in(engine, &rs, base).await?;
+        return Ok(dedup(names.into_iter().filter(|n| n.starts_with(partial))));
+    }
+
+    Ok(Vec::new())
+}
+
+/// List every package the providers know about (single cached filesystem walk).
+async fn all_packages(engine: &Arc<Engine>, rs: &Arc<RequestState>) -> anyhow::Result<Vec<String>> {
+    let m = Matcher::PackagePrefix(PkgBuf::from(""));
+    let it = engine.packages(&m, rs).await?;
+    let mut v = Vec::new();
+    for p in it {
+        v.push(p?);
+    }
+    Ok(v)
+}
+
+/// Render absolute package `p` as the relative path string that resolves back
+/// to it from `base` (e.g. `./sub`, `../sib`, `../`). Returns `None` for the
+/// current package itself — that is the `:name` form, not a path.
+fn render_relative_pkg(base: &PkgBuf, p: &PkgBuf) -> Option<String> {
+    let b: Vec<&str> = base.as_str().split('/').filter(|s| !s.is_empty()).collect();
+    let t: Vec<&str> = p.as_str().split('/').filter(|s| !s.is_empty()).collect();
+
+    let common = b.iter().zip(t.iter()).take_while(|(x, y)| x == y).count();
+    let ups = b.len() - common;
+    let rest = t.get(common..).map(|s| s.join("/")).unwrap_or_default();
+
+    if ups == 0 {
+        if rest.is_empty() {
+            return None; // p == base
+        }
+        return Some(format!("./{rest}"));
+    }
+    let mut s = "../".repeat(ups);
+    s.push_str(&rest);
+    Some(s)
+}
+
+/// Confirm a rendered relative path parses back to the intended package, so a
+/// faulty render is dropped rather than offered as a broken completion.
+fn round_trips(rel: &str, base: &PkgBuf, pkg: &PkgBuf) -> bool {
+    parse_addr_with_base(&format!("{rel}:__heph_probe__"), base)
+        .map(|a| a.package == *pkg)
+        .unwrap_or(false)
+}
+
+/// Filter `items` by `prefix`, render each survivor, then sort + dedup.
+fn filter_map_dedup(
+    items: Vec<String>,
+    prefix: &str,
+    render: impl Fn(&str) -> String,
+) -> Vec<String> {
+    dedup(
+        items
+            .into_iter()
+            .filter(|s| s.starts_with(prefix))
+            .map(|s| render(&s)),
+    )
 }
 
 /// List the target names defined in a single package.
@@ -248,5 +328,76 @@ mod tests {
             .expect("candidates");
 
         assert_eq!(got, vec![":bar".to_string(), ":baz".to_string()]);
+    }
+
+    /// root + foo (bar/baz/qux) + foo/sub (subtgt) + bar (bartgt).
+    fn fixture_nested(root: &std::path::Path) {
+        fixture(root);
+        let sub = root.join("foo").join("sub");
+        fs::create_dir_all(&sub).unwrap();
+        fs::write(
+            sub.join("BUILD"),
+            "target(name = \"subtgt\", driver = \"d\")\n",
+        )
+        .unwrap();
+        let bar = root.join("bar");
+        fs::create_dir_all(&bar).unwrap();
+        fs::write(
+            bar.join("BUILD"),
+            "target(name = \"bartgt\", driver = \"d\")\n",
+        )
+        .unwrap();
+    }
+
+    #[tokio::test]
+    async fn completes_bare_target_in_base_package() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        fixture(dir.path());
+        let engine = engine_at(dir.path().to_path_buf());
+
+        let got = addr_candidates(&engine, &PkgBuf::from("foo"), "ba")
+            .await
+            .expect("candidates");
+
+        assert_eq!(got, vec!["bar".to_string(), "baz".to_string()]);
+    }
+
+    #[tokio::test]
+    async fn completes_descendant_package_path() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        fixture_nested(dir.path());
+        let engine = engine_at(dir.path().to_path_buf());
+
+        let got = addr_candidates(&engine, &PkgBuf::from("foo"), "./")
+            .await
+            .expect("candidates");
+
+        assert_eq!(got, vec!["./sub:".to_string()]);
+    }
+
+    #[tokio::test]
+    async fn completes_relative_target_in_descendant_package() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        fixture_nested(dir.path());
+        let engine = engine_at(dir.path().to_path_buf());
+
+        let got = addr_candidates(&engine, &PkgBuf::from("foo"), "./sub:")
+            .await
+            .expect("candidates");
+
+        assert_eq!(got, vec!["./sub:subtgt".to_string()]);
+    }
+
+    #[tokio::test]
+    async fn completes_sibling_package_path() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        fixture_nested(dir.path());
+        let engine = engine_at(dir.path().to_path_buf());
+
+        let got = addr_candidates(&engine, &PkgBuf::from("foo"), "../bar")
+            .await
+            .expect("candidates");
+
+        assert_eq!(got, vec!["../bar:".to_string()]);
     }
 }

--- a/src/commands/completion.rs
+++ b/src/commands/completion.rs
@@ -1,0 +1,252 @@
+use std::ffi::OsStr;
+use std::sync::Arc;
+
+use clap_complete::engine::CompletionCandidate;
+use futures::TryStreamExt;
+
+use crate::commands::bootstrap;
+use crate::engine::request_state::RequestState;
+use crate::engine::{Engine, get_cwp};
+use crate::htmatcher::Matcher;
+use crate::htpkg::PkgBuf;
+
+/// clap dynamic-completion entry point for target-address arguments.
+///
+/// Spins up a short-lived engine, asks it for the packages / targets matching
+/// what the user has typed so far, and turns them into completion candidates.
+/// Any failure — not inside a heph workspace, a cancelled walk, an IO error —
+/// yields no candidates rather than surfacing an error to the shell.
+pub fn complete_target_addr(current: &OsStr) -> Vec<CompletionCandidate> {
+    let Some(partial) = current.to_str() else {
+        return Vec::new();
+    };
+
+    candidates(partial)
+        .unwrap_or_default()
+        .into_iter()
+        .map(CompletionCandidate::new)
+        .collect()
+}
+
+/// Build the engine and drive the async listing. Kept separate from
+/// [`complete_target_addr`] so the error path is a single `?`-chain.
+fn candidates(partial: &str) -> anyhow::Result<Vec<String>> {
+    let base = get_cwp()?;
+    bootstrap::block_on(async move {
+        // `new_engine` spawns tokio tasks, so it must run inside the runtime.
+        let (engine, _shutdown) = bootstrap::new_engine()?;
+        addr_candidates(&engine, &base, partial).await
+    })?
+}
+
+/// Core completion logic, factored out so it can be unit-tested against an
+/// in-memory engine without a real working directory or shell.
+///
+/// `base` is the current package, used to resolve the relative `:name` form.
+async fn addr_candidates(
+    engine: &Arc<Engine>,
+    base: &PkgBuf,
+    partial: &str,
+) -> anyhow::Result<Vec<String>> {
+    let rs = engine.new_state();
+
+    // Relative ":name" — complete targets in the current package, preserving
+    // the relative form the user is typing.
+    if let Some(name_prefix) = partial.strip_prefix(':') {
+        let names = targets_in(engine, &rs, base).await?;
+        return Ok(dedup(
+            names
+                .into_iter()
+                .filter(|n| n.starts_with(name_prefix))
+                .map(|n| format!(":{n}")),
+        ));
+    }
+
+    // Absolute address; the leading "//" may be only partially typed.
+    let body = partial.strip_prefix("//").unwrap_or(partial);
+
+    if let Some((pkg_part, name_prefix)) = body.rsplit_once(':') {
+        // "//pkg:name" — list targets in that exact package. Matching on
+        // `Package` yields `MatchYes` without a def eval, so this only costs
+        // one BUILD evaluation.
+        let pkg = PkgBuf::from(pkg_part);
+        let names = targets_in(engine, &rs, &pkg).await?;
+        return Ok(dedup(
+            names
+                .into_iter()
+                .filter(|n| n.starts_with(name_prefix))
+                .map(|n| format!("//{pkg}:{n}")),
+        ));
+    }
+
+    // "//pkg" prefix — list every package and keep those whose path starts
+    // with what's typed. A plain string prefix (not `PackagePrefix`, which
+    // narrows component-wise) is what the user expects mid-word: typing `go`
+    // must also surface a sibling `group`, not just the `go` subtree. clap
+    // does not post-filter `ArgValueCompleter` candidates, so we filter here.
+    // The trailing colon cues the shell into the next round of target names.
+    let m = Matcher::PackagePrefix(PkgBuf::from(""));
+    let pkgs = engine.packages(&m, &rs).await?;
+    let mut out = Vec::new();
+    for p in pkgs {
+        let p = p?;
+        if p.starts_with(body) {
+            out.push(format!("//{p}:"));
+        }
+    }
+    Ok(dedup(out))
+}
+
+/// List the target names defined in a single package.
+async fn targets_in(
+    engine: &Arc<Engine>,
+    rs: &Arc<RequestState>,
+    pkg: &PkgBuf,
+) -> anyhow::Result<Vec<String>> {
+    let m = Matcher::Package(pkg.clone());
+    let stream = engine.clone().query(rs.clone(), &m);
+    tokio::pin!(stream);
+
+    let mut names = Vec::new();
+    while let Some(addr) = stream.try_next().await? {
+        names.push(addr.name.clone());
+    }
+    Ok(names)
+}
+
+/// Sort + dedup candidates: multiple providers can surface the same package or
+/// target name, and shells show duplicates verbatim.
+fn dedup(it: impl IntoIterator<Item = String>) -> Vec<String> {
+    let mut v: Vec<String> = it.into_iter().collect();
+    v.sort();
+    v.dedup();
+    v
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::engine::{Config, Engine};
+    use crate::pluginbuildfile;
+    use std::fs;
+    use std::sync::Arc;
+
+    /// Build an engine with the `buildfile` provider rooted at `root`.
+    fn engine_at(root: std::path::PathBuf) -> Arc<Engine> {
+        let home_dir = root.join(".heph3");
+        let mut e = Engine::new(Config {
+            root,
+            home_dir,
+            parallelism: None,
+            ..Default::default()
+        })
+        .expect("engine");
+
+        e.register_provider_factory("buildfile", |root, skip_dirs, opts| {
+            Ok(Box::new(pluginbuildfile::Provider::from_options(
+                root.to_path_buf(),
+                skip_dirs,
+                opts,
+            )?))
+        })
+        .expect("register buildfile");
+
+        let file: crate::engine::config_file::ConfigFile =
+            serde_yaml::from_str("providers:\n  - name: buildfile\n").expect("yaml");
+        e.apply_config(&file.providers, &file.drivers)
+            .expect("apply_config");
+
+        Arc::new(e)
+    }
+
+    /// root BUILD (package "") + foo/BUILD with targets bar, baz, qux.
+    fn fixture(root: &std::path::Path) {
+        fs::write(
+            root.join("BUILD"),
+            "target(name = \"root_tgt\", driver = \"d\")\n",
+        )
+        .unwrap();
+        let foo = root.join("foo");
+        fs::create_dir_all(&foo).unwrap();
+        fs::write(
+            foo.join("BUILD"),
+            "target(name = \"bar\", driver = \"d\")\n\
+             target(name = \"baz\", driver = \"d\")\n\
+             target(name = \"qux\", driver = \"d\")\n",
+        )
+        .unwrap();
+    }
+
+    #[tokio::test]
+    async fn completes_packages_with_trailing_colon() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        fixture(dir.path());
+        let engine = engine_at(dir.path().to_path_buf());
+
+        let got = addr_candidates(&engine, &PkgBuf::from(""), "//")
+            .await
+            .expect("candidates");
+
+        assert!(got.contains(&"//foo:".to_string()), "{got:?}");
+        assert!(got.contains(&"//:".to_string()), "{got:?}");
+    }
+
+    #[tokio::test]
+    async fn filters_packages_by_string_prefix() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        fixture(dir.path());
+        let engine = engine_at(dir.path().to_path_buf());
+
+        let got = addr_candidates(&engine, &PkgBuf::from(""), "//fo")
+            .await
+            .expect("candidates");
+
+        assert_eq!(got, vec!["//foo:".to_string()]);
+    }
+
+    #[tokio::test]
+    async fn completes_targets_in_package() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        fixture(dir.path());
+        let engine = engine_at(dir.path().to_path_buf());
+
+        let got = addr_candidates(&engine, &PkgBuf::from(""), "//foo:")
+            .await
+            .expect("candidates");
+
+        assert_eq!(
+            got,
+            vec![
+                "//foo:bar".to_string(),
+                "//foo:baz".to_string(),
+                "//foo:qux".to_string(),
+            ]
+        );
+    }
+
+    #[tokio::test]
+    async fn filters_targets_by_name_prefix() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        fixture(dir.path());
+        let engine = engine_at(dir.path().to_path_buf());
+
+        let got = addr_candidates(&engine, &PkgBuf::from(""), "//foo:ba")
+            .await
+            .expect("candidates");
+
+        assert_eq!(got, vec!["//foo:bar".to_string(), "//foo:baz".to_string()]);
+    }
+
+    #[tokio::test]
+    async fn completes_relative_targets_in_base_package() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        fixture(dir.path());
+        let engine = engine_at(dir.path().to_path_buf());
+
+        let got = addr_candidates(&engine, &PkgBuf::from("foo"), ":b")
+            .await
+            .expect("candidates");
+
+        assert_eq!(got, vec![":bar".to_string(), ":baz".to_string()]);
+    }
+}

--- a/src/commands/inspect/def.rs
+++ b/src/commands/inspect/def.rs
@@ -2,10 +2,12 @@ use std::sync::Arc;
 
 use anyhow::Context;
 use async_trait::async_trait;
+use clap_complete::engine::ArgValueCompleter;
 use serde::Serialize;
 
 use crate::commands::GlobalOptions;
 use crate::commands::bootstrap;
+use crate::commands::completion::complete_target_addr;
 use crate::engine::Engine;
 use crate::engine::driver::sandbox::Sandbox;
 use crate::engine::driver::targetdef::TargetDef;
@@ -15,6 +17,7 @@ use crate::tui::{self, App, AppContext, LogSink};
 #[derive(clap::Args, Clone)]
 pub struct Args {
     /// Target address (e.g. //pkg:name)
+    #[arg(add = ArgValueCompleter::new(complete_target_addr))]
     pub addr: String,
     /// Show the direct def only, without applying transitive deps
     #[arg(long)]

--- a/src/commands/inspect/deps.rs
+++ b/src/commands/inspect/deps.rs
@@ -2,9 +2,11 @@ use std::sync::Arc;
 
 use anyhow::Context;
 use async_trait::async_trait;
+use clap_complete::engine::ArgValueCompleter;
 
 use crate::commands::GlobalOptions;
 use crate::commands::bootstrap;
+use crate::commands::completion::complete_target_addr;
 use crate::engine::Engine;
 use crate::htaddr::{self, Addr};
 use crate::tui::{self, App, AppContext, LogSink};
@@ -12,6 +14,7 @@ use crate::tui::{self, App, AppContext, LogSink};
 #[derive(clap::Args, Clone)]
 pub struct Args {
     /// Target address (e.g. //pkg:name)
+    #[arg(add = ArgValueCompleter::new(complete_target_addr))]
     pub addr: String,
     /// Explore the dependency tree in an interactive TUI (requires a terminal)
     #[arg(short = 'i', long = "interactive")]

--- a/src/commands/inspect/hashin.rs
+++ b/src/commands/inspect/hashin.rs
@@ -2,9 +2,11 @@ use std::sync::Arc;
 
 use anyhow::Context;
 use async_trait::async_trait;
+use clap_complete::engine::ArgValueCompleter;
 
 use crate::commands::GlobalOptions;
 use crate::commands::bootstrap;
+use crate::commands::completion::complete_target_addr;
 use crate::engine::Engine;
 use crate::htaddr::{self, Addr};
 use crate::tui::{self, App, AppContext, LogSink};
@@ -12,6 +14,7 @@ use crate::tui::{self, App, AppContext, LogSink};
 #[derive(clap::Args, Clone)]
 pub struct Args {
     /// Target address (e.g. //pkg:name)
+    #[arg(add = ArgValueCompleter::new(complete_target_addr))]
     pub addr: String,
 }
 

--- a/src/commands/inspect/hashout.rs
+++ b/src/commands/inspect/hashout.rs
@@ -2,9 +2,11 @@ use std::sync::Arc;
 
 use anyhow::Context;
 use async_trait::async_trait;
+use clap_complete::engine::ArgValueCompleter;
 
 use crate::commands::GlobalOptions;
 use crate::commands::bootstrap;
+use crate::commands::completion::complete_target_addr;
 use crate::engine::{Engine, OutputMatcher, ResultOptions};
 use crate::htaddr::{self, Addr};
 use crate::tui::{self, App, AppContext, LogSink};
@@ -12,6 +14,7 @@ use crate::tui::{self, App, AppContext, LogSink};
 #[derive(clap::Args, Clone)]
 pub struct Args {
     /// Target address (e.g. //pkg:name)
+    #[arg(add = ArgValueCompleter::new(complete_target_addr))]
     pub addr: String,
 }
 

--- a/src/commands/inspect/spec.rs
+++ b/src/commands/inspect/spec.rs
@@ -2,9 +2,11 @@ use std::sync::Arc;
 
 use anyhow::Context;
 use async_trait::async_trait;
+use clap_complete::engine::ArgValueCompleter;
 
 use crate::commands::GlobalOptions;
 use crate::commands::bootstrap;
+use crate::commands::completion::complete_target_addr;
 use crate::engine::Engine;
 use crate::htaddr::{self, Addr};
 use crate::tui::{self, App, AppContext, LogSink};
@@ -12,6 +14,7 @@ use crate::tui::{self, App, AppContext, LogSink};
 #[derive(clap::Args, Clone)]
 pub struct Args {
     /// Target address (e.g. //pkg:name)
+    #[arg(add = ArgValueCompleter::new(complete_target_addr))]
     pub addr: String,
 }
 

--- a/src/commands/mod.rs
+++ b/src/commands/mod.rs
@@ -1,4 +1,5 @@
 pub mod bootstrap;
+pub mod completion;
 pub mod errors;
 pub mod gendocs;
 mod global;

--- a/src/commands/query.rs
+++ b/src/commands/query.rs
@@ -1,10 +1,12 @@
 use std::sync::Arc;
 
 use async_trait::async_trait;
+use clap_complete::engine::ArgValueCompleter;
 use futures::TryStreamExt;
 
 use crate::commands::GlobalOptions;
 use crate::commands::bootstrap;
+use crate::commands::completion::complete_target_addr;
 use crate::commands::utils::matcher_from_args;
 use crate::engine::{Engine, get_cwp};
 use crate::htmatcher::Matcher;
@@ -16,13 +18,13 @@ use crate::tui::{self, App, AppContext, BufferedStdout, LogSink};
 )]
 pub struct Args {
     /// Target address (e.g., //pkg:name) OR Label
-    #[arg(value_name = "TARGET_ADDRESS/LABEL")]
+    #[arg(value_name = "TARGET_ADDRESS/LABEL", add = ArgValueCompleter::new(complete_target_addr))]
     pub arg1: String,
     /// Package matcher (only if first argument is a Label)
     #[arg(value_name = "PACKAGE_MATCHER")]
     pub arg2: Option<String>,
     /// Exclude target address (repeatable, e.g. -e //pkg:target)
-    #[arg(short = 'e', long = "exclude", value_name = "TARGET_ADDRESS")]
+    #[arg(short = 'e', long = "exclude", value_name = "TARGET_ADDRESS", add = ArgValueCompleter::new(complete_target_addr))]
     pub exclude: Vec<String>,
 }
 

--- a/src/commands/run.rs
+++ b/src/commands/run.rs
@@ -3,9 +3,11 @@ use std::sync::Arc;
 
 use async_trait::async_trait;
 use clap::Args;
+use clap_complete::engine::ArgValueCompleter;
 
 use crate::commands::GlobalOptions;
 use crate::commands::bootstrap;
+use crate::commands::completion::complete_target_addr;
 use crate::commands::utils::matcher_from_args;
 use crate::engine::{Engine, InteractiveWrapper, OutputMatcher, ResultOptions, get_cwp};
 use crate::htmatcher::Matcher;
@@ -15,7 +17,7 @@ use crate::tui::{self, App, AppContext, LogSink};
 #[command(override_usage = "heph run <TARGET_ADDRESS>\n       heph run <LABEL> <PACKAGE_MATCHER>")]
 pub struct RunArgs {
     /// Target address (e.g., //pkg:name) OR Label
-    #[arg(value_name = "TARGET_ADDRESS/LABEL")]
+    #[arg(value_name = "TARGET_ADDRESS/LABEL", add = ArgValueCompleter::new(complete_target_addr))]
     pub arg1: String,
     /// Package matcher (only if first argument is a Label)
     #[arg(value_name = "PACKAGE_MATCHER")]
@@ -33,7 +35,7 @@ pub struct RunArgs {
     #[arg(long = "list-out")]
     pub list_out: bool,
     /// Exclude target address (repeatable, e.g. -e //pkg:target)
-    #[arg(short = 'e', long = "exclude", value_name = "TARGET_ADDRESS")]
+    #[arg(short = 'e', long = "exclude", value_name = "TARGET_ADDRESS", add = ArgValueCompleter::new(complete_target_addr))]
     pub exclude: Vec<String>,
     /// Fail if generated output differs from the tree (CI check)
     #[arg(long = "frozen")]

--- a/src/commands/tool/completions.rs
+++ b/src/commands/tool/completions.rs
@@ -1,0 +1,46 @@
+use std::io::{self, Write};
+
+use anyhow::Context;
+use clap_complete::env::{Bash, Elvish, EnvCompleter, Fish, Powershell, Zsh};
+
+#[derive(clap::Args)]
+pub struct Args {
+    /// Shell to emit the completion-registration script for
+    #[arg(value_enum)]
+    pub shell: Shell,
+}
+
+/// Shells supported by the dynamic completion engine.
+#[derive(Clone, Copy, Debug, clap::ValueEnum)]
+pub enum Shell {
+    Bash,
+    Zsh,
+    Fish,
+    Elvish,
+    Powershell,
+}
+
+/// Print the registration snippet that wires up dynamic completion for the
+/// chosen shell. The script drives completion back through this binary via the
+/// `COMPLETE` env var, so target addresses are resolved live (see
+/// [`crate::commands::completion`]).
+///
+/// Install by sourcing it, e.g. for zsh: `source <(heph tool completions zsh)`
+/// in `~/.zshrc`.
+pub fn execute(args: &Args) -> anyhow::Result<()> {
+    let completer: &dyn EnvCompleter = match args.shell {
+        Shell::Bash => &Bash,
+        Shell::Zsh => &Zsh,
+        Shell::Fish => &Fish,
+        Shell::Elvish => &Elvish,
+        Shell::Powershell => &Powershell,
+    };
+
+    let stdout = io::stdout();
+    let mut lock = stdout.lock();
+    completer
+        .write_registration("COMPLETE", "heph", "heph", "heph", &mut lock)
+        .context("write completion registration")?;
+    lock.flush().context("flush stdout")?;
+    Ok(())
+}

--- a/src/commands/tool/mod.rs
+++ b/src/commands/tool/mod.rs
@@ -1,3 +1,4 @@
+mod completions;
 pub mod gc;
 mod gen_gitignore;
 
@@ -32,6 +33,14 @@ pub enum ToolCommands {
     /// Example: `heph tool gen-gitignore`
     #[command(name = "gen-gitignore")]
     GenGitignore(gen_gitignore::Args),
+    /// Print a shell completion-registration script
+    ///
+    /// Emits the script that enables dynamic tab-completion of subcommands,
+    /// flags, and target addresses for the given shell. Source it from your
+    /// shell rc, e.g. `source <(heph tool completions zsh)`.
+    ///
+    /// Example: `heph tool completions bash`
+    Completions(completions::Args),
 }
 
 impl ToolArgs {
@@ -49,6 +58,7 @@ impl ToolCommands {
         match self {
             ToolCommands::Gc(args) => gc::execute(args, sink, global),
             ToolCommands::GenGitignore(args) => gen_gitignore::execute(args, sink, global),
+            ToolCommands::Completions(args) => completions::execute(args),
         }
     }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,4 +1,4 @@
-use clap::Parser;
+use clap::{CommandFactory, Parser};
 use heph::commands;
 use heph::commands::GlobalOptions;
 use heph::log;
@@ -22,6 +22,14 @@ fn main() -> ExitCode {
     if let Some(fd) = parse_supervisor_args() {
         heph::process_supervisor::run_supervisor_main(fd);
     }
+
+    // Dynamic shell completion. A no-op unless the `COMPLETE` env var is set
+    // (a tab press or `heph tool completions` registration), in which case it
+    // emits candidates / the registration script and exits the process. Runs
+    // before the supervisor fork and logging init so a tab press never forks
+    // the sidecar or writes log noise; the address completers spin up their
+    // own short-lived engine on demand.
+    clap_complete::CompleteEnv::with_factory(Cli::command).complete();
 
     // Ignore SIGTTOU/SIGTTIN so terminal-control syscalls (tcsetattr,
     // tcgetattr, tcsetpgrp …) from a background process group fail with


### PR DESCRIPTION
## What

Dynamic shell tab-completion for `//package:name` target addresses across `run`, `query`, and the `inspect *` commands, plus completion of subcommands/flags.

Target addresses aren't a fixed set — they come from walking `BUILD` files and evaluating Starlark, so static completion files can't enumerate them. This uses clap_complete's **dynamic** engine, which calls a Rust closure at tab time to list candidates from a live engine.

## How

- **`main.rs`** — `CompleteEnv` hook. No-op unless the `COMPLETE` env var is set (a tab press or registration). Placed before the supervisor fork and logging init so a tab press never forks the sidecar or writes noise.
- **`src/commands/completion.rs`** — spins up a short-lived engine and lists:
  - `//<TAB>` → packages, string-prefix filtered, trailing `:` to cue the next round
  - `//pkg:<TAB>` → targets in that package (one `BUILD` eval via `Matcher::Package`, no def eval)
  - `:name` → relative targets in the cwd package
  - not inside a heph workspace / bad input → no candidates, never errors to the shell
- Completer attached to every address arg: `run`/`query` `arg1` + `exclude`, `inspect spec/def/hashin/hashout/deps` `addr`.
- **`heph tool completions <shell>`** — prints the registration script for bash/zsh/fish/elvish/powershell via `EnvCompleter::write_registration`.

## Install

```
source <(heph tool completions zsh)   # in ~/.zshrc
```

## Testing

- `cargo build`, `cargo clippy --all-targets -- -D warnings`, `cargo fmt` — clean
- 952 lib tests pass; 5 new completion unit tests (package list, string-prefix filter, target list, name-prefix filter, relative form) against an in-memory engine + temp BUILD fixtures
- Verified live in `example/`: `//he`→`//hello:`, `//go`→go subtree, `//hello:`→`hello`/`hello_out`, `-e` and `inspect` args all fire; registration script emits valid `#compdef`

Note: `Cargo.lock` churn is the new transitive deps pulled by `clap_complete` (`shlex`, etc.).

🤖 Generated with [Claude Code](https://claude.com/claude-code)