### PR TITLE
feat(plugin-stabby): surface dropped provider/driver metadata across the dylib ABI

### DIFF
--- a/crates/plugin-abi/src/convert.rs
+++ b/crates/plugin-abi/src/convert.rs
@@ -160,6 +160,74 @@ pub fn fn_signature_from_pb(s: pb::FnSignature) -> FnSignature {
     }
 }
 
+// ---- Schemas (provider state + driver config) ----
+//
+// `provider::StateField`/`StateSchema` and `driver::DriverField`/`DriverSchema`
+// are the same declarative shape; both cross as `pb::SchemaField`/`pb::Schema`.
+
+use hplugin::driver::{DriverField, DriverSchema};
+use hplugin::provider::{StateField, StateSchema};
+
+pub fn state_schema_to_pb(s: &StateSchema) -> pb::Schema {
+    pb::Schema {
+        fields: s
+            .fields
+            .iter()
+            .map(|f| pb::SchemaField {
+                name: f.name.clone(),
+                ty: Some(param_type_to_pb(&f.ty)),
+                doc: f.doc.clone(),
+                required: f.required,
+            })
+            .collect(),
+    }
+}
+
+pub fn state_schema_from_pb(s: pb::Schema) -> StateSchema {
+    StateSchema {
+        fields: s
+            .fields
+            .into_iter()
+            .map(|f| StateField {
+                name: f.name,
+                ty: f.ty.map(param_type_from_pb).unwrap_or(ParamType::Null),
+                doc: f.doc,
+                required: f.required,
+            })
+            .collect(),
+    }
+}
+
+pub fn driver_schema_to_pb(s: &DriverSchema) -> pb::Schema {
+    pb::Schema {
+        fields: s
+            .fields
+            .iter()
+            .map(|f| pb::SchemaField {
+                name: f.name.clone(),
+                ty: Some(param_type_to_pb(&f.ty)),
+                doc: f.doc.clone(),
+                required: f.required,
+            })
+            .collect(),
+    }
+}
+
+pub fn driver_schema_from_pb(s: pb::Schema) -> DriverSchema {
+    DriverSchema {
+        fields: s
+            .fields
+            .into_iter()
+            .map(|f| DriverField {
+                name: f.name,
+                ty: f.ty.map(param_type_from_pb).unwrap_or(ParamType::Null),
+                doc: f.doc,
+                required: f.required,
+            })
+            .collect(),
+    }
+}
+
 // ---- Options (plugin config map) ----
 //
 // A plugin's `options:` map (`BTreeMap<String, serde_yaml::Value>`) crosses the

--- a/crates/plugin-abi/src/convert.rs
+++ b/crates/plugin-abi/src/convert.rs
@@ -74,6 +74,92 @@ pub fn value_from_pb(v: pb::Value) -> Value {
     }
 }
 
+// ---- Provider functions (signature + def) ----
+//
+// A provider's BUILD-file functions cross the stable ABI as metadata (name /
+// signature / doc); the handler stays guest-side and is invoked via
+// `call_function`. The host reconstructs the `FnSignature` to enforce arity/type
+// and render it (`heph inspect functions`, LSP hover).
+
+use hcore::htvalue::signature::{FnSignature, Param, ParamType};
+
+pub fn param_type_to_pb(t: &ParamType) -> pb::ParamType {
+    use pb::param_type::{Kind, Scalar, Union};
+    let kind = match t {
+        ParamType::String => Kind::Scalar(Scalar::String as i32),
+        ParamType::Bool => Kind::Scalar(Scalar::Bool as i32),
+        ParamType::Int => Kind::Scalar(Scalar::Int as i32),
+        ParamType::Uint => Kind::Scalar(Scalar::Uint as i32),
+        ParamType::Float => Kind::Scalar(Scalar::Float as i32),
+        ParamType::Null => Kind::Scalar(Scalar::Null as i32),
+        ParamType::List(inner) => Kind::List(Box::new(param_type_to_pb(inner))),
+        ParamType::Map(value) => Kind::Map(Box::new(param_type_to_pb(value))),
+        ParamType::Union(types) => Kind::Union(Union {
+            types: types.iter().map(param_type_to_pb).collect(),
+        }),
+    };
+    pb::ParamType { kind: Some(kind) }
+}
+
+pub fn param_type_from_pb(t: pb::ParamType) -> ParamType {
+    use pb::param_type::{Kind, Scalar};
+    match t.kind {
+        Some(Kind::Scalar(s)) => match Scalar::try_from(s).unwrap_or(Scalar::Unspecified) {
+            Scalar::String | Scalar::Unspecified => ParamType::String,
+            Scalar::Bool => ParamType::Bool,
+            Scalar::Int => ParamType::Int,
+            Scalar::Uint => ParamType::Uint,
+            Scalar::Float => ParamType::Float,
+            Scalar::Null => ParamType::Null,
+        },
+        Some(Kind::List(inner)) => ParamType::list(param_type_from_pb(*inner)),
+        Some(Kind::Map(value)) => ParamType::map(param_type_from_pb(*value)),
+        Some(Kind::Union(u)) => {
+            ParamType::union(u.types.into_iter().map(param_type_from_pb).collect())
+        }
+        None => ParamType::Null,
+    }
+}
+
+fn param_to_pb(p: &Param) -> pb::Param {
+    pb::Param {
+        name: p.name.to_string(),
+        ty: Some(param_type_to_pb(&p.ty)),
+        default: p.default.as_ref().map(value_to_pb),
+    }
+}
+
+fn param_from_pb(p: pb::Param) -> Param {
+    // `Param::name` is `&'static str` (in-process defs use string literals).
+    // A def reconstructed from the wire owns its name; leak it to obtain the
+    // 'static borrow. Functions are read once per process (registry wiring is a
+    // `Once`), so this is a bounded, one-time leak — not a per-call cost.
+    let name: &'static str = Box::leak(p.name.into_boxed_str());
+    let ty = p.ty.map(param_type_from_pb).unwrap_or(ParamType::Null);
+    match p.default {
+        Some(d) => Param::optional(name, ty, value_from_pb(d)),
+        None => Param::required(name, ty),
+    }
+}
+
+pub fn fn_signature_to_pb(s: &FnSignature) -> pb::FnSignature {
+    pb::FnSignature {
+        positional: s.positional.iter().map(param_to_pb).collect(),
+        named: s.named.iter().map(param_to_pb).collect(),
+        variadic: s.variadic.as_ref().map(param_to_pb),
+        returns: Some(param_type_to_pb(&s.returns)),
+    }
+}
+
+pub fn fn_signature_from_pb(s: pb::FnSignature) -> FnSignature {
+    FnSignature {
+        positional: s.positional.into_iter().map(param_from_pb).collect(),
+        named: s.named.into_iter().map(param_from_pb).collect(),
+        variadic: s.variadic.map(param_from_pb),
+        returns: s.returns.map(param_type_from_pb).unwrap_or(ParamType::Null),
+    }
+}
+
 // ---- Options (plugin config map) ----
 //
 // A plugin's `options:` map (`BTreeMap<String, serde_yaml::Value>`) crosses the

