### PR TITLE
feat(buildfile): BUILD-file LSP

### DIFF
--- a/.github/workflows/heph.yml
+++ b/.github/workflows/heph.yml
@@ -31,6 +31,18 @@ jobs:
       - uses: cachix/install-nix-action@v31
         with:
           extra_nix_config: fallback = true
+      # Persist the Nix store (rust-overlay toolchain, devenv env, …) across runs.
+      # Cold runners otherwise re-realize the whole toolchain every job, which
+      # intermittently fails to fetch/realize a rust-overlay patch
+      # ("path '/nix/store/…fix-kill-doctest.patch' is not valid"), forcing reruns.
+      # Keyed on the devenv lock so a toolchain bump busts the cache.
+      - name: Cache Nix store
+        uses: nix-community/cache-nix-action@v6
+        with:
+          primary-key: nix-${{ runner.os }}-${{ hashFiles('devenv.lock', 'devenv.nix', 'devenv.yaml') }}
+          restore-prefixes-first-match: nix-${{ runner.os }}-
+          gc-max-store-size-linux: 5368709120
+          gc-max-store-size-macos: 5368709120
       - name: Install devenv.sh
         run: nix profile add nixpkgs#devenv
 
@@ -99,6 +111,18 @@ jobs:
       - uses: cachix/install-nix-action@v31
         with:
           extra_nix_config: fallback = true
+      # Persist the Nix store (rust-overlay toolchain, devenv env, …) across runs.
+      # Cold runners otherwise re-realize the whole toolchain every job, which
+      # intermittently fails to fetch/realize a rust-overlay patch
+      # ("path '/nix/store/…fix-kill-doctest.patch' is not valid"), forcing reruns.
+      # Keyed on the devenv lock so a toolchain bump busts the cache.
+      - name: Cache Nix store
+        uses: nix-community/cache-nix-action@v6
+        with:
+          primary-key: nix-${{ runner.os }}-${{ hashFiles('devenv.lock', 'devenv.nix', 'devenv.yaml') }}
+          restore-prefixes-first-match: nix-${{ runner.os }}-
+          gc-max-store-size-linux: 5368709120
+          gc-max-store-size-macos: 5368709120
       - name: Install devenv.sh
         run: nix profile add nixpkgs#devenv
 
@@ -215,6 +239,18 @@ jobs:
       - uses: cachix/install-nix-action@v31
         with:
           extra_nix_config: fallback = true
+      # Persist the Nix store (rust-overlay toolchain, devenv env, …) across runs.
+      # Cold runners otherwise re-realize the whole toolchain every job, which
+      # intermittently fails to fetch/realize a rust-overlay patch
+      # ("path '/nix/store/…fix-kill-doctest.patch' is not valid"), forcing reruns.
+      # Keyed on the devenv lock so a toolchain bump busts the cache.
+      - name: Cache Nix store
+        uses: nix-community/cache-nix-action@v6
+        with:
+          primary-key: nix-${{ runner.os }}-${{ hashFiles('devenv.lock', 'devenv.nix', 'devenv.yaml') }}
+          restore-prefixes-first-match: nix-${{ runner.os }}-
+          gc-max-store-size-linux: 5368709120
+          gc-max-store-size-macos: 5368709120
       - name: Install devenv.sh
         run: nix profile add nixpkgs#devenv
 
@@ -276,6 +312,18 @@ jobs:
       - uses: cachix/install-nix-action@v31
         with:
           extra_nix_config: fallback = true
