### PR TITLE
fix(query): dedup target addrs and packages

### DIFF
--- a/src/engine/packages.rs
+++ b/src/engine/packages.rs
@@ -113,7 +113,9 @@ mod tests {
         > {
             Box::pin(async {
                 Ok(Box::new(std::iter::empty())
-                    as Box<dyn Iterator<Item = anyhow::Result<ListResponse>> + Send>)
+                    as Box<
+                        dyn Iterator<Item = anyhow::Result<ListResponse>> + Send,
+                    >)
             })
         }
         fn list_packages<'a>(
@@ -134,7 +136,9 @@ mod tests {
                     }),
                 ];
                 Ok(Box::new(items.into_iter())
-                    as Box<dyn Iterator<Item = anyhow::Result<ListPackageResponse>> + Send>)
+                    as Box<
+                        dyn Iterator<Item = anyhow::Result<ListPackageResponse>> + Send,
+                    >)
             })
         }
         fn get<'a>(

--- a/src/engine/packages.rs
+++ b/src/engine/packages.rs
@@ -5,6 +5,7 @@ use crate::hmemoizer::unwrap_arc_err;
 use crate::htmatcher;
 use crate::htpkg::PkgBuf;
 use enclose::enclose;
+use rustc_hash::FxHashSet;
 use std::sync::Arc;
 
 /// Walk the matcher and pick the most specific `Package` / `PackagePrefix`
@@ -36,6 +37,10 @@ impl Engine {
         let prefix = narrowing_prefix(m);
 
         let mut all_packages = Vec::new();
+        // Different providers can list the same package; dedup so callers
+        // (e.g. `query`) don't scan a package more than once. First-seen
+        // order is preserved for determinism.
+        let mut seen: FxHashSet<String> = FxHashSet::default();
 
         for provider in &self.providers {
             let req = ListPackagesRequest {
@@ -63,7 +68,11 @@ impl Engine {
                 .await
                 .map_err(unwrap_arc_err)?;
 
-            all_packages.extend((*pkgs).clone());
+            for p in pkgs.iter() {
+                if seen.insert(p.clone()) {
+                    all_packages.push(p.clone());
+                }
+            }
         }
 
         Ok(Box::new(all_packages.into_iter().map(Ok)))
@@ -73,10 +82,108 @@ impl Engine {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::engine::Config;
+    use crate::engine::provider::{
+        ConfigRequest, ConfigResponse, GetError, GetRequest, GetResponse, ListPackageResponse,
+        ListPackagesRequest, ListRequest, ListResponse, ProbeRequest, ProbeResponse,
+    };
+    use crate::hasync::Cancellable;
     use crate::htmatcher::Matcher;
+    use futures::future::BoxFuture;
 
     fn pkg(s: &str) -> PkgBuf {
         PkgBuf::from(s)
+    }
+
+    // Lists `foo` twice; also used to register two instances under distinct names.
+    struct DupPkgs(&'static str);
+    impl crate::engine::provider::Provider for DupPkgs {
+        fn config(&self, _req: ConfigRequest) -> anyhow::Result<ConfigResponse> {
+            Ok(ConfigResponse {
+                name: self.0.to_string(),
+            })
+        }
+        fn list<'a>(
+            &'a self,
+            _req: ListRequest,
+            _ctoken: &'a (dyn Cancellable + Send + Sync),
+        ) -> BoxFuture<
+            'a,
+            anyhow::Result<Box<dyn Iterator<Item = anyhow::Result<ListResponse>> + Send>>,
+        > {
+            Box::pin(async {
+                Ok(Box::new(std::iter::empty())
+                    as Box<dyn Iterator<Item = anyhow::Result<ListResponse>> + Send>)
+            })
+        }
+        fn list_packages<'a>(
+            &'a self,
+            _req: ListPackagesRequest,
+            _ctoken: &'a (dyn Cancellable + Send + Sync),
+        ) -> BoxFuture<
+            'a,
+            anyhow::Result<Box<dyn Iterator<Item = anyhow::Result<ListPackageResponse>> + Send>>,
+        > {
+            Box::pin(async {
+                let items: Vec<anyhow::Result<ListPackageResponse>> = vec![
+                    Ok(ListPackageResponse {
+                        pkg: PkgBuf::from("foo"),
+                    }),
+                    Ok(ListPackageResponse {
+                        pkg: PkgBuf::from("foo"),
+                    }),
+                ];
+                Ok(Box::new(items.into_iter())
+                    as Box<dyn Iterator<Item = anyhow::Result<ListPackageResponse>> + Send>)
+            })
+        }
+        fn get<'a>(
+            &'a self,
+            _req: GetRequest,
+            _ctoken: &'a (dyn Cancellable + Send + Sync),
+        ) -> BoxFuture<'a, Result<GetResponse, GetError>> {
+            Box::pin(async { Err(GetError::NotFound) })
+        }
+        fn probe<'a>(
+            &'a self,
+            req: ProbeRequest,
+            _ctoken: &'a (dyn Cancellable + Send + Sync),
+        ) -> BoxFuture<'a, anyhow::Result<ProbeResponse>> {
+            let pkg = req.package.clone();
+            Box::pin(async move {
+                Ok(ProbeResponse {
+                    states: vec![crate::engine::provider::State {
+                        package: pkg,
+                        provider: "dp".to_string(),
+                        state: Default::default(),
+                    }],
+                })
+            })
+        }
+    }
+
+    #[tokio::test]
+    async fn packages_dedups_within_and_across_providers() -> anyhow::Result<()> {
+        let root = tempfile::tempdir()?;
+        let mut engine = Engine::new(Config {
+            root: root.path().to_path_buf(),
+            home_dir: std::path::PathBuf::new(),
+            parallelism: None,
+            ..Default::default()
+        })?;
+        // Each provider lists `foo` twice; two providers list it again.
+        engine.register_provider(move |_| Box::new(DupPkgs("p1")))?;
+        engine.register_provider(move |_| Box::new(DupPkgs("p2")))?;
+        let engine = Arc::new(engine);
+        let rs = engine.new_state();
+
+        let pkgs: Vec<String> = engine
+            .packages(&Matcher::PackagePrefix(pkg("")), &rs)
+            .await?
+            .collect::<anyhow::Result<Vec<_>>>()?;
+
+        assert_eq!(pkgs, vec!["foo".to_string()]);
+        Ok(())
     }
 
     #[test]

