### PR TITLE
Require explicit relative address forms; fix `inspect packages` matcher

### DIFF
--- a/src/commands/inspect/packages.rs
+++ b/src/commands/inspect/packages.rs
@@ -5,8 +5,8 @@ use async_trait::async_trait;
 use crate::commands::GlobalOptions;
 use crate::commands::bootstrap;
 use crate::engine::Engine;
-use crate::htmatcher::{self, Matcher};
-use crate::htpkg::PkgBuf;
+use crate::htmatcher::Matcher;
+use crate::htpkg::{self, PkgBuf};
 use crate::tui::{self, App, AppContext, BufferedStdout, LogSink};
 
 #[derive(clap::Args, Clone)]
@@ -62,7 +62,7 @@ pub fn execute(args: &Args, sink: LogSink, global: &GlobalOptions) -> anyhow::Re
 
 async fn execute_async(args: Args, sink: LogSink, global: GlobalOptions) -> anyhow::Result<()> {
     let matcher = match &args.matcher {
-        Some(s) => htmatcher::parse(s.as_str())?,
+        Some(s) => htpkg::parse(s.as_str(), &crate::engine::get_cwp()?)?,
         None => Matcher::PackagePrefix(PkgBuf::from("")),
     };
     let (engine, shutdown) = bootstrap::new_engine()?;

--- a/src/htaddr/parse.rs
+++ b/src/htaddr/parse.rs
@@ -151,8 +151,13 @@ pub fn parse_addr_with_base(input: &str, base: &PkgBuf) -> anyhow::Result<Addr> 
         return parse_addr(&full);
     }
 
-    // bare "name" or "name@args" — no slashes, colons, or leading dots
-    parse_addr(&format!("//{}:{}", base, input))
+    // A bare "name" (no leading ':', './', '../', or '//') is too ambiguous to
+    // accept — it reads like a plain identifier yet would silently resolve into
+    // the current package. Require an explicit ':' so relative references are
+    // unmistakable.
+    Err(anyhow::anyhow!(
+        "invalid address '{input}': relative references must start with ':', './', '../', or '//'"
+    ))
 }
 
 pub fn parse_addr(input: &str) -> anyhow::Result<Addr> {
@@ -214,17 +219,25 @@ mod tests {
     }
 
     #[test]
-    fn test_parse_addr_with_base_bare_name() {
+    fn test_parse_addr_with_base_bare_name_rejected() {
+        // A bare identifier is ambiguous and must be written as `:mytarget`.
         let base = PkgBuf::from("base/pkg");
-        let res = parse_addr_with_base("mytarget", &base).unwrap();
-        assert_eq!(res.package, "base/pkg");
-        assert_eq!(res.name, "mytarget");
+        let res = parse_addr_with_base("mytarget", &base);
+        assert!(res.is_err());
     }
 
     #[test]
-    fn test_parse_addr_with_base_bare_name_args() {
+    fn test_parse_addr_with_base_bare_name_args_rejected() {
         let base = PkgBuf::from("base/pkg");
-        let res = parse_addr_with_base("mytarget@k=v", &base).unwrap();
+        let res = parse_addr_with_base("mytarget@k=v", &base);
+        assert!(res.is_err());
+    }
+
+    #[test]
+    fn test_parse_addr_with_base_colon_name_args() {
+        // The explicit colon form still carries args through.
+        let base = PkgBuf::from("base/pkg");
+        let res = parse_addr_with_base(":mytarget@k=v", &base).unwrap();
         assert_eq!(res.package, "base/pkg");
         assert_eq!(res.name, "mytarget");
         assert_eq!(res.args.get("k").unwrap(), "v");

--- a/src/htmatcher/mod.rs
+++ b/src/htmatcher/mod.rs
@@ -1,5 +1,3 @@
 mod matcher;
-mod parse;
 
 pub use matcher::{MatchResult, Matcher};
-pub use parse::parse;

--- a/src/htmatcher/parse.rs
+++ b/src/htmatcher/parse.rs
@@ -1,8 +1,0 @@
-use crate::htmatcher;
-use crate::htpkg::PkgBuf;
-
-pub fn parse(s: &str) -> anyhow::Result<htmatcher::Matcher> {
-    let matcher = htmatcher::Matcher::Package(PkgBuf::from(s)); // TODO
-
-    Ok(matcher)
-}


### PR DESCRIPTION
## What

Spun out of the addressing docs PR (hephbuild.github.io#9). Rebased on master (which already added matcher `.`/`..` for the current package). Remaining changes:

### 1. Disallow bare `name` address form
`parse_addr_with_base` silently resolved a bare `name` into `//current/pkg:name`. A bare token reads like a plain identifier yet resolves relative — too ambiguous. Now requires an explicit prefix: `:name`, `./x`, `../x`, or `//x:y`. Bare identifiers error.

### 2. Fix `inspect packages` matcher
It built its matcher from a TODO stub (`htmatcher::parse`) that did no relative resolution, no `//` stripping, and ignored the current package. Now uses the real `htpkg::parse` with the current working package as base — same as `run` — so `.`, `//pkg/...`, `./x`, `../x` all work. Dead `htmatcher::parse` stub removed.

## Doc note correction (separate, website repo)
The note "Relative forms are only available on the command line. Inside BUILD files, always use absolute addresses" is **backwards**:
- BUILD files (`run_file.rs`) use `parse_addr_with_base` → relative forms work.
- CLI addr args use absolute-only `parse_addr`.

Fix the prose + drop the bare-`name` table row in hephbuild.github.io.

## Compatibility
Disallowing bare `name` is a behavioral change — BUILD deps/tools written as bare `name` must become `:name`. No in-repo fixtures used the bare form.

## Tests
`cargo build`, `cargo clippy -- -D warnings`, `cargo fmt` clean. plugingo (243), buildfile (61), htaddr/htpkg suites green. New tests cover bare-name rejection and `:name@args`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)