### PR TITLE
test(supervisor): fix fd-inheritance flake in supervisor tests

### DIFF
--- a/.github/workflows/heph.yml
+++ b/.github/workflows/heph.yml
@@ -43,6 +43,14 @@ jobs:
           restore-prefixes-first-match: nix-${{ runner.os }}-
           gc-max-store-size-linux: 5368709120
           gc-max-store-size-macos: 5368709120
+      # cache-nix-action occasionally restores a store with a registered-but-
+      # invalid path (e.g. a fixed-output patch source dropped by the store GC
+      # before save). The later `devenv shell` eval then hard-fails with
+      # "path '/nix/store/…' is not valid" instead of re-realizing it, forcing a
+      # manual rerun. Re-substitute any missing/invalid paths so the shell can
+      # evaluate. No-op (a few seconds) on a healthy store.
+      - name: Repair restored Nix store
+        run: nix-store --verify --repair
       - name: Install devenv.sh
         run: nix profile add nixpkgs#devenv
 
@@ -123,6 +131,14 @@ jobs:
           restore-prefixes-first-match: nix-${{ runner.os }}-
           gc-max-store-size-linux: 5368709120
           gc-max-store-size-macos: 5368709120
+      # cache-nix-action occasionally restores a store with a registered-but-
+      # invalid path (e.g. a fixed-output patch source dropped by the store GC
+      # before save). The later `devenv shell` eval then hard-fails with
+      # "path '/nix/store/…' is not valid" instead of re-realizing it, forcing a
+      # manual rerun. Re-substitute any missing/invalid paths so the shell can
+      # evaluate. No-op (a few seconds) on a healthy store.
+      - name: Repair restored Nix store
+        run: nix-store --verify --repair
       - name: Install devenv.sh
         run: nix profile add nixpkgs#devenv
 
@@ -251,6 +267,14 @@ jobs:
           restore-prefixes-first-match: nix-${{ runner.os }}-
           gc-max-store-size-linux: 5368709120
           gc-max-store-size-macos: 5368709120
+      # cache-nix-action occasionally restores a store with a registered-but-
+      # invalid path (e.g. a fixed-output patch source dropped by the store GC
+      # before save). The later `devenv shell` eval then hard-fails with
+      # "path '/nix/store/…' is not valid" instead of re-realizing it, forcing a
+      # manual rerun. Re-substitute any missing/invalid paths so the shell can
+      # evaluate. No-op (a few seconds) on a healthy store.
+      - name: Repair restored Nix store
+        run: nix-store --verify --repair
       - name: Install devenv.sh
         run: nix profile add nixpkgs#devenv
 
@@ -324,6 +348,14 @@ jobs:
           restore-prefixes-first-match: nix-${{ runner.os }}-
           gc-max-store-size-linux: 5368709120
           gc-max-store-size-macos: 5368709120
+      # cache-nix-action occasionally restores a store with a registered-but-
+      # invalid path (e.g. a fixed-output patch source dropped by the store GC
+      # before save). The later `devenv shell` eval then hard-fails with
+      # "path '/nix/store/…' is not valid" instead of re-realizing it, forcing a
+      # manual rerun. Re-substitute any missing/invalid paths so the shell can
+      # evaluate. No-op (a few seconds) on a healthy store.
+      - name: Repair restored Nix store
+        run: nix-store --verify --repair
       - name: Install devenv.sh
         run: nix profile add nixpkgs#devenv
 

--- a/tests/supervisor.rs
+++ b/tests/supervisor.rs
@@ -17,7 +17,29 @@ use std::os::unix::net::UnixStream;
 use std::os::unix::process::CommandExt as _;
 use std::path::PathBuf;
 use std::process::{Command, Stdio};
+use std::sync::{Mutex, MutexGuard};
 use std::time::{Duration, Instant};