--- a/src/engine/query.rs
+++ b/src/engine/query.rs
@@ -151,12 +151,18 @@ mod tests {
                 Box::pin(async {
                     let mk = || {
                         Ok(ListResponse {
-                            addr: Addr::new(PkgBuf::from("foo"), "a".to_string(), Default::default()),
+                            addr: Addr::new(
+                                PkgBuf::from("foo"),
+                                "a".to_string(),
+                                Default::default(),
+                            ),
                         })
                     };
                     let items: Vec<anyhow::Result<ListResponse>> = vec![mk(), mk()];
                     Ok(Box::new(items.into_iter())
-                        as Box<dyn Iterator<Item = anyhow::Result<ListResponse>> + Send>)
+                        as Box<
+                            dyn Iterator<Item = anyhow::Result<ListResponse>> + Send,
+                        >)
                 })
             }
             fn list_packages<'a>(
@@ -179,7 +185,9 @@ mod tests {
                         }),
                     ];
                     Ok(Box::new(items.into_iter())
-                        as Box<dyn Iterator<Item = anyhow::Result<ListPackageResponse>> + Send>)
+                        as Box<
+                            dyn Iterator<Item = anyhow::Result<ListPackageResponse>> + Send,
+                        >)
                 })
             }
             fn get<'a>(

--- a/src/engine/query.rs
+++ b/src/engine/query.rs
@@ -8,6 +8,7 @@ use crate::htmatcher;
 use crate::htmatcher::MatchResult;
 use crate::htpkg::PkgBuf;
 use futures::Stream;
