### PR TITLE
feat(config): HEPH_PROFILES layered config overlays

### DIFF
--- a/src/commands/bootstrap.rs
+++ b/src/commands/bootstrap.rs
@@ -6,7 +6,7 @@ use anyhow::Context;
 use tokio::runtime::{Builder, Runtime};
 use tokio::sync::mpsc;
 
-use crate::engine::config_file;
+use crate::engine::config_yaml;
 use crate::{
     engine, pluginbuildfile, pluginexec, plugingo, pluginhostbin, pluginnix, plugintextfile,
 };
@@ -91,7 +91,7 @@ pub fn telemetry_enabled_from_config() -> bool {
     let Ok(root) = engine::get_root() else {
         return true;
     };
-    config_file::load_from_root(&root)
+    config_yaml::load_from_root(&root)
         .map(|f| f.telemetry_enabled())
         .unwrap_or(true)
 }
@@ -102,82 +102,22 @@ pub fn new_engine() -> anyhow::Result<(Arc<engine::Engine>, ShutdownTrigger)> {
         Err(inner) => anyhow::bail!("Error: {}", inner),
     };
 
-    let file = config_file::load_from_root(&root)?;
+    // The config file is the all-optional, profile-layered YAML; `resolve`
+    // applies every default in one place and yields the engine's runtime config.
+    let file = config_yaml::load_from_root(&root)?;
+    let config = file.resolve(&root)?;
 
-    let home_dir = file
-        .home_dir
-        .as_ref()
-        .map(|p| root.join(p))
-        .unwrap_or_else(|| root.join(".heph3"));
-
-    let mem_cache = file
-        .mem_cache
-        .map(|c| engine::MemCacheOptions {
-            per_entry_bytes: c.per_entry_bytes,
-            capacity_bytes: c.capacity_bytes,
-        })
-        .unwrap_or_default();
-
-    let tmp_cache = file
-        .tmp_cache
-        .map(|c| engine::MemCacheOptions {
-            per_entry_bytes: c.per_entry_bytes,
-            capacity_bytes: c.capacity_bytes,
-        })
-        .unwrap_or_else(engine::MemCacheOptions::default_tmp);
-
-    let fuse = file.fuse.unwrap_or_default();
-
-    let spill_threshold_bytes = file
-        .cache
-        .and_then(|c| c.spill_threshold_bytes)
-        .unwrap_or(engine::DEFAULT_SPILL_THRESHOLD_BYTES);
-
-    // Read before the struct literal below moves `file.fs`.
-    let telemetry_enabled = file.telemetry_enabled();
-
-    let lock_backend = file
-        .lock
-        .and_then(|l| l.backend)
-        .map(|b| match b {
-            config_file::LockBackendConfig::Fs => engine::LockBackend::Fs,
-            config_file::LockBackendConfig::Mem => engine::LockBackend::Mem,
-        })
-        .unwrap_or_default();
-
-    // `caches:` is a name→config map; flatten into ordered defs (BTreeMap keeps
-    // a stable, name-sorted order). The engine measures latency to reorder reads.
-    let remote_caches: Vec<engine::RemoteCacheDef> = file
-        .caches
-        .iter()
-        .map(|(name, c)| engine::RemoteCacheDef {
-            name: name.clone(),
-            uri: c.uri.clone(),
-            read: c.read,
-            write: c.write,
-            concurrency: c.concurrency,
-        })
-        .collect();
-    // Captured before `remote_caches` is moved into `Config` below; reported via
-    // telemetry (backend kind/scheme only — never the URIs).
-    let remote_cache_backends: Vec<String> = remote_caches
+    // Captured before `config` is moved into the engine: the nix driver's state
+    // dir hangs off `home_dir`, and telemetry reports the remote-cache backend
+    // kinds (scheme only — never the URIs).
+    let home_dir = config.home_dir.clone();
+    let remote_cache_backends: Vec<String> = config
+        .remote_caches
         .iter()
         .map(|d| d.backend_kind().to_string())
         .collect();
 
-    let mut e = engine::Engine::new(engine::Config {
-        root: root.clone(),
-        home_dir: home_dir.clone(),
-        fs_skip: file.fs.map(|f| f.skip).unwrap_or_default(),
-        parallelism: None,
-        mem_cache,
-        tmp_cache,
-        fuse,
-        lock_backend,
-        spill_threshold_bytes,
-        telemetry_enabled,
-        remote_caches,
-    })?;
+    let mut e = engine::Engine::new(config)?;
 
     // `fs` (provider + driver) is registered by `Engine::new` itself, with the
     // engine's own skip dirs. The remaining built-ins have no config.
@@ -218,15 +158,15 @@ pub fn new_engine() -> anyhow::Result<(Arc<engine::Engine>, ShutdownTrigger)> {
         Ok(Box::new(pluginexec::Driver::from_options_sh(opts)?))
     })?;
     e.register_managed_driver_factory("go_golist", |_init, opts| {
-        config_file::deny_unknown("go_golist driver", opts, &[])?;
+        config_yaml::deny_unknown("go_golist driver", opts, &[])?;
         Ok(Box::new(plugingo::GoGolistDriver::new("//@heph/bin:go")))
     })?;
     e.register_managed_driver_factory("go_embed", |_init, opts| {
-        config_file::deny_unknown("go_embed driver", opts, &[])?;
+        config_yaml::deny_unknown("go_embed driver", opts, &[])?;
         Ok(Box::new(plugingo::GoEmbedDriver))
     })?;
     e.register_managed_driver_factory("go_testmain", |_init, opts| {
-        config_file::deny_unknown("go_testmain driver", opts, &[])?;
+        config_yaml::deny_unknown("go_testmain driver", opts, &[])?;
         Ok(Box::new(plugingo::GoTestmainDriver))
     })?;
 