--- a/crates/plugin-sdk/src/serve.rs
+++ b/crates/plugin-sdk/src/serve.rs
@@ -18,8 +18,8 @@ use hplugin::driver::{
     RunRequest, inputartifact,
 };
 use hplugin::provider::{
-    ConfigRequest, GetError, GetRequest, ListPackagesRequest, ListRequest, ProbeRequest, Provider,
-    ProviderExecutor,
+    ConfigRequest, FnArgs, FnCallContext, GetError, GetRequest, ListPackagesRequest, ListRequest,
+    ProbeRequest, Provider, ProviderExecutor,
 };
 use hplugin_stabby::abi::{DynExecutor, StableManagedDriver, StableProvider};
 use plugin_abi::convert;
@@ -240,6 +240,58 @@ impl StableProvider for StableProviderImpl {
                     states: pr.states.iter().map(convert::state_to_pb).collect(),
                 }),
                 Err(e) => err_body(e.to_string()),
+            };
+            unary(body)
+        })
+        .into()
+    }
+
+    extern "C" fn functions(&self) -> SVec<u8> {
+        let functions = self
+            .provider
+            .functions()
+            .into_iter()
+            .map(|d| pb::ProviderFunctionDef {
+                name: d.name,
+                signature: Some(convert::fn_signature_to_pb(&d.signature)),
+                doc: d.doc,
+            })
+            .collect();
+        SVec::from(
+            pb::FunctionsResponse { functions }
+                .encode_to_vec()
+                .as_slice(),
+        )
+    }
+
+    extern "C" fn call_function<'a>(&'a self, req: SVec<u8>) -> DynFuture<'a, SVec<u8>> {
+        let provider = Arc::clone(&self.provider);
+        stabby::boxed::Box::new(async move {
+            let req = pb::CallFunctionRequest::decode(&req[..]).unwrap_or_default();
+            // Re-derive the def each call (cheap; provider functions are static
+            // metadata). The handler is not transmissible, so it must be invoked
+            // here on the guest side.
+            let def = provider.functions().into_iter().find(|d| d.name == req.name);
+            let Some(def) = def else {
+                return unary(err_body(format!("unknown provider function `{}`", req.name)));
+            };
+            let ctx = FnCallContext {
+                pkg: &req.pkg,
+                root: std::path::Path::new(&req.root),
+            };
+            let args = FnArgs {
+                positional: req.positional.into_iter().map(convert::value_from_pb).collect(),
+                named: req
+                    .named
+                    .into_iter()
+                    .map(|(k, v)| (k, convert::value_from_pb(v)))
+                    .collect(),
+            };
+            let body = match def.func.call(&ctx, args).await {
+                Ok(v) => Body::CallFunctionResp(pb::CallFunctionResponse {
+                    value: Some(convert::value_to_pb(&v)),
+                }),
+                Err(e) => err_body(format!("{e:#}")),
             };
             unary(body)
         })
@@ -540,7 +592,7 @@ impl Content for DiskInputContent {
 mod tests {
     use super::*;
     use std::collections::BTreeMap;
-    use std::io::{Read as _, Write as _};
+    use std::io::Write as _;
 
     // A managed input's content is readable from the files the host materialized
     // under unpack_root, scoped to this input's files via the list file.
@@ -602,5 +654,142 @@ mod tests {
         assert_eq!(entries.get("a.txt").map(String::as_str), Some("alpha"));
         assert_eq!(entries.get("sub/b.txt").map(String::as_str), Some("beta"));
         assert!(!entries.contains_key("other.txt"));
+    }
+
+    use hcore::hasync::Cancellable;
+    use hcore::htvalue::Value;
+    use hcore::htvalue::signature::{FnSignature, Param, ParamType};
+    use hplugin::provider::{
+        ConfigResponse, GetResponse, ListPackageResponse, ListResponse, ProbeResponse, ProviderFn,
+        ProviderFunctionDef,
+    };
+    use std::path::Path;
+
+    // A provider exposing one function `echo(msg, times=1)` whose handler reads
+    // the call context's `pkg` — so the test proves both the call arguments and
+    // the FnCallContext cross the seam, not just the metadata.
+    struct FnProvider;
+
+    struct EchoFn;
+    #[async_trait::async_trait]
+    impl ProviderFn for EchoFn {
+        async fn call(&self, ctx: &FnCallContext<'_>, args: FnArgs) -> Result<Value> {
+            let msg = match args.positional.first() {
+                Some(Value::String(s)) => s.clone(),
+                _ => anyhow::bail!("echo: `msg` must be a string"),
+            };
+            let times = match args.named.get("times") {
+                Some(Value::Int(n)) => *n,
+                _ => 1,
+            };
+            Ok(Value::String(format!(
+                "{}:{}",
+                ctx.pkg,
+                msg.repeat(usize::try_from(times).unwrap_or(0))
+            )))
+        }
+    }
+
+    impl Provider for FnProvider {
+        fn config(&self, _req: ConfigRequest) -> Result<ConfigResponse> {
+            Ok(ConfigResponse {
+                name: "mock".into(),
+            })
+        }
+        fn list<'a>(
+            &'a self,
+            _req: ListRequest,
+            _ct: &'a (dyn Cancellable + Send + Sync),
+        ) -> futures::future::BoxFuture<
+            'a,
+            Result<Box<dyn Iterator<Item = Result<ListResponse>> + Send>>,
+        > {
+            Box::pin(async { Ok(Box::new(std::iter::empty()) as Box<_>) })
+        }
+        fn list_packages<'a>(
+            &'a self,
+            _req: ListPackagesRequest,
+            _ct: &'a (dyn Cancellable + Send + Sync),
+        ) -> futures::future::BoxFuture<
+            'a,
+            Result<Box<dyn Iterator<Item = Result<ListPackageResponse>> + Send>>,
+        > {
+            Box::pin(async { Ok(Box::new(std::iter::empty()) as Box<_>) })
+        }
+        fn get<'a>(
+            &'a self,
+            _req: GetRequest,
+            _ct: &'a (dyn Cancellable + Send + Sync),
+        ) -> futures::future::BoxFuture<'a, std::result::Result<GetResponse, GetError>> {
+            Box::pin(async { Err(GetError::NotFound) })
+        }
+        fn probe<'a>(
+            &'a self,
+            _req: ProbeRequest,
+            _ct: &'a (dyn Cancellable + Send + Sync),
+        ) -> futures::future::BoxFuture<'a, Result<ProbeResponse>> {
+            Box::pin(async { Ok(ProbeResponse { states: vec![] }) })
+        }
+        fn functions(&self) -> Vec<ProviderFunctionDef> {
+            vec![ProviderFunctionDef {
+                name: "echo".into(),
+                signature: FnSignature {
+                    positional: vec![Param::required("msg", ParamType::String)],
+                    named: vec![Param::optional("times", ParamType::Int, Value::Int(1))],
+                    variadic: None,
+                    returns: ParamType::String,
+                },
+                doc: "Echo `msg` `times` times, prefixed by the calling package.".into(),
+                func: Arc::new(EchoFn),
+            }]
+        }
+    }
+
+    // Provider functions survive the guest→host stable-ABI round trip: the host
+    // sees the same name/signature/doc, and invoking the proxied handler carries
+    // both the arguments and the FnCallContext across the seam.
+    #[test]
+    fn provider_functions_roundtrip() {
+        use hplugin_stabby::load_stable::StableRemoteProvider;
+
+        let dynp = make_dyn_provider(Arc::new(FnProvider) as Arc<dyn Provider>);
+        let host = StableRemoteProvider::new(dynp, "mock");
+
+        // Metadata crosses: exactly one function, rendered as declared.
+        let defs = host.functions();
+        assert_eq!(defs.len(), 1);
+        let def = &defs[0];
+        assert_eq!(def.name, "echo");
+        assert_eq!(def.signature.render("echo"), "echo(msg: string, times?: int) -> string");
+        assert!(def.doc.contains("Echo `msg`"));
+
+        let root = std::path::PathBuf::from("/ws");
+        let ctx = FnCallContext {
+            pkg: "mypkg",
+            root: Path::new(&root),
+        };
+        // Default `times` (omitted) → 1; the handler reads ctx.pkg.
+        let out = futures::executor::block_on(def.func.call(
+            &ctx,
+            FnArgs {
+                positional: vec![Value::String("hi".into())],
+                named: Default::default(),
+            },
+        ))
+        .expect("call echo");
+        assert_eq!(out, Value::String("mypkg:hi".into()));
+
+        // Named arg crosses and is honored.
+        let mut named = std::collections::HashMap::new();
+        named.insert("times".to_string(), Value::Int(3));
+        let out = futures::executor::block_on(def.func.call(
+            &ctx,
+            FnArgs {
+                positional: vec![Value::String("ab".into())],
+                named,
+            },
+        ))
+        .expect("call echo times=3");
+        assert_eq!(out, Value::String("mypkg:ababab".into()));
     }
 }