+use rustc_hash::FxHashSet;
 use std::sync::Arc;
 
 impl Engine {
@@ -17,6 +18,9 @@ impl Engine {
         m: &'a htmatcher::Matcher,
     ) -> impl Stream<Item = anyhow::Result<Addr>> + 'a {
         async_stream::try_stream! {
+            // Multiple providers can surface the same addr (or the same package
+            // from `packages()`), so dedup before yielding.
+            let mut seen: FxHashSet<Addr> = FxHashSet::default();
             for pkg_result in self.packages(m, &rs).await? {
                 let pkg = PkgBuf::from(pkg_result?);
 
@@ -41,7 +45,9 @@ impl Engine {
                         }
 
                         match m.matches_addr(&addr) {
-                            MatchResult::MatchYes => yield addr,
+                            MatchResult::MatchYes => {
+                                if seen.insert(addr.clone()) { yield addr; }
+                            }
                             MatchResult::MatchNo => {}
                             MatchResult::MatchShrug => {
                                 let spec = match Arc::clone(&self).get_spec(rs.clone(), &addr).await {
@@ -52,7 +58,9 @@ impl Engine {
                                 }?;
 
                                 match m.matches_spec(&spec) {
-                                    MatchResult::MatchYes => yield addr,
+                                    MatchResult::MatchYes => {
+                                        if seen.insert(addr.clone()) { yield addr; }
+                                    }
                                     MatchResult::MatchNo => {}
                                     MatchResult::MatchShrug => {
                                         let def = match Arc::clone(&self).get_def(rs.clone(), &addr).await {
@@ -63,7 +71,9 @@ impl Engine {
                                             Err(e) => Err(e)?,
                                         };
 
-                                        if m.matches(&def.target_def) == MatchResult::MatchYes {
+                                        if m.matches(&def.target_def) == MatchResult::MatchYes
+                                            && seen.insert(addr.clone())
+                                        {
                                             yield addr;
                                         }
                                     }
@@ -110,6 +120,112 @@ mod tests {
         let provider = pluginstatictarget::Provider::new(targets)?;
         engine.register_provider(move |_| Box::new(provider))?;
         Ok(Arc::new(engine))
+    }
+
+    #[tokio::test]
+    async fn query_dedups_repeated_addrs() -> anyhow::Result<()> {
+        use crate::engine::provider::{
+            ConfigRequest, ConfigResponse, GetError, GetRequest, GetResponse, ListPackageResponse,
+            ListPackagesRequest, ListResponse, ProbeRequest, ProbeResponse,
+        };
+        use crate::hasync::Cancellable;
+        use futures::future::BoxFuture;
+
+        // Provider that surfaces the same addr twice in one package, and the
+        // same package twice from `list_packages`.
+        struct Dup;
+        impl crate::engine::provider::Provider for Dup {
+            fn config(&self, _req: ConfigRequest) -> anyhow::Result<ConfigResponse> {
+                Ok(ConfigResponse {
+                    name: "dup".to_string(),
+                })
+            }
+            fn list<'a>(
+                &'a self,
+                _req: ListRequest,
+                _ctoken: &'a (dyn Cancellable + Send + Sync),
+            ) -> BoxFuture<
+                'a,
+                anyhow::Result<Box<dyn Iterator<Item = anyhow::Result<ListResponse>> + Send>>,
+            > {
+                Box::pin(async {
+                    let mk = || {
+                        Ok(ListResponse {
+                            addr: Addr::new(PkgBuf::from("foo"), "a".to_string(), Default::default()),
+                        })
+                    };
+                    let items: Vec<anyhow::Result<ListResponse>> = vec![mk(), mk()];
+                    Ok(Box::new(items.into_iter())
+                        as Box<dyn Iterator<Item = anyhow::Result<ListResponse>> + Send>)
+                })
+            }
+            fn list_packages<'a>(
+                &'a self,
+                _req: ListPackagesRequest,
+                _ctoken: &'a (dyn Cancellable + Send + Sync),
+            ) -> BoxFuture<
+                'a,
+                anyhow::Result<
+                    Box<dyn Iterator<Item = anyhow::Result<ListPackageResponse>> + Send>,
+                >,
+            > {
+                Box::pin(async {
+                    let items: Vec<anyhow::Result<ListPackageResponse>> = vec![
+                        Ok(ListPackageResponse {
+                            pkg: PkgBuf::from("foo"),
+                        }),
+                        Ok(ListPackageResponse {
+                            pkg: PkgBuf::from("foo"),
+                        }),
+                    ];
+                    Ok(Box::new(items.into_iter())
+                        as Box<dyn Iterator<Item = anyhow::Result<ListPackageResponse>> + Send>)
+                })
+            }
+            fn get<'a>(
+                &'a self,
+                _req: GetRequest,
+                _ctoken: &'a (dyn Cancellable + Send + Sync),
+            ) -> BoxFuture<'a, Result<GetResponse, GetError>> {
+                Box::pin(async { Err(GetError::NotFound) })
+            }
+            fn probe<'a>(
+                &'a self,
+                req: ProbeRequest,
+                _ctoken: &'a (dyn Cancellable + Send + Sync),
+            ) -> BoxFuture<'a, anyhow::Result<ProbeResponse>> {
+                let pkg = req.package.clone();
+                Box::pin(async move {
+                    Ok(ProbeResponse {
+                        states: vec![crate::engine::provider::State {
+                            package: pkg,
+                            provider: "dup".to_string(),
+                            state: Default::default(),
+                        }],
+                    })
+                })
+            }
+        }
+
+        let root = tempdir()?;
+        let mut engine = Engine::new(Config {
+            root: root.path().to_path_buf(),
+            home_dir: std::path::PathBuf::new(),
+            parallelism: None,
+            ..Default::default()
+        })?;
+        engine.register_provider(move |_| Box::new(Dup))?;
+        let engine = Arc::new(engine);
+
+        let rs = engine.new_state();
+        let addrs: Vec<Addr> = engine
+            .query(rs, &Matcher::Package(PkgBuf::from("foo")))
+            .try_collect()
+            .await?;
+
+        assert_eq!(addrs.len(), 1, "duplicate addrs collapsed");
+        assert_eq!(addrs[0].name, "a");
+        Ok(())
     }
 
     #[tokio::test]


### PR DESCRIPTION
## Problem
`heph query` printed duplicate entries. Root cause is in the engine, not the CLI: multiple providers can surface the same addr, and `Engine::packages` could return the same package from more than one provider — causing duplicate output and redundant per-package `list()` scans.

## Fix
- `Engine::query` dedups yielded addrs via an `FxHashSet<Addr>` at all yield sites. `Addr` is interned (Hash+Eq), so keys are cheap.
- `Engine::packages` dedups package names across providers, preserving first-seen order for determinism.

## Tests
- `query_dedups_repeated_addrs` — provider yields the same addr twice and the same package twice → 1 result.
- `packages_dedups_within_and_across_providers` — two providers each list `foo` twice → `["foo"]`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)