### PR TITLE
Configurable fs skip via htwalk::Ignore (dirs + globs), engine-owned

### DIFF
--- a/e2e/tests/common/mod.rs
+++ b/e2e/tests/common/mod.rs
@@ -26,7 +26,7 @@ impl Workspace {
         let p = parallelism.into();
         let builder = WorkspaceBuilder::new()
             .expect("workspace tempdir")
-            .with_provider(|root| Box::new(pluginbuildfile::Provider::new(root.to_path_buf())))
+            .with_provider(|init| Box::new(pluginbuildfile::Provider::new(init.root.to_path_buf())))
             .with_managed_driver(Box::new(pluginexec::Driver::new_exec()))
             .with_managed_driver(Box::new(pluginexec::Driver::new_bash()));
         let builder = if let Some(p) = p {
@@ -40,7 +40,7 @@ impl Workspace {
     pub fn with_static(targets: Vec<pluginstatictarget::Target>) -> Result<Self> {
         let provider = pluginstatictarget::Provider::new(targets)?;
         let ws = WorkspaceBuilder::new()?
-            .with_provider(move |_root| Box::new(provider))
+            .with_provider(move |_| Box::new(provider))
             .with_managed_driver(Box::new(pluginexec::Driver::new_exec()))
             .with_managed_driver(Box::new(pluginexec::Driver::new_bash()))
             .build()?;

--- a/plugingo-e2e/tests/common/mod.rs
+++ b/plugingo-e2e/tests/common/mod.rs
@@ -51,9 +51,9 @@ fn go_bin_path() -> String {
 
 pub fn make_workspace(dir: TempDir) -> anyhow::Result<Workspace> {
     let go_bin = go_bin_path();
+    // `fs` is auto-registered by `Engine::new`.
     WorkspaceBuilder::from_dir(dir)
-        .with_fs()
-        .with_provider(|root| Box::new(pluginbuildfile::Provider::new(root.to_path_buf())))
+        .with_provider(|init| Box::new(pluginbuildfile::Provider::new(init.root.to_path_buf())))
         .with_provider(move |_| {
             Box::new(
                 pluginstatictarget::Provider::new(vec![pluginstatictarget::Target {
@@ -68,8 +68,8 @@ pub fn make_workspace(dir: TempDir) -> anyhow::Result<Workspace> {
                 .expect("static provider"),
             )
         })
-        .with_provider(|root| {
-            Box::new(plugingo::Provider::new(root.to_path_buf()).expect("plugingo provider"))
+        .with_provider(|init| {
+            Box::new(plugingo::Provider::new(init.root.to_path_buf()).expect("plugingo provider"))
         })
         .with_managed_driver(Box::new(pluginexec::Driver::new_bash()))
         .with_managed_driver(Box::new(pluginexec::Driver::new_sh()))

--- a/plugingo-e2e/tests/common/mod.rs
+++ b/plugingo-e2e/tests/common/mod.rs
@@ -1,7 +1,6 @@
 use anyhow::Context as _;
 use heph::pluginbuildfile;
 use heph::pluginexec;
-use heph::pluginfs;
 use heph::plugingo;
 use heph::pluginstatictarget;
 use heph_testkit::{Workspace, WorkspaceBuilder, copy_dir_to_tempdir};
@@ -53,8 +52,8 @@ fn go_bin_path() -> String {
 pub fn make_workspace(dir: TempDir) -> anyhow::Result<Workspace> {
     let go_bin = go_bin_path();
     WorkspaceBuilder::from_dir(dir)
+        .with_fs()
         .with_provider(|root| Box::new(pluginbuildfile::Provider::new(root.to_path_buf())))
-        .with_provider(|_root| Box::new(pluginfs::Provider))
         .with_provider(move |_| {
             Box::new(
                 pluginstatictarget::Provider::new(vec![pluginstatictarget::Target {
@@ -77,7 +76,6 @@ pub fn make_workspace(dir: TempDir) -> anyhow::Result<Workspace> {
         .with_managed_driver(Box::new(pluginexec::Driver::new_exec()))
         .with_managed_driver(Box::new(plugingo::GoGolistDriver::new("//@heph/bin:go")))
         .with_managed_driver(Box::new(plugingo::GoEmbedDriver))
-        .with_driver(Box::new(pluginfs::Driver))
         .build()
         .context("build plugingo workspace")
 }

--- a/src/commands/bootstrap.rs
+++ b/src/commands/bootstrap.rs
@@ -84,6 +84,24 @@ impl SuppressionHandle {
     }
 }
 
+/// Reads the `skip` option (extra exclude globs) off the `fs` entry in the
+/// `drivers:` config list. Returns an empty list when `fs` is not listed.
+fn fs_driver_skip(drivers: &[config_file::PluginEntry]) -> anyhow::Result<Vec<String>> {
+    match drivers.iter().find(|d| d.name == "fs") {
+        Some(entry) => {
+            config_file::deny_unknown("fs driver", &entry.options, &["skip"])?;
+            Ok(config_file::decode_opt(&entry.options, "fs driver", "skip")?.unwrap_or_default())
+        }
+        None => Ok(vec![]),
+    }
+}
+
+/// The `drivers:` list minus the built-in `fs` entry, which is registered
+/// directly (with its options) rather than through `apply_config`.
+fn drivers_without_fs(drivers: &[config_file::PluginEntry]) -> Vec<config_file::PluginEntry> {
+    drivers.iter().filter(|d| d.name != "fs").cloned().collect()
+}
+
 pub fn new_engine() -> anyhow::Result<(Arc<engine::Engine>, ShutdownTrigger)> {
     let root = match engine::get_root() {
         Ok(r) => r,
@@ -127,9 +145,11 @@ pub fn new_engine() -> anyhow::Result<(Arc<engine::Engine>, ShutdownTrigger)> {
         lock_backend,
     })?;
 
-    // Auto-registered built-ins. The fs plugin prunes the engine's own skip dirs
-    // (the heph home) plus the `fs.skip` globs from the config file.
-    let fs_skip_globs = file.fs.map(|f| f.skip).unwrap_or_default();
+    // `fs` is a built-in registered directly, but its `skip` option is read from
+    // the `drivers: [{name: fs, options: {skip: […]}}]` entry like any other
+    // driver. The provider and driver share one `FsSkip` so BUILD-time `glob()`
+    // and the driver's run-time walk prune the same dirs.
+    let fs_skip_globs = fs_driver_skip(&file.drivers)?;
     let fs_skip = std::sync::Arc::new(pluginfs::FsSkip::new(
         &root,
         &e.skip_dirs(),
@@ -185,7 +205,10 @@ pub fn new_engine() -> anyhow::Result<(Arc<engine::Engine>, ShutdownTrigger)> {
         Ok(Box::new(plugingo::GoTestmainDriver))
     })?;
 
-    e.apply_config(&file.providers, &file.drivers)?;
+    // `fs` was registered directly above, so drop it from the list `apply_config`
+    // validates (it has no factory and would otherwise be "unknown driver 'fs'").
+    let drivers = drivers_without_fs(&file.drivers);
+    e.apply_config(&file.providers, &drivers)?;
 
     let engine = Arc::new(e);
     let (tx, rx) = mpsc::unbounded_channel();
@@ -260,7 +283,7 @@ mod tests {
             ..Default::default()
         })?;
 
-        let fs_skip_globs = file.fs.map(|f| f.skip).unwrap_or_default();
+        let fs_skip_globs = fs_driver_skip(&file.drivers)?;
         let fs_skip = std::sync::Arc::new(pluginfs::FsSkip::new(
             dir.path(),
             &e.skip_dirs(),
@@ -292,7 +315,8 @@ mod tests {
             Ok(Box::new(pluginexec::Driver::from_options_bash(opts)?))
         })?;
 
-        e.apply_config(&file.providers, &file.drivers)?;
+        let drivers = drivers_without_fs(&file.drivers);
+        e.apply_config(&file.providers, &drivers)?;
         Ok((dir, e))
     }
 
@@ -312,6 +336,33 @@ drivers:
         assert!(e.drivers_by_name.contains_key("exec"));
         assert!(e.drivers_by_name.contains_key("bash"));
         assert!(e.providers_by_name.contains_key("fs"));
+    }
+
+    #[test]
+    fn fs_driver_skip_option_applies() {
+        let yaml = r#"
+drivers:
+  - name: fs
+    options:
+      skip: [vendor/**]
+"#;
+        // `fs` listed with options builds the engine (registered directly, dropped
+        // from apply_config) and stays registered as both provider and driver.
+        let (_dir, e) = build_engine_from_yaml(yaml).expect("engine");
+        assert!(e.providers_by_name.contains_key("fs"));
+        assert!(e.drivers_by_name.contains_key("fs"));
+    }
+
+    #[test]
+    fn fs_driver_unknown_option_errors() {
+        let yaml = r#"
+drivers:
+  - name: fs
+    options:
+      bogus: 1
+"#;
+        let err = build_engine_from_yaml(yaml).err().expect("must error");
+        assert!(err.to_string().contains("bogus"), "{err}");
     }
 
     #[test]

--- a/src/commands/bootstrap.rs
+++ b/src/commands/bootstrap.rs
@@ -128,12 +128,11 @@ pub fn new_engine() -> anyhow::Result<(Arc<engine::Engine>, ShutdownTrigger)> {
         lock_backend,
     })?;
 
-    // `fs` is a built-in, registered directly. It gets the same engine skip
-    // config (home dir + `fs.skip` globs) the engine hands to provider factories,
-    // so its glob walk prunes the same paths. Provider + driver share one
-    // `FsSkip` so BUILD-time `glob()` and the run-time walk agree.
-    let skip = e.skip_config();
-    let fs_skip = std::sync::Arc::new(pluginfs::FsSkip::new(&root, &skip.dirs, &skip.globs)?);
+    // `fs` is a built-in, registered directly. It gets the same skip dirs (home +
+    // `fs.skip` dirs) the engine hands to provider factories, so its glob walk
+    // prunes the same dirs. Provider + driver share one `FsSkip` so BUILD-time
+    // `glob()` and the run-time walk agree.
+    let fs_skip = std::sync::Arc::new(pluginfs::FsSkip::new(&root, &e.skip_dirs())?);
     e.register_provider({
         let fs_skip = fs_skip.clone();
         move |_| Box::new(pluginfs::Provider::new(fs_skip))
@@ -260,9 +259,7 @@ mod tests {
             ..Default::default()
         })?;
 
-        let skip = e.skip_config();
-        let fs_skip =
-            std::sync::Arc::new(pluginfs::FsSkip::new(dir.path(), &skip.dirs, &skip.globs)?);
+        let fs_skip = std::sync::Arc::new(pluginfs::FsSkip::new(dir.path(), &e.skip_dirs())?);
         e.register_provider({
             let fs_skip = fs_skip.clone();
             move |_| Box::new(pluginfs::Provider::new(fs_skip))
@@ -312,15 +309,19 @@ drivers:
     }
 
     #[test]
-    fn fs_skip_config_threads_to_engine() {
+    fn fs_skip_dirs_resolved_relative_to_root() {
         let yaml = r#"
 fs:
-  skip: [vendor/**]
+  skip: [vendor]
 "#;
-        // The `fs.skip` globs reach the engine's skip config, which is handed to
-        // the fs plugin and every provider factory.
-        let (_dir, e) = build_engine_from_yaml(yaml).expect("engine");
-        assert_eq!(e.skip_config().globs, vec!["vendor/**".to_string()]);
+        // The `fs.skip` dir is resolved against the repo root and shows up in the
+        // engine skip dirs handed to the fs plugin and every provider factory.
+        let (dir, e) = build_engine_from_yaml(yaml).expect("engine");
+        assert!(
+            e.skip_dirs().contains(&dir.path().join("vendor")),
+            "{:?}",
+            e.skip_dirs()
+        );
         assert!(e.providers_by_name.contains_key("fs"));
         assert!(e.drivers_by_name.contains_key("fs"));
     }

--- a/src/commands/bootstrap.rs
+++ b/src/commands/bootstrap.rs
@@ -84,18 +84,6 @@ impl SuppressionHandle {
     }
 }
 
-/// Reads the `skip` option (extra exclude globs) off the `fs` entry in the
-/// `drivers:` config list. Returns an empty list when `fs` is not listed.
-fn fs_driver_skip(drivers: &[config_file::PluginEntry]) -> anyhow::Result<Vec<String>> {
-    match drivers.iter().find(|d| d.name == "fs") {
-        Some(entry) => {
-            config_file::deny_unknown("fs driver", &entry.options, &["skip"])?;
-            Ok(config_file::decode_opt(&entry.options, "fs driver", "skip")?.unwrap_or_default())
-        }
-        None => Ok(vec![]),
-    }
-}
-
 pub fn new_engine() -> anyhow::Result<(Arc<engine::Engine>, ShutdownTrigger)> {
     let root = match engine::get_root() {
         Ok(r) => r,
@@ -133,22 +121,19 @@ pub fn new_engine() -> anyhow::Result<(Arc<engine::Engine>, ShutdownTrigger)> {
     let mut e = engine::Engine::new(engine::Config {
         root: root.clone(),
         home_dir: home_dir.clone(),
+        fs_skip: file.fs.map(|f| f.skip).unwrap_or_default(),
         parallelism: None,
         mem_cache,
         fuse,
         lock_backend,
     })?;
 
-    // `fs` is a built-in registered directly, but its `skip` option is read from
-    // the `drivers: [{name: fs, options: {skip: […]}}]` entry like any other
-    // driver. The provider and driver share one `FsSkip` so BUILD-time `glob()`
-    // and the driver's run-time walk prune the same dirs.
-    let fs_skip_globs = fs_driver_skip(&file.drivers)?;
-    let fs_skip = std::sync::Arc::new(pluginfs::FsSkip::new(
-        &root,
-        &e.skip_dirs(),
-        &fs_skip_globs,
-    )?);
+    // `fs` is a built-in, registered directly. It gets the same engine skip
+    // config (home dir + `fs.skip` globs) the engine hands to provider factories,
+    // so its glob walk prunes the same paths. Provider + driver share one
+    // `FsSkip` so BUILD-time `glob()` and the run-time walk agree.
+    let skip = e.skip_config();
+    let fs_skip = std::sync::Arc::new(pluginfs::FsSkip::new(&root, &skip.dirs, &skip.globs)?);
     e.register_provider({
         let fs_skip = fs_skip.clone();
         move |_| Box::new(pluginfs::Provider::new(fs_skip))
@@ -162,17 +147,17 @@ pub fn new_engine() -> anyhow::Result<(Arc<engine::Engine>, ShutdownTrigger)> {
     )))?;
 
     // Opt-in factories — instantiated by `apply_config` if listed in the YAML.
-    e.register_provider_factory("buildfile", |root, skip_dirs, opts| {
+    e.register_provider_factory("buildfile", |root, skip, opts| {
         Ok(Box::new(pluginbuildfile::Provider::from_options(
             root.to_path_buf(),
-            skip_dirs,
+            skip,
             opts,
         )?))
     })?;
-    e.register_provider_factory("go", |root, skip_dirs, opts| {
+    e.register_provider_factory("go", |root, skip, opts| {
         Ok(Box::new(plugingo::Provider::from_options(
             root.to_path_buf(),
-            skip_dirs,
+            skip,
             opts,
         )?))
     })?;
@@ -270,16 +255,14 @@ mod tests {
         let mut e = engine::Engine::new(engine::Config {
             root,
             home_dir: home_dir.clone(),
+            fs_skip: file.fs.clone().map(|f| f.skip).unwrap_or_default(),
             parallelism: None,
             ..Default::default()
         })?;
 
-        let fs_skip_globs = fs_driver_skip(&file.drivers)?;
-        let fs_skip = std::sync::Arc::new(pluginfs::FsSkip::new(
-            dir.path(),
-            &e.skip_dirs(),
-            &fs_skip_globs,
-        )?);
+        let skip = e.skip_config();
+        let fs_skip =
+            std::sync::Arc::new(pluginfs::FsSkip::new(dir.path(), &skip.dirs, &skip.globs)?);
         e.register_provider({
             let fs_skip = fs_skip.clone();
             move |_| Box::new(pluginfs::Provider::new(fs_skip))
@@ -292,10 +275,10 @@ mod tests {
             home_dir.join("nix-driver"),
         )))?;
 
-        e.register_provider_factory("buildfile", |root, skip_dirs, opts| {
+        e.register_provider_factory("buildfile", |root, skip, opts| {
             Ok(Box::new(pluginbuildfile::Provider::from_options(
                 root.to_path_buf(),
-                skip_dirs,
+                skip,
                 opts,
             )?))
         })?;
@@ -329,30 +312,17 @@ drivers:
     }
 
     #[test]
-    fn fs_driver_skip_option_applies() {
+    fn fs_skip_config_threads_to_engine() {
         let yaml = r#"
-drivers:
-  - name: fs
-    options:
-      skip: [vendor/**]
+fs:
+  skip: [vendor/**]
 "#;
-        // `fs` listed with options builds the engine (registered directly, dropped
-        // from apply_config) and stays registered as both provider and driver.
+        // The `fs.skip` globs reach the engine's skip config, which is handed to
+        // the fs plugin and every provider factory.
         let (_dir, e) = build_engine_from_yaml(yaml).expect("engine");
+        assert_eq!(e.skip_config().globs, vec!["vendor/**".to_string()]);
         assert!(e.providers_by_name.contains_key("fs"));
         assert!(e.drivers_by_name.contains_key("fs"));
-    }
-
-    #[test]
-    fn fs_driver_unknown_option_errors() {
-        let yaml = r#"
-drivers:
-  - name: fs
-    options:
-      bogus: 1
-"#;
-        let err = build_engine_from_yaml(yaml).err().expect("must error");
-        assert!(err.to_string().contains("bogus"), "{err}");
     }
 
     #[test]

--- a/src/commands/bootstrap.rs
+++ b/src/commands/bootstrap.rs
@@ -96,12 +96,6 @@ fn fs_driver_skip(drivers: &[config_file::PluginEntry]) -> anyhow::Result<Vec<St
     }
 }
 
-/// The `drivers:` list minus the built-in `fs` entry, which is registered
-/// directly (with its options) rather than through `apply_config`.
-fn drivers_without_fs(drivers: &[config_file::PluginEntry]) -> Vec<config_file::PluginEntry> {
-    drivers.iter().filter(|d| d.name != "fs").cloned().collect()
-}
-
 pub fn new_engine() -> anyhow::Result<(Arc<engine::Engine>, ShutdownTrigger)> {
     let root = match engine::get_root() {
         Ok(r) => r,
@@ -205,10 +199,7 @@ pub fn new_engine() -> anyhow::Result<(Arc<engine::Engine>, ShutdownTrigger)> {
         Ok(Box::new(plugingo::GoTestmainDriver))
     })?;
 
-    // `fs` was registered directly above, so drop it from the list `apply_config`
-    // validates (it has no factory and would otherwise be "unknown driver 'fs'").
-    let drivers = drivers_without_fs(&file.drivers);
-    e.apply_config(&file.providers, &drivers)?;
+    e.apply_config(&file.providers, &file.drivers)?;
 
     let engine = Arc::new(e);
     let (tx, rx) = mpsc::unbounded_channel();
@@ -315,8 +306,7 @@ mod tests {
             Ok(Box::new(pluginexec::Driver::from_options_bash(opts)?))
         })?;
 
-        let drivers = drivers_without_fs(&file.drivers);
-        e.apply_config(&file.providers, &drivers)?;
+        e.apply_config(&file.providers, &file.drivers)?;
         Ok((dir, e))
     }
 

--- a/src/commands/bootstrap.rs
+++ b/src/commands/bootstrap.rs
@@ -8,8 +8,7 @@ use tokio::sync::mpsc;
 
 use crate::engine::config_file;
 use crate::{
-    engine, pluginbuildfile, pluginexec, pluginfs, plugingo, pluginhostbin, pluginnix,
-    plugintextfile,
+    engine, pluginbuildfile, pluginexec, plugingo, pluginhostbin, pluginnix, plugintextfile,
 };
 
 /// Builds the multi-thread runtime used by every command entry point.
@@ -128,57 +127,49 @@ pub fn new_engine() -> anyhow::Result<(Arc<engine::Engine>, ShutdownTrigger)> {
         lock_backend,
     })?;
 
-    // `fs` is a built-in, registered directly. It gets the same skip dirs (home +
-    // `fs.skip` dirs) the engine hands to provider factories, so its glob walk
-    // prunes the same dirs. Provider + driver share one `FsSkip` so BUILD-time
-    // `glob()` and the run-time walk agree.
-    let fs_skip = std::sync::Arc::new(pluginfs::FsSkip::new(&root, &e.skip_dirs())?);
-    e.register_provider({
-        let fs_skip = fs_skip.clone();
-        move |_| Box::new(pluginfs::Provider::new(fs_skip))
-    })?;
-    e.register_driver(Box::new(pluginfs::Driver::new(fs_skip)))?;
+    // `fs` (provider + driver) is registered by `Engine::new` itself, with the
+    // engine's own skip dirs. The remaining built-ins have no config.
     e.register_provider(|_| Box::new(pluginhostbin::Provider))?;
-    e.register_driver(Box::new(pluginhostbin::Driver))?;
-    e.register_driver(Box::new(plugintextfile::Driver))?;
-    e.register_managed_driver(Box::new(pluginnix::Driver::new(
-        home_dir.join("nix-driver"),
-    )))?;
+    e.register_driver(|_| Box::new(pluginhostbin::Driver))?;
+    e.register_driver(|_| Box::new(plugintextfile::Driver))?;
+    e.register_managed_driver(|_| Box::new(pluginnix::Driver::new(home_dir.join("nix-driver"))))?;
 
     // Opt-in factories — instantiated by `apply_config` if listed in the YAML.
-    e.register_provider_factory("buildfile", |root, skip, opts| {
+    e.register_provider_factory("buildfile", |init, opts| {
         Ok(Box::new(pluginbuildfile::Provider::from_options(
-            root.to_path_buf(),
-            skip,
+            init.root.to_path_buf(),
+            init.skip_dirs,
+            init.skip_globs,
             opts,
         )?))
     })?;
-    e.register_provider_factory("go", |root, skip, opts| {
+    e.register_provider_factory("go", |init, opts| {
         Ok(Box::new(plugingo::Provider::from_options(
-            root.to_path_buf(),
-            skip,
+            init.root.to_path_buf(),
+            init.skip_dirs,
+            init.skip_globs,
             opts,
         )?))
     })?;
 
-    e.register_managed_driver_factory("exec", |opts| {
+    e.register_managed_driver_factory("exec", |_init, opts| {
         Ok(Box::new(pluginexec::Driver::from_options_exec(opts)?))
     })?;
-    e.register_managed_driver_factory("bash", |opts| {
+    e.register_managed_driver_factory("bash", |_init, opts| {
         Ok(Box::new(pluginexec::Driver::from_options_bash(opts)?))
     })?;
-    e.register_managed_driver_factory("sh", |opts| {
+    e.register_managed_driver_factory("sh", |_init, opts| {
         Ok(Box::new(pluginexec::Driver::from_options_sh(opts)?))
     })?;
-    e.register_managed_driver_factory("go_golist", |opts| {
+    e.register_managed_driver_factory("go_golist", |_init, opts| {
         config_file::deny_unknown("go_golist driver", opts, &[])?;
         Ok(Box::new(plugingo::GoGolistDriver::new("//@heph/bin:go")))
     })?;
-    e.register_managed_driver_factory("go_embed", |opts| {
+    e.register_managed_driver_factory("go_embed", |_init, opts| {
         config_file::deny_unknown("go_embed driver", opts, &[])?;
         Ok(Box::new(plugingo::GoEmbedDriver))
     })?;
-    e.register_managed_driver_factory("go_testmain", |opts| {
+    e.register_managed_driver_factory("go_testmain", |_init, opts| {
         config_file::deny_unknown("go_testmain driver", opts, &[])?;
         Ok(Box::new(plugingo::GoTestmainDriver))
     })?;
@@ -259,30 +250,26 @@ mod tests {
             ..Default::default()
         })?;
 
-        let fs_skip = std::sync::Arc::new(pluginfs::FsSkip::new(dir.path(), &e.skip_dirs())?);
-        e.register_provider({
-            let fs_skip = fs_skip.clone();
-            move |_| Box::new(pluginfs::Provider::new(fs_skip))
-        })?;
-        e.register_driver(Box::new(pluginfs::Driver::new(fs_skip)))?;
+        // `fs` is auto-registered by `Engine::new`.
         e.register_provider(|_| Box::new(pluginhostbin::Provider))?;
-        e.register_driver(Box::new(pluginhostbin::Driver))?;
-        e.register_driver(Box::new(plugintextfile::Driver))?;
-        e.register_managed_driver(Box::new(pluginnix::Driver::new(
-            home_dir.join("nix-driver"),
-        )))?;
+        e.register_driver(|_| Box::new(pluginhostbin::Driver))?;
+        e.register_driver(|_| Box::new(plugintextfile::Driver))?;
+        e.register_managed_driver(|_| {
+            Box::new(pluginnix::Driver::new(home_dir.join("nix-driver")))
+        })?;
 
-        e.register_provider_factory("buildfile", |root, skip, opts| {
+        e.register_provider_factory("buildfile", |init, opts| {
             Ok(Box::new(pluginbuildfile::Provider::from_options(
-                root.to_path_buf(),
-                skip,
+                init.root.to_path_buf(),
+                init.skip_dirs,
+                init.skip_globs,
                 opts,
             )?))
         })?;
-        e.register_managed_driver_factory("exec", |opts| {
+        e.register_managed_driver_factory("exec", |_init, opts| {
             Ok(Box::new(pluginexec::Driver::from_options_exec(opts)?))
         })?;
-        e.register_managed_driver_factory("bash", |opts| {
+        e.register_managed_driver_factory("bash", |_init, opts| {
             Ok(Box::new(pluginexec::Driver::from_options_bash(opts)?))
         })?;
 
@@ -309,19 +296,21 @@ drivers:
     }
 
     #[test]
-    fn fs_skip_dirs_resolved_relative_to_root() {
+    fn fs_skip_splits_dirs_and_globs() {
         let yaml = r#"
 fs:
-  skip: [vendor]
+  skip: [vendor, "**/node_modules/**"]
 "#;
-        // The `fs.skip` dir is resolved against the repo root and shows up in the
-        // engine skip dirs handed to the fs plugin and every provider factory.
+        // Literal entries resolve to absolute skip dirs (relative to the repo
+        // root); glob entries become skip globs. Both are handed to the fs plugin
+        // and every provider factory.
         let (dir, e) = build_engine_from_yaml(yaml).expect("engine");
         assert!(
             e.skip_dirs().contains(&dir.path().join("vendor")),
             "{:?}",
             e.skip_dirs()
         );
+        assert_eq!(e.skip_globs(), vec!["**/node_modules/**".to_string()]);
         assert!(e.providers_by_name.contains_key("fs"));
         assert!(e.drivers_by_name.contains_key("fs"));
     }

--- a/src/commands/bootstrap.rs
+++ b/src/commands/bootstrap.rs
@@ -121,6 +121,7 @@ pub fn new_engine() -> anyhow::Result<(Arc<engine::Engine>, ShutdownTrigger)> {
     let mut e = engine::Engine::new(engine::Config {
         root: root.clone(),
         home_dir: home_dir.clone(),
+        skip: file.skip.clone(),
         parallelism: None,
         mem_cache,
         fuse,
@@ -128,8 +129,12 @@ pub fn new_engine() -> anyhow::Result<(Arc<engine::Engine>, ShutdownTrigger)> {
     })?;
 
     // Auto-registered built-ins (no options). The fs plugin prunes the engine's
-    // own skip dirs (the heph home) during glob walks.
-    let fs_skip = std::sync::Arc::new(pluginfs::FsSkip::new(&root, &e.skip_dirs())?);
+    // own skip dirs (the heph home) plus the config file's extra `skip` globs.
+    let fs_skip = std::sync::Arc::new(pluginfs::FsSkip::new(
+        &root,
+        &e.skip_dirs(),
+        e.skip_globs(),
+    )?);
     e.register_provider({
         let fs_skip = fs_skip.clone();
         move |_| Box::new(pluginfs::Provider::new(fs_skip))
@@ -251,11 +256,16 @@ mod tests {
         let mut e = engine::Engine::new(engine::Config {
             root,
             home_dir: home_dir.clone(),
+            skip: file.skip.clone(),
             parallelism: None,
             ..Default::default()
         })?;
 
-        let fs_skip = std::sync::Arc::new(pluginfs::FsSkip::new(dir.path(), &e.skip_dirs())?);
+        let fs_skip = std::sync::Arc::new(pluginfs::FsSkip::new(
+            dir.path(),
+            &e.skip_dirs(),
+            e.skip_globs(),
+        )?);
         e.register_provider({
             let fs_skip = fs_skip.clone();
             move |_| Box::new(pluginfs::Provider::new(fs_skip))

--- a/src/commands/bootstrap.rs
+++ b/src/commands/bootstrap.rs
@@ -299,14 +299,20 @@ drivers:
     fn fs_skip_splits_dirs_and_globs() {
         let yaml = r#"
 fs:
-  skip: [vendor, "**/node_modules/**"]
+  skip: [vendor, "./node_modules", "**/node_modules/**"]
 "#;
-        // Literal entries resolve to absolute skip dirs (relative to the repo
-        // root); glob entries become skip globs. Both are handed to the fs plugin
-        // and every provider factory.
+        // Literal entries (incl. the `./` "current dir" form) resolve to absolute
+        // root-relative skip dirs; glob entries become skip globs. Both are handed
+        // to the fs plugin and every provider factory.
         let (dir, e) = build_engine_from_yaml(yaml).expect("engine");
         assert!(
             e.skip_dirs().contains(&dir.path().join("vendor")),
+            "{:?}",
+            e.skip_dirs()
+        );
+        // `./node_modules` normalizes to the bare root-relative `node_modules`.
+        assert!(
+            e.skip_dirs().contains(&dir.path().join("node_modules")),
             "{:?}",
             e.skip_dirs()
         );

--- a/src/commands/bootstrap.rs
+++ b/src/commands/bootstrap.rs
@@ -127,9 +127,14 @@ pub fn new_engine() -> anyhow::Result<(Arc<engine::Engine>, ShutdownTrigger)> {
         lock_backend,
     })?;
 
-    // Auto-registered built-ins (no options).
-    e.register_provider(|_| Box::new(pluginfs::Provider))?;
-    e.register_driver(Box::new(pluginfs::Driver))?;
+    // Auto-registered built-ins (no options). The fs plugin prunes the engine's
+    // own skip dirs (the heph home) during glob walks.
+    let fs_skip = std::sync::Arc::new(pluginfs::FsSkip::new(&root, &e.skip_dirs())?);
+    e.register_provider({
+        let fs_skip = fs_skip.clone();
+        move |_| Box::new(pluginfs::Provider::new(fs_skip))
+    })?;
+    e.register_driver(Box::new(pluginfs::Driver::new(fs_skip)))?;
     e.register_provider(|_| Box::new(pluginhostbin::Provider))?;
     e.register_driver(Box::new(pluginhostbin::Driver))?;
     e.register_driver(Box::new(plugintextfile::Driver))?;
@@ -250,8 +255,12 @@ mod tests {
             ..Default::default()
         })?;
 
-        e.register_provider(|_| Box::new(pluginfs::Provider))?;
-        e.register_driver(Box::new(pluginfs::Driver))?;
+        let fs_skip = std::sync::Arc::new(pluginfs::FsSkip::new(dir.path(), &e.skip_dirs())?);
+        e.register_provider({
+            let fs_skip = fs_skip.clone();
+            move |_| Box::new(pluginfs::Provider::new(fs_skip))
+        })?;
+        e.register_driver(Box::new(pluginfs::Driver::new(fs_skip)))?;
         e.register_provider(|_| Box::new(pluginhostbin::Provider))?;
         e.register_driver(Box::new(pluginhostbin::Driver))?;
         e.register_driver(Box::new(plugintextfile::Driver))?;

--- a/src/commands/bootstrap.rs
+++ b/src/commands/bootstrap.rs
@@ -121,19 +121,19 @@ pub fn new_engine() -> anyhow::Result<(Arc<engine::Engine>, ShutdownTrigger)> {
     let mut e = engine::Engine::new(engine::Config {
         root: root.clone(),
         home_dir: home_dir.clone(),
-        skip: file.skip.clone(),
         parallelism: None,
         mem_cache,
         fuse,
         lock_backend,
     })?;
 
-    // Auto-registered built-ins (no options). The fs plugin prunes the engine's
-    // own skip dirs (the heph home) plus the config file's extra `skip` globs.
+    // Auto-registered built-ins. The fs plugin prunes the engine's own skip dirs
+    // (the heph home) plus the `fs.skip` globs from the config file.
+    let fs_skip_globs = file.fs.map(|f| f.skip).unwrap_or_default();
     let fs_skip = std::sync::Arc::new(pluginfs::FsSkip::new(
         &root,
         &e.skip_dirs(),
-        e.skip_globs(),
+        &fs_skip_globs,
     )?);
     e.register_provider({
         let fs_skip = fs_skip.clone();
@@ -256,15 +256,15 @@ mod tests {
         let mut e = engine::Engine::new(engine::Config {
             root,
             home_dir: home_dir.clone(),
-            skip: file.skip.clone(),
             parallelism: None,
             ..Default::default()
         })?;
 
+        let fs_skip_globs = file.fs.map(|f| f.skip).unwrap_or_default();
         let fs_skip = std::sync::Arc::new(pluginfs::FsSkip::new(
             dir.path(),
             &e.skip_dirs(),
-            e.skip_globs(),
+            &fs_skip_globs,
         )?);
         e.register_provider({
             let fs_skip = fs_skip.clone();

--- a/src/commands/bootstrap.rs
+++ b/src/commands/bootstrap.rs
@@ -310,7 +310,11 @@ fs:
             "{:?}",
             e.skip_dirs()
         );
-        assert_eq!(e.skip_globs(), vec!["**/node_modules/**".to_string()]);
+        // `.git` is an always-on engine built-in, ahead of the config globs.
+        assert_eq!(
+            e.skip_globs(),
+            vec!["**/.git/**".to_string(), "**/node_modules/**".to_string()]
+        );
         assert!(e.providers_by_name.contains_key("fs"));
         assert!(e.drivers_by_name.contains_key("fs"));
     }

--- a/src/commands/bootstrap.rs
+++ b/src/commands/bootstrap.rs
@@ -138,16 +138,16 @@ pub fn new_engine() -> anyhow::Result<(Arc<engine::Engine>, ShutdownTrigger)> {
     e.register_provider_factory("buildfile", |init, opts| {
         Ok(Box::new(pluginbuildfile::Provider::from_options(
             init.root.to_path_buf(),
-            init.skip_dirs,
-            init.skip_globs,
+            &init.skip_dirs,
+            &init.skip_globs,
             opts,
         )?))
     })?;
     e.register_provider_factory("go", |init, opts| {
         Ok(Box::new(plugingo::Provider::from_options(
             init.root.to_path_buf(),
-            init.skip_dirs,
-            init.skip_globs,
+            &init.skip_dirs,
+            &init.skip_globs,
             opts,
         )?))
     })?;
@@ -261,8 +261,8 @@ mod tests {
         e.register_provider_factory("buildfile", |init, opts| {
             Ok(Box::new(pluginbuildfile::Provider::from_options(
                 init.root.to_path_buf(),
-                init.skip_dirs,
-                init.skip_globs,
+                &init.skip_dirs,
+                &init.skip_globs,
                 opts,
             )?))
         })?;

--- a/src/commands/completion.rs
+++ b/src/commands/completion.rs
@@ -222,10 +222,10 @@ mod tests {
         })
         .expect("engine");
 
-        e.register_provider_factory("buildfile", |root, skip_dirs, opts| {
+        e.register_provider_factory("buildfile", |root, skip, opts| {
             Ok(Box::new(pluginbuildfile::Provider::from_options(
                 root.to_path_buf(),
-                skip_dirs,
+                skip,
                 opts,
             )?))
         })

--- a/src/commands/completion.rs
+++ b/src/commands/completion.rs
@@ -222,10 +222,11 @@ mod tests {
         })
         .expect("engine");
 
-        e.register_provider_factory("buildfile", |root, skip, opts| {
+        e.register_provider_factory("buildfile", |init, opts| {
             Ok(Box::new(pluginbuildfile::Provider::from_options(
-                root.to_path_buf(),
-                skip,
+                init.root.to_path_buf(),
+                init.skip_dirs,
+                init.skip_globs,
                 opts,
             )?))
         })

--- a/src/commands/completion.rs
+++ b/src/commands/completion.rs
@@ -225,8 +225,8 @@ mod tests {
         e.register_provider_factory("buildfile", |init, opts| {
             Ok(Box::new(pluginbuildfile::Provider::from_options(
                 init.root.to_path_buf(),
-                init.skip_dirs,
-                init.skip_globs,
+                &init.skip_dirs,
+                &init.skip_globs,
                 opts,
             )?))
         })

--- a/src/engine/config_file.rs
+++ b/src/engine/config_file.rs
@@ -12,11 +12,6 @@ pub type Options = BTreeMap<String, serde_yaml::Value>;
 pub struct ConfigFile {
     #[serde(default)]
     pub home_dir: Option<PathBuf>,
-    /// Extra workspace-relative glob patterns the `fs` plugin excludes from every
-    /// glob walk, on top of the always-skipped `.git` and engine-owned dirs.
-    /// Matched against file paths like a target's own `exclude`.
-    #[serde(default)]
-    pub skip: Vec<String>,
     #[serde(default)]
     pub providers: Vec<PluginEntry>,
     #[serde(default)]
@@ -27,6 +22,20 @@ pub struct ConfigFile {
     pub fuse: Option<FuseConfig>,
     #[serde(default)]
     pub lock: Option<LockConfig>,
+    /// Config for the built-in `fs` provider/driver.
+    #[serde(default)]
+    pub fs: Option<FsConfig>,
+}
+
+/// Config for the built-in `fs` provider/driver. `fs: { skip: [glob, ...] }`.
+#[derive(Debug, Deserialize, Default, Clone)]
+#[serde(deny_unknown_fields, rename_all = "camelCase")]
+pub struct FsConfig {
+    /// Extra workspace-relative glob patterns the `fs` plugin excludes from every
+    /// glob walk, on top of the always-skipped `.git` and engine-owned dirs.
+    /// Matched against file paths like a target's own `exclude`.
+    #[serde(default)]
+    pub skip: Vec<String>,
 }
 
 #[derive(Debug, Deserialize, Clone, Copy)]
@@ -222,19 +231,26 @@ drivers:
     }
 
     #[test]
-    fn parses_top_level_skip() {
-        let yaml = "skip:\n  - vendor/**\n  - \"**/*.tmp\"\n";
+    fn parses_fs_skip() {
+        let yaml = "fs:\n  skip:\n    - vendor/**\n    - \"**/*.tmp\"\n";
         let cfg: ConfigFile = serde_yaml::from_str(yaml).expect("parse");
+        let fs = cfg.fs.expect("fs config present");
         assert_eq!(
-            cfg.skip,
+            fs.skip,
             vec!["vendor/**".to_string(), "**/*.tmp".to_string()]
         );
     }
 
     #[test]
-    fn skip_defaults_empty() {
+    fn fs_config_defaults_absent() {
         let cfg: ConfigFile = serde_yaml::from_str("homeDir: .heph3\n").expect("parse");
-        assert!(cfg.skip.is_empty());
+        assert!(cfg.fs.is_none());
+    }
+
+    #[test]
+    fn rejects_unknown_fs_field() {
+        let err = serde_yaml::from_str::<ConfigFile>("fs:\n  bogus: 1\n").expect_err("must reject");
+        assert!(err.to_string().contains("bogus"), "{err}");
     }
 
     #[test]

--- a/src/engine/config_file.rs
+++ b/src/engine/config_file.rs
@@ -232,12 +232,13 @@ drivers:
 
     #[test]
     fn parses_fs_skip() {
-        let yaml = "fs:\n  skip: [vendor, third_party/foo]\n";
+        // `skip` mixes literal dirs and glob patterns.
+        let yaml = "fs:\n  skip: [vendor, \"**/node_modules/**\"]\n";
         let cfg: ConfigFile = serde_yaml::from_str(yaml).expect("parse");
         let fs = cfg.fs.expect("fs config present");
         assert_eq!(
             fs.skip,
-            vec!["vendor".to_string(), "third_party/foo".to_string()]
+            vec!["vendor".to_string(), "**/node_modules/**".to_string()]
         );
     }
 

--- a/src/engine/config_file.rs
+++ b/src/engine/config_file.rs
@@ -12,6 +12,11 @@ pub type Options = BTreeMap<String, serde_yaml::Value>;
 pub struct ConfigFile {
     #[serde(default)]
     pub home_dir: Option<PathBuf>,
+    /// Extra workspace-relative glob patterns the `fs` plugin excludes from every
+    /// glob walk, on top of the always-skipped `.git` and engine-owned dirs.
+    /// Matched against file paths like a target's own `exclude`.
+    #[serde(default)]
+    pub skip: Vec<String>,
     #[serde(default)]
     pub providers: Vec<PluginEntry>,
     #[serde(default)]
@@ -214,6 +219,22 @@ drivers:
             .expect("present");
         assert_eq!(patterns, vec!["BUILD2".to_string(), "*.BUILD2".to_string()]);
         assert_eq!(cfg.drivers.len(), 2);
+    }
+
+    #[test]
+    fn parses_top_level_skip() {
+        let yaml = "skip:\n  - vendor/**\n  - \"**/*.tmp\"\n";
+        let cfg: ConfigFile = serde_yaml::from_str(yaml).expect("parse");
+        assert_eq!(
+            cfg.skip,
+            vec!["vendor/**".to_string(), "**/*.tmp".to_string()]
+        );
+    }
+
+    #[test]
+    fn skip_defaults_empty() {
+        let cfg: ConfigFile = serde_yaml::from_str("homeDir: .heph3\n").expect("parse");
+        assert!(cfg.skip.is_empty());
     }
 
     #[test]

--- a/src/engine/config_file.rs
+++ b/src/engine/config_file.rs
@@ -22,20 +22,6 @@ pub struct ConfigFile {
     pub fuse: Option<FuseConfig>,
     #[serde(default)]
     pub lock: Option<LockConfig>,
-    /// Config for the built-in `fs` provider/driver.
-    #[serde(default)]
-    pub fs: Option<FsConfig>,
-}
-
-/// Config for the built-in `fs` provider/driver. `fs: { skip: [glob, ...] }`.
-#[derive(Debug, Deserialize, Default, Clone)]
-#[serde(deny_unknown_fields, rename_all = "camelCase")]
-pub struct FsConfig {
-    /// Extra workspace-relative glob patterns the `fs` plugin excludes from every
-    /// glob walk, on top of the always-skipped `.git` and engine-owned dirs.
-    /// Matched against file paths like a target's own `exclude`.
-    #[serde(default)]
-    pub skip: Vec<String>,
 }
 
 #[derive(Debug, Deserialize, Clone, Copy)]
@@ -138,7 +124,7 @@ pub enum LockBackendConfig {
     Mem,
 }
 
-#[derive(Debug, Deserialize)]
+#[derive(Debug, Deserialize, Clone)]
 #[serde(deny_unknown_fields)]
 pub struct PluginEntry {
     pub name: String,
@@ -231,26 +217,15 @@ drivers:
     }
 
     #[test]
-    fn parses_fs_skip() {
-        let yaml = "fs:\n  skip:\n    - vendor/**\n    - \"**/*.tmp\"\n";
+    fn parses_fs_driver_skip_option() {
+        let yaml = "drivers:\n  - name: fs\n    options:\n      skip: [vendor/**, \"**/*.tmp\"]\n";
         let cfg: ConfigFile = serde_yaml::from_str(yaml).expect("parse");
-        let fs = cfg.fs.expect("fs config present");
-        assert_eq!(
-            fs.skip,
-            vec!["vendor/**".to_string(), "**/*.tmp".to_string()]
-        );
-    }
-
-    #[test]
-    fn fs_config_defaults_absent() {
-        let cfg: ConfigFile = serde_yaml::from_str("homeDir: .heph3\n").expect("parse");
-        assert!(cfg.fs.is_none());
-    }
-
-    #[test]
-    fn rejects_unknown_fs_field() {
-        let err = serde_yaml::from_str::<ConfigFile>("fs:\n  bogus: 1\n").expect_err("must reject");
-        assert!(err.to_string().contains("bogus"), "{err}");
+        assert_eq!(cfg.drivers.len(), 1);
+        assert_eq!(cfg.drivers[0].name, "fs");
+        let skip: Vec<String> = decode_opt(&cfg.drivers[0].options, "fs driver", "skip")
+            .expect("decode")
+            .expect("present");
+        assert_eq!(skip, vec!["vendor/**".to_string(), "**/*.tmp".to_string()]);
     }
 
     #[test]

--- a/src/engine/config_file.rs
+++ b/src/engine/config_file.rs
@@ -22,6 +22,19 @@ pub struct ConfigFile {
     pub fuse: Option<FuseConfig>,
     #[serde(default)]
     pub lock: Option<LockConfig>,
+    #[serde(default)]
+    pub fs: Option<FsConfig>,
+}
+
+/// Filesystem-walk config shared across plugins. `fs: { skip: [glob, ...] }`.
+/// The engine hands `skip` to every plugin factory that walks the tree (the
+/// built-in `fs` plugin, the buildfile/go providers), so it prunes the same
+/// workspace-relative paths everywhere.
+#[derive(Debug, Deserialize, Default, Clone)]
+#[serde(deny_unknown_fields, rename_all = "camelCase")]
+pub struct FsConfig {
+    #[serde(default)]
+    pub skip: Vec<String>,
 }
 
 #[derive(Debug, Deserialize, Clone, Copy)]
@@ -217,15 +230,26 @@ drivers:
     }
 
     #[test]
-    fn parses_fs_driver_skip_option() {
-        let yaml = "drivers:\n  - name: fs\n    options:\n      skip: [vendor/**, \"**/*.tmp\"]\n";
+    fn parses_fs_skip() {
+        let yaml = "fs:\n  skip: [vendor/**, \"**/*.tmp\"]\n";
         let cfg: ConfigFile = serde_yaml::from_str(yaml).expect("parse");
-        assert_eq!(cfg.drivers.len(), 1);
-        assert_eq!(cfg.drivers[0].name, "fs");
-        let skip: Vec<String> = decode_opt(&cfg.drivers[0].options, "fs driver", "skip")
-            .expect("decode")
-            .expect("present");
-        assert_eq!(skip, vec!["vendor/**".to_string(), "**/*.tmp".to_string()]);
+        let fs = cfg.fs.expect("fs config present");
+        assert_eq!(
+            fs.skip,
+            vec!["vendor/**".to_string(), "**/*.tmp".to_string()]
+        );
+    }
+
+    #[test]
+    fn fs_config_defaults_absent() {
+        let cfg: ConfigFile = serde_yaml::from_str("homeDir: .heph3\n").expect("parse");
+        assert!(cfg.fs.is_none());
+    }
+
+    #[test]
+    fn rejects_unknown_fs_field() {
+        let err = serde_yaml::from_str::<ConfigFile>("fs:\n  bogus: 1\n").expect_err("must reject");
+        assert!(err.to_string().contains("bogus"), "{err}");
     }
 
     #[test]

--- a/src/engine/config_file.rs
+++ b/src/engine/config_file.rs
@@ -124,7 +124,7 @@ pub enum LockBackendConfig {
     Mem,
 }
 
-#[derive(Debug, Deserialize, Clone)]
+#[derive(Debug, Deserialize)]
 #[serde(deny_unknown_fields)]
 pub struct PluginEntry {
     pub name: String,

--- a/src/engine/config_file.rs
+++ b/src/engine/config_file.rs
@@ -26,10 +26,11 @@ pub struct ConfigFile {
     pub fs: Option<FsConfig>,
 }
 
-/// Filesystem-walk config shared across plugins. `fs: { skip: [glob, ...] }`.
-/// The engine hands `skip` to every plugin factory that walks the tree (the
-/// built-in `fs` plugin, the buildfile/go providers), so it prunes the same
-/// workspace-relative paths everywhere.
+/// Filesystem-walk config shared across plugins. `fs: { skip: [dir, ...] }`.
+/// Each `skip` entry is a directory path relative to the repo root (no globs);
+/// the engine resolves them to absolute paths and hands them to every plugin
+/// that walks the tree (the built-in `fs` plugin, the buildfile/go providers),
+/// so every walk prunes the same directories.
 #[derive(Debug, Deserialize, Default, Clone)]
 #[serde(deny_unknown_fields, rename_all = "camelCase")]
 pub struct FsConfig {
@@ -231,12 +232,12 @@ drivers:
 
     #[test]
     fn parses_fs_skip() {
-        let yaml = "fs:\n  skip: [vendor/**, \"**/*.tmp\"]\n";
+        let yaml = "fs:\n  skip: [vendor, third_party/foo]\n";
         let cfg: ConfigFile = serde_yaml::from_str(yaml).expect("parse");
         let fs = cfg.fs.expect("fs config present");
         assert_eq!(
             fs.skip,
-            vec!["vendor/**".to_string(), "**/*.tmp".to_string()]
+            vec!["vendor".to_string(), "third_party/foo".to_string()]
         );
     }
 

--- a/src/engine/engine.rs
+++ b/src/engine/engine.rs
@@ -55,21 +55,15 @@ impl Default for MemCacheOptions {
 ///
 /// [`skip_dirs`]: PluginInit::skip_dirs
 /// [`skip_globs`]: PluginInit::skip_globs
-pub struct PluginInit<'a> {
-    pub root: &'a Path,
+pub struct PluginInit {
+    pub root: PathBuf,
     /// Absolute directories to prune by exact path: the heph home plus the
     /// literal (non-glob) `fs.skip` entries, resolved relative to the repo root.
-    pub skip_dirs: &'a [PathBuf],
+    pub skip_dirs: Vec<PathBuf>,
     /// Workspace-relative `fs.skip` glob patterns (e.g. `**/node_modules/**`),
     /// matched against entry paths.
-    pub skip_globs: &'a [String],
+    pub skip_globs: Vec<String>,
 }
-
-/// Always-on exclude glob: a `.git` directory at any depth is never a build
-/// input (and submodules nest it). Handed to every tree-walking plugin via
-/// [`Engine::skip_globs`], so the fs plugin and the buildfile/go providers all
-/// prune it without each hardcoding the rule.
-const GIT_SKIP_GLOB: &str = "**/.git/**";
 
 /// True if `entry` contains wax glob metacharacters — used to split `fs.skip`
 /// into literal directories vs glob patterns.
@@ -443,10 +437,14 @@ impl Engine {
         });
     }
 
-    /// Builds the owned data backing a [`PluginInit`] (`root`, skip dirs, skip
-    /// globs). Borrow the parts into a `PluginInit` at the call site.
-    fn plugin_init_parts(&self) -> (PathBuf, Vec<PathBuf>, Vec<String>) {
-        (self.cfg.root.clone(), self.skip_dirs(), self.skip_globs())
+    /// The [`PluginInit`] context handed to every plugin constructor (direct
+    /// registration or factory): workspace root + the engine's skip dirs/globs.
+    fn plugin_init_payload(&self) -> PluginInit {
+        PluginInit {
+            root: self.cfg.root.clone(),
+            skip_dirs: self.skip_dirs(),
+            skip_globs: self.skip_globs(),
+        }
     }
 
     /// Registers an already-constructed driver. Shared by [`Self::register_driver`]
@@ -472,12 +470,7 @@ impl Engine {
         &mut self,
         factory: impl FnOnce(&PluginInit) -> Box<dyn SDKManagedDriver>,
     ) -> anyhow::Result<()> {
-        let (root, skip_dirs, skip_globs) = self.plugin_init_parts();
-        let managed = factory(&PluginInit {
-            root: &root,
-            skip_dirs: &skip_dirs,
-            skip_globs: &skip_globs,
-        });
+        let managed = factory(&self.plugin_init_payload());
         let driver = self.new_managed_driver(managed);
         self.insert_driver(Box::new(driver))
     }
@@ -486,12 +479,7 @@ impl Engine {
         &mut self,
         factory: impl FnOnce(&PluginInit) -> Box<dyn SDKDriver>,
     ) -> anyhow::Result<()> {
-        let (root, skip_dirs, skip_globs) = self.plugin_init_parts();
-        let driver = factory(&PluginInit {
-            root: &root,
-            skip_dirs: &skip_dirs,
-            skip_globs: &skip_globs,
-        });
+        let driver = factory(&self.plugin_init_payload());
         self.insert_driver(driver)
     }
 
@@ -499,12 +487,7 @@ impl Engine {
         &mut self,
         factory: impl FnOnce(&PluginInit) -> Box<dyn SDKProvider>,
     ) -> anyhow::Result<()> {
-        let (root, skip_dirs, skip_globs) = self.plugin_init_parts();
-        let provider = factory(&PluginInit {
-            root: &root,
-            skip_dirs: &skip_dirs,
-            skip_globs: &skip_globs,
-        });
+        let provider = factory(&self.plugin_init_payload());
 
         let provider = Arc::new(Provider {
             name: provider.config(provider::ConfigRequest {})?.name,
@@ -597,10 +580,11 @@ impl Engine {
     }
 
     /// Exclude globs every tree-walking plugin honors: the always-on `.git`
-    /// exclusion plus the glob `fs.skip` entries (e.g. `**/node_modules/**`),
-    /// matched against workspace-relative paths.
+    /// exclusion (a `.git` dir is never a build input, and submodules nest it)
+    /// plus the glob `fs.skip` entries (e.g. `**/node_modules/**`), matched
+    /// against workspace-relative paths.
     pub fn skip_globs(&self) -> Vec<String> {
-        std::iter::once(GIT_SKIP_GLOB.to_string())
+        std::iter::once("**/.git/**".to_string())
             .chain(self.cfg.fs_skip.iter().filter(|e| is_skip_glob(e)).cloned())
             .collect()
     }
@@ -613,12 +597,7 @@ impl Engine {
         providers: &[PluginEntry],
         drivers: &[PluginEntry],
     ) -> anyhow::Result<()> {
-        let (root, skip_dirs, skip_globs) = self.plugin_init_parts();
-        let init = PluginInit {
-            root: &root,
-            skip_dirs: &skip_dirs,
-            skip_globs: &skip_globs,
-        };
+        let init = self.plugin_init_payload();
         for entry in providers {
             let factory = self
                 .provider_factories

--- a/src/engine/engine.rs
+++ b/src/engine/engine.rs
@@ -21,6 +21,9 @@ pub struct Config {
     pub root: PathBuf,
     /// Workspace state/cache directory. If empty, defaults to `root/.heph3`.
     pub home_dir: PathBuf,
+    /// Extra workspace-relative glob patterns the `fs` plugin excludes from every
+    /// glob walk (from the config file's top-level `skip`).
+    pub skip: Vec<String>,
     pub parallelism: Option<usize>,
     pub mem_cache: MemCacheOptions,
     pub fuse: FuseConfig,
@@ -504,6 +507,12 @@ impl Engine {
     /// the same engine-owned subtrees.
     pub fn skip_dirs(&self) -> Vec<PathBuf> {
         vec![self.home.clone()]
+    }
+
+    /// Extra workspace-relative exclude globs from the config file's `skip`,
+    /// applied to every `fs` glob walk on top of [`Engine::skip_dirs`].
+    pub fn skip_globs(&self) -> &[String] {
+        &self.cfg.skip
     }
 
     /// Instantiates every provider/driver listed in the entries by looking up the

--- a/src/engine/engine.rs
+++ b/src/engine/engine.rs
@@ -65,6 +65,12 @@ pub struct PluginInit<'a> {
     pub skip_globs: &'a [String],
 }
 
+/// Always-on exclude glob: a `.git` directory at any depth is never a build
+/// input (and submodules nest it). Handed to every tree-walking plugin via
+/// [`Engine::skip_globs`], so the fs plugin and the buildfile/go providers all
+/// prune it without each hardcoding the rule.
+const GIT_SKIP_GLOB: &str = "**/.git/**";
+
 /// True if `entry` contains wax glob metacharacters — used to split `fs.skip`
 /// into literal directories vs glob patterns.
 pub(crate) fn is_skip_glob(entry: &str) -> bool {
@@ -591,14 +597,12 @@ impl Engine {
         dirs
     }
 
-    /// The glob `fs.skip` entries (e.g. `**/node_modules/**`), matched against
-    /// workspace-relative paths by every tree-walking plugin.
+    /// Exclude globs every tree-walking plugin honors: the always-on `.git`
+    /// exclusion plus the glob `fs.skip` entries (e.g. `**/node_modules/**`),
+    /// matched against workspace-relative paths.
     pub fn skip_globs(&self) -> Vec<String> {
-        self.cfg
-            .fs_skip
-            .iter()
-            .filter(|e| is_skip_glob(e))
-            .cloned()
+        std::iter::once(GIT_SKIP_GLOB.to_string())
+            .chain(self.cfg.fs_skip.iter().filter(|e| is_skip_glob(e)).cloned())
             .collect()
     }
 

--- a/src/engine/engine.rs
+++ b/src/engine/engine.rs
@@ -21,9 +21,6 @@ pub struct Config {
     pub root: PathBuf,
     /// Workspace state/cache directory. If empty, defaults to `root/.heph3`.
     pub home_dir: PathBuf,
-    /// Extra workspace-relative glob patterns the `fs` plugin excludes from every
-    /// glob walk (from the config file's top-level `skip`).
-    pub skip: Vec<String>,
     pub parallelism: Option<usize>,
     pub mem_cache: MemCacheOptions,
     pub fuse: FuseConfig,
@@ -507,12 +504,6 @@ impl Engine {
     /// the same engine-owned subtrees.
     pub fn skip_dirs(&self) -> Vec<PathBuf> {
         vec![self.home.clone()]
-    }
-
-    /// Extra workspace-relative exclude globs from the config file's `skip`,
-    /// applied to every `fs` glob walk on top of [`Engine::skip_dirs`].
-    pub fn skip_globs(&self) -> &[String] {
-        &self.cfg.skip
     }
 
     /// Instantiates every provider/driver listed in the entries by looking up the

--- a/src/engine/engine.rs
+++ b/src/engine/engine.rs
@@ -365,20 +365,24 @@ impl Engine {
         engine.register_driver(|_| Box::new(crate::plugingroup::Driver))?;
         engine.register_provider(|_| Box::new(crate::pluginquery::Provider))?;
 
-        // The `fs` provider + driver are always-on built-ins. The engine owns
-        // their ignore set (home + `fs.skip` dirs/globs) and builds it once from
-        // the same data it hands every plugin via `PluginInit`, so every fs glob
-        // walk prunes the same paths. Provider + driver share one `Ignore` so
-        // BUILD-time `glob()` and the run-time walk agree.
-        let fs_skip = Arc::new(crate::htwalk::Ignore::new(
-            &engine.skip_dirs(),
-            &engine.skip_globs(),
-        )?);
-        engine.register_provider({
-            let fs_skip = fs_skip.clone();
-            move |_| Box::new(crate::pluginfs::Provider::new(fs_skip))
+        // The `fs` provider + driver are always-on built-ins. Each builds its
+        // `Ignore` from the same `PluginInit` (home + `fs.skip` dirs/globs) the
+        // engine hands every plugin, so every fs glob walk prunes the same paths.
+        // The fallible variant lets a bad `fs.skip` glob surface as an error here.
+        engine.try_register_provider(|init| {
+            let ignore = Arc::new(crate::htwalk::Ignore::new(
+                &init.skip_dirs,
+                &init.skip_globs,
+            )?);
+            Ok(Box::new(crate::pluginfs::Provider::new(ignore)))
         })?;
-        engine.register_driver(move |_| Box::new(crate::pluginfs::Driver::new(fs_skip)))?;
+        engine.try_register_driver(|init| {
+            let ignore = Arc::new(crate::htwalk::Ignore::new(
+                &init.skip_dirs,
+                &init.skip_globs,
+            )?);
+            Ok(Box::new(crate::pluginfs::Driver::new(ignore)))
+        })?;
 
         Ok(engine)
     }
@@ -479,7 +483,16 @@ impl Engine {
         &mut self,
         factory: impl FnOnce(&PluginInit) -> Box<dyn SDKDriver>,
     ) -> anyhow::Result<()> {
-        let driver = factory(&self.plugin_init_payload());
+        self.try_register_driver(|init| Ok(factory(init)))
+    }
+
+    /// Like [`Self::register_driver`], but the factory may fail (e.g. compiling a
+    /// glob set). The error propagates out of registration.
+    pub fn try_register_driver(
+        &mut self,
+        factory: impl FnOnce(&PluginInit) -> anyhow::Result<Box<dyn SDKDriver>>,
+    ) -> anyhow::Result<()> {
+        let driver = factory(&self.plugin_init_payload())?;
         self.insert_driver(driver)
     }
 
@@ -487,7 +500,16 @@ impl Engine {
         &mut self,
         factory: impl FnOnce(&PluginInit) -> Box<dyn SDKProvider>,
     ) -> anyhow::Result<()> {
-        let provider = factory(&self.plugin_init_payload());
+        self.try_register_provider(|init| Ok(factory(init)))
+    }
+
+    /// Like [`Self::register_provider`], but the factory may fail (e.g. compiling
+    /// a glob set). The error propagates out of registration.
+    pub fn try_register_provider(
+        &mut self,
+        factory: impl FnOnce(&PluginInit) -> anyhow::Result<Box<dyn SDKProvider>>,
+    ) -> anyhow::Result<()> {
+        let provider = factory(&self.plugin_init_payload())?;
 
         let provider = Arc::new(Provider {
             name: provider.config(provider::ConfigRequest {})?.name,

--- a/src/engine/engine.rs
+++ b/src/engine/engine.rs
@@ -21,8 +21,8 @@ pub struct Config {
     pub root: PathBuf,
     /// Workspace state/cache directory. If empty, defaults to `root/.heph3`.
     pub home_dir: PathBuf,
-    /// Workspace-relative exclude globs from the config file's `fs.skip`, handed
-    /// to every plugin that walks the tree. See [`SkipConfig`].
+    /// Repo-root-relative directories from the config file's `fs.skip`, pruned by
+    /// every plugin that walks the tree. See [`Engine::skip_dirs`].
     pub fs_skip: Vec<String>,
     pub parallelism: Option<usize>,
     pub mem_cache: MemCacheOptions,
@@ -47,20 +47,10 @@ impl Default for MemCacheOptions {
     }
 }
 
-/// Filesystem-walk config the engine hands to every plugin factory that walks
-/// the workspace tree, so they prune the same paths. `dirs` are absolute
-/// engine-owned directories (e.g. the heph home) matched by exact path; `globs`
-/// are workspace-relative exclude patterns from the config file's `fs.skip`.
-#[derive(Debug, Clone, Default)]
-pub struct SkipConfig {
-    pub dirs: Vec<PathBuf>,
-    pub globs: Vec<String>,
-}
-
-/// Factory args: workspace root, the engine's filesystem-skip config (see
-/// [`SkipConfig`]), and the provider's YAML options.
+/// Factory args: workspace root, the absolute directories every walk must prune
+/// (see [`Engine::skip_dirs`]), and the provider's YAML options.
 pub type ProviderFactory = Box<
-    dyn FnOnce(&Path, &SkipConfig, &Options) -> anyhow::Result<Box<dyn SDKProvider>> + Send + Sync,
+    dyn FnOnce(&Path, &[PathBuf], &Options) -> anyhow::Result<Box<dyn SDKProvider>> + Send + Sync,
 >;
 pub type DriverFactory =
     Box<dyn FnOnce(&Options) -> anyhow::Result<Box<dyn SDKDriver>> + Send + Sync>;
@@ -459,7 +449,7 @@ impl Engine {
     pub fn register_provider_factory(
         &mut self,
         name: &str,
-        factory: impl FnOnce(&Path, &SkipConfig, &Options) -> anyhow::Result<Box<dyn SDKProvider>>
+        factory: impl FnOnce(&Path, &[PathBuf], &Options) -> anyhow::Result<Box<dyn SDKProvider>>
         + Send
         + Sync
         + 'static,
@@ -511,14 +501,14 @@ impl Engine {
         Ok(())
     }
 
-    /// Filesystem-skip config handed to every plugin that walks the tree: the
-    /// engine-owned dirs to prune (the heph home, holding cache/sandboxes/locks —
-    /// never packages) plus the config file's `fs.skip` globs.
-    pub fn skip_config(&self) -> SkipConfig {
-        SkipConfig {
-            dirs: vec![self.home.clone()],
-            globs: self.cfg.fs_skip.clone(),
-        }
+    /// Absolute directories every plugin that walks the tree must prune: the
+    /// engine-owned home (cache/sandboxes/locks — never packages) plus the config
+    /// file's `fs.skip` dirs, resolved relative to the repo root.
+    pub fn skip_dirs(&self) -> Vec<PathBuf> {
+        let mut dirs = Vec::with_capacity(1 + self.cfg.fs_skip.len());
+        dirs.push(self.home.clone());
+        dirs.extend(self.cfg.fs_skip.iter().map(|rel| self.cfg.root.join(rel)));
+        dirs
     }
 
     /// Instantiates every provider/driver listed in the entries by looking up the
@@ -530,13 +520,13 @@ impl Engine {
         drivers: &[PluginEntry],
     ) -> anyhow::Result<()> {
         let root = self.cfg.root.clone();
-        let skip = self.skip_config();
+        let skip_dirs = self.skip_dirs();
         for entry in providers {
             let factory = self
                 .provider_factories
                 .remove(&entry.name)
                 .ok_or_else(|| anyhow::anyhow!("unknown provider '{}'", entry.name))?;
-            let provider = factory(&root, &skip, &entry.options)?;
+            let provider = factory(&root, &skip_dirs, &entry.options)?;
             let resolved_name = provider.config(provider::ConfigRequest {})?.name;
             if resolved_name != entry.name {
                 return Err(anyhow::anyhow!(

--- a/src/engine/engine.rs
+++ b/src/engine/engine.rs
@@ -372,12 +372,11 @@ impl Engine {
         engine.register_provider(|_| Box::new(crate::pluginquery::Provider))?;
 
         // The `fs` provider + driver are always-on built-ins. The engine owns
-        // their skip set (home + `fs.skip` dirs/globs) and builds it once from the
-        // same data it hands every plugin via `PluginInit`, so every fs glob walk
-        // prunes the same paths. Provider + driver share one `FsSkip` so BUILD-time
-        // `glob()` and the run-time walk agree.
-        let fs_skip = Arc::new(crate::pluginfs::FsSkip::new(
-            &root,
+        // their ignore set (home + `fs.skip` dirs/globs) and builds it once from
+        // the same data it hands every plugin via `PluginInit`, so every fs glob
+        // walk prunes the same paths. Provider + driver share one `Ignore` so
+        // BUILD-time `glob()` and the run-time walk agree.
+        let fs_skip = Arc::new(crate::htwalk::Ignore::new(
             &engine.skip_dirs(),
             &engine.skip_globs(),
         )?);

--- a/src/engine/engine.rs
+++ b/src/engine/engine.rs
@@ -547,6 +547,10 @@ impl Engine {
             } else if let Some(factory) = self.managed_driver_factories.remove(&entry.name) {
                 let driver = factory(&entry.options)?;
                 self.register_managed_driver(driver)?;
+            } else if self.drivers_by_name.contains_key(&entry.name) {
+                // A built-in registered directly (e.g. `fs`) may be listed to
+                // carry options, which are consumed where it is registered. The
+                // entry is allowed here but does not re-instantiate the driver.
             } else {
                 return Err(anyhow::anyhow!("unknown driver '{}'", entry.name));
             }

--- a/src/engine/engine.rs
+++ b/src/engine/engine.rs
@@ -21,6 +21,9 @@ pub struct Config {
     pub root: PathBuf,
     /// Workspace state/cache directory. If empty, defaults to `root/.heph3`.
     pub home_dir: PathBuf,
+    /// Workspace-relative exclude globs from the config file's `fs.skip`, handed
+    /// to every plugin that walks the tree. See [`SkipConfig`].
+    pub fs_skip: Vec<String>,
     pub parallelism: Option<usize>,
     pub mem_cache: MemCacheOptions,
     pub fuse: FuseConfig,
@@ -44,10 +47,20 @@ impl Default for MemCacheOptions {
     }
 }
 
-/// Factory args: workspace root, the engine-owned directories every provider
-/// must skip (e.g. the heph home dir), and the provider's YAML options.
+/// Filesystem-walk config the engine hands to every plugin factory that walks
+/// the workspace tree, so they prune the same paths. `dirs` are absolute
+/// engine-owned directories (e.g. the heph home) matched by exact path; `globs`
+/// are workspace-relative exclude patterns from the config file's `fs.skip`.
+#[derive(Debug, Clone, Default)]
+pub struct SkipConfig {
+    pub dirs: Vec<PathBuf>,
+    pub globs: Vec<String>,
+}
+
+/// Factory args: workspace root, the engine's filesystem-skip config (see
+/// [`SkipConfig`]), and the provider's YAML options.
 pub type ProviderFactory = Box<
-    dyn FnOnce(&Path, &[PathBuf], &Options) -> anyhow::Result<Box<dyn SDKProvider>> + Send + Sync,
+    dyn FnOnce(&Path, &SkipConfig, &Options) -> anyhow::Result<Box<dyn SDKProvider>> + Send + Sync,
 >;
 pub type DriverFactory =
     Box<dyn FnOnce(&Options) -> anyhow::Result<Box<dyn SDKDriver>> + Send + Sync>;
@@ -446,7 +459,7 @@ impl Engine {
     pub fn register_provider_factory(
         &mut self,
         name: &str,
-        factory: impl FnOnce(&Path, &[PathBuf], &Options) -> anyhow::Result<Box<dyn SDKProvider>>
+        factory: impl FnOnce(&Path, &SkipConfig, &Options) -> anyhow::Result<Box<dyn SDKProvider>>
         + Send
         + Sync
         + 'static,
@@ -498,12 +511,14 @@ impl Engine {
         Ok(())
     }
 
-    /// Directories the engine owns and no provider/driver should walk into. The
-    /// home dir holds the local cache, sandboxes, locks — never packages. Handed
-    /// to provider factories (and the built-in `fs` plugin) so every walk prunes
-    /// the same engine-owned subtrees.
-    pub fn skip_dirs(&self) -> Vec<PathBuf> {
-        vec![self.home.clone()]
+    /// Filesystem-skip config handed to every plugin that walks the tree: the
+    /// engine-owned dirs to prune (the heph home, holding cache/sandboxes/locks —
+    /// never packages) plus the config file's `fs.skip` globs.
+    pub fn skip_config(&self) -> SkipConfig {
+        SkipConfig {
+            dirs: vec![self.home.clone()],
+            globs: self.cfg.fs_skip.clone(),
+        }
     }
 
     /// Instantiates every provider/driver listed in the entries by looking up the
@@ -515,13 +530,13 @@ impl Engine {
         drivers: &[PluginEntry],
     ) -> anyhow::Result<()> {
         let root = self.cfg.root.clone();
-        let skip_dirs = self.skip_dirs();
+        let skip = self.skip_config();
         for entry in providers {
             let factory = self
                 .provider_factories
                 .remove(&entry.name)
                 .ok_or_else(|| anyhow::anyhow!("unknown provider '{}'", entry.name))?;
-            let provider = factory(&root, &skip_dirs, &entry.options)?;
+            let provider = factory(&root, &skip, &entry.options)?;
             let resolved_name = provider.config(provider::ConfigRequest {})?.name;
             if resolved_name != entry.name {
                 return Err(anyhow::anyhow!(
@@ -547,10 +562,6 @@ impl Engine {
             } else if let Some(factory) = self.managed_driver_factories.remove(&entry.name) {
                 let driver = factory(&entry.options)?;
                 self.register_managed_driver(driver)?;
-            } else if self.drivers_by_name.contains_key(&entry.name) {
-                // A built-in registered directly (e.g. `fs`) may be listed to
-                // carry options, which are consumed where it is registered. The
-                // entry is allowed here but does not re-instantiate the driver.
             } else {
                 return Err(anyhow::anyhow!("unknown driver '{}'", entry.name));
             }

--- a/src/engine/engine.rs
+++ b/src/engine/engine.rs
@@ -47,15 +47,38 @@ impl Default for MemCacheOptions {
     }
 }
 
-/// Factory args: workspace root, the absolute directories every walk must prune
-/// (see [`Engine::skip_dirs`]), and the provider's YAML options.
-pub type ProviderFactory = Box<
-    dyn FnOnce(&Path, &[PathBuf], &Options) -> anyhow::Result<Box<dyn SDKProvider>> + Send + Sync,
->;
+/// Context the engine injects when constructing any plugin (provider, driver, or
+/// managed driver — whether registered directly or through a factory): the
+/// workspace root plus the filesystem-skip config every tree walk must honor.
+/// `fs.skip` entries are split by the engine into literal directories ([`skip_dirs`])
+/// and glob patterns ([`skip_globs`]).
+///
+/// [`skip_dirs`]: PluginInit::skip_dirs
+/// [`skip_globs`]: PluginInit::skip_globs
+pub struct PluginInit<'a> {
+    pub root: &'a Path,
+    /// Absolute directories to prune by exact path: the heph home plus the
+    /// literal (non-glob) `fs.skip` entries, resolved relative to the repo root.
+    pub skip_dirs: &'a [PathBuf],
+    /// Workspace-relative `fs.skip` glob patterns (e.g. `**/node_modules/**`),
+    /// matched against entry paths.
+    pub skip_globs: &'a [String],
+}
+
+/// True if `entry` contains wax glob metacharacters — used to split `fs.skip`
+/// into literal directories vs glob patterns.
+pub(crate) fn is_skip_glob(entry: &str) -> bool {
+    entry.contains(['*', '?', '[', ']', '{', '}'])
+}
+
+/// Factory args: the [`PluginInit`] context and the plugin's YAML options.
+pub type ProviderFactory =
+    Box<dyn FnOnce(&PluginInit, &Options) -> anyhow::Result<Box<dyn SDKProvider>> + Send + Sync>;
 pub type DriverFactory =
-    Box<dyn FnOnce(&Options) -> anyhow::Result<Box<dyn SDKDriver>> + Send + Sync>;
-pub type ManagedDriverFactory =
-    Box<dyn FnOnce(&Options) -> anyhow::Result<Box<dyn SDKManagedDriver>> + Send + Sync>;
+    Box<dyn FnOnce(&PluginInit, &Options) -> anyhow::Result<Box<dyn SDKDriver>> + Send + Sync>;
+pub type ManagedDriverFactory = Box<
+    dyn FnOnce(&PluginInit, &Options) -> anyhow::Result<Box<dyn SDKManagedDriver>> + Send + Sync,
+>;
 
 pub struct Engine {
     pub(crate) cfg: Config,
@@ -339,8 +362,25 @@ impl Engine {
             result_lock,
             provider_functions_wired: std::sync::Once::new(),
         };
-        engine.register_driver(Box::new(crate::plugingroup::Driver))?;
+        engine.register_driver(|_| Box::new(crate::plugingroup::Driver))?;
         engine.register_provider(|_| Box::new(crate::pluginquery::Provider))?;
+
+        // The `fs` provider + driver are always-on built-ins. The engine owns
+        // their skip set (home + `fs.skip` dirs/globs) and builds it once from the
+        // same data it hands every plugin via `PluginInit`, so every fs glob walk
+        // prunes the same paths. Provider + driver share one `FsSkip` so BUILD-time
+        // `glob()` and the run-time walk agree.
+        let fs_skip = Arc::new(crate::pluginfs::FsSkip::new(
+            &root,
+            &engine.skip_dirs(),
+            &engine.skip_globs(),
+        )?);
+        engine.register_provider({
+            let fs_skip = fs_skip.clone();
+            move |_| Box::new(crate::pluginfs::Provider::new(fs_skip))
+        })?;
+        engine.register_driver(move |_| Box::new(crate::pluginfs::Driver::new(fs_skip)))?;
+
         Ok(engine)
     }
 
@@ -398,15 +438,15 @@ impl Engine {
         });
     }
 
-    pub fn register_managed_driver(
-        &mut self,
-        driver: Box<dyn SDKManagedDriver>,
-    ) -> anyhow::Result<()> {
-        let driver = self.new_managed_driver(driver);
-        self.register_driver(Box::new(driver))
+    /// Builds the owned data backing a [`PluginInit`] (`root`, skip dirs, skip
+    /// globs). Borrow the parts into a `PluginInit` at the call site.
+    fn plugin_init_parts(&self) -> (PathBuf, Vec<PathBuf>, Vec<String>) {
+        (self.cfg.root.clone(), self.skip_dirs(), self.skip_globs())
     }
 
-    pub fn register_driver(&mut self, driver: Box<dyn SDKDriver>) -> anyhow::Result<()> {
+    /// Registers an already-constructed driver. Shared by [`Self::register_driver`]
+    /// and [`Self::register_managed_driver`].
+    fn insert_driver(&mut self, driver: Box<dyn SDKDriver>) -> anyhow::Result<()> {
         let driver = Arc::new(Driver {
             name: driver.config(driver::ConfigRequest {})?.name,
             driver,
@@ -423,11 +463,43 @@ impl Engine {
         Ok(())
     }
 
+    pub fn register_managed_driver(
+        &mut self,
+        factory: impl FnOnce(&PluginInit) -> Box<dyn SDKManagedDriver>,
+    ) -> anyhow::Result<()> {
+        let (root, skip_dirs, skip_globs) = self.plugin_init_parts();
+        let managed = factory(&PluginInit {
+            root: &root,
+            skip_dirs: &skip_dirs,
+            skip_globs: &skip_globs,
+        });
+        let driver = self.new_managed_driver(managed);
+        self.insert_driver(Box::new(driver))
+    }
+
+    pub fn register_driver(
+        &mut self,
+        factory: impl FnOnce(&PluginInit) -> Box<dyn SDKDriver>,
+    ) -> anyhow::Result<()> {
+        let (root, skip_dirs, skip_globs) = self.plugin_init_parts();
+        let driver = factory(&PluginInit {
+            root: &root,
+            skip_dirs: &skip_dirs,
+            skip_globs: &skip_globs,
+        });
+        self.insert_driver(driver)
+    }
+
     pub fn register_provider(
         &mut self,
-        provider_factory: impl FnOnce(&Path) -> Box<dyn SDKProvider>,
+        factory: impl FnOnce(&PluginInit) -> Box<dyn SDKProvider>,
     ) -> anyhow::Result<()> {
-        let provider = provider_factory(self.cfg.root.as_path());
+        let (root, skip_dirs, skip_globs) = self.plugin_init_parts();
+        let provider = factory(&PluginInit {
+            root: &root,
+            skip_dirs: &skip_dirs,
+            skip_globs: &skip_globs,
+        });
 
         let provider = Arc::new(Provider {
             name: provider.config(provider::ConfigRequest {})?.name,
@@ -449,7 +521,7 @@ impl Engine {
     pub fn register_provider_factory(
         &mut self,
         name: &str,
-        factory: impl FnOnce(&Path, &[PathBuf], &Options) -> anyhow::Result<Box<dyn SDKProvider>>
+        factory: impl FnOnce(&PluginInit, &Options) -> anyhow::Result<Box<dyn SDKProvider>>
         + Send
         + Sync
         + 'static,
@@ -467,7 +539,10 @@ impl Engine {
     pub fn register_driver_factory(
         &mut self,
         name: &str,
-        factory: impl FnOnce(&Options) -> anyhow::Result<Box<dyn SDKDriver>> + Send + Sync + 'static,
+        factory: impl FnOnce(&PluginInit, &Options) -> anyhow::Result<Box<dyn SDKDriver>>
+        + Send
+        + Sync
+        + 'static,
     ) -> anyhow::Result<()> {
         if self.driver_factories.contains_key(name)
             || self.managed_driver_factories.contains_key(name)
@@ -484,7 +559,7 @@ impl Engine {
     pub fn register_managed_driver_factory(
         &mut self,
         name: &str,
-        factory: impl FnOnce(&Options) -> anyhow::Result<Box<dyn SDKManagedDriver>>
+        factory: impl FnOnce(&PluginInit, &Options) -> anyhow::Result<Box<dyn SDKManagedDriver>>
         + Send
         + Sync
         + 'static,
@@ -501,14 +576,30 @@ impl Engine {
         Ok(())
     }
 
-    /// Absolute directories every plugin that walks the tree must prune: the
-    /// engine-owned home (cache/sandboxes/locks — never packages) plus the config
-    /// file's `fs.skip` dirs, resolved relative to the repo root.
+    /// Absolute directories every plugin that walks the tree must prune by exact
+    /// path: the engine-owned home (cache/sandboxes/locks — never packages) plus
+    /// the literal (non-glob) `fs.skip` entries, resolved relative to the root.
     pub fn skip_dirs(&self) -> Vec<PathBuf> {
-        let mut dirs = Vec::with_capacity(1 + self.cfg.fs_skip.len());
-        dirs.push(self.home.clone());
-        dirs.extend(self.cfg.fs_skip.iter().map(|rel| self.cfg.root.join(rel)));
+        let mut dirs = vec![self.home.clone()];
+        dirs.extend(
+            self.cfg
+                .fs_skip
+                .iter()
+                .filter(|e| !is_skip_glob(e))
+                .map(|rel| self.cfg.root.join(rel)),
+        );
         dirs
+    }
+
+    /// The glob `fs.skip` entries (e.g. `**/node_modules/**`), matched against
+    /// workspace-relative paths by every tree-walking plugin.
+    pub fn skip_globs(&self) -> Vec<String> {
+        self.cfg
+            .fs_skip
+            .iter()
+            .filter(|e| is_skip_glob(e))
+            .cloned()
+            .collect()
     }
 
     /// Instantiates every provider/driver listed in the entries by looking up the
@@ -519,14 +610,18 @@ impl Engine {
         providers: &[PluginEntry],
         drivers: &[PluginEntry],
     ) -> anyhow::Result<()> {
-        let root = self.cfg.root.clone();
-        let skip_dirs = self.skip_dirs();
+        let (root, skip_dirs, skip_globs) = self.plugin_init_parts();
+        let init = PluginInit {
+            root: &root,
+            skip_dirs: &skip_dirs,
+            skip_globs: &skip_globs,
+        };
         for entry in providers {
             let factory = self
                 .provider_factories
                 .remove(&entry.name)
                 .ok_or_else(|| anyhow::anyhow!("unknown provider '{}'", entry.name))?;
-            let provider = factory(&root, &skip_dirs, &entry.options)?;
+            let provider = factory(&init, &entry.options)?;
             let resolved_name = provider.config(provider::ConfigRequest {})?.name;
             if resolved_name != entry.name {
                 return Err(anyhow::anyhow!(
@@ -539,7 +634,7 @@ impl Engine {
         }
         for entry in drivers {
             if let Some(factory) = self.driver_factories.remove(&entry.name) {
-                let driver = factory(&entry.options)?;
+                let driver = factory(&init, &entry.options)?;
                 let resolved_name = driver.config(driver::ConfigRequest {})?.name;
                 if resolved_name != entry.name {
                     return Err(anyhow::anyhow!(
@@ -548,10 +643,11 @@ impl Engine {
                         resolved_name
                     ));
                 }
-                self.register_driver(driver)?;
+                self.insert_driver(driver)?;
             } else if let Some(factory) = self.managed_driver_factories.remove(&entry.name) {
-                let driver = factory(&entry.options)?;
-                self.register_managed_driver(driver)?;
+                let managed = factory(&init, &entry.options)?;
+                let driver = self.new_managed_driver(managed);
+                self.insert_driver(Box::new(driver))?;
             } else {
                 return Err(anyhow::anyhow!("unknown driver '{}'", entry.name));
             }

--- a/src/engine/engine.rs
+++ b/src/engine/engine.rs
@@ -498,6 +498,14 @@ impl Engine {
         Ok(())
     }
 
+    /// Directories the engine owns and no provider/driver should walk into. The
+    /// home dir holds the local cache, sandboxes, locks — never packages. Handed
+    /// to provider factories (and the built-in `fs` plugin) so every walk prunes
+    /// the same engine-owned subtrees.
+    pub fn skip_dirs(&self) -> Vec<PathBuf> {
+        vec![self.home.clone()]
+    }
+
     /// Instantiates every provider/driver listed in the entries by looking up the
     /// matching factory by name. Errors if any name has no registered factory.
     /// Factories are consumed — calling twice on the same name will error.
@@ -507,9 +515,7 @@ impl Engine {
         drivers: &[PluginEntry],
     ) -> anyhow::Result<()> {
         let root = self.cfg.root.clone();
-        // Directories the engine owns and no provider should walk into. The
-        // home dir holds the local cache, sandboxes, locks — never packages.
-        let skip_dirs = [self.home.clone()];
+        let skip_dirs = self.skip_dirs();
         for entry in providers {
             let factory = self
                 .provider_factories

--- a/src/engine/engine.rs
+++ b/src/engine/engine.rs
@@ -71,6 +71,13 @@ pub(crate) fn is_skip_glob(entry: &str) -> bool {
     entry.contains(['*', '?', '[', ']', '{', '}'])
 }
 
+/// Normalizes a `fs.skip` entry to a root-relative path: a leading `./` (the
+/// "current dir" form, e.g. `./node_modules`) is dropped so it resolves the same
+/// as the bare form.
+pub(crate) fn normalize_skip(entry: &str) -> &str {
+    entry.strip_prefix("./").unwrap_or(entry)
+}
+
 /// Factory args: the [`PluginInit`] context and the plugin's YAML options.
 pub type ProviderFactory =
     Box<dyn FnOnce(&PluginInit, &Options) -> anyhow::Result<Box<dyn SDKProvider>> + Send + Sync>;
@@ -596,18 +603,24 @@ impl Engine {
                 .fs_skip
                 .iter()
                 .filter(|e| !is_skip_glob(e))
-                .map(|rel| self.cfg.root.join(rel)),
+                .map(|rel| self.cfg.root.join(normalize_skip(rel))),
         );
         dirs
     }
 
     /// Exclude globs every tree-walking plugin honors: the always-on `.git`
     /// exclusion (a `.git` dir is never a build input, and submodules nest it)
-    /// plus the glob `fs.skip` entries (e.g. `**/node_modules/**`), matched
-    /// against workspace-relative paths.
+    /// plus the glob `fs.skip` entries (e.g. `**/node_modules/**`). All are
+    /// root-relative.
     pub fn skip_globs(&self) -> Vec<String> {
         std::iter::once("**/.git/**".to_string())
-            .chain(self.cfg.fs_skip.iter().filter(|e| is_skip_glob(e)).cloned())
+            .chain(
+                self.cfg
+                    .fs_skip
+                    .iter()
+                    .filter(|e| is_skip_glob(e))
+                    .map(|e| normalize_skip(e).to_string()),
+            )
             .collect()
     }
 

--- a/src/engine/expand.rs
+++ b/src/engine/expand.rs
@@ -410,8 +410,8 @@ mod tests {
         // needs adding here. The fs provider/driver resolves the synthesized
         // `@heph/fs` inputs produced by introspect-outputs expansion.
         engine.register_managed_driver(Box::new(crate::pluginexec::Driver::new_exec()))?;
-        engine.register_provider(|_| Box::new(crate::pluginfs::Provider))?;
-        engine.register_driver(Box::new(crate::pluginfs::Driver))?;
+        engine.register_provider(|_| Box::new(crate::pluginfs::Provider::default()))?;
+        engine.register_driver(Box::new(crate::pluginfs::Driver::default()))?;
         engine.register_provider(move |_| Box::new(CannedProvider { specs }))?;
         Ok((Arc::new(engine), root))
     }

--- a/src/engine/expand.rs
+++ b/src/engine/expand.rs
@@ -406,12 +406,10 @@ mod tests {
             parallelism: None,
             ..Default::default()
         })?;
-        // group driver is registered by Engine::new; only the exec driver
-        // needs adding here. The fs provider/driver resolves the synthesized
-        // `@heph/fs` inputs produced by introspect-outputs expansion.
-        engine.register_managed_driver(Box::new(crate::pluginexec::Driver::new_exec()))?;
-        engine.register_provider(|_| Box::new(crate::pluginfs::Provider::default()))?;
-        engine.register_driver(Box::new(crate::pluginfs::Driver::default()))?;
+        // group + fs are registered by Engine::new; only the exec driver needs
+        // adding here. The fs provider/driver resolves the synthesized `@heph/fs`
+        // inputs produced by introspect-outputs expansion.
+        engine.register_managed_driver(|_| Box::new(crate::pluginexec::Driver::new_exec()))?;
         engine.register_provider(move |_| Box::new(CannedProvider { specs }))?;
         Ok((Arc::new(engine), root))
     }

--- a/src/engine/mod.rs
+++ b/src/engine/mod.rs
@@ -7,6 +7,7 @@ pub use engine::Config;
 pub use engine::Engine;
 pub use engine::EngineFuse;
 pub use engine::MemCacheOptions;
+pub use engine::PluginInit;
 pub mod config_file;
 pub use config_file::{FuseConfig, FuseMode};
 mod cwd;

--- a/src/engine/mod.rs
+++ b/src/engine/mod.rs
@@ -7,6 +7,7 @@ pub use engine::Config;
 pub use engine::Engine;
 pub use engine::EngineFuse;
 pub use engine::MemCacheOptions;
+pub use engine::SkipConfig;
 pub mod config_file;
 pub use config_file::{FuseConfig, FuseMode};
 mod cwd;

--- a/src/engine/mod.rs
+++ b/src/engine/mod.rs
@@ -7,7 +7,6 @@ pub use engine::Config;
 pub use engine::Engine;
 pub use engine::EngineFuse;
 pub use engine::MemCacheOptions;
-pub use engine::SkipConfig;
 pub mod config_file;
 pub use config_file::{FuseConfig, FuseMode};
 mod cwd;

--- a/src/engine/query.rs
+++ b/src/engine/query.rs
@@ -269,11 +269,17 @@ mod tests {
             .await?;
 
         let recorded = list_states.lock().unwrap();
-        assert_eq!(recorded.len(), 1, "list called once");
-        let pkgs: Vec<String> = recorded[0]
+        // The built-in `fs` provider also advertises its `@heph/fs` package, so
+        // `list` may run for that too; assert the call for the queried package.
+        let abc = recorded
             .iter()
-            .map(|s| s.package.as_str().to_string())
-            .collect();
+            .find(|states| {
+                states
+                    .first()
+                    .is_some_and(|s| s.package.as_str() == "a/b/c")
+            })
+            .expect("list called for queried package a/b/c");
+        let pkgs: Vec<String> = abc.iter().map(|s| s.package.as_str().to_string()).collect();
         assert_eq!(pkgs, vec!["a/b/c", "a/b", "a", ""]);
         Ok(())
     }

--- a/src/engine/result.rs
+++ b/src/engine/result.rs
@@ -2245,16 +2245,14 @@ mod tests {
     #[test]
     fn provider_functions_lists_exposed_functions() {
         let root = tempdir().unwrap();
-        let mut engine = Engine::new(Config {
+        // `fs` is auto-registered by `Engine::new`.
+        let engine = Engine::new(Config {
             root: root.path().to_path_buf(),
             home_dir: std::path::PathBuf::new(),
             parallelism: None,
             ..Default::default()
         })
         .unwrap();
-        engine
-            .register_provider(|_| Box::new(crate::pluginfs::Provider::default()))
-            .unwrap();
         let fns = engine.provider_functions();
         assert!(
             fns.contains(&("fs".to_string(), "glob".to_string())),
@@ -2285,8 +2283,10 @@ mod tests {
             parallelism: None,
             ..Default::default()
         })?;
-        engine.register_provider(|root| {
-            Box::new(crate::pluginbuildfile::Provider::new(root.to_path_buf()))
+        engine.register_provider(|init| {
+            Box::new(crate::pluginbuildfile::Provider::new(
+                init.root.to_path_buf(),
+            ))
         })?;
         let engine = SArc::new(engine);
         let rs = engine.new_state();
@@ -2328,9 +2328,11 @@ mod tests {
             parallelism: None,
             ..Default::default()
         })?;
-        engine.register_provider(|_| Box::new(crate::pluginfs::Provider::default()))?;
-        engine.register_provider(|root| {
-            Box::new(crate::pluginbuildfile::Provider::new(root.to_path_buf()))
+        // `fs` is auto-registered by `Engine::new`.
+        engine.register_provider(|init| {
+            Box::new(crate::pluginbuildfile::Provider::new(
+                init.root.to_path_buf(),
+            ))
         })?;
         let engine = SArc::new(engine);
         let rs = engine.new_state();
@@ -2502,7 +2504,7 @@ mod tests {
             parallelism: None,
             ..Default::default()
         })?;
-        engine.register_managed_driver(Box::new(crate::pluginexec::Driver::new_exec()))?;
+        engine.register_managed_driver(|_| Box::new(crate::pluginexec::Driver::new_exec()))?;
         let provider = pluginstatictarget::Provider::new(targets)?;
         engine.register_provider(move |_| Box::new(provider))?;
         Ok(Arc::new(engine))
@@ -3254,7 +3256,7 @@ mod tests {
             parallelism: None,
             ..Default::default()
         })?;
-        engine.register_managed_driver(Box::new(crate::pluginexec::Driver::new_exec()))?;
+        engine.register_managed_driver(|_| Box::new(crate::pluginexec::Driver::new_exec()))?;
         let provider = pluginstatictarget::Provider::new(targets)?;
         engine.register_provider(move |_| Box::new(provider))?;
         Ok((Arc::new(engine), root))
@@ -3778,10 +3780,12 @@ mod tests {
             },
             ..Default::default()
         })?;
-        engine.register_driver(Box::new(BlockingDriver {
-            exec_count,
-            outputs: SArc::new(outputs),
-        }))?;
+        engine.register_driver(|_| {
+            Box::new(BlockingDriver {
+                exec_count,
+                outputs: SArc::new(outputs),
+            })
+        })?;
         let addr = Addr::new(PkgBuf::from("pkg"), "a".to_string(), Default::default());
         let spec = TargetSpec {
             addr: addr.clone(),
@@ -3973,10 +3977,9 @@ mod tests {
         })?;
         // `bash` driver wraps the `run` string into `bash -u -e -c <script>`,
         // so codegen targets can run real shell. The `@heph/fs` provider+driver
-        // resolves the synthesized introspect-outputs inputs.
-        engine.register_managed_driver(Box::new(crate::pluginexec::Driver::new_bash()))?;
-        engine.register_provider(|_| Box::new(crate::pluginfs::Provider::default()))?;
-        engine.register_driver(Box::new(crate::pluginfs::Driver::default()))?;
+        // (auto-registered by `Engine::new`) resolves the synthesized
+        // introspect-outputs inputs.
+        engine.register_managed_driver(|_| Box::new(crate::pluginexec::Driver::new_bash()))?;
         let provider = pluginstatictarget::Provider::new(targets)?;
         engine.register_provider(move |_| Box::new(provider))?;
         Ok((Arc::new(engine), root))

--- a/src/engine/result.rs
+++ b/src/engine/result.rs
@@ -2253,7 +2253,7 @@ mod tests {
         })
         .unwrap();
         engine
-            .register_provider(|_| Box::new(crate::pluginfs::Provider))
+            .register_provider(|_| Box::new(crate::pluginfs::Provider::default()))
             .unwrap();
         let fns = engine.provider_functions();
         assert!(
@@ -2328,7 +2328,7 @@ mod tests {
             parallelism: None,
             ..Default::default()
         })?;
-        engine.register_provider(|_| Box::new(crate::pluginfs::Provider))?;
+        engine.register_provider(|_| Box::new(crate::pluginfs::Provider::default()))?;
         engine.register_provider(|root| {
             Box::new(crate::pluginbuildfile::Provider::new(root.to_path_buf()))
         })?;
@@ -3975,8 +3975,8 @@ mod tests {
         // so codegen targets can run real shell. The `@heph/fs` provider+driver
         // resolves the synthesized introspect-outputs inputs.
         engine.register_managed_driver(Box::new(crate::pluginexec::Driver::new_bash()))?;
-        engine.register_provider(|_| Box::new(crate::pluginfs::Provider))?;
-        engine.register_driver(Box::new(crate::pluginfs::Driver))?;
+        engine.register_provider(|_| Box::new(crate::pluginfs::Provider::default()))?;
+        engine.register_driver(Box::new(crate::pluginfs::Driver::default()))?;
         let provider = pluginstatictarget::Provider::new(targets)?;
         engine.register_provider(move |_| Box::new(provider))?;
         Ok((Arc::new(engine), root))

--- a/src/engine/validate.rs
+++ b/src/engine/validate.rs
@@ -208,9 +208,7 @@ mod tests {
         // exec driver parses specs into defs (with codegen-stamped outputs); the
         // fs provider/driver resolves any synthesized inputs; the static provider
         // supplies the specs and the `list_packages` query needs.
-        engine.register_managed_driver(Box::new(crate::pluginexec::Driver::new_exec()))?;
-        engine.register_provider(|_| Box::new(crate::pluginfs::Provider::default()))?;
-        engine.register_driver(Box::new(crate::pluginfs::Driver::default()))?;
+        engine.register_managed_driver(|_| Box::new(crate::pluginexec::Driver::new_exec()))?;
         let provider = pluginstatictarget::Provider::new(targets)?;
         engine.register_provider(move |_| Box::new(provider))?;
         Ok((Arc::new(engine), root))

--- a/src/engine/validate.rs
+++ b/src/engine/validate.rs
@@ -209,8 +209,8 @@ mod tests {
         // fs provider/driver resolves any synthesized inputs; the static provider
         // supplies the specs and the `list_packages` query needs.
         engine.register_managed_driver(Box::new(crate::pluginexec::Driver::new_exec()))?;
-        engine.register_provider(|_| Box::new(crate::pluginfs::Provider))?;
-        engine.register_driver(Box::new(crate::pluginfs::Driver))?;
+        engine.register_provider(|_| Box::new(crate::pluginfs::Provider::default()))?;
+        engine.register_driver(Box::new(crate::pluginfs::Driver::default()))?;
         let provider = pluginstatictarget::Provider::new(targets)?;
         engine.register_provider(move |_| Box::new(provider))?;
         Ok((Arc::new(engine), root))

--- a/src/htwalk/mod.rs
+++ b/src/htwalk/mod.rs
@@ -1,0 +1,205 @@
+//! Filesystem-walk ignore rules shared by every tree-walking plugin (the `fs`
+//! driver/provider, and the buildfile/go providers).
+//!
+//! The core idea: distinguish *pruning* a directory subtree (stop descending —
+//! cheap, the whole point of an ignore) from merely *excluding* individual
+//! files. A recursive ignore glob — one ending in `/**` or `/**/*` — targets a
+//! whole subtree, so [`Ignore`] derives a directory matcher from its prefix and
+//! prunes the directory itself (`**/node_modules/**` never walks into
+//! `node_modules`). A non-recursive glob (`**/*.tmp`, `foo/*`) only filters
+//! files. No probing or sentinel paths.
+//!
+//! Two ignore sources:
+//!  - `dirs`: absolute directories pruned by exact path (e.g. the heph home).
+//!  - `globs`: workspace-relative wax glob patterns.
+
+use anyhow::Context as _;
+use std::path::{Path, PathBuf};
+use std::sync::Arc;
+use wax::{Any, Glob, Program as _};
+
+/// Directory + glob ignore rules for a filesystem walk. See the module docs.
+#[derive(Debug, Clone)]
+pub struct Ignore {
+    /// Absolute directories pruned by exact path.
+    dirs: Vec<PathBuf>,
+    /// The raw ignore globs, kept so callers can chain them with a target's own
+    /// excludes when compiling a per-target matcher.
+    globs: Vec<String>,
+    /// Compiled `globs` — matches a workspace-relative file path that is excluded.
+    file_any: Arc<Any<'static>>,
+    /// Compiled directory matchers derived from the recursive (`…/**`, `…/**/*`)
+    /// `globs` — matches a workspace-relative directory whose subtree is pruned.
+    dir_any: Arc<Any<'static>>,
+}
+
+impl Default for Ignore {
+    fn default() -> Self {
+        Self::new(&[], &[]).expect("empty ignore set is valid")
+    }
+}
+
+impl Ignore {
+    /// Builds an ignore set from absolute `dirs` (exact-path prune) and
+    /// workspace-relative `globs`.
+    pub fn new(dirs: &[PathBuf], globs: &[String]) -> anyhow::Result<Self> {
+        let file_any = compile_any(globs.iter().map(String::as_str))?;
+        // A directory is pruned when its own path matches a glob (so `vendor` /
+        // `**/vendor` prune the `vendor` dir directly), OR when it matches the
+        // prefix of a recursive glob (so `**/node_modules/**`, which only matches
+        // *files* under node_modules, still prunes the dir via `**/node_modules`).
+        let dir_globs: Vec<&str> = globs
+            .iter()
+            .map(String::as_str)
+            .chain(globs.iter().filter_map(|g| prune_prefix(g)))
+            .collect();
+        let dir_any = compile_any(dir_globs.into_iter())?;
+        Ok(Self {
+            dirs: dirs.to_vec(),
+            globs: globs.to_vec(),
+            file_any,
+            dir_any,
+        })
+    }
+
+    /// True if the directory at absolute `abs` (workspace-relative `rel`) must be
+    /// pruned — never descended into. Either an exact `dirs` entry, or a directory
+    /// whose path matches a glob / a recursive glob's prefix.
+    ///
+    /// The walk root itself (`rel == ""`) is never glob-pruned — you are
+    /// explicitly walking it — only exact-`dirs` pruning applies.
+    pub fn prune_dir(&self, abs: &Path, rel: &Path) -> bool {
+        if self.dirs.iter().any(|d| d == abs) {
+            return true;
+        }
+        !rel.as_os_str().is_empty() && self.dir_any.is_match(rel)
+    }
+
+    /// True if the file at workspace-relative `rel` is excluded by an ignore glob.
+    pub fn exclude_file(&self, rel: &Path) -> bool {
+        self.file_any.is_match(rel)
+    }
+
+    /// The raw ignore globs, for chaining with a target's own exclude patterns.
+    pub fn globs(&self) -> &[String] {
+        &self.globs
+    }
+
+    /// The compiled file-exclude matcher, reused directly as the "no extra
+    /// excludes" matcher by callers that compile per-target exclude unions.
+    pub fn file_matcher(&self) -> &Arc<Any<'static>> {
+        &self.file_any
+    }
+}
+
+/// If `pattern` recursively covers a subtree (ends in `/**` or `/**/*`), returns
+/// the directory-matching prefix whose subtree should be pruned. A wax `**`
+/// matches zero-or-more components, so the prefix matches the target dir at any
+/// depth (`**/node_modules/**` → `**/node_modules`, matching `node_modules` and
+/// `a/b/node_modules`). Non-recursive patterns return `None` (file-only).
+fn prune_prefix(pattern: &str) -> Option<&str> {
+    for suffix in ["/**/*", "/**"] {
+        if let Some(prefix) = pattern.strip_suffix(suffix)
+            && !prefix.is_empty()
+        {
+            return Some(prefix);
+        }
+    }
+    None
+}
+
+/// Compiles glob patterns into one `wax::Any`. An empty set yields an `Any` that
+/// matches nothing.
+fn compile_any<'a>(patterns: impl Iterator<Item = &'a str>) -> anyhow::Result<Arc<Any<'static>>> {
+    let globs = patterns
+        .map(|s| {
+            Glob::new(s)
+                .map(Glob::into_owned)
+                .with_context(|| format!("invalid ignore pattern '{s}'"))
+        })
+        .collect::<anyhow::Result<Vec<_>>>()?;
+    Ok(Arc::new(
+        wax::any(globs).context("compiling ignore patterns")?,
+    ))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn p(s: &str) -> &Path {
+        Path::new(s)
+    }
+
+    #[test]
+    fn recursive_glob_prunes_dir_at_any_depth() {
+        let ig = Ignore::new(&[], &["**/node_modules/**".to_string()]).unwrap();
+        // The directory itself is pruned (root + nested), without a probe.
+        assert!(ig.prune_dir(p("/ws/node_modules"), p("node_modules")));
+        assert!(ig.prune_dir(p("/ws/a/b/node_modules"), p("a/b/node_modules")));
+        // A sibling dir is not pruned.
+        assert!(!ig.prune_dir(p("/ws/src"), p("src")));
+        // Files inside are excluded too.
+        assert!(ig.exclude_file(p("a/node_modules/dep/index.js")));
+        assert!(!ig.exclude_file(p("a/main.rs")));
+    }
+
+    #[test]
+    fn trailing_star_star_slash_star_prunes() {
+        let ig = Ignore::new(&[], &["vendor/**/*".to_string()]).unwrap();
+        assert!(ig.prune_dir(p("/ws/vendor"), p("vendor")));
+        assert!(ig.exclude_file(p("vendor/x/y.go")));
+    }
+
+    #[test]
+    fn bare_name_glob_prunes_matching_dir() {
+        // A non-recursive pattern that names a directory still prunes it (the
+        // long-standing buildfile/go `skip` semantics).
+        let ig = Ignore::new(&[], &["internal".to_string()]).unwrap();
+        assert!(ig.prune_dir(p("/ws/internal"), p("internal")));
+        assert!(!ig.prune_dir(p("/ws/src"), p("src")));
+    }
+
+    #[test]
+    fn non_recursive_glob_excludes_files_but_does_not_prune() {
+        let ig = Ignore::new(&[], &["**/*.tmp".to_string()]).unwrap();
+        assert!(ig.exclude_file(p("a/b/c.tmp")));
+        assert!(!ig.exclude_file(p("a/b/c.rs")));
+        // `*.tmp` is not a subtree — directories are still walked.
+        assert!(!ig.prune_dir(p("/ws/a"), p("a")));
+    }
+
+    #[test]
+    fn exact_dirs_are_pruned() {
+        let home = PathBuf::from("/ws/.heph3");
+        let ig = Ignore::new(std::slice::from_ref(&home), &[]).unwrap();
+        assert!(ig.prune_dir(&home, p(".heph3")));
+        assert!(!ig.prune_dir(p("/ws/src"), p("src")));
+    }
+
+    #[test]
+    fn walk_root_is_never_glob_pruned() {
+        // The root's rel is empty; a glob must not prune it (else the whole walk
+        // yields nothing). Only an exact `dirs` entry can prune.
+        let ig = Ignore::new(&[], &["**/node_modules/**".to_string()]).unwrap();
+        assert!(!ig.prune_dir(p("/ws"), p("")));
+    }
+
+    #[test]
+    fn empty_ignore_matches_nothing() {
+        let ig = Ignore::default();
+        assert!(!ig.prune_dir(p("/ws/anything"), p("anything")));
+        assert!(!ig.exclude_file(p("anything")));
+    }
+
+    #[test]
+    fn prune_prefix_extraction() {
+        assert_eq!(prune_prefix("**/node_modules/**"), Some("**/node_modules"));
+        assert_eq!(prune_prefix("vendor/**"), Some("vendor"));
+        assert_eq!(prune_prefix("vendor/**/*"), Some("vendor"));
+        assert_eq!(prune_prefix("**/*.tmp"), None);
+        assert_eq!(prune_prefix("foo/*"), None);
+        // Whole-tree patterns have no dir prefix to prune.
+        assert_eq!(prune_prefix("**"), None);
+    }
+}

--- a/src/htwalk/mod.rs
+++ b/src/htwalk/mod.rs
@@ -3,15 +3,16 @@
 //!
 //! The core idea: distinguish *pruning* a directory subtree (stop descending —
 //! cheap, the whole point of an ignore) from merely *excluding* individual
-//! files. A recursive ignore glob — one ending in `/**` or `/**/*` — targets a
-//! whole subtree, so [`Ignore`] derives a directory matcher from its prefix and
-//! prunes the directory itself (`**/node_modules/**` never walks into
-//! `node_modules`). A non-recursive glob (`**/*.tmp`, `foo/*`) only filters
-//! files. No probing or sentinel paths.
+//! files. A glob prunes a directory when it names directories — its final
+//! component is a literal (`foo/**/bar` prunes every `bar` under `foo`), or it
+//! ends in a recursive `/**` / `/**/*` whose prefix names the dir
+//! (`**/node_modules/**` → `**/node_modules`). A glob whose final component is a
+//! wildcard (`some/*.go`) only filters files. No probing or sentinel paths.
 //!
-//! Two ignore sources:
-//!  - `dirs`: absolute directories pruned by exact path (e.g. the heph home).
-//!  - `globs`: workspace-relative wax glob patterns.
+//! Two ignore sources, both workspace-root-relative:
+//!  - `dirs`: absolute directories pruned by exact path (heph home + literal
+//!    `fs.skip` entries resolved against the root).
+//!  - `globs`: wax glob patterns matched against root-relative paths.
 
 use anyhow::Context as _;
 use std::path::{Path, PathBuf};
@@ -44,13 +45,16 @@ impl Ignore {
     /// workspace-relative `globs`.
     pub fn new(dirs: &[PathBuf], globs: &[String]) -> anyhow::Result<Self> {
         let file_any = compile_any(globs.iter().map(String::as_str))?;
-        // A directory is pruned when its own path matches a glob (so `vendor` /
-        // `**/vendor` prune the `vendor` dir directly), OR when it matches the
-        // prefix of a recursive glob (so `**/node_modules/**`, which only matches
-        // *files* under node_modules, still prunes the dir via `**/node_modules`).
+        // A directory is pruned when a glob names directories of that path —
+        // i.e. its final component is a literal (`foo/**/bar` prunes every `bar`
+        // dir under `foo`) — OR when it matches the prefix of a recursive glob
+        // (`**/node_modules/**`, which only matches *files* under node_modules,
+        // still prunes the dir via its `**/node_modules` prefix). A glob whose
+        // last component is a wildcard (`some/*.go`) is file-only and never prunes.
         let dir_globs: Vec<&str> = globs
             .iter()
             .map(String::as_str)
+            .filter(|g| names_directory(g))
             .chain(globs.iter().filter_map(|g| prune_prefix(g)))
             .collect();
         let dir_any = compile_any(dir_globs.into_iter())?;
@@ -90,6 +94,17 @@ impl Ignore {
     pub fn file_matcher(&self) -> &Arc<Any<'static>> {
         &self.file_any
     }
+}
+
+/// True if `pattern`'s final path component is a literal (no glob
+/// metacharacter): the pattern names directories of that path, so a matching
+/// directory is pruned (`foo/**/bar`, `internal`). A wildcard final component
+/// (`some/*.go`, `vendor/**`) is not directory-naming.
+fn names_directory(pattern: &str) -> bool {
+    pattern
+        .rsplit('/')
+        .next()
+        .is_some_and(|last| !last.is_empty() && !last.contains(['*', '?', '[', ']', '{', '}']))
 }
 
 /// If `pattern` recursively covers a subtree (ends in `/**` or `/**/*`), returns
@@ -167,6 +182,27 @@ mod tests {
         assert!(!ig.exclude_file(p("a/b/c.rs")));
         // `*.tmp` is not a subtree — directories are still walked.
         assert!(!ig.prune_dir(p("/ws/a"), p("a")));
+    }
+
+    #[test]
+    fn mid_doublestar_with_literal_tail_prunes() {
+        // `foo/**/bar` prunes every `bar` dir under `foo` (final component is a
+        // literal, so it names directories), root-relative.
+        let ig = Ignore::new(&[], &["foo/**/bar".to_string()]).unwrap();
+        assert!(ig.prune_dir(p("/ws/foo/bar"), p("foo/bar")));
+        assert!(ig.prune_dir(p("/ws/foo/x/y/bar"), p("foo/x/y/bar")));
+        assert!(!ig.prune_dir(p("/ws/foo/x"), p("foo/x")));
+        // Not under `foo`.
+        assert!(!ig.prune_dir(p("/ws/bar"), p("bar")));
+    }
+
+    #[test]
+    fn file_glob_with_wildcard_tail_does_not_prune() {
+        // `some/*.go` is a file pattern (wildcard final component): excludes the
+        // matching files, never prunes a directory.
+        let ig = Ignore::new(&[], &["some/*.go".to_string()]).unwrap();
+        assert!(ig.exclude_file(p("some/a.go")));
+        assert!(!ig.prune_dir(p("/ws/some"), p("some")));
     }
 
     #[test]

--- a/src/htwalk/mod.rs
+++ b/src/htwalk/mod.rs
@@ -214,6 +214,14 @@ mod tests {
     }
 
     #[test]
+    fn exact_dir_with_trailing_slash_matches() {
+        // `node_modules/` resolves to a skip dir with a trailing slash; `Path`
+        // equality is component-wise, so it still prunes the walked dir.
+        let ig = Ignore::new(&[PathBuf::from("/ws/node_modules/")], &[]).unwrap();
+        assert!(ig.prune_dir(p("/ws/node_modules"), p("node_modules")));
+    }
+
+    #[test]
     fn walk_root_is_never_glob_pruned() {
         // The root's rel is empty; a glob must not prune it (else the whole walk
         // yields nothing). Only an exact `dirs` entry can prune.

--- a/src/htwalk/mod.rs
+++ b/src/htwalk/mod.rs
@@ -84,6 +84,22 @@ impl Ignore {
         self.file_any.is_match(rel)
     }
 
+    /// True if the package at workspace-relative `pkg` lies inside a pruned
+    /// subtree — `pkg` itself or any ancestor directory is pruned. Used by
+    /// `get`/`list` so a directly-addressed target under a skipped dir resolves
+    /// to nothing, matching what the package walk would have surfaced. `root`
+    /// resolves absolute paths for exact-dir matching.
+    pub fn prunes_package(&self, root: &Path, pkg: &Path) -> bool {
+        let mut cur = Some(pkg);
+        while let Some(c) = cur {
+            if !c.as_os_str().is_empty() && self.prune_dir(&root.join(c), c) {
+                return true;
+            }
+            cur = c.parent();
+        }
+        false
+    }
+
     /// The raw ignore globs, for chaining with a target's own exclude patterns.
     pub fn globs(&self) -> &[String] {
         &self.globs
@@ -211,6 +227,25 @@ mod tests {
         let ig = Ignore::new(std::slice::from_ref(&home), &[]).unwrap();
         assert!(ig.prune_dir(&home, p(".heph3")));
         assert!(!ig.prune_dir(p("/ws/src"), p("src")));
+    }
+
+    #[test]
+    fn prunes_package_checks_ancestors() {
+        let ig = Ignore::new(
+            &[PathBuf::from("/ws/node_modules")],
+            &["**/gen/**".to_string()],
+        )
+        .unwrap();
+        // Package directly under an exact skip dir.
+        assert!(ig.prunes_package(p("/ws"), p("node_modules/dep")));
+        // Package under a glob-pruned dir (any depth).
+        assert!(ig.prunes_package(p("/ws"), p("a/gen/proto")));
+        // The skip dir / pruned dir itself.
+        assert!(ig.prunes_package(p("/ws"), p("node_modules")));
+        // Unrelated package.
+        assert!(!ig.prunes_package(p("/ws"), p("src/lib")));
+        // Root package is never pruned.
+        assert!(!ig.prunes_package(p("/ws"), p("")));
     }
 
     #[test]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -40,6 +40,7 @@ pub mod htmatcher;
 pub mod htpkg;
 pub mod htplatform;
 pub mod htvalue;
+pub mod htwalk;
 pub mod log;
 pub mod pluginbuildfile;
 pub mod pluginexec;

--- a/src/pluginbuildfile/provider.rs
+++ b/src/pluginbuildfile/provider.rs
@@ -126,7 +126,7 @@ impl Provider {
 
     pub fn from_options(
         root: std::path::PathBuf,
-        skip_dirs: &[std::path::PathBuf],
+        skip: &crate::engine::SkipConfig,
         opts: &crate::engine::config_file::Options,
     ) -> anyhow::Result<Self> {
         crate::engine::config_file::deny_unknown(
@@ -143,10 +143,14 @@ impl Provider {
                 glob::Pattern::new(&p).with_context(|| format!("invalid buildfile pattern `{p}`"))
             })
             .collect::<anyhow::Result<Vec<_>>>()?;
-        let skip_globs: Vec<String> =
+        // Engine-wide `fs.skip` globs are merged ahead of this provider's own
+        // `skip` option so both prune the same workspace-relative paths.
+        let mut skip_globs = skip.globs.clone();
+        let user_skip: Vec<String> =
             crate::engine::config_file::decode_opt(opts, "buildfile provider", "skip")?
                 .unwrap_or_default();
-        let skip = SkipMatcher::new(skip_dirs, &skip_globs)?;
+        skip_globs.extend(user_skip);
+        let skip = SkipMatcher::new(&skip.dirs, &skip_globs)?;
         let default_driver: Option<String> =
             crate::engine::config_file::decode_opt(opts, "buildfile provider", "defaultDriver")?;
         Ok(Self {
@@ -364,8 +368,12 @@ mod tests {
     #[test]
     fn from_options_defaults_to_build() {
         let dir = tempdir().expect("tempdir");
-        let p = Provider::from_options(dir.path().to_path_buf(), &[], &Options::new())
-            .expect("from_options");
+        let p = Provider::from_options(
+            dir.path().to_path_buf(),
+            &crate::engine::SkipConfig::default(),
+            &Options::new(),
+        )
+        .expect("from_options");
         let names: Vec<&str> = p.build_file_patterns.iter().map(|p| p.as_str()).collect();
         assert_eq!(names, vec!["BUILD"]);
     }
@@ -378,7 +386,12 @@ mod tests {
             "patterns".to_string(),
             serde_yaml::from_str("[BUILD2, \"*.BUILD2\"]").expect("yaml"),
         );
-        let p = Provider::from_options(dir.path().to_path_buf(), &[], &opts).expect("from_options");
+        let p = Provider::from_options(
+            dir.path().to_path_buf(),
+            &crate::engine::SkipConfig::default(),
+            &opts,
+        )
+        .expect("from_options");
         let names: Vec<&str> = p.build_file_patterns.iter().map(|p| p.as_str()).collect();
         assert_eq!(names, vec!["BUILD2", "*.BUILD2"]);
     }
@@ -391,9 +404,13 @@ mod tests {
             "patterns".to_string(),
             serde_yaml::from_str("[\"[bad\"]").expect("yaml"),
         );
-        let err = Provider::from_options(dir.path().to_path_buf(), &[], &opts)
-            .err()
-            .expect("must error");
+        let err = Provider::from_options(
+            dir.path().to_path_buf(),
+            &crate::engine::SkipConfig::default(),
+            &opts,
+        )
+        .err()
+        .expect("must error");
         assert!(err.to_string().contains("[bad"), "{err}");
     }
 
@@ -402,9 +419,13 @@ mod tests {
         let dir = tempdir().expect("tempdir");
         let mut opts = Options::new();
         opts.insert("bogus".to_string(), serde_yaml::Value::Bool(true));
-        let err = Provider::from_options(dir.path().to_path_buf(), &[], &opts)
-            .err()
-            .expect("must error");
+        let err = Provider::from_options(
+            dir.path().to_path_buf(),
+            &crate::engine::SkipConfig::default(),
+            &opts,
+        )
+        .err()
+        .expect("must error");
         assert!(err.to_string().contains("bogus"), "{err}");
     }
 
@@ -416,9 +437,13 @@ mod tests {
             "patterns".to_string(),
             serde_yaml::Value::String("not a list".to_string()),
         );
-        let err = Provider::from_options(dir.path().to_path_buf(), &[], &opts)
-            .err()
-            .expect("must error");
+        let err = Provider::from_options(
+            dir.path().to_path_buf(),
+            &crate::engine::SkipConfig::default(),
+            &opts,
+        )
+        .err()
+        .expect("must error");
         assert!(err.to_string().contains("patterns"), "{err}");
     }
 
@@ -457,15 +482,24 @@ mod tests {
             "defaultDriver".to_string(),
             serde_yaml::Value::String("exec".to_string()),
         );
-        let p = Provider::from_options(dir.path().to_path_buf(), &[], &opts).expect("from_options");
+        let p = Provider::from_options(
+            dir.path().to_path_buf(),
+            &crate::engine::SkipConfig::default(),
+            &opts,
+        )
+        .expect("from_options");
         assert_eq!(p.default_driver.as_deref(), Some("exec"));
     }
 
     #[test]
     fn from_options_default_driver_absent_is_none() {
         let dir = tempdir().expect("tempdir");
-        let p = Provider::from_options(dir.path().to_path_buf(), &[], &Options::new())
-            .expect("from_options");
+        let p = Provider::from_options(
+            dir.path().to_path_buf(),
+            &crate::engine::SkipConfig::default(),
+            &Options::new(),
+        )
+        .expect("from_options");
         assert!(p.default_driver.is_none());
     }
 
@@ -554,8 +588,11 @@ mod tests {
             "skip".to_string(),
             serde_yaml::from_str("[vendor]").expect("yaml"),
         );
-        let provider =
-            Provider::from_options(root.to_path_buf(), &[heph.clone()], &opts).expect("provider");
+        let skip = crate::engine::SkipConfig {
+            dirs: vec![heph.clone()],
+            globs: vec![],
+        };
+        let provider = Provider::from_options(root.to_path_buf(), &skip, &opts).expect("provider");
 
         let ctoken = StdCancellationToken::new();
         let res = provider
@@ -576,6 +613,47 @@ mod tests {
             "core dir not pruned"
         );
         assert!(!packages.contains(&"vendor".to_string()), "glob not pruned");
+    }
+
+    #[tokio::test]
+    async fn list_packages_skips_engine_fs_skip_globs() {
+        let tmp_dir = tempdir().unwrap();
+        let root = tmp_dir.path();
+
+        fs::write(root.join("BUILD"), "").unwrap();
+        let vendor = root.join("vendor");
+        fs::create_dir_all(&vendor).unwrap();
+        fs::write(vendor.join("BUILD"), "").unwrap();
+        let src = root.join("src");
+        fs::create_dir_all(&src).unwrap();
+        fs::write(src.join("BUILD"), "").unwrap();
+
+        // `vendor/**` comes from the engine's `fs.skip` (SkipConfig.globs), not
+        // the provider's own `skip` option — proving the engine threads it in.
+        let skip = crate::engine::SkipConfig {
+            dirs: vec![],
+            globs: vec!["vendor".to_string()],
+        };
+        let provider =
+            Provider::from_options(root.to_path_buf(), &skip, &Options::new()).expect("provider");
+
+        let ctoken = StdCancellationToken::new();
+        let res = provider
+            .list_packages(
+                ListPackagesRequest {
+                    prefix: PkgBuf::from(""),
+                },
+                &ctoken,
+            )
+            .await
+            .unwrap();
+        let packages: Vec<String> = res.map(|r| r.unwrap().pkg.to_string()).collect();
+
+        assert!(packages.contains(&"src".to_string()));
+        assert!(
+            !packages.contains(&"vendor".to_string()),
+            "engine fs.skip glob not pruned: {packages:?}"
+        );
     }
 
     #[tokio::test]

--- a/src/pluginbuildfile/provider.rs
+++ b/src/pluginbuildfile/provider.rs
@@ -126,7 +126,7 @@ impl Provider {
 
     pub fn from_options(
         root: std::path::PathBuf,
-        skip: &crate::engine::SkipConfig,
+        skip_dirs: &[std::path::PathBuf],
         opts: &crate::engine::config_file::Options,
     ) -> anyhow::Result<Self> {
         crate::engine::config_file::deny_unknown(
@@ -143,14 +143,10 @@ impl Provider {
                 glob::Pattern::new(&p).with_context(|| format!("invalid buildfile pattern `{p}`"))
             })
             .collect::<anyhow::Result<Vec<_>>>()?;
-        // Engine-wide `fs.skip` globs are merged ahead of this provider's own
-        // `skip` option so both prune the same workspace-relative paths.
-        let mut skip_globs = skip.globs.clone();
-        let user_skip: Vec<String> =
+        let skip_globs: Vec<String> =
             crate::engine::config_file::decode_opt(opts, "buildfile provider", "skip")?
                 .unwrap_or_default();
-        skip_globs.extend(user_skip);
-        let skip = SkipMatcher::new(&skip.dirs, &skip_globs)?;
+        let skip = SkipMatcher::new(skip_dirs, &skip_globs)?;
         let default_driver: Option<String> =
             crate::engine::config_file::decode_opt(opts, "buildfile provider", "defaultDriver")?;
         Ok(Self {
@@ -368,12 +364,8 @@ mod tests {
     #[test]
     fn from_options_defaults_to_build() {
         let dir = tempdir().expect("tempdir");
-        let p = Provider::from_options(
-            dir.path().to_path_buf(),
-            &crate::engine::SkipConfig::default(),
-            &Options::new(),
-        )
-        .expect("from_options");
+        let p = Provider::from_options(dir.path().to_path_buf(), &[], &Options::new())
+            .expect("from_options");
         let names: Vec<&str> = p.build_file_patterns.iter().map(|p| p.as_str()).collect();
         assert_eq!(names, vec!["BUILD"]);
     }
@@ -386,12 +378,7 @@ mod tests {
             "patterns".to_string(),
             serde_yaml::from_str("[BUILD2, \"*.BUILD2\"]").expect("yaml"),
         );
-        let p = Provider::from_options(
-            dir.path().to_path_buf(),
-            &crate::engine::SkipConfig::default(),
-            &opts,
-        )
-        .expect("from_options");
+        let p = Provider::from_options(dir.path().to_path_buf(), &[], &opts).expect("from_options");
         let names: Vec<&str> = p.build_file_patterns.iter().map(|p| p.as_str()).collect();
         assert_eq!(names, vec!["BUILD2", "*.BUILD2"]);
     }
@@ -404,13 +391,9 @@ mod tests {
             "patterns".to_string(),
             serde_yaml::from_str("[\"[bad\"]").expect("yaml"),
         );
-        let err = Provider::from_options(
-            dir.path().to_path_buf(),
-            &crate::engine::SkipConfig::default(),
-            &opts,
-        )
-        .err()
-        .expect("must error");
+        let err = Provider::from_options(dir.path().to_path_buf(), &[], &opts)
+            .err()
+            .expect("must error");
         assert!(err.to_string().contains("[bad"), "{err}");
     }
 
@@ -419,13 +402,9 @@ mod tests {
         let dir = tempdir().expect("tempdir");
         let mut opts = Options::new();
         opts.insert("bogus".to_string(), serde_yaml::Value::Bool(true));
-        let err = Provider::from_options(
-            dir.path().to_path_buf(),
-            &crate::engine::SkipConfig::default(),
-            &opts,
-        )
-        .err()
-        .expect("must error");
+        let err = Provider::from_options(dir.path().to_path_buf(), &[], &opts)
+            .err()
+            .expect("must error");
         assert!(err.to_string().contains("bogus"), "{err}");
     }
 
@@ -437,13 +416,9 @@ mod tests {
             "patterns".to_string(),
             serde_yaml::Value::String("not a list".to_string()),
         );
-        let err = Provider::from_options(
-            dir.path().to_path_buf(),
-            &crate::engine::SkipConfig::default(),
-            &opts,
-        )
-        .err()
-        .expect("must error");
+        let err = Provider::from_options(dir.path().to_path_buf(), &[], &opts)
+            .err()
+            .expect("must error");
         assert!(err.to_string().contains("patterns"), "{err}");
     }
 
@@ -482,24 +457,15 @@ mod tests {
             "defaultDriver".to_string(),
             serde_yaml::Value::String("exec".to_string()),
         );
-        let p = Provider::from_options(
-            dir.path().to_path_buf(),
-            &crate::engine::SkipConfig::default(),
-            &opts,
-        )
-        .expect("from_options");
+        let p = Provider::from_options(dir.path().to_path_buf(), &[], &opts).expect("from_options");
         assert_eq!(p.default_driver.as_deref(), Some("exec"));
     }
 
     #[test]
     fn from_options_default_driver_absent_is_none() {
         let dir = tempdir().expect("tempdir");
-        let p = Provider::from_options(
-            dir.path().to_path_buf(),
-            &crate::engine::SkipConfig::default(),
-            &Options::new(),
-        )
-        .expect("from_options");
+        let p = Provider::from_options(dir.path().to_path_buf(), &[], &Options::new())
+            .expect("from_options");
         assert!(p.default_driver.is_none());
     }
 
@@ -588,11 +554,8 @@ mod tests {
             "skip".to_string(),
             serde_yaml::from_str("[vendor]").expect("yaml"),
         );
-        let skip = crate::engine::SkipConfig {
-            dirs: vec![heph.clone()],
-            globs: vec![],
-        };
-        let provider = Provider::from_options(root.to_path_buf(), &skip, &opts).expect("provider");
+        let provider =
+            Provider::from_options(root.to_path_buf(), &[heph.clone()], &opts).expect("provider");
 
         let ctoken = StdCancellationToken::new();
         let res = provider
@@ -616,7 +579,7 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn list_packages_skips_engine_fs_skip_globs() {
+    async fn list_packages_skips_engine_skip_dirs() {
         let tmp_dir = tempdir().unwrap();
         let root = tmp_dir.path();
 
@@ -628,14 +591,11 @@ mod tests {
         fs::create_dir_all(&src).unwrap();
         fs::write(src.join("BUILD"), "").unwrap();
 
-        // `vendor/**` comes from the engine's `fs.skip` (SkipConfig.globs), not
+        // `vendor` comes in as an engine skip dir (the resolved `fs.skip`), not
         // the provider's own `skip` option — proving the engine threads it in.
-        let skip = crate::engine::SkipConfig {
-            dirs: vec![],
-            globs: vec!["vendor".to_string()],
-        };
         let provider =
-            Provider::from_options(root.to_path_buf(), &skip, &Options::new()).expect("provider");
+            Provider::from_options(root.to_path_buf(), &[vendor.clone()], &Options::new())
+                .expect("provider");
 
         let ctoken = StdCancellationToken::new();
         let res = provider
@@ -652,7 +612,7 @@ mod tests {
         assert!(packages.contains(&"src".to_string()));
         assert!(
             !packages.contains(&"vendor".to_string()),
-            "engine fs.skip glob not pruned: {packages:?}"
+            "engine skip dir not pruned: {packages:?}"
         );
     }
 

--- a/src/pluginbuildfile/provider.rs
+++ b/src/pluginbuildfile/provider.rs
@@ -8,6 +8,7 @@ use crate::hasync::Cancellable;
 use crate::hmemoizer::Memoizer;
 use crate::htaddr::Addr;
 use crate::htpkg::PkgBuf;
+use crate::htwalk::Ignore;
 use crate::pluginbuildfile::run_file::RunResult;
 use anyhow::Context;
 use enclose::enclose;
@@ -17,63 +18,14 @@ use std::collections::HashMap;
 use std::path::PathBuf;
 use std::sync::{Arc, Mutex, OnceLock};
 
-/// Sentinel child filename used to decide whether a `<…>/**`-style skip glob
-/// covers a whole directory subtree (so the walk can prune it).
-const PRUNE_PROBE: &str = "\u{0}heph-prune-probe";
-
-/// Prunes directories during the BUILD-file walk. Two prune sources:
-///  - `dirs`: absolute paths the engine hands every provider (the heph home plus
-///    literal `fs.skip` dirs); matched by exact path.
-///  - `globs`: `fs.skip` glob entries plus the provider's own `skip` option,
-///    matched against the workspace-relative package path (and against a sentinel
-///    child, so a `<dir>/**` pattern prunes the whole subtree).
-#[derive(Debug, Default)]
-pub struct SkipMatcher {
-    dirs: Vec<PathBuf>,
-    globs: Option<wax::Any<'static>>,
-}
-
-impl SkipMatcher {
-    fn new(dirs: &[PathBuf], globs: &[String]) -> anyhow::Result<Self> {
-        let compiled = if globs.is_empty() {
-            None
-        } else {
-            let gs = globs
-                .iter()
-                .map(|s| {
-                    wax::Glob::new(s)
-                        .map(wax::Glob::into_owned)
-                        .with_context(|| format!("buildfile provider: invalid skip pattern `{s}`"))
-                })
-                .collect::<anyhow::Result<Vec<_>>>()?;
-            Some(wax::any(gs).context("compiling buildfile skip patterns")?)
-        };
-        Ok(Self {
-            dirs: dirs.to_vec(),
-            globs: compiled,
-        })
-    }
-
-    /// True if the dir at absolute `path` (workspace-relative `rel`) is pruned.
-    fn is_skipped(&self, path: &std::path::Path, rel: &std::path::Path) -> bool {
-        use wax::Program as _;
-        if self.dirs.iter().any(|d| d == path) {
-            return true;
-        }
-        self.globs
-            .as_ref()
-            .is_some_and(|any| any.is_match(rel) || any.is_match(rel.join(PRUNE_PROBE).as_path()))
-    }
-}
-
 pub struct RequestState {}
 
 pub struct Provider {
     pub root: std::path::PathBuf,
     pub build_file_patterns: Vec<glob::Pattern>,
-    /// Directories to prune during the BUILD-file walk: engine-owned dirs
-    /// (e.g. the heph home) plus user `skip` globs. See [`SkipMatcher`].
-    pub skip: Arc<SkipMatcher>,
+    /// Directories pruned during the BUILD-file walk: engine skip dirs/globs plus
+    /// this provider's own `skip` option. See [`crate::htwalk::Ignore`].
+    pub skip: Arc<Ignore>,
     /// Driver applied to targets that omit `driver` in their `target(...)` call.
     /// Set via the `defaultDriver` provider option. `None` means a target with no
     /// driver is an error.
@@ -110,7 +62,7 @@ impl Default for Provider {
         Self {
             root: std::path::PathBuf::from("/"),
             build_file_patterns: vec![glob::Pattern::new("BUILD").expect("BUILD literal")],
-            skip: Arc::new(SkipMatcher::default()),
+            skip: Arc::new(Ignore::default()),
             default_driver: None,
             requests: Mutex::new(HashMap::new()),
             pkg_cache: Memoizer::with_tag("buildfile_pkg"),
@@ -158,7 +110,7 @@ impl Provider {
             crate::engine::config_file::decode_opt(opts, "buildfile provider", "skip")?
                 .unwrap_or_default();
         globs.extend(user_skip);
-        let skip = SkipMatcher::new(skip_dirs, &globs)?;
+        let skip = Ignore::new(skip_dirs, &globs)?;
         let default_driver: Option<String> =
             crate::engine::config_file::decode_opt(opts, "buildfile provider", "defaultDriver")?;
         Ok(Self {
@@ -175,7 +127,7 @@ fn find_packages_sync(
     path: &std::path::Path,
     root: &std::path::Path,
     patterns: &[glob::Pattern],
-    skip: &SkipMatcher,
+    skip: &Ignore,
     packages: &mut std::collections::HashSet<String>,
 ) -> anyhow::Result<()> {
     let mut has_build_file = false;
@@ -195,7 +147,7 @@ fn find_packages_sync(
             }
         } else if ft.is_dir() {
             let rel = entry_path.strip_prefix(root).unwrap_or(&entry_path);
-            if skip.is_skipped(&entry_path, rel) {
+            if skip.prune_dir(&entry_path, rel) {
                 continue;
             }
             find_packages_sync(&entry_path, root, patterns, skip, packages)?;

--- a/src/pluginbuildfile/provider.rs
+++ b/src/pluginbuildfile/provider.rs
@@ -17,11 +17,16 @@ use std::collections::HashMap;
 use std::path::PathBuf;
 use std::sync::{Arc, Mutex, OnceLock};
 
+/// Sentinel child filename used to decide whether a `<…>/**`-style skip glob
+/// covers a whole directory subtree (so the walk can prune it).
+const PRUNE_PROBE: &str = "\u{0}heph-prune-probe";
+
 /// Prunes directories during the BUILD-file walk. Two prune sources:
-///  - `dirs`: absolute engine-owned paths (e.g. the heph home) the engine hands
-///    every provider; matched by exact path.
-///  - `globs`: user `skip` wax patterns, matched against the workspace-relative
-///    package path.
+///  - `dirs`: absolute paths the engine hands every provider (the heph home plus
+///    literal `fs.skip` dirs); matched by exact path.
+///  - `globs`: `fs.skip` glob entries plus the provider's own `skip` option,
+///    matched against the workspace-relative package path (and against a sentinel
+///    child, so a `<dir>/**` pattern prunes the whole subtree).
 #[derive(Debug, Default)]
 pub struct SkipMatcher {
     dirs: Vec<PathBuf>,
@@ -55,7 +60,9 @@ impl SkipMatcher {
         if self.dirs.iter().any(|d| d == path) {
             return true;
         }
-        self.globs.as_ref().is_some_and(|any| any.is_match(rel))
+        self.globs
+            .as_ref()
+            .is_some_and(|any| any.is_match(rel) || any.is_match(rel.join(PRUNE_PROBE).as_path()))
     }
 }
 
@@ -127,6 +134,7 @@ impl Provider {
     pub fn from_options(
         root: std::path::PathBuf,
         skip_dirs: &[std::path::PathBuf],
+        skip_globs: &[String],
         opts: &crate::engine::config_file::Options,
     ) -> anyhow::Result<Self> {
         crate::engine::config_file::deny_unknown(
@@ -143,10 +151,14 @@ impl Provider {
                 glob::Pattern::new(&p).with_context(|| format!("invalid buildfile pattern `{p}`"))
             })
             .collect::<anyhow::Result<Vec<_>>>()?;
-        let skip_globs: Vec<String> =
+        // Engine-wide `fs.skip` globs are merged ahead of this provider's own
+        // `skip` option so both prune the same workspace-relative paths.
+        let mut globs = skip_globs.to_vec();
+        let user_skip: Vec<String> =
             crate::engine::config_file::decode_opt(opts, "buildfile provider", "skip")?
                 .unwrap_or_default();
-        let skip = SkipMatcher::new(skip_dirs, &skip_globs)?;
+        globs.extend(user_skip);
+        let skip = SkipMatcher::new(skip_dirs, &globs)?;
         let default_driver: Option<String> =
             crate::engine::config_file::decode_opt(opts, "buildfile provider", "defaultDriver")?;
         Ok(Self {
@@ -364,7 +376,7 @@ mod tests {
     #[test]
     fn from_options_defaults_to_build() {
         let dir = tempdir().expect("tempdir");
-        let p = Provider::from_options(dir.path().to_path_buf(), &[], &Options::new())
+        let p = Provider::from_options(dir.path().to_path_buf(), &[], &[], &Options::new())
             .expect("from_options");
         let names: Vec<&str> = p.build_file_patterns.iter().map(|p| p.as_str()).collect();
         assert_eq!(names, vec!["BUILD"]);
@@ -378,7 +390,8 @@ mod tests {
             "patterns".to_string(),
             serde_yaml::from_str("[BUILD2, \"*.BUILD2\"]").expect("yaml"),
         );
-        let p = Provider::from_options(dir.path().to_path_buf(), &[], &opts).expect("from_options");
+        let p = Provider::from_options(dir.path().to_path_buf(), &[], &[], &opts)
+            .expect("from_options");
         let names: Vec<&str> = p.build_file_patterns.iter().map(|p| p.as_str()).collect();
         assert_eq!(names, vec!["BUILD2", "*.BUILD2"]);
     }
@@ -391,7 +404,7 @@ mod tests {
             "patterns".to_string(),
             serde_yaml::from_str("[\"[bad\"]").expect("yaml"),
         );
-        let err = Provider::from_options(dir.path().to_path_buf(), &[], &opts)
+        let err = Provider::from_options(dir.path().to_path_buf(), &[], &[], &opts)
             .err()
             .expect("must error");
         assert!(err.to_string().contains("[bad"), "{err}");
@@ -402,7 +415,7 @@ mod tests {
         let dir = tempdir().expect("tempdir");
         let mut opts = Options::new();
         opts.insert("bogus".to_string(), serde_yaml::Value::Bool(true));
-        let err = Provider::from_options(dir.path().to_path_buf(), &[], &opts)
+        let err = Provider::from_options(dir.path().to_path_buf(), &[], &[], &opts)
             .err()
             .expect("must error");
         assert!(err.to_string().contains("bogus"), "{err}");
@@ -416,7 +429,7 @@ mod tests {
             "patterns".to_string(),
             serde_yaml::Value::String("not a list".to_string()),
         );
-        let err = Provider::from_options(dir.path().to_path_buf(), &[], &opts)
+        let err = Provider::from_options(dir.path().to_path_buf(), &[], &[], &opts)
             .err()
             .expect("must error");
         assert!(err.to_string().contains("patterns"), "{err}");
@@ -457,14 +470,15 @@ mod tests {
             "defaultDriver".to_string(),
             serde_yaml::Value::String("exec".to_string()),
         );
-        let p = Provider::from_options(dir.path().to_path_buf(), &[], &opts).expect("from_options");
+        let p = Provider::from_options(dir.path().to_path_buf(), &[], &[], &opts)
+            .expect("from_options");
         assert_eq!(p.default_driver.as_deref(), Some("exec"));
     }
 
     #[test]
     fn from_options_default_driver_absent_is_none() {
         let dir = tempdir().expect("tempdir");
-        let p = Provider::from_options(dir.path().to_path_buf(), &[], &Options::new())
+        let p = Provider::from_options(dir.path().to_path_buf(), &[], &[], &Options::new())
             .expect("from_options");
         assert!(p.default_driver.is_none());
     }
@@ -554,8 +568,8 @@ mod tests {
             "skip".to_string(),
             serde_yaml::from_str("[vendor]").expect("yaml"),
         );
-        let provider =
-            Provider::from_options(root.to_path_buf(), &[heph.clone()], &opts).expect("provider");
+        let provider = Provider::from_options(root.to_path_buf(), &[heph.clone()], &[], &opts)
+            .expect("provider");
 
         let ctoken = StdCancellationToken::new();
         let res = provider
@@ -594,7 +608,7 @@ mod tests {
         // `vendor` comes in as an engine skip dir (the resolved `fs.skip`), not
         // the provider's own `skip` option — proving the engine threads it in.
         let provider =
-            Provider::from_options(root.to_path_buf(), &[vendor.clone()], &Options::new())
+            Provider::from_options(root.to_path_buf(), &[vendor.clone()], &[], &Options::new())
                 .expect("provider");
 
         let ctoken = StdCancellationToken::new();

--- a/src/pluginbuildfile/provider.rs
+++ b/src/pluginbuildfile/provider.rs
@@ -187,6 +187,15 @@ impl EProvider for Provider {
     ) -> BoxFuture<'a, anyhow::Result<Box<dyn Iterator<Item = anyhow::Result<ListResponse>> + Send>>>
     {
         Box::pin(async move {
+            // A package inside a skipped subtree lists nothing — matching what the
+            // package walk would have surfaced.
+            if self
+                .skip
+                .prunes_package(&self.root, std::path::Path::new(req.package.as_str()))
+            {
+                return Ok(Box::new(std::iter::empty())
+                    as Box<dyn Iterator<Item = anyhow::Result<ListResponse>> + Send>);
+            }
             let res = self.run_pkg(req.package.as_str()).await?;
 
             let items: Vec<anyhow::Result<ListResponse>> = res
@@ -253,6 +262,13 @@ impl EProvider for Provider {
         _ctoken: &'a (dyn Cancellable + Send + Sync),
     ) -> BoxFuture<'a, Result<GetResponse, GetError>> {
         Box::pin(async move {
+            // A target inside a skipped subtree does not resolve.
+            if self
+                .skip
+                .prunes_package(&self.root, std::path::Path::new(req.addr.package.as_str()))
+            {
+                return Err(NotFound);
+            }
             let res = self
                 .run_pkg(req.addr.package.as_str())
                 .await
@@ -580,6 +596,49 @@ mod tests {
             !packages.contains(&"vendor".to_string()),
             "engine skip dir not pruned: {packages:?}"
         );
+    }
+
+    #[tokio::test]
+    async fn get_and_list_skip_pruned_packages() {
+        let tmp_dir = tempdir().unwrap();
+        let root = tmp_dir.path();
+        let vendor_dep = root.join("vendor/dep");
+        fs::create_dir_all(&vendor_dep).unwrap();
+        fs::write(
+            vendor_dep.join("BUILD"),
+            r#"target(name = "t", driver = "d")"#,
+        )
+        .unwrap();
+
+        // `vendor` is an engine skip dir; a target directly addressed under it
+        // must not resolve, and listing it yields nothing.
+        let provider = Provider::from_options(
+            root.to_path_buf(),
+            &[root.join("vendor")],
+            &[],
+            &Options::new(),
+        )
+        .expect("provider");
+
+        let ctoken = StdCancellationToken::new();
+        let got = provider.get(get_req("vendor/dep", "t"), &ctoken).await;
+        assert!(
+            matches!(got, Err(NotFound)),
+            "expected NotFound for skipped pkg"
+        );
+
+        let listed = provider
+            .list(
+                ListRequest {
+                    request_id: "test".to_string(),
+                    package: PkgBuf::from("vendor/dep"),
+                    states: vec![],
+                },
+                &ctoken,
+            )
+            .await
+            .unwrap();
+        assert_eq!(listed.count(), 0);
     }
 
     #[tokio::test]

--- a/src/pluginbuildfile/run_file.rs
+++ b/src/pluginbuildfile/run_file.rs
@@ -2009,30 +2009,6 @@ target(name = "t_in_app", driver = SHARED)
     }
 
     #[test]
-    fn test_heph_fs_glob_excludes_builtin_dirs() {
-        let tmp_dir = tempdir().unwrap();
-        let pkg = tmp_dir.path().join("mypkg");
-        let git = pkg.join(".git");
-        fs::create_dir_all(&git).unwrap();
-        fs::write(git.join("HEAD"), "").unwrap();
-        fs::write(pkg.join("main.rs"), "").unwrap();
-        fs::write(
-            pkg.join("BUILD"),
-            r#"target(name = "t", driver = "d", srcs = heph.fs.glob("**/*"))"#,
-        )
-        .unwrap();
-
-        let provider = make_provider(&tmp_dir);
-        let result = run_pkg_blocking(&provider, "mypkg").unwrap();
-        let srcs = expect_string_list(result.targets[0].config.get("srcs"));
-        assert!(
-            !srcs.iter().any(|s| s.starts_with(".git")),
-            ".git entries should be excluded: {srcs:?}"
-        );
-        assert!(srcs.contains(&"main.rs".to_string()), "{srcs:?}");
-    }
-
-    #[test]
     fn test_heph_fs_glob_at_workspace_root_returns_unprefixed() {
         let tmp_dir = tempdir().unwrap();
         let root = tmp_dir.path();

--- a/src/pluginbuildfile/run_file.rs
+++ b/src/pluginbuildfile/run_file.rs
@@ -942,7 +942,7 @@ mod tests {
     fn fs_registry() -> Arc<ProviderFunctionRegistry> {
         use crate::engine::provider::Provider as _;
         let mut reg = ProviderFunctionRegistry::default();
-        reg.insert_provider("fs", crate::pluginfs::Provider.functions());
+        reg.insert_provider("fs", crate::pluginfs::Provider::default().functions());
         Arc::new(reg)
     }
 

--- a/src/pluginfs/mod.rs
+++ b/src/pluginfs/mod.rs
@@ -109,16 +109,29 @@ impl EProvider for Provider {
 
     fn list_packages<'a>(
         &'a self,
-        _req: ListPackagesRequest,
+        req: ListPackagesRequest,
         _ctoken: &'a (dyn Cancellable + Send + Sync),
     ) -> BoxFuture<
         'a,
         anyhow::Result<Box<dyn Iterator<Item = anyhow::Result<ListPackageResponse>> + Send>>,
     > {
         Box::pin(async move {
-            let items: Vec<anyhow::Result<ListPackageResponse>> = vec![Ok(ListPackageResponse {
-                pkg: PkgBuf::from(PKG),
-            })];
+            // `fs` owns exactly one synthetic package (`@heph/fs`). Yield it only
+            // when it falls under the requested prefix, so a narrowed query (e.g.
+            // `//a/b/c:...`) doesn't spuriously surface it.
+            let prefix = req.prefix.as_str();
+            let under_prefix = prefix.is_empty()
+                || prefix == PKG
+                || PKG
+                    .strip_prefix(prefix)
+                    .is_some_and(|rest| rest.starts_with('/'));
+            let items: Vec<anyhow::Result<ListPackageResponse>> = if under_prefix {
+                vec![Ok(ListPackageResponse {
+                    pkg: PkgBuf::from(PKG),
+                })]
+            } else {
+                vec![]
+            };
             Ok(Box::new(items.into_iter())
                 as Box<
                     dyn Iterator<Item = anyhow::Result<ListPackageResponse>> + Send,
@@ -362,34 +375,46 @@ impl ProviderFn for BaseFn {
 
 // ─── Driver ──────────────────────────────────────────────────────────────────
 
-/// Directories the fs walk never descends into. Two sources:
+/// Directories the fs walk never descends into. Sources:
 ///  - `.git`, pruned by basename at any depth (a VCS dir is never a build input,
 ///    and submodules nest it).
 ///  - `skip_dirs`: absolute engine-owned paths handed in by the engine (see
-///    [`Engine::skip_dirs`](crate::engine::Engine::skip_dirs)) — the heph home,
-///    holding the cache/sandboxes/locks. Matched by exact path.
+///    [`Engine::skip_dirs`](crate::engine::Engine::skip_dirs)) — the heph home and
+///    the literal `fs.skip` dirs. Matched by exact path.
+///  - `skip_globs`: the glob `fs.skip` entries (e.g. `**/node_modules/**`),
+///    matched against the workspace-relative path.
 ///
 /// Replaces the former hardcoded `BUILT_IN_*` lists: the engine is now the single
-/// source of truth for which engine-owned subtrees to skip.
+/// source of truth for which subtrees to skip.
 #[derive(Debug)]
 pub struct FsSkip {
-    /// Absolute engine-owned directories pruned by exact path during the walk.
+    /// Absolute directories pruned by exact path during the walk.
     skip_dirs: Vec<std::path::PathBuf>,
-    /// Built-in exclude glob patterns — `**/.git/**` plus a root-relative
-    /// `<rel>/**` for each skip dir under the workspace root. Chained ahead of a
-    /// target's user excludes when compiling its exclude `Any`.
+    /// Built-in exclude glob patterns — `**/.git/**`, a root-relative `<rel>/**`
+    /// for each skip dir under the root, and the `fs.skip` glob entries. Chained
+    /// ahead of a target's user excludes when compiling its exclude `Any`.
     exclude_globs: Vec<String>,
     /// Compiled [`exclude_globs`](Self::exclude_globs), reused as the `not`
-    /// matcher for the common case of a target with no user excludes.
+    /// matcher for the common case of a target with no user excludes, and as the
+    /// glob source for walk-time directory pruning.
     builtin_any: Arc<wax::Any<'static>>,
 }
 
+/// Sentinel filename probed under a directory to decide whether a `<…>/**`-style
+/// exclude glob covers the whole subtree (so the walk can prune it). Chosen to be
+/// extremely unlikely to be a real file an exclude pattern targets by name.
+const PRUNE_PROBE: &str = "\u{0}heph-prune-probe";
+
 impl FsSkip {
-    /// Builds the skip set from the engine-provided `skip_dirs` (absolute paths:
-    /// the heph home plus the config file's `fs.skip` dirs). Each skip dir located
-    /// under `root` also contributes a `<rel>/**` exclude glob so the compiled
-    /// `not` matcher agrees with the walk-time pruning.
-    pub fn new(root: &std::path::Path, skip_dirs: &[std::path::PathBuf]) -> anyhow::Result<Self> {
+    /// Builds the skip set from the engine-provided `skip_dirs` (absolute: heph
+    /// home + literal `fs.skip` dirs) and `skip_globs` (glob `fs.skip` entries).
+    /// Each skip dir under `root` also contributes a `<rel>/**` exclude glob so the
+    /// compiled `not` matcher agrees with the walk-time pruning.
+    pub fn new(
+        root: &std::path::Path,
+        skip_dirs: &[std::path::PathBuf],
+        skip_globs: &[String],
+    ) -> anyhow::Result<Self> {
         let mut exclude_globs = vec!["**/.git/**".to_string()];
         for dir in skip_dirs {
             if let Some(rel) = dir.strip_prefix(root).ok().and_then(|r| r.to_str())
@@ -398,6 +423,7 @@ impl FsSkip {
                 exclude_globs.push(format!("{rel}/**"));
             }
         }
+        exclude_globs.extend(skip_globs.iter().cloned());
         let builtin_any = compile_any(&exclude_globs).context("compiling built-in fs excludes")?;
         Ok(Self {
             skip_dirs: skip_dirs.to_vec(),
@@ -406,18 +432,23 @@ impl FsSkip {
         })
     }
 
-    /// True if the directory at absolute `path` must be pruned: a `.git` dir at
-    /// any depth, or one of the engine-owned skip dirs.
-    fn is_pruned_dir(&self, path: &std::path::Path) -> bool {
+    /// True if the directory at absolute `path` (workspace-relative `rel`) must be
+    /// pruned: a `.git` dir at any depth, an exact skip dir, or a directory whose
+    /// entire subtree is covered by a built-in/`fs.skip` exclude glob (probed by
+    /// testing a sentinel child against the compiled excludes — so
+    /// `**/node_modules/**` prunes `node_modules` instead of walking into it).
+    fn is_pruned_dir(&self, path: &std::path::Path, rel: &std::path::Path) -> bool {
+        use wax::Program as _;
         path.file_name().and_then(|n| n.to_str()) == Some(".git")
             || self.skip_dirs.iter().any(|d| d == path)
+            || self.builtin_any.is_match(rel.join(PRUNE_PROBE).as_path())
     }
 }
 
 impl Default for FsSkip {
     fn default() -> Self {
         // Only `.git` is pruned; the `**/.git/**` literal is statically valid.
-        Self::new(std::path::Path::new(""), &[]).expect("built-in .git exclude is valid")
+        Self::new(std::path::Path::new(""), &[], &[]).expect("built-in .git exclude is valid")
     }
 }
 
@@ -650,9 +681,14 @@ fn walk_glob(
     let walker = walkdir::WalkDir::new(&walk_root)
         .into_iter()
         .filter_entry(|entry| {
-            // Never descend into always-excluded subtrees (.git + engine-owned
-            // skip dirs like the heph home).
-            !(entry.file_type().is_dir() && compiled.skip.is_pruned_dir(entry.path()))
+            // Never descend into always-excluded subtrees (.git, the heph home +
+            // literal `fs.skip` dirs, and `fs.skip` glob subtrees like
+            // `**/node_modules/**`).
+            if !entry.file_type().is_dir() {
+                return true;
+            }
+            let rel = entry.path().strip_prefix(root).unwrap_or(entry.path());
+            !compiled.skip.is_pruned_dir(entry.path(), rel)
         });
 
     for entry in walker {
@@ -1250,6 +1286,30 @@ mod tests {
         );
     }
 
+    async fn list_pkgs(prefix: &str) -> Vec<String> {
+        let p = Provider::default();
+        let it = p
+            .list_packages(
+                ListPackagesRequest {
+                    prefix: PkgBuf::from(prefix),
+                },
+                &ctoken(),
+            )
+            .await
+            .unwrap();
+        it.map(|r| r.unwrap().pkg.to_string()).collect()
+    }
+
+    #[tokio::test]
+    async fn test_list_packages_honors_prefix() {
+        // Yielded only when `@heph/fs` falls under the requested prefix.
+        assert_eq!(list_pkgs("").await, vec![PKG.to_string()]);
+        assert_eq!(list_pkgs("@heph").await, vec![PKG.to_string()]);
+        assert_eq!(list_pkgs(PKG).await, vec![PKG.to_string()]);
+        assert!(list_pkgs("a/b/c").await.is_empty());
+        assert!(list_pkgs("@hep").await.is_empty());
+    }
+
     // ─── Driver tests ──────────────────────────────────────────────────────
 
     fn make_parse_req(config: std::collections::HashMap<String, Value>) -> ParseRequest {
@@ -1646,7 +1706,7 @@ mod tests {
 
         // The engine hands the fs plugin its skip dirs (the heph home); the walk
         // must prune that subtree rather than relying on a hardcoded basename.
-        let skip = Arc::new(FsSkip::new(tmp.path(), &[home]).unwrap());
+        let skip = Arc::new(FsSkip::new(tmp.path(), &[home], &[]).unwrap());
         let driver = Driver::new(skip);
 
         let config =
@@ -1683,7 +1743,7 @@ mod tests {
 
         // A `fs.skip` dir from the config file (resolved to an absolute path) is
         // pruned just like the engine home.
-        let skip = Arc::new(FsSkip::new(tmp.path(), &[tmp.path().join("vendor")]).unwrap());
+        let skip = Arc::new(FsSkip::new(tmp.path(), &[tmp.path().join("vendor")], &[]).unwrap());
         let driver = Driver::new(skip);
 
         let config =
@@ -1708,6 +1768,44 @@ mod tests {
             names,
             vec!["main.rs"],
             "config skip dir must be pruned: {names:?}"
+        );
+    }
+
+    #[tokio::test]
+    async fn test_driver_run_glob_excludes_config_skip_glob() {
+        let tmp = tempdir().unwrap();
+        fs::create_dir_all(tmp.path().join("pkg/node_modules/dep")).unwrap();
+        fs::write(tmp.path().join("pkg/node_modules/dep/index.js"), b"").unwrap();
+        fs::write(tmp.path().join("pkg/main.rs"), b"").unwrap();
+
+        // A `fs.skip` glob (`**/node_modules/**`) excludes the whole subtree at
+        // any depth — and prunes the dir so the walk never descends into it.
+        let skip =
+            Arc::new(FsSkip::new(tmp.path(), &[], &["**/node_modules/**".to_string()]).unwrap());
+        let driver = Driver::new(skip);
+
+        let config =
+            std::collections::HashMap::from([("p".to_string(), Value::String("**/*".to_string()))]);
+        let parse_res = driver
+            .parse(make_parse_req(config), &ctoken())
+            .await
+            .unwrap();
+
+        let request_id = "test".to_string();
+        let hashin = String::new();
+        let req = make_run_req(
+            &parse_res.target_def,
+            &request_id,
+            tmp.path().to_path_buf(),
+            &hashin,
+        );
+        let res = driver.run(req, &ctoken()).await.unwrap();
+
+        let names: Vec<_> = res.artifacts.iter().map(|a| a.name.as_str()).collect();
+        assert_eq!(
+            names,
+            vec!["pkg_main.rs"],
+            "config skip glob must exclude node_modules subtree: {names:?}"
         );
     }
 

--- a/src/pluginfs/mod.rs
+++ b/src/pluginfs/mod.rs
@@ -110,29 +110,16 @@ impl EProvider for Provider {
 
     fn list_packages<'a>(
         &'a self,
-        req: ListPackagesRequest,
+        _req: ListPackagesRequest,
         _ctoken: &'a (dyn Cancellable + Send + Sync),
     ) -> BoxFuture<
         'a,
         anyhow::Result<Box<dyn Iterator<Item = anyhow::Result<ListPackageResponse>> + Send>>,
     > {
         Box::pin(async move {
-            // `fs` owns exactly one synthetic package (`@heph/fs`). Yield it only
-            // when it falls under the requested prefix, so a narrowed query (e.g.
-            // `//a/b/c:...`) doesn't spuriously surface it.
-            let prefix = req.prefix.as_str();
-            let under_prefix = prefix.is_empty()
-                || prefix == PKG
-                || PKG
-                    .strip_prefix(prefix)
-                    .is_some_and(|rest| rest.starts_with('/'));
-            let items: Vec<anyhow::Result<ListPackageResponse>> = if under_prefix {
-                vec![Ok(ListPackageResponse {
-                    pkg: PkgBuf::from(PKG),
-                })]
-            } else {
-                vec![]
-            };
+            let items: Vec<anyhow::Result<ListPackageResponse>> = vec![Ok(ListPackageResponse {
+                pkg: PkgBuf::from(PKG),
+            })];
             Ok(Box::new(items.into_iter())
                 as Box<
                     dyn Iterator<Item = anyhow::Result<ListPackageResponse>> + Send,
@@ -1211,30 +1198,6 @@ mod tests {
             result.target_spec.config.get("p"),
             Some(&Value::String("src/*.rs".to_string()))
         );
-    }
-
-    async fn list_pkgs(prefix: &str) -> Vec<String> {
-        let p = Provider::default();
-        let it = p
-            .list_packages(
-                ListPackagesRequest {
-                    prefix: PkgBuf::from(prefix),
-                },
-                &ctoken(),
-            )
-            .await
-            .unwrap();
-        it.map(|r| r.unwrap().pkg.to_string()).collect()
-    }
-
-    #[tokio::test]
-    async fn test_list_packages_honors_prefix() {
-        // Yielded only when `@heph/fs` falls under the requested prefix.
-        assert_eq!(list_pkgs("").await, vec![PKG.to_string()]);
-        assert_eq!(list_pkgs("@heph").await, vec![PKG.to_string()]);
-        assert_eq!(list_pkgs(PKG).await, vec![PKG.to_string()]);
-        assert!(list_pkgs("a/b/c").await.is_empty());
-        assert!(list_pkgs("@hep").await.is_empty());
     }
 
     // ─── Driver tests ──────────────────────────────────────────────────────

--- a/src/pluginfs/mod.rs
+++ b/src/pluginfs/mod.rs
@@ -385,10 +385,16 @@ pub struct FsSkip {
 }
 
 impl FsSkip {
-    /// Builds the skip set from the engine-provided `skip_dirs` (absolute paths).
-    /// Each skip dir located under `root` also contributes a `<rel>/**` exclude
-    /// glob so the compiled `not` matcher agrees with the walk-time pruning.
-    pub fn new(root: &std::path::Path, skip_dirs: &[std::path::PathBuf]) -> anyhow::Result<Self> {
+    /// Builds the skip set from the engine-provided `skip_dirs` (absolute paths)
+    /// plus `extra_globs` — workspace-relative exclude patterns from the config
+    /// file's top-level `skip`. Each skip dir located under `root` also
+    /// contributes a `<rel>/**` exclude glob so the compiled `not` matcher agrees
+    /// with the walk-time pruning.
+    pub fn new(
+        root: &std::path::Path,
+        skip_dirs: &[std::path::PathBuf],
+        extra_globs: &[String],
+    ) -> anyhow::Result<Self> {
         let mut exclude_globs = vec!["**/.git/**".to_string()];
         for dir in skip_dirs {
             if let Some(rel) = dir.strip_prefix(root).ok().and_then(|r| r.to_str())
@@ -397,6 +403,7 @@ impl FsSkip {
                 exclude_globs.push(format!("{rel}/**"));
             }
         }
+        exclude_globs.extend(extra_globs.iter().cloned());
         let builtin_any = compile_any(&exclude_globs).context("compiling built-in fs excludes")?;
         Ok(Self {
             skip_dirs: skip_dirs.to_vec(),
@@ -416,7 +423,7 @@ impl FsSkip {
 impl Default for FsSkip {
     fn default() -> Self {
         // Only `.git` is pruned; the `**/.git/**` literal is statically valid.
-        Self::new(std::path::Path::new(""), &[]).expect("built-in .git exclude is valid")
+        Self::new(std::path::Path::new(""), &[], &[]).expect("built-in .git exclude is valid")
     }
 }
 
@@ -1645,7 +1652,7 @@ mod tests {
 
         // The engine hands the fs plugin its skip dirs (the heph home); the walk
         // must prune that subtree rather than relying on a hardcoded basename.
-        let skip = Arc::new(FsSkip::new(tmp.path(), &[home]).unwrap());
+        let skip = Arc::new(FsSkip::new(tmp.path(), &[home], &[]).unwrap());
         let driver = Driver::new(skip);
 
         let config =
@@ -1670,6 +1677,42 @@ mod tests {
             names,
             vec!["main.rs"],
             "engine skip dir must be pruned: {names:?}"
+        );
+    }
+
+    #[tokio::test]
+    async fn test_driver_run_glob_excludes_config_extra_skip() {
+        let tmp = tempdir().unwrap();
+        fs::create_dir_all(tmp.path().join("vendor")).unwrap();
+        fs::write(tmp.path().join("vendor").join("dep.rs"), b"").unwrap();
+        fs::write(tmp.path().join("main.rs"), b"").unwrap();
+
+        // Extra exclude globs from the config file's top-level `skip`.
+        let skip = Arc::new(FsSkip::new(tmp.path(), &[], &["vendor/**".to_string()]).unwrap());
+        let driver = Driver::new(skip);
+
+        let config =
+            std::collections::HashMap::from([("p".to_string(), Value::String("**/*".to_string()))]);
+        let parse_res = driver
+            .parse(make_parse_req(config), &ctoken())
+            .await
+            .unwrap();
+
+        let request_id = "test".to_string();
+        let hashin = String::new();
+        let req = make_run_req(
+            &parse_res.target_def,
+            &request_id,
+            tmp.path().to_path_buf(),
+            &hashin,
+        );
+        let res = driver.run(req, &ctoken()).await.unwrap();
+
+        let names: Vec<_> = res.artifacts.iter().map(|a| a.name.as_str()).collect();
+        assert_eq!(
+            names,
+            vec!["main.rs"],
+            "config extra skip glob must exclude matched files: {names:?}"
         );
     }
 

--- a/src/pluginfs/mod.rs
+++ b/src/pluginfs/mod.rs
@@ -74,7 +74,17 @@ pub fn is_glob_addr(addr: &Addr) -> bool {
 
 // ─── Provider ────────────────────────────────────────────────────────────────
 
-pub struct Provider;
+#[derive(Default)]
+pub struct Provider {
+    /// Dirs the `glob` provider function must prune, shared with the driver.
+    skip: Arc<FsSkip>,
+}
+
+impl Provider {
+    pub fn new(skip: Arc<FsSkip>) -> Self {
+        Self { skip }
+    }
+}
 
 impl EProvider for Provider {
     fn config(&self, _req: ProviderConfigRequest) -> anyhow::Result<ProviderConfigResponse> {
@@ -163,7 +173,9 @@ impl EProvider for Provider {
         vec![
             ProviderFunctionDef {
                 name: "glob".to_string(),
-                func: Arc::new(GlobFn),
+                func: Arc::new(GlobFn {
+                    skip: self.skip.clone(),
+                }),
             },
             ProviderFunctionDef {
                 name: "join".to_string(),
@@ -188,8 +200,10 @@ impl EProvider for Provider {
 /// to that package. Uses the exact same `wax` walk as the `fs` driver
 /// ([`compile_glob`] + [`walk_glob`]), so BUILD-time expansion matches what the
 /// driver globs at execution time: brace alternation, `.`/`..` normalization, and
-/// the built-in `.git`/`.heph`/`.heph3` pruning. Result is sorted.
-struct GlobFn;
+/// the built-in `.git` + engine skip-dir pruning. Result is sorted.
+struct GlobFn {
+    skip: Arc<FsSkip>,
+}
 
 #[async_trait]
 impl ProviderFn for GlobFn {
@@ -209,7 +223,7 @@ impl ProviderFn for GlobFn {
 
         // No user excludes, so `request_id` is irrelevant (the built-in exclude
         // path is taken). Reuses the driver's compiled glob + walk verbatim.
-        let compiled = compile_glob("heph.fs.glob", &resolved, &[])?;
+        let compiled = compile_glob(&self.skip, "heph.fs.glob", &resolved, &[])?;
         let artifacts = walk_glob(ctx.root, &compiled)?;
 
         let pkg_prefix = (!ctx.pkg.is_empty()).then(|| std::path::Path::new(ctx.pkg));
@@ -348,14 +362,79 @@ impl ProviderFn for BaseFn {
 
 // ─── Driver ──────────────────────────────────────────────────────────────────
 
-const BUILT_IN_GLOB_EXCLUDES: &[&str] = &["**/.git/**", "**/.heph3/**", "**/.heph/**"];
+/// Directories the fs walk never descends into. Two sources:
+///  - `.git`, pruned by basename at any depth (a VCS dir is never a build input,
+///    and submodules nest it).
+///  - `skip_dirs`: absolute engine-owned paths handed in by the engine (see
+///    [`Engine::skip_dirs`](crate::engine::Engine::skip_dirs)) — the heph home,
+///    holding the cache/sandboxes/locks. Matched by exact path.
+///
+/// Replaces the former hardcoded `BUILT_IN_*` lists: the engine is now the single
+/// source of truth for which engine-owned subtrees to skip.
+#[derive(Debug)]
+pub struct FsSkip {
+    /// Absolute engine-owned directories pruned by exact path during the walk.
+    skip_dirs: Vec<std::path::PathBuf>,
+    /// Built-in exclude glob patterns — `**/.git/**` plus a root-relative
+    /// `<rel>/**` for each skip dir under the workspace root. Chained ahead of a
+    /// target's user excludes when compiling its exclude `Any`.
+    exclude_globs: Vec<String>,
+    /// Compiled [`exclude_globs`](Self::exclude_globs), reused as the `not`
+    /// matcher for the common case of a target with no user excludes.
+    builtin_any: Arc<wax::Any<'static>>,
+}
 
-/// Directory basenames whose subtree is always excluded — pruned during the
-/// walk so we never descend into them. Kept in sync with the recursive
-/// `**/<name>/**` entries in `BUILT_IN_GLOB_EXCLUDES`: matching the basename at
-/// any depth is equivalent to those patterns, and every descendant is excluded,
-/// so pruning is a pure optimization with identical results.
-const BUILT_IN_PRUNE_DIRS: &[&str] = &[".git", ".heph3", ".heph"];
+impl FsSkip {
+    /// Builds the skip set from the engine-provided `skip_dirs` (absolute paths).
+    /// Each skip dir located under `root` also contributes a `<rel>/**` exclude
+    /// glob so the compiled `not` matcher agrees with the walk-time pruning.
+    pub fn new(root: &std::path::Path, skip_dirs: &[std::path::PathBuf]) -> anyhow::Result<Self> {
+        let mut exclude_globs = vec!["**/.git/**".to_string()];
+        for dir in skip_dirs {
+            if let Some(rel) = dir.strip_prefix(root).ok().and_then(|r| r.to_str())
+                && !rel.is_empty()
+            {
+                exclude_globs.push(format!("{rel}/**"));
+            }
+        }
+        let builtin_any = compile_any(&exclude_globs).context("compiling built-in fs excludes")?;
+        Ok(Self {
+            skip_dirs: skip_dirs.to_vec(),
+            exclude_globs,
+            builtin_any,
+        })
+    }
+
+    /// True if the directory at absolute `path` must be pruned: a `.git` dir at
+    /// any depth, or one of the engine-owned skip dirs.
+    fn is_pruned_dir(&self, path: &std::path::Path) -> bool {
+        path.file_name().and_then(|n| n.to_str()) == Some(".git")
+            || self.skip_dirs.iter().any(|d| d == path)
+    }
+}
+
+impl Default for FsSkip {
+    fn default() -> Self {
+        // Only `.git` is pruned; the `**/.git/**` literal is statically valid.
+        Self::new(std::path::Path::new(""), &[]).expect("built-in .git exclude is valid")
+    }
+}
+
+/// Compiles a set of glob patterns into a single `wax::Any`, reusing the
+/// process-wide [`cached_glob`] cache for each pattern.
+fn compile_any(patterns: &[String]) -> anyhow::Result<Arc<wax::Any<'static>>> {
+    let globs = patterns
+        .iter()
+        .map(|s| {
+            cached_glob(s)
+                .map(|g| (*g).clone())
+                .with_context(|| format!("invalid exclude pattern '{s}'"))
+        })
+        .collect::<anyhow::Result<Vec<_>>>()?;
+    Ok(Arc::new(
+        wax::any(globs).context("compiling exclude patterns")?,
+    ))
+}
 
 /// Returns the leading literal path prefix of `pattern` — the run of complete
 /// components that contain no glob metacharacters.
@@ -415,6 +494,8 @@ struct CompiledGlob {
     not: Arc<wax::Any<'static>>,
     /// Literal directory prefix of the pattern, used as the walk root.
     prefix: String,
+    /// Engine-owned + built-in dirs to prune during the walk.
+    skip: Arc<FsSkip>,
 }
 
 /// Process-global cache of compiled globs keyed by pattern string.
@@ -439,28 +520,6 @@ fn cached_glob(pattern: &str) -> Result<Arc<wax::Glob<'static>>, wax::BuildError
         .entry(pattern.to_owned())
         .or_insert_with(|| glob.clone());
     Ok(glob)
-}
-
-/// Returns the compiled built-in exclude `Any`, built once per process.
-///
-/// The common case is a glob target with no user excludes, so reusing this Arc
-/// avoids rebuilding the 3-pattern regex union (`**/.git/**`, …) on every parse.
-fn builtin_excludes() -> anyhow::Result<Arc<wax::Any<'static>>> {
-    static BUILTIN: OnceLock<Arc<wax::Any<'static>>> = OnceLock::new();
-    if let Some(a) = BUILTIN.get() {
-        return Ok(a.clone());
-    }
-    let globs = BUILT_IN_GLOB_EXCLUDES
-        .iter()
-        .map(|s| {
-            cached_glob(s)
-                .map(|g| (*g).clone())
-                .with_context(|| format!("invalid built-in exclude pattern '{s}'"))
-        })
-        .collect::<anyhow::Result<Vec<_>>>()?;
-    let any = Arc::new(wax::any(globs).context("compiling built-in exclude patterns")?);
-    // Lost a race? Keep whichever value won; both are equivalent.
-    Ok(BUILTIN.get_or_init(|| any).clone())
 }
 
 /// Per-request cache of compiled exclude `Any` unions.
@@ -499,8 +558,9 @@ fn glob_result_cache() -> &'static RwLock<GlobResultCache> {
 
 /// Returns the compiled exclude `Any` (built-ins + user `exclude`) for
 /// `request_id`, memoizing across calls within that request. `exclude` must be
-/// non-empty; the no-exclude case uses the cheaper [`builtin_excludes`] path.
+/// non-empty; the no-exclude case reuses `skip.builtin_any` directly.
 fn cached_exclude_any(
+    skip: &FsSkip,
     request_id: &str,
     exclude: &[String],
 ) -> anyhow::Result<Arc<wax::Any<'static>>> {
@@ -516,17 +576,13 @@ fn cached_exclude_any(
         return Ok(a.clone());
     }
 
-    let exclude_globs: Vec<wax::Glob<'static>> = BUILT_IN_GLOB_EXCLUDES
+    let patterns: Vec<String> = skip
+        .exclude_globs
         .iter()
-        .copied()
-        .chain(exclude.iter().map(String::as_str))
-        .map(|s| {
-            cached_glob(s)
-                .map(|g| (*g).clone())
-                .with_context(|| format!("invalid exclude pattern '{s}'"))
-        })
-        .collect::<anyhow::Result<Vec<_>>>()?;
-    let any = Arc::new(wax::any(exclude_globs).context("compiling exclude patterns")?);
+        .cloned()
+        .chain(exclude.iter().cloned())
+        .collect();
+    let any = compile_any(&patterns)?;
 
     Ok(exclude_any_cache()
         .write()
@@ -551,23 +607,25 @@ enum FsDef {
 }
 
 fn compile_glob(
+    skip: &Arc<FsSkip>,
     request_id: &str,
     pattern: &str,
     exclude: &[String],
 ) -> anyhow::Result<CompiledGlob> {
     let glob = cached_glob(pattern).with_context(|| format!("invalid glob pattern '{pattern}'"))?;
 
-    // No user excludes: reuse the cached built-in `Any` directly.
+    // No user excludes: reuse the skip's prebuilt built-in `Any` directly.
     let not = if exclude.is_empty() {
-        builtin_excludes()?
+        skip.builtin_any.clone()
     } else {
-        cached_exclude_any(request_id, exclude)?
+        cached_exclude_any(skip, request_id, exclude)?
     };
 
     Ok(CompiledGlob {
         glob,
         not,
         prefix: literal_prefix(pattern).to_owned(),
+        skip: skip.clone(),
     })
 }
 
@@ -591,12 +649,9 @@ fn walk_glob(
     let walker = walkdir::WalkDir::new(&walk_root)
         .into_iter()
         .filter_entry(|entry| {
-            // Never descend into always-excluded subtrees (.git, …).
-            !(entry.file_type().is_dir()
-                && entry
-                    .file_name()
-                    .to_str()
-                    .is_some_and(|n| BUILT_IN_PRUNE_DIRS.contains(&n)))
+            // Never descend into always-excluded subtrees (.git + engine-owned
+            // skip dirs like the heph home).
+            !(entry.file_type().is_dir() && compiled.skip.is_pruned_dir(entry.path()))
         });
 
     for entry in walker {
@@ -720,7 +775,17 @@ fn cached_glob_walk(
         .clone())
 }
 
-pub struct Driver;
+#[derive(Default)]
+pub struct Driver {
+    /// Engine-owned + built-in dirs pruned during glob walks.
+    skip: Arc<FsSkip>,
+}
+
+impl Driver {
+    pub fn new(skip: Arc<FsSkip>) -> Self {
+        Self { skip }
+    }
+}
 
 #[cfg(unix)]
 fn is_exec(meta: &std::fs::Metadata) -> bool {
@@ -825,7 +890,12 @@ impl crate::engine::driver::Driver for Driver {
                 }
                 let hash = format!("{:x}", h.digest()).into_bytes();
 
-                let compiled = Arc::new(compile_glob(&req.request_id, &pattern, &exclude)?);
+                let compiled = Arc::new(compile_glob(
+                    &self.skip,
+                    &req.request_id,
+                    &pattern,
+                    &exclude,
+                )?);
                 let def = FsDef::Glob {
                     pattern: pattern.clone(),
                     exclude,
@@ -1008,7 +1078,13 @@ mod tests {
             positional: vec![Value::String(pattern.to_string())],
             named: Default::default(),
         };
-        let v = futures::executor::block_on(GlobFn.call(&ctx, args)).unwrap();
+        let v = futures::executor::block_on(
+            GlobFn {
+                skip: Arc::<FsSkip>::default(),
+            }
+            .call(&ctx, args),
+        )
+        .unwrap();
         match v {
             Value::List(l) => l
                 .into_iter()
@@ -1124,7 +1200,7 @@ mod tests {
 
     #[tokio::test]
     async fn test_provider_wrong_package_not_found() {
-        let p = Provider;
+        let p = Provider::default();
         let result = p
             .get(make_get_req("//other/pkg:file@f=foo.txt"), &ctoken())
             .await;
@@ -1133,7 +1209,7 @@ mod tests {
 
     #[tokio::test]
     async fn test_provider_wrong_name_not_found() {
-        let p = Provider;
+        let p = Provider::default();
         let result = p
             .get(
                 make_get_req(&format!("//{PKG}:unknown@f=foo.txt")),
@@ -1145,7 +1221,7 @@ mod tests {
 
     #[tokio::test]
     async fn test_provider_file_returns_spec() {
-        let p = Provider;
+        let p = Provider::default();
         let result = p
             .get(make_get_req(&format!("//{PKG}:file@f=foo.txt")), &ctoken())
             .await
@@ -1160,7 +1236,7 @@ mod tests {
 
     #[tokio::test]
     async fn test_provider_glob_returns_spec() {
-        let p = Provider;
+        let p = Provider::default();
         let result = p
             .get(make_get_req(&format!("//{PKG}:glob@p=src/*.rs")), &ctoken())
             .await
@@ -1209,7 +1285,7 @@ mod tests {
 
     #[tokio::test]
     async fn test_driver_parse_missing_both_errors() {
-        let driver = Driver;
+        let driver = Driver::default();
         let result = driver
             .parse(make_parse_req(Default::default()), &ctoken())
             .await;
@@ -1225,7 +1301,7 @@ mod tests {
 
     #[tokio::test]
     async fn test_driver_parse_invalid_glob_fails() {
-        let driver = Driver;
+        let driver = Driver::default();
         // Unmatched alternation — wax rejects at parse time.
         let config = std::collections::HashMap::from([(
             "p".to_string(),
@@ -1244,7 +1320,7 @@ mod tests {
 
     #[tokio::test]
     async fn test_driver_parse_invalid_exclude_fails() {
-        let driver = Driver;
+        let driver = Driver::default();
         let config = std::collections::HashMap::from([
             ("p".to_string(), Value::String("*.rs".to_string())),
             (
@@ -1265,7 +1341,7 @@ mod tests {
 
     #[tokio::test]
     async fn test_driver_parse_file_config() {
-        let driver = Driver;
+        let driver = Driver::default();
         let config = std::collections::HashMap::from([(
             "f".to_string(),
             Value::String("src/main.rs".to_string()),
@@ -1282,7 +1358,7 @@ mod tests {
 
     #[tokio::test]
     async fn test_driver_parse_glob_config() {
-        let driver = Driver;
+        let driver = Driver::default();
         let config = std::collections::HashMap::from([(
             "p".to_string(),
             Value::String("src/*.rs".to_string()),
@@ -1297,7 +1373,7 @@ mod tests {
 
     #[tokio::test]
     async fn test_driver_parse_glob_with_exclude() {
-        let driver = Driver;
+        let driver = Driver::default();
         let config = std::collections::HashMap::from([
             ("p".to_string(), Value::String("**/*.rs".to_string())),
             (
@@ -1320,7 +1396,7 @@ mod tests {
 
     #[tokio::test]
     async fn test_driver_run_file_exists() {
-        let driver = Driver;
+        let driver = Driver::default();
         let tmp = tempdir().unwrap();
         let file_path = tmp.path().join("hello.txt");
         fs::write(&file_path, b"hello world").unwrap();
@@ -1359,7 +1435,7 @@ mod tests {
 
     #[tokio::test]
     async fn test_driver_run_file_missing_errors() {
-        let driver = Driver;
+        let driver = Driver::default();
         let tmp = tempdir().unwrap();
 
         let config = std::collections::HashMap::from([(
@@ -1441,7 +1517,7 @@ mod tests {
     #[cfg(unix)]
     #[tokio::test]
     async fn test_driver_run_glob_follows_file_links_and_skips_dir_links() {
-        let driver = Driver;
+        let driver = Driver::default();
         let tmp = tempdir().unwrap();
         let root = tmp.path();
         fs::write(root.join("real.txt"), b"real").unwrap();
@@ -1494,7 +1570,7 @@ mod tests {
 
     #[tokio::test]
     async fn test_driver_run_glob_matches_files() {
-        let driver = Driver;
+        let driver = Driver::default();
         let tmp = tempdir().unwrap();
         fs::write(tmp.path().join("a.rs"), b"").unwrap();
         fs::write(tmp.path().join("b.rs"), b"").unwrap();
@@ -1525,7 +1601,7 @@ mod tests {
 
     #[tokio::test]
     async fn test_driver_run_glob_excludes_git() {
-        let driver = Driver;
+        let driver = Driver::default();
         let tmp = tempdir().unwrap();
         let git_dir = tmp.path().join(".git");
         fs::create_dir_all(&git_dir).unwrap();
@@ -1560,8 +1636,46 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn test_driver_run_glob_excludes_engine_skip_dir() {
+        let tmp = tempdir().unwrap();
+        let home = tmp.path().join(".heph3");
+        fs::create_dir_all(home.join("cache")).unwrap();
+        fs::write(home.join("cache").join("blob"), b"").unwrap();
+        fs::write(tmp.path().join("main.rs"), b"").unwrap();
+
+        // The engine hands the fs plugin its skip dirs (the heph home); the walk
+        // must prune that subtree rather than relying on a hardcoded basename.
+        let skip = Arc::new(FsSkip::new(tmp.path(), &[home]).unwrap());
+        let driver = Driver::new(skip);
+
+        let config =
+            std::collections::HashMap::from([("p".to_string(), Value::String("**/*".to_string()))]);
+        let parse_res = driver
+            .parse(make_parse_req(config), &ctoken())
+            .await
+            .unwrap();
+
+        let request_id = "test".to_string();
+        let hashin = String::new();
+        let req = make_run_req(
+            &parse_res.target_def,
+            &request_id,
+            tmp.path().to_path_buf(),
+            &hashin,
+        );
+        let res = driver.run(req, &ctoken()).await.unwrap();
+
+        let names: Vec<_> = res.artifacts.iter().map(|a| a.name.as_str()).collect();
+        assert_eq!(
+            names,
+            vec!["main.rs"],
+            "engine skip dir must be pruned: {names:?}"
+        );
+    }
+
+    #[tokio::test]
     async fn test_driver_run_glob_user_exclude() {
-        let driver = Driver;
+        let driver = Driver::default();
         let tmp = tempdir().unwrap();
         fs::write(tmp.path().join("keep.rs"), b"").unwrap();
         fs::write(tmp.path().join("skip.rs"), b"").unwrap();
@@ -1591,7 +1705,7 @@ mod tests {
 
     #[tokio::test]
     async fn test_driver_run_glob_out_path_relative() {
-        let driver = Driver;
+        let driver = Driver::default();
         let tmp = tempdir().unwrap();
         let sub = tmp.path().join("sub");
         fs::create_dir_all(&sub).unwrap();
@@ -1677,7 +1791,7 @@ mod tests {
 
     #[tokio::test]
     async fn test_provider_accepts_file_addr() {
-        let p = Provider;
+        let p = Provider::default();
         let addr = file_addr("README.md");
         let result = p
             .get(
@@ -1718,7 +1832,7 @@ mod tests {
         // Pattern with `/./` in the middle previously compiled in wax but
         // matched nothing because wax walks on-disk paths that never contain
         // literal `.` segments. Driver normalizes before compile.
-        let driver = Driver;
+        let driver = Driver::default();
         let tmp = tempdir().unwrap();
         let nested = tmp.path().join("mgmt/protos/x/bsdiff/v1");
         fs::create_dir_all(&nested).unwrap();
@@ -1766,7 +1880,7 @@ mod tests {
     async fn test_driver_run_glob_parent_segment_in_middle_matches() {
         // `a/b/../c` is equivalent to `a/c` on disk; wax does not collapse
         // `..` so driver normalizes before compile.
-        let driver = Driver;
+        let driver = Driver::default();
         let tmp = tempdir().unwrap();
         fs::create_dir_all(tmp.path().join("mgmt/protos/x")).unwrap();
         fs::write(tmp.path().join("mgmt/protos/x/go.mod"), b"").unwrap();
@@ -1797,7 +1911,7 @@ mod tests {
 
     #[tokio::test]
     async fn test_driver_parse_glob_rejects_root_escape() {
-        let driver = Driver;
+        let driver = Driver::default();
         let config = std::collections::HashMap::from([(
             "p".to_string(),
             Value::String("some/../../file".to_string()),
@@ -1815,7 +1929,7 @@ mod tests {
 
     #[tokio::test]
     async fn test_driver_parse_glob_rejects_leading_parent() {
-        let driver = Driver;
+        let driver = Driver::default();
         let config = std::collections::HashMap::from([(
             "p".to_string(),
             Value::String("../escape/**".to_string()),
@@ -1826,7 +1940,7 @@ mod tests {
 
     #[tokio::test]
     async fn test_driver_parse_file_rejects_root_escape() {
-        let driver = Driver;
+        let driver = Driver::default();
         let config = std::collections::HashMap::from([(
             "f".to_string(),
             Value::String("a/../../file.txt".to_string()),
@@ -1844,7 +1958,7 @@ mod tests {
 
     #[tokio::test]
     async fn test_driver_run_glob_parent_segments_hash_equivalence() {
-        let driver = Driver;
+        let driver = Driver::default();
         let with_parent = std::collections::HashMap::from([(
             "p".to_string(),
             Value::String("a/b/../c/**/*.rs".to_string()),
@@ -1872,7 +1986,7 @@ mod tests {
     async fn test_driver_run_glob_dot_segments_hash_equivalence() {
         // Two semantically equal patterns must produce the same hash, so the
         // cache key is stable regardless of how the user wrote the path.
-        let driver = Driver;
+        let driver = Driver::default();
         let with_dot = std::collections::HashMap::from([(
             "p".to_string(),
             Value::String("a/./b/**/*.rs".to_string()),
@@ -1898,7 +2012,7 @@ mod tests {
 
     #[tokio::test]
     async fn test_driver_run_glob_missing_path_is_empty() {
-        let driver = Driver;
+        let driver = Driver::default();
         let tmp = tempdir().unwrap();
 
         let pattern = "does/not/exist/*.rs";
@@ -1925,7 +2039,7 @@ mod tests {
 
     #[tokio::test]
     async fn test_driver_run_glob_missing_root_is_empty() {
-        let driver = Driver;
+        let driver = Driver::default();
         let tmp = tempdir().unwrap();
         let missing_root = tmp.path().join("nonexistent");
 
@@ -1948,7 +2062,7 @@ mod tests {
 
     #[tokio::test]
     async fn test_driver_run_glob_brace_pattern() {
-        let driver = Driver;
+        let driver = Driver::default();
         let tmp = tempdir().unwrap();
         let sub = tmp.path().join("dir");
         fs::create_dir_all(&sub).unwrap();
@@ -1999,19 +2113,12 @@ mod tests {
     }
 
     #[test]
-    fn test_builtin_excludes_shared() {
-        let a = builtin_excludes().unwrap();
-        let b = builtin_excludes().unwrap();
-        assert!(Arc::ptr_eq(&a, &b), "built-in Any built once per process");
-    }
-
-    #[test]
     fn test_compile_glob_no_exclude_reuses_builtin() {
-        let builtin = builtin_excludes().unwrap();
-        let compiled = compile_glob("req-test", "**/*.rs", &[]).unwrap();
+        let skip = Arc::new(FsSkip::default());
+        let compiled = compile_glob(&skip, "req-test", "**/*.rs", &[]).unwrap();
         assert!(
-            Arc::ptr_eq(&compiled.not, &builtin),
-            "empty-exclude path must reuse the cached built-in Any"
+            Arc::ptr_eq(&compiled.not, &skip.builtin_any),
+            "empty-exclude path must reuse the skip's prebuilt built-in Any"
         );
     }
 
@@ -2019,15 +2126,28 @@ mod tests {
     fn test_compile_glob_user_exclude_shares_any() {
         // Within one request, the same exclude set (any order) reuses one
         // compiled `Any`; a different set does not.
+        let skip = Arc::new(FsSkip::default());
         let req = "req-share";
-        let a = compile_glob(req, "**/*.go", &["vendor/**".into(), "out/**".into()]).unwrap();
-        let b = compile_glob(req, "src/**/*.go", &["out/**".into(), "vendor/**".into()]).unwrap();
+        let a = compile_glob(
+            &skip,
+            req,
+            "**/*.go",
+            &["vendor/**".into(), "out/**".into()],
+        )
+        .unwrap();
+        let b = compile_glob(
+            &skip,
+            req,
+            "src/**/*.go",
+            &["out/**".into(), "vendor/**".into()],
+        )
+        .unwrap();
         assert!(
             Arc::ptr_eq(&a.not, &b.not),
             "identical exclude sets must share one Any regardless of order"
         );
 
-        let c = compile_glob(req, "**/*.go", &["other/**".into()]).unwrap();
+        let c = compile_glob(&skip, req, "**/*.go", &["other/**".into()]).unwrap();
         assert!(
             !Arc::ptr_eq(&a.not, &c.not),
             "distinct exclude sets must not share an Any"
@@ -2038,9 +2158,10 @@ mod tests {
     fn test_compile_glob_exclude_cache_is_per_request() {
         // Different request ids do not share exclude `Any`s, even for the same
         // set — buckets are keyed by request.
+        let skip = Arc::new(FsSkip::default());
         let exclude = ["vendor/**".to_string()];
-        let a = compile_glob("req-iso-a", "**/*.go", &exclude).unwrap();
-        let b = compile_glob("req-iso-b", "**/*.go", &exclude).unwrap();
+        let a = compile_glob(&skip, "req-iso-a", "**/*.go", &exclude).unwrap();
+        let b = compile_glob(&skip, "req-iso-b", "**/*.go", &exclude).unwrap();
         assert!(
             !Arc::ptr_eq(&a.not, &b.not),
             "distinct requests must not share an exclude Any"
@@ -2051,7 +2172,7 @@ mod tests {
     async fn test_driver_run_glob_memoized_per_request_skips_rewalk() {
         // Within one request the walk result is memoized: a file created after
         // the first run must NOT appear in a second run with the same id.
-        let driver = Driver;
+        let driver = Driver::default();
         let tmp = tempdir().unwrap();
         fs::write(tmp.path().join("a.rs"), b"").unwrap();
 
@@ -2105,7 +2226,7 @@ mod tests {
     #[tokio::test]
     async fn test_driver_run_glob_distinct_requests_rewalk() {
         // A different request id must not see the first request's memoized walk.
-        let driver = Driver;
+        let driver = Driver::default();
         let tmp = tempdir().unwrap();
         fs::write(tmp.path().join("a.rs"), b"").unwrap();
 
@@ -2172,7 +2293,7 @@ mod tests {
     async fn test_driver_run_glob_rooted_prefix_ignores_siblings() {
         // A rooted pattern walks only its literal-prefix subtree; sibling
         // directories with matching-looking files must not appear.
-        let driver = Driver;
+        let driver = Driver::default();
         let tmp = tempdir().unwrap();
         fs::create_dir_all(tmp.path().join("pkg/sub")).unwrap();
         fs::write(tmp.path().join("pkg/keep.rs"), b"").unwrap();
@@ -2206,7 +2327,7 @@ mod tests {
 
     #[tokio::test]
     async fn test_provider_accepts_glob_addr() {
-        let p = Provider;
+        let p = Provider::default();
         let addr = glob_addr("**/*.rs", &[]);
         let result = p
             .get(
@@ -2237,7 +2358,7 @@ mod tests {
 
     #[tokio::test]
     async fn test_driver_run_glob_excludes_stamped_codegen() {
-        let driver = Driver;
+        let driver = Driver::default();
         let tmp = tempdir().unwrap();
         let plain = tmp.path().join("plain.rs");
         let generated = tmp.path().join("generated.rs");
@@ -2273,7 +2394,7 @@ mod tests {
 
     #[tokio::test]
     async fn test_driver_run_file_stamped_codegen_yields_nothing() {
-        let driver = Driver;
+        let driver = Driver::default();
         let tmp = tempdir().unwrap();
         let generated = tmp.path().join("generated.rs");
         fs::write(&generated, b"generated").unwrap();
@@ -2309,7 +2430,7 @@ mod tests {
 
     #[tokio::test]
     async fn test_driver_run_file_plain_yields_one_artifact() {
-        let driver = Driver;
+        let driver = Driver::default();
         let tmp = tempdir().unwrap();
         let plain = tmp.path().join("plain.rs");
         fs::write(&plain, b"plain").unwrap();

--- a/src/pluginfs/mod.rs
+++ b/src/pluginfs/mod.rs
@@ -17,6 +17,7 @@ use crate::hasync::Cancellable;
 use crate::htaddr::Addr;
 use crate::htpkg::PkgBuf;
 use crate::htvalue::Value;
+use crate::htwalk::Ignore;
 use anyhow::Context;
 use async_trait::async_trait;
 use futures::future::BoxFuture;
@@ -77,11 +78,11 @@ pub fn is_glob_addr(addr: &Addr) -> bool {
 #[derive(Default)]
 pub struct Provider {
     /// Dirs the `glob` provider function must prune, shared with the driver.
-    skip: Arc<FsSkip>,
+    skip: Arc<Ignore>,
 }
 
 impl Provider {
-    pub fn new(skip: Arc<FsSkip>) -> Self {
+    pub fn new(skip: Arc<Ignore>) -> Self {
         Self { skip }
     }
 }
@@ -215,7 +216,7 @@ impl EProvider for Provider {
 /// driver globs at execution time: brace alternation, `.`/`..` normalization, and
 /// the engine's skip dirs/globs. Result is sorted.
 struct GlobFn {
-    skip: Arc<FsSkip>,
+    skip: Arc<Ignore>,
 }
 
 #[async_trait]
@@ -375,80 +376,6 @@ impl ProviderFn for BaseFn {
 
 // ─── Driver ──────────────────────────────────────────────────────────────────
 
-/// Directories the fs walk never descends into. Both sources come from the
-/// engine — pluginfs hardcodes nothing:
-///  - `skip_dirs`: absolute paths (see
-///    [`Engine::skip_dirs`](crate::engine::Engine::skip_dirs)) — the heph home and
-///    the literal `fs.skip` dirs. Matched by exact path.
-///  - `skip_globs`: exclude globs (see
-///    [`Engine::skip_globs`](crate::engine::Engine::skip_globs)), matched against
-///    the workspace-relative path.
-#[derive(Debug)]
-pub struct FsSkip {
-    /// Absolute directories pruned by exact path during the walk.
-    skip_dirs: Vec<std::path::PathBuf>,
-    /// Exclude glob patterns: a root-relative `<rel>/**` for each skip dir under
-    /// the root, plus the engine's `skip_globs`. Chained ahead of a target's user
-    /// excludes when compiling its exclude `Any`.
-    exclude_globs: Vec<String>,
-    /// Compiled [`exclude_globs`](Self::exclude_globs), reused as the `not`
-    /// matcher for the common case of a target with no user excludes, and as the
-    /// glob source for walk-time directory pruning.
-    builtin_any: Arc<wax::Any<'static>>,
-}
-
-/// Sentinel filename probed under a directory to decide whether a `<…>/**`-style
-/// exclude glob covers the whole subtree (so the walk can prune it). Chosen to be
-/// extremely unlikely to be a real file an exclude pattern targets by name.
-const PRUNE_PROBE: &str = "\u{0}heph-prune-probe";
-
-impl FsSkip {
-    /// Builds the skip set from the engine-provided `skip_dirs` (absolute: heph
-    /// home + literal `fs.skip` dirs) and `skip_globs` (glob `fs.skip` entries).
-    /// Each skip dir under `root` also contributes a `<rel>/**` exclude glob so the
-    /// compiled `not` matcher agrees with the walk-time pruning.
-    pub fn new(
-        root: &std::path::Path,
-        skip_dirs: &[std::path::PathBuf],
-        skip_globs: &[String],
-    ) -> anyhow::Result<Self> {
-        let mut exclude_globs = Vec::new();
-        for dir in skip_dirs {
-            if let Some(rel) = dir.strip_prefix(root).ok().and_then(|r| r.to_str())
-                && !rel.is_empty()
-            {
-                exclude_globs.push(format!("{rel}/**"));
-            }
-        }
-        exclude_globs.extend(skip_globs.iter().cloned());
-        let builtin_any = compile_any(&exclude_globs).context("compiling built-in fs excludes")?;
-        Ok(Self {
-            skip_dirs: skip_dirs.to_vec(),
-            exclude_globs,
-            builtin_any,
-        })
-    }
-
-    /// True if the directory at absolute `path` (workspace-relative `rel`) must be
-    /// pruned: an exact skip dir, or a directory whose entire subtree is covered
-    /// by an exclude glob (probed by testing a sentinel child against the compiled
-    /// excludes — so a `**/node_modules/**`-style glob prunes the dir instead of
-    /// walking into it).
-    fn is_pruned_dir(&self, path: &std::path::Path, rel: &std::path::Path) -> bool {
-        use wax::Program as _;
-        self.skip_dirs.iter().any(|d| d == path)
-            || self.builtin_any.is_match(rel.join(PRUNE_PROBE).as_path())
-    }
-}
-
-impl Default for FsSkip {
-    fn default() -> Self {
-        // No skip dirs/globs — the engine supplies them via `skip_dirs`/
-        // `skip_globs`. An empty exclude set matches nothing.
-        Self::new(std::path::Path::new(""), &[], &[]).expect("empty fs skip set is valid")
-    }
-}
-
 /// Compiles a set of glob patterns into a single `wax::Any`, reusing the
 /// process-wide [`cached_glob`] cache for each pattern.
 fn compile_any(patterns: &[String]) -> anyhow::Result<Arc<wax::Any<'static>>> {
@@ -523,8 +450,8 @@ struct CompiledGlob {
     not: Arc<wax::Any<'static>>,
     /// Literal directory prefix of the pattern, used as the walk root.
     prefix: String,
-    /// Engine-owned + built-in dirs to prune during the walk.
-    skip: Arc<FsSkip>,
+    /// Engine-provided dirs/globs to prune during the walk.
+    skip: Arc<Ignore>,
 }
 
 /// Process-global cache of compiled globs keyed by pattern string.
@@ -585,11 +512,11 @@ fn glob_result_cache() -> &'static RwLock<GlobResultCache> {
     CACHE.get_or_init(|| RwLock::new(GlobResultCache::default()))
 }
 
-/// Returns the compiled exclude `Any` (built-ins + user `exclude`) for
+/// Returns the compiled exclude `Any` (engine ignore globs + user `exclude`) for
 /// `request_id`, memoizing across calls within that request. `exclude` must be
-/// non-empty; the no-exclude case reuses `skip.builtin_any` directly.
+/// non-empty; the no-exclude case reuses the ignore's file matcher directly.
 fn cached_exclude_any(
-    skip: &FsSkip,
+    skip: &Ignore,
     request_id: &str,
     exclude: &[String],
 ) -> anyhow::Result<Arc<wax::Any<'static>>> {
@@ -606,7 +533,7 @@ fn cached_exclude_any(
     }
 
     let patterns: Vec<String> = skip
-        .exclude_globs
+        .globs()
         .iter()
         .cloned()
         .chain(exclude.iter().cloned())
@@ -636,16 +563,16 @@ enum FsDef {
 }
 
 fn compile_glob(
-    skip: &Arc<FsSkip>,
+    skip: &Arc<Ignore>,
     request_id: &str,
     pattern: &str,
     exclude: &[String],
 ) -> anyhow::Result<CompiledGlob> {
     let glob = cached_glob(pattern).with_context(|| format!("invalid glob pattern '{pattern}'"))?;
 
-    // No user excludes: reuse the skip's prebuilt built-in `Any` directly.
+    // No user excludes: reuse the ignore's prebuilt file matcher directly.
     let not = if exclude.is_empty() {
-        skip.builtin_any.clone()
+        skip.file_matcher().clone()
     } else {
         cached_exclude_any(skip, request_id, exclude)?
     };
@@ -684,7 +611,7 @@ fn walk_glob(
                 return true;
             }
             let rel = entry.path().strip_prefix(root).unwrap_or(entry.path());
-            !compiled.skip.is_pruned_dir(entry.path(), rel)
+            !compiled.skip.prune_dir(entry.path(), rel)
         });
 
     for entry in walker {
@@ -811,11 +738,11 @@ fn cached_glob_walk(
 #[derive(Default)]
 pub struct Driver {
     /// Engine-owned + built-in dirs pruned during glob walks.
-    skip: Arc<FsSkip>,
+    skip: Arc<Ignore>,
 }
 
 impl Driver {
-    pub fn new(skip: Arc<FsSkip>) -> Self {
+    pub fn new(skip: Arc<Ignore>) -> Self {
         Self { skip }
     }
 }
@@ -1106,14 +1033,14 @@ mod tests {
     // ─── Exposed-function (glob) tests ─────────────────────────────────────
 
     fn call_glob(root: &std::path::Path, pkg: &str, pattern: &str) -> Vec<String> {
-        call_glob_with_skip(root, pkg, pattern, Arc::<FsSkip>::default())
+        call_glob_with_skip(root, pkg, pattern, Arc::<Ignore>::default())
     }
 
     fn call_glob_with_skip(
         root: &std::path::Path,
         pkg: &str,
         pattern: &str,
-        skip: Arc<FsSkip>,
+        skip: Arc<Ignore>,
     ) -> Vec<String> {
         let ctx = FnCallContext { pkg, root };
         let args = FnArgs {
@@ -1158,8 +1085,7 @@ mod tests {
         fs::write(pkg.join("main.rs"), "").unwrap();
 
         // The engine's skip globs prune matching subtrees for `heph.fs.glob` too.
-        let skip =
-            Arc::new(FsSkip::new(tmp.path(), &[], &["**/node_modules/**".to_string()]).unwrap());
+        let skip = Arc::new(Ignore::new(&[], &["**/node_modules/**".to_string()]).unwrap());
         let got = call_glob_with_skip(tmp.path(), "mypkg", "**/*", skip);
         assert!(!got.iter().any(|s| s.contains("node_modules")), "{got:?}");
         assert!(got.contains(&"main.rs".to_string()), "{got:?}");
@@ -1671,7 +1597,7 @@ mod tests {
 
         // The engine hands the fs plugin its skip dirs (the heph home); the walk
         // must prune that subtree.
-        let skip = Arc::new(FsSkip::new(tmp.path(), &[home], &[]).unwrap());
+        let skip = Arc::new(Ignore::new(&[home], &[]).unwrap());
         let driver = Driver::new(skip);
 
         let config =
@@ -1708,7 +1634,7 @@ mod tests {
 
         // A `fs.skip` dir from the config file (resolved to an absolute path) is
         // pruned just like the engine home.
-        let skip = Arc::new(FsSkip::new(tmp.path(), &[tmp.path().join("vendor")], &[]).unwrap());
+        let skip = Arc::new(Ignore::new(&[tmp.path().join("vendor")], &[]).unwrap());
         let driver = Driver::new(skip);
 
         let config =
@@ -1745,8 +1671,7 @@ mod tests {
 
         // A `fs.skip` glob (`**/node_modules/**`) excludes the whole subtree at
         // any depth — and prunes the dir so the walk never descends into it.
-        let skip =
-            Arc::new(FsSkip::new(tmp.path(), &[], &["**/node_modules/**".to_string()]).unwrap());
+        let skip = Arc::new(Ignore::new(&[], &["**/node_modules/**".to_string()]).unwrap());
         let driver = Driver::new(skip);
 
         let config =
@@ -2215,11 +2140,11 @@ mod tests {
 
     #[test]
     fn test_compile_glob_no_exclude_reuses_builtin() {
-        let skip = Arc::new(FsSkip::default());
+        let skip = Arc::new(Ignore::default());
         let compiled = compile_glob(&skip, "req-test", "**/*.rs", &[]).unwrap();
         assert!(
-            Arc::ptr_eq(&compiled.not, &skip.builtin_any),
-            "empty-exclude path must reuse the skip's prebuilt built-in Any"
+            Arc::ptr_eq(&compiled.not, skip.file_matcher()),
+            "empty-exclude path must reuse the ignore's prebuilt file matcher"
         );
     }
 
@@ -2227,7 +2152,7 @@ mod tests {
     fn test_compile_glob_user_exclude_shares_any() {
         // Within one request, the same exclude set (any order) reuses one
         // compiled `Any`; a different set does not.
-        let skip = Arc::new(FsSkip::default());
+        let skip = Arc::new(Ignore::default());
         let req = "req-share";
         let a = compile_glob(
             &skip,
@@ -2259,7 +2184,7 @@ mod tests {
     fn test_compile_glob_exclude_cache_is_per_request() {
         // Different request ids do not share exclude `Any`s, even for the same
         // set — buckets are keyed by request.
-        let skip = Arc::new(FsSkip::default());
+        let skip = Arc::new(Ignore::default());
         let exclude = ["vendor/**".to_string()];
         let a = compile_glob(&skip, "req-iso-a", "**/*.go", &exclude).unwrap();
         let b = compile_glob(&skip, "req-iso-b", "**/*.go", &exclude).unwrap();

--- a/src/pluginfs/mod.rs
+++ b/src/pluginfs/mod.rs
@@ -213,7 +213,7 @@ impl EProvider for Provider {
 /// to that package. Uses the exact same `wax` walk as the `fs` driver
 /// ([`compile_glob`] + [`walk_glob`]), so BUILD-time expansion matches what the
 /// driver globs at execution time: brace alternation, `.`/`..` normalization, and
-/// the built-in `.git` + engine skip-dir pruning. Result is sorted.
+/// the engine's skip dirs/globs. Result is sorted.
 struct GlobFn {
     skip: Arc<FsSkip>,
 }
@@ -375,24 +375,21 @@ impl ProviderFn for BaseFn {
 
 // ─── Driver ──────────────────────────────────────────────────────────────────
 
-/// Directories the fs walk never descends into. Sources:
-///  - `.git`, pruned by basename at any depth (a VCS dir is never a build input,
-///    and submodules nest it).
-///  - `skip_dirs`: absolute engine-owned paths handed in by the engine (see
+/// Directories the fs walk never descends into. Both sources come from the
+/// engine — pluginfs hardcodes nothing:
+///  - `skip_dirs`: absolute paths (see
 ///    [`Engine::skip_dirs`](crate::engine::Engine::skip_dirs)) — the heph home and
 ///    the literal `fs.skip` dirs. Matched by exact path.
-///  - `skip_globs`: the glob `fs.skip` entries (e.g. `**/node_modules/**`),
-///    matched against the workspace-relative path.
-///
-/// Replaces the former hardcoded `BUILT_IN_*` lists: the engine is now the single
-/// source of truth for which subtrees to skip.
+///  - `skip_globs`: exclude globs (see
+///    [`Engine::skip_globs`](crate::engine::Engine::skip_globs)), matched against
+///    the workspace-relative path.
 #[derive(Debug)]
 pub struct FsSkip {
     /// Absolute directories pruned by exact path during the walk.
     skip_dirs: Vec<std::path::PathBuf>,
-    /// Built-in exclude glob patterns — `**/.git/**`, a root-relative `<rel>/**`
-    /// for each skip dir under the root, and the `fs.skip` glob entries. Chained
-    /// ahead of a target's user excludes when compiling its exclude `Any`.
+    /// Exclude glob patterns: a root-relative `<rel>/**` for each skip dir under
+    /// the root, plus the engine's `skip_globs`. Chained ahead of a target's user
+    /// excludes when compiling its exclude `Any`.
     exclude_globs: Vec<String>,
     /// Compiled [`exclude_globs`](Self::exclude_globs), reused as the `not`
     /// matcher for the common case of a target with no user excludes, and as the
@@ -415,7 +412,7 @@ impl FsSkip {
         skip_dirs: &[std::path::PathBuf],
         skip_globs: &[String],
     ) -> anyhow::Result<Self> {
-        let mut exclude_globs = vec!["**/.git/**".to_string()];
+        let mut exclude_globs = Vec::new();
         for dir in skip_dirs {
             if let Some(rel) = dir.strip_prefix(root).ok().and_then(|r| r.to_str())
                 && !rel.is_empty()
@@ -433,22 +430,22 @@ impl FsSkip {
     }
 
     /// True if the directory at absolute `path` (workspace-relative `rel`) must be
-    /// pruned: a `.git` dir at any depth, an exact skip dir, or a directory whose
-    /// entire subtree is covered by a built-in/`fs.skip` exclude glob (probed by
-    /// testing a sentinel child against the compiled excludes — so
-    /// `**/node_modules/**` prunes `node_modules` instead of walking into it).
+    /// pruned: an exact skip dir, or a directory whose entire subtree is covered
+    /// by an exclude glob (probed by testing a sentinel child against the compiled
+    /// excludes — so a `**/node_modules/**`-style glob prunes the dir instead of
+    /// walking into it).
     fn is_pruned_dir(&self, path: &std::path::Path, rel: &std::path::Path) -> bool {
         use wax::Program as _;
-        path.file_name().and_then(|n| n.to_str()) == Some(".git")
-            || self.skip_dirs.iter().any(|d| d == path)
+        self.skip_dirs.iter().any(|d| d == path)
             || self.builtin_any.is_match(rel.join(PRUNE_PROBE).as_path())
     }
 }
 
 impl Default for FsSkip {
     fn default() -> Self {
-        // Only `.git` is pruned; the `**/.git/**` literal is statically valid.
-        Self::new(std::path::Path::new(""), &[], &[]).expect("built-in .git exclude is valid")
+        // No skip dirs/globs — the engine supplies them via `skip_dirs`/
+        // `skip_globs`. An empty exclude set matches nothing.
+        Self::new(std::path::Path::new(""), &[], &[]).expect("empty fs skip set is valid")
     }
 }
 
@@ -681,9 +678,8 @@ fn walk_glob(
     let walker = walkdir::WalkDir::new(&walk_root)
         .into_iter()
         .filter_entry(|entry| {
-            // Never descend into always-excluded subtrees (.git, the heph home +
-            // literal `fs.skip` dirs, and `fs.skip` glob subtrees like
-            // `**/node_modules/**`).
+            // Never descend into the engine's skip dirs (heph home + literal
+            // `fs.skip` dirs) or skip-glob subtrees (e.g. `**/node_modules/**`).
             if !entry.file_type().is_dir() {
                 return true;
             }
@@ -1110,18 +1106,21 @@ mod tests {
     // ─── Exposed-function (glob) tests ─────────────────────────────────────
 
     fn call_glob(root: &std::path::Path, pkg: &str, pattern: &str) -> Vec<String> {
+        call_glob_with_skip(root, pkg, pattern, Arc::<FsSkip>::default())
+    }
+
+    fn call_glob_with_skip(
+        root: &std::path::Path,
+        pkg: &str,
+        pattern: &str,
+        skip: Arc<FsSkip>,
+    ) -> Vec<String> {
         let ctx = FnCallContext { pkg, root };
         let args = FnArgs {
             positional: vec![Value::String(pattern.to_string())],
             named: Default::default(),
         };
-        let v = futures::executor::block_on(
-            GlobFn {
-                skip: Arc::<FsSkip>::default(),
-            }
-            .call(&ctx, args),
-        )
-        .unwrap();
+        let v = futures::executor::block_on(GlobFn { skip }.call(&ctx, args)).unwrap();
         match v {
             Value::List(l) => l
                 .into_iter()
@@ -1151,16 +1150,18 @@ mod tests {
     }
 
     #[test]
-    fn test_glob_fn_excludes_builtin_dirs() {
+    fn test_glob_fn_excludes_skip_globs() {
         let tmp = tempdir().unwrap();
         let pkg = tmp.path().join("mypkg");
-        let git = pkg.join(".git");
-        fs::create_dir_all(&git).unwrap();
-        fs::write(git.join("HEAD"), "").unwrap();
+        fs::create_dir_all(pkg.join("node_modules/dep")).unwrap();
+        fs::write(pkg.join("node_modules/dep/index.js"), "").unwrap();
         fs::write(pkg.join("main.rs"), "").unwrap();
 
-        let got = call_glob(tmp.path(), "mypkg", "**/*");
-        assert!(!got.iter().any(|s| s.starts_with(".git")), "{got:?}");
+        // The engine's skip globs prune matching subtrees for `heph.fs.glob` too.
+        let skip =
+            Arc::new(FsSkip::new(tmp.path(), &[], &["**/node_modules/**".to_string()]).unwrap());
+        let got = call_glob_with_skip(tmp.path(), "mypkg", "**/*", skip);
+        assert!(!got.iter().any(|s| s.contains("node_modules")), "{got:?}");
         assert!(got.contains(&"main.rs".to_string()), "{got:?}");
     }
 
@@ -1661,42 +1662,6 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn test_driver_run_glob_excludes_git() {
-        let driver = Driver::default();
-        let tmp = tempdir().unwrap();
-        let git_dir = tmp.path().join(".git");
-        fs::create_dir_all(&git_dir).unwrap();
-        fs::write(git_dir.join("config"), b"").unwrap();
-        fs::write(tmp.path().join("main.rs"), b"").unwrap();
-
-        let config =
-            std::collections::HashMap::from([("p".to_string(), Value::String("**/*".to_string()))]);
-        let parse_res = driver
-            .parse(make_parse_req(config), &ctoken())
-            .await
-            .unwrap();
-
-        let request_id = "test".to_string();
-        let hashin = String::new();
-        let req = make_run_req(
-            &parse_res.target_def,
-            &request_id,
-            tmp.path().to_path_buf(),
-            &hashin,
-        );
-        let res = driver.run(req, &ctoken()).await.unwrap();
-
-        let names: Vec<_> = res.artifacts.iter().map(|a| &a.name).collect();
-        assert!(
-            names.iter().all(|n| !n.contains(".git")),
-            "should exclude .git: {:?}",
-            names
-        );
-        assert_eq!(res.artifacts.len(), 1);
-        assert_eq!(res.artifacts[0].name, "main.rs");
-    }
-
-    #[tokio::test]
     async fn test_driver_run_glob_excludes_engine_skip_dir() {
         let tmp = tempdir().unwrap();
         let home = tmp.path().join(".heph3");
@@ -1705,7 +1670,7 @@ mod tests {
         fs::write(tmp.path().join("main.rs"), b"").unwrap();
 
         // The engine hands the fs plugin its skip dirs (the heph home); the walk
-        // must prune that subtree rather than relying on a hardcoded basename.
+        // must prune that subtree.
         let skip = Arc::new(FsSkip::new(tmp.path(), &[home], &[]).unwrap());
         let driver = Driver::new(skip);
 

--- a/src/pluginfs/mod.rs
+++ b/src/pluginfs/mod.rs
@@ -385,16 +385,11 @@ pub struct FsSkip {
 }
 
 impl FsSkip {
-    /// Builds the skip set from the engine-provided `skip_dirs` (absolute paths)
-    /// plus `extra_globs` — workspace-relative exclude patterns from the config
-    /// file's top-level `skip`. Each skip dir located under `root` also
-    /// contributes a `<rel>/**` exclude glob so the compiled `not` matcher agrees
-    /// with the walk-time pruning.
-    pub fn new(
-        root: &std::path::Path,
-        skip_dirs: &[std::path::PathBuf],
-        extra_globs: &[String],
-    ) -> anyhow::Result<Self> {
+    /// Builds the skip set from the engine-provided `skip_dirs` (absolute paths:
+    /// the heph home plus the config file's `fs.skip` dirs). Each skip dir located
+    /// under `root` also contributes a `<rel>/**` exclude glob so the compiled
+    /// `not` matcher agrees with the walk-time pruning.
+    pub fn new(root: &std::path::Path, skip_dirs: &[std::path::PathBuf]) -> anyhow::Result<Self> {
         let mut exclude_globs = vec!["**/.git/**".to_string()];
         for dir in skip_dirs {
             if let Some(rel) = dir.strip_prefix(root).ok().and_then(|r| r.to_str())
@@ -403,7 +398,6 @@ impl FsSkip {
                 exclude_globs.push(format!("{rel}/**"));
             }
         }
-        exclude_globs.extend(extra_globs.iter().cloned());
         let builtin_any = compile_any(&exclude_globs).context("compiling built-in fs excludes")?;
         Ok(Self {
             skip_dirs: skip_dirs.to_vec(),
@@ -423,7 +417,7 @@ impl FsSkip {
 impl Default for FsSkip {
     fn default() -> Self {
         // Only `.git` is pruned; the `**/.git/**` literal is statically valid.
-        Self::new(std::path::Path::new(""), &[], &[]).expect("built-in .git exclude is valid")
+        Self::new(std::path::Path::new(""), &[]).expect("built-in .git exclude is valid")
     }
 }
 
@@ -1652,7 +1646,7 @@ mod tests {
 
         // The engine hands the fs plugin its skip dirs (the heph home); the walk
         // must prune that subtree rather than relying on a hardcoded basename.
-        let skip = Arc::new(FsSkip::new(tmp.path(), &[home], &[]).unwrap());
+        let skip = Arc::new(FsSkip::new(tmp.path(), &[home]).unwrap());
         let driver = Driver::new(skip);
 
         let config =
@@ -1681,14 +1675,15 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn test_driver_run_glob_excludes_config_extra_skip() {
+    async fn test_driver_run_glob_excludes_config_skip_dir() {
         let tmp = tempdir().unwrap();
         fs::create_dir_all(tmp.path().join("vendor")).unwrap();
         fs::write(tmp.path().join("vendor").join("dep.rs"), b"").unwrap();
         fs::write(tmp.path().join("main.rs"), b"").unwrap();
 
-        // Extra exclude globs from the config file's top-level `skip`.
-        let skip = Arc::new(FsSkip::new(tmp.path(), &[], &["vendor/**".to_string()]).unwrap());
+        // A `fs.skip` dir from the config file (resolved to an absolute path) is
+        // pruned just like the engine home.
+        let skip = Arc::new(FsSkip::new(tmp.path(), &[tmp.path().join("vendor")]).unwrap());
         let driver = Driver::new(skip);
 
         let config =
@@ -1712,7 +1707,7 @@ mod tests {
         assert_eq!(
             names,
             vec!["main.rs"],
-            "config extra skip glob must exclude matched files: {names:?}"
+            "config skip dir must be pruned: {names:?}"
         );
     }
 

--- a/src/plugingo/provider.rs
+++ b/src/plugingo/provider.rs
@@ -178,17 +178,21 @@ impl Provider {
 
     pub fn from_options(
         workspace_root: PathBuf,
-        skip_dirs: &[PathBuf],
+        skip: &crate::engine::SkipConfig,
         opts: &crate::engine::config_file::Options,
     ) -> anyhow::Result<Self> {
         crate::engine::config_file::deny_unknown("go provider", opts, &["gotool", "skip"])?;
         let go_bin_addr: String =
             crate::engine::config_file::decode_opt(opts, "go provider", "gotool")?
                 .unwrap_or_else(|| DEFAULT_GO_BIN_ADDR.to_string());
-        let skip_globs: Vec<String> =
+        // Engine-wide `fs.skip` globs are merged ahead of this provider's own
+        // `skip` option so both prune the same workspace-relative paths.
+        let mut skip_globs = skip.globs.clone();
+        let user_skip: Vec<String> =
             crate::engine::config_file::decode_opt(opts, "go provider", "skip")?
                 .unwrap_or_default();
-        let skip = Arc::new(SkipMatcher::new(skip_dirs, &skip_globs)?);
+        skip_globs.extend(user_skip);
+        let skip = Arc::new(SkipMatcher::new(&skip.dirs, &skip_globs)?);
         Self::with_config(workspace_root, Config { go_bin_addr, skip })
     }
 

--- a/src/plugingo/provider.rs
+++ b/src/plugingo/provider.rs
@@ -8,6 +8,7 @@ use crate::hmemoizer::{Memoizer, downcast_chain_ref, unwrap_arc_err};
 use crate::htaddr::Addr;
 use crate::htpkg::PkgBuf;
 use crate::htvalue::{Value, parse_strings};
+use crate::htwalk::Ignore;
 use crate::pluginfs;
 use crate::plugingo::addr_util::{
     GoPackageKind, decode_package, encode_firstparty, encode_stdlib, encode_thirdparty,
@@ -37,67 +38,18 @@ use std::sync::Arc;
 
 const DEFAULT_GO_BIN_ADDR: &str = "//@heph/bin:go";
 
-/// Sentinel child filename used to decide whether a `<…>/**`-style skip glob
-/// covers a whole directory subtree (so discovery can prune it).
-const PRUNE_PROBE: &str = "\u{0}heph-prune-probe";
-
-/// Prunes directories during Go package discovery. Two prune sources:
-///  - `dirs`: absolute paths the engine hands every provider (the heph home plus
-///    literal `fs.skip` dirs); matched by exact path.
-///  - `globs`: `fs.skip` glob entries plus the provider's own `skip` option,
-///    matched against the workspace-relative package path (and against a sentinel
-///    child, so a `<dir>/**` pattern prunes the whole subtree).
-#[derive(Debug, Default)]
-pub struct SkipMatcher {
-    dirs: Vec<PathBuf>,
-    globs: Option<wax::Any<'static>>,
-}
-
-impl SkipMatcher {
-    fn new(dirs: &[PathBuf], globs: &[String]) -> anyhow::Result<Self> {
-        let compiled = if globs.is_empty() {
-            None
-        } else {
-            let gs = globs
-                .iter()
-                .map(|s| {
-                    wax::Glob::new(s)
-                        .map(wax::Glob::into_owned)
-                        .with_context(|| format!("go provider: invalid skip pattern `{s}`"))
-                })
-                .collect::<anyhow::Result<Vec<_>>>()?;
-            Some(wax::any(gs).context("compiling go skip patterns")?)
-        };
-        Ok(Self {
-            dirs: dirs.to_vec(),
-            globs: compiled,
-        })
-    }
-
-    /// True if the dir at absolute `path` (workspace-relative `rel`) is pruned.
-    fn is_skipped(&self, path: &Path, rel: &Path) -> bool {
-        use wax::Program as _;
-        if self.dirs.iter().any(|d| d == path) {
-            return true;
-        }
-        self.globs
-            .as_ref()
-            .is_some_and(|any| any.is_match(rel) || any.is_match(rel.join(PRUNE_PROBE).as_path()))
-    }
-}
-
 pub struct Config {
     pub go_bin_addr: String,
-    /// Directories to prune during package discovery: engine-owned dirs plus
-    /// user `skip` globs. See [`SkipMatcher`].
-    pub skip: Arc<SkipMatcher>,
+    /// Directories pruned during package discovery: engine skip dirs/globs plus
+    /// this provider's own `skip` option. See [`crate::htwalk::Ignore`].
+    pub skip: Arc<Ignore>,
 }
 
 impl Default for Config {
     fn default() -> Self {
         Self {
             go_bin_addr: DEFAULT_GO_BIN_ADDR.to_string(),
-            skip: Arc::new(SkipMatcher::default()),
+            skip: Arc::new(Ignore::default()),
         }
     }
 }
@@ -117,7 +69,7 @@ pub(crate) struct ProviderInner {
     gocache: String,
     go_bin_addr: String,
     /// Directories pruned during `collect_go_packages` (engine home + user globs).
-    skip: Arc<SkipMatcher>,
+    skip: Arc<Ignore>,
     /// Cache: golist addr → parsed GoPackage. Memoizes the artifact parse only;
     /// the underlying `executor.result(golist_addr)` is always called outside
     /// the `once` closure so every caller (owner + waiter) registers the
@@ -200,7 +152,7 @@ impl Provider {
             crate::engine::config_file::decode_opt(opts, "go provider", "skip")?
                 .unwrap_or_default();
         globs.extend(user_skip);
-        let skip = Arc::new(SkipMatcher::new(skip_dirs, &globs)?);
+        let skip = Arc::new(Ignore::new(skip_dirs, &globs)?);
         Self::with_config(workspace_root, Config { go_bin_addr, skip })
     }
 
@@ -269,7 +221,7 @@ fn collect_go_packages(
     dir: &Path,
     workspace_root: &Path,
     under_gomod: bool,
-    skip: &SkipMatcher,
+    skip: &Ignore,
     result: &mut Vec<anyhow::Result<ListPackageResponse>>,
 ) {
     let is_under = under_gomod || crate::plugingo::addr_util::find_go_mod(dir).is_some();
@@ -307,7 +259,7 @@ fn collect_go_packages(
         let rel = entry_path
             .strip_prefix(workspace_root)
             .unwrap_or(&entry_path);
-        if skip.is_skipped(&entry_path, rel) {
+        if skip.prune_dir(&entry_path, rel) {
             continue;
         }
         collect_go_packages(&entry_path, workspace_root, is_under, skip, result);
@@ -2413,7 +2365,7 @@ mod tests {
         std::fs::create_dir_all(root.join("internal")).unwrap();
         std::fs::create_dir_all(root.join("src")).unwrap();
 
-        let skip = SkipMatcher::new(&[home.clone()], &["internal".to_string()]).unwrap();
+        let skip = Ignore::new(&[home.clone()], &["internal".to_string()]).unwrap();
         let mut out = Vec::new();
         collect_go_packages(root, root, false, &skip, &mut out);
         let pkgs: Vec<String> = out

--- a/src/plugingo/provider.rs
+++ b/src/plugingo/provider.rs
@@ -178,21 +178,17 @@ impl Provider {
 
     pub fn from_options(
         workspace_root: PathBuf,
-        skip: &crate::engine::SkipConfig,
+        skip_dirs: &[PathBuf],
         opts: &crate::engine::config_file::Options,
     ) -> anyhow::Result<Self> {
         crate::engine::config_file::deny_unknown("go provider", opts, &["gotool", "skip"])?;
         let go_bin_addr: String =
             crate::engine::config_file::decode_opt(opts, "go provider", "gotool")?
                 .unwrap_or_else(|| DEFAULT_GO_BIN_ADDR.to_string());
-        // Engine-wide `fs.skip` globs are merged ahead of this provider's own
-        // `skip` option so both prune the same workspace-relative paths.
-        let mut skip_globs = skip.globs.clone();
-        let user_skip: Vec<String> =
+        let skip_globs: Vec<String> =
             crate::engine::config_file::decode_opt(opts, "go provider", "skip")?
                 .unwrap_or_default();
-        skip_globs.extend(user_skip);
-        let skip = Arc::new(SkipMatcher::new(&skip.dirs, &skip_globs)?);
+        let skip = Arc::new(SkipMatcher::new(skip_dirs, &skip_globs)?);
         Self::with_config(workspace_root, Config { go_bin_addr, skip })
     }
 

--- a/src/plugingo/provider.rs
+++ b/src/plugingo/provider.rs
@@ -37,11 +37,16 @@ use std::sync::Arc;
 
 const DEFAULT_GO_BIN_ADDR: &str = "//@heph/bin:go";
 
+/// Sentinel child filename used to decide whether a `<…>/**`-style skip glob
+/// covers a whole directory subtree (so discovery can prune it).
+const PRUNE_PROBE: &str = "\u{0}heph-prune-probe";
+
 /// Prunes directories during Go package discovery. Two prune sources:
-///  - `dirs`: absolute engine-owned paths (e.g. the heph home) the engine hands
-///    every provider; matched by exact path.
-///  - `globs`: user `skip` wax patterns, matched against the workspace-relative
-///    package path.
+///  - `dirs`: absolute paths the engine hands every provider (the heph home plus
+///    literal `fs.skip` dirs); matched by exact path.
+///  - `globs`: `fs.skip` glob entries plus the provider's own `skip` option,
+///    matched against the workspace-relative package path (and against a sentinel
+///    child, so a `<dir>/**` pattern prunes the whole subtree).
 #[derive(Debug, Default)]
 pub struct SkipMatcher {
     dirs: Vec<PathBuf>,
@@ -75,7 +80,9 @@ impl SkipMatcher {
         if self.dirs.iter().any(|d| d == path) {
             return true;
         }
-        self.globs.as_ref().is_some_and(|any| any.is_match(rel))
+        self.globs
+            .as_ref()
+            .is_some_and(|any| any.is_match(rel) || any.is_match(rel.join(PRUNE_PROBE).as_path()))
     }
 }
 
@@ -179,16 +186,21 @@ impl Provider {
     pub fn from_options(
         workspace_root: PathBuf,
         skip_dirs: &[PathBuf],
+        skip_globs: &[String],
         opts: &crate::engine::config_file::Options,
     ) -> anyhow::Result<Self> {
         crate::engine::config_file::deny_unknown("go provider", opts, &["gotool", "skip"])?;
         let go_bin_addr: String =
             crate::engine::config_file::decode_opt(opts, "go provider", "gotool")?
                 .unwrap_or_else(|| DEFAULT_GO_BIN_ADDR.to_string());
-        let skip_globs: Vec<String> =
+        // Engine-wide `fs.skip` globs are merged ahead of this provider's own
+        // `skip` option so both prune the same workspace-relative paths.
+        let mut globs = skip_globs.to_vec();
+        let user_skip: Vec<String> =
             crate::engine::config_file::decode_opt(opts, "go provider", "skip")?
                 .unwrap_or_default();
-        let skip = Arc::new(SkipMatcher::new(skip_dirs, &skip_globs)?);
+        globs.extend(user_skip);
+        let skip = Arc::new(SkipMatcher::new(skip_dirs, &globs)?);
         Self::with_config(workspace_root, Config { go_bin_addr, skip })
     }
 
@@ -3096,15 +3108,15 @@ golang.org/x/oauth2 v0.0.0-20200107190931-bf48bf16ab8d h1:pE8b58s1HRDMi8RDc79m0H
         e.register_provider(|_| Box::new(crate::pluginhostbin::Provider))
             .unwrap();
 
-        e.register_driver(Box::new(crate::pluginhostbin::Driver))
+        e.register_driver(|_| Box::new(crate::pluginhostbin::Driver))
             .unwrap();
 
-        e.register_managed_driver(Box::new(crate::pluginexec::Driver::new_sh()))
+        e.register_managed_driver(|_| Box::new(crate::pluginexec::Driver::new_sh()))
             .unwrap();
-        e.register_managed_driver(Box::new(crate::pluginexec::Driver::new_exec()))
+        e.register_managed_driver(|_| Box::new(crate::pluginexec::Driver::new_exec()))
             .unwrap();
 
-        e.register_provider(|root| Box::new(Provider::new(root.to_path_buf()).unwrap()))
+        e.register_provider(|init| Box::new(Provider::new(init.root.to_path_buf()).unwrap()))
             .unwrap();
 
         Arc::new(e)

--- a/src/plugingo/provider.rs
+++ b/src/plugingo/provider.rs
@@ -337,6 +337,17 @@ impl ProviderInner {
                 }
             };
 
+            // A first-party package inside a skipped subtree lists nothing —
+            // mirroring what the package walk (`collect_go_packages`) prunes.
+            if matches!(&*kind, GoPackageKind::FirstParty { .. })
+                && self
+                    .skip
+                    .prunes_package(&self.workspace_root, Path::new(req.package.as_str()))
+            {
+                return Ok(Box::new(std::iter::empty())
+                    as Box<dyn Iterator<Item = anyhow::Result<ListResponse>> + Send>);
+            }
+
             match &*kind {
                 GoPackageKind::Stdlib { .. } => {
                     let addrs = vec![
@@ -649,6 +660,16 @@ impl ProviderInner {
             Some(k) => k,
             None => return Err(GetError::NotFound),
         };
+
+        // A first-party package inside a skipped subtree does not resolve —
+        // mirroring what the package walk (`collect_go_packages`) prunes.
+        if matches!(&*kind, GoPackageKind::FirstParty { .. })
+            && self
+                .skip
+                .prunes_package(&self.workspace_root, Path::new(addr.package.as_str()))
+        {
+            return Err(GetError::NotFound);
+        }
 
         // _golist — generate spec without executing go list (before stdlib check so
         // stdlib packages can also expose a _golist target for cached dep resolution)

--- a/testkit/src/lib.rs
+++ b/testkit/src/lib.rs
@@ -61,17 +61,13 @@ impl WorkspaceBuilder {
     }
 
     /// Registers the built-in `fs` provider + driver, wired with the engine's own
-    /// skip dirs (the heph home) and config skip globs — mirroring how the real
-    /// bootstrap registers them. Prefer this over registering `pluginfs` manually
-    /// so glob walks prune the engine-owned subtrees.
+    /// skip dirs (the heph home) — mirroring how the real bootstrap registers
+    /// them. Prefer this over registering `pluginfs` manually so glob walks prune
+    /// the engine-owned subtrees.
     pub fn with_fs(mut self) -> Self {
         let root = self.dir.path().to_path_buf();
         self.setups.push(Box::new(move |e: &mut Engine| {
-            let skip = Arc::new(heph::pluginfs::FsSkip::new(
-                &root,
-                &e.skip_dirs(),
-                e.skip_globs(),
-            )?);
+            let skip = Arc::new(heph::pluginfs::FsSkip::new(&root, &e.skip_dirs(), &[])?);
             e.register_provider({
                 let skip = skip.clone();
                 move |_| Box::new(heph::pluginfs::Provider::new(skip))

--- a/testkit/src/lib.rs
+++ b/testkit/src/lib.rs
@@ -67,7 +67,8 @@ impl WorkspaceBuilder {
     pub fn with_fs(mut self) -> Self {
         let root = self.dir.path().to_path_buf();
         self.setups.push(Box::new(move |e: &mut Engine| {
-            let skip = Arc::new(heph::pluginfs::FsSkip::new(&root, &e.skip_dirs(), &[])?);
+            let skip = e.skip_config();
+            let skip = Arc::new(heph::pluginfs::FsSkip::new(&root, &skip.dirs, &skip.globs)?);
             e.register_provider({
                 let skip = skip.clone();
                 move |_| Box::new(heph::pluginfs::Provider::new(skip))

--- a/testkit/src/lib.rs
+++ b/testkit/src/lib.rs
@@ -67,8 +67,7 @@ impl WorkspaceBuilder {
     pub fn with_fs(mut self) -> Self {
         let root = self.dir.path().to_path_buf();
         self.setups.push(Box::new(move |e: &mut Engine| {
-            let skip = e.skip_config();
-            let skip = Arc::new(heph::pluginfs::FsSkip::new(&root, &skip.dirs, &skip.globs)?);
+            let skip = Arc::new(heph::pluginfs::FsSkip::new(&root, &e.skip_dirs())?);
             e.register_provider({
                 let skip = skip.clone();
                 move |_| Box::new(heph::pluginfs::Provider::new(skip))

--- a/testkit/src/lib.rs
+++ b/testkit/src/lib.rs
@@ -2,7 +2,9 @@ use anyhow::Context as _;
 use heph::engine::driver::Driver as SDKDriver;
 use heph::engine::driver_managed::ManagedDriver as SDKManagedDriver;
 use heph::engine::provider::Provider as SDKProvider;
-use heph::engine::{Config, EResult, Engine, EngineTargetSpec, OutputMatcher, ResultOptions};
+use heph::engine::{
+    Config, EResult, Engine, EngineTargetSpec, OutputMatcher, PluginInit, ResultOptions,
+};
 use heph::htaddr::{Addr, parse_addr};
 use std::path::{Path, PathBuf};
 use std::sync::Arc;
@@ -40,7 +42,7 @@ impl WorkspaceBuilder {
 
     pub fn with_provider(
         mut self,
-        factory: impl FnOnce(&Path) -> Box<dyn SDKProvider> + 'static,
+        factory: impl FnOnce(&PluginInit) -> Box<dyn SDKProvider> + 'static,
     ) -> Self {
         self.setups
             .push(Box::new(move |e: &mut Engine| e.register_provider(factory)));
@@ -49,30 +51,14 @@ impl WorkspaceBuilder {
 
     pub fn with_managed_driver(mut self, driver: Box<dyn SDKManagedDriver>) -> Self {
         self.setups.push(Box::new(move |e: &mut Engine| {
-            e.register_managed_driver(driver)
+            e.register_managed_driver(|_| driver)
         }));
         self
     }
 
     pub fn with_driver(mut self, driver: Box<dyn SDKDriver>) -> Self {
-        self.setups
-            .push(Box::new(move |e: &mut Engine| e.register_driver(driver)));
-        self
-    }
-
-    /// Registers the built-in `fs` provider + driver, wired with the engine's own
-    /// skip dirs (the heph home) — mirroring how the real bootstrap registers
-    /// them. Prefer this over registering `pluginfs` manually so glob walks prune
-    /// the engine-owned subtrees.
-    pub fn with_fs(mut self) -> Self {
-        let root = self.dir.path().to_path_buf();
         self.setups.push(Box::new(move |e: &mut Engine| {
-            let skip = Arc::new(heph::pluginfs::FsSkip::new(&root, &e.skip_dirs())?);
-            e.register_provider({
-                let skip = skip.clone();
-                move |_| Box::new(heph::pluginfs::Provider::new(skip))
-            })?;
-            e.register_driver(Box::new(heph::pluginfs::Driver::new(skip)))
+            e.register_driver(|_| driver)
         }));
         self
     }

--- a/testkit/src/lib.rs
+++ b/testkit/src/lib.rs
@@ -60,6 +60,27 @@ impl WorkspaceBuilder {
         self
     }
 
+    /// Registers the built-in `fs` provider + driver, wired with the engine's own
+    /// skip dirs (the heph home) and config skip globs — mirroring how the real
+    /// bootstrap registers them. Prefer this over registering `pluginfs` manually
+    /// so glob walks prune the engine-owned subtrees.
+    pub fn with_fs(mut self) -> Self {
+        let root = self.dir.path().to_path_buf();
+        self.setups.push(Box::new(move |e: &mut Engine| {
+            let skip = Arc::new(heph::pluginfs::FsSkip::new(
+                &root,
+                &e.skip_dirs(),
+                e.skip_globs(),
+            )?);
+            e.register_provider({
+                let skip = skip.clone();
+                move |_| Box::new(heph::pluginfs::Provider::new(skip))
+            })?;
+            e.register_driver(Box::new(heph::pluginfs::Driver::new(skip)))
+        }));
+        self
+    }
+
     pub fn build(self) -> anyhow::Result<Workspace> {
         let mut e = Engine::new(Config {
             root: self.dir.path().to_path_buf(),


### PR DESCRIPTION
## Summary

Replaces the fs plugin's hardcoded skip lists with a single, engine-owned
ignore model shared by every tree-walking plugin, and makes it configurable.

### Config — `fs.skip`
A top-level block in `.hephconfig2`, all entries **root-relative**:

```yaml
fs:
  skip:
    - node_modules          # literal dir → prune (also ./node_modules, node_modules/)
    - foo/**/bar            # glob, literal tail → prune every bar dir under foo
    - some/*.go             # glob, wildcard tail → file exclusion only (no prune)
```

`.git` is an always-on built-in (like the heph home), never hardcoded in pluginfs.

### `src/htwalk` — shared `Ignore`
New module used by the fs driver/provider and the buildfile/go providers
(replaces three duplicate `SkipMatcher`/`FsSkip` types). It distinguishes
**pruning** a directory subtree from **excluding** files, deriving the
directory matcher from the glob shape — no sentinel-child probe:
- glob whose final component is a literal names directories → prune (`foo/**/bar`);
- recursive `…/**` / `…/**/*` → prune via its prefix (`**/node_modules/**` → `**/node_modules`);
- wildcard-tail glob (`some/*.go`) → file-only;
- exact `dirs` (heph home + literal `fs.skip`) → prune by path (component-wise, so `node_modules/` works).

### Engine plumbing
- `PluginInit { root, skip_dirs, skip_globs }` injected into every register method.
  `register_provider`/`register_driver`/`register_managed_driver` take a closure
  receiving it; `*_factory` variants compose with `&Options`.
- Fallible `try_register_provider` / `try_register_driver`: the built-in `fs`
  plugin composes its `Ignore` from `PluginInit` inside the closure, so a bad
  `fs.skip` glob surfaces as an error from `Engine::new`.
- `fs` is an always-on built-in registered by `Engine::new` (like plugingroup/pluginquery).

### list & get honor the ignore
Package discovery already pruned skipped dirs; now buildfile/go `list` and `get`
also return empty / NotFound for a package inside a pruned subtree
(`Ignore::prunes_package` walks the package dir + ancestors). So a direct
`heph run //node_modules/x:y` no longer resolves. (stdlib/third-party go
packages live outside the workspace, so skips don't apply.)

## Tests
- `htwalk`: prune-vs-exclude, literal-tail / recursive / wildcard-tail globs,
  `./` normalize, trailing slash, ancestor `prunes_package`.
- config_file / bootstrap: `fs.skip` split into dirs+globs, `./` normalize, `.git` built-in.
- pluginfs / buildfile: skip-dir & skip-glob pruning in walks; `get`/`list` skip pruned packages.
- testkit: e2e wires fs via `Engine::new` auto-registration.

`cargo clippy --all-targets --locked -- -D warnings` clean; 987 lib + plugingo-e2e green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)