--- a/crates/plugin-sdk/src/serve.rs
+++ b/crates/plugin-sdk/src/serve.rs
@@ -11,6 +11,7 @@ use anyhow::{Context, Result};
 use hcore::hartifactcontent::tar::TarPacker;
 use hcore::hartifactcontent::{Content, WalkEntry, WalkEntryKind};
 use hcore::hasync::StdCancellationToken;
+use hcore::htvalue::Value;
 use hdriver_support::driver_managed::{ManagedDriver, ManagedRunInput, ManagedRunRequest};
 use hmodel::htpkg::PkgBuf;
 use hplugin::driver::{
@@ -19,9 +20,13 @@ use hplugin::driver::{
 };
 use hplugin::provider::{
     ConfigRequest, FnArgs, FnCallContext, GetError, GetRequest, ListPackagesRequest, ListRequest,
-    ProbeRequest, Provider, ProviderExecutor,
+    ProbeRequest, Provider, ProviderExecutor, ProviderFn, ProviderFunctionDef,
+    ProviderFunctionRegistry,
 };
-use hplugin_stabby::abi::{DynExecutor, StableManagedDriver, StableProvider};
+use hplugin_stabby::abi::{
+    DynExecutor, DynFunctionRegistry, StableFunctionRegistryDyn, StableManagedDriver,
+    StableProvider,
+};
 use plugin_abi::convert;
 use plugin_abi::pb;
 use plugin_abi::pb::frame::Body;
@@ -271,16 +276,26 @@ impl StableProvider for StableProviderImpl {
             // Re-derive the def each call (cheap; provider functions are static
             // metadata). The handler is not transmissible, so it must be invoked
             // here on the guest side.
-            let def = provider.functions().into_iter().find(|d| d.name == req.name);
+            let def = provider
+                .functions()
+                .into_iter()
+                .find(|d| d.name == req.name);
             let Some(def) = def else {
-                return unary(err_body(format!("unknown provider function `{}`", req.name)));
+                return unary(err_body(format!(
+                    "unknown provider function `{}`",
+                    req.name
+                )));
             };
             let ctx = FnCallContext {
                 pkg: &req.pkg,
                 root: std::path::Path::new(&req.root),
             };
             let args = FnArgs {
-                positional: req.positional.into_iter().map(convert::value_from_pb).collect(),
+                positional: req
+                    .positional
+                    .into_iter()
+                    .map(convert::value_from_pb)
+                    .collect(),
                 named: req
                     .named
                     .into_iter()
@@ -296,6 +311,84 @@ impl StableProvider for StableProviderImpl {
             unary(body)
         })
         .into()
+    }
+
+    extern "C" fn state_schema(&self) -> SVec<u8> {
+        // Empty SVec == `None`; an encoded Schema == `Some` (see the ABI doc).
+        match self.provider.state_schema() {
+            Some(s) => SVec::from(convert::state_schema_to_pb(&s).encode_to_vec().as_slice()),
+            None => SVec::new(),
+        }
+    }
+
+    extern "C" fn set_function_registry(&self, metadata: SVec<u8>, reg: DynFunctionRegistry) {
+        let meta = pb::FunctionRegistry::decode(&metadata[..]).unwrap_or_default();
+        // Shared across every proxy handler — each dispatches back over the host
+        // callback to invoke the actual function.
+        let reg = Arc::new(reg);
+        let mut by_provider: std::collections::HashMap<String, Vec<ProviderFunctionDef>> =
+            std::collections::HashMap::new();
+        for f in meta.functions {
+            let Some(signature) = f.signature.map(convert::fn_signature_from_pb) else {
+                continue;
+            };
+            by_provider
+                .entry(f.provider.clone())
+                .or_default()
+                .push(ProviderFunctionDef {
+                    name: f.name.clone(),
+                    signature,
+                    doc: f.doc,
+                    func: Arc::new(GuestRegisteredFn {
+                        reg: Arc::clone(&reg),
+                        provider: f.provider,
+                        name: f.name,
+                    }),
+                });
+        }
+        let mut registry = ProviderFunctionRegistry::default();
+        for (provider, defs) in by_provider {
+            registry.insert_provider(&provider, defs);
+        }
+        self.provider.set_function_registry(Arc::new(registry));
+    }
+}
+
+/// Guest-side proxy for a function in the host's aggregate registry: dispatches
+/// `call_registered` back over the host callback, decoding the returned value.
+struct GuestRegisteredFn {
+    reg: Arc<DynFunctionRegistry>,
+    provider: String,
+    name: String,
+}
+
+#[async_trait::async_trait]
+impl ProviderFn for GuestRegisteredFn {
+    async fn call(&self, ctx: &FnCallContext<'_>, args: FnArgs) -> Result<Value> {
+        let pb_req = pb::CallRegisteredRequest {
+            provider: self.provider.clone(),
+            name: self.name.clone(),
+            pkg: ctx.pkg.to_string(),
+            root: ctx.root.to_string_lossy().into_owned(),
+            positional: args.positional.iter().map(convert::value_to_pb).collect(),
+            named: args
+                .named
+                .iter()
+                .map(|(k, v)| (k.clone(), convert::value_to_pb(v)))
+                .collect(),
+        }
+        .encode_to_vec();
+        let bytes = self
+            .reg
+            .call_registered(SVec::from(pb_req.as_slice()))
+            .await;
+        match pb::Frame::decode(&bytes[..])?.body {
+            Some(Body::CallFunctionResp(r)) => {
+                Ok(convert::value_from_pb(r.value.unwrap_or_default()))
+            }
+            Some(Body::Error(e)) => anyhow::bail!("{}", e.message),
+            other => anyhow::bail!("unexpected call_registered response: {other:?}"),
+        }
     }
 }
 
