### PR TITLE
ci(plugin-abi): guard ABI_SEMVER bump on plugin ABI surface changes

### DIFF
--- a/.github/workflows/heph.yml
+++ b/.github/workflows/heph.yml
@@ -228,6 +228,22 @@ jobs:
           prerelease: true
           files: dist/*
 
+  abi:
+    name: ABI guard
+    # PR-only: it diffs the branch against the PR base. Pure git + bash, so it
+    # skips the devenv toolchain and runs in seconds.
+    if: github.event_name == 'pull_request'
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+        with:
+          # Full history so merge-base with the PR base resolves.
+          fetch-depth: 0
+      - name: Check plugin ABI version
+        run: scripts/abi-check.sh "origin/${{ github.base_ref }}"
+
   lint:
     name: Lint
     runs-on: ubuntu-latest

--- a/crates/plugin-stabby/ABI_VERSIONING.md
+++ b/crates/plugin-stabby/ABI_VERSIONING.md
@@ -1,0 +1,71 @@
+# Plugin ABI versioning
+
+The in-process stable-ABI plugin transport (`plugin-stabby`) crosses the cdylib
+boundary as native stabby vtables (hot path) + prost bytes (cold path). Host and
+plugin are compiled separately and linked at load time. The compatibility gate is
+stabby's `get_stabbied`: it verifies the plugin's type report (every type reachable
+from `CreateFn`) against the host's at load and **hard-fails on any difference**.
+So the frozen stabby surface in `crates/plugin-stabby/src/abi.rs` must not drift —
+that is what `ABI_SEMVER` (`crates/plugin-abi/src/lib.rs`) tracks.
+
+`scripts/abi-check.sh` (the `abi` job in `.github/workflows/heph.yml`, run on every
+PR) enforces this mechanically: if the frozen surface changes without `ABI_SEMVER`
+moving, the check fails.
+
+## The dispatch model — most growth is additive, no bump
+
+The cold surface is a **frozen generic dispatch**, not one vtable slot per RPC. A
+method is a `pb::ProviderMethod` / `pb::DriverMethod` id carried over the fixed
+`invoke*` slots; payloads are prost bytes. So **adding an RPC does NOT touch the
+vtable**:
+
+- New RPC = a new `ProviderMethod`/`DriverMethod` enum value + a new guest `match`
+  arm. The type report is unchanged, so an older plugin still loads; it answers an
+  unknown id with `Error{Unimplemented}` and the host falls back.
+- New cold-path wire field, new `RunInFrame`/`RunOutFrame` oneof variant, new
+  `pb::CreateConfig` field — all additive (prost ignores unknowns).
+
+**None of these need an `ABI_SEMVER` bump** and none touch `abi.rs`. This additive
+lane is the whole point of the dispatch collapse — grow capability without breaking
+old plugins. (Bump the minor only if you want to *signal* the new capability.)
+
+## When `ABI_SEMVER` MUST be bumped (major) — the frozen surface changed
+
+Any change to the native stabby surface in `crates/plugin-stabby/src/abi.rs`, i.e.
+anything `get_stabbied` would reject:
+
+- Add, remove, reorder, or re-sign a method on a `#[stabby::stabby]` trait — the
+  vtable slots: `StableProvider`, `StableManagedDriver` (the `invoke*` slots),
+  `StableExecutor`, `StableItemStream`, `StableRead`, `StableArtifactContent`,
+  `StableFunctionRegistry`, `StableMeta`, `StableCancel`.
+- Add, remove, or reorder a field on a `#[stabby::stabby]` struct: `StableAddr`,
+  `StableArg`, `NoteDepOutcome`, `ResultOutcome`, `QueryOutcome`, `NamedDriver`,
+  `PluginComponents`.
+- Change a `dynptr!` / type-alias: `DynRead`, `DynArtifact`, `DynItemStream`,
+  `DynExecutor`, `DynProvider`, `DynManagedDriver`, `DynFunctionRegistry`.
+- Rename or retype `CREATE_SYMBOL` or `CreateFn` — the entry point.
+- Change the `stabby` dependency version in any crate that links the boundary
+  (`plugin-stabby`, `plugin-sdk`, `plugin-go-cdylib`). stabby keys its type reports
+  to its own version; a mismatch fails `get_stabbied`.
+
+A **removed** or **renumbered** proto field (vs an added one) is wire-breaking →
+also major.
+
+## What does NOT require a bump
+
+- A new `ProviderMethod`/`DriverMethod` id + guest arm, a new proto field/variant —
+  the additive lane above.
+- Comments / doc changes with no layout effect.
+- Host-only (`crate::host`) or guest-only (`crate::guest`, `plugin-sdk/serve`)
+  adapter internals that don't touch the shared `abi` types.
+- Engine-internal types that never cross the seam.
+
+## Intentional breaks (pre-1.0)
+
+Below 1.0 the contract may be redefined in place without bumping (no plugins are
+released against it). To land a frozen-surface change without moving `ABI_SEMVER`,
+put `ABI-BREAK-ACK: <reason>` in a commit message on the PR — the guard treats that
+as an acknowledged break and passes. (Past 1.0, bump instead.)
+
+When in doubt, bump. A false bump is cheap; a missed real break ships a host/plugin
+pair that mismatches at load and aborts the plugin.

--- a/scripts/abi-check.sh
+++ b/scripts/abi-check.sh
@@ -1,0 +1,121 @@
+#!/usr/bin/env bash
+#
+# Guard the plugin ABI version.
+#
+# The in-process stable-ABI plugin transport links a separately-compiled host
+# and plugin at load time, so any drift in the shared layout is an ABI break.
+# `ABI_SEMVER` (crates/plugin-abi/src/lib.rs) is the contract version. If a PR
+# touches the ABI surface but leaves `ABI_SEMVER` unchanged, the host/plugin
+# pair would mismatch at load and abort the plugin — so this fails the build.
+#
+# The full rules (what is a major vs minor bump) live in
+# crates/plugin-stabby/ABI_VERSIONING.md. This script enforces the mechanical
+# part: surface changed => version must move.
+#
+# Usage: scripts/abi-check.sh [base-ref]
+#   base-ref defaults to origin/master (override in CI with the PR base).
+
+set -euo pipefail
+
+base_ref="${1:-origin/master}"
+doc="crates/plugin-stabby/ABI_VERSIONING.md"
+
+# The version constant and the native stabby surface. ANY content change to a
+# hard-surface path requires a bump — it may alter vtable/struct layout, which
+# is not something we can classify cheaply, so we conservatively force the bump
+# and let the author pick major/minor per the doc.
+version_file="crates/plugin-abi/src/lib.rs"
+hard_paths=(
+  "crates/plugin-stabby/src/abi.rs"
+)
+# stabby pins: a version change reshapes every type report -> hard ABI break.
+stabby_pin_files=(
+  "crates/plugin-stabby/Cargo.toml"
+  "crates/plugin-sdk/Cargo.toml"
+  "crates/plugin-go-cdylib/Cargo.toml"
+)
+# Cold-path wire messages: prost is lenient, additive changes are minor. We warn
+# (don't fail) so doc/comment proto edits stay quiet but real edits get a nudge.
+soft_glob="proto/plugin/v1/"
+
+# Resolve the merge-base so we compare only what this branch introduced, not
+# unrelated commits that landed on the base since it forked.
+if ! base_sha=$(git merge-base "$base_ref" HEAD 2>/dev/null); then
+  echo "abi-check: cannot resolve merge-base with '$base_ref'; skipping" >&2
+  exit 0
+fi
+
+changed=$(git diff --name-only "$base_sha" HEAD)
+
+matches() { # path, pattern...  -> true if path appears in $changed
+  local p
+  for p in "$@"; do
+    grep -qxF "$p" <<<"$changed" && return 0
+  done
+  return 1
+}
+
+# Pull the ABI_SEMVER literal out of a given revision (empty if absent).
+read_version() { # ref
+  git show "$1:$version_file" 2>/dev/null \
+    | sed -n 's/.*ABI_SEMVER[^"]*"\([^"]*\)".*/\1/p' \
+    | head -n1
+}
+
+# Pull the stabby version pin out of a given revision (first match wins; all
+# pins are kept in lockstep, so one is representative).
+read_stabby() { # ref
+  local f
+  for f in "${stabby_pin_files[@]}"; do
+    git show "$1:$f" 2>/dev/null \
+      | sed -n 's/.*stabby[^0-9]*\([0-9][0-9.]*\).*/\1/p' \
+      | head -n1 && return 0
+  done
+}
+
+base_version=$(read_version "$base_sha")
+head_version=$(read_version HEAD)
+base_stabby=$(read_stabby "$base_sha")
+head_stabby=$(read_stabby HEAD)
+
+reasons=()
+if matches "${hard_paths[@]}"; then
+  reasons+=("native stabby surface changed (${hard_paths[*]})")
+fi
+if [ "$base_stabby" != "$head_stabby" ]; then
+  reasons+=("stabby pin changed ($base_stabby -> $head_stabby)")
+fi
+
+# Pre-1.0 escape: an acknowledged intentional break (e.g. redefining the contract
+# in place before any plugin is released) carries `ABI-BREAK-ACK` in a commit
+# message on the branch. See ABI_VERSIONING.md.
+ack=""
+if git log --format='%B' "$base_sha"..HEAD 2>/dev/null | grep -q 'ABI-BREAK-ACK'; then
+  ack=1
+fi
+
+if [ ${#reasons[@]} -gt 0 ] && [ "$base_version" = "$head_version" ]; then
+  if [ -n "$ack" ]; then
+    echo "abi-check: ABI surface changed, ABI_SEMVER unchanged — ABI-BREAK-ACK present, allowing." >&2
+  else
+    echo "::error::ABI surface changed but ABI_SEMVER did not move ($head_version)" >&2
+    echo "" >&2
+    echo "abi-check: the plugin ABI changed and requires a version bump:" >&2
+    for r in "${reasons[@]}"; do echo "  - $r" >&2; done
+    echo "" >&2
+    echo "Bump ABI_SEMVER in $version_file (currently \"$head_version\"), or — for an" >&2
+    echo "intentional pre-1.0 redefine — add 'ABI-BREAK-ACK: <reason>' to a commit." >&2
+    echo "Major vs minor: see $doc" >&2
+    exit 1
+  fi
+elif [ ${#reasons[@]} -gt 0 ]; then
+  echo "abi-check: ABI surface changed; ABI_SEMVER bumped $base_version -> $head_version. OK"
+else
+  echo "abi-check: no hard ABI surface change. OK"
+fi
+
+# Soft surface: any proto/plugin/v1 edit. Non-fatal — but if it added/removed a
+# wire field, the author should bump at least the minor (see the doc).
+if grep -q "^${soft_glob}" <<<"$changed"; then
+  echo "::warning::proto/plugin/v1 changed — if a wire field was added/removed, bump ABI_SEMVER minor (see $doc)" >&2
+fi


### PR DESCRIPTION
## What

Auto-triggering CI guard (`abi` job) that fails a PR when the **frozen stable-ABI surface** changes without `ABI_SEMVER` moving — so a host/plugin pair can't silently mismatch at `get_stabbied` load.

Rebased onto current master (now includes the #94 dispatch ABI); the doc + rules describe that merged model.

## The model (post-#94)

`crates/plugin-stabby/ABI_VERSIONING.md`:
- **Additive — no bump:** a new `ProviderMethod`/`DriverMethod` id + guest `match` arm, a new proto field/oneof variant. The frozen `invoke*` vtable is untouched, so old plugins still load (and answer unknown ids with `Unimplemented`). This is the common growth lane.
- **Major — must bump (or ack):** any change to the frozen stabby surface in `abi.rs` (add/remove/reorder/re-sign a vtable slot, a struct field, a `dynptr!` alias, `CreateFn`/`CREATE_SYMBOL`) or the `stabby` pin — exactly what `get_stabbied` rejects.

## The guard

- `scripts/abi-check.sh` — diffs the branch vs base; fails if `abi.rs` or the stabby pin changed while `ABI_SEMVER` stayed put. Warns (non-fatal) on `proto/plugin/v1/` edits. Pure git+bash.
- New `abi` CI job (PR-only, plain ubuntu, no devenv).
- **Pre-1.0 escape:** an intentional in-place redefine can carry `ABI-BREAK-ACK: <reason>` in a commit message to pass without a bump (this is how #94 redefined the 0.1.0 contract).

## Verified

Guard fails on `abi.rs` change w/o bump; passes with a bump; passes with `ABI-BREAK-ACK`; clean on non-surface changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)