+      # Persist the Nix store (rust-overlay toolchain, devenv env, …) across runs.
+      # Cold runners otherwise re-realize the whole toolchain every job, which
+      # intermittently fails to fetch/realize a rust-overlay patch
+      # ("path '/nix/store/…fix-kill-doctest.patch' is not valid"), forcing reruns.
+      # Keyed on the devenv lock so a toolchain bump busts the cache.
+      - name: Cache Nix store
+        uses: nix-community/cache-nix-action@v6
+        with:
+          primary-key: nix-${{ runner.os }}-${{ hashFiles('devenv.lock', 'devenv.nix', 'devenv.yaml') }}
+          restore-prefixes-first-match: nix-${{ runner.os }}-
+          gc-max-store-size-linux: 5368709120
+          gc-max-store-size-macos: 5368709120
       - name: Install devenv.sh
         run: nix profile add nixpkgs#devenv
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1573,6 +1573,8 @@ dependencies = [
  "indexmap",
  "itertools 0.13.0",
  "libc",
+ "lsp-server",
+ "lsp-types",
  "memoize",
  "minijinja",
  "nom 7.1.3",
@@ -1595,6 +1597,7 @@ dependencies = [
  "smart-default",
  "stacker",
  "starlark",
+ "starlark_lsp",
  "tar",
  "tempfile",
  "thiserror 1.0.69",
@@ -2274,6 +2277,19 @@ name = "lru-slab"
 version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "112b39cec0b298b6c1999fee3e31427f74f676e4cb9879ed1a121b43661a4154"
+
+[[package]]
+name = "lsp-server"
+version = "0.7.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7d6ada348dbc2703cbe7637b2dda05cff84d3da2819c24abcb305dd613e0ba2e"
+dependencies = [
+ "crossbeam-channel",
+ "log",
+ "serde",
+ "serde_derive",
+ "serde_json",
+]
 
 [[package]]
 name = "lsp-types"
@@ -4120,6 +4136,26 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 2.0.117",
+]
+
+[[package]]
+name = "starlark_lsp"
+version = "0.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2b9deaaf246230eb4d562069f526960c79936de9a1c2e83b10c1d4b05e74d653"
+dependencies = [
+ "anyhow",
+ "derivative",
+ "derive_more 1.0.0",
+ "dupe",
+ "itertools 0.13.0",
+ "lsp-server",
+ "lsp-types",
+ "serde",
+ "serde_json",
+ "starlark",
+ "starlark_syntax",
+ "thiserror 1.0.69",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -107,6 +107,9 @@ smart-default = "0.7.1"
 humantime = "2.3.0"
 tokio-util = { version = "0.7.18", features = ["io", "io-util"] }
 starlark = "0.13.0"
+starlark_lsp = "0.13.0"
+lsp-server = "0.7"
+lsp-types = "0.94"
 rayon = "1.12.0"
 xxhash-rust = { version = "0.8.15" , features = ["xxh3", "std"]}
 itertools = "0.13.0"

--- a/src/commands/tool/build_lsp.rs
+++ b/src/commands/tool/build_lsp.rs
@@ -6,7 +6,7 @@ use crate::tui::LogSink;
 
 /// Hidden developer command: run the BUILD-file language server over stdio.
 ///
-/// Editors launch this (directly, or via the `//@heph/build:lsp` target). It
+/// Editors launch this directly (`heph tool build-lsp`). It
 /// speaks LSP JSON-RPC on stdin/stdout and runs until the client disconnects.
 #[derive(ClapArgs, Clone)]
 pub struct Args {}

--- a/src/commands/tool/build_lsp.rs
+++ b/src/commands/tool/build_lsp.rs
@@ -1,0 +1,26 @@
+use anyhow::Context;
+use clap::Args as ClapArgs;
+
+use crate::commands::{GlobalOptions, bootstrap};
+use crate::tui::LogSink;
+
+/// Hidden developer command: run the BUILD-file language server over stdio.
+///
+/// Editors launch this (directly, or via the `//@heph/build:lsp` target). It
+/// speaks LSP JSON-RPC on stdin/stdout and runs until the client disconnects.
+#[derive(ClapArgs, Clone)]
+pub struct Args {}
+
+pub fn execute(_args: &Args, _sink: LogSink, _global: &GlobalOptions) -> anyhow::Result<()> {
+    // Engine construction spawns background tasks (signal/shutdown handlers), so
+    // it must run inside a runtime context. The LSP itself is a blocking stdio
+    // loop that owns its own lifecycle via the LSP shutdown/exit handshake, so we
+    // run it on this thread rather than through the TUI/engine shutdown path.
+    let runtime = tokio::runtime::Builder::new_multi_thread()
+        .enable_all()
+        .build()
+        .context("building tokio runtime for build-lsp")?;
+    let _guard = runtime.enter();
+    let (engine, _shutdown) = bootstrap::new_engine()?;
+    crate::pluginbuildfile::serve_stdio(engine)
+}

--- a/src/commands/tool/mod.rs
+++ b/src/commands/tool/mod.rs
@@ -1,3 +1,4 @@
+mod build_lsp;
 mod cache;
 mod completions;
 pub mod gc;
@@ -48,6 +49,9 @@ pub enum ToolCommands {
     ///
     /// Example: `heph tool completions bash`
     Completions(completions::Args),
+    /// Run the BUILD-file language server over stdio (used by editors).
+    #[command(name = "build-lsp", hide = true)]
+    BuildLsp(build_lsp::Args),
 }
 
 impl ToolArgs {
@@ -67,6 +71,7 @@ impl ToolCommands {
             ToolCommands::GenGitignore(args) => gen_gitignore::execute(args, sink, global),
             ToolCommands::Cache(args) => args.execute(sink, global),
             ToolCommands::Completions(args) => completions::execute(args),
+            ToolCommands::BuildLsp(args) => build_lsp::execute(args, sink, global),
         }
     }
 }

--- a/src/engine/driver.rs
+++ b/src/engine/driver.rs
@@ -727,9 +727,36 @@ pub struct RunResponse {
     pub fuse_slot_guards: Vec<crate::sandboxfuse::SlotGuard>,
 }
 
+/// One config field a driver accepts in a `target(...)` call, with its type and
+/// documentation. Consumed by the BUILD-file LSP to offer completion and hover for
+/// a target's driver-specific keyword arguments.
+#[derive(Clone, Debug)]
+pub struct DriverField {
+    pub name: String,
+    pub ty: crate::htvalue::signature::ParamType,
+    pub doc: String,
+    pub required: bool,
+}
+
+/// Declarative description of the config a driver understands. Returned by
+/// [`Driver::schema`]; `None` means the driver exposes no schema (the default).
+#[derive(Clone, Debug, Default)]
+pub struct DriverSchema {
+    pub fields: Vec<DriverField>,
+}
+
 #[async_trait]
 pub trait Driver: Send + Sync {
     fn config(&self, req: ConfigRequest) -> anyhow::Result<ConfigResponse>;
+
+    /// Optional: describe the config fields this driver accepts on a target, so
+    /// tooling (the BUILD-file LSP) can complete and document them. Drivers that
+    /// don't implement this return `None` and the LSP simply offers no
+    /// driver-specific field hints.
+    fn schema(&self) -> Option<DriverSchema> {
+        None
+    }
+
     async fn parse(
         &self,
         req: ParseRequest,

--- a/src/engine/driver_managed.rs
+++ b/src/engine/driver_managed.rs
@@ -65,6 +65,11 @@ pub struct ManagedRunResponse {
 #[async_trait]
 pub trait ManagedDriver: Send + Sync {
     fn config(&self, req: ConfigRequest) -> anyhow::Result<ConfigResponse>;
+    /// Optional config schema, forwarded by the bridge's [`Driver::schema`]. See
+    /// [`crate::engine::driver::Driver::schema`].
+    fn schema(&self) -> Option<crate::engine::driver::DriverSchema> {
+        None
+    }
     async fn parse(
         &self,
         req: ParseRequest,
@@ -196,6 +201,10 @@ impl ManagedDriverBridge {
 impl Driver for ManagedDriverBridge {
     fn config(&self, req: ConfigRequest) -> anyhow::Result<ConfigResponse> {
         self.os.driver.config(req)
+    }
+
+    fn schema(&self) -> Option<crate::engine::driver::DriverSchema> {
+        self.os.driver.schema()
     }
 
     async fn parse(

--- a/src/engine/engine.rs
+++ b/src/engine/engine.rs
@@ -460,6 +460,15 @@ impl Engine {
             .and_then(|d| d.driver.schema())
     }
 
+    /// The state schema a registered provider exposes, if any. Used by the
+    /// BUILD-file LSP to complete and document `provider_state(provider="<name>", …)`
+    /// args. Returns `None` for unknown providers or providers without a schema.
+    pub fn provider_state_schema(&self, name: &str) -> Option<provider::StateSchema> {
+        self.providers_by_name
+            .get(name)
+            .and_then(|p| p.provider.state_schema())
+    }
+
     /// Every `(provider name, function name, rendered signature)` exposed across
     /// all registered providers, sorted. The rendered signature looks like
     /// `glob(pattern: string) -> list[string]`. Surfaced via `heph inspect functions`.

--- a/src/engine/engine.rs
+++ b/src/engine/engine.rs
@@ -435,6 +435,31 @@ impl Engine {
         &self.result_lock
     }
 
+    /// Workspace root.
+    pub fn root(&self) -> &std::path::Path {
+        &self.cfg.root
+    }
+
+    /// The aggregate provider-function registry (every provider's `heph.<p>.<fn>`
+    /// functions), built fresh. Used by the BUILD-file LSP to assemble the same
+    /// Starlark globals BUILD evaluation sees, for symbol completion/hover.
+    pub fn provider_function_registry(&self) -> Arc<provider::ProviderFunctionRegistry> {
+        let mut registry = provider::ProviderFunctionRegistry::default();
+        for provider in &self.providers {
+            registry.insert_provider(&provider.name, provider.provider.functions());
+        }
+        Arc::new(registry)
+    }
+
+    /// The config schema a registered driver exposes, if any. Used by the
+    /// BUILD-file LSP to complete and document a target's driver-specific config
+    /// fields. Returns `None` for unknown drivers or drivers without a schema.
+    pub fn driver_schema(&self, name: &str) -> Option<crate::engine::driver::DriverSchema> {
+        self.drivers_by_name
+            .get(name)
+            .and_then(|d| d.driver.schema())
+    }
+
     /// Every `(provider name, function name, rendered signature)` exposed across
     /// all registered providers, sorted. The rendered signature looks like
     /// `glob(pattern: string) -> list[string]`. Surfaced via `heph inspect functions`.

--- a/src/engine/engine.rs
+++ b/src/engine/engine.rs
@@ -460,6 +460,14 @@ impl Engine {
             .and_then(|d| d.driver.schema())
     }
 
+    /// Names of all registered drivers, sorted. Used by the BUILD-file LSP to
+    /// complete the `driver =` argument of a `target(...)` call.
+    pub fn driver_names(&self) -> Vec<String> {
+        let mut names: Vec<String> = self.drivers_by_name.keys().cloned().collect();
+        names.sort();
+        names
+    }
+
     /// The state schema a registered provider exposes, if any. Used by the
     /// BUILD-file LSP to complete and document `provider_state(provider="<name>", …)`
     /// args. Returns `None` for unknown providers or providers without a schema.

--- a/src/engine/provider.rs
+++ b/src/engine/provider.rs
@@ -42,6 +42,23 @@ pub struct State {
     pub state: HashMap<String, Value>,
 }
 
+/// One frame of a target's source provenance: a call site on the Starlark call
+/// stack at the moment `target(...)` ran. The innermost frame is the `target()`
+/// call itself; outer frames are the user macros / loops that led to it. Lets
+/// tooling (the BUILD-file LSP) map a source position back to every target that
+/// originated from the symbol at that position. Lines/columns are 1-based.
+#[derive(Default, Clone, Debug, PartialEq, Serialize, Deserialize)]
+pub struct ProvenanceFrame {
+    /// Name of the function whose body this call site is in (`<module>` at top level).
+    pub fn_name: String,
+    /// Absolute path of the BUILD/.bzl file containing the call site.
+    pub file: String,
+    pub line_start: u32,
+    pub line_end: u32,
+    pub col_start: u32,
+    pub col_end: u32,
+}
+
 #[derive(Default, Clone, Serialize, Deserialize)]
 pub struct TargetSpec {
     pub addr: Addr,

--- a/src/engine/provider.rs
+++ b/src/engine/provider.rs
@@ -223,6 +223,24 @@ impl std::fmt::Debug for GetError {
     }
 }
 
+/// One keyword argument a provider accepts in a `provider_state(provider="X", …)`
+/// call, with its type and docs. Consumed by the BUILD-file LSP for completion and
+/// hover of provider-state args.
+#[derive(Clone, Debug)]
+pub struct StateField {
+    pub name: String,
+    pub ty: crate::htvalue::signature::ParamType,
+    pub doc: String,
+    pub required: bool,
+}
+
+/// Declarative description of the state a provider accepts. Returned by
+/// [`Provider::state_schema`]; `None` means the provider declares no state schema.
+#[derive(Clone, Debug, Default)]
+pub struct StateSchema {
+    pub fields: Vec<StateField>,
+}
+
 pub trait Provider: Send + Sync {
     fn config(&self, req: ConfigRequest) -> anyhow::Result<ConfigResponse>;
     fn list<'a>(
@@ -253,6 +271,13 @@ pub trait Provider: Send + Sync {
     /// Default: none.
     fn functions(&self) -> Vec<ProviderFunctionDef> {
         vec![]
+    }
+
+    /// Optional: the keyword args this provider accepts in a
+    /// `provider_state(provider="<name>", …)` call, so the BUILD-file LSP can
+    /// complete and document them. Default: none.
+    fn state_schema(&self) -> Option<StateSchema> {
+        None
     }
 
     /// Hand this provider the aggregated registry of every provider's functions.

--- a/src/engine/provider.rs
+++ b/src/engine/provider.rs
@@ -51,7 +51,7 @@ pub struct State {
 pub struct ProvenanceFrame {
     /// Name of the function whose body this call site is in (`<module>` at top level).
     pub fn_name: String,
-    /// Absolute path of the BUILD/.bzl file containing the call site.
+    /// Absolute path of the BUILD file containing the call site.
     pub file: String,
     pub line_start: u32,
     pub line_end: u32,

--- a/src/htvalue/signature.rs
+++ b/src/htvalue/signature.rs
@@ -24,6 +24,9 @@ pub enum ParamType {
     List(Box<ParamType>),
     /// String-keyed map; value type boxed.
     Map(Box<ParamType>),
+    /// Accepts any one of several types, e.g. `cache` being `bool | map[bool]`.
+    /// Rendered as the members joined by ` | `; matches if any member matches.
+    Union(Vec<ParamType>),
 }
 
 impl ParamType {
@@ -37,6 +40,11 @@ impl ParamType {
         ParamType::Map(Box::new(value))
     }
 
+    /// Convenience: a union accepting any of `types`.
+    pub fn union(types: Vec<ParamType>) -> ParamType {
+        ParamType::Union(types)
+    }
+
     /// Human-readable name used in rendered signatures and error messages.
     pub fn render(&self) -> String {
         match self {
@@ -48,12 +56,20 @@ impl ParamType {
             ParamType::Null => "null".to_string(),
             ParamType::List(inner) => format!("list[{}]", inner.render()),
             ParamType::Map(value) => format!("map[{}]", value.render()),
+            ParamType::Union(types) => types
+                .iter()
+                .map(ParamType::render)
+                .collect::<Vec<_>>()
+                .join(" | "),
         }
     }
 
     /// Whether `v` structurally matches this type. Recurses into `List`/`Map`
     /// element types; an empty list/map trivially matches.
     pub fn matches(&self, v: &Value) -> bool {
+        if let ParamType::Union(types) = self {
+            return types.iter().any(|t| t.matches(v));
+        }
         match (self, v) {
             (ParamType::String, Value::String(_)) => true,
             (ParamType::Bool, Value::Bool(_)) => true,
@@ -261,6 +277,18 @@ mod tests {
             variadic: None,
             returns: ParamType::list(ParamType::String),
         }
+    }
+
+    #[test]
+    fn union_renders_and_matches_any_member() {
+        let ty = ParamType::union(vec![ParamType::Bool, ParamType::map(ParamType::Bool)]);
+        assert_eq!(ty.render(), "bool | map[bool]");
+        assert!(ty.matches(&Value::Bool(true)));
+        assert!(ty.matches(&Value::Map(std::collections::HashMap::from([(
+            "skip".to_string(),
+            Value::Bool(true)
+        )]))));
+        assert!(!ty.matches(&Value::Int(3)));
     }
 
     #[test]

--- a/src/pluginbuildfile/lsp/context.rs
+++ b/src/pluginbuildfile/lsp/context.rs
@@ -25,6 +25,13 @@ use starlark_lsp::server::{LspContext, LspEvalResult, LspUrl, StringLiteralResul
 use std::collections::HashMap;
 use std::path::{Path, PathBuf};
 use std::sync::{Arc, Mutex, OnceLock};
+use std::time::{Duration, Instant};
+
+/// How long a listing provider (and its internal package/target memoization) is
+/// reused before being rebuilt. Bursts of completion requests (keystrokes) within
+/// the window are served from its cache; after it, a fresh provider re-walks the
+/// workspace so newly-added packages/targets show up without restarting the LSP.
+const LISTING_TTL: Duration = Duration::from_secs(2);
 
 pub(crate) struct HephLspContext {
     root: PathBuf,
@@ -36,8 +43,9 @@ pub(crate) struct HephLspContext {
     /// BUILD-file name patterns, from the buildfile provider's `patterns` config
     /// option (defaulting to `BUILD`). Used for both listing and load resolution.
     patterns: Vec<glob::Pattern>,
-    /// Buildfile provider used only for package/target listing during completion.
-    provider: Provider,
+    /// Buildfile provider used only for package/target listing during completion,
+    /// with its build timestamp. Rebuilt after [`LISTING_TTL`] (see [`Self::provider`]).
+    provider: Mutex<(Instant, Arc<Provider>)>,
     pub(crate) shared: Arc<SharedState>,
 }
 
@@ -47,14 +55,7 @@ impl HephLspContext {
         let registry = engine.provider_function_registry();
         let doc_globals = build_globals(&registry).documentation();
         let patterns = buildfile_patterns(&root);
-        // Listing provider configured with the same patterns the engine's
-        // buildfile provider uses, so completion sees the right BUILD files.
-        let provider = Provider {
-            root: root.clone(),
-            build_file_patterns: patterns.clone(),
-            ..Provider::default()
-        };
-        provider.set_function_registry(Arc::clone(&registry));
+        let provider = build_listing_provider(&root, &patterns, &registry);
         let shared = SharedState::new(engine, root.clone(), patterns.clone());
         HephLspContext {
             root,
@@ -62,9 +63,24 @@ impl HephLspContext {
             doc_globals,
             globals: Arc::new(OnceLock::new()),
             patterns,
-            provider,
+            provider: Mutex::new((Instant::now(), provider)),
             shared,
         }
+    }
+
+    /// The listing provider, rebuilt if older than [`LISTING_TTL`]. Reuse within
+    /// the window keeps repeated completion requests fast (served from the
+    /// provider's own memoization); a rebuild drops that cache so the next walk
+    /// reflects the current workspace.
+    fn provider(&self) -> Arc<Provider> {
+        let mut cell = self.provider.lock().expect("provider lock");
+        if cell.0.elapsed() >= LISTING_TTL {
+            *cell = (
+                Instant::now(),
+                build_listing_provider(&self.root, &self.patterns, &self.registry),
+            );
+        }
+        Arc::clone(&cell.1)
     }
 
     /// Package name for a BUILD file path (its parent dir, workspace-relative,
@@ -91,8 +107,9 @@ impl HephLspContext {
 
     /// List package names beginning with `prefix` (no leading `//`).
     fn list_packages(&self, prefix: &str) -> Vec<String> {
+        let provider = self.provider();
         let ctoken = StdCancellationToken::new();
-        let fut = self.provider.list_packages(
+        let fut = provider.list_packages(
             ListPackagesRequest {
                 prefix: PkgBuf::from(prefix),
             },
@@ -110,8 +127,9 @@ impl HephLspContext {
 
     /// List target names in `package`.
     fn list_targets(&self, package: &str) -> Vec<String> {
+        let provider = self.provider();
         let ctoken = StdCancellationToken::new();
-        let fut = self.provider.list(
+        let fut = provider.list(
             ListRequest {
                 request_id: "lsp".to_string(),
                 package: PkgBuf::from(package),
@@ -147,6 +165,23 @@ fn first_build_file(dir: &Path, patterns: &[glob::Pattern]) -> Option<PathBuf> {
             && patterns.iter().any(|p| p.matches(&name.to_string_lossy()));
         matches.then(|| e.path())
     })
+}
+
+/// Build a fresh buildfile provider for package/target listing, configured with
+/// the same patterns the engine's provider uses and the aggregated function
+/// registry (so `list(pkg)` can evaluate BUILD files).
+fn build_listing_provider(
+    root: &Path,
+    patterns: &[glob::Pattern],
+    registry: &Arc<ProviderFunctionRegistry>,
+) -> Arc<Provider> {
+    let provider = Provider {
+        root: root.to_path_buf(),
+        build_file_patterns: patterns.to_vec(),
+        ..Provider::default()
+    };
+    provider.set_function_registry(Arc::clone(registry));
+    Arc::new(provider)
 }
 
 /// BUILD-file name patterns from the workspace's buildfile-provider config,

--- a/src/pluginbuildfile/lsp/context.rs
+++ b/src/pluginbuildfile/lsp/context.rs
@@ -207,9 +207,10 @@ impl LspContext for HephLspContext {
         // half-typed buffer that fails to evaluate simply yields no index — we do
         // not surface eval errors as diagnostics (they would be noisy while typing).
         let pkg = self.path_to_pkg(&path);
+        let source = content.clone();
         if let Ok(result) = eval_source(&filename, content, &pkg, &self.loader()) {
             self.shared
-                .set_index(uri.clone(), DocIndex::build(&result, &pkg));
+                .set_index(uri.clone(), DocIndex::build(&result, &pkg, source));
         } else {
             self.shared.set_index(uri.clone(), DocIndex::default());
         }

--- a/src/pluginbuildfile/lsp/context.rs
+++ b/src/pluginbuildfile/lsp/context.rs
@@ -12,7 +12,9 @@ use crate::engine::provider::{
 use crate::hasync::StdCancellationToken;
 use crate::htpkg::PkgBuf;
 use crate::pluginbuildfile::Provider;
-use crate::pluginbuildfile::run_file::{BuildFileLoader, build_globals, eval_source};
+use crate::pluginbuildfile::run_file::{
+    BuildFileLoader, build_globals, eval_source, resolve_load_target,
+};
 use starlark::docs::DocModule;
 use starlark::environment::Globals;
 use starlark::errors::EvalMessage;
@@ -125,21 +127,25 @@ impl HephLspContext {
         }
     }
 
-    /// The on-disk BUILD file URL for a package: the first file in the package
-    /// dir whose name matches a configured pattern (handles literal names like
-    /// `BUILD` and globs like `*.BUILD` alike).
+    /// The on-disk BUILD file URL for a package.
     fn build_file_url(&self, package: &str) -> Option<LspUrl> {
-        let dir = self.root.join(package);
-        let entry = std::fs::read_dir(&dir).ok()?.flatten().find(|e| {
-            let name = e.file_name();
-            let name = name.to_string_lossy();
-            e.file_type().map(|t| t.is_file()).unwrap_or(false)
-                && self.patterns.iter().any(|p| p.matches(&name))
-        })?;
-        lsp_types::Url::from_file_path(entry.path())
+        let path = first_build_file(&self.root.join(package), &self.patterns)?;
+        lsp_types::Url::from_file_path(path)
             .ok()
             .and_then(|u| LspUrl::try_from(u).ok())
     }
+}
+
+/// First file in `dir` whose name matches one of `patterns` (handles literal
+/// names like `BUILD` and globs like `*.BUILD`). Used to resolve a package /
+/// `load("//pkg", …)` directory to its actual BUILD file.
+fn first_build_file(dir: &Path, patterns: &[glob::Pattern]) -> Option<PathBuf> {
+    std::fs::read_dir(dir).ok()?.flatten().find_map(|e| {
+        let name = e.file_name();
+        let matches = e.file_type().map(|t| t.is_file()).unwrap_or(false)
+            && patterns.iter().any(|p| p.matches(&name.to_string_lossy()));
+        matches.then(|| e.path())
+    })
 }
 
 /// BUILD-file name patterns from the workspace's buildfile-provider config,
@@ -220,19 +226,23 @@ impl LspContext for HephLspContext {
         current_file: &LspUrl,
         _workspace_root: Option<&Path>,
     ) -> anyhow::Result<LspUrl> {
-        // `//pkg:file` → <root>/pkg/file ; `:file` or relative → next to current.
-        let resolved = if let Some(rest) = path.strip_prefix("//") {
-            let (pkg, file) = rest.split_once(':').unwrap_or((rest, ""));
-            self.root.join(pkg).join(file)
+        // Resolve exactly as the buildfile loader does (`//pkg`, `//pkg/x.BUILD`,
+        // `./rel`, `../rel`), so loaded symbols point at the same file heph reads.
+        let current_pkg = match current_file {
+            LspUrl::File(p) => self.path_to_pkg(p),
+            _ => String::new(),
+        };
+        let resolved = resolve_load_target(&self.root, &current_pkg, path)?;
+        // `load("//pkg", …)` targets a directory: resolve to its BUILD file so the
+        // file can be parsed for its exported symbols.
+        let file = if resolved.is_dir() {
+            first_build_file(&resolved, &self.patterns)
+                .ok_or_else(|| anyhow::anyhow!("no BUILD file in {}", resolved.display()))?
         } else {
-            let rel = path.strip_prefix(':').unwrap_or(path);
-            match current_file {
-                LspUrl::File(p) => p.parent().unwrap_or(Path::new("")).join(rel),
-                _ => PathBuf::from(rel),
-            }
+            resolved
         };
         Ok(LspUrl::try_from(
-            lsp_types::Url::from_file_path(&resolved)
+            lsp_types::Url::from_file_path(&file)
                 .map_err(|()| anyhow::anyhow!("non-file load path"))?,
         )?)
     }
@@ -310,11 +320,23 @@ impl LspContext for HephLspContext {
         current_value: &str,
         _workspace_root: Option<&Path>,
     ) -> anyhow::Result<Vec<StringCompletionResult>> {
-        // Only complete target-address-looking strings (skip load-path strings,
-        // which starlark_lsp handles via resolve_load).
-        if !matches!(kind, StringCompletionType::String) {
-            return Ok(vec![]);
+        // The first argument of a `load(...)`: complete package paths (`//pkg`),
+        // which heph resolves to that package's BUILD file.
+        if matches!(kind, StringCompletionType::LoadPath) {
+            let prefix = current_value.strip_prefix("//").unwrap_or("");
+            return Ok(self
+                .list_packages(prefix)
+                .into_iter()
+                .filter(|p| !p.is_empty())
+                .map(|pkg| StringCompletionResult {
+                    value: format!("//{pkg}"),
+                    insert_text: None,
+                    insert_text_offset: 0,
+                    kind: lsp_types::CompletionItemKind::MODULE,
+                })
+                .collect());
         }
+
         let Some(rest) = current_value.strip_prefix("//") else {
             return Ok(vec![]);
         };
@@ -345,5 +367,29 @@ impl LspContext for HephLspContext {
                 .collect(),
         };
         Ok(results)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::first_build_file;
+
+    #[test]
+    fn first_build_file_matches_literal_and_glob_patterns() {
+        let dir = tempfile::tempdir().unwrap();
+        std::fs::write(dir.path().join("notes.txt"), "").unwrap();
+        std::fs::write(dir.path().join("pkg.BUILD"), "").unwrap();
+
+        // Glob pattern resolves the `*.BUILD` file (not the .txt).
+        let glob = vec![glob::Pattern::new("*.BUILD").unwrap()];
+        let found = first_build_file(dir.path(), &glob).unwrap();
+        assert_eq!(found.file_name().unwrap(), "pkg.BUILD");
+
+        // A literal pattern that doesn't match anything → None.
+        let literal = vec![glob::Pattern::new("BUILD").unwrap()];
+        assert!(first_build_file(dir.path(), &literal).is_none());
+
+        // Missing directory → None, not a panic.
+        assert!(first_build_file(&dir.path().join("nope"), &glob).is_none());
     }
 }

--- a/src/pluginbuildfile/lsp/context.rs
+++ b/src/pluginbuildfile/lsp/context.rs
@@ -31,6 +31,9 @@ pub(crate) struct HephLspContext {
     doc_globals: DocModule,
     /// Lazily-built Starlark globals, shared across per-buffer evaluations.
     globals: Arc<OnceLock<Globals>>,
+    /// BUILD-file name patterns, from the buildfile provider's `patterns` config
+    /// option (defaulting to `BUILD`). Used for both listing and load resolution.
+    patterns: Vec<glob::Pattern>,
     /// Buildfile provider used only for package/target listing during completion.
     provider: Provider,
     pub(crate) shared: Arc<SharedState>,
@@ -41,13 +44,21 @@ impl HephLspContext {
         let root = engine.root().to_path_buf();
         let registry = engine.provider_function_registry();
         let doc_globals = build_globals(&registry).documentation();
-        let provider = Provider::new(root.clone());
+        let patterns = buildfile_patterns(&root);
+        // Listing provider configured with the same patterns the engine's
+        // buildfile provider uses, so completion sees the right BUILD files.
+        let provider = Provider {
+            root: root.clone(),
+            build_file_patterns: patterns.clone(),
+            ..Provider::default()
+        };
         provider.set_function_registry(Arc::clone(&registry));
         HephLspContext {
             root,
             registry,
             doc_globals,
             globals: Arc::new(OnceLock::new()),
+            patterns,
             provider,
             shared: SharedState::new(engine),
         }
@@ -64,7 +75,7 @@ impl HephLspContext {
     fn loader(&self) -> BuildFileLoader {
         BuildFileLoader::new(
             self.root.clone(),
-            vec![glob::Pattern::new("BUILD").expect("BUILD literal")],
+            self.patterns.clone(),
             // Fresh per-call caches: the open buffer may differ from disk, so the
             // main file must never be served from a stale cache.
             Arc::new(Mutex::new(HashMap::new())),
@@ -114,16 +125,53 @@ impl HephLspContext {
         }
     }
 
-    /// The on-disk BUILD file URL for a package, if it has one.
+    /// The on-disk BUILD file URL for a package: the first file in the package
+    /// dir whose name matches a configured pattern (handles literal names like
+    /// `BUILD` and globs like `*.BUILD` alike).
     fn build_file_url(&self, package: &str) -> Option<LspUrl> {
-        let path = self.root.join(package).join("BUILD");
-        if path.exists() {
-            lsp_types::Url::from_file_path(&path)
-                .ok()
-                .and_then(|u| LspUrl::try_from(u).ok())
-        } else {
-            None
-        }
+        let dir = self.root.join(package);
+        let entry = std::fs::read_dir(&dir).ok()?.flatten().find(|e| {
+            let name = e.file_name();
+            let name = name.to_string_lossy();
+            e.file_type().map(|t| t.is_file()).unwrap_or(false)
+                && self.patterns.iter().any(|p| p.matches(&name))
+        })?;
+        lsp_types::Url::from_file_path(entry.path())
+            .ok()
+            .and_then(|u| LspUrl::try_from(u).ok())
+    }
+}
+
+/// BUILD-file name patterns from the workspace's buildfile-provider config,
+/// mirroring what the engine's provider uses. Falls back to `["BUILD"]` when the
+/// config is absent, lists no patterns, or none compile.
+fn buildfile_patterns(root: &Path) -> Vec<glob::Pattern> {
+    use crate::engine::config_yaml;
+    let names: Vec<String> = config_yaml::load_from_root(root)
+        .ok()
+        .and_then(|cfg| {
+            cfg.providers
+                .iter()
+                .find(|p| p.name == "buildfile")
+                .and_then(|p| {
+                    config_yaml::decode_opt::<Vec<String>>(
+                        &p.options,
+                        "buildfile provider",
+                        "patterns",
+                    )
+                    .ok()
+                    .flatten()
+                })
+        })
+        .unwrap_or_default();
+    let compiled: Vec<glob::Pattern> = names
+        .iter()
+        .filter_map(|n| glob::Pattern::new(n).ok())
+        .collect();
+    if compiled.is_empty() {
+        vec![glob::Pattern::new("BUILD").expect("BUILD literal")]
+    } else {
+        compiled
     }
 }
 

--- a/src/pluginbuildfile/lsp/context.rs
+++ b/src/pluginbuildfile/lsp/context.rs
@@ -55,6 +55,7 @@ impl HephLspContext {
             ..Provider::default()
         };
         provider.set_function_registry(Arc::clone(&registry));
+        let shared = SharedState::new(engine, root.clone(), patterns.clone());
         HephLspContext {
             root,
             registry,
@@ -62,7 +63,7 @@ impl HephLspContext {
             globals: Arc::new(OnceLock::new()),
             patterns,
             provider,
-            shared: SharedState::new(engine),
+            shared,
         }
     }
 

--- a/src/pluginbuildfile/lsp/context.rs
+++ b/src/pluginbuildfile/lsp/context.rs
@@ -1,0 +1,301 @@
+//! heph's [`LspContext`] implementation: it teaches `starlark_lsp` about heph's
+//! globals (so the builtins complete and hover), resolves `load()` paths and
+//! target-address string literals, completes target addresses, and — as a side
+//! effect of evaluating each opened buffer — populates the per-document index the
+//! proxy uses for the provenance hover and driver-schema completion.
+
+use super::index::{DocIndex, SharedState};
+use crate::engine::engine::Engine;
+use crate::engine::provider::{
+    ListPackagesRequest, ListRequest, Provider as EProvider, ProviderFunctionRegistry,
+};
+use crate::hasync::StdCancellationToken;
+use crate::htpkg::PkgBuf;
+use crate::pluginbuildfile::Provider;
+use crate::pluginbuildfile::run_file::{BuildFileLoader, build_globals, eval_source};
+use starlark::docs::DocModule;
+use starlark::environment::Globals;
+use starlark::errors::EvalMessage;
+use starlark::syntax::{AstModule, Dialect};
+use starlark_lsp::completion::{StringCompletionResult, StringCompletionType};
+use starlark_lsp::error::eval_message_to_lsp_diagnostic;
+use starlark_lsp::server::{LspContext, LspEvalResult, LspUrl, StringLiteralResult};
+use std::collections::HashMap;
+use std::path::{Path, PathBuf};
+use std::sync::{Arc, Mutex, OnceLock};
+
+pub(crate) struct HephLspContext {
+    root: PathBuf,
+    registry: Arc<ProviderFunctionRegistry>,
+    /// Docs for the heph globals; drives `starlark_lsp`'s builtin completion/hover.
+    doc_globals: DocModule,
+    /// Lazily-built Starlark globals, shared across per-buffer evaluations.
+    globals: Arc<OnceLock<Globals>>,
+    /// Buildfile provider used only for package/target listing during completion.
+    provider: Provider,
+    pub(crate) shared: Arc<SharedState>,
+}
+
+impl HephLspContext {
+    pub(crate) fn new(engine: Arc<Engine>) -> HephLspContext {
+        let root = engine.root().to_path_buf();
+        let registry = engine.provider_function_registry();
+        let doc_globals = build_globals(&registry).documentation();
+        let provider = Provider::new(root.clone());
+        provider.set_function_registry(Arc::clone(&registry));
+        HephLspContext {
+            root,
+            registry,
+            doc_globals,
+            globals: Arc::new(OnceLock::new()),
+            provider,
+            shared: SharedState::new(engine),
+        }
+    }
+
+    /// Package name for a BUILD file path (its parent dir, workspace-relative,
+    /// forward-slashed). Empty string for a BUILD file at the workspace root.
+    fn path_to_pkg(&self, path: &Path) -> String {
+        let parent = path.parent().unwrap_or(path);
+        let rel = parent.strip_prefix(&self.root).unwrap_or(parent);
+        rel.to_string_lossy().replace('\\', "/")
+    }
+
+    fn loader(&self) -> BuildFileLoader {
+        BuildFileLoader::new(
+            self.root.clone(),
+            vec![glob::Pattern::new("BUILD").expect("BUILD literal")],
+            // Fresh per-call caches: the open buffer may differ from disk, so the
+            // main file must never be served from a stale cache.
+            Arc::new(Mutex::new(HashMap::new())),
+            Arc::new(Mutex::new(HashMap::new())),
+            Arc::clone(&self.registry),
+            Arc::clone(&self.globals),
+            Arc::new(crate::htwalk::CachedWalker::disabled()),
+        )
+    }
+
+    /// List package names beginning with `prefix` (no leading `//`).
+    fn list_packages(&self, prefix: &str) -> Vec<String> {
+        let ctoken = StdCancellationToken::new();
+        let fut = self.provider.list_packages(
+            ListPackagesRequest {
+                prefix: PkgBuf::from(prefix),
+            },
+            &ctoken,
+        );
+        match futures::executor::block_on(fut) {
+            Ok(iter) => iter
+                .filter_map(Result::ok)
+                .map(|r| r.pkg.to_string())
+                .filter(|p| p.starts_with(prefix))
+                .collect(),
+            Err(_) => Vec::new(),
+        }
+    }
+
+    /// List target names in `package`.
+    fn list_targets(&self, package: &str) -> Vec<String> {
+        let ctoken = StdCancellationToken::new();
+        let fut = self.provider.list(
+            ListRequest {
+                request_id: "lsp".to_string(),
+                package: PkgBuf::from(package),
+                states: vec![],
+            },
+            &ctoken,
+        );
+        match futures::executor::block_on(fut) {
+            Ok(iter) => iter
+                .filter_map(Result::ok)
+                .map(|r| r.addr.name.clone())
+                .collect(),
+            Err(_) => Vec::new(),
+        }
+    }
+
+    /// The on-disk BUILD file URL for a package, if it has one.
+    fn build_file_url(&self, package: &str) -> Option<LspUrl> {
+        let path = self.root.join(package).join("BUILD");
+        if path.exists() {
+            lsp_types::Url::from_file_path(&path)
+                .ok()
+                .and_then(|u| LspUrl::try_from(u).ok())
+        } else {
+            None
+        }
+    }
+}
+
+impl LspContext for HephLspContext {
+    fn parse_file_with_contents(&self, uri: &LspUrl, content: String) -> LspEvalResult {
+        let path = match uri {
+            LspUrl::File(p) | LspUrl::Starlark(p) => p.clone(),
+            _ => return LspEvalResult::default(),
+        };
+        let filename = path.to_string_lossy().to_string();
+
+        // Parse the AST for starlark_lsp (symbols, hover, goto); parse errors
+        // become diagnostics.
+        let ast = match AstModule::parse(&filename, content.clone(), &Dialect::Extended) {
+            Ok(ast) => ast,
+            Err(e) => {
+                return LspEvalResult {
+                    diagnostics: vec![eval_message_to_lsp_diagnostic(EvalMessage::from_error(
+                        &path, &e,
+                    ))],
+                    ast: None,
+                };
+            }
+        };
+
+        // Best-effort evaluation to populate the provenance / driver index. A
+        // half-typed buffer that fails to evaluate simply yields no index — we do
+        // not surface eval errors as diagnostics (they would be noisy while typing).
+        let pkg = self.path_to_pkg(&path);
+        if let Ok(result) = eval_source(&filename, content, &pkg, &self.loader()) {
+            self.shared
+                .set_index(uri.clone(), DocIndex::build(&result, &pkg));
+        } else {
+            self.shared.set_index(uri.clone(), DocIndex::default());
+        }
+
+        LspEvalResult {
+            diagnostics: vec![],
+            ast: Some(ast),
+        }
+    }
+
+    fn resolve_load(
+        &self,
+        path: &str,
+        current_file: &LspUrl,
+        _workspace_root: Option<&Path>,
+    ) -> anyhow::Result<LspUrl> {
+        // `//pkg:file` → <root>/pkg/file ; `:file` or relative → next to current.
+        let resolved = if let Some(rest) = path.strip_prefix("//") {
+            let (pkg, file) = rest.split_once(':').unwrap_or((rest, ""));
+            self.root.join(pkg).join(file)
+        } else {
+            let rel = path.strip_prefix(':').unwrap_or(path);
+            match current_file {
+                LspUrl::File(p) => p.parent().unwrap_or(Path::new("")).join(rel),
+                _ => PathBuf::from(rel),
+            }
+        };
+        Ok(LspUrl::try_from(
+            lsp_types::Url::from_file_path(&resolved)
+                .map_err(|()| anyhow::anyhow!("non-file load path"))?,
+        )?)
+    }
+
+    fn render_as_load(
+        &self,
+        target: &LspUrl,
+        _current_file: &LspUrl,
+        _workspace_root: Option<&Path>,
+    ) -> anyhow::Result<String> {
+        match target {
+            LspUrl::File(target_path) => {
+                let pkg = self.path_to_pkg(target_path);
+                let file = target_path
+                    .file_name()
+                    .map(|f| f.to_string_lossy().to_string())
+                    .unwrap_or_default();
+                Ok(format!("//{pkg}:{file}"))
+            }
+            _ => anyhow::bail!("can only render file:// load paths"),
+        }
+    }
+
+    fn resolve_string_literal(
+        &self,
+        literal: &str,
+        current_file: &LspUrl,
+        _workspace_root: Option<&Path>,
+    ) -> anyhow::Result<Option<StringLiteralResult>> {
+        // Goto-definition on a target address: `//pkg:name` (absolute) or `:name`
+        // (relative to the current file's package). Jump to the package's BUILD
+        // file. Non-address strings resolve to nothing.
+        let package = if let Some(rest) = literal.strip_prefix("//") {
+            rest.split_once(':').map(|(p, _)| p.to_string())
+        } else if let Some(_name) = literal.strip_prefix(':') {
+            match current_file {
+                LspUrl::File(p) => Some(self.path_to_pkg(p)),
+                _ => None,
+            }
+        } else {
+            None
+        };
+
+        Ok(package.and_then(|pkg| {
+            self.build_file_url(&pkg).map(|url| StringLiteralResult {
+                url,
+                location_finder: None,
+            })
+        }))
+    }
+
+    fn get_load_contents(&self, uri: &LspUrl) -> anyhow::Result<Option<String>> {
+        match uri {
+            LspUrl::File(p) => Ok(std::fs::read_to_string(p).ok()),
+            _ => Ok(None),
+        }
+    }
+
+    fn get_environment(&self, _uri: &LspUrl) -> DocModule {
+        self.doc_globals.clone()
+    }
+
+    fn get_url_for_global_symbol(
+        &self,
+        _current_file: &LspUrl,
+        _symbol: &str,
+    ) -> anyhow::Result<Option<LspUrl>> {
+        Ok(None)
+    }
+
+    fn get_string_completion_options(
+        &self,
+        _document_uri: &LspUrl,
+        kind: StringCompletionType,
+        current_value: &str,
+        _workspace_root: Option<&Path>,
+    ) -> anyhow::Result<Vec<StringCompletionResult>> {
+        // Only complete target-address-looking strings (skip load-path strings,
+        // which starlark_lsp handles via resolve_load).
+        if !matches!(kind, StringCompletionType::String) {
+            return Ok(vec![]);
+        }
+        let Some(rest) = current_value.strip_prefix("//") else {
+            return Ok(vec![]);
+        };
+
+        let results = match rest.split_once(':') {
+            // After the colon: complete target names in the (typed) package.
+            Some((pkg, name_prefix)) => self
+                .list_targets(pkg)
+                .into_iter()
+                .filter(|n| n.starts_with(name_prefix))
+                .map(|name| StringCompletionResult {
+                    value: format!("//{pkg}:{name}"),
+                    insert_text: None,
+                    insert_text_offset: 0,
+                    kind: lsp_types::CompletionItemKind::VALUE,
+                })
+                .collect(),
+            // Before the colon: complete package names.
+            None => self
+                .list_packages(rest)
+                .into_iter()
+                .map(|pkg| StringCompletionResult {
+                    value: format!("//{pkg}"),
+                    insert_text: None,
+                    insert_text_offset: 0,
+                    kind: lsp_types::CompletionItemKind::MODULE,
+                })
+                .collect(),
+        };
+        Ok(results)
+    }
+}

--- a/src/pluginbuildfile/lsp/index.rs
+++ b/src/pluginbuildfile/lsp/index.rs
@@ -1,0 +1,219 @@
+//! Per-document index the LSP builds while evaluating a BUILD buffer, and the
+//! shared state the proxy reads to enrich hover/completion responses.
+//!
+//! Two things are indexed from a successful evaluation:
+//! - **call → targets**: every source call site (the `target()` call and the
+//!   macros/loops above it) mapped to the addresses it produced. Drives the
+//!   "Generated targets" hover.
+//! - **target-call → driver**: each `target()` call's source span and its
+//!   `driver`, so completion inside that call can offer the driver's config
+//!   fields.
+
+use crate::engine::engine::Engine;
+use crate::engine::provider::ProvenanceFrame;
+use crate::pluginbuildfile::run_file::RunResult;
+use starlark_lsp::server::LspUrl;
+use std::collections::BTreeMap;
+use std::collections::HashMap;
+use std::sync::Arc;
+use std::sync::Mutex;
+
+/// A 1-based source span within a single file.
+#[derive(Clone, Copy, Debug, PartialEq, Eq, PartialOrd, Ord)]
+pub(crate) struct Span {
+    pub line_start: u32,
+    pub col_start: u32,
+    pub line_end: u32,
+    pub col_end: u32,
+}
+
+impl Span {
+    fn of(frame: &ProvenanceFrame) -> Span {
+        Span {
+            line_start: frame.line_start,
+            col_start: frame.col_start,
+            line_end: frame.line_end,
+            col_end: frame.col_end,
+        }
+    }
+
+    /// Whether this span covers the 1-based (line, col) position.
+    fn covers(&self, line: u32, col: u32) -> bool {
+        (line, col) >= (self.line_start, self.col_start)
+            && (line, col) <= (self.line_end, self.col_end)
+    }
+}
+
+/// A call site mapped to the target addresses that originated from it.
+#[derive(Clone, Debug)]
+pub(crate) struct CallTargets {
+    pub span: Span,
+    pub addrs: Vec<String>,
+}
+
+/// A `target()` call site and the driver it selected.
+#[derive(Clone, Debug)]
+pub(crate) struct TargetCall {
+    pub span: Span,
+    pub driver: String,
+}
+
+/// Everything the proxy needs to answer position-based requests for one document.
+#[derive(Clone, Debug, Default)]
+pub(crate) struct DocIndex {
+    pub call_targets: Vec<CallTargets>,
+    pub target_calls: Vec<TargetCall>,
+}
+
+impl DocIndex {
+    /// Build the index from an evaluated buffer. `pkg` is the buffer's package
+    /// (used to format `//pkg:name` addresses).
+    pub(crate) fn build(result: &RunResult, pkg: &str) -> DocIndex {
+        // Aggregate addresses per unique call-site span. BTreeMap keeps a stable
+        // order and dedups identical spans (e.g. a loop body line that produced
+        // several targets).
+        let mut by_span: BTreeMap<Span, Vec<String>> = BTreeMap::new();
+        let mut target_calls = Vec::new();
+
+        for target in &result.targets {
+            let addr = format!("//{pkg}:{}", target.name);
+            for frame in &target.provenance {
+                by_span
+                    .entry(Span::of(frame))
+                    .or_default()
+                    .push(addr.clone());
+            }
+            // The innermost frame is the `target()` call itself.
+            if let Some(inner) = target.provenance.first()
+                && !target.driver.is_empty()
+            {
+                target_calls.push(TargetCall {
+                    span: Span::of(inner),
+                    driver: target.driver.clone(),
+                });
+            }
+        }
+
+        let call_targets = by_span
+            .into_iter()
+            .map(|(span, mut addrs)| {
+                addrs.sort();
+                addrs.dedup();
+                CallTargets { span, addrs }
+            })
+            .collect();
+
+        DocIndex {
+            call_targets,
+            target_calls,
+        }
+    }
+
+    /// The most specific (smallest) call site covering the 1-based position and
+    /// the addresses it produced.
+    pub(crate) fn targets_at(&self, line: u32, col: u32) -> Option<&[String]> {
+        self.call_targets
+            .iter()
+            .filter(|ct| ct.span.covers(line, col))
+            // Prefer the innermost (smallest) covering span.
+            .min_by_key(|ct| {
+                (
+                    ct.span.line_end - ct.span.line_start,
+                    ct.span.col_end.saturating_sub(ct.span.col_start),
+                )
+            })
+            .map(|ct| ct.addrs.as_slice())
+    }
+
+    /// The driver of the `target()` call covering the 1-based position, if any.
+    pub(crate) fn driver_at(&self, line: u32, col: u32) -> Option<&str> {
+        self.target_calls
+            .iter()
+            .find(|tc| tc.span.covers(line, col))
+            .map(|tc| tc.driver.as_str())
+    }
+}
+
+/// State shared between the [`super::context::HephLspContext`] (writer) and the
+/// [`super::proxy`] (reader): the per-document indexes plus the engine handle the
+/// proxy uses to resolve driver schemas.
+pub(crate) struct SharedState {
+    pub engine: Arc<Engine>,
+    docs: Mutex<HashMap<LspUrl, DocIndex>>,
+}
+
+impl SharedState {
+    pub(crate) fn new(engine: Arc<Engine>) -> Arc<SharedState> {
+        Arc::new(SharedState {
+            engine,
+            docs: Mutex::new(HashMap::new()),
+        })
+    }
+
+    pub(crate) fn set_index(&self, uri: LspUrl, index: DocIndex) {
+        self.docs.lock().expect("docs lock").insert(uri, index);
+    }
+
+    pub(crate) fn index(&self, uri: &LspUrl) -> Option<DocIndex> {
+        self.docs.lock().expect("docs lock").get(uri).cloned()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::pluginbuildfile::run_file::{BuildFileLoader, eval_source};
+    use std::collections::HashMap;
+
+    fn index_for(content: &str) -> DocIndex {
+        let tmp = tempfile::tempdir().unwrap();
+        let loader = BuildFileLoader::new(
+            tmp.path().to_path_buf(),
+            vec![glob::Pattern::new("BUILD").unwrap()],
+            Arc::new(Mutex::new(HashMap::new())),
+            Arc::new(Mutex::new(HashMap::new())),
+            Arc::new(crate::engine::provider::ProviderFunctionRegistry::default()),
+            Arc::new(std::sync::OnceLock::new()),
+            Arc::new(crate::htwalk::CachedWalker::disabled()),
+        );
+        let result = eval_source("BUILD", content.to_string(), "pkg", &loader).unwrap();
+        DocIndex::build(&result, "pkg")
+    }
+
+    #[test]
+    fn hover_over_macro_call_lists_all_generated_targets() {
+        // Line 6 is the `my_macro("m")` call; line 7 is the direct target().
+        let content = "\
+def my_macro(prefix):
+    target(name = prefix + \"_a\", driver = \"exec\")
+    target(name = prefix + \"_b\", driver = \"exec\")
+
+my_macro(\"m\")
+target(name = \"direct\", driver = \"exec\")
+";
+        let index = index_for(content);
+
+        // Hovering the macro call site (line 5, 1-based) lists both generated targets.
+        let at_macro = index.targets_at(5, 1).unwrap();
+        assert_eq!(
+            at_macro,
+            &["//pkg:m_a".to_string(), "//pkg:m_b".to_string()]
+        );
+
+        // Hovering the direct target() (line 6) lists only it.
+        let at_direct = index.targets_at(6, 1).unwrap();
+        assert_eq!(at_direct, &["//pkg:direct".to_string()]);
+
+        // A blank position yields nothing.
+        assert!(index.targets_at(4, 1).is_none());
+    }
+
+    #[test]
+    fn driver_at_target_call_resolves_driver() {
+        let content = "target(name = \"t\", driver = \"exec\")\n";
+        let index = index_for(content);
+        // The target() call is on line 1.
+        assert_eq!(index.driver_at(1, 1), Some("exec"));
+        assert!(index.driver_at(50, 1).is_none());
+    }
+}

--- a/src/pluginbuildfile/lsp/index.rs
+++ b/src/pluginbuildfile/lsp/index.rs
@@ -4,7 +4,7 @@
 //! Two things are indexed from a successful evaluation:
 //! - **call → targets**: every source call site (the `target()` call and the
 //!   macros/loops above it) mapped to the addresses it produced. Drives the
-//!   "Generated targets" hover.
+//!   "Targets" hover.
 //! - **target-call → driver**: each `target()` call's source span and its
 //!   `driver`, so completion inside that call can offer the driver's config
 //!   fields.

--- a/src/pluginbuildfile/lsp/index.rs
+++ b/src/pluginbuildfile/lsp/index.rs
@@ -58,11 +58,19 @@ pub(crate) struct TargetCall {
     pub driver: String,
 }
 
+/// A `provider_state()` call site and the provider it targets.
+#[derive(Clone, Debug)]
+pub(crate) struct StateCall {
+    pub span: Span,
+    pub provider: String,
+}
+
 /// Everything the proxy needs to answer position-based requests for one document.
 #[derive(Clone, Debug, Default)]
 pub(crate) struct DocIndex {
     pub call_targets: Vec<CallTargets>,
     pub target_calls: Vec<TargetCall>,
+    pub state_calls: Vec<StateCall>,
     /// Rendered hover doc for each top-level function binding (`def` in this file
     /// or imported via `load`), keyed by name. Used to synthesize a signature
     /// tooltip for undocumented functions, which the stock server skips.
@@ -116,13 +124,35 @@ impl DocIndex {
             })
             .collect();
 
+        // `provider_state()` call sites → provider, for state-arg completion.
+        let state_calls = result
+            .states
+            .iter()
+            .filter_map(|s| {
+                let inner = s.provenance.first()?;
+                Some(StateCall {
+                    span: Span::of(inner),
+                    provider: s.provider.clone(),
+                })
+            })
+            .collect();
+
         DocIndex {
             call_targets,
             target_calls,
+            state_calls,
             defs,
             loaded,
             source,
         }
+    }
+
+    /// The provider of the `provider_state()` call covering the 1-based position.
+    pub(crate) fn state_provider_at(&self, line: u32, col: u32) -> Option<&str> {
+        self.state_calls
+            .iter()
+            .find(|sc| sc.span.covers(line, col))
+            .map(|sc| sc.provider.as_str())
     }
 
     /// The load path and exported name for the loaded symbol at the 1-based
@@ -365,6 +395,15 @@ target(name = \"direct\", driver = \"exec\")
         // The target() call is on line 1.
         assert_eq!(index.driver_at(1, 1), Some("exec"));
         assert!(index.driver_at(50, 1).is_none());
+    }
+
+    #[test]
+    fn state_provider_at_resolves_provider() {
+        let content = "provider_state(provider = \"go\", go_codegen_root = True)\n";
+        let index = index_for(content);
+        // Cursor inside the provider_state() call on line 1.
+        assert_eq!(index.state_provider_at(1, 1), Some("go"));
+        assert!(index.state_provider_at(50, 1).is_none());
     }
 
     #[test]

--- a/src/pluginbuildfile/lsp/index.rs
+++ b/src/pluginbuildfile/lsp/index.rs
@@ -67,6 +67,11 @@ pub(crate) struct DocIndex {
     /// or imported via `load`), keyed by name. Used to synthesize a signature
     /// tooltip for undocumented functions, which the stock server skips.
     pub defs: std::collections::HashMap<String, String>,
+    /// Symbols imported via `load`, keyed by their local name → (load path,
+    /// exported name in the loaded package). Drives cross-file goto-definition:
+    /// heph merges every BUILD file in a package, but the stock server only parses
+    /// one, so we resolve loaded symbols across all of them ourselves.
+    pub loaded: HashMap<String, (String, String)>,
     /// The buffer's source text, for extracting the identifier under the cursor.
     pub source: String,
 }
@@ -76,6 +81,7 @@ impl DocIndex {
     /// (used to format `//pkg:name` addresses); `source` is the buffer text.
     pub(crate) fn build(result: &RunResult, pkg: &str, source: String) -> DocIndex {
         let defs = function_docs(result);
+        let loaded = parse_load_symbols(&source);
         // Aggregate addresses per unique call-site span. BTreeMap keeps a stable
         // order and dedups identical spans (e.g. a loop body line that produced
         // several targets).
@@ -114,8 +120,18 @@ impl DocIndex {
             call_targets,
             target_calls,
             defs,
+            loaded,
             source,
         }
+    }
+
+    /// The load path and exported name for the loaded symbol at the 1-based
+    /// position, if the identifier under the cursor was imported via `load`.
+    pub(crate) fn loaded_symbol_at(&self, line: u32, col: u32) -> Option<(&str, &str)> {
+        let word = word_at(&self.source, line, col)?;
+        self.loaded
+            .get(word)
+            .map(|(path, exported)| (path.as_str(), exported.as_str()))
     }
 
     /// Rendered hover for the function named by the identifier at the 1-based
@@ -172,6 +188,70 @@ fn function_docs(result: &RunResult) -> HashMap<String, String> {
     out
 }
 
+/// Parse `load(...)` statements out of the source, mapping each imported local
+/// name to `(load path, exported name)`. Handles positional imports
+/// (`load("//p", "sym")` → local == exported == `sym`) and aliased ones
+/// (`load("//p", alias = "sym")` → local `alias`, exported `sym`). A best-effort
+/// textual scan — load statements are simple, single-line in practice.
+fn parse_load_symbols(source: &str) -> HashMap<String, (String, String)> {
+    let mut out = HashMap::new();
+    for line in source.lines() {
+        let trimmed = line.trim_start();
+        let Some(rest) = trimmed.strip_prefix("load(") else {
+            continue;
+        };
+        let Some(close) = rest.find(')') else {
+            continue;
+        };
+        let Some(args) = rest.get(..close) else {
+            continue;
+        };
+        // Split on commas (symbol/path strings never contain commas).
+        let mut parts = args.split(',');
+        let Some(path) = parts.next().and_then(unquote) else {
+            continue;
+        };
+        for part in parts {
+            let part = part.trim();
+            if part.is_empty() {
+                continue;
+            }
+            match part.split_once('=') {
+                // `alias = "exported"`
+                Some((local, exported)) => {
+                    let local = local.trim();
+                    if let Some(exported) = unquote(exported)
+                        && !local.is_empty()
+                    {
+                        out.insert(local.to_string(), (path.clone(), exported));
+                    }
+                }
+                // positional `"sym"` — local name equals exported name
+                None => {
+                    if let Some(sym) = unquote(part) {
+                        out.insert(sym.clone(), (path.clone(), sym));
+                    }
+                }
+            }
+        }
+    }
+    out
+}
+
+/// Strip surrounding single or double quotes from a trimmed token.
+fn unquote(s: &str) -> Option<String> {
+    let s = s.trim();
+    let bytes = s.as_bytes();
+    if bytes.len() >= 2
+        && (bytes.first() == Some(&b'"') || bytes.first() == Some(&b'\''))
+        && bytes.last() == bytes.first()
+    {
+        s.get(1..s.len() - 1).map(str::to_string)
+    } else {
+        None
+    }
+}
+
 /// The identifier (ASCII alphanumeric + `_`) under the 1-based `(line, col)` in
 /// `source`. Returns `None` when the cursor isn't on an identifier character —
 /// Starlark identifiers are ASCII, so byte indexing is safe here.
@@ -199,13 +279,23 @@ fn word_at(source: &str, line: u32, col: u32) -> Option<&str> {
 /// proxy uses to resolve driver schemas.
 pub(crate) struct SharedState {
     pub engine: Arc<Engine>,
+    /// Workspace root + BUILD-file patterns, so the proxy can resolve a loaded
+    /// symbol's package directory and scan its files for the definition.
+    pub root: std::path::PathBuf,
+    pub patterns: Vec<glob::Pattern>,
     docs: Mutex<HashMap<LspUrl, DocIndex>>,
 }
 
 impl SharedState {
-    pub(crate) fn new(engine: Arc<Engine>) -> Arc<SharedState> {
+    pub(crate) fn new(
+        engine: Arc<Engine>,
+        root: std::path::PathBuf,
+        patterns: Vec<glob::Pattern>,
+    ) -> Arc<SharedState> {
         Arc::new(SharedState {
             engine,
+            root,
+            patterns,
             docs: Mutex::new(HashMap::new()),
         })
     }
@@ -291,6 +381,25 @@ target(name = \"direct\", driver = \"exec\")
         assert!(doc.contains('a') && doc.contains('b'), "params: {doc}");
         // A non-identifier / unknown word yields nothing.
         assert!(index.def_hover_at(2, 1).is_none() || !index.defs.contains_key("return"));
+    }
+
+    #[test]
+    fn parse_load_symbols_handles_positional_and_aliased() {
+        let src = r#"load("//lib", "make_name", greeting = "GREETING")
+load("//other", "x")
+"#;
+        let m = super::parse_load_symbols(src);
+        // positional: local == exported
+        assert_eq!(
+            m.get("make_name"),
+            Some(&("//lib".to_string(), "make_name".to_string()))
+        );
+        // aliased: local `greeting` → exported `GREETING`
+        assert_eq!(
+            m.get("greeting"),
+            Some(&("//lib".to_string(), "GREETING".to_string()))
+        );
+        assert_eq!(m.get("x"), Some(&("//other".to_string(), "x".to_string())));
     }
 
     #[test]

--- a/src/pluginbuildfile/lsp/index.rs
+++ b/src/pluginbuildfile/lsp/index.rs
@@ -63,12 +63,19 @@ pub(crate) struct TargetCall {
 pub(crate) struct DocIndex {
     pub call_targets: Vec<CallTargets>,
     pub target_calls: Vec<TargetCall>,
+    /// Rendered hover doc for each top-level function binding (`def` in this file
+    /// or imported via `load`), keyed by name. Used to synthesize a signature
+    /// tooltip for undocumented functions, which the stock server skips.
+    pub defs: std::collections::HashMap<String, String>,
+    /// The buffer's source text, for extracting the identifier under the cursor.
+    pub source: String,
 }
 
 impl DocIndex {
     /// Build the index from an evaluated buffer. `pkg` is the buffer's package
-    /// (used to format `//pkg:name` addresses).
-    pub(crate) fn build(result: &RunResult, pkg: &str) -> DocIndex {
+    /// (used to format `//pkg:name` addresses); `source` is the buffer text.
+    pub(crate) fn build(result: &RunResult, pkg: &str, source: String) -> DocIndex {
+        let defs = function_docs(result);
         // Aggregate addresses per unique call-site span. BTreeMap keeps a stable
         // order and dedups identical spans (e.g. a loop body line that produced
         // several targets).
@@ -106,7 +113,16 @@ impl DocIndex {
         DocIndex {
             call_targets,
             target_calls,
+            defs,
+            source,
         }
+    }
+
+    /// Rendered hover for the function named by the identifier at the 1-based
+    /// position, if that identifier resolves to a known `def`.
+    pub(crate) fn def_hover_at(&self, line: u32, col: u32) -> Option<&str> {
+        let word = word_at(&self.source, line, col)?;
+        self.defs.get(word).map(String::as_str)
     }
 
     /// The most specific (smallest) call site covering the 1-based position and
@@ -132,6 +148,50 @@ impl DocIndex {
             .find(|tc| tc.span.covers(line, col))
             .map(|tc| tc.driver.as_str())
     }
+}
+
+/// Render a hover doc for every top-level function binding in the evaluated
+/// module — `def`s in this file and functions pulled in via `load`. Non-function
+/// bindings (constants, target addresses) are skipped.
+fn function_docs(result: &RunResult) -> HashMap<String, String> {
+    use starlark::docs::{DocItem, DocMember};
+    let mut out = HashMap::new();
+    for name in result.module.names() {
+        let name = name.as_str();
+        let Ok(value) = result.module.get(name) else {
+            continue;
+        };
+        let doc = value.value().documentation();
+        if matches!(doc, DocItem::Member(DocMember::Function(_))) {
+            out.insert(
+                name.to_string(),
+                starlark::docs::markdown::render_doc_item_no_link(name, &doc),
+            );
+        }
+    }
+    out
+}
+
+/// The identifier (ASCII alphanumeric + `_`) under the 1-based `(line, col)` in
+/// `source`. Returns `None` when the cursor isn't on an identifier character —
+/// Starlark identifiers are ASCII, so byte indexing is safe here.
+fn word_at(source: &str, line: u32, col: u32) -> Option<&str> {
+    let line_str = source.lines().nth((line.checked_sub(1)?) as usize)?;
+    let col0 = col.checked_sub(1)? as usize;
+    let b = line_str.as_bytes();
+    let is_ident = |c: u8| c.is_ascii_alphanumeric() || c == b'_';
+    if !b.get(col0).copied().is_some_and(is_ident) {
+        return None;
+    }
+    let mut start = col0;
+    while start > 0 && b.get(start - 1).copied().is_some_and(is_ident) {
+        start -= 1;
+    }
+    let mut end = col0 + 1;
+    while b.get(end).copied().is_some_and(is_ident) {
+        end += 1;
+    }
+    line_str.get(start..end)
 }
 
 /// State shared between the [`super::context::HephLspContext`] (writer) and the
@@ -177,7 +237,7 @@ mod tests {
             Arc::new(crate::htwalk::CachedWalker::disabled()),
         );
         let result = eval_source("BUILD", content.to_string(), "pkg", &loader).unwrap();
-        DocIndex::build(&result, "pkg")
+        DocIndex::build(&result, "pkg", content.to_string())
     }
 
     #[test]
@@ -215,5 +275,29 @@ target(name = \"direct\", driver = \"exec\")
         // The target() call is on line 1.
         assert_eq!(index.driver_at(1, 1), Some("exec"));
         assert!(index.driver_at(50, 1).is_none());
+    }
+
+    #[test]
+    fn def_hover_renders_signature_for_undocumented_function() {
+        // No docstring — the stock server gives no hover; we synthesize one.
+        let content = "def my_fn(a, b):\n    return a\n\nmy_fn(1, 2)\n";
+        let index = index_for(content);
+        // Hover the usage `my_fn(1, 2)` on line 4.
+        let doc = index.def_hover_at(4, 1).expect("def hover");
+        assert!(
+            doc.contains("my_fn"),
+            "hover should name the function: {doc}"
+        );
+        assert!(doc.contains('a') && doc.contains('b'), "params: {doc}");
+        // A non-identifier / unknown word yields nothing.
+        assert!(index.def_hover_at(2, 1).is_none() || !index.defs.contains_key("return"));
+    }
+
+    #[test]
+    fn word_at_extracts_identifier_under_cursor() {
+        let src = "foo bar_baz qux\n";
+        assert_eq!(super::word_at(src, 1, 6), Some("bar_baz")); // inside bar_baz
+        assert_eq!(super::word_at(src, 1, 1), Some("foo"));
+        assert_eq!(super::word_at(src, 1, 4), None); // the space
     }
 }

--- a/src/pluginbuildfile/lsp/index.rs
+++ b/src/pluginbuildfile/lsp/index.rs
@@ -104,10 +104,10 @@ impl DocIndex {
                     .or_default()
                     .push(addr.clone());
             }
-            // The innermost frame is the `target()` call itself.
-            if let Some(inner) = target.provenance.first()
-                && !target.driver.is_empty()
-            {
+            // The innermost frame is the `target()` call itself. Recorded for every
+            // target (driver may be empty) so completion can offer the base
+            // `target()` args even before a driver is chosen.
+            if let Some(inner) = target.provenance.first() {
                 target_calls.push(TargetCall {
                     span: Span::of(inner),
                     driver: target.driver.clone(),
@@ -187,7 +187,9 @@ impl DocIndex {
             .map(|ct| ct.addrs.as_slice())
     }
 
-    /// The driver of the `target()` call covering the 1-based position, if any.
+    /// If the 1-based position is inside a `target()` call, its driver (which may
+    /// be the empty string when no `driver=` is set yet); `None` if not in a
+    /// `target()` call.
     pub(crate) fn driver_at(&self, line: u32, col: u32) -> Option<&str> {
         self.target_calls
             .iter()

--- a/src/pluginbuildfile/lsp/mod.rs
+++ b/src/pluginbuildfile/lsp/mod.rs
@@ -22,26 +22,32 @@ pub fn serve_stdio(engine: Arc<Engine>) -> anyhow::Result<()> {
     let ctx = HephLspContext::new(engine);
     let shared = Arc::clone(&ctx.shared);
 
-    let (stdio, io_threads) = Connection::stdio();
+    // `_io_threads` is intentionally never joined — see the `process::exit` note
+    // below. Kept bound (not dropped) so the stdout writer thread stays alive to
+    // flush responses until the process exits.
+    let (stdio, _io_threads) = Connection::stdio();
     // `proxy_end` is the client-facing side of the in-memory pair; `server_end`
     // is what the starlark_lsp server reads/writes.
     let (proxy_end, server_end) = Connection::memory();
 
-    std::thread::scope(|scope| -> anyhow::Result<()> {
-        let server = scope.spawn(move || {
+    std::thread::scope(|scope| {
+        let _server = scope.spawn(move || {
             // The stock server owns the initialize handshake and main loop on its
             // connection; the proxy just pipes bytes through.
             starlark_lsp::server::server_with_connection(server_end, ctx)
         });
 
+        // Returns once the client sends `exit` (or stdin closes) and the inner
+        // server finishes.
         proxy::run(&stdio, &proxy_end, shared);
 
-        server
-            .join()
-            .map_err(|_panic| anyhow::anyhow!("lsp server thread panicked"))??;
-        Ok(())
-    })?;
-
-    io_threads.join()?;
-    Ok(())
+        // Per the LSP spec, `exit` means terminate the process immediately. We must
+        // NOT fall through to `io_threads.join()`: its stdin-reader thread blocks
+        // until the client closes stdin, which editors (e.g. VS Code) only do
+        // *after* the server has exited — so joining here would deadlock, the
+        // client would SIGKILL us, and "restart server" would fail. The shutdown
+        // response was already written and flushed (the client sequences `shutdown`
+        // before `exit`), so there is nothing left to drain.
+        std::process::exit(0);
+    })
 }

--- a/src/pluginbuildfile/lsp/mod.rs
+++ b/src/pluginbuildfile/lsp/mod.rs
@@ -1,0 +1,47 @@
+//! BUILD-file language server.
+//!
+//! `heph tool build-lsp` runs this. It reuses the official `starlark_lsp` server
+//! for the standard surface (diagnostics, symbol completion/hover, goto-def, load
+//! resolution) via [`HephLspContext`], and layers heph specifics on top through a
+//! small [`proxy`] that enriches hover and completion responses (provenance,
+//! driver config schemas). See the submodule docs for detail.
+
+mod context;
+mod index;
+mod proxy;
+
+use crate::engine::engine::Engine;
+use context::HephLspContext;
+use lsp_server::Connection;
+use std::sync::Arc;
+
+/// Serve the BUILD-file LSP over stdio until the client disconnects. The
+/// `starlark_lsp` server runs on an in-memory connection; a proxy bridges it to
+/// the real stdio and enriches hover/completion.
+pub fn serve_stdio(engine: Arc<Engine>) -> anyhow::Result<()> {
+    let ctx = HephLspContext::new(engine);
+    let shared = Arc::clone(&ctx.shared);
+
+    let (stdio, io_threads) = Connection::stdio();
+    // `proxy_end` is the client-facing side of the in-memory pair; `server_end`
+    // is what the starlark_lsp server reads/writes.
+    let (proxy_end, server_end) = Connection::memory();
+
+    std::thread::scope(|scope| -> anyhow::Result<()> {
+        let server = scope.spawn(move || {
+            // The stock server owns the initialize handshake and main loop on its
+            // connection; the proxy just pipes bytes through.
+            starlark_lsp::server::server_with_connection(server_end, ctx)
+        });
+
+        proxy::run(&stdio, &proxy_end, shared);
+
+        server
+            .join()
+            .map_err(|_panic| anyhow::anyhow!("lsp server thread panicked"))??;
+        Ok(())
+    })?;
+
+    io_threads.join()?;
+    Ok(())
+}

--- a/src/pluginbuildfile/lsp/proxy.rs
+++ b/src/pluginbuildfile/lsp/proxy.rs
@@ -1,0 +1,204 @@
+//! A transparent middleware that sits between the editor (stdio) and the
+//! `starlark_lsp` server (an in-memory connection). It forwards every message
+//! untouched except `textDocument/hover` and `textDocument/completion`: those are
+//! forwarded too, but their responses are enriched on the way back with heph
+//! specifics the stock server can't know about —
+//! - hover gains a "Generated targets" block (the addresses produced by the
+//!   symbol under the cursor), and
+//! - completion gains the config fields of the target's `driver` (from the
+//!   driver's [`schema`](crate::engine::driver::Driver::schema)).
+
+use super::index::SharedState;
+use lsp_server::{Connection, Message, RequestId};
+use lsp_types::{
+    CompletionItem, CompletionItemKind, CompletionResponse, Hover, HoverContents, MarkedString,
+    MarkupContent, MarkupKind,
+};
+use starlark_lsp::server::LspUrl;
+use std::collections::HashMap;
+use std::sync::{Arc, Mutex};
+
+/// What an intercepted request was, so its response can be enriched.
+#[derive(Clone)]
+enum Pending {
+    Hover { uri: LspUrl, line: u32, col: u32 },
+    Completion { uri: LspUrl, line: u32, col: u32 },
+}
+
+/// Pump messages between `client` (editor stdio) and `server` (starlark_lsp),
+/// enriching hover/completion responses. Returns when either side closes.
+pub(crate) fn run(client: &Connection, server: &Connection, shared: Arc<SharedState>) {
+    let pending: Arc<Mutex<HashMap<RequestId, Pending>>> = Arc::new(Mutex::new(HashMap::new()));
+
+    std::thread::scope(|scope| {
+        // client → server: forward, recording hover/completion requests.
+        scope.spawn(|| {
+            for msg in &client.receiver {
+                if let Message::Request(req) = &msg
+                    && let Some(p) = classify(&req.method, &req.params)
+                {
+                    pending.lock().expect("pending").insert(req.id.clone(), p);
+                }
+                let stop = matches!(&msg, Message::Notification(n) if n.method == "exit");
+                if server.sender.send(msg).is_err() || stop {
+                    break;
+                }
+            }
+        });
+
+        // server → client: forward, enriching recorded responses.
+        scope.spawn(|| {
+            for msg in &server.receiver {
+                let out = match msg {
+                    Message::Response(mut resp) => {
+                        if let Some(p) = pending.lock().expect("pending").remove(&resp.id) {
+                            enrich(&mut resp, &p, &shared);
+                        }
+                        Message::Response(resp)
+                    }
+                    other => other,
+                };
+                if client.sender.send(out).is_err() {
+                    break;
+                }
+            }
+        });
+    });
+}
+
+/// Extract `(uri, line, col)` for the requests we enrich. Positions are 0-based,
+/// as sent by the client.
+fn classify(method: &str, params: &serde_json::Value) -> Option<Pending> {
+    let pos = params.get("position")?;
+    let line = pos.get("line")?.as_u64()? as u32;
+    let col = pos.get("character")?.as_u64()? as u32;
+    let uri_str = params.get("textDocument")?.get("uri")?.as_str()?;
+    let uri = LspUrl::try_from(lsp_types::Url::parse(uri_str).ok()?).ok()?;
+    match method {
+        "textDocument/hover" => Some(Pending::Hover { uri, line, col }),
+        "textDocument/completion" => Some(Pending::Completion { uri, line, col }),
+        _ => None,
+    }
+}
+
+fn enrich(resp: &mut lsp_server::Response, pending: &Pending, shared: &SharedState) {
+    match pending {
+        Pending::Hover { uri, line, col } => enrich_hover(resp, uri, *line, *col, shared),
+        Pending::Completion { uri, line, col } => enrich_completion(resp, uri, *line, *col, shared),
+    }
+}
+
+fn enrich_hover(
+    resp: &mut lsp_server::Response,
+    uri: &LspUrl,
+    line: u32,
+    col: u32,
+    shared: &SharedState,
+) {
+    let Some(index) = shared.index(uri) else {
+        return;
+    };
+    // Index positions are 1-based.
+    let Some(addrs) = index.targets_at(line + 1, col + 1) else {
+        return;
+    };
+    if addrs.is_empty() {
+        return;
+    }
+
+    let mut md = existing_hover_markdown(resp);
+    if !md.is_empty() {
+        md.push_str("\n\n---\n\n");
+    }
+    md.push_str(&format!("**Generated targets ({})**\n\n```\n", addrs.len()));
+    for a in addrs {
+        md.push_str(a);
+        md.push('\n');
+    }
+    md.push_str("```\n");
+
+    let hover = Hover {
+        contents: HoverContents::Markup(MarkupContent {
+            kind: MarkupKind::Markdown,
+            value: md,
+        }),
+        range: None,
+    };
+    resp.result = Some(serde_json::to_value(hover).expect("serialize hover"));
+    resp.error = None;
+}
+
+/// Pull whatever markdown/plain text the stock server already produced for hover.
+fn existing_hover_markdown(resp: &lsp_server::Response) -> String {
+    let Some(value) = &resp.result else {
+        return String::new();
+    };
+    let Ok(hover) = serde_json::from_value::<Hover>(value.clone()) else {
+        return String::new();
+    };
+    match hover.contents {
+        HoverContents::Markup(m) => m.value,
+        HoverContents::Scalar(s) => marked_string_text(s),
+        HoverContents::Array(items) => items
+            .into_iter()
+            .map(marked_string_text)
+            .collect::<Vec<_>>()
+            .join("\n\n"),
+    }
+}
+
+fn marked_string_text(s: MarkedString) -> String {
+    match s {
+        MarkedString::String(s) => s,
+        MarkedString::LanguageString(ls) => format!("```{}\n{}\n```", ls.language, ls.value),
+    }
+}
+
+fn enrich_completion(
+    resp: &mut lsp_server::Response,
+    uri: &LspUrl,
+    line: u32,
+    col: u32,
+    shared: &SharedState,
+) {
+    let Some(index) = shared.index(uri) else {
+        return;
+    };
+    let Some(driver) = index.driver_at(line + 1, col + 1) else {
+        return;
+    };
+    let Some(schema) = shared.engine.driver_schema(driver) else {
+        return;
+    };
+
+    let extra: Vec<CompletionItem> = schema
+        .fields
+        .into_iter()
+        .map(|f| CompletionItem {
+            label: f.name.clone(),
+            kind: Some(CompletionItemKind::FIELD),
+            detail: Some(format!("{}: {}", driver, f.ty.render())),
+            documentation: Some(lsp_types::Documentation::String(f.doc)),
+            // Insert as `name = ` to match the keyword-argument call site.
+            insert_text: Some(format!("{} = ", f.name)),
+            ..Default::default()
+        })
+        .collect();
+    if extra.is_empty() {
+        return;
+    }
+
+    let mut items: Vec<CompletionItem> = match resp.result.take() {
+        Some(v) => match serde_json::from_value::<CompletionResponse>(v) {
+            Ok(CompletionResponse::Array(a)) => a,
+            Ok(CompletionResponse::List(l)) => l.items,
+            Err(_) => vec![],
+        },
+        None => vec![],
+    };
+    // Driver fields first, then whatever the stock server proposed.
+    let mut merged = extra;
+    merged.append(&mut items);
+    resp.result = Some(serde_json::to_value(CompletionResponse::Array(merged)).expect("serialize"));
+    resp.error = None;
+}

--- a/src/pluginbuildfile/lsp/proxy.rs
+++ b/src/pluginbuildfile/lsp/proxy.rs
@@ -327,20 +327,26 @@ fn in_driver_value(prefix: &str) -> bool {
     let Some(q) = prefix.rfind('"') else {
         return false;
     };
+    // A `"` is ASCII, so `q` is a char boundary.
+    let (before, value) = (prefix.get(..q), prefix.get(q + 1..));
+    let (Some(before), Some(value)) = (before, value) else {
+        return false;
+    };
     // No further quote after the last one → still inside the string.
-    let value = &prefix[q + 1..];
     if value.contains('"') {
         return false;
     }
-    let Some(head) = prefix[..q].trim_end().strip_suffix('=') else {
+    let Some(head) = before.trim_end().strip_suffix('=') else {
         return false;
     };
     let head = head.trim_end();
-    head.ends_with("driver")
-        && head[..head.len() - "driver".len()]
-            .chars()
-            .last()
-            .is_none_or(|ch| !ch.is_alphanumeric() && ch != '_')
+    let Some(stem) = head.strip_suffix("driver") else {
+        return false;
+    };
+    // The token must be exactly `driver`, not a suffix of a longer identifier.
+    stem.chars()
+        .last()
+        .is_none_or(|ch| !ch.is_alphanumeric() && ch != '_')
 }
 
 fn field_item(name: &str, ty: &str, doc: String, ctx: &str) -> CompletionItem {

--- a/src/pluginbuildfile/lsp/proxy.rs
+++ b/src/pluginbuildfile/lsp/proxy.rs
@@ -3,7 +3,7 @@
 //! untouched except `textDocument/hover` and `textDocument/completion`: those are
 //! forwarded too, but their responses are enriched on the way back with heph
 //! specifics the stock server can't know about —
-//! - hover gains a "Generated targets" block (the addresses produced by the
+//! - hover gains a "Targets" block (the addresses produced by the
 //!   symbol under the cursor), and
 //! - completion gains the config fields of the target's `driver` (from the
 //!   driver's [`schema`](crate::engine::driver::Driver::schema)).
@@ -268,10 +268,7 @@ fn enrich_hover(
         if !md.is_empty() {
             md.push_str("\n\n---\n\n");
         }
-        md.push_str(&format!(
-            "**Generated targets ({})**\n\n```\n",
-            targets.len()
-        ));
+        md.push_str(&format!("**Targets ({})**\n\n```\n", targets.len()));
         for a in targets {
             md.push_str(a);
             md.push('\n');

--- a/src/pluginbuildfile/lsp/proxy.rs
+++ b/src/pluginbuildfile/lsp/proxy.rs
@@ -323,6 +323,10 @@ fn field_item(name: &str, ty: &str, doc: String, ctx: &str) -> CompletionItem {
         documentation: Some(lsp_types::Documentation::String(doc)),
         // Insert as `name = ` to match the keyword-argument call site.
         insert_text: Some(format!("{name} = ")),
+        // Editors rank by `sort_text` (falling back to the label), ignoring list
+        // order. The `0_` prefix sorts these schema fields ahead of every
+        // stock/builtin item (whose effective sort key starts with a letter).
+        sort_text: Some(format!("0_{name}")),
         ..Default::default()
     }
 }

--- a/src/pluginbuildfile/lsp/proxy.rs
+++ b/src/pluginbuildfile/lsp/proxy.rs
@@ -98,24 +98,37 @@ fn enrich_hover(
     let Some(index) = shared.index(uri) else {
         return;
     };
+
     // Index positions are 1-based.
-    let Some(addrs) = index.targets_at(line + 1, col + 1) else {
-        return;
-    };
-    if addrs.is_empty() {
-        return;
+    let mut md = existing_hover_markdown(resp);
+
+    // If the stock server produced no hover (e.g. an undocumented `def`), fall
+    // back to the function's rendered signature.
+    if md.is_empty()
+        && let Some(doc) = index.def_hover_at(line + 1, col + 1)
+    {
+        md.push_str(doc);
     }
 
-    let mut md = existing_hover_markdown(resp);
-    if !md.is_empty() {
-        md.push_str("\n\n---\n\n");
+    // Append the targets this call site produced, if any.
+    let targets = index.targets_at(line + 1, col + 1).unwrap_or(&[]);
+    if md.is_empty() && targets.is_empty() {
+        return;
     }
-    md.push_str(&format!("**Generated targets ({})**\n\n```\n", addrs.len()));
-    for a in addrs {
-        md.push_str(a);
-        md.push('\n');
+    if !targets.is_empty() {
+        if !md.is_empty() {
+            md.push_str("\n\n---\n\n");
+        }
+        md.push_str(&format!(
+            "**Generated targets ({})**\n\n```\n",
+            targets.len()
+        ));
+        for a in targets {
+            md.push_str(a);
+            md.push('\n');
+        }
+        md.push_str("```\n");
     }
-    md.push_str("```\n");
 
     let hover = Hover {
         contents: HoverContents::Markup(MarkupContent {

--- a/src/pluginbuildfile/lsp/proxy.rs
+++ b/src/pluginbuildfile/lsp/proxy.rs
@@ -9,13 +9,15 @@
 //!   driver's [`schema`](crate::engine::driver::Driver::schema)).
 
 use super::index::SharedState;
+use crate::pluginbuildfile::run_file::resolve_load_target;
 use lsp_server::{Connection, Message, RequestId};
 use lsp_types::{
-    CompletionItem, CompletionItemKind, CompletionResponse, Hover, HoverContents, MarkedString,
-    MarkupContent, MarkupKind,
+    CompletionItem, CompletionItemKind, CompletionResponse, Hover, HoverContents, LocationLink,
+    MarkedString, MarkupContent, MarkupKind, Position, Range,
 };
 use starlark_lsp::server::LspUrl;
 use std::collections::HashMap;
+use std::path::Path;
 use std::sync::{Arc, Mutex};
 
 /// What an intercepted request was, so its response can be enriched.
@@ -23,6 +25,7 @@ use std::sync::{Arc, Mutex};
 enum Pending {
     Hover { uri: LspUrl, line: u32, col: u32 },
     Completion { uri: LspUrl, line: u32, col: u32 },
+    Definition { uri: LspUrl, line: u32, col: u32 },
 }
 
 /// Pump messages between `client` (editor stdio) and `server` (starlark_lsp),
@@ -77,6 +80,7 @@ fn classify(method: &str, params: &serde_json::Value) -> Option<Pending> {
     match method {
         "textDocument/hover" => Some(Pending::Hover { uri, line, col }),
         "textDocument/completion" => Some(Pending::Completion { uri, line, col }),
+        "textDocument/definition" => Some(Pending::Definition { uri, line, col }),
         _ => None,
     }
 }
@@ -85,7 +89,143 @@ fn enrich(resp: &mut lsp_server::Response, pending: &Pending, shared: &SharedSta
     match pending {
         Pending::Hover { uri, line, col } => enrich_hover(resp, uri, *line, *col, shared),
         Pending::Completion { uri, line, col } => enrich_completion(resp, uri, *line, *col, shared),
+        Pending::Definition { uri, line, col } => enrich_definition(resp, uri, *line, *col, shared),
     }
+}
+
+/// Resolve goto-definition for a `load`-imported symbol across every BUILD file
+/// in its package. The stock server only parses one file per package, so a symbol
+/// defined in a sibling file resolves to the `load(...)` line (or nothing); we
+/// scan the whole package and point at the real definition.
+fn enrich_definition(
+    resp: &mut lsp_server::Response,
+    uri: &LspUrl,
+    line: u32,
+    col: u32,
+    shared: &SharedState,
+) {
+    let LspUrl::File(doc_path) = uri else {
+        return;
+    };
+    let Some(index) = shared.index(uri) else {
+        return;
+    };
+    let Some((load_path, exported)) = index.loaded_symbol_at(line + 1, col + 1) else {
+        return;
+    };
+
+    // If the stock server already resolved into another file, it's correct — leave it.
+    if result_points_to_other_file(resp.result.as_ref(), doc_path) {
+        return;
+    }
+
+    let current_pkg = pkg_of(&shared.root, doc_path);
+    let Ok(resolved) = resolve_load_target(&shared.root, &current_pkg, load_path) else {
+        return;
+    };
+    // The load target is a package dir (scan every BUILD file) or an explicit file.
+    let files: Vec<std::path::PathBuf> = if resolved.is_dir() {
+        package_build_files(&resolved, &shared.patterns)
+    } else {
+        vec![resolved]
+    };
+
+    for file in files {
+        if let Some((dl, c0, c1)) = find_symbol_def(&file, exported) {
+            let Ok(url) = lsp_types::Url::from_file_path(&file) else {
+                continue;
+            };
+            let target_range = Range {
+                start: Position::new(dl, c0),
+                end: Position::new(dl, c1),
+            };
+            let link = LocationLink {
+                origin_selection_range: None,
+                target_uri: url,
+                target_range,
+                target_selection_range: target_range,
+            };
+            resp.result = Some(serde_json::to_value(vec![link]).expect("serialize definition"));
+            resp.error = None;
+            return;
+        }
+    }
+}
+
+/// Whether a goto response already points at a file other than `doc_path` (i.e.
+/// the stock server resolved it cross-file and we should not override).
+fn result_points_to_other_file(result: Option<&serde_json::Value>, doc_path: &Path) -> bool {
+    let Some(value) = result else { return false };
+    let doc = lsp_types::Url::from_file_path(doc_path).ok();
+    let targets = match value {
+        serde_json::Value::Array(a) => a.clone(),
+        serde_json::Value::Object(_) => vec![value.clone()],
+        _ => return false,
+    };
+    targets.iter().any(|t| {
+        let uri = t
+            .get("targetUri")
+            .or_else(|| t.get("uri"))
+            .and_then(|u| u.as_str());
+        match (uri, &doc) {
+            (Some(u), Some(d)) => u != d.as_str(),
+            (Some(_), None) => true,
+            _ => false,
+        }
+    })
+}
+
+/// Files in `dir` matching a BUILD pattern, sorted by name (heph's merge order).
+fn package_build_files(dir: &Path, patterns: &[glob::Pattern]) -> Vec<std::path::PathBuf> {
+    let mut files: Vec<std::path::PathBuf> = std::fs::read_dir(dir)
+        .into_iter()
+        .flatten()
+        .flatten()
+        .filter(|e| e.file_type().map(|t| t.is_file()).unwrap_or(false))
+        .filter(|e| {
+            patterns
+                .iter()
+                .any(|p| p.matches(&e.file_name().to_string_lossy()))
+        })
+        .map(|e| e.path())
+        .collect();
+    files.sort();
+    files
+}
+
+/// Find the top-level definition of `name` (a `def` or an assignment) in `path`,
+/// returning the 0-based `(line, name_col_start, name_col_end)`. Identifiers are
+/// ASCII, so byte offsets equal columns.
+fn find_symbol_def(path: &Path, name: &str) -> Option<(u32, u32, u32)> {
+    let content = std::fs::read_to_string(path).ok()?;
+    for (i, line) in content.lines().enumerate() {
+        let trimmed = line.trim_start();
+        let is_def = trimmed
+            .strip_prefix("def ")
+            .map(str::trim_start)
+            .and_then(|r| r.strip_prefix(name))
+            .is_some_and(|r| r.trim_start().starts_with('('));
+        let is_assign = trimmed
+            .strip_prefix(name)
+            .map(str::trim_start)
+            .is_some_and(|r| r.starts_with('=') && !r.starts_with("=="));
+        if is_def || is_assign {
+            let col = line.find(name)? as u32;
+            return Some((i as u32, col, col + name.len() as u32));
+        }
+    }
+    None
+}
+
+/// Package name for a BUILD-file path: its parent dir, workspace-relative,
+/// forward-slashed (empty at the root).
+fn pkg_of(root: &Path, path: &Path) -> String {
+    let parent = path.parent().unwrap_or(path);
+    parent
+        .strip_prefix(root)
+        .unwrap_or(parent)
+        .to_string_lossy()
+        .replace('\\', "/")
 }
 
 fn enrich_hover(
@@ -214,4 +354,52 @@ fn enrich_completion(
     merged.append(&mut items);
     resp.result = Some(serde_json::to_value(CompletionResponse::Array(merged)).expect("serialize"));
     resp.error = None;
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{find_symbol_def, pkg_of, result_points_to_other_file};
+    use std::path::Path;
+
+    #[test]
+    fn find_symbol_def_locates_def_and_assignment() {
+        let dir = tempfile::tempdir().unwrap();
+        let file = dir.path().join("macros.BUILD");
+        std::fs::write(
+            &file,
+            "# top\n\ndef make_name(p):\n    return p\n\nFOO = 1\nFOOBAR = 2\n",
+        )
+        .unwrap();
+
+        // `def make_name(` on line index 2; name starts at col 4.
+        assert_eq!(find_symbol_def(&file, "make_name"), Some((2, 4, 13)));
+        // `FOO = 1` on line 5, col 0..3 — must not match the `FOOBAR` prefix line.
+        assert_eq!(find_symbol_def(&file, "FOO"), Some((5, 0, 3)));
+        assert_eq!(find_symbol_def(&file, "FOOBAR"), Some((6, 0, 6)));
+        // Unknown symbol → None.
+        assert_eq!(find_symbol_def(&file, "nope"), None);
+    }
+
+    #[test]
+    fn pkg_of_is_workspace_relative() {
+        let root = Path::new("/ws");
+        assert_eq!(pkg_of(root, Path::new("/ws/lib/BUILD")), "lib");
+        assert_eq!(pkg_of(root, Path::new("/ws/BUILD")), "");
+    }
+
+    #[test]
+    fn result_points_to_other_file_detects_cross_file_resolution() {
+        let doc = Path::new("/ws/app/BUILD");
+        // Already resolved into a different file → true (don't override).
+        let other = serde_json::json!([{"targetUri": "file:///ws/lib/BUILD"}]);
+        assert!(result_points_to_other_file(Some(&other), doc));
+        // Resolved to the same doc (the load statement) → false (we should override).
+        let same = serde_json::json!([{"targetUri": "file:///ws/app/BUILD"}]);
+        assert!(!result_points_to_other_file(Some(&same), doc));
+        // Empty result → false.
+        assert!(!result_points_to_other_file(
+            Some(&serde_json::json!([])),
+            doc
+        ));
+    }
 }

--- a/src/pluginbuildfile/lsp/proxy.rs
+++ b/src/pluginbuildfile/lsp/proxy.rs
@@ -10,7 +10,7 @@
 
 use super::index::SharedState;
 use crate::pluginbuildfile::run_file::resolve_load_target;
-use lsp_server::{Connection, Message, RequestId};
+use lsp_server::{Connection, Message, Notification, RequestId};
 use lsp_types::{
     CompletionItem, CompletionItemKind, CompletionResponse, Hover, HoverContents, LocationLink,
     MarkedString, MarkupContent, MarkupKind, Position, Range,
@@ -47,6 +47,15 @@ pub(crate) fn run(client: &Connection, server: &Connection, shared: Arc<SharedSt
                     break;
                 }
             }
+            // The client side ended — either an `exit` notification, or stdin
+            // closed (the editor disconnected without the shutdown/exit handshake).
+            // Tell the inner server to exit so its main loop returns and the
+            // server→client thread unblocks; otherwise the process would hang.
+            // Ignore the result: the inner server may already be gone.
+            let _sent = server.sender.send(Message::Notification(Notification {
+                method: "exit".to_string(),
+                params: serde_json::Value::Null,
+            }));
         });
 
         // server → client: forward, enriching recorded responses.

--- a/src/pluginbuildfile/lsp/proxy.rs
+++ b/src/pluginbuildfile/lsp/proxy.rs
@@ -315,6 +315,34 @@ fn marked_string_text(s: MarkedString) -> String {
 
 /// A keyword-argument completion item for a driver/provider schema field. `ctx`
 /// is the driver or provider name, shown in the detail line.
+/// Whether the cursor (end of `prefix`, the line text before it) sits inside an
+/// unclosed string literal. Approximate: counts unescaped double quotes.
+fn in_string(prefix: &str) -> bool {
+    prefix.bytes().filter(|&b| b == b'"').count() % 2 == 1
+}
+
+/// Whether the cursor sits inside the value of a `driver = "…"` keyword argument
+/// (`driver = "<partial>` with no closing quote yet on this line).
+fn in_driver_value(prefix: &str) -> bool {
+    let Some(q) = prefix.rfind('"') else {
+        return false;
+    };
+    // No further quote after the last one → still inside the string.
+    let value = &prefix[q + 1..];
+    if value.contains('"') {
+        return false;
+    }
+    let Some(head) = prefix[..q].trim_end().strip_suffix('=') else {
+        return false;
+    };
+    let head = head.trim_end();
+    head.ends_with("driver")
+        && head[..head.len() - "driver".len()]
+            .chars()
+            .last()
+            .is_none_or(|ch| !ch.is_alphanumeric() && ch != '_')
+}
+
 fn field_item(name: &str, ty: &str, doc: String, ctx: &str) -> CompletionItem {
     CompletionItem {
         label: name.to_string(),
@@ -343,19 +371,48 @@ fn enrich_completion(
     };
     let (l, c) = (line + 1, col + 1);
 
-    // Inside a `target(driver="X", …)` → that driver's config fields; inside a
-    // `provider_state(provider="X", …)` → that provider's state fields.
-    let extra: Vec<CompletionItem> = if let Some(driver) = index.driver_at(l, c) {
+    // The source up to the cursor on its line, for string-context detection.
+    let line_text = index.source.lines().nth(line as usize).unwrap_or("");
+    let prefix = line_text
+        .get(..(col as usize).min(line_text.len()))
+        .unwrap_or("");
+
+    // Inside a `driver = "…"` string → the registered driver names. Otherwise inside
+    // a `target(...)` → the driver-independent base args plus (when a driver is
+    // chosen) that driver's config fields. Inside a `provider_state(provider="X", …)`
+    // → that provider's state fields. Inside any other string we add nothing (the
+    // address/string completion path handles those).
+    let extra: Vec<CompletionItem> = if in_driver_value(prefix) {
         shared
             .engine
-            .driver_schema(driver)
-            .map(|s| {
-                s.fields
-                    .into_iter()
-                    .map(|f| field_item(&f.name, &f.ty.render(), f.doc, driver))
-                    .collect()
+            .driver_names()
+            .into_iter()
+            .map(|name| CompletionItem {
+                label: name.clone(),
+                kind: Some(CompletionItemKind::ENUM_MEMBER),
+                detail: Some("driver".to_string()),
+                sort_text: Some(format!("0_{name}")),
+                ..Default::default()
             })
-            .unwrap_or_default()
+            .collect()
+    } else if in_string(prefix) {
+        vec![]
+    } else if let Some(driver) = index.driver_at(l, c) {
+        let mut items: Vec<CompletionItem> = crate::pluginbuildfile::run_file::target_base_fields()
+            .into_iter()
+            .map(|f| field_item(&f.name, &f.ty.render(), f.doc, "target"))
+            .collect();
+        if !driver.is_empty()
+            && let Some(schema) = shared.engine.driver_schema(driver)
+        {
+            items.extend(
+                schema
+                    .fields
+                    .into_iter()
+                    .map(|f| field_item(&f.name, &f.ty.render(), f.doc, driver)),
+            );
+        }
+        items
     } else if let Some(provider) = index.state_provider_at(l, c) {
         shared
             .engine
@@ -411,6 +468,22 @@ mod tests {
         assert_eq!(find_symbol_def(&file, "FOOBAR"), Some((6, 0, 6)));
         // Unknown symbol → None.
         assert_eq!(find_symbol_def(&file, "nope"), None);
+    }
+
+    #[test]
+    fn in_driver_value_detects_driver_string() {
+        use super::{in_driver_value, in_string};
+        assert!(in_driver_value(r#"target(name = "t", driver = ""#));
+        assert!(in_driver_value(r#"target(name = "t", driver = "ex"#));
+        assert!(in_driver_value(r#"  driver="b"#)); // no spaces
+        // Not the driver arg.
+        assert!(!in_driver_value(r#"target(name = ""#));
+        assert!(!in_driver_value(r#"target(mydriver = ""#)); // prefix collision
+        // Closed string → not inside it anymore.
+        assert!(!in_driver_value(r#"driver = "exec", "#));
+        // in_string sanity.
+        assert!(in_string(r#"name = "t"#));
+        assert!(!in_string(r#"name = "t", "#));
     }
 
     #[test]

--- a/src/pluginbuildfile/lsp/proxy.rs
+++ b/src/pluginbuildfile/lsp/proxy.rs
@@ -307,6 +307,20 @@ fn marked_string_text(s: MarkedString) -> String {
     }
 }
 
+/// A keyword-argument completion item for a driver/provider schema field. `ctx`
+/// is the driver or provider name, shown in the detail line.
+fn field_item(name: &str, ty: &str, doc: String, ctx: &str) -> CompletionItem {
+    CompletionItem {
+        label: name.to_string(),
+        kind: Some(CompletionItemKind::FIELD),
+        detail: Some(format!("{ctx}: {ty}")),
+        documentation: Some(lsp_types::Documentation::String(doc)),
+        // Insert as `name = ` to match the keyword-argument call site.
+        insert_text: Some(format!("{name} = ")),
+        ..Default::default()
+    }
+}
+
 fn enrich_completion(
     resp: &mut lsp_server::Response,
     uri: &LspUrl,
@@ -317,26 +331,35 @@ fn enrich_completion(
     let Some(index) = shared.index(uri) else {
         return;
     };
-    let Some(driver) = index.driver_at(line + 1, col + 1) else {
-        return;
-    };
-    let Some(schema) = shared.engine.driver_schema(driver) else {
-        return;
-    };
+    let (l, c) = (line + 1, col + 1);
 
-    let extra: Vec<CompletionItem> = schema
-        .fields
-        .into_iter()
-        .map(|f| CompletionItem {
-            label: f.name.clone(),
-            kind: Some(CompletionItemKind::FIELD),
-            detail: Some(format!("{}: {}", driver, f.ty.render())),
-            documentation: Some(lsp_types::Documentation::String(f.doc)),
-            // Insert as `name = ` to match the keyword-argument call site.
-            insert_text: Some(format!("{} = ", f.name)),
-            ..Default::default()
-        })
-        .collect();
+    // Inside a `target(driver="X", …)` → that driver's config fields; inside a
+    // `provider_state(provider="X", …)` → that provider's state fields.
+    let extra: Vec<CompletionItem> = if let Some(driver) = index.driver_at(l, c) {
+        shared
+            .engine
+            .driver_schema(driver)
+            .map(|s| {
+                s.fields
+                    .into_iter()
+                    .map(|f| field_item(&f.name, &f.ty.render(), f.doc, driver))
+                    .collect()
+            })
+            .unwrap_or_default()
+    } else if let Some(provider) = index.state_provider_at(l, c) {
+        shared
+            .engine
+            .provider_state_schema(provider)
+            .map(|s| {
+                s.fields
+                    .into_iter()
+                    .map(|f| field_item(&f.name, &f.ty.render(), f.doc, provider))
+                    .collect()
+            })
+            .unwrap_or_default()
+    } else {
+        vec![]
+    };
     if extra.is_empty() {
         return;
     }

--- a/src/pluginbuildfile/mod.rs
+++ b/src/pluginbuildfile/mod.rs
@@ -1,4 +1,6 @@
+mod lsp;
 mod provider;
 mod run_file;
 
+pub use lsp::serve_stdio;
 pub use provider::Provider;

--- a/src/pluginbuildfile/provider.rs
+++ b/src/pluginbuildfile/provider.rs
@@ -18,6 +18,42 @@ use std::collections::HashMap;
 use std::path::PathBuf;
 use std::sync::{Arc, Mutex, OnceLock};
 
+/// Synthetic package + target the buildfile provider always exposes for the
+/// BUILD-file language server. Built (via the `exec` driver) by re-execing the
+/// current heph binary as `heph tool build-lsp`. Uncached — it is a long-lived
+/// server, not a reproducible artifact.
+const LSP_PKG: &str = "@heph/build";
+const LSP_NAME: &str = "lsp";
+
+/// Build the synthetic `TargetSpec` for `//@heph/build:lsp`: an `exec` target
+/// that runs the current binary's `tool build-lsp` hidden command with caching
+/// off. Does not touch the filesystem or any BUILD file.
+fn synth_lsp_spec(addr: Addr) -> TargetSpec {
+    use crate::htvalue::Value;
+    let heph_bin = std::env::current_exe()
+        .ok()
+        .and_then(|p| p.to_str().map(str::to_owned))
+        .unwrap_or_else(|| "heph".to_string());
+    let mut config = HashMap::new();
+    config.insert(
+        "run".to_string(),
+        Value::List(vec![
+            Value::String(heph_bin),
+            Value::String("tool".to_string()),
+            Value::String("build-lsp".to_string()),
+        ]),
+    );
+    // Long-running server: never cache.
+    config.insert("cache".to_string(), Value::Bool(false));
+    TargetSpec {
+        addr,
+        driver: "exec".to_string(),
+        config,
+        labels: vec![],
+        transitive: Default::default(),
+    }
+}
+
 pub struct RequestState {}
 
 pub struct Provider {
@@ -204,6 +240,18 @@ impl EProvider for Provider {
     ) -> BoxFuture<'a, anyhow::Result<Box<dyn Iterator<Item = anyhow::Result<ListResponse>> + Send>>>
     {
         Box::pin(async move {
+            // The synthetic LSP package lists exactly its one target.
+            if req.package == LSP_PKG {
+                let item = Ok(ListResponse {
+                    addr: Addr::new(
+                        req.package.clone(),
+                        LSP_NAME.to_string(),
+                        Default::default(),
+                    ),
+                });
+                return Ok(Box::new(std::iter::once(item))
+                    as Box<dyn Iterator<Item = anyhow::Result<ListResponse>> + Send>);
+            }
             // A package inside a skipped subtree lists nothing — matching what the
             // package walk would have surfaced.
             if self
@@ -266,6 +314,10 @@ impl EProvider for Provider {
                         pkg: PkgBuf::from(p.as_str()),
                     })
                 })
+                // Always surface the synthetic LSP package alongside the walked ones.
+                .chain(std::iter::once(Ok(ListPackageResponse {
+                    pkg: PkgBuf::from(LSP_PKG),
+                })))
                 .collect();
 
             Ok(Box::new(items.into_iter())
@@ -281,6 +333,16 @@ impl EProvider for Provider {
         _ctoken: &'a (dyn Cancellable + Send + Sync),
     ) -> BoxFuture<'a, Result<GetResponse, GetError>> {
         Box::pin(async move {
+            // The synthetic LSP package never hits the filesystem: only `:lsp`
+            // resolves, any other name in it is NotFound.
+            if req.addr.package == LSP_PKG {
+                if req.addr.name == LSP_NAME {
+                    return Ok(GetResponse {
+                        target_spec: synth_lsp_spec(req.addr.clone()),
+                    });
+                }
+                return Err(NotFound);
+            }
             // A target inside a skipped subtree does not resolve.
             if self
                 .skip
@@ -356,9 +418,97 @@ impl EProvider for Provider {
 mod tests {
     use super::*;
     use crate::engine::config_yaml::Options;
+    use crate::engine::provider::GetRequest;
     use crate::hasync::StdCancellationToken;
+    use crate::htaddr::parse_addr;
     use std::fs;
     use tempfile::tempdir;
+
+    #[tokio::test]
+    async fn test_synth_lsp_target_get_list_and_packages() {
+        let tmp = tempdir().unwrap();
+        let provider = Provider {
+            root: tmp.path().to_path_buf(),
+            ..Provider::default()
+        };
+        let ctoken = StdCancellationToken::new();
+
+        // get(//@heph/build:lsp) → exec driver, cache off, runs `tool build-lsp`.
+        let res = provider
+            .get(
+                GetRequest {
+                    request_id: "t".to_string(),
+                    addr: parse_addr("//@heph/build:lsp").unwrap(),
+                    states: vec![],
+                    executor: Arc::new(NoopExecutor),
+                },
+                &ctoken,
+            )
+            .await
+            .unwrap();
+        let spec = res.target_spec;
+        assert_eq!(spec.driver, "exec");
+        assert_eq!(
+            spec.config.get("cache"),
+            Some(&crate::htvalue::Value::Bool(false))
+        );
+        let run = match spec.config.get("run") {
+            Some(crate::htvalue::Value::List(v)) => v.clone(),
+            other => panic!("expected run list, got {other:?}"),
+        };
+        let run_strs: Vec<&str> = run
+            .iter()
+            .map(|v| match v {
+                crate::htvalue::Value::String(s) => s.as_str(),
+                _ => panic!("run entries must be strings"),
+            })
+            .collect();
+        assert_eq!(&run_strs[run_strs.len() - 2..], &["tool", "build-lsp"]);
+
+        // Wrong name in the synthetic package is NotFound.
+        let miss = provider
+            .get(
+                GetRequest {
+                    request_id: "t".to_string(),
+                    addr: parse_addr("//@heph/build:nope").unwrap(),
+                    states: vec![],
+                    executor: Arc::new(NoopExecutor),
+                },
+                &ctoken,
+            )
+            .await;
+        assert!(matches!(miss, Err(GetError::NotFound)));
+
+        // list(@heph/build) yields exactly `lsp`.
+        let listed: Vec<String> = provider
+            .list(
+                ListRequest {
+                    request_id: "t".to_string(),
+                    package: PkgBuf::from(LSP_PKG),
+                    states: vec![],
+                },
+                &ctoken,
+            )
+            .await
+            .unwrap()
+            .map(|r| r.unwrap().addr.name.clone())
+            .collect();
+        assert_eq!(listed, vec!["lsp".to_string()]);
+
+        // list_packages includes the synthetic package.
+        let pkgs: Vec<String> = provider
+            .list_packages(
+                ListPackagesRequest {
+                    prefix: PkgBuf::from(""),
+                },
+                &ctoken,
+            )
+            .await
+            .unwrap()
+            .map(|r| r.unwrap().pkg.to_string())
+            .collect();
+        assert!(pkgs.iter().any(|p| p == LSP_PKG));
+    }
 
     /// Package discovery is cached across runs through the shared walker: a fresh
     /// provider sharing the fswalk db reuses the discovered set for an unchanged
@@ -388,7 +538,12 @@ mod tests {
                 )
                 .await
                 .unwrap();
-            let mut v: Vec<String> = res.map(|r| r.unwrap().pkg.to_string()).collect();
+            // Drop the always-present synthetic LSP package; this test covers the
+            // filesystem walk.
+            let mut v: Vec<String> = res
+                .map(|r| r.unwrap().pkg.to_string())
+                .filter(|p| p != LSP_PKG)
+                .collect();
             v.sort();
             v
         };
@@ -636,7 +791,12 @@ mod tests {
             )
             .await
             .unwrap();
-        let packages: Vec<String> = res.map(|r| r.unwrap().pkg.to_string()).collect();
+        let packages: Vec<String> = res
+            .map(|r| r.unwrap().pkg.to_string())
+            // Exclude the always-present synthetic LSP package; this test covers
+            // filesystem-based package discovery.
+            .filter(|p| p != LSP_PKG)
+            .collect();
 
         assert!(packages.contains(&"".to_string()));
         assert!(packages.contains(&"src".to_string()));
@@ -676,7 +836,12 @@ mod tests {
             )
             .await
             .unwrap();
-        let packages: Vec<String> = res.map(|r| r.unwrap().pkg.to_string()).collect();
+        let packages: Vec<String> = res
+            .map(|r| r.unwrap().pkg.to_string())
+            // Exclude the always-present synthetic LSP package; this test covers
+            // filesystem-based package discovery.
+            .filter(|p| p != LSP_PKG)
+            .collect();
 
         assert!(packages.contains(&"src".to_string()));
         assert!(
@@ -761,7 +926,12 @@ mod tests {
         };
         let ctoken = StdCancellationToken::new();
         let res = provider.list_packages(req, &ctoken).await.unwrap();
-        let packages: Vec<String> = res.map(|r| r.unwrap().pkg.to_string()).collect();
+        let packages: Vec<String> = res
+            .map(|r| r.unwrap().pkg.to_string())
+            // Exclude the always-present synthetic LSP package; this test covers
+            // filesystem-based package discovery.
+            .filter(|p| p != LSP_PKG)
+            .collect();
 
         assert_eq!(packages.len(), 4);
         assert!(packages.contains(&"".to_string()));
@@ -800,7 +970,12 @@ mod tests {
         };
         let ctoken = StdCancellationToken::new();
         let res = provider.list_packages(req, &ctoken).await.unwrap();
-        let packages: Vec<String> = res.map(|r| r.unwrap().pkg.to_string()).collect();
+        let packages: Vec<String> = res
+            .map(|r| r.unwrap().pkg.to_string())
+            // Exclude the always-present synthetic LSP package; this test covers
+            // filesystem-based package discovery.
+            .filter(|p| p != LSP_PKG)
+            .collect();
 
         assert_eq!(packages.len(), 2);
         assert!(packages.contains(&"".to_string()));
@@ -843,7 +1018,12 @@ mod tests {
         };
         let ctoken = StdCancellationToken::new();
         let res = provider.list_packages(req, &ctoken).await.unwrap();
-        let packages: Vec<String> = res.map(|r| r.unwrap().pkg.to_string()).collect();
+        let packages: Vec<String> = res
+            .map(|r| r.unwrap().pkg.to_string())
+            // Exclude the always-present synthetic LSP package; this test covers
+            // filesystem-based package discovery.
+            .filter(|p| p != LSP_PKG)
+            .collect();
 
         assert_eq!(packages.len(), 3);
         assert!(packages.contains(&"".to_string()));
@@ -883,7 +1063,12 @@ mod tests {
         };
         let ctoken = StdCancellationToken::new();
         let res = provider.list_packages(req, &ctoken).await.unwrap();
-        let packages: Vec<String> = res.map(|r| r.unwrap().pkg.to_string()).collect();
+        let packages: Vec<String> = res
+            .map(|r| r.unwrap().pkg.to_string())
+            // Exclude the always-present synthetic LSP package; this test covers
+            // filesystem-based package discovery.
+            .filter(|p| p != LSP_PKG)
+            .collect();
 
         assert_eq!(packages.len(), 2);
         assert!(packages.contains(&"".to_string()));

--- a/src/pluginbuildfile/provider.rs
+++ b/src/pluginbuildfile/provider.rs
@@ -45,6 +45,12 @@ fn synth_lsp_spec(addr: Addr) -> TargetSpec {
     );
     // Long-running server: never cache.
     config.insert("cache".to_string(), Value::Bool(false));
+    // Pass the editor's full environment through to the server at run time
+    // (PATH, locale, tool config, …); `"*"` is the exec wildcard. Not hashed.
+    config.insert(
+        "runtime_pass_env".to_string(),
+        Value::List(vec![Value::String("*".to_string())]),
+    );
     TargetSpec {
         addr,
         driver: "exec".to_string(),
@@ -464,6 +470,13 @@ mod tests {
             })
             .collect();
         assert_eq!(&run_strs[run_strs.len() - 2..], &["tool", "build-lsp"]);
+        // Server inherits the editor's full environment at runtime.
+        assert_eq!(
+            spec.config.get("runtime_pass_env"),
+            Some(&crate::htvalue::Value::List(vec![
+                crate::htvalue::Value::String("*".to_string())
+            ]))
+        );
 
         // Wrong name in the synthetic package is NotFound.
         let miss = provider

--- a/src/pluginbuildfile/provider.rs
+++ b/src/pluginbuildfile/provider.rs
@@ -18,48 +18,6 @@ use std::collections::HashMap;
 use std::path::PathBuf;
 use std::sync::{Arc, Mutex, OnceLock};
 
-/// Synthetic package + target the buildfile provider always exposes for the
-/// BUILD-file language server. Built (via the `exec` driver) by re-execing the
-/// current heph binary as `heph tool build-lsp`. Uncached — it is a long-lived
-/// server, not a reproducible artifact.
-const LSP_PKG: &str = "@heph/build";
-const LSP_NAME: &str = "lsp";
-
-/// Build the synthetic `TargetSpec` for `//@heph/build:lsp`: an `exec` target
-/// that runs the current binary's `tool build-lsp` hidden command with caching
-/// off. Does not touch the filesystem or any BUILD file.
-fn synth_lsp_spec(addr: Addr) -> TargetSpec {
-    use crate::htvalue::Value;
-    let heph_bin = std::env::current_exe()
-        .ok()
-        .and_then(|p| p.to_str().map(str::to_owned))
-        .unwrap_or_else(|| "heph".to_string());
-    let mut config = HashMap::new();
-    config.insert(
-        "run".to_string(),
-        Value::List(vec![
-            Value::String(heph_bin),
-            Value::String("tool".to_string()),
-            Value::String("build-lsp".to_string()),
-        ]),
-    );
-    // Long-running server: never cache.
-    config.insert("cache".to_string(), Value::Bool(false));
-    // Pass the editor's full environment through to the server at run time
-    // (PATH, locale, tool config, …); `"*"` is the exec wildcard. Not hashed.
-    config.insert(
-        "runtime_pass_env".to_string(),
-        Value::List(vec![Value::String("*".to_string())]),
-    );
-    TargetSpec {
-        addr,
-        driver: "exec".to_string(),
-        config,
-        labels: vec![],
-        transitive: Default::default(),
-    }
-}
-
 pub struct RequestState {}
 
 pub struct Provider {
@@ -246,18 +204,6 @@ impl EProvider for Provider {
     ) -> BoxFuture<'a, anyhow::Result<Box<dyn Iterator<Item = anyhow::Result<ListResponse>> + Send>>>
     {
         Box::pin(async move {
-            // The synthetic LSP package lists exactly its one target.
-            if req.package == LSP_PKG {
-                let item = Ok(ListResponse {
-                    addr: Addr::new(
-                        req.package.clone(),
-                        LSP_NAME.to_string(),
-                        Default::default(),
-                    ),
-                });
-                return Ok(Box::new(std::iter::once(item))
-                    as Box<dyn Iterator<Item = anyhow::Result<ListResponse>> + Send>);
-            }
             // A package inside a skipped subtree lists nothing — matching what the
             // package walk would have surfaced.
             if self
@@ -320,10 +266,6 @@ impl EProvider for Provider {
                         pkg: PkgBuf::from(p.as_str()),
                     })
                 })
-                // Always surface the synthetic LSP package alongside the walked ones.
-                .chain(std::iter::once(Ok(ListPackageResponse {
-                    pkg: PkgBuf::from(LSP_PKG),
-                })))
                 .collect();
 
             Ok(Box::new(items.into_iter())
@@ -339,16 +281,6 @@ impl EProvider for Provider {
         _ctoken: &'a (dyn Cancellable + Send + Sync),
     ) -> BoxFuture<'a, Result<GetResponse, GetError>> {
         Box::pin(async move {
-            // The synthetic LSP package never hits the filesystem: only `:lsp`
-            // resolves, any other name in it is NotFound.
-            if req.addr.package == LSP_PKG {
-                if req.addr.name == LSP_NAME {
-                    return Ok(GetResponse {
-                        target_spec: synth_lsp_spec(req.addr.clone()),
-                    });
-                }
-                return Err(NotFound);
-            }
             // A target inside a skipped subtree does not resolve.
             if self
                 .skip
@@ -429,100 +361,6 @@ mod tests {
     use crate::htaddr::parse_addr;
     use std::fs;
     use tempfile::tempdir;
-
-    #[tokio::test]
-    async fn test_synth_lsp_target_get_list_and_packages() {
-        let tmp = tempdir().unwrap();
-        let provider = Provider {
-            root: tmp.path().to_path_buf(),
-            ..Provider::default()
-        };
-        let ctoken = StdCancellationToken::new();
-
-        // get(//@heph/build:lsp) → exec driver, cache off, runs `tool build-lsp`.
-        let res = provider
-            .get(
-                GetRequest {
-                    request_id: "t".to_string(),
-                    addr: parse_addr("//@heph/build:lsp").unwrap(),
-                    states: vec![],
-                    executor: Arc::new(NoopExecutor),
-                },
-                &ctoken,
-            )
-            .await
-            .unwrap();
-        let spec = res.target_spec;
-        assert_eq!(spec.driver, "exec");
-        assert_eq!(
-            spec.config.get("cache"),
-            Some(&crate::htvalue::Value::Bool(false))
-        );
-        let run = match spec.config.get("run") {
-            Some(crate::htvalue::Value::List(v)) => v.clone(),
-            other => panic!("expected run list, got {other:?}"),
-        };
-        let run_strs: Vec<&str> = run
-            .iter()
-            .map(|v| match v {
-                crate::htvalue::Value::String(s) => s.as_str(),
-                _ => panic!("run entries must be strings"),
-            })
-            .collect();
-        assert_eq!(&run_strs[run_strs.len() - 2..], &["tool", "build-lsp"]);
-        // Server inherits the editor's full environment at runtime.
-        assert_eq!(
-            spec.config.get("runtime_pass_env"),
-            Some(&crate::htvalue::Value::List(vec![
-                crate::htvalue::Value::String("*".to_string())
-            ]))
-        );
-
-        // Wrong name in the synthetic package is NotFound.
-        let miss = provider
-            .get(
-                GetRequest {
-                    request_id: "t".to_string(),
-                    addr: parse_addr("//@heph/build:nope").unwrap(),
-                    states: vec![],
-                    executor: Arc::new(NoopExecutor),
-                },
-                &ctoken,
-            )
-            .await;
-        assert!(matches!(miss, Err(GetError::NotFound)));
-
-        // list(@heph/build) yields exactly `lsp`.
-        let listed: Vec<String> = provider
-            .list(
-                ListRequest {
-                    request_id: "t".to_string(),
-                    package: PkgBuf::from(LSP_PKG),
-                    states: vec![],
-                },
-                &ctoken,
-            )
-            .await
-            .unwrap()
-            .map(|r| r.unwrap().addr.name.clone())
-            .collect();
-        assert_eq!(listed, vec!["lsp".to_string()]);
-
-        // list_packages includes the synthetic package.
-        let pkgs: Vec<String> = provider
-            .list_packages(
-                ListPackagesRequest {
-                    prefix: PkgBuf::from(""),
-                },
-                &ctoken,
-            )
-            .await
-            .unwrap()
-            .map(|r| r.unwrap().pkg.to_string())
-            .collect();
-        assert!(pkgs.iter().any(|p| p == LSP_PKG));
-    }
-
     /// Package discovery is cached across runs through the shared walker: a fresh
     /// provider sharing the fswalk db reuses the discovered set for an unchanged
     /// tree, and a newly-added package (which bumps a recorded dir's mtime) is
@@ -553,10 +391,7 @@ mod tests {
                 .unwrap();
             // Drop the always-present synthetic LSP package; this test covers the
             // filesystem walk.
-            let mut v: Vec<String> = res
-                .map(|r| r.unwrap().pkg.to_string())
-                .filter(|p| p != LSP_PKG)
-                .collect();
+            let mut v: Vec<String> = res.map(|r| r.unwrap().pkg.to_string()).collect();
             v.sort();
             v
         };
@@ -804,12 +639,7 @@ mod tests {
             )
             .await
             .unwrap();
-        let packages: Vec<String> = res
-            .map(|r| r.unwrap().pkg.to_string())
-            // Exclude the always-present synthetic LSP package; this test covers
-            // filesystem-based package discovery.
-            .filter(|p| p != LSP_PKG)
-            .collect();
+        let packages: Vec<String> = res.map(|r| r.unwrap().pkg.to_string()).collect();
 
         assert!(packages.contains(&"".to_string()));
         assert!(packages.contains(&"src".to_string()));
@@ -849,12 +679,7 @@ mod tests {
             )
             .await
             .unwrap();
-        let packages: Vec<String> = res
-            .map(|r| r.unwrap().pkg.to_string())
-            // Exclude the always-present synthetic LSP package; this test covers
-            // filesystem-based package discovery.
-            .filter(|p| p != LSP_PKG)
-            .collect();
+        let packages: Vec<String> = res.map(|r| r.unwrap().pkg.to_string()).collect();
 
         assert!(packages.contains(&"src".to_string()));
         assert!(
@@ -939,12 +764,7 @@ mod tests {
         };
         let ctoken = StdCancellationToken::new();
         let res = provider.list_packages(req, &ctoken).await.unwrap();
-        let packages: Vec<String> = res
-            .map(|r| r.unwrap().pkg.to_string())
-            // Exclude the always-present synthetic LSP package; this test covers
-            // filesystem-based package discovery.
-            .filter(|p| p != LSP_PKG)
-            .collect();
+        let packages: Vec<String> = res.map(|r| r.unwrap().pkg.to_string()).collect();
 
         assert_eq!(packages.len(), 4);
         assert!(packages.contains(&"".to_string()));
@@ -983,12 +803,7 @@ mod tests {
         };
         let ctoken = StdCancellationToken::new();
         let res = provider.list_packages(req, &ctoken).await.unwrap();
-        let packages: Vec<String> = res
-            .map(|r| r.unwrap().pkg.to_string())
-            // Exclude the always-present synthetic LSP package; this test covers
-            // filesystem-based package discovery.
-            .filter(|p| p != LSP_PKG)
-            .collect();
+        let packages: Vec<String> = res.map(|r| r.unwrap().pkg.to_string()).collect();
 
         assert_eq!(packages.len(), 2);
         assert!(packages.contains(&"".to_string()));
@@ -1031,12 +846,7 @@ mod tests {
         };
         let ctoken = StdCancellationToken::new();
         let res = provider.list_packages(req, &ctoken).await.unwrap();
-        let packages: Vec<String> = res
-            .map(|r| r.unwrap().pkg.to_string())
-            // Exclude the always-present synthetic LSP package; this test covers
-            // filesystem-based package discovery.
-            .filter(|p| p != LSP_PKG)
-            .collect();
+        let packages: Vec<String> = res.map(|r| r.unwrap().pkg.to_string()).collect();
 
         assert_eq!(packages.len(), 3);
         assert!(packages.contains(&"".to_string()));
@@ -1076,12 +886,7 @@ mod tests {
         };
         let ctoken = StdCancellationToken::new();
         let res = provider.list_packages(req, &ctoken).await.unwrap();
-        let packages: Vec<String> = res
-            .map(|r| r.unwrap().pkg.to_string())
-            // Exclude the always-present synthetic LSP package; this test covers
-            // filesystem-based package discovery.
-            .filter(|p| p != LSP_PKG)
-            .collect();
+        let packages: Vec<String> = res.map(|r| r.unwrap().pkg.to_string()).collect();
 
         assert_eq!(packages.len(), 2);
         assert!(packages.contains(&"".to_string()));

--- a/src/pluginbuildfile/run_file.rs
+++ b/src/pluginbuildfile/run_file.rs
@@ -317,6 +317,9 @@ impl Sandbox {
 pub(crate) struct OnStatePayload {
     pub provider: String,
     pub args: HashMap<String, htvalue::Value>,
+    /// Source call sites of the `provider_state()` call (innermost first). Only
+    /// captured for the LSP; empty on the normal build path. See [`ProvenanceFrame`].
+    pub provenance: Vec<ProvenanceFrame>,
 }
 
 #[derive(Debug)]
@@ -646,9 +649,16 @@ fn starlark_module(builder: &mut GlobalsBuilder) {
             )));
         }
 
+        let provenance = if extra.capture_provenance {
+            capture_provenance(eval)
+        } else {
+            Vec::new()
+        };
+
         (extra.on_state)(OnStatePayload {
             provider,
             args: kwargs,
+            provenance,
         })?;
 
         Ok(starlark::values::none::NoneType)

--- a/src/pluginbuildfile/run_file.rs
+++ b/src/pluginbuildfile/run_file.rs
@@ -82,6 +82,7 @@ fn param_type_to_ty(t: &ParamType) -> starlark::typing::Ty {
         ParamType::Null => Ty::none(),
         ParamType::List(inner) => Ty::list(param_type_to_ty(inner)),
         ParamType::Map(value) => Ty::dict(Ty::string(), param_type_to_ty(value)),
+        ParamType::Union(types) => Ty::unions(types.iter().map(param_type_to_ty).collect()),
     }
 }
 

--- a/src/pluginbuildfile/run_file.rs
+++ b/src/pluginbuildfile/run_file.rs
@@ -932,7 +932,11 @@ impl BuildFileLoader {
 ///   `//pkg/...`     absolute, relative to workspace root
 ///   `./rel/...`     relative to `current_pkg`'s directory
 ///   `../rel/...`    relative to `current_pkg`'s directory (walks up via `..`)
-fn resolve_load_target(root: &Path, current_pkg: &str, path: &str) -> anyhow::Result<PathBuf> {
+pub(crate) fn resolve_load_target(
+    root: &Path,
+    current_pkg: &str,
+    path: &str,
+) -> anyhow::Result<PathBuf> {
     let raw = if let Some(rel) = path.strip_prefix("//") {
         if rel.is_empty() {
             anyhow::bail!("load() path must not be empty after `//`");

--- a/src/pluginbuildfile/run_file.rs
+++ b/src/pluginbuildfile/run_file.rs
@@ -1,6 +1,8 @@
 use crate::engine::driver::TargetAddr;
 use crate::engine::driver::sandbox::{Dep, Env, EnvValue, Mode, Sandbox, Tool};
-use crate::engine::provider::{FnArgs, FnCallContext, ProviderFn, ProviderFunctionRegistry};
+use crate::engine::provider::{
+    FnArgs, FnCallContext, ProvenanceFrame, ProviderFn, ProviderFunctionRegistry,
+};
 use crate::hmemoizer::unwrap_arc_err;
 use crate::htaddr;
 use crate::htpkg::PkgBuf;
@@ -27,7 +29,7 @@ use std::sync::{Arc, Mutex, OnceLock};
 /// `heph.core` host/platform namespace, plus a dynamic `heph.<provider>.<fn>`
 /// namespace for every function the providers expose. Built once per
 /// buildfile-provider lifetime (the registry is fixed after the engine injects it).
-fn build_globals(registry: &ProviderFunctionRegistry) -> Globals {
+pub(crate) fn build_globals(registry: &ProviderFunctionRegistry) -> Globals {
     let mut builder = GlobalsBuilder::standard();
     builder = builder.with(starlark_module);
     builder
@@ -206,6 +208,9 @@ pub(crate) struct OnTargetPayload {
     pub labels: Vec<String>,
     pub transitive: Sandbox,
     pub config: HashMap<String, htvalue::Value>,
+    /// Source call sites that produced this target (innermost `target()` call
+    /// first). See [`crate::engine::provider::ProvenanceFrame`].
+    pub provenance: Vec<ProvenanceFrame>,
 }
 
 impl Sandbox {
@@ -369,6 +374,11 @@ pub(crate) struct Extra<'a> {
     pub root: &'a Path,
     pub on_state: Box<dyn Fn(OnStatePayload) -> anyhow::Result<()>>,
     pub on_target: Box<dyn Fn(OnTargetPayload) -> anyhow::Result<()>>,
+    /// Capture each target's source call-stack provenance. Off on the normal
+    /// build path (walking `eval.call_stack()` per `target()` call is needless
+    /// overhead there); on only for the LSP, which needs it to map a source
+    /// position back to the targets a symbol produced.
+    pub capture_provenance: bool,
 }
 
 // Unsupported starlark value types (not str/bool/int/float/list/dict) are a programming error
@@ -437,8 +447,38 @@ fn resolve_fs_path(eval: &Evaluator, path: &str, abs: bool) -> String {
     }
 }
 
+/// Snapshot the Starlark call stack at the moment `target()` runs into a chain of
+/// [`ProvenanceFrame`]s — the innermost frame is the `target()` call site, outer
+/// frames are the macro/loop call sites that led there. Frames without a source
+/// location (native-only calls) are dropped. Lines/columns are converted from
+/// starlark's 0-based positions to 1-based.
+fn capture_provenance(eval: &Evaluator) -> Vec<ProvenanceFrame> {
+    eval.call_stack()
+        .frames
+        .iter()
+        .filter_map(|frame| {
+            let span = frame.location.as_ref()?;
+            let rs = span.resolve_span();
+            Some(ProvenanceFrame {
+                fn_name: frame.name.clone(),
+                file: span.filename().to_string(),
+                line_start: rs.begin.line as u32 + 1,
+                col_start: rs.begin.column as u32 + 1,
+                line_end: rs.end.line as u32 + 1,
+                col_end: rs.end.column as u32 + 1,
+            })
+        })
+        .collect()
+}
+
 #[starlark_module]
 fn starlark_module(builder: &mut GlobalsBuilder) {
+    /// Declare a build target.
+    ///
+    /// `name` is required. `driver` selects which driver builds it (falls back to
+    /// the provider's `defaultDriver` when omitted). `labels` and `transitive`
+    /// (sandbox `deps`/`tools`/`env`) are recognized; every other keyword argument
+    /// becomes driver-specific config. Returns the target's `//pkg:name` address.
     fn target<'v>(
         eval: &mut Evaluator<'v, '_, '_>,
         args: &Arguments<'v, '_>,
@@ -503,12 +543,19 @@ fn starlark_module(builder: &mut GlobalsBuilder) {
         // An empty driver is allowed here: the provider resolves it against the
         // configured `defaultDriver` (and errors if neither is set).
 
+        let provenance = if extra.capture_provenance {
+            capture_provenance(eval)
+        } else {
+            Vec::new()
+        };
+
         let p = OnTargetPayload {
             name: name.clone(),
             driver,
             labels,
             transitive,
             config,
+            provenance,
         };
 
         (extra.on_target)(p)?;
@@ -516,6 +563,8 @@ fn starlark_module(builder: &mut GlobalsBuilder) {
         Ok(htaddr::Addr::new(PkgBuf::from(extra.pkg), name, Default::default()).format())
     }
 
+    /// Reference a single file as a dependency address. Resolved relative to the
+    /// current package unless `abs = True`. Returns an `fs` provider address.
     fn file<'v>(
         eval: &mut Evaluator<'v, '_, '_>,
         path: &str,
@@ -525,6 +574,9 @@ fn starlark_module(builder: &mut GlobalsBuilder) {
         Ok(crate::pluginfs::file_addr(&resolved).format())
     }
 
+    /// Reference files matching a glob `pattern` (with optional `exclude`) as a
+    /// dependency address. Package-relative unless `abs = True`. Returns an `fs`
+    /// provider address.
     fn glob<'v>(
         eval: &mut Evaluator<'v, '_, '_>,
         pattern: &str,
@@ -548,6 +600,7 @@ fn starlark_module(builder: &mut GlobalsBuilder) {
         Ok(crate::pluginfs::glob_addr(&resolved, &excludes_ref).format())
     }
 
+    /// Build a struct (dict) from keyword arguments, for nested target config.
     fn r#struct<'v>(
         eval: &mut Evaluator<'v, '_, '_>,
         args: &Arguments<'v, '_>,
@@ -558,6 +611,8 @@ fn starlark_module(builder: &mut GlobalsBuilder) {
         Ok(eval.heap().alloc(starlark::values::dict::AllocDict(pairs)))
     }
 
+    /// Declare package-level provider state, read by the named `provider` when it
+    /// resolves targets in this package. Remaining keyword arguments form the state.
     fn provider_state<'v>(
         eval: &mut Evaluator<'v, '_, '_>,
         args: &Arguments<'v, '_>,
@@ -682,7 +737,7 @@ pub(crate) struct BuildFileLoader {
 }
 
 impl BuildFileLoader {
-    fn new(
+    pub(crate) fn new(
         root: PathBuf,
         patterns: Vec<glob::Pattern>,
         file_cache: Arc<Mutex<HashMap<PathBuf, Arc<RunResult>>>>,
@@ -941,7 +996,31 @@ fn find_build_files(
 fn eval_file(path: &Path, pkg: &str, loader: &BuildFileLoader) -> anyhow::Result<RunResult> {
     let ast: AstModule =
         AstModule::parse_file(path, &Dialect::Extended).map_err(starlark::Error::into_anyhow)?;
+    // Normal build path: provenance capture off (walking the call stack per
+    // target() is needless overhead unless tooling asks for it).
+    eval_ast(ast, pkg, loader, false)
+}
 
+/// Parse `content` as a BUILD file named `filename` and evaluate it. Used by the
+/// LSP to evaluate in-editor (possibly unsaved) buffers; `capture_provenance` is
+/// enabled so each target records its source call sites.
+pub(crate) fn eval_source(
+    filename: &str,
+    content: String,
+    pkg: &str,
+    loader: &BuildFileLoader,
+) -> anyhow::Result<RunResult> {
+    let ast: AstModule = AstModule::parse(filename, content, &Dialect::Extended)
+        .map_err(starlark::Error::into_anyhow)?;
+    eval_ast(ast, pkg, loader, true)
+}
+
+fn eval_ast(
+    ast: AstModule,
+    pkg: &str,
+    loader: &BuildFileLoader,
+    capture_provenance: bool,
+) -> anyhow::Result<RunResult> {
     let globals = loader.globals();
 
     let module = Module::new();
@@ -953,6 +1032,7 @@ fn eval_file(path: &Path, pkg: &str, loader: &BuildFileLoader) -> anyhow::Result
         let extra = Extra {
             pkg,
             root: &loader.root,
+            capture_provenance,
             on_target: {
                 let targets = targets.clone();
                 Box::new(move |p| {
@@ -1032,6 +1112,91 @@ mod tests {
         let mut reg = ProviderFunctionRegistry::default();
         reg.insert_provider("fs", crate::pluginfs::Provider::default().functions());
         Arc::new(reg)
+    }
+
+    fn source_loader(root: PathBuf) -> BuildFileLoader {
+        BuildFileLoader::new(
+            root,
+            vec![glob::Pattern::new("BUILD").unwrap()],
+            Arc::new(Mutex::new(HashMap::new())),
+            Arc::new(Mutex::new(HashMap::new())),
+            Arc::new(ProviderFunctionRegistry::default()),
+            Arc::new(OnceLock::new()),
+            Arc::new(CachedWalker::disabled()),
+        )
+    }
+
+    #[test]
+    fn test_provenance_captures_macro_and_target_call_sites() {
+        // A user macro that emits two targets, plus one direct target(). Each
+        // produced target must record the chain of call sites that led to it:
+        // the inner target() call and (for the macro ones) the macro call site.
+        let tmp = tempdir().unwrap();
+        let loader = source_loader(tmp.path().to_path_buf());
+        let content = r#"
+def my_macro(prefix):
+    target(name = prefix + "_a", driver = "exec")
+    target(name = prefix + "_b", driver = "exec")
+
+my_macro("m")
+target(name = "direct", driver = "exec")
+"#;
+        let result =
+            eval_source("BUILD", content.to_string(), "pkg", &loader).expect("eval_source");
+
+        let by_name: HashMap<&str, &OnTargetPayload> = result
+            .targets
+            .iter()
+            .map(|t| (t.name.as_str(), t))
+            .collect();
+        assert_eq!(by_name.len(), 3);
+
+        // Each target carries at least one provenance frame, all pointing at this BUILD.
+        for t in &result.targets {
+            assert!(
+                !t.provenance.is_empty(),
+                "target {} has no provenance",
+                t.name
+            );
+            assert!(t.provenance.iter().all(|f| f.file == "BUILD"));
+        }
+
+        // The macro-produced targets carry a frame inside `my_macro` (the target()
+        // call) AND a frame at module level (the `my_macro("m")` call site, line 6).
+        let m_a = by_name["m_a"];
+        assert!(
+            m_a.provenance.iter().any(|f| f.fn_name == "my_macro"),
+            "m_a missing my_macro frame: {:?}",
+            m_a.provenance
+        );
+        assert!(
+            m_a.provenance.iter().any(|f| f.line_start == 6),
+            "m_a missing macro call site at line 6: {:?}",
+            m_a.provenance
+        );
+
+        // The direct target's innermost frame is its own call site (line 7), and it
+        // is NOT attributed to my_macro.
+        let direct = by_name["direct"];
+        assert!(direct.provenance.iter().any(|f| f.line_start == 7));
+        assert!(direct.provenance.iter().all(|f| f.fn_name != "my_macro"));
+    }
+
+    #[test]
+    fn test_provenance_off_on_normal_eval() {
+        // eval_file (normal build path) must not pay for provenance capture.
+        let tmp = tempdir().unwrap();
+        let pkg_dir = tmp.path().join("p");
+        fs::create_dir_all(&pkg_dir).unwrap();
+        fs::write(
+            pkg_dir.join("BUILD"),
+            "target(name=\"t\", driver=\"exec\")\n",
+        )
+        .unwrap();
+        let loader = source_loader(tmp.path().to_path_buf());
+        let result = loader.load_pkg("p").unwrap();
+        assert_eq!(result.targets.len(), 1);
+        assert!(result.targets[0].provenance.is_empty());
     }
 
     #[test]

--- a/src/pluginbuildfile/run_file.rs
+++ b/src/pluginbuildfile/run_file.rs
@@ -475,6 +475,44 @@ fn capture_provenance(eval: &Evaluator) -> Vec<ProvenanceFrame> {
         .collect()
 }
 
+/// The driver-independent keyword arguments the `target()` builtin always
+/// accepts, for BUILD-file LSP completion. Kept next to the `target()` builtin
+/// (below) so the two don't drift. Driver-specific config args come from the
+/// driver's own schema and are merged in by the LSP.
+pub(crate) fn target_base_fields() -> Vec<crate::engine::driver::DriverField> {
+    use crate::engine::driver::DriverField;
+    let f = |name: &str, ty: ParamType, doc: &str, required: bool| DriverField {
+        name: name.to_string(),
+        ty,
+        doc: doc.to_string(),
+        required,
+    };
+    vec![
+        f("name", ParamType::String, "Target name (required).", true),
+        f(
+            "driver",
+            ParamType::String,
+            "Driver that builds this target; falls back to the provider's `defaultDriver`.",
+            false,
+        ),
+        f(
+            "labels",
+            ParamType::union(vec![ParamType::String, ParamType::list(ParamType::String)]),
+            "Labels for querying/filtering this target.",
+            false,
+        ),
+        f(
+            "transitive",
+            ParamType::map(ParamType::union(vec![
+                ParamType::list(ParamType::String),
+                ParamType::map(ParamType::list(ParamType::String)),
+            ])),
+            "Sandbox applied transitively: `deps`, `tools`, `env`, `pass_env`, `runtime_pass_env`, `runtime_env`.",
+            false,
+        ),
+    ]
+}
+
 #[starlark_module]
 fn starlark_module(builder: &mut GlobalsBuilder) {
     /// Declare a build target.

--- a/src/pluginexec/mod.rs
+++ b/src/pluginexec/mod.rs
@@ -445,6 +445,10 @@ impl engine::driver_managed::ManagedDriver for Driver {
         })
     }
 
+    fn schema(&self) -> Option<engine::driver::DriverSchema> {
+        Some(spec::TargetSpec::schema())
+    }
+
     async fn parse(
         &self,
         req: ParseRequest,

--- a/src/pluginexec/mod.rs
+++ b/src/pluginexec/mod.rs
@@ -539,11 +539,17 @@ impl engine::driver_managed::ManagedDriver for Driver {
                 .push(input.clone());
         }
 
-        let pass_env: BTreeMap<String, String> = spec
-            .pass_env
-            .into_iter()
-            .filter_map(|name| std::env::var(&name).ok().map(|val| (name, val)))
-            .collect();
+        // `"*"` is a wildcard: pass through every host env var. Snapshotted at
+        // parse time and hashed like any other pass_env (so the input hash
+        // captures the whole environment — only use it on uncached targets).
+        let pass_env: BTreeMap<String, String> = if spec.pass_env.iter().any(|n| n == "*") {
+            std::env::vars().collect()
+        } else {
+            spec.pass_env
+                .into_iter()
+                .filter_map(|name| std::env::var(&name).ok().map(|val| (name, val)))
+                .collect()
+        };
 
         let def = TargetDef {
             run: spec.run,
@@ -973,9 +979,14 @@ impl Driver {
 
         env.extend(def.pass_env.iter().map(|(k, v)| (k.clone(), v.clone())));
 
-        for name in &def.runtime_pass_env {
-            if let Ok(value) = std::env::var(name) {
-                env.insert(name.clone(), value);
+        // `"*"` passes through every host env var at run time (not hashed).
+        if def.runtime_pass_env.iter().any(|n| n == "*") {
+            env.extend(std::env::vars());
+        } else {
+            for name in &def.runtime_pass_env {
+                if let Ok(value) = std::env::var(name) {
+                    env.insert(name.clone(), value);
+                }
             }
         }
 
@@ -1924,6 +1935,23 @@ mod tests {
         )
         .await?;
         assert_eq!(out, "runtime_pass_value");
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn test_run_runtime_pass_env_wildcard_passes_all() -> anyhow::Result<()> {
+        unsafe {
+            std::env::set_var("heph_TEST_WILDCARD_VAR", "wildcard_value");
+        }
+        // `"*"` passes every host var through without naming it.
+        let out = run_bash_env(
+            "echo $heph_TEST_WILDCARD_VAR",
+            BTreeMap::new(),
+            vec!["*".to_string()],
+            HashMap::new(),
+        )
+        .await?;
+        assert_eq!(out, "wildcard_value");
         Ok(())
     }
 

--- a/src/pluginexec/spec.rs
+++ b/src/pluginexec/spec.rs
@@ -1,4 +1,6 @@
 use crate::engine::driver::targetdef::path::CodegenMode;
+use crate::engine::driver::{DriverField, DriverSchema};
+use crate::htvalue::signature::ParamType;
 use crate::htvalue::{
     Value, parse_bool, parse_map_string_string, parse_map_string_strings, parse_string,
     parse_strings,
@@ -168,6 +170,88 @@ impl TargetSpec {
 
         Ok(spec)
     }
+
+    /// Declarative schema of the config fields exec accepts, for the BUILD-file
+    /// LSP. Kept in this file alongside [`TargetSpec::from`] so the two field
+    /// lists are edited together and don't drift.
+    pub(crate) fn schema() -> DriverSchema {
+        use ParamType::String as Str;
+        let field = |name: &str, ty: ParamType, doc: &str| DriverField {
+            name: name.to_string(),
+            ty,
+            doc: doc.to_string(),
+            required: false,
+        };
+        DriverSchema {
+            fields: vec![
+                field(
+                    "run",
+                    ParamType::list(Str),
+                    "Command to execute, as an argv list. `$OUT`, `$SRC_<group>`, `$TOOL_<group>` and declared env vars are available.",
+                ),
+                field(
+                    "out",
+                    ParamType::map(ParamType::list(Str)),
+                    "Declared outputs, grouped by name → list of output paths the target writes.",
+                ),
+                field(
+                    "cache",
+                    ParamType::Bool,
+                    "Caching: bool toggles local+remote, or a dict `{enabled, remote, history}`.",
+                ),
+                field(
+                    "support_files",
+                    ParamType::list(Str),
+                    "Extra files materialized into the sandbox but not hashed as deps.",
+                ),
+                field(
+                    "codegen",
+                    Str,
+                    "Codegen mode: `copy` or `in_place`. Omit for a normal (non-codegen) target.",
+                ),
+                field(
+                    "deps",
+                    ParamType::map(ParamType::list(Str)),
+                    "Hashed + runtime dependencies, grouped by name → list of target addresses.",
+                ),
+                field(
+                    "hash_deps",
+                    ParamType::map(ParamType::list(Str)),
+                    "Dependencies that contribute to the input hash but are not materialized at runtime.",
+                ),
+                field(
+                    "runtime_deps",
+                    ParamType::map(ParamType::list(Str)),
+                    "Dependencies materialized at runtime but excluded from the input hash.",
+                ),
+                field(
+                    "tools",
+                    ParamType::map(ParamType::list(Str)),
+                    "Build tools, grouped by name → list of target addresses; symlinked under `tools/`.",
+                ),
+                field(
+                    "env",
+                    ParamType::map(Str),
+                    "Environment variables set for the command.",
+                ),
+                field(
+                    "pass_env",
+                    ParamType::list(Str),
+                    "Names of host environment variables passed through (hashed).",
+                ),
+                field(
+                    "runtime_pass_env",
+                    ParamType::list(Str),
+                    "Host environment variables passed through at runtime only (not hashed).",
+                ),
+                field(
+                    "runtime_env",
+                    ParamType::map(Str),
+                    "Environment variables set at runtime only (not hashed).",
+                ),
+            ],
+        }
+    }
 }
 
 #[cfg(test)]
@@ -181,6 +265,39 @@ mod tests {
         let mut m = HashMap::from([("run".to_string(), Value::String("echo".to_string()))]);
         m.extend(extra.into_iter().map(|(k, v)| (k.to_string(), v)));
         TargetSpec::from(m)
+    }
+
+    #[test]
+    fn test_schema_lists_known_fields_with_types() {
+        let schema = TargetSpec::schema();
+        let by_name: HashMap<&str, &DriverField> =
+            schema.fields.iter().map(|f| (f.name.as_str(), f)).collect();
+        // Every config key TargetSpec::from understands must appear in the schema,
+        // so the two lists are caught drifting apart.
+        for key in [
+            "run",
+            "out",
+            "cache",
+            "support_files",
+            "codegen",
+            "deps",
+            "hash_deps",
+            "runtime_deps",
+            "tools",
+            "env",
+            "pass_env",
+            "runtime_pass_env",
+            "runtime_env",
+        ] {
+            assert!(by_name.contains_key(key), "schema missing field `{key}`");
+        }
+        assert_eq!(by_name["run"].ty, ParamType::list(ParamType::String));
+        assert_eq!(
+            by_name["deps"].ty,
+            ParamType::map(ParamType::list(ParamType::String))
+        );
+        assert_eq!(by_name["env"].ty, ParamType::map(ParamType::String));
+        assert!(!by_name["run"].doc.is_empty());
     }
 
     #[test]

--- a/src/pluginexec/spec.rs
+++ b/src/pluginexec/spec.rs
@@ -237,12 +237,12 @@ impl TargetSpec {
                 field(
                     "pass_env",
                     ParamType::list(Str),
-                    "Names of host environment variables passed through (hashed).",
+                    "Names of host environment variables passed through (hashed). `\"*\"` passes all.",
                 ),
                 field(
                     "runtime_pass_env",
                     ParamType::list(Str),
-                    "Host environment variables passed through at runtime only (not hashed).",
+                    "Host env vars passed through at runtime only (not hashed). `\"*\"` passes all.",
                 ),
                 field(
                     "runtime_env",

--- a/src/pluginexec/spec.rs
+++ b/src/pluginexec/spec.rs
@@ -196,7 +196,7 @@ impl TargetSpec {
                 ),
                 field(
                     "cache",
-                    ParamType::Bool,
+                    ParamType::union(vec![ParamType::Bool, ParamType::map(ParamType::Bool)]),
                     "Caching: bool toggles local+remote, or a dict `{enabled, remote, history}`.",
                 ),
                 field(

--- a/src/pluginexec/spec.rs
+++ b/src/pluginexec/spec.rs
@@ -182,26 +182,43 @@ impl TargetSpec {
             doc: doc.to_string(),
             required: false,
         };
+        // Types mirror exactly what the `parse_*` helpers accept (see
+        // `TargetSpec::from`), each of which is effectively a union:
+        //   parse_strings           → string | list[string]
+        //   parse_map_string_strings→ string | list[string] | map[string | list[string]]
+        //   parse_map_string_string → string | map[string]
+        let str_or_list = || ParamType::union(vec![Str, ParamType::list(Str)]);
+        let group_strings = || {
+            ParamType::union(vec![
+                Str,
+                ParamType::list(Str),
+                ParamType::map(str_or_list()),
+            ])
+        };
+        let str_or_map = || ParamType::union(vec![Str, ParamType::map(Str)]);
         DriverSchema {
             fields: vec![
                 field(
                     "run",
-                    ParamType::list(Str),
+                    str_or_list(),
                     "Command to execute, as an argv list. `$OUT`, `$SRC_<group>`, `$TOOL_<group>` and declared env vars are available.",
                 ),
                 field(
                     "out",
-                    ParamType::map(ParamType::list(Str)),
+                    group_strings(),
                     "Declared outputs, grouped by name → list of output paths the target writes.",
                 ),
                 field(
                     "cache",
-                    ParamType::union(vec![ParamType::Bool, ParamType::map(ParamType::Bool)]),
+                    ParamType::union(vec![
+                        ParamType::Bool,
+                        ParamType::map(ParamType::union(vec![ParamType::Bool, ParamType::Int])),
+                    ]),
                     "Caching: bool toggles local+remote, or a dict `{enabled, remote, history}`.",
                 ),
                 field(
                     "support_files",
-                    ParamType::list(Str),
+                    str_or_list(),
                     "Extra files materialized into the sandbox but not hashed as deps.",
                 ),
                 field(
@@ -211,42 +228,42 @@ impl TargetSpec {
                 ),
                 field(
                     "deps",
-                    ParamType::map(ParamType::list(Str)),
+                    group_strings(),
                     "Hashed + runtime dependencies, grouped by name → list of target addresses.",
                 ),
                 field(
                     "hash_deps",
-                    ParamType::map(ParamType::list(Str)),
+                    group_strings(),
                     "Dependencies that contribute to the input hash but are not materialized at runtime.",
                 ),
                 field(
                     "runtime_deps",
-                    ParamType::map(ParamType::list(Str)),
+                    group_strings(),
                     "Dependencies materialized at runtime but excluded from the input hash.",
                 ),
                 field(
                     "tools",
-                    ParamType::map(ParamType::list(Str)),
+                    group_strings(),
                     "Build tools, grouped by name → list of target addresses; symlinked under `tools/`.",
                 ),
                 field(
                     "env",
-                    ParamType::map(Str),
+                    str_or_map(),
                     "Environment variables set for the command.",
                 ),
                 field(
                     "pass_env",
-                    ParamType::list(Str),
+                    str_or_list(),
                     "Names of host environment variables passed through (hashed). `\"*\"` passes all.",
                 ),
                 field(
                     "runtime_pass_env",
-                    ParamType::list(Str),
+                    str_or_list(),
                     "Host env vars passed through at runtime only (not hashed). `\"*\"` passes all.",
                 ),
                 field(
                     "runtime_env",
-                    ParamType::map(Str),
+                    str_or_map(),
                     "Environment variables set at runtime only (not hashed).",
                 ),
             ],
@@ -291,12 +308,23 @@ mod tests {
         ] {
             assert!(by_name.contains_key(key), "schema missing field `{key}`");
         }
-        assert_eq!(by_name["run"].ty, ParamType::list(ParamType::String));
+        // Types are unions mirroring the `parse_*` helpers.
+        let str_or_list =
+            ParamType::union(vec![ParamType::String, ParamType::list(ParamType::String)]);
+        assert_eq!(by_name["run"].ty, str_or_list);
+        assert_eq!(by_name["run"].ty.render(), "string | list[string]");
         assert_eq!(
             by_name["deps"].ty,
-            ParamType::map(ParamType::list(ParamType::String))
+            ParamType::union(vec![
+                ParamType::String,
+                ParamType::list(ParamType::String),
+                ParamType::map(str_or_list.clone()),
+            ])
         );
-        assert_eq!(by_name["env"].ty, ParamType::map(ParamType::String));
+        assert_eq!(
+            by_name["env"].ty,
+            ParamType::union(vec![ParamType::String, ParamType::map(ParamType::String)])
+        );
         assert!(!by_name["run"].doc.is_empty());
     }
 

--- a/src/plugingo/provider.rs
+++ b/src/plugingo/provider.rs
@@ -440,6 +440,35 @@ impl ProviderTrait for Provider {
             func: Arc::new(BuildAddrFn),
         }]
     }
+
+    fn state_schema(&self) -> Option<crate::engine::provider::StateSchema> {
+        use crate::engine::provider::{StateField, StateSchema};
+        let field = |name: &str, ty: ParamType, doc: &str| StateField {
+            name: name.to_string(),
+            ty,
+            doc: doc.to_string(),
+            required: false,
+        };
+        Some(StateSchema {
+            fields: vec![
+                field(
+                    "go_codegen_root",
+                    ParamType::Bool,
+                    "Mark this package (and descendants) as a Go codegen root.",
+                ),
+                field(
+                    "go_codegen_deps",
+                    ParamType::list(ParamType::String),
+                    "Extra dependencies (target addresses) injected into generated Go targets.",
+                ),
+                field(
+                    "test",
+                    ParamType::map(ParamType::Bool),
+                    "Test settings for this package, e.g. `{\"skip\": True}` to skip its tests.",
+                ),
+            ],
+        })
+    }
 }
 
 /// `heph.go.build_addr(pkg, goos, goarch, tags=[])` — format the heph

--- a/src/plugingroup/mod.rs
+++ b/src/plugingroup/mod.rs
@@ -26,6 +26,20 @@ impl crate::engine::driver::Driver for Driver {
         })
     }
 
+    fn schema(&self) -> Option<crate::engine::driver::DriverSchema> {
+        use crate::engine::driver::{DriverField, DriverSchema};
+        use crate::htvalue::signature::ParamType;
+        Some(DriverSchema {
+            fields: vec![DriverField {
+                name: "deps".to_string(),
+                ty: ParamType::union(vec![ParamType::String, ParamType::list(ParamType::String)]),
+                doc: "Target addresses this group aggregates; the group re-exports their outputs."
+                    .to_string(),
+                required: false,
+            }],
+        })
+    }
+
     async fn parse(
         &self,
         req: ParseRequest,
@@ -145,6 +159,21 @@ mod tests {
                 transitive: Default::default(),
             }),
         }
+    }
+
+    #[test]
+    fn test_schema_lists_deps() {
+        use crate::engine::driver::Driver as _;
+        use crate::htvalue::signature::ParamType;
+        let schema = Driver.schema().expect("group exposes a schema");
+        assert_eq!(schema.fields.len(), 1);
+        let f = &schema.fields[0];
+        assert_eq!(f.name, "deps");
+        assert_eq!(
+            f.ty,
+            ParamType::union(vec![ParamType::String, ParamType::list(ParamType::String)])
+        );
+        assert!(!f.doc.is_empty());
     }
 
     #[tokio::test]

--- a/src/pluginnix/mod.rs
+++ b/src/pluginnix/mod.rs
@@ -222,6 +222,47 @@ impl ManagedDriver for Driver {
         })
     }
 
+    fn schema(&self) -> Option<crate::engine::driver::DriverSchema> {
+        use crate::engine::driver::{DriverField, DriverSchema};
+        use crate::htvalue::signature::ParamType;
+        let str_or_list =
+            || ParamType::union(vec![ParamType::String, ParamType::list(ParamType::String)]);
+        let f = |name: &str, ty: ParamType, doc: &str, required: bool| DriverField {
+            name: name.to_string(),
+            ty,
+            doc: doc.to_string(),
+            required,
+        };
+        Some(DriverSchema {
+            fields: vec![
+                f(
+                    "nixpkgs",
+                    ParamType::String,
+                    "nixpkgs reference (required).",
+                    true,
+                ),
+                f(
+                    "packages",
+                    str_or_list(),
+                    "Nix packages to provide (required, non-empty).",
+                    true,
+                ),
+                f(
+                    "programs",
+                    str_or_list(),
+                    "Programs to expose from the packages (required, non-empty).",
+                    true,
+                ),
+                f(
+                    "system",
+                    ParamType::String,
+                    "Nix system (e.g. `aarch64-darwin`); defaults to the host.",
+                    false,
+                ),
+            ],
+        })
+    }
+
     async fn parse(
         &self,
         req: ParseRequest,

--- a/src/plugintextfile/mod.rs
+++ b/src/plugintextfile/mod.rs
@@ -49,6 +49,39 @@ impl crate::engine::driver::Driver for Driver {
         })
     }
 
+    fn schema(&self) -> Option<crate::engine::driver::DriverSchema> {
+        use crate::engine::driver::{DriverField, DriverSchema};
+        use crate::htvalue::signature::ParamType;
+        let f = |name: &str, ty: ParamType, doc: &str, required: bool| DriverField {
+            name: name.to_string(),
+            ty,
+            doc: doc.to_string(),
+            required,
+        };
+        Some(DriverSchema {
+            fields: vec![
+                f(
+                    "text",
+                    ParamType::String,
+                    "File contents to write (required, trimmed).",
+                    true,
+                ),
+                f(
+                    "out",
+                    ParamType::String,
+                    "Output filename; defaults to the target name.",
+                    false,
+                ),
+                f(
+                    "executable",
+                    ParamType::Bool,
+                    "Mark the written file executable.",
+                    false,
+                ),
+            ],
+        })
+    }
+
     async fn parse(
         &self,
         req: ParseRequest,

--- a/tests/lsp_lifecycle.rs
+++ b/tests/lsp_lifecycle.rs
@@ -1,0 +1,116 @@
+//! The BUILD-file language server (`heph tool build-lsp`) must terminate when the
+//! editor ends the session — both on the LSP `exit` notification and on a plain
+//! stdin close (disconnect). Regression test for a hang where the server blocked
+//! on `io_threads.join()` (its stdin reader never ending), so the editor SIGKILLed
+//! it and "restart language server" failed.
+
+use std::io::Write;
+use std::path::PathBuf;
+use std::process::{Command, Stdio};
+use std::time::{Duration, Instant};
+
+fn heph_bin() -> PathBuf {
+    PathBuf::from(env!("CARGO_BIN_EXE_heph"))
+}
+
+/// A minimal heph workspace (buildfile provider + exec driver).
+fn workspace() -> tempfile::TempDir {
+    let dir = tempfile::tempdir().expect("tempdir");
+    std::fs::write(
+        dir.path().join(".hephconfig2"),
+        "providers:\n  - name: buildfile\ndrivers:\n  - name: exec\n",
+    )
+    .expect("write config");
+    dir
+}
+
+fn frame(msg: &str) -> Vec<u8> {
+    format!("Content-Length: {}\r\n\r\n{}", msg.len(), msg).into_bytes()
+}
+
+/// Wait up to `timeout` for the child to exit; return whether it did.
+fn exited_within(child: &mut std::process::Child, timeout: Duration) -> bool {
+    let start = Instant::now();
+    while start.elapsed() < timeout {
+        match child.try_wait() {
+            Ok(Some(_)) => return true,
+            Ok(None) => std::thread::sleep(Duration::from_millis(50)),
+            Err(_) => return false,
+        }
+    }
+    false
+}
+
+fn spawn_lsp(ws: &tempfile::TempDir) -> std::process::Child {
+    let mut child = Command::new(heph_bin())
+        .args(["tool", "build-lsp"])
+        .current_dir(ws.path())
+        .stdin(Stdio::piped())
+        .stdout(Stdio::piped())
+        .stderr(Stdio::null())
+        .spawn()
+        .expect("spawn build-lsp");
+    // Drain stdout so the server never blocks writing responses.
+    let stdout = child.stdout.take().expect("stdout");
+    std::thread::spawn(move || {
+        use std::io::Read;
+        let mut sink = Vec::new();
+        let _n = std::io::BufReader::new(stdout).read_to_end(&mut sink);
+    });
+    child
+}
+
+#[test]
+fn build_lsp_exits_on_exit_notification() {
+    let ws = workspace();
+    let mut child = spawn_lsp(&ws);
+    let root = format!("file://{}", ws.path().display());
+    {
+        let mut stdin = child.stdin.take().expect("stdin");
+        let init = format!(
+            r#"{{"jsonrpc":"2.0","id":1,"method":"initialize","params":{{"capabilities":{{}},"rootUri":"{root}"}}}}"#
+        );
+        stdin.write_all(&frame(&init)).unwrap();
+        stdin
+            .write_all(&frame(
+                r#"{"jsonrpc":"2.0","method":"initialized","params":{}}"#,
+            ))
+            .unwrap();
+        stdin
+            .write_all(&frame(
+                r#"{"jsonrpc":"2.0","id":2,"method":"shutdown","params":null}"#,
+            ))
+            .unwrap();
+        stdin
+            .write_all(&frame(r#"{"jsonrpc":"2.0","method":"exit","params":null}"#))
+            .unwrap();
+        stdin.flush().unwrap();
+        // stdin stays open (dropped at scope end) — the server must exit on the
+        // `exit` notification alone, not because stdin closed.
+    }
+
+    assert!(
+        exited_within(&mut child, Duration::from_secs(15)),
+        "server did not exit on the `exit` notification"
+    );
+}
+
+#[test]
+fn build_lsp_exits_on_stdin_close() {
+    let ws = workspace();
+    let mut child = spawn_lsp(&ws);
+    let root = format!("file://{}", ws.path().display());
+    let init = format!(
+        r#"{{"jsonrpc":"2.0","id":1,"method":"initialize","params":{{"capabilities":{{}},"rootUri":"{root}"}}}}"#
+    );
+    {
+        let mut stdin = child.stdin.take().expect("stdin");
+        stdin.write_all(&frame(&init)).unwrap();
+        stdin.flush().unwrap();
+        // Drop stdin → client disconnect without the shutdown/exit handshake.
+    }
+    assert!(
+        exited_within(&mut child, Duration::from_secs(15)),
+        "server did not exit when stdin closed"
+    );
+}


### PR DESCRIPTION
## What

A Language Server for BUILD files, launchable two ways:
- the hidden command `heph tool build-lsp`, and
- a synthetic, **uncached** target `//@heph/build:lsp` (exposed by the `pluginbuildfile` provider, `exec` driver, re-execs the current heph binary into `tool build-lsp`).

Built on the official **`starlark_lsp`** crate via an `LspContext` impl, plus a thin stdio↔in-memory **proxy** that enriches `hover`/`completion` responses the stock server can't produce.

## Features

- **Builtin symbol resolution** — `target` / `file` / `glob` / `struct` / `provider_state`, `heph.core.*`, and provider functions complete and hover, sourced from the same globals BUILD evaluation uses (now carrying doc comments).
- **Target-address autocomplete** — `//pkg:…` completes packages, `//pkg:name` completes target names.
- **Goto-definition** on address strings — both absolute `//pkg:name` and relative `:name`.
- **Driver schema** — `Driver`/`ManagedDriver` gain an optional `schema()` (implemented for `exec`); completion inside a `target(driver="exec", …)` call offers that driver's config fields with types/docs, via `Engine::driver_schema`.
- **Provenance hover** — every target records its source call-stack provenance, so hovering a `target()` call (or a macro that produced several targets) shows a copyable **"Generated targets"** block. Capture is gated to the LSP eval path, so normal builds pay nothing.

## How it fits together

```
editor ──stdio──▶ heph tool build-lsp ──▶ proxy ──▶ starlark_lsp(HephLspContext)
                                           └─ enriches hover (provenance) + completion (driver schema)
```

The proxy is required because `LspContext` has no hover hook and can't do call-context-dependent completion. Everything else (diagnostics, builtin completion/hover, load resolution, address completion/goto) is pure `LspContext`.

## Verification

- New unit tests: exec `schema()`, provenance capture incl. macro call-site chains, `DocIndex` hover/driver lookup, synthetic-target `get`/`list`/`list_packages`, provenance-off on the normal eval path.
- End-to-end smoke against the `example/` workspace through a real engine: builtin hover shows docs; hovering a macro call returns the generated-targets block; completion inside `target(driver="exec")` includes the exec fields; `inspect spec //@heph/build:lsp` resolves to the exec spec with cache off.
- Full `cargo test` green; `cargo clippy --all-targets -- -D warnings` and `cargo fmt --check` clean.

## Notes / follow-ups

- BUILD-file patterns default to `BUILD` in the LSP (not yet read from workspace config).
- Engine bootstrap logging should stay on stderr (stdout is the JSON-RPC channel); verified in the smoke test.

🤖 Generated with [Claude Code](https://claude.com/claude-code)