### PR TITLE
fix(engine): contain provider-induced cycles in get_spec

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2416,6 +2416,7 @@ name = "plugingo-e2e"
 version = "0.1.0"
 dependencies = [
  "anyhow",
+ "futures",
  "heph",
  "heph-testkit",
  "tempfile",

--- a/plugingo-e2e/Cargo.toml
+++ b/plugingo-e2e/Cargo.toml
@@ -13,3 +13,4 @@ heph-testkit = { path = "../testkit" }
 tokio = { version = "1", features = ["rt", "rt-multi-thread", "macros"] }
 anyhow = "1"
 tempfile = "3"
+futures = "0.3"

--- a/plugingo-e2e/tests/codegen.rs
+++ b/plugingo-e2e/tests/codegen.rs
@@ -1,7 +1,9 @@
 mod common;
 
 use anyhow::Context as _;
-use common::{artifact_paths, artifact_string, fixture, make_workspace, require_go};
+use common::{
+    artifact_paths, artifact_string, fixture, make_workspace, make_workspace_go_first, require_go,
+};
 use std::fs;
 
 #[tokio::test]
@@ -93,5 +95,59 @@ async fn test_codegen_build_binary_outputs_hello() -> anyhow::Result<()> {
 
     let stdout = String::from_utf8(output.stdout).context("binary stdout is utf8")?;
     assert_eq!(stdout.trim(), "hello", "binary must print 'hello'");
+    Ok(())
+}
+
+// Regression: with the go provider registered BEFORE the buildfile provider,
+// `q <label> .` must still find a buildfile codegen target (`//:gen`, labeled
+// `go_src`) that lives in a Go package dir. `get_spec(//:gen)` asks the go
+// provider first; it over-claims the name, drags in `go list` + its
+// `q@label=go_src` query, and that closes a cycle. The engine must contain that
+// cycle (fall through to the buildfile provider), not drop the target — `q all`
+// finds it (addr-only match, no get_spec), so `q go_src` must too.
+#[tokio::test]
+async fn test_query_by_label_finds_codegen_target_go_first() -> anyhow::Result<()> {
+    use futures::TryStreamExt as _;
+    use heph::htmatcher::Matcher;
+    use heph::htpkg::PkgBuf;
+
+    require_go!();
+    let dir = fixture("codegen")?;
+    // Guard off: let the go provider over-claim `//:gen` so the engine's
+    // cycle-containment (fall through to the buildfile provider) is what's tested.
+    let ws = make_workspace_go_first(dir, false)?;
+
+    let m = Matcher::And(vec![
+        Matcher::Label("go_src".to_string()),
+        Matcher::Package(PkgBuf::from("")),
+    ]);
+    let rs = ws.engine.new_state();
+    let addrs: Vec<heph::htaddr::Addr> = ws.engine.clone().query(rs, &m).try_collect().await?;
+
+    let formatted: Vec<String> = addrs.iter().map(|a| a.format()).collect();
+    assert!(
+        formatted.iter().any(|a| a == "//:gen"),
+        "q go_src . must find the codegen target //:gen, got: {formatted:?}"
+    );
+
+    Ok(())
+}
+
+// Defect-2 guard: a failed go-provider attempt for `//:gen` must not leave a
+// stale `gen -> _golist` edge in the request DAG, or a later legitimate
+// `build_lib -> _golist -> go_src group -> gen` resolution would close a FALSE
+// cycle. Building `//:build_lib` over the go-first workspace must still succeed.
+#[tokio::test]
+async fn test_build_lib_still_builds_go_first() -> anyhow::Result<()> {
+    require_go!();
+    let dir = fixture("codegen")?;
+    // Guard off: the failed go over-claim of `//:gen` must not leave a stale DAG
+    // edge that false-cycles this legit build.
+    let ws = make_workspace_go_first(dir, false)?;
+    let result = ws.run("//:build_lib").await?;
+    assert!(
+        !artifact_paths(&result).is_empty(),
+        "build_lib must produce the .a archive even with go registered first"
+    );
     Ok(())
 }

--- a/plugingo-e2e/tests/common/mod.rs
+++ b/plugingo-e2e/tests/common/mod.rs
@@ -50,9 +50,49 @@ fn go_bin_path() -> String {
 }
 
 pub fn make_workspace(dir: TempDir) -> anyhow::Result<Workspace> {
+    make_workspace_ordered(dir, false, true)
+}
+
+/// Same as [`make_workspace`] but registers the **go provider before** the
+/// buildfile provider. Provider order = registration order, so with go first a
+/// `get_spec` for a buildfile target in a Go package dir asks the go provider
+/// first — exercising the engine's cycle-containment path.
+///
+/// `foreign_name_guard` toggles the go provider's
+/// [`plugingo::Config::foreign_name_guard`]: pass `false` to let the go provider
+/// over-claim foreign names (so the engine's cycle containment is what's tested).
+pub fn make_workspace_go_first(
+    dir: TempDir,
+    foreign_name_guard: bool,
+) -> anyhow::Result<Workspace> {
+    make_workspace_ordered(dir, true, foreign_name_guard)
+}
+
+fn make_workspace_ordered(
+    dir: TempDir,
+    go_first: bool,
+    foreign_name_guard: bool,
+) -> anyhow::Result<Workspace> {
     let go_bin = go_bin_path();
     // `fs` is auto-registered by `Engine::new`.
-    WorkspaceBuilder::from_dir(dir)
+    let mut b = WorkspaceBuilder::from_dir(dir);
+
+    if go_first {
+        b = b.with_provider(move |init| {
+            Box::new(
+                plugingo::Provider::with_config(
+                    init.root.to_path_buf(),
+                    plugingo::Config {
+                        foreign_name_guard,
+                        ..Default::default()
+                    },
+                )
+                .expect("plugingo provider"),
+            )
+        });
+    }
+
+    b = b
         .with_provider(|init| Box::new(pluginbuildfile::Provider::new(init.root.to_path_buf())))
         .with_provider(move |_| {
             Box::new(
@@ -67,11 +107,24 @@ pub fn make_workspace(dir: TempDir) -> anyhow::Result<Workspace> {
                 }])
                 .expect("static provider"),
             )
-        })
-        .with_provider(|init| {
-            Box::new(plugingo::Provider::new(init.root.to_path_buf()).expect("plugingo provider"))
-        })
-        .with_managed_driver(Box::new(pluginexec::Driver::new_bash()))
+        });
+
+    if !go_first {
+        b = b.with_provider(move |init| {
+            Box::new(
+                plugingo::Provider::with_config(
+                    init.root.to_path_buf(),
+                    plugingo::Config {
+                        foreign_name_guard,
+                        ..Default::default()
+                    },
+                )
+                .expect("plugingo provider"),
+            )
+        });
+    }
+
+    b.with_managed_driver(Box::new(pluginexec::Driver::new_bash()))
         .with_managed_driver(Box::new(pluginexec::Driver::new_sh()))
         .with_managed_driver(Box::new(pluginexec::Driver::new_exec()))
         .with_managed_driver(Box::new(plugingo::GoGolistDriver::new("//@heph/bin:go")))