@@ -300,7 +240,7 @@ mod tests {
     use super::*;
 
     fn build_engine_from_yaml(yaml: &str) -> anyhow::Result<(tempfile::TempDir, engine::Engine)> {
-        let file: config_file::ConfigFile = serde_yaml::from_str(yaml)?;
+        let file: config_yaml::ConfigYaml = serde_yaml::from_str(yaml)?;
         let dir = tempfile::tempdir()?;
         let root = dir.path().to_path_buf();
         let home_dir = file

--- a/src/commands/completion.rs
+++ b/src/commands/completion.rs
@@ -232,7 +232,7 @@ mod tests {
         })
         .expect("register buildfile");
 
-        let file: crate::engine::config_file::ConfigFile =
+        let file: crate::engine::config_yaml::ConfigYaml =
             serde_yaml::from_str("providers:\n  - name: buildfile\n").expect("yaml");
         e.apply_config(&file.providers, &file.drivers)
             .expect("apply_config");

--- a/src/engine/config.rs
+++ b/src/engine/config.rs
@@ -1,0 +1,170 @@
+//! The engine's **resolved** runtime configuration.
+//!
+//! This is the counterpart to [`ConfigYaml`](crate::engine::config_yaml::ConfigYaml):
+//! where the YAML layer is all-optional and built up by layering profiles, this
+//! layer has *no* optional fields — every default is applied exactly once, in
+//! [`ConfigYaml::resolve`]. Everything downstream of [`resolve`](ConfigYaml::resolve)
+//! sees a fully-populated [`Config`] and never has to reason about defaults.
+
+use std::path::{Path, PathBuf};
+
+use crate::engine::RemoteCacheDef;
+use crate::engine::config_yaml::{ConfigYaml, FuseConfig, LockBackendConfig, MemCacheConfig};
+use crate::engine::result_lock::LockBackend;
+
+#[derive(Debug, Clone, PartialEq)]
+pub struct Config {
+    pub root: PathBuf,
+    /// Workspace state/cache directory. If empty, defaults to `root/.heph3`.
+    pub home_dir: PathBuf,
+    /// Repo-root-relative directories from the config file's `fs.skip`, pruned by
+    /// every plugin that walks the tree. See [`Engine::skip_dirs`].
+    ///
+    /// [`Engine::skip_dirs`]: crate::engine::Engine::skip_dirs
+    pub fs_skip: Vec<String>,
+    pub parallelism: Option<usize>,
+    /// In-memory tier fronting the durable (SQLite) local cache.
+    pub mem_cache: MemCacheOptions,
+    /// Mem-only store for tmp/uncacheable revisions ([`LocalCacheTmp`]).
+    /// Entries over `per_entry_bytes`, or that would push the store past
+    /// `capacity_bytes`, spill to the durable cache.
+    ///
+    /// [`LocalCacheTmp`]: crate::engine::local_cache_tmp::LocalCacheTmp
+    pub tmp_cache: MemCacheOptions,
+    pub fuse: FuseConfig,
+    /// Backend serializing the execute phase per addr. Defaults to `Fs`.
+    pub lock_backend: LockBackend,
+    /// Durable blobs strictly larger than this spill to plain files under
+    /// `<home>/cache/blobs/` instead of being stored inline in the sqlite DB;
+    /// manifests always stay in sqlite. Keeps the DB / WAL small and lets large
+    /// artifacts stream from the filesystem. See [`DEFAULT_SPILL_THRESHOLD_BYTES`].
+    pub spill_threshold_bytes: u64,
+    /// Anonymous usage telemetry. Defaults to `true` (opt-out via config).
+    pub telemetry_enabled: bool,
+    /// Named remote (shared) caches from the config's `caches:` map. Empty
+    /// disables the remote-cache layer entirely. See [`RemoteCacheSet`].
+    ///
+    /// [`RemoteCacheSet`]: crate::engine::RemoteCacheSet
+    pub remote_caches: Vec<RemoteCacheDef>,
+}
+
+/// Default spill threshold: 8 MiB. Above a few MB the filesystem beats sqlite
+/// blob storage on throughput and big blobs would bloat the single-file DB and
+/// its WAL; below it, artifacts stay in sqlite where small indexed reads and the
+/// mem tier win. Tunable via `cache.spillThresholdBytes`.
+pub const DEFAULT_SPILL_THRESHOLD_BYTES: u64 = 8 * 1024 * 1024;
+
+impl Default for Config {
+    fn default() -> Self {
+        Self {
+            root: PathBuf::new(),
+            home_dir: PathBuf::new(),
+            fs_skip: Vec::new(),
+            parallelism: None,
+            mem_cache: MemCacheOptions::default(),
+            tmp_cache: MemCacheOptions::default_tmp(),
+            fuse: FuseConfig::default(),
+            lock_backend: LockBackend::default(),
+            spill_threshold_bytes: DEFAULT_SPILL_THRESHOLD_BYTES,
+            telemetry_enabled: true,
+            remote_caches: Vec::new(),
+        }
+    }
+}
+
+/// Byte limits for one in-memory cache store. Used for both the local-cache mem
+/// tier (`mem_cache`) and the tmp store (`tmp_cache`).
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct MemCacheOptions {
+    /// Per-entry size cap. For `mem_cache`, larger entries pass through
+    /// uncached; for `tmp_cache`, larger entries spill to the durable cache.
+    pub per_entry_bytes: usize,
+    /// Total byte budget. For `mem_cache`, `0` disables the in-memory layer
+    /// entirely; for `tmp_cache`, entries that would exceed it spill to durable.
+    pub capacity_bytes: u64,
+}
+
+impl Default for MemCacheOptions {
+    /// Defaults for the local-cache mem tier.
+    fn default() -> Self {
+        Self {
+            per_entry_bytes: 16 * 1024,
+            capacity_bytes: 64 * 1024 * 1024,
+        }
+    }
+}
+
+impl MemCacheOptions {
+    /// Defaults for the tmp store: 1 MiB per entry, 64 MiB total budget.
+    pub fn default_tmp() -> Self {
+        Self {
+            per_entry_bytes: 1024 * 1024,
+            capacity_bytes: 64 * 1024 * 1024,
+        }
+    }
+}
+
+impl ConfigYaml {
+    /// Resolve this optional, profile-layered YAML into the engine's runtime
+    /// [`Config`], applying every default in one place. This is the single
+    /// boundary between the all-optional config-file shape and the
+    /// fully-populated config the engine runs on — callers downstream never see
+    /// an `Option` or a default fallback.
+    ///
+    /// `providers`/`drivers` are intentionally *not* part of [`Config`] (they are
+    /// applied to the engine registry separately, post-construction), so they
+    /// stay on the [`ConfigYaml`].
+    pub fn resolve(&self, root: &Path) -> anyhow::Result<Config> {
+        let mem_cache_opts = |c: &MemCacheConfig| MemCacheOptions {
+            per_entry_bytes: c.per_entry_bytes,
+            capacity_bytes: c.capacity_bytes,
+        };
+
+        let defaults = Config::default();
+        Ok(Config {
+            root: root.to_path_buf(),
+            home_dir: self
+                .home_dir
+                .as_ref()
+                .map(|p| root.join(p))
+                .unwrap_or_else(|| root.join(".heph3")),
+            fs_skip: self.fs.as_ref().map(|f| f.skip.clone()).unwrap_or_default(),
+            parallelism: None,
+            mem_cache: self
+                .mem_cache
+                .as_ref()
+                .map(mem_cache_opts)
+                .unwrap_or(defaults.mem_cache),
+            tmp_cache: self
+                .tmp_cache
+                .as_ref()
+                .map(mem_cache_opts)
+                .unwrap_or(defaults.tmp_cache),
+            fuse: self.fuse.unwrap_or(defaults.fuse),
+            lock_backend: self
+                .lock
+                .and_then(|l| l.backend)
+                .map(|b| match b {
+                    LockBackendConfig::Fs => LockBackend::Fs,
+                    LockBackendConfig::Mem => LockBackend::Mem,
+                })
+                .unwrap_or(defaults.lock_backend),
+            spill_threshold_bytes: self
+                .cache
+                .and_then(|c| c.spill_threshold_bytes)
+                .unwrap_or(defaults.spill_threshold_bytes),
+            telemetry_enabled: self.telemetry_enabled(),
+            remote_caches: self
+                .resolved_caches()?
+                .into_iter()
+                .map(|(name, c)| RemoteCacheDef {
+                    name,
+                    uri: c.uri,
+                    read: c.read,
+                    write: c.write,
+                    concurrency: c.concurrency,
+                })
+                .collect(),
+        })
+    }
+}

--- a/src/engine/config_file.rs
+++ b/src/engine/config_file.rs
@@ -82,6 +82,58 @@ impl ConfigFile {
     pub fn telemetry_enabled(&self) -> bool {
         self.telemetry.map(|t| t.enabled).unwrap_or(true)
     }
+
+    /// Apply `other` on top of `self`, mutating in place. Used to layer profile
+    /// configs over the base `.hephconfig2` (see [`load_from_root`]).
+    ///
+    /// Optional/scalar fields override only when present in `other` — a profile
+    /// that omits a field leaves the base value untouched. `caches` merge by key
+    /// (a later entry replaces the whole entry under that name), and
+    /// `providers`/`drivers` merge by name (matching entry replaced, new ones
+    /// appended in order).
+    pub fn merge(&mut self, other: ConfigFile) {
+        if other.home_dir.is_some() {
+            self.home_dir = other.home_dir;
+        }
+        if other.mem_cache.is_some() {
+            self.mem_cache = other.mem_cache;
+        }
+        if other.tmp_cache.is_some() {
+            self.tmp_cache = other.tmp_cache;
+        }
+        if other.fuse.is_some() {
+            self.fuse = other.fuse;
+        }
+        if other.lock.is_some() {
+            self.lock = other.lock;
+        }
+        if other.fs.is_some() {
+            self.fs = other.fs;
+        }
+        if other.cache.is_some() {
+            self.cache = other.cache;
+        }
+        if other.telemetry.is_some() {
+            self.telemetry = other.telemetry;
+        }
+
+        // Caches override by key: extend replaces matching names, keeps the rest.
+        self.caches.extend(other.caches);
+
+        merge_plugins(&mut self.providers, other.providers);
+        merge_plugins(&mut self.drivers, other.drivers);
+    }
+}
+
+/// Merge `inc` plugin entries into `base` by name: an entry whose name already
+/// exists replaces it in place; a new name is appended, preserving order.
+fn merge_plugins(base: &mut Vec<PluginEntry>, inc: Vec<PluginEntry>) {
+    for entry in inc {
+        match base.iter_mut().find(|e| e.name == entry.name) {
+            Some(existing) => *existing = entry,
+            None => base.push(entry),
+        }
+    }
 }
 
 /// Anonymous usage telemetry. `telemetry: { enabled: false }` opts out; omitting
@@ -234,9 +286,51 @@ pub struct PluginEntry {
 /// [`crate::engine::get_root`] both build on it.
 pub const CONFIG_FILE_NAME: &str = ".hephconfig2";
 
-/// Load the workspace config from `<root>/.hephconfig2`.
+/// Env var naming the comma-separated list of config profiles to layer on top of
+/// the base config, in order. See [`load_from_root`].
+pub const PROFILES_ENV: &str = "HEPH_PROFILES";
+
+/// Profiles requested via `HEPH_PROFILES`, in order. Empty/whitespace entries are
+/// dropped, so `HEPH_PROFILES=a,,b ` yields `["a", "b"]`.
+fn profiles_from_env() -> Vec<String> {
+    std::env::var(PROFILES_ENV)
+        .ok()
+        .map(|v| {
+            v.split(',')
+                .map(str::trim)
+                .filter(|s| !s.is_empty())
+                .map(String::from)
+                .collect()
+        })
+        .unwrap_or_default()
+}
+
+/// Load the workspace config from `<root>/.hephconfig2`, then layer each profile
+/// named in `HEPH_PROFILES` on top.
+///
+/// Profiles apply in the order listed: `HEPH_PROFILES=a,b` loads the base
+/// `.hephconfig2`, then applies `a.hephconfig2`, then `b.hephconfig2`, each
+/// merged over the accumulated config via [`ConfigFile::merge`] (so e.g. a cache
+/// entry is overridden by its key). A named profile file that is missing or
+/// invalid is a hard error.
 pub fn load_from_root(root: &Path) -> anyhow::Result<ConfigFile> {
-    load(&root.join(CONFIG_FILE_NAME))
+    load_with_profiles(root, &profiles_from_env())
+}
+
+/// Core of [`load_from_root`], with the profile list passed in so it can be
+/// exercised without touching the process environment.
+fn load_with_profiles(root: &Path, profiles: &[impl AsRef<str>]) -> anyhow::Result<ConfigFile> {
+    let mut cfg = load(&root.join(CONFIG_FILE_NAME))?;
+    for profile in profiles {
+        let profile = profile.as_ref();
+        // CONFIG_FILE_NAME carries the leading dot, so this is `<profile>.hephconfig2`.
+        let file_name = format!("{profile}{CONFIG_FILE_NAME}");
+        tracing::debug!(profile, file = %file_name, "applying config profile");
+        let overlay = load(&root.join(&file_name))
+            .with_context(|| format!("loading config profile {file_name}"))?;
+        cfg.merge(overlay);
+    }
+    Ok(cfg)
 }
 
 pub fn load(path: &Path) -> anyhow::Result<ConfigFile> {
@@ -575,5 +669,116 @@ caches:
         let yaml = "telemetry:\n  bogus: 1\n";
         let err = serde_yaml::from_str::<ConfigFile>(yaml).expect_err("must reject");
         assert!(err.to_string().contains("bogus"), "{err}");
+    }
+
+    #[test]
+    fn merge_overrides_caches_by_key() {
+        let mut base: ConfigFile = serde_yaml::from_str(
+            "caches:\n  a:\n    uri: s3://base/a\n  b:\n    uri: s3://base/b\n",
+        )
+        .expect("parse base");
+        let overlay: ConfigFile = serde_yaml::from_str(
+            "caches:\n  b:\n    uri: s3://prof/b\n  c:\n    uri: s3://prof/c\n",
+        )
+        .expect("parse overlay");
+
+        base.merge(overlay);
+
+        assert_eq!(base.caches.len(), 3);
+        // Untouched key keeps its base value.
+        assert_eq!(base.caches.get("a").expect("a").uri, "s3://base/a");
+        // Shared key is overridden by the overlay.
+        assert_eq!(base.caches.get("b").expect("b").uri, "s3://prof/b");
+        // New key is added.
+        assert_eq!(base.caches.get("c").expect("c").uri, "s3://prof/c");
+    }
+
+    #[test]
+    fn merge_overrides_scalars_only_when_present() {
+        let mut base: ConfigFile =
+            serde_yaml::from_str("homeDir: .base\nlock:\n  backend: fs\n").expect("parse base");
+        // Overlay sets homeDir but omits lock — lock must survive.
+        let overlay: ConfigFile = serde_yaml::from_str("homeDir: .prof\n").expect("parse overlay");
+
+        base.merge(overlay);
+
+        assert_eq!(base.home_dir.as_deref(), Some(Path::new(".prof")));
+        assert_eq!(
+            base.lock.expect("lock survives").backend,
+            Some(LockBackendConfig::Fs)
+        );
+    }
+
+    #[test]
+    fn merge_providers_by_name() {
+        let mut base: ConfigFile = serde_yaml::from_str(
+            "providers:\n  - name: buildfile\n    options:\n      patterns: [BUILD]\n  - name: go\n",
+        )
+        .expect("parse base");
+        let overlay: ConfigFile = serde_yaml::from_str(
+            "providers:\n  - name: buildfile\n    options:\n      patterns: [BUILD2]\n  - name: rust\n",
+        )
+        .expect("parse overlay");
+
+        base.merge(overlay);
+
+        // buildfile replaced, go kept, rust appended — order preserved.
+        let names: Vec<&str> = base.providers.iter().map(|p| p.name.as_str()).collect();
+        assert_eq!(names, vec!["buildfile", "go", "rust"]);
+        let patterns: Vec<String> = decode_opt(&base.providers[0].options, "buildfile", "patterns")
+            .expect("decode")
+            .expect("present");
+        assert_eq!(patterns, vec!["BUILD2".to_string()]);
+    }
+
+    #[test]
+    fn load_with_profiles_layers_in_order() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let root = dir.path();
+        std::fs::write(
+            root.join(".hephconfig2"),
+            "homeDir: .base\ncaches:\n  shared:\n    uri: s3://base/shared\n",
+        )
+        .expect("write base");
+        std::fs::write(
+            root.join("a.hephconfig2"),
+            "caches:\n  shared:\n    uri: s3://a/shared\n",
+        )
+        .expect("write a");
+        std::fs::write(
+            root.join("b.hephconfig2"),
+            "homeDir: .b\ncaches:\n  shared:\n    uri: s3://b/shared\n",
+        )
+        .expect("write b");
+
+        let cfg = load_with_profiles(root, &["a", "b"]).expect("load");
+
+        // Last profile wins per key / scalar.
+        assert_eq!(cfg.home_dir.as_deref(), Some(Path::new(".b")));
+        assert_eq!(
+            cfg.caches.get("shared").expect("shared").uri,
+            "s3://b/shared"
+        );
+    }
+
+    #[test]
+    fn load_with_profiles_no_profiles_is_base() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let root = dir.path();
+        std::fs::write(root.join(".hephconfig2"), "homeDir: .base\n").expect("write base");
+
+        let cfg = load_with_profiles(root, &[] as &[&str]).expect("load");
+        assert_eq!(cfg.home_dir.as_deref(), Some(Path::new(".base")));
+    }
+
+    #[test]
+    fn load_with_profiles_missing_profile_errors() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let root = dir.path();
+        std::fs::write(root.join(".hephconfig2"), "homeDir: .base\n").expect("write base");
+
+        let err = load_with_profiles(root, &["missing"]).expect_err("must error");
+        let msg = format!("{err:#}");
+        assert!(msg.contains("missing.hephconfig2"), "{msg}");
     }
 }