+
+/// Serializes every `Command::spawn` in this test binary.
+///
+/// The four tests run as threads in a single process under plain `cargo test`.
+/// Spawning a child is fork+exec, and a fork snapshots the entire fd table.
+/// While one thread has a socketpair fd with `CLOEXEC` temporarily cleared —
+/// on macOS `socketpair` + `fcntl` is not atomic, and we deliberately clear it
+/// on the supervisor end so it survives `exec` — a concurrent fork on another
+/// thread inherits that fd. If the leaked fd is the *parent* end of a
+/// supervisor socket, that supervisor never observes EOF when its owning test
+/// drops the parent: it blocks in `read` forever and the tracked child is
+/// never reaped (15s timeout). Holding this gate across each spawn's fd-setup
+/// window guarantees no fork ever overlaps another thread's cleared-`CLOEXEC`
+/// window, so no socket end can leak between tests.
+static SPAWN_GATE: Mutex<()> = Mutex::new(());
+
+fn spawn_gate() -> MutexGuard<'static, ()> {
+    SPAWN_GATE
+        .lock()
+        .unwrap_or_else(|poisoned| poisoned.into_inner())
+}
 
 /// How long to wait for the supervisor subprocess to observe socket EOF and
 /// SIGKILL its tracked targets. Generous because under a loaded CI runner
@@ -70,6 +92,7 @@ fn spawn_sleep_session_leader(secs: u64) -> std::process::Child {
             Ok(())
         });
     }
+    let _gate = spawn_gate();
     cmd.spawn().expect("spawn sleep")
 }
 
@@ -77,6 +100,10 @@ fn spawn_sleep_session_leader(secs: u64) -> std::process::Child {
 /// parent's end and the supervisor's `Child` handle. The parent end has
 /// CLOEXEC set; the supervisor's end has CLOEXEC cleared.
 fn spawn_supervisor() -> (UnixStream, std::process::Child) {
+    // Hold the gate across the whole fd-setup window: socketpair creation, the
+    // CLOEXEC toggles, the supervisor fork, and closing our copy of the child
+    // end. No other thread may fork while any of these fds is CLOEXEC-cleared.
+    let _gate = spawn_gate();
     let (parent, child) = UnixStream::pair().expect("socketpair");
     set_cloexec(parent.as_raw_fd(), true);
     let child_fd = child.into_raw_fd();
@@ -213,7 +240,10 @@ fn supervisor_reaps_non_setsid_child_via_direct_kill() {
         .stdin(Stdio::null())
         .stdout(Stdio::null())
         .stderr(Stdio::null());
-    let mut sleep_child = cmd.spawn().expect("spawn sleep without setsid");
+    let mut sleep_child = {
+        let _gate = spawn_gate();
+        cmd.spawn().expect("spawn sleep without setsid")
+    };
     let sleep_pid = sleep_child.id();
 
     let (mut parent, mut supervisor) = spawn_supervisor();
@@ -260,7 +290,10 @@ fn supervisor_reaps_grandchildren_via_pgid_kill() {
             Ok(())
         });
     }
-    let mut sh = cmd.spawn().expect("spawn sh");
+    let mut sh = {
+        let _gate = spawn_gate();
+        cmd.spawn().expect("spawn sh")
+    };
     let sh_pid = sh.id();
 
     // Poll for the pid file to appear.


### PR DESCRIPTION
## Problem

`supervisor_reaps_non_setsid_child_via_direct_kill` (and occasionally the other supervisor tests) flakes on macOS CI — e.g. [run 27494413332](https://github.com/hephbuild/heph/actions/runs/27494413332/job/81265850664), where it hit the full 15s `REAP_TIMEOUT` (`supervisor must kill non-setsid pid …`). A prior fix only bumped the timeout 3s→15s, which masked but didn't cure it.

## Root cause

The four supervisor integration tests run as **threads in one process** under plain `cargo test`. `Command::spawn` is fork+exec, and a fork snapshots the entire fd table. `spawn_supervisor` deliberately clears `CLOEXEC` on the supervisor end of its socketpair so it survives `exec` — and on macOS `socketpair` + `fcntl` isn't atomic, so there's also a brief window where the *parent* end is inheritable.

If another thread's fork lands inside that window, the new child inherits the socket fd. When the leaked fd is the **parent** end, the owning test's supervisor never sees EOF after it drops its parent — it blocks in `read` forever, the tracked child is never reaped, and the test times out at 15s. The same fd cross-talk also occasionally caused an *untracked* child to be killed.

Reproduced locally at ~10% (4/40 runs).

## Fix

Serialize every `Command::spawn` in the test binary behind a process-global mutex, held across each spawn's fd-setup window. No fork can then overlap another thread's cleared-`CLOEXEC` window, so no socket end leaks between tests.

**0 failures in 150+ runs** after the fix (vs ~10% before).

## Production unaffected

`process_supervisor::init` forks the real supervisor once at startup, **before** any driver thread spawns children, so its fd-setup window is never raced. This is a test-harness concurrency issue only; no production code changed.