@@ -320,6 +413,14 @@ impl StableManagedDriver for StableManagedDriverImpl {
             .map(|r| r.name)
             .unwrap_or_default()
             .into()
+    }
+
+    extern "C" fn schema(&self) -> SVec<u8> {
+        SVec::from(
+            convert::driver_schema_to_pb(&self.driver.schema())
+                .encode_to_vec()
+                .as_slice(),
+        )
     }
 
     extern "C" fn parse<'a>(&'a self, req: SVec<u8>) -> DynFuture<'a, SVec<u8>> {
@@ -743,6 +844,17 @@ mod tests {
                 func: Arc::new(EchoFn),
             }]
         }
+        fn state_schema(&self) -> Option<hplugin::provider::StateSchema> {
+            use hplugin::provider::{StateField, StateSchema};
+            Some(StateSchema {
+                fields: vec![StateField {
+                    name: "verbose".into(),
+                    ty: ParamType::Bool,
+                    doc: "Enable verbose output for this package.".into(),
+                    required: false,
+                }],
+            })
+        }
     }
 
     // Provider functions survive the guest→host stable-ABI round trip: the host
@@ -760,7 +872,10 @@ mod tests {
         assert_eq!(defs.len(), 1);
         let def = &defs[0];
         assert_eq!(def.name, "echo");
-        assert_eq!(def.signature.render("echo"), "echo(msg: string, times?: int) -> string");
+        assert_eq!(
+            def.signature.render("echo"),
+            "echo(msg: string, times?: int) -> string"
+        );
         assert!(def.doc.contains("Echo `msg`"));
 
         let root = std::path::PathBuf::from("/ws");
@@ -791,5 +906,178 @@ mod tests {
         ))
         .expect("call echo times=3");
         assert_eq!(out, Value::String("mypkg:ababab".into()));
+
+        // The provider's state schema crosses too (Some, with its one field).
+        let schema = host.state_schema().expect("state schema crosses as Some");
+        assert_eq!(schema.fields.len(), 1);
+        assert_eq!(schema.fields[0].name, "verbose");
+        assert_eq!(schema.fields[0].ty, ParamType::Bool);
+        assert!(schema.fields[0].doc.contains("verbose output"));
+        assert!(!schema.fields[0].required);
+    }
+
+    // The host's aggregate function registry is injected into a dylib provider:
+    // the provider receives proxy handlers that dispatch back over the host
+    // callback, so invoking one reaches the real (host-side) function — args and
+    // FnCallContext included.
+    #[test]
+    fn function_registry_injection_roundtrip() {
+        use hplugin_stabby::load_stable::StableRemoteProvider;
+        use std::sync::Mutex;
+
+        // A provider that records the registry it is handed.
+        struct Recorder {
+            stored: Arc<Mutex<Option<Arc<ProviderFunctionRegistry>>>>,
+        }
+        impl Provider for Recorder {
+            fn config(&self, _req: ConfigRequest) -> Result<ConfigResponse> {
+                Ok(ConfigResponse {
+                    name: "recorder".into(),
+                })
+            }
+            fn list<'a>(
+                &'a self,
+                _req: ListRequest,
+                _ct: &'a (dyn Cancellable + Send + Sync),
+            ) -> futures::future::BoxFuture<
+                'a,
+                Result<Box<dyn Iterator<Item = Result<ListResponse>> + Send>>,
+            > {
+                Box::pin(async { Ok(Box::new(std::iter::empty()) as Box<_>) })
+            }
+            fn list_packages<'a>(
+                &'a self,
+                _req: ListPackagesRequest,
+                _ct: &'a (dyn Cancellable + Send + Sync),
+            ) -> futures::future::BoxFuture<
+                'a,
+                Result<Box<dyn Iterator<Item = Result<ListPackageResponse>> + Send>>,
+            > {
+                Box::pin(async { Ok(Box::new(std::iter::empty()) as Box<_>) })
+            }
+            fn get<'a>(
+                &'a self,
+                _req: GetRequest,
+                _ct: &'a (dyn Cancellable + Send + Sync),
+            ) -> futures::future::BoxFuture<'a, std::result::Result<GetResponse, GetError>>
+            {
+                Box::pin(async { Err(GetError::NotFound) })
+            }
+            fn probe<'a>(
+                &'a self,
+                _req: ProbeRequest,
+                _ct: &'a (dyn Cancellable + Send + Sync),
+            ) -> futures::future::BoxFuture<'a, Result<ProbeResponse>> {
+                Box::pin(async { Ok(ProbeResponse { states: vec![] }) })
+            }
+            fn set_function_registry(&self, reg: Arc<ProviderFunctionRegistry>) {
+                *self.stored.lock().unwrap() = Some(reg);
+            }
+        }
+
+        let stored = Arc::new(Mutex::new(None));
+        let recorder = Arc::new(Recorder {
+            stored: Arc::clone(&stored),
+        });
+        let dynp = make_dyn_provider(recorder as Arc<dyn Provider>);
+        let host = StableRemoteProvider::new(dynp, "recorder");
+
+        // A host-side aggregate registry holding one function under "greeter".
+        let mut reg = ProviderFunctionRegistry::default();
+        reg.insert_provider(
+            "greeter",
+            vec![ProviderFunctionDef {
+                name: "echo".into(),
+                signature: FnSignature {
+                    positional: vec![Param::required("msg", ParamType::String)],
+                    named: vec![],
+                    variadic: None,
+                    returns: ParamType::String,
+                },
+                doc: "echo".into(),
+                func: Arc::new(EchoFn),
+            }],
+        );
+        host.set_function_registry(Arc::new(reg));
+
+        // The recorder received a registry; its proxy resolves back to the host
+        // EchoFn, carrying both the arg and ctx.pkg across the (reverse) seam.
+        let received = stored.lock().unwrap().clone().expect("registry injected");
+        let rf = received.get("greeter", "echo").expect("echo registered");
+        let root = std::path::PathBuf::from("/ws");
+        let ctx = FnCallContext {
+            pkg: "callerpkg",
+            root: Path::new(&root),
+        };
+        let out = futures::executor::block_on(rf.func.call(
+            &ctx,
+            FnArgs {
+                positional: vec![Value::String("yo".into())],
+                named: Default::default(),
+            },
+        ))
+        .expect("call proxied echo");
+        assert_eq!(out, Value::String("callerpkg:yo".into()));
+    }
+
+    // A managed driver's config schema survives the round trip (LSP kwargs).
+    #[test]
+    fn driver_schema_roundtrip() {
+        use hdriver_support::driver_managed::{ManagedRunRequest, ManagedRunResponse};
+        use hplugin::driver::{DriverField, DriverSchema};
+        use hplugin_stabby::load_stable::StableRemoteManagedDriver;
+
+        struct SchemaDriver;
+        #[async_trait::async_trait]
+        impl ManagedDriver for SchemaDriver {
+            fn config(
+                &self,
+                _req: hplugin::driver::ConfigRequest,
+            ) -> Result<hplugin::driver::ConfigResponse> {
+                Ok(hplugin::driver::ConfigResponse {
+                    name: "mockdrv".into(),
+                })
+            }
+            fn schema(&self) -> DriverSchema {
+                DriverSchema {
+                    fields: vec![DriverField {
+                        name: "args".into(),
+                        ty: ParamType::list(ParamType::String),
+                        doc: "Command arguments.".into(),
+                        required: true,
+                    }],
+                }
+            }
+            async fn parse(
+                &self,
+                _req: hplugin::driver::ParseRequest,
+                _ct: &(dyn Cancellable + Send + Sync),
+            ) -> Result<hplugin::driver::ParseResponse> {
+                anyhow::bail!("unused")
+            }
+            async fn apply_transitive(
+                &self,
+                _req: hplugin::driver::ApplyTransitiveRequest,
+                _ct: &(dyn Cancellable + Send + Sync),
+            ) -> Result<hplugin::driver::ApplyTransitiveResponse> {
+                anyhow::bail!("unused")
+            }
+            async fn run<'a, 'io>(
+                &self,
+                _req: ManagedRunRequest<'a, 'io>,
+                _ct: &(dyn Cancellable + Send + Sync),
+            ) -> Result<ManagedRunResponse> {
+                anyhow::bail!("unused")
+            }
+        }
+
+        let dynd = make_dyn_managed_driver(Arc::new(SchemaDriver) as Arc<dyn ManagedDriver>);
+        let host = StableRemoteManagedDriver::new(dynd, "mockdrv");
+        let schema = host.schema();
+        assert_eq!(schema.fields.len(), 1);
+        assert_eq!(schema.fields[0].name, "args");
+        assert_eq!(schema.fields[0].ty, ParamType::list(ParamType::String));
+        assert!(schema.fields[0].required);
+        assert!(schema.fields[0].doc.contains("Command arguments"));
     }
 }

