### PR TITLE
refactor(plugin-go): drop go_bin option, reuse gotool

### DIFF
--- a/.github/workflows/heph.yml
+++ b/.github/workflows/heph.yml
@@ -231,7 +231,7 @@ jobs:
           path: ${{steps.build.outputs.plugin_go_name}}
 
   upload_artifacts:
-    name: Upload artifacts
+    name: Pre-release
     needs: [gen, build]
     if: always() && needs.gen.result == 'success'
     runs-on: ubuntu-latest
@@ -441,8 +441,7 @@ jobs:
   release:
     name: Release
     needs: [gen, upload_artifacts, lint, test]
-    # Disabled. Re-enable by restoring: if: github.ref == 'refs/heads/master'
-    if: false
+    if: github.ref == 'refs/heads/master'
     runs-on: ubuntu-latest
     timeout-minutes: 10
     steps:

--- a/crates/plugin-abi/src/convert.rs
+++ b/crates/plugin-abi/src/convert.rs
@@ -728,7 +728,7 @@ mod tests {
         // A plugin options map crosses the ABI as pb::Value bytes and decodes back
         // unchanged — covering scalars, nesting, and a list.
         let yaml = r#"
-go_bin: "//@heph/bin:go"
+gotool: "//@heph/bin:go"
 parallel: 4
 flag: true
 nested: { a: 1, b: [x, y] }
@@ -740,8 +740,8 @@ nested: { a: 1, b: [x, y] }
         assert_eq!(back, opts);
 
         // Typed decode through the same path a plugin author uses.
-        let go_bin: String = serde_yaml::from_value(back["go_bin"].clone()).expect("go_bin");
-        assert_eq!(go_bin, "//@heph/bin:go");
+        let gotool: String = serde_yaml::from_value(back["gotool"].clone()).expect("gotool");
+        assert_eq!(gotool, "//@heph/bin:go");
 
         // Empty payload decodes to an empty map (absent options).
         assert!(options_from_pb_bytes(&[]).expect("empty").is_empty());

--- a/crates/plugin-go-cdylib/src/lib.rs
+++ b/crates/plugin-go-cdylib/src/lib.rs
@@ -39,16 +39,17 @@ fn build(cfg: CreateConfig) -> anyhow::Result<PluginComponents> {
     // Tunables come from the plugin's `options:` map (config yaml), decoded the
     // same way an in-process plugin reads its options.
     let mut options = plugin_sdk::stabby::options_from_pb_bytes(&cfg.options[..])?;
-    // `go_bin`/`walk_db` are this cdylib's own (driver/walker) options — consume
-    // them here and keep them out of the provider's map, whose `from_options`
-    // rejects unknown keys (it knows only its provider options, e.g. `gotool`).
-    let go_bin = hplugin::config::decode_opt::<String>(&options, "go", "go_bin")?
+    // The golist driver needs the same go binary addr the provider resolves from
+    // its `gotool` option — peek it here (non-destructive; the provider still
+    // reads it) so there's a single source of truth, no separate `go_bin` knob.
+    let go_bin = hplugin::config::decode_opt::<String>(&options, "go", "gotool")?
         .unwrap_or_else(|| "//@heph/bin:go".to_string());
     // The walker db lives in the engine's home dir (e.g. `.heph3`), not the repo
-    // root — `home` comes from the engine, never hardcoded.
+    // root — `home` comes from the engine, never hardcoded. It's this cdylib's own
+    // option — consume it so it's kept out of the provider's map, whose
+    // `from_options` rejects unknown keys.
     let walk_db = hplugin::config::decode_opt::<PathBuf>(&options, "go", "walk_db")?
         .unwrap_or_else(|| home.join("heph-plugin-go-fswalk.db"));
-    options.remove("go_bin");
     options.remove("walk_db");
 
     let walker = Arc::new(hwalk::CachedWalker::open(&walk_db));


### PR DESCRIPTION
## Summary
- **Go plugin:** drop the cdylib's own `go_bin` option. The golist driver now reads the go binary addr from the provider's `gotool` option (non-destructive peek; the provider still consumes it) — single source of truth, one fewer knob to keep in sync. Same `//@heph/bin:go` default.
- Renamed the unrelated `options_pb_bytes_roundtrip` sample key `go_bin`→`gotool` so no stale option name lingers.
- **CI:** re-enable the `release` job (`if: false` → `if: github.ref == 'refs/heads/master'`).
- **CI:** rename the `upload_artifacts` job display name to **Pre-release** (job id kept — referenced by `needs`).

## Test
- `cargo build -p plugin-go-cdylib -p plugin-abi` clean.
- `cargo test -p plugin-abi --features convert options_pb_bytes_roundtrip` passes.
- `cargo fmt` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)