### PR TITLE
ci: harden nix setup against cache-restore flakes

### DIFF
--- a/.github/actions/setup-nix/action.yml
+++ b/.github/actions/setup-nix/action.yml
@@ -1,0 +1,101 @@
+name: Setup Nix + devenv
+description: >-
+  Install Nix, restore the persisted Nix store, repair/re-substitute any
+  invalid paths, install devenv, and warm the devenv shell with self-healing
+  retries so a partial or poisoned cache restore recovers instead of failing
+  the job. Optionally restores the cargo registry + sccache caches.
+
+inputs:
+  cargo-target:
+    description: >-
+      Rust target triple used to key the cargo registry + sccache caches. Leave
+      empty to skip those caches (e.g. the codegen job, which does not compile).
+    required: false
+    default: ""
+  cache-suffix:
+    description: >-
+      Extra suffix appended to the cargo/sccache cache keys so jobs that compile
+      different artifact sets (e.g. test vs build) do not clobber each other.
+    required: false
+    default: ""
+
+runs:
+  using: composite
+  steps:
+    # download-attempts/timeouts make fixed-output fetches (e.g. rust-overlay
+    # patches) retry instead of hard-failing on a transient network blip, which
+    # was a recurring "path '/nix/store/…patch' is not valid" rerun trigger.
+    # narinfo negative-ttl=0 stops a momentary "not found" from being cached for
+    # the rest of the job.
+    - uses: cachix/install-nix-action@v31
+      with:
+        extra_nix_config: |
+          fallback = true
+          connect-timeout = 20
+          download-attempts = 5
+          stalled-download-timeout = 90
+          narinfo-cache-negative-ttl = 0
+
+    # Persist the Nix store (rust-overlay toolchain, devenv env, …) across runs.
+    # Cold runners otherwise re-realize the whole toolchain every job, which
+    # intermittently fails to fetch/realize a rust-overlay patch, forcing reruns.
+    # Keyed on the devenv lock so a toolchain bump busts the cache.
+    - name: Cache Nix store
+      uses: nix-community/cache-nix-action@v6
+      with:
+        primary-key: nix-${{ runner.os }}-${{ hashFiles('devenv.lock', 'devenv.nix', 'devenv.yaml') }}
+        restore-prefixes-first-match: nix-${{ runner.os }}-
+        gc-max-store-size-linux: 5368709120
+        gc-max-store-size-macos: 5368709120
+
+    - name: Install devenv.sh
+      shell: bash
+      run: nix profile add nixpkgs#devenv
+
+    # A restored cache can be partial or corrupt — on macOS the gtar restore
+    # itself sometimes aborts mid-extraction ("Failed to restore the cache"),
+    # and the store GC can drop a fixed-output source — leaving registered-but-
+    # invalid paths. `devenv shell` then hard-fails with "Failed to get drvPath
+    # from shell derivation" / "path '/nix/store/…' is not valid" and the job
+    # needs a manual rerun. Repair (re-substitute) the store, then warm the
+    # devenv shell with retries: each failed attempt repairs again and drops the
+    # local devenv eval cache so a poisoned restore self-heals in place. On a
+    # healthy store this is a few seconds and a no-op.
+    - name: Repair store + warm devenv shell
+      shell: bash
+      run: |
+        repair() { nix-store --verify --check-contents --repair || true; }
+        repair
+        for attempt in 1 2 3; do
+          if devenv shell true; then
+            exit 0
+          fi
+          echo "::warning title=devenv shell::eval failed (attempt $attempt); repairing store and retrying"
+          repair
+          rm -rf .devenv .devenv.flake.nix 2>/dev/null || true
+        done
+        # Surface the real error if the store is still broken after retries.
+        devenv shell true
+
+    # Cargo registry/git only — crate downloads + index. Compiled artifacts are
+    # handled by sccache (below), so target/ is intentionally not cached here.
+    - name: Cargo registry cache
+      if: inputs.cargo-target != ''
+      uses: actions/cache@v5
+      with:
+        path: |
+          ~/.cargo/registry/index/
+          ~/.cargo/registry/cache/
+          ~/.cargo/git/db/
+        key: cargo-${{ inputs.cargo-target }}${{ inputs.cache-suffix }}-${{ hashFiles('**/Cargo.lock') }}
+        restore-keys: |
+          cargo-${{ inputs.cargo-target }}${{ inputs.cache-suffix }}-
+
+    - name: sccache cache
+      if: inputs.cargo-target != ''
+      uses: actions/cache@v5
+      with:
+        path: ${{ github.workspace }}/.sccache
+        key: sccache-${{ inputs.cargo-target }}${{ inputs.cache-suffix }}-${{ hashFiles('**/Cargo.lock') }}
+        restore-keys: |
+          sccache-${{ inputs.cargo-target }}${{ inputs.cache-suffix }}-