--- a/crates/plugin-stabby/src/abi.rs
+++ b/crates/plugin-stabby/src/abi.rs
@@ -127,6 +127,14 @@ pub trait StableProvider {
     extern "C" fn list_packages<'a>(&'a self, req: SVec<u8>) -> DynFuture<'a, SVec<u8>>;
     extern "C" fn get<'a>(&'a self, req: SVec<u8>, exec: DynExecutor) -> DynFuture<'a, SVec<u8>>;
     extern "C" fn probe<'a>(&'a self, req: SVec<u8>) -> DynFuture<'a, SVec<u8>>;
+    /// The BUILD-file functions this provider exposes, as prost-encoded
+    /// `pb::FunctionsResponse` bytes (metadata only — handlers stay guest-side,
+    /// reached via `call_function`). Sync: it is provider-static metadata read
+    /// once during host registry wiring, not a per-request call.
+    extern "C" fn functions(&self) -> SVec<u8>;
+    /// Invoke one exposed function by name. `req` is raw `pb::CallFunctionRequest`
+    /// bytes; the reply is a `pb::Frame` carrying `CallFunctionResp` or `Error`.
+    extern "C" fn call_function<'a>(&'a self, req: SVec<u8>) -> DynFuture<'a, SVec<u8>>;
 }
 
 /// The cold managed-driver surface (same transport contract as [`StableProvider`]).

--- a/crates/plugin-stabby/src/abi.rs
+++ b/crates/plugin-stabby/src/abi.rs
@@ -110,6 +110,21 @@ pub trait StableExecutor {
 /// plugin's `get`/`parse`.
 pub type DynExecutor = stabby::dynptr!(stabby::boxed::Box<dyn StableExecutor + Send + Sync>);
 
+/// The host's provider-function registry, called by a plugin that was handed the
+/// aggregate registry (via `set_function_registry`) and wants to invoke one of
+/// the functions in it. Mirrors a lookup + [`hplugin::provider::ProviderFn::call`]
+/// on the host side. `req` is raw `pb::CallRegisteredRequest` bytes; the reply is
+/// a `pb::Frame` carrying `CallFunctionResp` (the returned value) or `Error`.
+#[stabby::stabby]
+pub trait StableFunctionRegistry {
+    extern "C" fn call_registered<'a>(&'a self, req: SVec<u8>) -> DynFuture<'a, SVec<u8>>;
+}
+
+/// An owned, ABI-stable handle to the host's function registry — what the host
+/// passes into the plugin's `set_function_registry`.
+pub type DynFunctionRegistry =
+    stabby::dynptr!(stabby::boxed::Box<dyn StableFunctionRegistry + Send + Sync>);
+
 /// The cold provider surface, called by the host. Direct stabby vtable dispatch —
 /// no async mux, no channels, no duplex (that machinery was the entire cold-path
 /// cost; see ai-docs/PERFORMANCE.md). Requests/responses cross as prost-encoded
@@ -135,6 +150,16 @@ pub trait StableProvider {
     /// Invoke one exposed function by name. `req` is raw `pb::CallFunctionRequest`
     /// bytes; the reply is a `pb::Frame` carrying `CallFunctionResp` or `Error`.
     extern "C" fn call_function<'a>(&'a self, req: SVec<u8>) -> DynFuture<'a, SVec<u8>>;