--- a/src/engine/result.rs
+++ b/src/engine/result.rs
@@ -1913,6 +1913,13 @@ impl Engine {
         addr: &Addr,
     ) -> anyhow::Result<Arc<EngineTargetSpec>> {
         let states = Arc::clone(&self).probe_segments(rs, &addr.package).await?;
+        // A provider whose `get()` cycles doesn't preclude a later provider
+        // resolving the same addr acyclically (e.g. the go provider over-claims a
+        // buildfile codegen target in a Go package dir and drags `go list` into a
+        // cycle; the buildfile provider resolves it cleanly). Skip the cyclic
+        // provider and keep going; surface the cycle only if NO provider succeeds
+        // — never deadlock, never silently drop a resolvable target.
+        let mut pending_cycle: Option<anyhow::Error> = None;
         for provider in self.providers.iter() {
             let provider_rs = rs.with_skip_provider(&provider.name);
             let executor: Arc<dyn ProviderExecutor> = Arc::new(EngineProviderExecutor {
@@ -1941,7 +1948,13 @@ impl Engine {
                 Err(GetError::NotFound) => continue,
                 // Return e directly (not bail!(e)) to preserve typed-error downcast
                 // through the anyhow::Error chain — required for CycleError handling.
-                Err(GetError::Other(e)) => return Err(e),
+                Err(GetError::Other(e)) => {
+                    if downcast_chain_ref::<CycleError>(&e).is_some() {
+                        pending_cycle = Some(e);
+                        continue;
+                    }
+                    return Err(e);
+                }
             };
 
             return anyhow::Ok(Arc::new(EngineTargetSpec {
@@ -1950,6 +1963,11 @@ impl Engine {
             }));
         }
 
+        // No provider produced a spec. If one cycled, that's the meaningful
+        // failure (hard fail, loud); otherwise the addr is genuinely unknown.
+        if let Some(e) = pending_cycle {
+            return Err(e);
+        }
         Err(TargetNotFoundError { addr: addr.clone() }.into())
     }
 }
@@ -2563,6 +2581,138 @@ mod tests {
             .expect("expected cycle error");
         assert!(
             err.downcast_ref::<CycleError>().is_some(),
+            "expected CycleError, got: {err:#}"
+        );
+        Ok(())
+    }
+
+    /// Provider whose `get` fails with a typed `CycleError` for one addr (and
+    /// `NotFound` otherwise) — models a provider that over-claims a name and
+    /// induces a cycle deep in resolution (like the go provider over-claiming a
+    /// buildfile codegen target). Used to verify the engine *contains* the
+    /// cycle: it falls through to the next provider rather than aborting.
+    struct CyclingProvider {
+        name: String,
+        cycles_for: String,
+    }
+    impl crate::engine::provider::Provider for CyclingProvider {
+        fn config(&self, _req: ConfigRequest) -> anyhow::Result<ConfigResponse> {
+            Ok(ConfigResponse {
+                name: self.name.clone(),
+            })
+        }
+        fn list<'a>(
+            &'a self,
+            _req: ListRequest,
+            _ctoken: &'a (dyn Cancellable + Send + Sync),
+        ) -> BoxFuture<
+            'a,
+            anyhow::Result<Box<dyn Iterator<Item = anyhow::Result<ListResponse>> + Send>>,
+        > {
+            Box::pin(async {
+                Ok(Box::new(std::iter::empty()) as Box<dyn Iterator<Item = _> + Send>)
+            })
+        }
+        fn list_packages<'a>(
+            &'a self,
+            _req: ListPackagesRequest,
+            _ctoken: &'a (dyn Cancellable + Send + Sync),
+        ) -> BoxFuture<
+            'a,
+            anyhow::Result<Box<dyn Iterator<Item = anyhow::Result<ListPackageResponse>> + Send>>,
+        > {
+            Box::pin(async {
+                Ok(Box::new(std::iter::empty()) as Box<dyn Iterator<Item = _> + Send>)
+            })
+        }
+        fn get<'a>(
+            &'a self,
+            req: GetRequest,
+            _ctoken: &'a (dyn Cancellable + Send + Sync),
+        ) -> BoxFuture<'a, Result<GetResponse, GetError>> {
+            let cycles = req.addr.format() == self.cycles_for;
+            let addr = req.addr.clone();
+            Box::pin(async move {
+                if cycles {
+                    Err(GetError::Other(
+                        CycleError {
+                            from: addr.clone(),
+                            to: addr,
+                        }
+                        .into(),
+                    ))
+                } else {
+                    Err(GetError::NotFound)
+                }
+            })
+        }
+        fn probe<'a>(
+            &'a self,
+            _req: ProbeRequest,
+            _ctoken: &'a (dyn Cancellable + Send + Sync),
+        ) -> BoxFuture<'a, anyhow::Result<ProbeResponse>> {
+            Box::pin(async { Ok(ProbeResponse { states: vec![] }) })
+        }
+    }
+
+    fn engine_with_cycling(
+        cycles_for: &str,
+        statics: Vec<pluginstatictarget::Target>,
+    ) -> anyhow::Result<Arc<Engine>> {
+        let root = tempdir()?;
+        let mut engine = Engine::new(Config {
+            root: root.path().to_path_buf(),
+            home_dir: std::path::PathBuf::new(),
+            parallelism: None,
+            ..Default::default()
+        })?;
+        engine.register_managed_driver(|_| Box::new(crate::pluginexec::Driver::new_exec()))?;
+        // Cycling provider FIRST, so `get_spec` hits it before the static one.
+        let cycles_for = cycles_for.to_string();
+        engine.register_provider(move |_| {
+            Box::new(CyclingProvider {
+                name: "cyc".to_string(),
+                cycles_for: cycles_for.clone(),
+            })
+        })?;
+        if !statics.is_empty() {
+            let provider = pluginstatictarget::Provider::new(statics)?;
+            engine.register_provider(move |_| Box::new(provider))?;
+        }
+        Ok(Arc::new(engine))
+    }
+
+    // A provider whose `get` cycles must not abort `get_spec`: the engine falls
+    // through to the next provider that resolves the addr acyclically. This is
+    // the engine-level containment that makes `q <label> .` find a buildfile
+    // target even when the go provider (registered first) over-claims it.
+    #[tokio::test]
+    async fn get_spec_falls_through_a_cyclic_provider_to_the_next() -> anyhow::Result<()> {
+        let engine = engine_with_cycling("//pkg:t", vec![static_target("//pkg:t", &["lbl"], &[])])?;
+        let addr = crate::htaddr::parse_addr("//pkg:t")?;
+        let spec = engine.clone().get_spec(engine.new_state(), &addr).await?;
+        assert_eq!(
+            spec.spec.labels,
+            vec!["lbl".to_string()],
+            "must resolve via the non-cyclic provider"
+        );
+        Ok(())
+    }
+
+    // When the ONLY provider serving an addr cycles, `get_spec` hard-fails with
+    // the typed `CycleError` (loud) — never deadlocks, never silently NotFound.
+    #[tokio::test]
+    async fn get_spec_hard_fails_when_every_provider_cycles() -> anyhow::Result<()> {
+        let engine = engine_with_cycling("//pkg:t", vec![])?;
+        let addr = crate::htaddr::parse_addr("//pkg:t")?;
+        let err = engine
+            .clone()
+            .get_spec(engine.new_state(), &addr)
+            .await
+            .err()
+            .expect("expected a cycle error");
+        assert!(
+            crate::hmemoizer::downcast_chain_ref::<CycleError>(&err).is_some(),
             "expected CycleError, got: {err:#}"
         );
         Ok(())

--- a/src/plugingo/mod.rs
+++ b/src/plugingo/mod.rs
@@ -19,4 +19,4 @@ mod thirdparty;
 pub use driver_embed::GoEmbedDriver;
 pub use driver_golist::GoGolistDriver;
 pub use driver_testmain::GoTestmainDriver;
-pub use provider::Provider;
+pub use provider::{Config, Provider};

--- a/src/plugingo/provider.rs
+++ b/src/plugingo/provider.rs
@@ -2635,6 +2635,10 @@ golang.org/x/oauth2 v0.0.0-20200107190931-bf48bf16ab8d h1:pE8b58s1HRDMi8RDc79m0H
     // binary needed: a correct provider bails before any `go list`.
     #[tokio::test]
     async fn foreign_target_name_not_found_without_golist_resolve() {
+        // `Provider::new` resolves GOROOT via `go env`, so this needs `go` even
+        // though the guard short-circuits before any go list / query.
+        require_go!();
+
         // `Provider::new` enables the foreign-name guard by default, so a name
         // this provider doesn't own resolves to NotFound without touching the
         // executor (no `go list`, no `q@label=go_src` query).

--- a/src/plugingo/provider.rs
+++ b/src/plugingo/provider.rs
@@ -43,6 +43,15 @@ pub struct Config {
     /// Directories pruned during package discovery: engine skip dirs/globs plus
     /// this provider's own `skip` option. See [`crate::htwalk::Ignore`].
     pub skip: Arc<Ignore>,
+    /// Reject target names this provider doesn't own *before* the `_golist`
+    /// resolve (see [`is_known_go_target_name`]). On by default: it avoids a
+    /// wasted `go list` for foreign names (e.g. a buildfile codegen target
+    /// sharing a Go package dir) and the cycle that resolve would induce. The
+    /// engine contains that cycle regardless (a cyclic provider attempt falls
+    /// through to the next provider), so this is a perf/clarity guard, not a
+    /// correctness crutch — tests that exercise the engine's containment path
+    /// turn it off.
+    pub foreign_name_guard: bool,
 }
 
 impl Default for Config {
@@ -50,6 +59,7 @@ impl Default for Config {
         Self {
             go_bin_addr: DEFAULT_GO_BIN_ADDR.to_string(),
             skip: Arc::new(Ignore::default()),
+            foreign_name_guard: true,
         }
     }
 }
@@ -70,6 +80,8 @@ pub(crate) struct ProviderInner {
     go_bin_addr: String,
     /// Directories pruned during `collect_go_packages` (engine home + user globs).
     skip: Arc<Ignore>,
+    /// See [`Config::foreign_name_guard`].
+    foreign_name_guard: bool,
     /// Cache: golist addr → parsed GoPackage. Memoizes the artifact parse only;
     /// the underlying `executor.result(golist_addr)` is always called outside
     /// the `once` closure so every caller (owner + waiter) registers the
@@ -153,7 +165,14 @@ impl Provider {
                 .unwrap_or_default();
         globs.extend(user_skip);
         let skip = Arc::new(Ignore::new(skip_dirs, &globs)?);
-        Self::with_config(workspace_root, Config { go_bin_addr, skip })
+        Self::with_config(
+            workspace_root,
+            Config {
+                go_bin_addr,
+                skip,
+                ..Default::default()
+            },
+        )
     }
 
     pub fn go_bin_addr(&self) -> &str {
@@ -174,6 +193,7 @@ impl Provider {
                 gocache,
                 go_bin_addr: config.go_bin_addr,
                 skip: config.skip,
+                foreign_name_guard: config.foreign_name_guard,
                 pkg_cache: Memoizer::with_tag("pkg_cache"),
                 pkg_addrs_cache: Memoizer::with_tag("pkg_addrs_cache"),
                 libs_cache: Memoizer::with_tag("libs_cache"),
@@ -540,6 +560,23 @@ fn is_test_target_name(name: &str) -> bool {
     TEST_TARGET_NAMES.contains(&name)
 }
 
+/// Targets handled by `handle_get` *before* the `_golist` resolve (no go list
+/// needed): the golist target itself, the go.mod copy, and the module download.
+const SPECIAL_TARGET_NAMES: &[&str] = &["_golist", "_go_mod", "download"];
+
+/// Non-test first-party/thirdparty target names this provider owns and resolves
+/// through `_golist` (see the `match addr.name` arms in `handle_get`).
+const GOLIST_TARGET_NAMES: &[&str] = &["build_lib", "build", "embed"];
+
+/// Whether this provider owns `name` — the complete set of go targets it can
+/// generate: the pre-golist special targets, the `_golist`-resolved non-test
+/// targets, and every test variant.
+fn is_known_go_target_name(name: &str) -> bool {
+    SPECIAL_TARGET_NAMES.contains(&name)
+        || GOLIST_TARGET_NAMES.contains(&name)
+        || TEST_TARGET_NAMES.contains(&name)
+}
+
 /// Choose which lib variant of P (the current package) to expose in the
 /// xtest_lib compile and the build_xtest link, so both agree.
 ///
@@ -730,6 +767,15 @@ impl ProviderInner {
         // variant before the `_golist` resolve below so a skipped pkg never
         // forces a `go list` round-trip purely to learn there are no tests.
         if is_test_target_name(&addr.name) && pick_test_skip(&req.states) {
+            return Err(GetError::NotFound);
+        }
+
+        // Foreign names this provider doesn't own would otherwise drag `go list`
+        // and its `q@label=go_src` query into resolution, which trips a cycle.
+        // On by default (perf/clarity); the engine contains the cycle regardless
+        // (cyclic provider attempts fall through to the next provider), so tests
+        // exercising that path disable it via `Config::foreign_name_guard`.
+        if self.foreign_name_guard && !is_known_go_target_name(&addr.name) {
             return Err(GetError::NotFound);
         }
 
@@ -2573,6 +2619,67 @@ golang.org/x/oauth2 v0.0.0-20200107190931-bf48bf16ab8d h1:pE8b58s1HRDMi8RDc79m0H
             2,
             "every read_golist_package must call executor.result so all \
              callers register the parent → golist edge in DepDag"
+        );
+    }
+
+    // Regression: a target name the go provider doesn't own (e.g. a buildfile
+    // codegen target sharing a Go package dir) must resolve to NotFound WITHOUT
+    // resolving `_golist`. Otherwise the `q@label=go_src` query that `_golist`
+    // pulls in re-enters get_spec for this same addr, trips a false CycleError,
+    // and `Engine::query` silently drops the target — so `q codegen .` misses
+    // targets that `q all .` (addr-only match, no get_spec) finds. No `go`
+    // binary needed: a correct provider bails before any `go list`.
+    #[tokio::test]
+    async fn foreign_target_name_not_found_without_golist_resolve() {
+        // `Provider::new` enables the foreign-name guard by default, so a name
+        // this provider doesn't own resolves to NotFound without touching the
+        // executor (no `go list`, no `q@label=go_src` query).
+        struct BailExecutor {
+            calls: Arc<std::sync::atomic::AtomicUsize>,
+        }
+        impl ProviderExecutor for BailExecutor {
+            fn result<'a>(&'a self, addr: &'a Addr) -> BoxFuture<'a, anyhow::Result<Arc<EResult>>> {
+                self.calls.fetch_add(1, std::sync::atomic::Ordering::SeqCst);
+                let a = addr.format();
+                Box::pin(async move { anyhow::bail!("BailExecutor: result called for {a}") })
+            }
+            fn query<'a>(
+                &'a self,
+                _m: &'a crate::htmatcher::Matcher,
+                _extra_skip: &'a [String],
+            ) -> BoxFuture<'a, anyhow::Result<Vec<Addr>>> {
+                self.calls.fetch_add(1, std::sync::atomic::Ordering::SeqCst);
+                Box::pin(async { anyhow::bail!("BailExecutor: query called") })
+            }
+        }
+
+        let dir = tempfile::tempdir().expect("tempdir");
+        std::fs::write(dir.path().join("go.mod"), "module example.com/x\n").unwrap();
+        let p = Provider::new(dir.path().to_path_buf()).unwrap();
+
+        let calls = Arc::new(std::sync::atomic::AtomicUsize::new(0));
+        let executor: Arc<dyn ProviderExecutor> = Arc::new(BailExecutor {
+            calls: Arc::clone(&calls),
+        });
+        let ctoken = StdCancellationToken::new();
+        let req = GetRequest {
+            request_id: "test".to_string(),
+            addr: make_addr("", "codegen_gen"),
+            states: vec![],
+            executor,
+        };
+
+        let res = p.get(req, &ctoken).await;
+        assert!(
+            matches!(res, Err(GetError::NotFound)),
+            "foreign name must be NotFound, got driver: {:?}",
+            res.map(|r| r.target_spec.driver)
+        );
+        assert_eq!(
+            calls.load(std::sync::atomic::Ordering::SeqCst),
+            0,
+            "go provider must not resolve _golist (or its go_src query) for a \
+             target name it doesn't own — that re-entry is what trips the false cycle"
         );
     }
 

--- a/src/plugingo/provider.rs
+++ b/src/plugingo/provider.rs
@@ -708,6 +708,19 @@ impl ProviderInner {
             return Err(GetError::NotFound);
         }
 
+        // Reject names this provider doesn't own as early as possible — before any
+        // special-case handler or `go list`. A foreign name (e.g. a buildfile
+        // codegen target sharing a Go package dir) would otherwise drag `go list`
+        // and its `q@label=go_src` query into resolution and trip a cycle. On by
+        // default (perf/clarity); the engine contains the cycle regardless (cyclic
+        // provider attempts fall through to the next provider), so tests exercising
+        // that path disable it via `Config::foreign_name_guard`. Owned names —
+        // including the specials handled just below (`_golist`/`_go_mod`/`download`)
+        // — are in `is_known_go_target_name`, so this never rejects a real target.
+        if self.foreign_name_guard && !is_known_go_target_name(&addr.name) {
+            return Err(GetError::NotFound);
+        }
+
         // _golist — generate spec without executing go list (before stdlib check so
         // stdlib packages can also expose a _golist target for cached dep resolution)
         if addr.name == "_golist" {
@@ -767,15 +780,6 @@ impl ProviderInner {
         // variant before the `_golist` resolve below so a skipped pkg never
         // forces a `go list` round-trip purely to learn there are no tests.
         if is_test_target_name(&addr.name) && pick_test_skip(&req.states) {
-            return Err(GetError::NotFound);
-        }
-
-        // Foreign names this provider doesn't own would otherwise drag `go list`
-        // and its `q@label=go_src` query into resolution, which trips a cycle.
-        // On by default (perf/clarity); the engine contains the cycle regardless
-        // (cyclic provider attempts fall through to the next provider), so tests
-        // exercising that path disable it via `Config::foreign_name_guard`.
-        if self.foreign_name_guard && !is_known_go_target_name(&addr.name) {
             return Err(GetError::NotFound);
         }
 


### PR DESCRIPTION
## Problem

`heph q all .` finds a target (e.g. one labeled `codegen`/`go_src`), but `heph q <label> .` does **not** — only when the **go provider is registered before the buildfile provider** and the target sits in a Go package dir.

- `q all .` uses a `Package` matcher → `matches_addr` = `MatchYes` → yields the addr **without** resolving its spec.
- `q <label> .` uses `And[Label, Package]` → `Label` shrugs → the query must call `get_spec(addr)` to read labels.

With go first, `get_spec(//:gen)` asks the go provider first. It over-claims the foreign name, drags in `go list` + its `q@label=go_src` query, and closes a cycle:

```
//:gen → //:_golist → //@heph/query:q@…label=go_src → //:gen
```

`get_spec_inner` then did `Err(GetError::Other(e)) => return Err(e)`, aborting the whole `get_spec` — so the engine never tried the buildfile provider that resolves `//:gen` cleanly. The target was silently dropped.

## Fix

Contain the cycle at the **engine** level (a misbehaving provider is the engine's problem, not each provider's). In `get_spec_inner`, a provider `get()` that returns a `CycleError` is **skipped** (try the next provider); the cycle is surfaced only if **no** provider resolves the addr:

```rust
Err(GetError::Other(e)) => {
    if downcast_chain_ref::<CycleError>(&e).is_some() {
        pending_cycle = Some(e);   // skip this provider, try the next
        continue;
    }
    return Err(e);                  // real errors still loud
}
// after the loop: succeed → use it; else cyclic → hard-fail; else NotFound
```

Skip-or-fail, never deadlock, never silently lose a resolvable target. An instrumented repro confirmed the cycle-closing edge is exactly what the Pearce-Kelly `add_dep` **rejects** (never persisted), so no stale edge survives — fallthrough alone is sufficient, and real builds over the same workspace still succeed.

## Go provider guard → Config option

The go provider's foreign-name guard (reject names it doesn't own before the `_golist` resolve) is now a `Config` option (`foreign_name_guard`, **default `true`**) rather than always-on. It still avoids a wasted `go list` for foreign names, but is now a perf/clarity guard, not a correctness crutch — the engine contains the cycle regardless. The owned-name set is completed with the pre-golist specials (`_golist`, `_go_mod`, `download`); audited 1:1 against every name `handle_get` serves.

## Tests

- **plugingo-e2e** (`make_workspace_go_first`, guard disabled to exercise the engine path):
  - `test_query_by_label_finds_codegen_target_go_first` — `q go_src .` finds `//:gen`.
  - `test_build_lib_still_builds_go_first` — `//:build_lib` still builds (no false cycle).
- **engine** (`src/engine/result.rs`): `get_spec` falls through a cyclic provider to the next; hard-fails with `CycleError` when every provider cycles.
- Restored the go-provider unit test (guard on by default → `NotFound`, zero executor calls).

All suites green; lib clippy clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)