--- a/.github/workflows/heph.yml
+++ b/.github/workflows/heph.yml
@@ -64,7 +64,7 @@ jobs:
   build:
     name: Build ${{ matrix.os }}/${{ matrix.arch }}
     runs-on: ${{ matrix.runs-on }}
-    timeout-minutes: 15
+    timeout-minutes: 30
     needs: gen
     strategy:
       fail-fast: false

--- a/.github/workflows/heph.yml
+++ b/.github/workflows/heph.yml
@@ -6,6 +6,13 @@ on:
   pull_request:
     branches: ["master"]
 
+# Cancel superseded runs on a branch/PR so a new push doesn't leave the old run
+# burning runners (and showing up as a noisy "cancelled"). master is never
+# cancelled — its runs publish releases and must always finish.
+concurrency:
+  group: ci-${{ github.ref }}
+  cancel-in-progress: ${{ github.ref != 'refs/heads/master' }}
+
 # sccache config shared by every compiling job. RUSTC_WRAPPER=sccache is set by
 # the devenv shell; here we pin the cache dir to a workspace path so actions/cache
 # can persist it, and disable incremental compilation (sccache cannot cache
@@ -28,31 +35,9 @@ jobs:
         uses: actions/checkout@v6
         with:
           fetch-depth: 0
-      - uses: cachix/install-nix-action@v31
-        with:
-          extra_nix_config: fallback = true
-      # Persist the Nix store (rust-overlay toolchain, devenv env, …) across runs.
-      # Cold runners otherwise re-realize the whole toolchain every job, which
-      # intermittently fails to fetch/realize a rust-overlay patch
-      # ("path '/nix/store/…fix-kill-doctest.patch' is not valid"), forcing reruns.
-      # Keyed on the devenv lock so a toolchain bump busts the cache.
-      - name: Cache Nix store
-        uses: nix-community/cache-nix-action@v6
-        with:
-          primary-key: nix-${{ runner.os }}-${{ hashFiles('devenv.lock', 'devenv.nix', 'devenv.yaml') }}
-          restore-prefixes-first-match: nix-${{ runner.os }}-
-          gc-max-store-size-linux: 5368709120
-          gc-max-store-size-macos: 5368709120
-      # cache-nix-action occasionally restores a store with a registered-but-
-      # invalid path (e.g. a fixed-output patch source dropped by the store GC
-      # before save). The later `devenv shell` eval then hard-fails with
-      # "path '/nix/store/…' is not valid" instead of re-realizing it, forcing a
-      # manual rerun. Re-substitute any missing/invalid paths so the shell can
-      # evaluate. No-op (a few seconds) on a healthy store.
-      - name: Repair restored Nix store
-        run: nix-store --verify --check-contents --repair || true
-      - name: Install devenv.sh
-        run: nix profile add nixpkgs#devenv
+
+      - name: Setup Nix + devenv
+        uses: ./.github/actions/setup-nix
 
       - name: Compute version
         id: version
@@ -116,52 +101,10 @@ jobs:
           name: repo
           path: .
 
-      - uses: cachix/install-nix-action@v31
+      - name: Setup Nix + devenv
+        uses: ./.github/actions/setup-nix
         with:
-          extra_nix_config: fallback = true
-      # Persist the Nix store (rust-overlay toolchain, devenv env, …) across runs.
-      # Cold runners otherwise re-realize the whole toolchain every job, which
-      # intermittently fails to fetch/realize a rust-overlay patch
-      # ("path '/nix/store/…fix-kill-doctest.patch' is not valid"), forcing reruns.
-      # Keyed on the devenv lock so a toolchain bump busts the cache.
-      - name: Cache Nix store
-        uses: nix-community/cache-nix-action@v6
-        with:
-          primary-key: nix-${{ runner.os }}-${{ hashFiles('devenv.lock', 'devenv.nix', 'devenv.yaml') }}
-          restore-prefixes-first-match: nix-${{ runner.os }}-
-          gc-max-store-size-linux: 5368709120
-          gc-max-store-size-macos: 5368709120
-      # cache-nix-action occasionally restores a store with a registered-but-
-      # invalid path (e.g. a fixed-output patch source dropped by the store GC
-      # before save). The later `devenv shell` eval then hard-fails with
-      # "path '/nix/store/…' is not valid" instead of re-realizing it, forcing a
-      # manual rerun. Re-substitute any missing/invalid paths so the shell can
-      # evaluate. No-op (a few seconds) on a healthy store.
-      - name: Repair restored Nix store
-        run: nix-store --verify --check-contents --repair || true
-      - name: Install devenv.sh
-        run: nix profile add nixpkgs#devenv
-
-      # Cargo registry/git only — crate downloads + index. Compiled artifacts are
-      # handled by sccache (below), so target/ is intentionally not cached here.
-      - name: Cargo registry cache
-        uses: actions/cache@v5
-        with:
-          path: |
-            ~/.cargo/registry/index/
-            ~/.cargo/registry/cache/
-            ~/.cargo/git/db/
-          key: cargo-${{ matrix.target }}-${{ hashFiles('**/Cargo.lock') }}
-          restore-keys: |
-            cargo-${{ matrix.target }}-
-
-      - name: sccache cache
-        uses: actions/cache@v5
-        with:
-          path: ${{ github.workspace }}/.sccache
-          key: sccache-${{ matrix.target }}-${{ hashFiles('**/Cargo.lock') }}
-          restore-keys: |
-            sccache-${{ matrix.target }}-
+          cargo-target: ${{ matrix.target }}
 
       - name: Build
         id: build
@@ -297,50 +240,10 @@ jobs:
           name: repo
           path: .
 
-      - uses: cachix/install-nix-action@v31
+      - name: Setup Nix + devenv
+        uses: ./.github/actions/setup-nix
         with:
-          extra_nix_config: fallback = true
-      # Persist the Nix store (rust-overlay toolchain, devenv env, …) across runs.
-      # Cold runners otherwise re-realize the whole toolchain every job, which
-      # intermittently fails to fetch/realize a rust-overlay patch
-      # ("path '/nix/store/…fix-kill-doctest.patch' is not valid"), forcing reruns.
-      # Keyed on the devenv lock so a toolchain bump busts the cache.
-      - name: Cache Nix store
-        uses: nix-community/cache-nix-action@v6
-        with:
-          primary-key: nix-${{ runner.os }}-${{ hashFiles('devenv.lock', 'devenv.nix', 'devenv.yaml') }}
-          restore-prefixes-first-match: nix-${{ runner.os }}-
-          gc-max-store-size-linux: 5368709120
-          gc-max-store-size-macos: 5368709120
-      # cache-nix-action occasionally restores a store with a registered-but-
-      # invalid path (e.g. a fixed-output patch source dropped by the store GC
-      # before save). The later `devenv shell` eval then hard-fails with
-      # "path '/nix/store/…' is not valid" instead of re-realizing it, forcing a
-      # manual rerun. Re-substitute any missing/invalid paths so the shell can
-      # evaluate. No-op (a few seconds) on a healthy store.
-      - name: Repair restored Nix store
-        run: nix-store --verify --check-contents --repair || true
-      - name: Install devenv.sh
-        run: nix profile add nixpkgs#devenv
-
-      - name: Cargo registry cache
-        uses: actions/cache@v5
-        with:
-          path: |
-            ~/.cargo/registry/index/
-            ~/.cargo/registry/cache/
-            ~/.cargo/git/db/
-          key: cargo-x86_64-unknown-linux-gnu-${{ hashFiles('**/Cargo.lock') }}
-          restore-keys: |
-            cargo-x86_64-unknown-linux-gnu-
-
-      - name: sccache cache
-        uses: actions/cache@v5
-        with:
-          path: ${{ github.workspace }}/.sccache
-          key: sccache-x86_64-unknown-linux-gnu-${{ hashFiles('**/Cargo.lock') }}
-          restore-keys: |
-            sccache-x86_64-unknown-linux-gnu-
+          cargo-target: x86_64-unknown-linux-gnu
 
       - name: Lint
         shell: devenv shell bash -- -e {0}
@@ -378,50 +281,11 @@ jobs:
           name: repo
           path: .
 
-      - uses: cachix/install-nix-action@v31
+      - name: Setup Nix + devenv
+        uses: ./.github/actions/setup-nix
         with:
-          extra_nix_config: fallback = true
-      # Persist the Nix store (rust-overlay toolchain, devenv env, …) across runs.
-      # Cold runners otherwise re-realize the whole toolchain every job, which
-      # intermittently fails to fetch/realize a rust-overlay patch
-      # ("path '/nix/store/…fix-kill-doctest.patch' is not valid"), forcing reruns.
-      # Keyed on the devenv lock so a toolchain bump busts the cache.
-      - name: Cache Nix store
-        uses: nix-community/cache-nix-action@v6
-        with:
-          primary-key: nix-${{ runner.os }}-${{ hashFiles('devenv.lock', 'devenv.nix', 'devenv.yaml') }}
-          restore-prefixes-first-match: nix-${{ runner.os }}-
-          gc-max-store-size-linux: 5368709120
-          gc-max-store-size-macos: 5368709120
-      # cache-nix-action occasionally restores a store with a registered-but-
-      # invalid path (e.g. a fixed-output patch source dropped by the store GC
-      # before save). The later `devenv shell` eval then hard-fails with
-      # "path '/nix/store/…' is not valid" instead of re-realizing it, forcing a
-      # manual rerun. Re-substitute any missing/invalid paths so the shell can
-      # evaluate. No-op (a few seconds) on a healthy store.
-      - name: Repair restored Nix store
-        run: nix-store --verify --check-contents --repair || true
-      - name: Install devenv.sh
-        run: nix profile add nixpkgs#devenv
-
-      - name: Cargo registry cache
-        uses: actions/cache@v5
-        with:
-          path: |
-            ~/.cargo/registry/index/
-            ~/.cargo/registry/cache/
-            ~/.cargo/git/db/
-          key: cargo-${{ matrix.target }}-test-${{ hashFiles('**/Cargo.lock') }}
-          restore-keys: |
-            cargo-${{ matrix.target }}-test-
-
-      - name: sccache cache
-        uses: actions/cache@v5
-        with:
-          path: ${{ github.workspace }}/.sccache
-          key: sccache-${{ matrix.target }}-test-${{ hashFiles('**/Cargo.lock') }}
-          restore-keys: |
-            sccache-${{ matrix.target }}-test-
+          cargo-target: ${{ matrix.target }}
+          cache-suffix: "-test"
 
       # No macFUSE on the runner: the macOS binaries weak-link libfuse, so they
       # launch with the dylib absent. `support_check` finds no macfuse.fs and


### PR DESCRIPTION
## Problem

CI fails *a lot* on Nix infra rather than on code. Two recurring flake modes from the run history:

1. **macOS cache restore aborts mid-extraction** — `cache-nix-action`'s `gtar` exits 2 (`Cannot mkdir / Cannot open … No such file or directory` → `Failed to restore the cache`), leaving a partial store. The next `devenv shell` eval then hard-fails:
   ```
   ✖ Evaluating shell (failed)
   × Failed to get drvPath from shell derivation
   ##[error]Process completed with exit code 1
   ```
   → manual rerun required.
2. **Cold fixed-output fetch flake** — re-realizing the toolchain intermittently fails to fetch a rust-overlay patch (`path '/nix/store/…patch' is not valid`), with no retry.

The existing one-shot `Repair restored Nix store` step wasn't enough — a poisoned restore still took the eval down.

## Changes

Extracted the nix setup that was **duplicated across all four jobs** (`gen`, `build`, `lint`, `test`) into a shared composite action `.github/actions/setup-nix`, and hardened it:

- **Retry-tolerant nix config** — `download-attempts=5`, `connect-timeout`, `stalled-download-timeout`, so a transient network blip retries instead of failing the realize; `narinfo-cache-negative-ttl=0` so a momentary miss isn't cached for the rest of the job.
- **Self-healing devenv warm** — after repairing the store, warm `devenv shell` with retries; each failed attempt repairs again and drops the local devenv eval cache, so a partial/corrupt restore recovers **in place** instead of forcing a rerun. No-op on a healthy store.
- **Concurrency group** — a new push cancels the superseded branch/PR run (master never cancels — it publishes releases), cutting wasted runners and "cancelled" noise.

Net: 4× duplicated setup collapses to one action (`-156 / +121`).

## Scope note

Genuine flaky *tests* seen in the same history (`plugin-abi` shm, `plugin-echo`) are **out of scope** here — those are real code/test issues and should keep failing until fixed. This PR only addresses the Nix infrastructure flakes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)