+    /// The provider's state schema (the kwargs of `provider_state(provider=…, …)`)
+    /// as prost-encoded `pb::Schema` bytes. An EMPTY `SVec` means the provider
+    /// declares no schema (`None`); an encoded (possibly fields-empty) `Schema`
+    /// means it does. Sync provider-static metadata, like `functions`.
+    extern "C" fn state_schema(&self) -> SVec<u8>;
+    /// Hand the provider the aggregate registry of every provider's functions:
+    /// `metadata` is prost `pb::FunctionRegistry` bytes (names/signatures/docs);
+    /// `reg` is the host callback used to actually invoke any of them. Called once
+    /// before the first dispatch, mirroring [`hplugin::provider::Provider::set_function_registry`].
+    extern "C" fn set_function_registry(&self, metadata: SVec<u8>, reg: DynFunctionRegistry);
 }
 
 /// The cold managed-driver surface (same transport contract as [`StableProvider`]).
@@ -145,6 +170,9 @@ pub trait StableManagedDriver {
     extern "C" fn apply_transitive<'a>(&'a self, req: SVec<u8>) -> DynFuture<'a, SVec<u8>>;
     /// `shell` selects `run_shell` over `run`.
     extern "C" fn run<'a>(&'a self, req: SVec<u8>, shell: bool) -> DynFuture<'a, SVec<u8>>;
+    /// The driver's config schema (the driver-specific kwargs of `target(...)`)
+    /// as prost-encoded `pb::Schema` bytes. Sync driver-static metadata.
+    extern "C" fn schema(&self) -> SVec<u8>;
 }
 
 /// Owned ABI-stable handles to a loaded plugin's components.

--- a/crates/plugin-stabby/src/host.rs
+++ b/crates/plugin-stabby/src/host.rs
@@ -2,18 +2,22 @@
 //! a loaded plugin can call back via direct stabby vtable dispatch.
 
 use crate::abi::{
-    DynArtifact, DynExecutor, DynRead, NoteDepOutcome, QueryOutcome, ResultOutcome, StableAddr,
-    StableArtifactContent, StableExecutor, StableRead,
+    DynArtifact, DynExecutor, DynFunctionRegistry, DynRead, NoteDepOutcome, QueryOutcome,
+    ResultOutcome, StableAddr, StableArtifactContent, StableExecutor, StableFunctionRegistry,
+    StableRead,
 };
 use hcore::hartifactcontent::Content;
 use hmodel::htaddr::Addr;
 use hmodel::htpkg::PkgBuf;
-use hplugin::provider::ProviderExecutor;
+use hplugin::provider::{FnArgs, FnCallContext, ProviderExecutor, ProviderFunctionRegistry};
+use plugin_abi::pb::frame::Body;
+use plugin_abi::{convert, pb};
 use prost::Message;
 use stabby::future::DynFutureUnsync as DynFuture;
 use stabby::string::String as SString;
 use stabby::vec::Vec as SVec;
 use std::io::Read;
+use std::path::Path;
 use std::sync::Arc;
 
 /// Chunk size for streaming an artifact across the seam — bounds peak memory per
@@ -70,6 +74,79 @@ impl StableArtifactContent for HostArtifactContent {
 
     extern "C" fn byte_size(&self) -> u64 {
         self.content.byte_size().unwrap_or(u64::MAX)
+    }
+}
+
+/// Encode a unary `pb::Frame` reply carrying `body`.
+fn unary(body: Body) -> SVec<u8> {
+    SVec::from(
+        pb::Frame {
+            id: 0,
+            body: Some(body),
+        }
+        .encode_to_vec()
+        .as_slice(),
+    )
+}
+
+fn err_body(message: String) -> Body {
+    Body::Error(pb::Error {
+        kind: pb::error::Kind::Other as i32,
+        message,
+    })
+}
+
+/// Wraps the host's aggregate function registry; handed to a plugin as a
+/// [`DynFunctionRegistry`] so it can invoke any registered function.
+pub struct HostFunctionRegistry {
+    inner: Arc<ProviderFunctionRegistry>,
+}
+
+impl HostFunctionRegistry {
+    /// Wrap the aggregate registry as an ABI-stable [`DynFunctionRegistry`].
+    pub fn wrap(inner: Arc<ProviderFunctionRegistry>) -> DynFunctionRegistry {
+        stabby::boxed::Box::new(HostFunctionRegistry { inner }).into()
+    }
+}
+
+impl StableFunctionRegistry for HostFunctionRegistry {
+    extern "C" fn call_registered<'a>(&'a self, req: SVec<u8>) -> DynFuture<'a, SVec<u8>> {
+        stabby::boxed::Box::new(async move {
+            let req = match pb::CallRegisteredRequest::decode(&req[..]) {
+                Ok(r) => r,
+                Err(e) => return unary(err_body(format!("call_registered decode: {e}"))),
+            };
+            let Some(rf) = self.inner.get(&req.provider, &req.name) else {
+                return unary(err_body(format!(
+                    "unknown registered function `{}.{}`",
+                    req.provider, req.name
+                )));
+            };
+            let root = std::path::PathBuf::from(req.root);
+            let ctx = FnCallContext {
+                pkg: &req.pkg,
+                root: Path::new(&root),
+            };
+            let args = FnArgs {
+                positional: req
+                    .positional
+                    .into_iter()
+                    .map(convert::value_from_pb)
+                    .collect(),
+                named: req
+                    .named
+                    .into_iter()
+                    .map(|(k, v)| (k, convert::value_from_pb(v)))
+                    .collect(),
+            };
+            match rf.func.call(&ctx, args).await {
+                Ok(v) => unary(Body::CallFunctionResp(pb::CallFunctionResponse {
+                    value: Some(convert::value_to_pb(&v)),
+                })),
+                Err(e) => unary(err_body(format!("{e:#}"))),
+            }
+        })
+        .into()
     }
 }
 

--- a/crates/plugin-stabby/src/load_stable.rs
+++ b/crates/plugin-stabby/src/load_stable.rs
@@ -12,6 +12,7 @@ use crate::host::HostExecutor;
 use async_trait::async_trait;
 use futures::future::BoxFuture;
 use hcore::hasync::Cancellable;
+use hcore::htvalue::Value;
 use hdriver_support::driver_managed::{
     ManagedDriver, ManagedRunInput, ManagedRunRequest, ManagedRunResponse,
 };
@@ -21,11 +22,11 @@ use hplugin::driver::{
     ConfigResponse as DriverConfigResponse, DriverSchema, ParseRequest, ParseResponse,
     inputartifact,
 };
-use hcore::htvalue::Value;
 use hplugin::provider::{
     ConfigRequest, ConfigResponse, FnArgs, FnCallContext, GetError, GetRequest, GetResponse,
     ListPackageResponse, ListPackagesRequest, ListRequest, ListResponse, ProbeRequest,
-    ProbeResponse, Provider, ProviderFn, ProviderFunctionDef,
+    ProbeResponse, Provider, ProviderFn, ProviderFunctionDef, ProviderFunctionRegistry,
+    StateSchema,
 };
 use plugin_abi::pb::frame::Body;
 use plugin_abi::{convert, pb};
