### PR TITLE
test(packages): account for always-on built-in fs provider

### DIFF
--- a/src/engine/packages.rs
+++ b/src/engine/packages.rs
@@ -186,7 +186,10 @@ mod tests {
             .await?
             .collect::<anyhow::Result<Vec<_>>>()?;
 
-        assert_eq!(pkgs, vec!["foo".to_string()]);
+        // The always-on built-in `fs` provider also advertises its `@heph/fs`
+        // package; it sorts first because it is registered before `p1`/`p2`.
+        // `foo` still appears exactly once despite four listings across providers.
+        assert_eq!(pkgs, vec!["@heph/fs".to_string(), "foo".to_string()]);
         Ok(())
     }
 


### PR DESCRIPTION
## Summary
Fixes CI failure in `engine::packages::tests::packages_dedups_within_and_across_providers` (failing on both linux/amd64 and darwin/arm64).

`Engine::new` registers the `pluginfs` provider as an always-on built-in, which advertises the `@heph/fs` package via `list_packages`. The dedup test predated that and asserted only `["foo"]`, so it failed with:

```
left:  ["@heph/fs", "foo"]
right: ["foo"]
```

The assertion now expects the builtin package. `foo` still dedups to a single entry across four listings (p1×2, p2×2), so the test's intent — dedup within and across providers — is preserved. Order is deterministic: the fs provider is registered before `p1`/`p2`.

## Test plan
- `cargo test --lib packages_dedups` → passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)