--- a/src/engine/config_yaml.rs
+++ b/src/engine/config_yaml.rs
@@ -9,7 +9,7 @@ pub type Options = BTreeMap<String, serde_yaml::Value>;
 
 #[derive(Debug, Deserialize, Default)]
 #[serde(deny_unknown_fields, rename_all = "camelCase")]
-pub struct ConfigFile {
+pub struct ConfigYaml {
     #[serde(default)]
     pub home_dir: Option<PathBuf>,
     #[serde(default)]
@@ -29,36 +29,84 @@ pub struct ConfigFile {
     #[serde(default)]
     pub cache: Option<CacheConfig>,
     /// Named remote (shared) caches. Each entry is keyed by a name and carries a
-    /// `uri` plus `read`/`write` permissions. See [`RemoteCacheConfig`].
+    /// `uri` plus `read`/`write` permissions. Parsed as patches so a profile can
+    /// override individual fields; resolve with [`ConfigYaml::resolved_caches`].
     #[serde(default)]
-    pub caches: BTreeMap<String, RemoteCacheConfig>,
+    pub caches: BTreeMap<String, RemoteCacheConfigPatch>,
     #[serde(default)]
     pub telemetry: Option<TelemetryConfig>,
 }
 
-/// One named remote cache: `caches: { name: { uri, read, write } }`.
+/// One resolved named remote cache: `caches: { name: { uri, read, write } }`.
 ///
 /// `uri` selects the backend by scheme — `s3://bucket/prefix`,
 /// `gs://bucket/prefix` (credentials come from the environment, e.g.
 /// `AWS_ACCESS_KEY_ID` / `GOOGLE_SERVICE_ACCOUNT`), plus `memory://` and
 /// `file://` for tests/local use. `read`/`write` gate whether the cache is
 /// consulted on lookups and pushed to on writes; both default to `true`.
-#[derive(Debug, Deserialize, Clone, PartialEq, Eq)]
-#[serde(deny_unknown_fields, rename_all = "camelCase")]
+///
+/// Produced from one or more layered [`RemoteCacheConfigPatch`]es — see
+/// [`ConfigYaml::resolved_caches`].
+#[derive(Debug, Clone, PartialEq, Eq)]
 pub struct RemoteCacheConfig {
     pub uri: String,
-    #[serde(default = "default_true")]
     pub read: bool,
-    #[serde(default = "default_true")]
     pub write: bool,
     /// Max in-flight requests to this cache (object_store `LimitStore`). Caps how
     /// many connections a wide build fan-out opens at once. Defaults to 10.
-    #[serde(default = "default_cache_concurrency")]
     pub concurrency: usize,
 }
 
-fn default_true() -> bool {
-    true
+/// Parse/overlay shape for one named cache. Every field is optional so a profile
+/// can patch a single setting (e.g. flip `write`) without restating `uri`.
+/// Layered patches are deep-merged by [`merge`](Self::merge), then finalized into
+/// a [`RemoteCacheConfig`] by [`resolve`](Self::resolve).
+#[derive(Debug, Deserialize, Clone, PartialEq, Eq, Default)]
+#[serde(deny_unknown_fields, rename_all = "camelCase")]
+pub struct RemoteCacheConfigPatch {
+    #[serde(default)]
+    pub uri: Option<String>,
+    #[serde(default)]
+    pub read: Option<bool>,
+    #[serde(default)]
+    pub write: Option<bool>,
+    #[serde(default)]
+    pub concurrency: Option<usize>,
+}
+
+impl RemoteCacheConfigPatch {
+    /// Apply `other` on top of self — each field present in `other` wins, the
+    /// rest are left untouched. This is what lets a profile flip `read`/`write`
+    /// while inheriting the base `uri`.
+    fn merge(&mut self, other: RemoteCacheConfigPatch) {
+        if other.uri.is_some() {
+            self.uri = other.uri;
+        }
+        if other.read.is_some() {
+            self.read = other.read;
+        }
+        if other.write.is_some() {
+            self.write = other.write;
+        }
+        if other.concurrency.is_some() {
+            self.concurrency = other.concurrency;
+        }
+    }
+
+    /// Finalize into a [`RemoteCacheConfig`], applying defaults for omitted
+    /// fields. Errors if `uri` was never set across the base + any profiles.
+    fn resolve(&self, name: &str) -> anyhow::Result<RemoteCacheConfig> {
+        let uri = self
+            .uri
+            .clone()
+            .with_context(|| format!("cache `{name}` is missing required `uri`"))?;
+        Ok(RemoteCacheConfig {
+            uri,
+            read: self.read.unwrap_or(true),
+            write: self.write.unwrap_or(true),
+            concurrency: self.concurrency.unwrap_or_else(default_cache_concurrency),
+        })
+    }
 }
 
 fn default_cache_concurrency() -> usize {
@@ -76,22 +124,31 @@ pub struct CacheConfig {
     pub spill_threshold_bytes: Option<u64>,
 }
 
-impl ConfigFile {
+impl ConfigYaml {
     /// Whether anonymous usage telemetry is enabled. Opt-out: enabled unless the
     /// config explicitly sets `telemetry.enabled: false`.
     pub fn telemetry_enabled(&self) -> bool {
         self.telemetry.map(|t| t.enabled).unwrap_or(true)
     }
 
+    /// Finalize the layered cache patches into resolved configs, applying field
+    /// defaults. Errors if any cache never had its required `uri` set.
+    pub fn resolved_caches(&self) -> anyhow::Result<BTreeMap<String, RemoteCacheConfig>> {
+        self.caches
+            .iter()
+            .map(|(name, patch)| Ok((name.clone(), patch.resolve(name)?)))
+            .collect()
+    }
+
     /// Apply `other` on top of `self`, mutating in place. Used to layer profile
     /// configs over the base `.hephconfig2` (see [`load_from_root`]).
     ///
     /// Optional/scalar fields override only when present in `other` — a profile
-    /// that omits a field leaves the base value untouched. `caches` merge by key
-    /// (a later entry replaces the whole entry under that name), and
-    /// `providers`/`drivers` merge by name (matching entry replaced, new ones
-    /// appended in order).
-    pub fn merge(&mut self, other: ConfigFile) {
+    /// that omits a field leaves the base value untouched. `caches` deep-merge by
+    /// key (each cache's fields are patched individually, so a profile can flip
+    /// `read`/`write` while inheriting the base `uri`), and `providers`/`drivers`
+    /// merge by name (matching entry replaced, new ones appended in order).
+    pub fn merge(&mut self, other: ConfigYaml) {
         if other.home_dir.is_some() {
             self.home_dir = other.home_dir;
         }
@@ -117,8 +174,11 @@ impl ConfigFile {
             self.telemetry = other.telemetry;
         }
 
-        // Caches override by key: extend replaces matching names, keeps the rest.
-        self.caches.extend(other.caches);
+        // Caches deep-merge by key: a profile patches individual fields (e.g.
+        // flips read/write) while inheriting the rest of the base entry.
+        for (name, patch) in other.caches {
+            self.caches.entry(name).or_default().merge(patch);
+        }
 
         merge_plugins(&mut self.providers, other.providers);
         merge_plugins(&mut self.drivers, other.drivers);
@@ -310,16 +370,16 @@ fn profiles_from_env() -> Vec<String> {
 ///
 /// Profiles apply in the order listed: `HEPH_PROFILES=a,b` loads the base
 /// `.hephconfig2`, then applies `a.hephconfig2`, then `b.hephconfig2`, each
-/// merged over the accumulated config via [`ConfigFile::merge`] (so e.g. a cache
+/// merged over the accumulated config via [`ConfigYaml::merge`] (so e.g. a cache
 /// entry is overridden by its key). A named profile file that is missing or
 /// invalid is a hard error.
-pub fn load_from_root(root: &Path) -> anyhow::Result<ConfigFile> {
+pub fn load_from_root(root: &Path) -> anyhow::Result<ConfigYaml> {
     load_with_profiles(root, &profiles_from_env())
 }
 
 /// Core of [`load_from_root`], with the profile list passed in so it can be
 /// exercised without touching the process environment.
-fn load_with_profiles(root: &Path, profiles: &[impl AsRef<str>]) -> anyhow::Result<ConfigFile> {
+fn load_with_profiles(root: &Path, profiles: &[impl AsRef<str>]) -> anyhow::Result<ConfigYaml> {
     let mut cfg = load(&root.join(CONFIG_FILE_NAME))?;
     for profile in profiles {
         let profile = profile.as_ref();
@@ -333,13 +393,13 @@ fn load_with_profiles(root: &Path, profiles: &[impl AsRef<str>]) -> anyhow::Resu
     Ok(cfg)
 }
 
-pub fn load(path: &Path) -> anyhow::Result<ConfigFile> {
+pub fn load(path: &Path) -> anyhow::Result<ConfigYaml> {
     let bytes =
         std::fs::read(path).with_context(|| format!("reading config file {}", path.display()))?;
     if bytes.is_empty() {
-        return Ok(ConfigFile::default());
+        return Ok(ConfigYaml::default());
     }
-    let cfg: ConfigFile = serde_yaml::from_slice(&bytes)
+    let cfg: ConfigYaml = serde_yaml::from_slice(&bytes)
         .with_context(|| format!("parsing YAML config {}", path.display()))?;
     Ok(cfg)
 }
@@ -406,7 +466,7 @@ drivers:
     options:
       path: [/usr/bin]
 "#;
-        let cfg: ConfigFile = serde_yaml::from_str(yaml).expect("parse");
+        let cfg: ConfigYaml = serde_yaml::from_str(yaml).expect("parse");
         assert_eq!(cfg.home_dir.as_deref(), Some(Path::new(".heph2")));
         let mc = cfg.mem_cache.expect("mem_cache present");
         assert_eq!(mc.per_entry_bytes, 16384);
@@ -426,20 +486,20 @@ drivers:
     #[test]
     fn parses_cache_spill_threshold() {
         let yaml = "cache:\n  spillThresholdBytes: 104857600\n";
-        let cfg: ConfigFile = serde_yaml::from_str(yaml).expect("parse");
+        let cfg: ConfigYaml = serde_yaml::from_str(yaml).expect("parse");
         let c = cfg.cache.expect("cache present");
         assert_eq!(c.spill_threshold_bytes, Some(104857600));
     }
 
     #[test]
     fn cache_config_omitted_is_none() {
-        let cfg: ConfigFile = serde_yaml::from_str("homeDir: .heph3\n").expect("parse");
+        let cfg: ConfigYaml = serde_yaml::from_str("homeDir: .heph3\n").expect("parse");
         assert!(cfg.cache.is_none());
     }
 
     #[test]
     fn rejects_unknown_cache_field() {
-        let err = serde_yaml::from_str::<ConfigFile>("cache:\n  bogus: 1\n").expect_err("reject");
+        let err = serde_yaml::from_str::<ConfigYaml>("cache:\n  bogus: 1\n").expect_err("reject");
         assert!(err.to_string().contains("bogus"), "{err}");
     }
 
@@ -454,14 +514,15 @@ caches:
   local:
     uri: file:///tmp/heph-cache
 "#;
-        let cfg: ConfigFile = serde_yaml::from_str(yaml).expect("parse");
+        let cfg: ConfigYaml = serde_yaml::from_str(yaml).expect("parse");
         assert_eq!(cfg.caches.len(), 2);
-        let remote = cfg.caches.get("remote").expect("remote present");
+        let caches = cfg.resolved_caches().expect("resolve");
+        let remote = caches.get("remote").expect("remote present");
         assert_eq!(remote.uri, "s3://my-bucket/heph");
         assert!(remote.read);
         assert!(!remote.write);
         // read/write/concurrency default when omitted.
-        let local = cfg.caches.get("local").expect("local present");
+        let local = caches.get("local").expect("local present");
         assert!(local.read);
         assert!(local.write);
         assert_eq!(local.concurrency, 10);
@@ -470,20 +531,31 @@ caches:
     #[test]
     fn cache_concurrency_is_configurable() {
         let yaml = "caches:\n  c:\n    uri: s3://b/p\n    concurrency: 32\n";
-        let cfg: ConfigFile = serde_yaml::from_str(yaml).expect("parse");
-        assert_eq!(cfg.caches.get("c").expect("present").concurrency, 32);
+        let cfg: ConfigYaml = serde_yaml::from_str(yaml).expect("parse");
+        let caches = cfg.resolved_caches().expect("resolve");
+        assert_eq!(caches.get("c").expect("present").concurrency, 32);
+    }
+
+    #[test]
+    fn resolved_caches_errors_on_missing_uri() {
+        // A cache that only ever sets read/write (no base uri) cannot resolve.
+        let cfg: ConfigYaml =
+            serde_yaml::from_str("caches:\n  c:\n    read: false\n").expect("parse");
+        let err = cfg.resolved_caches().expect_err("must error");
+        let msg = format!("{err:#}");
+        assert!(msg.contains("`c`") && msg.contains("uri"), "{msg}");
     }
 
     #[test]
     fn caches_omitted_is_empty() {
-        let cfg: ConfigFile = serde_yaml::from_str("homeDir: .heph3\n").expect("parse");
+        let cfg: ConfigYaml = serde_yaml::from_str("homeDir: .heph3\n").expect("parse");
         assert!(cfg.caches.is_empty());
     }
 
     #[test]
     fn rejects_unknown_cache_entry_field() {
         let yaml = "caches:\n  r:\n    uri: memory:///r\n    bogus: 1\n";
-        let err = serde_yaml::from_str::<ConfigFile>(yaml).expect_err("must reject");
+        let err = serde_yaml::from_str::<ConfigYaml>(yaml).expect_err("must reject");
         assert!(err.to_string().contains("bogus"), "{err}");
     }
 
@@ -491,7 +563,7 @@ caches:
     fn parses_fs_skip() {
         // `skip` mixes literal dirs and glob patterns.
         let yaml = "fs:\n  skip: [vendor, \"**/node_modules/**\"]\n";
-        let cfg: ConfigFile = serde_yaml::from_str(yaml).expect("parse");
+        let cfg: ConfigYaml = serde_yaml::from_str(yaml).expect("parse");
         let fs = cfg.fs.expect("fs config present");
         assert_eq!(
             fs.skip,
@@ -501,13 +573,13 @@ caches:
 
     #[test]
     fn fs_config_defaults_absent() {
-        let cfg: ConfigFile = serde_yaml::from_str("homeDir: .heph3\n").expect("parse");
+        let cfg: ConfigYaml = serde_yaml::from_str("homeDir: .heph3\n").expect("parse");
         assert!(cfg.fs.is_none());
     }
 
     #[test]
     fn rejects_unknown_fs_field() {
-        let err = serde_yaml::from_str::<ConfigFile>("fs:\n  bogus: 1\n").expect_err("must reject");
+        let err = serde_yaml::from_str::<ConfigYaml>("fs:\n  bogus: 1\n").expect_err("must reject");
         assert!(err.to_string().contains("bogus"), "{err}");
     }
 
@@ -525,7 +597,7 @@ caches:
     #[test]
     fn rejects_unknown_top_level_field() {
         let yaml = "bogus: 1\n";
-        let err = serde_yaml::from_str::<ConfigFile>(yaml).expect_err("must reject");
+        let err = serde_yaml::from_str::<ConfigYaml>(yaml).expect_err("must reject");
         assert!(err.to_string().contains("bogus"), "{err}");
     }
 
@@ -549,7 +621,7 @@ caches:
     #[test]
     fn fuse_config_enabled_true() {
         let yaml = "fuse:\n  enabled: true\n";
-        let cfg: ConfigFile = serde_yaml::from_str(yaml).expect("parse");
+        let cfg: ConfigYaml = serde_yaml::from_str(yaml).expect("parse");
         let f = cfg.fuse.expect("fuse present");
         assert_eq!(f.mode(), FuseMode::On);
     }
@@ -557,7 +629,7 @@ caches:
     #[test]
     fn fuse_config_enabled_false() {
         let yaml = "fuse:\n  enabled: false\n";
-        let cfg: ConfigFile = serde_yaml::from_str(yaml).expect("parse");
+        let cfg: ConfigYaml = serde_yaml::from_str(yaml).expect("parse");
         let f = cfg.fuse.expect("fuse present");
         assert_eq!(f.mode(), FuseMode::Off);
     }
@@ -565,7 +637,7 @@ caches:
     #[test]
     fn fuse_config_defaults_when_omitted() {
         let yaml = "fuse: {}\n";
-        let cfg: ConfigFile = serde_yaml::from_str(yaml).expect("parse");
+        let cfg: ConfigYaml = serde_yaml::from_str(yaml).expect("parse");
         let f = cfg.fuse.expect("fuse present");
         assert_eq!(f.mode(), FuseMode::Off);
         assert!(f.is_off());
@@ -575,14 +647,14 @@ caches:
     #[test]
     fn fuse_config_rejects_unknown_field() {
         let yaml = "fuse:\n  bogus: 1\n";
-        let err = serde_yaml::from_str::<ConfigFile>(yaml).expect_err("must reject");
+        let err = serde_yaml::from_str::<ConfigYaml>(yaml).expect_err("must reject");
         assert!(err.to_string().contains("bogus"), "{err}");
     }
 
     #[test]
     fn fuse_config_enabled_auto() {
         let yaml = "fuse:\n  enabled: auto\n";
-        let cfg: ConfigFile = serde_yaml::from_str(yaml).expect("parse");
+        let cfg: ConfigYaml = serde_yaml::from_str(yaml).expect("parse");
         let f = cfg.fuse.expect("fuse present");
         assert_eq!(f.mode(), FuseMode::Auto);
         assert!(!f.is_off());
@@ -592,7 +664,7 @@ caches:
     #[test]
     fn fuse_config_enabled_rejects_unknown_string() {
         let yaml = "fuse:\n  enabled: maybe\n";
-        let err = serde_yaml::from_str::<ConfigFile>(yaml).expect_err("must reject");
+        let err = serde_yaml::from_str::<ConfigYaml>(yaml).expect_err("must reject");
         assert!(err.to_string().contains("maybe"), "{err}");
     }
 
@@ -606,7 +678,7 @@ caches:
     #[test]
     fn lock_config_backend_mem() {
         let yaml = "lock:\n  backend: mem\n";
-        let cfg: ConfigFile = serde_yaml::from_str(yaml).expect("parse");
+        let cfg: ConfigYaml = serde_yaml::from_str(yaml).expect("parse");
         let l = cfg.lock.expect("lock present");
         assert_eq!(l.backend, Some(LockBackendConfig::Mem));
     }
@@ -614,7 +686,7 @@ caches:
     #[test]
     fn lock_config_backend_fs() {
         let yaml = "lock:\n  backend: fs\n";
-        let cfg: ConfigFile = serde_yaml::from_str(yaml).expect("parse");
+        let cfg: ConfigYaml = serde_yaml::from_str(yaml).expect("parse");
         assert_eq!(
             cfg.lock.expect("lock present").backend,
             Some(LockBackendConfig::Fs)
@@ -624,35 +696,35 @@ caches:
     #[test]
     fn lock_config_omitted_is_none() {
         let yaml = "providers: []\n";
-        let cfg: ConfigFile = serde_yaml::from_str(yaml).expect("parse");
+        let cfg: ConfigYaml = serde_yaml::from_str(yaml).expect("parse");
         assert!(cfg.lock.is_none());
     }
 
     #[test]
     fn lock_config_rejects_unknown_backend() {
         let yaml = "lock:\n  backend: sqlite\n";
-        let err = serde_yaml::from_str::<ConfigFile>(yaml).expect_err("must reject");
+        let err = serde_yaml::from_str::<ConfigYaml>(yaml).expect_err("must reject");
         assert!(err.to_string().contains("sqlite"), "{err}");
     }
 
     #[test]
     fn lock_config_rejects_unknown_field() {
         let yaml = "lock:\n  bogus: 1\n";
-        let err = serde_yaml::from_str::<ConfigFile>(yaml).expect_err("must reject");
+        let err = serde_yaml::from_str::<ConfigYaml>(yaml).expect_err("must reject");
         assert!(err.to_string().contains("bogus"), "{err}");
     }
 
     #[test]
     fn telemetry_defaults_enabled_when_omitted() {
         // Opt-out: no `telemetry:` block means telemetry stays on.
-        let cfg: ConfigFile = serde_yaml::from_str("providers: []\n").expect("parse");
+        let cfg: ConfigYaml = serde_yaml::from_str("providers: []\n").expect("parse");
         assert!(cfg.telemetry.is_none());
         assert!(cfg.telemetry_enabled());
     }
 
     #[test]
     fn telemetry_can_be_disabled() {
-        let cfg: ConfigFile =
+        let cfg: ConfigYaml =
             serde_yaml::from_str("telemetry:\n  enabled: false\n").expect("parse");
         assert!(!cfg.telemetry_enabled());
     }
@@ -660,45 +732,68 @@ caches:
     #[test]
     fn telemetry_empty_block_defaults_enabled() {
         // `telemetry: {}` present but `enabled` omitted → still on.
-        let cfg: ConfigFile = serde_yaml::from_str("telemetry: {}\n").expect("parse");
+        let cfg: ConfigYaml = serde_yaml::from_str("telemetry: {}\n").expect("parse");
         assert!(cfg.telemetry_enabled());
     }
 
     #[test]
     fn telemetry_rejects_unknown_field() {
         let yaml = "telemetry:\n  bogus: 1\n";
-        let err = serde_yaml::from_str::<ConfigFile>(yaml).expect_err("must reject");
+        let err = serde_yaml::from_str::<ConfigYaml>(yaml).expect_err("must reject");
         assert!(err.to_string().contains("bogus"), "{err}");
     }
 
     #[test]
     fn merge_overrides_caches_by_key() {
-        let mut base: ConfigFile = serde_yaml::from_str(
+        let mut base: ConfigYaml = serde_yaml::from_str(
             "caches:\n  a:\n    uri: s3://base/a\n  b:\n    uri: s3://base/b\n",
         )
         .expect("parse base");
-        let overlay: ConfigFile = serde_yaml::from_str(
+        let overlay: ConfigYaml = serde_yaml::from_str(
             "caches:\n  b:\n    uri: s3://prof/b\n  c:\n    uri: s3://prof/c\n",
         )
         .expect("parse overlay");
 
         base.merge(overlay);
 
-        assert_eq!(base.caches.len(), 3);
+        let caches = base.resolved_caches().expect("resolve");
+        assert_eq!(caches.len(), 3);
         // Untouched key keeps its base value.
-        assert_eq!(base.caches.get("a").expect("a").uri, "s3://base/a");
-        // Shared key is overridden by the overlay.
-        assert_eq!(base.caches.get("b").expect("b").uri, "s3://prof/b");
+        assert_eq!(caches.get("a").expect("a").uri, "s3://base/a");
+        // Shared key's uri is overridden by the overlay.
+        assert_eq!(caches.get("b").expect("b").uri, "s3://prof/b");
         // New key is added.
-        assert_eq!(base.caches.get("c").expect("c").uri, "s3://prof/c");
+        assert_eq!(caches.get("c").expect("c").uri, "s3://prof/c");
+    }
+
+    #[test]
+    fn merge_deep_merges_cache_fields() {
+        // Base defines uri (+ default read/write); profile flips write only.
+        let mut base: ConfigYaml =
+            serde_yaml::from_str("caches:\n  remote:\n    uri: s3://base/remote\n")
+                .expect("parse base");
+        let overlay: ConfigYaml =
+            serde_yaml::from_str("caches:\n  remote:\n    write: false\n").expect("parse overlay");
+
+        base.merge(overlay);
+
+        let remote = base
+            .resolved_caches()
+            .expect("resolve")
+            .remove("remote")
+            .expect("remote present");
+        // uri inherited from base, write patched by profile, read still default.
+        assert_eq!(remote.uri, "s3://base/remote");
+        assert!(remote.read);
+        assert!(!remote.write);
     }
 
     #[test]
     fn merge_overrides_scalars_only_when_present() {
-        let mut base: ConfigFile =
+        let mut base: ConfigYaml =
             serde_yaml::from_str("homeDir: .base\nlock:\n  backend: fs\n").expect("parse base");
         // Overlay sets homeDir but omits lock — lock must survive.
-        let overlay: ConfigFile = serde_yaml::from_str("homeDir: .prof\n").expect("parse overlay");
+        let overlay: ConfigYaml = serde_yaml::from_str("homeDir: .prof\n").expect("parse overlay");
 
         base.merge(overlay);
 
@@ -711,11 +806,11 @@ caches:
 
     #[test]
     fn merge_providers_by_name() {
-        let mut base: ConfigFile = serde_yaml::from_str(
+        let mut base: ConfigYaml = serde_yaml::from_str(
             "providers:\n  - name: buildfile\n    options:\n      patterns: [BUILD]\n  - name: go\n",
         )
         .expect("parse base");
-        let overlay: ConfigFile = serde_yaml::from_str(
+        let overlay: ConfigYaml = serde_yaml::from_str(
             "providers:\n  - name: buildfile\n    options:\n      patterns: [BUILD2]\n  - name: rust\n",
         )
         .expect("parse overlay");
@@ -755,10 +850,8 @@ caches:
 
         // Last profile wins per key / scalar.
         assert_eq!(cfg.home_dir.as_deref(), Some(Path::new(".b")));
-        assert_eq!(
-            cfg.caches.get("shared").expect("shared").uri,
-            "s3://b/shared"
-        );
+        let caches = cfg.resolved_caches().expect("resolve");
+        assert_eq!(caches.get("shared").expect("shared").uri, "s3://b/shared");
     }
 
     #[test]
@@ -780,5 +873,50 @@ caches:
         let err = load_with_profiles(root, &["missing"]).expect_err("must error");
         let msg = format!("{err:#}");
         assert!(msg.contains("missing.hephconfig2"), "{msg}");
+    }
+
+    #[test]
+    fn resolve_applies_defaults_for_empty_yaml() {
+        // An empty config resolves to the engine defaults, with home_dir
+        // root-joined to `.heph3`.
+        let yaml = ConfigYaml::default();
+        let root = Path::new("/repo");
+        let cfg = yaml.resolve(root).expect("resolve");
+
+        let defaults = crate::engine::Config::default();
+        assert_eq!(cfg.root, root);
+        assert_eq!(cfg.home_dir, root.join(".heph3"));
+        assert_eq!(cfg.mem_cache, defaults.mem_cache);
+        assert_eq!(cfg.tmp_cache, defaults.tmp_cache);
+        assert_eq!(cfg.lock_backend, defaults.lock_backend);
+        assert_eq!(cfg.spill_threshold_bytes, defaults.spill_threshold_bytes);
+        assert!(cfg.telemetry_enabled);
+        assert!(cfg.remote_caches.is_empty());
+    }
+
+    #[test]
+    fn resolve_overrides_present_fields() {
+        let yaml: ConfigYaml = serde_yaml::from_str(
+            "homeDir: .custom\nlock:\n  backend: mem\ntelemetry:\n  enabled: false\ncaches:\n  r:\n    uri: s3://b/p\n    write: false\n",
+        )
+        .expect("parse");
+        let cfg = yaml.resolve(Path::new("/repo")).expect("resolve");
+
+        assert_eq!(cfg.home_dir, Path::new("/repo/.custom"));
+        assert_eq!(cfg.lock_backend, crate::engine::LockBackend::Mem);
+        assert!(!cfg.telemetry_enabled);
+        assert_eq!(cfg.remote_caches.len(), 1);
+        let r = &cfg.remote_caches[0];
+        assert_eq!(r.uri, "s3://b/p");
+        assert!(r.read);
+        assert!(!r.write);
+    }
+
+    #[test]
+    fn resolve_errors_on_cache_missing_uri() {
+        let yaml: ConfigYaml =
+            serde_yaml::from_str("caches:\n  r:\n    write: false\n").expect("parse");
+        let err = yaml.resolve(Path::new("/repo")).expect_err("must error");
+        assert!(format!("{err:#}").contains("uri"), "{err}");
     }
 }

--- a/src/engine/driver_managed.rs
+++ b/src/engine/driver_managed.rs
@@ -1,7 +1,7 @@
 use crate::engine::Engine;
 #[cfg(test)]
-use crate::engine::config_file::FuseEnabled;
-use crate::engine::config_file::{FuseConfig, FuseMode};
+use crate::engine::config_yaml::FuseEnabled;
+use crate::engine::config_yaml::{FuseConfig, FuseMode};
 use crate::engine::driver::inputartifact;
 use crate::engine::driver::outputartifact::Content::TarPath;
 use crate::engine::driver::targetdef::path::{self, Content};

--- a/src/engine/engine.rs
+++ b/src/engine/engine.rs
@@ -1,4 +1,5 @@
-use crate::engine::config_file::{FuseConfig, Options, PluginEntry};
+use crate::engine::config::Config;
+use crate::engine::config_yaml::{FuseConfig, Options, PluginEntry};
 use crate::engine::driver::Driver as SDKDriver;
 use crate::engine::driver_managed::ManagedDriver as SDKManagedDriver;
 use crate::engine::local_cache::LocalCache;
@@ -6,7 +7,7 @@ use crate::engine::local_cache_mem::LocalCacheMem;
 use crate::engine::local_cache_sqlite::LocalCacheSQLite;
 use crate::engine::provider::Provider as SDKProvider;
 use crate::engine::request_state::RequestState;
-use crate::engine::result_lock::{LockBackend, ResultLock};
+use crate::engine::result_lock::ResultLock;
 use crate::engine::{driver, provider};
 use crate::sandboxfuse;
 use anyhow::Context;
@@ -15,94 +16,6 @@ use std::path::{Path, PathBuf};
 use std::sync::{Arc, Mutex, Weak};
 use tokio::sync::Semaphore;
 use tracing::warn;
-
-#[derive(Debug, Clone, PartialEq)]
-pub struct Config {
-    pub root: PathBuf,
-    /// Workspace state/cache directory. If empty, defaults to `root/.heph3`.
-    pub home_dir: PathBuf,
-    /// Repo-root-relative directories from the config file's `fs.skip`, pruned by
-    /// every plugin that walks the tree. See [`Engine::skip_dirs`].
-    pub fs_skip: Vec<String>,
-    pub parallelism: Option<usize>,
-    /// In-memory tier fronting the durable (SQLite) local cache.
-    pub mem_cache: MemCacheOptions,
-    /// Mem-only store for tmp/uncacheable revisions ([`LocalCacheTmp`]).
-    /// Entries over `per_entry_bytes`, or that would push the store past
-    /// `capacity_bytes`, spill to the durable cache.
-    ///
-    /// [`LocalCacheTmp`]: crate::engine::local_cache_tmp::LocalCacheTmp
-    pub tmp_cache: MemCacheOptions,
-    pub fuse: FuseConfig,
-    /// Backend serializing the execute phase per addr. Defaults to `Fs`.
-    pub lock_backend: LockBackend,
-    /// Durable blobs strictly larger than this spill to plain files under
-    /// `<home>/cache/blobs/` instead of being stored inline in the sqlite DB;
-    /// manifests always stay in sqlite. Keeps the DB / WAL small and lets large
-    /// artifacts stream from the filesystem. See [`DEFAULT_SPILL_THRESHOLD_BYTES`].
-    pub spill_threshold_bytes: u64,
-    /// Anonymous usage telemetry. Defaults to `true` (opt-out via config).
-    pub telemetry_enabled: bool,
-    /// Named remote (shared) caches from the config's `caches:` map. Empty
-    /// disables the remote-cache layer entirely. See [`RemoteCacheSet`].
-    pub remote_caches: Vec<crate::engine::RemoteCacheDef>,
-}
-
-/// Default spill threshold: 8 MiB. Above a few MB the filesystem beats sqlite
-/// blob storage on throughput and big blobs would bloat the single-file DB and
-/// its WAL; below it, artifacts stay in sqlite where small indexed reads and the
-/// mem tier win. Tunable via `cache.spillThresholdBytes`.
-pub const DEFAULT_SPILL_THRESHOLD_BYTES: u64 = 8 * 1024 * 1024;
-
-impl Default for Config {
-    fn default() -> Self {
-        Self {
-            root: PathBuf::new(),
-            home_dir: PathBuf::new(),
-            fs_skip: Vec::new(),
-            parallelism: None,
-            mem_cache: MemCacheOptions::default(),
-            tmp_cache: MemCacheOptions::default_tmp(),
-            fuse: FuseConfig::default(),
-            lock_backend: LockBackend::default(),
-            spill_threshold_bytes: DEFAULT_SPILL_THRESHOLD_BYTES,
-            telemetry_enabled: true,
-            remote_caches: Vec::new(),
-        }
-    }
-}
-
-/// Byte limits for one in-memory cache store. Used for both the local-cache mem
-/// tier (`mem_cache`) and the tmp store (`tmp_cache`).
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
-pub struct MemCacheOptions {
-    /// Per-entry size cap. For `mem_cache`, larger entries pass through
-    /// uncached; for `tmp_cache`, larger entries spill to the durable cache.
-    pub per_entry_bytes: usize,
-    /// Total byte budget. For `mem_cache`, `0` disables the in-memory layer
-    /// entirely; for `tmp_cache`, entries that would exceed it spill to durable.
-    pub capacity_bytes: u64,
-}
-
-impl Default for MemCacheOptions {
-    /// Defaults for the local-cache mem tier.
-    fn default() -> Self {
-        Self {
-            per_entry_bytes: 16 * 1024,
-            capacity_bytes: 64 * 1024 * 1024,
-        }
-    }
-}
-
-impl MemCacheOptions {
-    /// Defaults for the tmp store: 1 MiB per entry, 64 MiB total budget.
-    pub fn default_tmp() -> Self {
-        Self {
-            per_entry_bytes: 1024 * 1024,
-            capacity_bytes: 64 * 1024 * 1024,
-        }
-    }
-}
 
 /// Context the engine injects when constructing any plugin (provider, driver, or
 /// managed driver — whether registered directly or through a factory): the

--- a/src/engine/mod.rs
+++ b/src/engine/mod.rs
@@ -3,14 +3,15 @@
     reason = "module and struct share name by design"
 )]
 pub mod engine;
-pub use engine::Config;
-pub use engine::DEFAULT_SPILL_THRESHOLD_BYTES;
 pub use engine::Engine;
 pub use engine::EngineFuse;
-pub use engine::MemCacheOptions;
 pub use engine::PluginInit;
-pub mod config_file;
-pub use config_file::{FuseConfig, FuseMode};
+pub mod config;
+pub use config::Config;
+pub use config::DEFAULT_SPILL_THRESHOLD_BYTES;
+pub use config::MemCacheOptions;
+pub mod config_yaml;
+pub use config_yaml::{FuseConfig, FuseMode};
 mod cwd;
 mod result;
 pub use cwd::get_cwd;

--- a/src/engine/root.rs
+++ b/src/engine/root.rs
@@ -13,7 +13,7 @@ pub fn get_root_inner() -> Result<PathBuf, String> {
     let mut current = Path::new(&cwd).to_path_buf();
 
     loop {
-        let config_file = current.join(crate::engine::config_file::CONFIG_FILE_NAME);
+        let config_file = current.join(crate::engine::config_yaml::CONFIG_FILE_NAME);
         if config_file.exists() {
             return Ok(current);
         }
@@ -26,6 +26,6 @@ pub fn get_root_inner() -> Result<PathBuf, String> {
 
     Err(format!(
         "Could not find {} file in any parent directory",
-        crate::engine::config_file::CONFIG_FILE_NAME
+        crate::engine::config_yaml::CONFIG_FILE_NAME
     ))
 }

--- a/src/pluginbuildfile/provider.rs
+++ b/src/pluginbuildfile/provider.rs
@@ -103,15 +103,15 @@ impl Provider {
         root: std::path::PathBuf,
         skip_dirs: &[std::path::PathBuf],
         skip_globs: &[String],
-        opts: &crate::engine::config_file::Options,
+        opts: &crate::engine::config_yaml::Options,
     ) -> anyhow::Result<Self> {
-        crate::engine::config_file::deny_unknown(
+        crate::engine::config_yaml::deny_unknown(
             "buildfile provider",
             opts,
             &["patterns", "skip", "defaultDriver"],
         )?;
         let patterns: Vec<String> =
-            crate::engine::config_file::decode_opt(opts, "buildfile provider", "patterns")?
+            crate::engine::config_yaml::decode_opt(opts, "buildfile provider", "patterns")?
                 .unwrap_or_else(|| vec!["BUILD".to_string()]);
         let compiled = patterns
             .into_iter()
@@ -123,12 +123,12 @@ impl Provider {
         // `skip` option so both prune the same workspace-relative paths.
         let mut globs = skip_globs.to_vec();
         let user_skip: Vec<String> =
-            crate::engine::config_file::decode_opt(opts, "buildfile provider", "skip")?
+            crate::engine::config_yaml::decode_opt(opts, "buildfile provider", "skip")?
                 .unwrap_or_default();
         globs.extend(user_skip);
         let skip = Ignore::new(skip_dirs, &globs)?;
         let default_driver: Option<String> =
-            crate::engine::config_file::decode_opt(opts, "buildfile provider", "defaultDriver")?;
+            crate::engine::config_yaml::decode_opt(opts, "buildfile provider", "defaultDriver")?;
         Ok(Self {
             root,
             build_file_patterns: compiled,
@@ -355,7 +355,7 @@ impl EProvider for Provider {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::engine::config_file::Options;
+    use crate::engine::config_yaml::Options;
     use crate::hasync::StdCancellationToken;
     use std::fs;
     use tempfile::tempdir;

--- a/src/pluginexec/mod.rs
+++ b/src/pluginexec/mod.rs
@@ -267,21 +267,21 @@ impl Driver {
         }
     }
 
-    pub fn from_options_exec(opts: &crate::engine::config_file::Options) -> anyhow::Result<Self> {
+    pub fn from_options_exec(opts: &crate::engine::config_yaml::Options) -> anyhow::Result<Self> {
         Ok(Self {
             search_path: decode_path(opts)?,
             ..Self::new_exec()
         })
     }
 
-    pub fn from_options_bash(opts: &crate::engine::config_file::Options) -> anyhow::Result<Self> {
+    pub fn from_options_bash(opts: &crate::engine::config_yaml::Options) -> anyhow::Result<Self> {
         Ok(Self {
             search_path: decode_path(opts)?,
             ..Self::new_bash()
         })
     }
 
-    pub fn from_options_sh(opts: &crate::engine::config_file::Options) -> anyhow::Result<Self> {
+    pub fn from_options_sh(opts: &crate::engine::config_yaml::Options) -> anyhow::Result<Self> {
         Ok(Self {
             search_path: decode_path(opts)?,
             ..Self::new_sh()
@@ -309,10 +309,10 @@ fn spec_path_to_target_path(raw: &str, pkg: &crate::htpkg::PkgBuf, codegen: &Cod
     }
 }
 
-fn decode_path(opts: &crate::engine::config_file::Options) -> anyhow::Result<Vec<String>> {
-    crate::engine::config_file::deny_unknown("exec/bash/sh driver", opts, &["path"])?;
+fn decode_path(opts: &crate::engine::config_yaml::Options) -> anyhow::Result<Vec<String>> {
+    crate::engine::config_yaml::deny_unknown("exec/bash/sh driver", opts, &["path"])?;
     Ok(
-        crate::engine::config_file::decode_opt(opts, "exec/bash/sh driver", "path")?
+        crate::engine::config_yaml::decode_opt(opts, "exec/bash/sh driver", "path")?
             .unwrap_or_default(),
     )
 }
@@ -1354,7 +1354,7 @@ mod tests {
 
     #[test]
     fn from_options_sh_no_path() {
-        let opts = crate::engine::config_file::Options::new();
+        let opts = crate::engine::config_yaml::Options::new();
         let d = Driver::from_options_sh(&opts).expect("from_options");
         assert_eq!(d.name, "sh");
         assert!(d.search_path.is_empty());
@@ -1362,7 +1362,7 @@ mod tests {
 
     #[test]
     fn from_options_exec_no_path() {
-        let opts = crate::engine::config_file::Options::new();
+        let opts = crate::engine::config_yaml::Options::new();
         let d = Driver::from_options_exec(&opts).expect("from_options");
         assert_eq!(d.name, "exec");
         assert!(d.search_path.is_empty());
@@ -1370,7 +1370,7 @@ mod tests {
 
     #[test]
     fn from_options_exec_reads_path() {
-        let mut opts = crate::engine::config_file::Options::new();
+        let mut opts = crate::engine::config_yaml::Options::new();
         opts.insert(
             "path".to_string(),
             serde_yaml::from_str("[/usr/bin, /bin]").expect("yaml"),
@@ -1381,7 +1381,7 @@ mod tests {
 
     #[test]
     fn from_options_bash_rejects_unknown_key() {
-        let mut opts = crate::engine::config_file::Options::new();
+        let mut opts = crate::engine::config_yaml::Options::new();
         opts.insert("bogus".to_string(), serde_yaml::Value::Bool(true));
         let err = Driver::from_options_bash(&opts).err().expect("must error");
         assert!(err.to_string().contains("bogus"), "{err}");

--- a/src/plugingo/provider.rs
+++ b/src/plugingo/provider.rs
@@ -199,18 +199,18 @@ impl Provider {
         workspace_root: PathBuf,
         skip_dirs: &[PathBuf],
         skip_globs: &[String],
-        opts: &crate::engine::config_file::Options,
+        opts: &crate::engine::config_yaml::Options,
         walker: Arc<CachedWalker>,
     ) -> anyhow::Result<Self> {
-        crate::engine::config_file::deny_unknown("go provider", opts, &["gotool", "skip"])?;
+        crate::engine::config_yaml::deny_unknown("go provider", opts, &["gotool", "skip"])?;
         let go_bin_addr: String =
-            crate::engine::config_file::decode_opt(opts, "go provider", "gotool")?
+            crate::engine::config_yaml::decode_opt(opts, "go provider", "gotool")?
                 .unwrap_or_else(|| DEFAULT_GO_BIN_ADDR.to_string());
         // Engine-wide `fs.skip` globs are merged ahead of this provider's own
         // `skip` option so both prune the same workspace-relative paths.
         let mut globs = skip_globs.to_vec();
         let user_skip: Vec<String> =
-            crate::engine::config_file::decode_opt(opts, "go provider", "skip")?
+            crate::engine::config_yaml::decode_opt(opts, "go provider", "skip")?
                 .unwrap_or_default();
         globs.extend(user_skip);
         let skip = Arc::new(Ignore::new(skip_dirs, &globs)?);


### PR DESCRIPTION
## What

Add a `HEPH_PROFILES` env var: a comma-separated, ordered list of config *profiles*. Each profile layers a `<profile>.hephconfig2` file on top of the base `.hephconfig2`.

`HEPH_PROFILES=a,b` loads `.hephconfig2`, then applies `a.hephconfig2`, then `b.hephconfig2` — each merged over the accumulated config.

## Config layering (`ConfigYaml::merge`)

- Optional/scalar fields (`homeDir`, `lock`, `fuse`, `telemetry`, …) override **only when present** in the overlay.
- `caches` **deep-merge by key**: each cache's fields are patched individually, so the base can define `uri` (+ defaults) while a profile flips `read`/`write` without restating `uri` (`RemoteCacheConfigPatch`).
- `providers`/`drivers` merge **by name**: matching entry replaced in place, new ones appended, order preserved.
- A named profile file that is missing or invalid is a **hard error**.

## Two-layer config split

Mirrors the Go `YAMLConfig`/`Config` separation:

- **`config_yaml.rs`** (renamed from `config_file.rs`) — the all-optional, profile-layered parse layer (`ConfigYaml`). Profiles are merged here.
- **`config.rs`** (new) — the resolved runtime `Config`, no optionals, every default applied exactly once. `MemCacheOptions` + the spill-threshold default move here from `engine.rs`.
- `ConfigYaml::resolve(root)` is the single boundary that applies defaults and yields `Config`; `bootstrap::new_engine` resolves once instead of scattering `unwrap_or` fallbacks across the call site.

## Tests

`merge` (caches deep-merge / by-key, scalar-only-when-present, providers by name), `resolve` (defaults applied, overrides, missing-uri error), and `load_with_profiles` (ordered layering, no-profiles base, missing-profile error). Full lib suite (1083 tests) green; clippy clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)