@@ -317,6 +318,35 @@ impl Provider for StableRemoteProvider {
             })
             .collect()
     }
+
+    fn state_schema(&self) -> Option<StateSchema> {
+        // An empty SVec encodes `None`; any encoded `Schema` (even fields-empty)
+        // encodes `Some`.
+        let bytes = self.inner.state_schema();
+        if bytes.is_empty() {
+            return None;
+        }
+        pb::Schema::decode(&bytes[..])
+            .ok()
+            .map(convert::state_schema_from_pb)
+    }
+
+    fn set_function_registry(&self, reg: Arc<ProviderFunctionRegistry>) {
+        // Cross the metadata once, and hand the plugin a callback to invoke any
+        // function in the aggregate registry (handlers are not transmissible).
+        let functions = reg
+            .iter()
+            .map(|(provider, name, rf)| pb::RegisteredFunction {
+                provider: provider.to_string(),
+                name: name.to_string(),
+                signature: Some(convert::fn_signature_to_pb(&rf.signature)),
+                doc: rf.doc.clone(),
+            })
+            .collect();
+        let metadata = pb::FunctionRegistry { functions }.encode_to_vec();
+        let cb = crate::host::HostFunctionRegistry::wrap(reg);
+        self.inner.set_function_registry(sv(&metadata), cb);
+    }
 }
 
 /// Proxy handler for a dylib provider function: each call encodes its args and
@@ -377,7 +407,10 @@ impl ManagedDriver for StableRemoteManagedDriver {
     }
 
     fn schema(&self) -> DriverSchema {
-        DriverSchema::default()
+        let bytes = self.inner.schema();
+        pb::Schema::decode(&bytes[..])
+            .map(convert::driver_schema_from_pb)
+            .unwrap_or_default()
     }
 
     async fn parse(

--- a/crates/plugin-stabby/src/load_stable.rs
+++ b/crates/plugin-stabby/src/load_stable.rs
@@ -21,9 +21,11 @@ use hplugin::driver::{
     ConfigResponse as DriverConfigResponse, DriverSchema, ParseRequest, ParseResponse,
     inputartifact,
 };
+use hcore::htvalue::Value;
 use hplugin::provider::{
-    ConfigRequest, ConfigResponse, GetError, GetRequest, GetResponse, ListPackageResponse,
-    ListPackagesRequest, ListRequest, ListResponse, ProbeRequest, ProbeResponse, Provider,
+    ConfigRequest, ConfigResponse, FnArgs, FnCallContext, GetError, GetRequest, GetResponse,
+    ListPackageResponse, ListPackagesRequest, ListRequest, ListResponse, ProbeRequest,
+    ProbeResponse, Provider, ProviderFn, ProviderFunctionDef,
 };
 use plugin_abi::pb::frame::Body;
 use plugin_abi::{convert, pb};
@@ -288,6 +290,64 @@ impl Provider for StableRemoteProvider {
                 other => anyhow::bail!("unexpected probe response: {other:?}"),
             }
         })
+    }
+
+    fn functions(&self) -> Vec<ProviderFunctionDef> {
+        // Sync metadata call across the seam; decode the plugin's function defs
+        // and wrap each handler in a proxy that dispatches back over the ABI.
+        let bytes = self.inner.functions();
+        let resp = match pb::FunctionsResponse::decode(&bytes[..]) {
+            Ok(r) => r,
+            // A decode failure here would be an ABI bug; surface no functions
+            // rather than poison registry wiring (which has no error channel).
+            Err(_) => return Vec::new(),
+        };
+        resp.functions
+            .into_iter()
+            .filter_map(|d| {
+                Some(ProviderFunctionDef {
+                    signature: convert::fn_signature_from_pb(d.signature?),
+                    doc: d.doc,
+                    func: Arc::new(StableRemoteFn {
+                        inner: Arc::clone(&self.inner),
+                        name: d.name.clone(),
+                    }),
+                    name: d.name,
+                })
+            })
+            .collect()
+    }
+}
+
+/// Proxy handler for a dylib provider function: each call encodes its args and
+/// the `FnCallContext`, dispatches `call_function` over the stable ABI, and
+/// decodes the returned [`Value`].
+struct StableRemoteFn {
+    inner: Arc<DynProvider>,
+    name: String,
+}
+
+#[async_trait]
+impl ProviderFn for StableRemoteFn {
+    async fn call(&self, ctx: &FnCallContext<'_>, args: FnArgs) -> anyhow::Result<Value> {
+        let pb_req = pb::CallFunctionRequest {
+            name: self.name.clone(),
+            pkg: ctx.pkg.to_string(),
+            root: ctx.root.to_string_lossy().into_owned(),
+            positional: args.positional.iter().map(convert::value_to_pb).collect(),
+            named: args
+                .named
+                .iter()
+                .map(|(k, v)| (k.clone(), convert::value_to_pb(v)))
+                .collect(),
+        }
+        .encode_to_vec();
+        let bytes = self.inner.call_function(sv(&pb_req)).await;
+        match decode_unary(&bytes)? {
+            Body::CallFunctionResp(r) => Ok(convert::value_from_pb(r.value.unwrap_or_default())),
+            Body::Error(e) => anyhow::bail!("{}", e.message),
+            other => anyhow::bail!("unexpected call_function response: {other:?}"),
+        }
     }
 }
 

