### PR TITLE
chore(gitignore): reflect move of gen-gitignore under `tool`

### DIFF
--- a/crates/engine/src/engine/gitignore.rs
+++ b/crates/engine/src/engine/gitignore.rs
@@ -3,7 +3,7 @@
 //! Codegen targets with `codegen = copy` write generated files into the source
 //! tree; those files must be gitignored. This module owns the *core* logic —
 //! enumerating the patterns and rendering the marked section — so it can be
-//! reused by the `gen-gitignore` command and by future validations (e.g. a
+//! reused by the `tool gen-gitignore` command and by future validations (e.g. a
 //! CI check that the committed `.gitignore` is up to date). The command layer
 //! only handles file IO and progress reporting.
 
@@ -21,8 +21,14 @@ use hmodel::htmatcher::{MatchResult, Matcher};
 /// are owned by heph and rewritten on every run; everything outside is
 /// preserved verbatim.
 pub const BEGIN_MARKER: &str =
-    "# BEGIN heph-generated (managed by `heph gen-gitignore` — do not edit)";
+    "# BEGIN heph-generated (managed by `heph tool gen-gitignore` — do not edit)";
 pub const END_MARKER: &str = "# END heph-generated";
+
+/// Stable prefix of [`BEGIN_MARKER`]. Detection matches on this rather than the
+/// full marker so that changing the parenthetical (e.g. the command name) never
+/// orphans an already-committed section — the old block is still found and
+/// rewritten with the current [`BEGIN_MARKER`] text.
+pub const BEGIN_MARKER_PREFIX: &str = "# BEGIN heph-generated";
 
 /// Separator between a gitignore pattern and the trailing `# //pkg:target`
 /// comment naming the emitting target. The space-hash-space form keeps the
@@ -130,7 +136,10 @@ fn parse_entry(line: &str) -> GitignoreEntry {
     reason = "slice indices come from `find` on ASCII markers — always char-aligned"
 )]
 pub fn parse_section(existing: &str) -> Vec<GitignoreEntry> {
-    let (Some(start), Some(end)) = (existing.find(BEGIN_MARKER), existing.find(END_MARKER)) else {
+    let (Some(start), Some(end)) = (
+        existing.find(BEGIN_MARKER_PREFIX),
+        existing.find(END_MARKER),
+    ) else {
         return Vec::new();
     };
     if end < start {
@@ -139,7 +148,7 @@ pub fn parse_section(existing: &str) -> Vec<GitignoreEntry> {
     existing[start..end]
         .lines()
         .map(str::trim)
-        .filter(|l| !l.is_empty() && !l.starts_with(BEGIN_MARKER))
+        .filter(|l| !l.is_empty() && !l.starts_with(BEGIN_MARKER_PREFIX))
         .map(parse_entry)
         .collect()
 }
@@ -199,7 +208,10 @@ pub fn render(existing: &str, entries: &[GitignoreEntry]) -> String {
     }
     section.push_str(END_MARKER);
 
-    match (existing.find(BEGIN_MARKER), existing.find(END_MARKER)) {
+    match (
+        existing.find(BEGIN_MARKER_PREFIX),
+        existing.find(END_MARKER),
+    ) {
         (Some(start), Some(end_marker_pos)) if end_marker_pos >= start => {
             let end = end_marker_pos + END_MARKER.len();
             let mut result = String::with_capacity(existing.len() + section.len());
@@ -302,6 +314,19 @@ mod tests {
             out,
             format!("top\n{BEGIN_MARKER}\n/new\n{END_MARKER}\nbottom\n")
         );
+    }
+
+    #[test]
+    fn detects_and_rewrites_legacy_begin_marker() {
+        // A section committed before the command moved to `heph tool gen-gitignore`
+        // carries the old parenthetical. Detection keys on the stable prefix, so the
+        // block is found, parsed, and rewritten with the current marker text — never
+        // orphaned into a duplicate.
+        let legacy = "# BEGIN heph-generated (managed by `heph gen-gitignore` — do not edit)\n/old\n# END heph-generated\n";
+        assert_eq!(parse_section(legacy), vec![bare("/old")]);
+
+        let out = render(legacy, &[bare("/new")]);
+        assert_eq!(out, format!("{BEGIN_MARKER}\n/new\n{END_MARKER}\n"));
     }
 
     #[test]

--- a/example/.gitignore
+++ b/example/.gitignore
@@ -2,6 +2,6 @@
 profile.json.gz
 profile.json.syms.json
 
-# BEGIN heph-generated (managed by `heph gen-gitignore` — do not edit)
+# BEGIN heph-generated (managed by `heph tool gen-gitignore` — do not edit)
 /fmt/generated.txt
 # END heph-generated

--- a/src/commands/tool/gen_gitignore.rs
+++ b/src/commands/tool/gen_gitignore.rs
@@ -12,7 +12,9 @@ use crate::htpkg::{self, PkgBuf};
 use crate::tui::{self, App, AppContext, BufferedStdout, LogSink};
 
 #[derive(clap::Args, Clone)]
-#[command(override_usage = "heph gen-gitignore\n       heph gen-gitignore <PACKAGE_MATCHER>")]
+#[command(
+    override_usage = "heph tool gen-gitignore\n       heph tool gen-gitignore <PACKAGE_MATCHER>"
+)]
 pub struct Args {
     /// Package matcher (e.g. //pkg/...); omit to regenerate the whole section.
     /// When given, only the lines emitted by targets under that matcher are

--- a/src/commands/validate.rs
+++ b/src/commands/validate.rs
@@ -144,7 +144,9 @@ impl App for ValidateApp {
                 ));
             }
             if stale {
-                problems.push("`.gitignore` is out of date — run `heph gen-gitignore`".to_string());
+                problems.push(
+                    "`.gitignore` is out of date — run `heph tool gen-gitignore`".to_string(),
+                );
             }
             if !problems.is_empty() {
                 anyhow::bail!("validation failed:\n  {}", problems.join("\n  "));


### PR DESCRIPTION
## Summary

`gen-gitignore` moved to `heph tool gen-gitignore`. This updates every remaining touchpoint that still referenced the old `heph gen-gitignore` form:

- The heph-managed `.gitignore` `BEGIN` marker text
- The `validate` staleness hint message
- The command's `override_usage` string
- Module-level docs in `gitignore.rs`
- The committed `example/.gitignore` marker

## Backward compatibility

Detection of an existing managed `.gitignore` section now keys on a stable `BEGIN_MARKER_PREFIX` (`# BEGIN heph-generated`) instead of the full marker text. Without this, changing the parenthetical command name would orphan already-committed sections (old marker not found → duplicate block appended on next run). With the prefix, the old block is found, parsed, and rewritten with the current marker.

## Tests

- New `detects_and_rewrites_legacy_begin_marker` covers an old-marker section being detected and rewritten.
- All 15 `gitignore` tests pass; clippy clean with `-D warnings`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)