--- a/proto/plugin/v1/envelope.proto
+++ b/proto/plugin/v1/envelope.proto
@@ -101,6 +101,9 @@ message Frame {
     RunResponse run_resp = 30;
     ManagedRunRequest managed_run_req = 53;
     ManagedRunResponse managed_run_resp = 54;
+    // call_function request crosses as raw CallFunctionRequest bytes (like
+    // list/get); only the response rides a frame body.
+    CallFunctionResponse call_function_resp = 55;
 
     // host-exported callbacks (plugin->host request / host->plugin response)
     ResultRequest result_req = 40;

--- a/proto/plugin/v1/provider.proto
+++ b/proto/plugin/v1/provider.proto
@@ -129,3 +129,49 @@ message CallFunctionRequest {
 message CallFunctionResponse {
   Value value = 1;
 }
+
+// ---- Schemas (provider state + driver config) ----
+//
+// One declarative keyword-arg surface, shared by provider `state_schema()`
+// (the args of `provider_state(provider=…, …)`) and driver `schema()` (the
+// driver-specific kwargs of a `target(...)`). Consumed by the BUILD-file LSP.
+
+// Mirrors provider::StateField / driver::DriverField.
+message SchemaField {
+  string name = 1;
+  ParamType ty = 2;
+  string doc = 3;
+  bool required = 4;
+}
+// Mirrors provider::StateSchema / driver::DriverSchema.
+message Schema {
+  repeated SchemaField fields = 1;
+}
+
+// ---- Function registry injection (set_function_registry) ----
+//
+// The host hands a provider the aggregate of every provider's functions. The
+// metadata (below) crosses once; handlers are reached back over the host
+// callback (`call_registered`, mirroring the executor callback).
+
+// One registered function's metadata, addressed by `provider`.`name`.
+message RegisteredFunction {
+  string provider = 1;
+  string name = 2;
+  FnSignature signature = 3;
+  string doc = 4;
+}
+message FunctionRegistry {
+  repeated RegisteredFunction functions = 1;
+}
+
+// Invoke a registered function on the host (the inverse of CallFunctionRequest:
+// the addressing carries the owning `provider`).
+message CallRegisteredRequest {
+  string provider = 1;
+  string name = 2;
+  string pkg = 3;
+  string root = 4;
+  repeated Value positional = 5;
+  map<string, Value> named = 6;
+}

--- a/proto/plugin/v1/provider.proto
+++ b/proto/plugin/v1/provider.proto
@@ -1,9 +1,9 @@
 syntax = "proto3";
 
 // Provider-exported methods. Mirrors the hplugin::Provider trait.
-// NOTE: functions()/state_schema() (BUILD-file Starlark integration) are not
-// yet modeled here; they are not on the remote data path and will be added
-// when the remote provider needs to surface provider functions.
+// NOTE: state_schema() (BUILD-file LSP integration) is not yet modeled here;
+// functions() (below) is, so dylib-wrapped providers surface their BUILD-file
+// functions to `heph inspect functions` and to BUILD evaluation.
 package heph.plugin.v1;
 
 import "plugin/v1/common.proto";
@@ -59,4 +59,73 @@ message ProbeRequest {
 }
 message ProbeResponse {
   repeated State states = 1;
+}
+
+// ---- Provider functions (BUILD-file Starlark integration) ----
+//
+// A provider exposes named functions to BUILD files as `heph.<provider>.<fn>`.
+// `functions()` returns their metadata (name/signature/doc) so the host can
+// register and render them; `call_function` invokes one by name.
+
+// Mirrors hcore::htvalue::signature::ParamType (recursive).
+message ParamType {
+  enum Scalar {
+    SCALAR_UNSPECIFIED = 0;
+    SCALAR_STRING = 1;
+    SCALAR_BOOL = 2;
+    SCALAR_INT = 3;
+    SCALAR_UINT = 4;
+    SCALAR_FLOAT = 5;
+    SCALAR_NULL = 6;
+  }
+  message Union {
+    repeated ParamType types = 1;
+  }
+  oneof kind {
+    Scalar scalar = 1;
+    ParamType list = 2; // homogeneous list element type
+    ParamType map = 3;  // string-keyed map value type
+    Union union = 4;
+  }
+}
+
+// Mirrors signature::Param. An unset `default` means the parameter is required.
+message Param {
+  string name = 1;
+  ParamType ty = 2;
+  optional Value default = 3;
+}
+
+// Mirrors signature::FnSignature.
+message FnSignature {
+  repeated Param positional = 1;
+  repeated Param named = 2;
+  optional Param variadic = 3;
+  ParamType returns = 4;
+}
+
+// Mirrors provider::ProviderFunctionDef sans its handler (which stays guest-side
+// and is reached via call_function).
+message ProviderFunctionDef {
+  string name = 1;
+  FnSignature signature = 2;
+  string doc = 3;
+}
+
+// Reply to the provider `functions()` ABI call.
+message FunctionsResponse {
+  repeated ProviderFunctionDef functions = 1;
+}
+
+// Invoke a provider function by name. `pkg`/`root` reconstruct the
+// FnCallContext; `positional`/`named` are the call arguments.
+message CallFunctionRequest {
+  string name = 1;
+  string pkg = 2;
+  string root = 3;
+  repeated Value positional = 4;
+  map<string, Value> named = 5;
+}
+message CallFunctionResponse {
+  Value value = 1;
 }


### PR DESCRIPTION
## Problem

Dylib-loaded providers/drivers are wrapped host-side by `StableRemoteProvider` / `StableRemoteManagedDriver`. Several `Provider`/`ManagedDriver` trait methods returning **metadata** had no representation on the stable ABI, so the wrappers fell back to the trait defaults — the metadata vanished once a plugin was loaded as a cdylib.

Concretely, for the go plugin (loaded as a dylib):
- `heph.go.build_addr` was absent from `heph inspect functions` and unusable in BUILD files.
- `provider_state(provider="go", …)` kwargs had no LSP completion/hover.
- the go drivers' config kwargs had no LSP docs/validation.

## Change

Model the dropped metadata on the stable ABI (host + guest + proto + conversions):

1. **`functions()` / `call_function()`** — provider BUILD-file functions. Metadata (name/signature/doc) crosses as prost bytes; handlers stay guest-side and are invoked via `call_function`, carrying args + `FnCallContext`.
2. **`state_schema()`** — provider state schema (empty bytes = `None`), for `provider_state(...)` LSP.
3. **`set_function_registry()`** — the host injects the aggregate function registry into dylib providers. Metadata crosses once; a new `StableFunctionRegistry` host callback (mirroring the executor callback) lets the plugin invoke any registered function. The guest rebuilds a `ProviderFunctionRegistry` whose handlers proxy back over that callback.
4. **driver `schema()`** — driver config schema (was hardcoded `DriverSchema::default()`), for driver-kwarg LSP.

Supporting:
- **proto**: `ParamType`/`Param`/`FnSignature`/`ProviderFunctionDef`, `SchemaField`/`Schema`, `RegisteredFunction`/`FunctionRegistry`, the function/registry request & response messages, one new `Frame` body variant.
- **plugin-abi `convert`**: `fn_signature_{to,from}_pb` (+ Param/ParamType) and `{state,driver}_schema_{to,from}_pb`. The host leaks reconstructed `Param` names to obtain the `&'static str` the in-process type wants — bounded, one-time (registry wiring is a `Once`).

Net effect: a dylib provider/driver now surfaces functions, state schema, driver schema, and participates in the function registry identically to an in-process one.

## Tests

Guest→host round-trip tests in `plugin-sdk`:
- `provider_functions_roundtrip` — metadata renders identically; invoking the proxied handler carries args + `FnCallContext` (also asserts the state schema crosses).
- `function_registry_injection_roundtrip` — a recorder provider receives the injected registry; a proxied call reaches the real host-side function (args + ctx) across the reverse seam.
- `driver_schema_roundtrip` — a driver's config schema survives the round trip.

Local gates green: `cargo clippy --all-targets --locked`, `--all-features --locked`, `cargo fmt --check`, `cargo test --all` + `plugin-stabby --features host` + `plugin-sdk --features stabby`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)