### PR TITLE
refactor(plugin-stabby): collapse cold ABI to frozen prost dispatch

### DIFF
--- a/crates/core/src/hartifactcontent/mod.rs
+++ b/crates/core/src/hartifactcontent/mod.rs
@@ -51,4 +51,13 @@ pub trait Content: Send + Sync {
     fn byte_size(&self) -> Option<u64> {
         None
     }
+    /// The on-disk path backing this content, when it is a real file on the
+    /// local filesystem (e.g. an on-disk cache artifact). `None` for synthetic
+    /// or non-file backends (in-memory, sqlite blobs). Lets an in-process
+    /// consumer open the file directly instead of streaming its bytes — notably
+    /// the stable-ABI seam, where a guest can read the file rather than pulling
+    /// it chunk-by-chunk across the vtable.
+    fn file_path(&self) -> Option<std::path::PathBuf> {
+        None
+    }
 }

--- a/crates/core/src/hartifactcontent/unpack.rs
+++ b/crates/core/src/hartifactcontent/unpack.rs
@@ -78,6 +78,12 @@ pub fn unpack(
         None => None,
     };
 
+    // Many entries share a parent dir; `create_dir_all` per entry re-walks those
+    // ancestors every time (a measurable chunk of unpack — see ai-docs/PERFORMANCE.md).
+    // Skip dirs already created this unpack.
+    let mut created_dirs: std::collections::HashSet<std::path::PathBuf> =
+        std::collections::HashSet::new();
+
     for entry in content
         .walk()
         .with_context(|| format!("walk content for unpack into {:?}", dst))?
@@ -90,7 +96,9 @@ pub fn unpack(
             continue;
         }
         let dest = dst.join(&entry.path);
-        if let Some(parent) = dest.parent() {
+        if let Some(parent) = dest.parent()
+            && created_dirs.insert(parent.to_path_buf())
+        {
             fs::create_dir_all(parent).with_context(|| {
                 format!(
                     "create parent dir {:?} for unpack entry {:?} (existing={})",

--- a/crates/engine/src/engine/local_cache.rs
+++ b/crates/engine/src/engine/local_cache.rs
@@ -125,6 +125,12 @@ pub trait LocalCache: Send + Sync {
     ) -> anyhow::Result<Option<Box<dyn hartifactcontent::ReadSeek + Send>>> {
         Ok(None)
     }
+    /// The on-disk path of a cached artifact when the backend is a real
+    /// filesystem (so an in-process consumer can open it directly). `None` for
+    /// non-file backends. Defaults to `None`.
+    fn file_path(&self, _addr: &Addr, _hashin: &str, _name: &str) -> Option<std::path::PathBuf> {
+        None
+    }
 }
 
 #[derive(Debug, thiserror::Error)]
@@ -182,6 +188,10 @@ impl hartifactcontent::Content for CacheArtifact {
 
     fn byte_size(&self) -> Option<u64> {
         Some(self.size)
+    }
+
+    fn file_path(&self) -> Option<std::path::PathBuf> {
+        self.cache.file_path(&self.addr, &self.hashin, &self.name)
     }
 }
 

--- a/crates/engine/src/engine/local_cache_fs.rs
+++ b/crates/engine/src/engine/local_cache_fs.rs
@@ -138,6 +138,10 @@ impl LocalCache for LocalCacheFS {
             }
         }
     }
+
+    fn file_path(&self, addr: &Addr, hashin: &str, name: &str) -> Option<PathBuf> {
+        Some(self.get_path(addr, hashin, name))
+    }
 }
 
 /// Recursively walk `dir`; for each `__target_*` directory (one per target),

--- a/crates/engine/src/engine/plugin_load.rs
+++ b/crates/engine/src/engine/plugin_load.rs
@@ -16,17 +16,20 @@ impl Engine {
     /// host, and register the provider + drivers it exports (the plugin
     /// self-describes its names via `config()`).
     pub fn register_plugins(&mut self, plugins: &[config_yaml::PluginSpec]) -> anyhow::Result<()> {
-        let mut manifests: Vec<(config_yaml::PluginIdentifier, Vec<u8>)> = Vec::new();
+        let mut manifests: Vec<(
+            config_yaml::PluginIdentifier,
+            std::collections::HashMap<String, hplugin_abi::pb::Value>,
+        )> = Vec::new();
         for spec in plugins {
             match &spec.identifier {
                 config_yaml::PluginIdentifier::Builtin(name) => self
                     .apply_builtin(name, &spec.options)
                     .with_context(|| format!("apply builtin plugin `{name}`"))?,
-                // Manifest plugin: encode options once (pb::Value bytes) for the
-                // cdylib's create entry, resolve + load below.
+                // Manifest plugin: carry the options as structured pb map data for
+                // the cdylib's create entry (pb::CreateConfig), resolve + load below.
                 _ => manifests.push((
                     spec.identifier.clone(),
-                    hplugin_abi::convert::options_to_pb_bytes(&spec.options),
+                    hplugin_abi::convert::options_to_pb_map(&spec.options),
                 )),
             }
         }
@@ -64,7 +67,10 @@ fn load_dylib_plugins(
     e: &mut Engine,
     root: &std::path::Path,
     home_dir: &std::path::Path,
-    manifests: Vec<(config_yaml::PluginIdentifier, Vec<u8>)>,
+    manifests: Vec<(
+        config_yaml::PluginIdentifier,
+        std::collections::HashMap<String, hplugin_abi::pb::Value>,
+    )>,
 ) -> anyhow::Result<()> {
     use rayon::prelude::*;
 
@@ -75,9 +81,9 @@ fn load_dylib_plugins(
     let home_str = home_dir.to_string_lossy().into_owned();
     let loaded = manifests
         .into_par_iter()
-        .map(|(src, options_pb)| -> anyhow::Result<_> {
+        .map(|(src, options)| -> anyhow::Result<_> {
             let dylib = resolve_manifest_dylib(&src, root)?;
-            hplugin_stabby::load_stable::load(&dylib, &root_str, &home_str, &options_pb)
+            hplugin_stabby::load_stable::load(&dylib, &root_str, &home_str, options)
                 .with_context(|| format!("load plugin dylib {}", dylib.display()))
         })
         .collect::<anyhow::Result<Vec<_>>>()?;

--- a/crates/plugin-abi/src/convert.rs
+++ b/crates/plugin-abi/src/convert.rs
@@ -293,37 +293,29 @@ fn pb_to_yaml(v: pb::Value) -> serde_yaml::Value {
     }
 }
 
-/// Encode a plugin `options:` map to `pb::Value` (Map) prost bytes for the ABI.
-pub fn options_to_pb_bytes(opts: &BTreeMap<String, serde_yaml::Value>) -> Vec<u8> {
-    use prost::Message;
-    let map = pb::value::Map {
-        entries: opts
-            .iter()
-            .map(|(k, v)| (k.clone(), yaml_to_pb(v)))
-            .collect(),
-    };
-    pb::Value {
-        kind: Some(pb::value::Kind::MapVal(map)),
-    }
-    .encode_to_vec()
+/// A plugin `options:` map as structured `pb::CreateConfig.options` data (each
+/// value a `pb::Value`) — no nested encode, the map is a field of `CreateConfig`.
+pub fn options_to_pb_map(
+    opts: &BTreeMap<String, serde_yaml::Value>,
+) -> std::collections::HashMap<String, pb::Value> {
+    opts.iter()
+        .map(|(k, v)| (k.clone(), yaml_to_pb(v)))
+        .collect()
 }
 
-/// Decode ABI options bytes back into a plugin `options:` map. Non-map / empty
-/// payloads decode to an empty map.
-pub fn options_from_pb_bytes(bytes: &[u8]) -> anyhow::Result<BTreeMap<String, serde_yaml::Value>> {
+/// Convert the structured `CreateConfig.options` map back into a plugin
+/// `options:` map.
+pub fn options_from_pb_map(
+    map: std::collections::HashMap<String, pb::Value>,
+) -> BTreeMap<String, serde_yaml::Value> {
+    map.into_iter().map(|(k, v)| (k, pb_to_yaml(v))).collect()
+}
+
+/// Decode the cdylib create-entry config from its prost bytes (the SDK exposes
+/// this so plugin authors decode `CreateConfig` without depending on prost).
+pub fn create_config_from_bytes(bytes: &[u8]) -> anyhow::Result<pb::CreateConfig> {
     use prost::Message;
-    if bytes.is_empty() {
-        return Ok(BTreeMap::new());
-    }
-    let v = pb::Value::decode(bytes).context("decode plugin options pb::Value")?;
-    match v.kind {
-        Some(pb::value::Kind::MapVal(m)) => Ok(m
-            .entries
-            .into_iter()
-            .map(|(k, v)| (k, pb_to_yaml(v)))
-            .collect()),
-        _ => Ok(BTreeMap::new()),
-    }
+    pb::CreateConfig::decode(bytes).context("decode CreateConfig")
 }
 
 // ---- State ----
@@ -878,9 +870,9 @@ mod tests {
     }
 
     #[test]
-    fn options_pb_bytes_roundtrip() {
-        // A plugin options map crosses the ABI as pb::Value bytes and decodes back
-        // unchanged — covering scalars, nesting, and a list.
+    fn options_pb_map_roundtrip() {
+        // A plugin options map crosses the ABI as structured CreateConfig.options
+        // and converts back unchanged — covering scalars, nesting, and a list.
         let yaml = r#"
 gotool: "//@heph/bin:go"
 parallel: 4
@@ -889,15 +881,15 @@ nested: { a: 1, b: [x, y] }
 "#;
         let opts: BTreeMap<String, serde_yaml::Value> =
             serde_yaml::from_str(yaml).expect("parse opts");
-        let bytes = options_to_pb_bytes(&opts);
-        let back = options_from_pb_bytes(&bytes).expect("decode opts");
+        let map = options_to_pb_map(&opts);
+        let back = options_from_pb_map(map);
         assert_eq!(back, opts);
 
         // Typed decode through the same path a plugin author uses.
         let gotool: String = serde_yaml::from_value(back["gotool"].clone()).expect("gotool");
         assert_eq!(gotool, "//@heph/bin:go");
 
-        // Empty payload decodes to an empty map (absent options).
-        assert!(options_from_pb_bytes(&[]).expect("empty").is_empty());
+        // Empty map converts to an empty options map (absent options).
+        assert!(options_from_pb_map(Default::default()).is_empty());
     }
 }

--- a/crates/plugin-go-cdylib/src/lib.rs
+++ b/crates/plugin-go-cdylib/src/lib.rs
@@ -11,16 +11,19 @@
 
 use hdriver_support::driver_managed::ManagedDriver;
 use hplugin_go::plugingo::{GoEmbedDriver, GoGolistDriver, GoTestmainDriver, Provider};
-use plugin_sdk::stabby::abi::{CreateConfig, NamedDriver, PluginComponents};
-use plugin_sdk::stabby::{make_dyn_managed_driver, make_dyn_provider};
+use plugin_sdk::stabby::abi::{NamedDriver, PluginComponents};
+use plugin_sdk::stabby::{
+    create_config_from_bytes, make_dyn_managed_driver, make_dyn_provider, options_from_pb_map,
+};
 use std::path::PathBuf;
 use std::sync::Arc;
 
 /// Stable ABI create entry. `#[stabby::export]` emits the type-report symbols the
-/// host's `get_stabbied` checks for ABI compatibility.
+/// host's `get_stabbied` checks for ABI compatibility. `cfg` is prost-encoded
+/// `pb::CreateConfig` bytes, so config fields are additive across versions.
 #[stabby::export]
-pub extern "C" fn heph_plugin_create(cfg: CreateConfig) -> PluginComponents {
-    match build(cfg) {
+pub extern "C" fn heph_plugin_create(cfg: stabby::vec::Vec<u8>) -> PluginComponents {
+    match build(&cfg) {
         Ok(c) => c,
         Err(e) => {
             // No safe way to surface an error through the stable bundle (it must
@@ -32,13 +35,14 @@ pub extern "C" fn heph_plugin_create(cfg: CreateConfig) -> PluginComponents {
     }
 }
 
-fn build(cfg: CreateConfig) -> anyhow::Result<PluginComponents> {
-    let root = PathBuf::from(cfg.root.to_string());
-    let home = PathBuf::from(cfg.home.to_string());
+fn build(cfg: &[u8]) -> anyhow::Result<PluginComponents> {
+    let cfg = create_config_from_bytes(cfg)?;
+    let root = PathBuf::from(cfg.root);
+    let home = PathBuf::from(cfg.home);
 
-    // Tunables come from the plugin's `options:` map (config yaml), decoded the
-    // same way an in-process plugin reads its options.
-    let mut options = plugin_sdk::stabby::options_from_pb_bytes(&cfg.options[..])?;
+    // Tunables come from the plugin's `options:` map (config yaml), carried as
+    // structured CreateConfig data — read the same way an in-process plugin does.
+    let mut options = options_from_pb_map(cfg.options);
     // The golist driver needs the same go binary addr the provider resolves from
     // its `gotool` option — peek it here (non-destructive; the provider still
     // reads it) so there's a single source of truth, no separate `go_bin` knob.
@@ -77,5 +81,7 @@ fn build(cfg: CreateConfig) -> anyhow::Result<PluginComponents> {
         provider_name: "go".into(),
         provider: make_dyn_provider(provider),
         drivers,
+        // No return-side metadata to report yet.
+        meta: stabby::vec::Vec::new(),
     })
 }

--- a/crates/plugin-sdk/src/guest.rs
+++ b/crates/plugin-sdk/src/guest.rs
@@ -2,7 +2,7 @@
 //! ProviderExecutor`] so plugin code calls back exactly as in-process — the calls
 //! are direct stabby vtable dispatch into the host, no serialization.
 
-use anyhow::Result;
+use anyhow::{Context, Result};
 use futures::future::BoxFuture;
 use hcore::hartifactcontent::{Content, WalkEntry};
 use hmodel::htaddr::Addr;
@@ -127,12 +127,33 @@ struct StableContent {
 
 impl Content for StableContent {
     fn reader(&self) -> Result<Box<dyn Read>> {
+        // In-process: if the host artifact is a real on-disk file, open it
+        // directly — no per-chunk hop across the seam. Empty path => stream over
+        // the handle (synthetic / non-file content).
+        let p = self.handle.path();
+        if !p.is_empty() {
+            return Ok(Box::new(
+                std::fs::File::open(&*p).with_context(|| format!("open artifact file {p}"))?,
+            ));
+        }
         Ok(Box::new(GuestRead::new(self.handle.open())))
     }
     fn walk(&self) -> Result<Box<dyn Iterator<Item = Result<WalkEntry>> + '_>> {
         Ok(Box::new(hcore::hartifactcontent::tar::TarWalker::new(
             self.reader()?,
         )?))
+    }
+    fn seekable_reader(
+        &self,
+    ) -> Result<Option<Box<dyn hcore::hartifactcontent::ReadSeek + Send>>> {
+        // A file-backed artifact is seekable directly; the stream handle is not.
+        let p = self.handle.path();
+        if p.is_empty() {
+            return Ok(None);
+        }
+        Ok(Some(Box::new(
+            std::fs::File::open(&*p).with_context(|| format!("open artifact file {p}"))?,
+        )))
     }
     fn hashout(&self) -> Result<String> {
         Ok(self.handle.hashout().to_string())
@@ -267,6 +288,89 @@ mod tests {
             .unwrap()
             .read_to_end(&mut buf2)
             .unwrap();
+        assert_eq!(buf2, big_payload());
+    }
+
+    struct MockExecFile {
+        path: std::path::PathBuf,
+    }
+    impl ProviderExecutor for MockExecFile {
+        fn note_dep<'a>(&'a self, _addr: &'a Addr) -> BoxFuture<'a, Result<()>> {
+            Box::pin(async { Ok(()) })
+        }
+        fn result<'a>(&'a self, _addr: &'a Addr) -> BoxFuture<'a, Result<Arc<EResult>>> {
+            let path = self.path.clone();
+            Box::pin(async move {
+                Ok(Arc::new(EResult {
+                    artifacts: vec![Arc::new(FileBacked { path }) as Arc<dyn Content>],
+                    support_artifacts: vec![],
+                    artifacts_meta: vec![ArtifactMeta {
+                        hashout: "h2".into(),
+                    }],
+                }))
+            })
+        }
+        fn query<'a>(
+            &'a self,
+            _m: &'a Matcher,
+            _s: &'a [String],
+        ) -> BoxFuture<'a, Result<Vec<Addr>>> {
+            Box::pin(async { Ok(vec![]) })
+        }
+    }
+
+    /// A file-backed artifact: its byte stream deliberately errors, so reading it
+    /// at all proves the consumer went through `file_path`, not `reader()`/`open()`.
+    struct FileBacked {
+        path: std::path::PathBuf,
+    }
+    impl Content for FileBacked {
+        fn reader(&self) -> Result<Box<dyn Read>> {
+            anyhow::bail!("file-backed artifact must be read via file_path, not the stream")
+        }
+        fn walk(&self) -> Result<Box<dyn Iterator<Item = Result<WalkEntry>> + '_>> {
+            anyhow::bail!("no walk in test")
+        }
+        fn hashout(&self) -> Result<String> {
+            Ok("h2".into())
+        }
+        fn file_path(&self) -> Option<std::path::PathBuf> {
+            Some(self.path.clone())
+        }
+    }
+
+    // A file-backed result artifact crosses the seam as a PATH: the guest opens the
+    // real file directly rather than streaming chunks over the vtable. (The host
+    // Content's stream bails, so any successful read proves the path was used.)
+    #[test]
+    fn file_backed_artifact_reads_from_disk_not_stream() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let path = dir.path().join("art.bin");
+        std::fs::write(&path, big_payload()).expect("write artifact");
+
+        let mock = Arc::new(MockExecFile { path });
+        let dynexec = HostExecutor::wrap(mock as Arc<dyn ProviderExecutor>);
+        let guest = GuestExecutor::new(dynexec);
+        let addr = parse_addr("//pkg/a:b").expect("parse addr");
+
+        let eres = futures::executor::block_on(guest.result(&addr)).expect("result");
+        assert_eq!(eres.artifacts.len(), 1);
+
+        let mut buf = Vec::new();
+        eres.artifacts[0]
+            .reader()
+            .expect("reader opens the file directly")
+            .read_to_end(&mut buf)
+            .expect("read");
+        assert_eq!(buf, big_payload(), "bytes must match the on-disk file");
+
+        // seekable_reader() also serves the real file (enables tar-index/FUSE paths).
+        let mut seek = eres.artifacts[0]
+            .seekable_reader()
+            .expect("seekable_reader")
+            .expect("Some for file-backed");
+        let mut buf2 = Vec::new();
+        seek.read_to_end(&mut buf2).expect("read seekable");
         assert_eq!(buf2, big_payload());
     }
 }

--- a/crates/plugin-sdk/src/guest.rs
+++ b/crates/plugin-sdk/src/guest.rs
@@ -143,9 +143,7 @@ impl Content for StableContent {
             self.reader()?,
         )?))
     }
-    fn seekable_reader(
-        &self,
-    ) -> Result<Option<Box<dyn hcore::hartifactcontent::ReadSeek + Send>>> {
+    fn seekable_reader(&self) -> Result<Option<Box<dyn hcore::hartifactcontent::ReadSeek + Send>>> {
         // A file-backed artifact is seekable directly; the stream handle is not.
         let p = self.handle.path();
         if p.is_empty() {

--- a/crates/plugin-sdk/src/lib.rs
+++ b/crates/plugin-sdk/src/lib.rs
@@ -33,10 +33,11 @@ pub mod stabby {
     pub use crate::guest::GuestExecutor;
     pub use crate::serve::{make_dyn_managed_driver, make_dyn_provider};
 
-    /// Decode a plugin's `options:` map from the `CreateConfig.options` bytes
-    /// (a `pb::Value` map). Authors then read typed values via
-    /// [`hplugin::config::decode_opt`], exactly as in-process plugins do.
-    pub use plugin_abi::convert::options_from_pb_bytes;
+    /// Decode the cdylib create-entry config (`pb::CreateConfig`) from its prost
+    /// bytes, and convert its structured `options` map into a plugin `options:`
+    /// map. Authors then read typed values via [`hplugin::config::decode_opt`],
+    /// exactly as in-process plugins do.
+    pub use plugin_abi::convert::{create_config_from_bytes, options_from_pb_map};
 
     /// The ABI version this transport builds against.
     pub use plugin_abi::ABI_SEMVER;

--- a/crates/plugin-sdk/src/serve.rs
+++ b/crates/plugin-sdk/src/serve.rs
@@ -24,15 +24,14 @@ use hplugin::provider::{
     ProviderFunctionRegistry,
 };
 use hplugin_stabby::abi::{
-    DynExecutor, DynFunctionRegistry, StableFunctionRegistryDyn, StableManagedDriver,
-    StableProvider,
+    DynExecutor, DynFunctionRegistry, RunIo, StableFunctionRegistryDyn, StableManagedDriver,
+    StableMeta, StableProvider,
 };
 use plugin_abi::convert;
 use plugin_abi::pb;
 use plugin_abi::pb::frame::Body;
 use prost::Message;
 use stabby::future::DynFutureUnsync as DynFuture;
-use stabby::string::String as SString;
 use stabby::vec::Vec as SVec;
 use std::io::Read;
 use std::path::PathBuf;
@@ -120,237 +119,281 @@ pub struct StableProviderImpl {
     pub provider: Arc<dyn Provider>,
 }
 
-impl StableProvider for StableProviderImpl {
-    extern "C" fn config(&self) -> SString {
-        self.provider
-            .config(ConfigRequest {})
-            .map(|r| r.name)
-            .unwrap_or_default()
-            .into()
-    }
+/// Unary reply for a dispatch method the plugin does not implement. A newer host
+/// calling a method this (older) plugin predates gets this back and falls back —
+/// the mechanism that keeps added dispatch methods additive (see ABI_VERSIONING.md).
+fn unimplemented(method: u32) -> SVec<u8> {
+    unary(Body::Error(pb::Error {
+        kind: pb::error::Kind::Unimplemented as i32,
+        message: format!("dispatch method {method} not implemented"),
+    }))
+}
 
-    extern "C" fn list<'a>(&'a self, req: SVec<u8>) -> DynFuture<'a, SVec<u8>> {
-        let provider = Arc::clone(&self.provider);
-        stabby::boxed::Box::new(async move {
-            let req = pb::ListRequest::decode(&req[..]).unwrap_or_default();
-            let tok = StdCancellationToken::new();
-            let lreq = ListRequest {
-                request_id: req.request_id,
-                package: PkgBuf::from(req.package),
-                states: req.states.into_iter().map(convert::state_from_pb).collect(),
-            };
-            let mut bodies = Vec::new();
-            match provider.list(lreq, &tok).await {
-                Ok(iter) => {
-                    for item in iter {
-                        match item {
-                            Ok(lr) => bodies.push(Body::StreamItem(pb::StreamItem {
-                                item: pb::ListResponse {
-                                    addr: Some(convert::addr_to_pb(&lr.addr)),
-                                }
-                                .encode_to_vec()
-                                .into(),
-                            })),
-                            Err(e) => {
-                                bodies.push(stream_err(e.to_string()));
-                                return stream(bodies);
-                            }
+// ---- Provider RPC bodies (moved verbatim out of the old per-method vtable slots
+// into helpers; the dispatch impls below route method ids to them) ----
+
+async fn provider_list(provider: Arc<dyn Provider>, req: SVec<u8>) -> SVec<u8> {
+    let req = pb::ListRequest::decode(&req[..]).unwrap_or_default();
+    let tok = StdCancellationToken::new();
+    let lreq = ListRequest {
+        request_id: req.request_id,
+        package: PkgBuf::from(req.package),
+        states: req.states.into_iter().map(convert::state_from_pb).collect(),
+    };
+    let mut bodies = Vec::new();
+    match provider.list(lreq, &tok).await {
+        Ok(iter) => {
+            for item in iter {
+                match item {
+                    Ok(lr) => bodies.push(Body::StreamItem(pb::StreamItem {
+                        item: pb::ListResponse {
+                            addr: Some(convert::addr_to_pb(&lr.addr)),
                         }
+                        .encode_to_vec()
+                        .into(),
+                    })),
+                    Err(e) => {
+                        bodies.push(stream_err(e.to_string()));
+                        return stream(bodies);
                     }
-                    bodies.push(Body::StreamEnd(pb::StreamEnd { error: None }));
                 }
-                Err(e) => bodies.push(stream_err(e.to_string())),
             }
-            stream(bodies)
-        })
-        .into()
+            bodies.push(Body::StreamEnd(pb::StreamEnd { error: None }));
+        }
+        Err(e) => bodies.push(stream_err(e.to_string())),
     }
+    stream(bodies)
+}
 
-    extern "C" fn list_packages<'a>(&'a self, req: SVec<u8>) -> DynFuture<'a, SVec<u8>> {
-        let provider = Arc::clone(&self.provider);
-        stabby::boxed::Box::new(async move {
-            let req = pb::ListPackagesRequest::decode(&req[..]).unwrap_or_default();
-            let tok = StdCancellationToken::new();
-            let lreq = ListPackagesRequest {
-                prefix: PkgBuf::from(req.prefix),
-            };
-            let mut bodies = Vec::new();
-            match provider.list_packages(lreq, &tok).await {
-                Ok(iter) => {
-                    for item in iter {
-                        match item {
-                            Ok(lpr) => bodies.push(Body::StreamItem(pb::StreamItem {
-                                item: pb::ListPackageResponse {
-                                    pkg: lpr.pkg.as_str().to_string(),
-                                }
-                                .encode_to_vec()
-                                .into(),
-                            })),
-                            Err(e) => {
-                                bodies.push(stream_err(e.to_string()));
-                                return stream(bodies);
-                            }
+async fn provider_list_packages(provider: Arc<dyn Provider>, req: SVec<u8>) -> SVec<u8> {
+    let req = pb::ListPackagesRequest::decode(&req[..]).unwrap_or_default();
+    let tok = StdCancellationToken::new();
+    let lreq = ListPackagesRequest {
+        prefix: PkgBuf::from(req.prefix),
+    };
+    let mut bodies = Vec::new();
+    match provider.list_packages(lreq, &tok).await {
+        Ok(iter) => {
+            for item in iter {
+                match item {
+                    Ok(lpr) => bodies.push(Body::StreamItem(pb::StreamItem {
+                        item: pb::ListPackageResponse {
+                            pkg: lpr.pkg.as_str().to_string(),
                         }
+                        .encode_to_vec()
+                        .into(),
+                    })),
+                    Err(e) => {
+                        bodies.push(stream_err(e.to_string()));
+                        return stream(bodies);
                     }
-                    bodies.push(Body::StreamEnd(pb::StreamEnd { error: None }));
                 }
-                Err(e) => bodies.push(stream_err(e.to_string())),
             }
-            stream(bodies)
-        })
-        .into()
+            bodies.push(Body::StreamEnd(pb::StreamEnd { error: None }));
+        }
+        Err(e) => bodies.push(stream_err(e.to_string())),
     }
+    stream(bodies)
+}
 
-    extern "C" fn get<'a>(&'a self, req: SVec<u8>, exec: DynExecutor) -> DynFuture<'a, SVec<u8>> {
-        let provider = Arc::clone(&self.provider);
-        stabby::boxed::Box::new(async move {
-            let req = pb::GetRequest::decode(&req[..]).unwrap_or_default();
-            let executor: Arc<dyn ProviderExecutor> = Arc::new(GuestExecutor::new(exec));
-            let tok = StdCancellationToken::new();
-            let greq = GetRequest {
-                request_id: req.request_id,
-                addr: convert::addr_from_pb(req.addr.unwrap_or_default()),
-                states: req.states.into_iter().map(convert::state_from_pb).collect(),
-                executor,
-            };
-            let body = match provider.get(greq, &tok).await {
-                Ok(gr) => Body::GetResp(pb::GetResponse {
-                    target_spec: Some(convert::target_spec_to_pb(&gr.target_spec)),
-                }),
-                Err(GetError::NotFound) => Body::GetErr(pb::GetError {
-                    kind: pb::get_error::Kind::NotFound as i32,
-                    message: String::new(),
-                }),
-                Err(GetError::Other(e)) => Body::GetErr(pb::GetError {
-                    kind: get_error_kind(&e) as i32,
-                    message: e.to_string(),
-                }),
-            };
-            unary(body)
-        })
-        .into()
-    }
+async fn provider_get(provider: Arc<dyn Provider>, req: SVec<u8>, exec: DynExecutor) -> SVec<u8> {
+    let req = pb::GetRequest::decode(&req[..]).unwrap_or_default();
+    let executor: Arc<dyn ProviderExecutor> = Arc::new(GuestExecutor::new(exec));
+    let tok = StdCancellationToken::new();
+    let greq = GetRequest {
+        request_id: req.request_id,
+        addr: convert::addr_from_pb(req.addr.unwrap_or_default()),
+        states: req.states.into_iter().map(convert::state_from_pb).collect(),
+        executor,
+    };
+    let body = match provider.get(greq, &tok).await {
+        Ok(gr) => Body::GetResp(pb::GetResponse {
+            target_spec: Some(convert::target_spec_to_pb(&gr.target_spec)),
+        }),
+        Err(GetError::NotFound) => Body::GetErr(pb::GetError {
+            kind: pb::get_error::Kind::NotFound as i32,
+            message: String::new(),
+        }),
+        Err(GetError::Other(e)) => Body::GetErr(pb::GetError {
+            kind: get_error_kind(&e) as i32,
+            message: e.to_string(),
+        }),
+    };
+    unary(body)
+}
 
-    extern "C" fn probe<'a>(&'a self, req: SVec<u8>) -> DynFuture<'a, SVec<u8>> {
-        let provider = Arc::clone(&self.provider);
-        stabby::boxed::Box::new(async move {
-            let req = pb::ProbeRequest::decode(&req[..]).unwrap_or_default();
-            let tok = StdCancellationToken::new();
-            let preq = ProbeRequest {
-                request_id: req.request_id,
-                package: PkgBuf::from(req.package),
-            };
-            let body = match provider.probe(preq, &tok).await {
-                Ok(pr) => Body::ProbeResp(pb::ProbeResponse {
-                    states: pr.states.iter().map(convert::state_to_pb).collect(),
-                }),
-                Err(e) => err_body(e.to_string()),
-            };
-            unary(body)
-        })
-        .into()
-    }
+async fn provider_probe(provider: Arc<dyn Provider>, req: SVec<u8>) -> SVec<u8> {
+    let req = pb::ProbeRequest::decode(&req[..]).unwrap_or_default();
+    let tok = StdCancellationToken::new();
+    let preq = ProbeRequest {
+        request_id: req.request_id,
+        package: PkgBuf::from(req.package),
+    };
+    let body = match provider.probe(preq, &tok).await {
+        Ok(pr) => Body::ProbeResp(pb::ProbeResponse {
+            states: pr.states.iter().map(convert::state_to_pb).collect(),
+        }),
+        Err(e) => err_body(e.to_string()),
+    };
+    unary(body)
+}
 
-    extern "C" fn functions(&self) -> SVec<u8> {
-        let functions = self
-            .provider
-            .functions()
+async fn provider_call_function(provider: Arc<dyn Provider>, req: SVec<u8>) -> SVec<u8> {
+    let req = pb::CallFunctionRequest::decode(&req[..]).unwrap_or_default();
+    // Re-derive the def each call (cheap; provider functions are static
+    // metadata). The handler is not transmissible, so it must be invoked
+    // here on the guest side.
+    let def = provider
+        .functions()
+        .into_iter()
+        .find(|d| d.name == req.name);
+    let Some(def) = def else {
+        return unary(err_body(format!("unknown provider function `{}`", req.name)));
+    };
+    let ctx = FnCallContext {
+        pkg: &req.pkg,
+        root: std::path::Path::new(&req.root),
+    };
+    let args = FnArgs {
+        positional: req
+            .positional
             .into_iter()
-            .map(|d| pb::ProviderFunctionDef {
-                name: d.name,
-                signature: Some(convert::fn_signature_to_pb(&d.signature)),
-                doc: d.doc,
-            })
-            .collect();
-        SVec::from(
-            pb::FunctionsResponse { functions }
-                .encode_to_vec()
-                .as_slice(),
-        )
-    }
+            .map(convert::value_from_pb)
+            .collect(),
+        named: req
+            .named
+            .into_iter()
+            .map(|(k, v)| (k, convert::value_from_pb(v)))
+            .collect(),
+    };
+    let body = match def.func.call(&ctx, args).await {
+        Ok(v) => Body::CallFunctionResp(pb::CallFunctionResponse {
+            value: Some(convert::value_to_pb(&v)),
+        }),
+        Err(e) => err_body(format!("{e:#}")),
+    };
+    unary(body)
+}
 
-    extern "C" fn call_function<'a>(&'a self, req: SVec<u8>) -> DynFuture<'a, SVec<u8>> {
+// Sync metadata helpers. Each returns the metadatum's RAW prost bytes (NOT a
+// `Frame` — matching the prior `functions()`/`state_schema()`/`config()` wire).
+
+fn provider_config(provider: &Arc<dyn Provider>) -> SVec<u8> {
+    let name = provider
+        .config(ConfigRequest {})
+        .map(|r| r.name)
+        .unwrap_or_default();
+    SVec::from(pb::ConfigResponse { name }.encode_to_vec().as_slice())
+}
+
+fn provider_functions(provider: &Arc<dyn Provider>) -> SVec<u8> {
+    let functions = provider
+        .functions()
+        .into_iter()
+        .map(|d| pb::ProviderFunctionDef {
+            name: d.name,
+            signature: Some(convert::fn_signature_to_pb(&d.signature)),
+            doc: d.doc,
+        })
+        .collect();
+    SVec::from(
+        pb::FunctionsResponse { functions }
+            .encode_to_vec()
+            .as_slice(),
+    )
+}
+
+fn provider_state_schema(provider: &Arc<dyn Provider>) -> SVec<u8> {
+    // Empty SVec == `None`; an encoded Schema == `Some` (see the ABI doc).
+    match provider.state_schema() {
+        Some(s) => SVec::from(convert::state_schema_to_pb(&s).encode_to_vec().as_slice()),
+        None => SVec::new(),
+    }
+}
+
+fn provider_set_registry(provider: &Arc<dyn Provider>, metadata: SVec<u8>, reg: DynFunctionRegistry) {
+    let meta = pb::FunctionRegistry::decode(&metadata[..]).unwrap_or_default();
+    // Shared across every proxy handler — each dispatches back over the host
+    // callback to invoke the actual function.
+    let reg = Arc::new(reg);
+    let mut by_provider: std::collections::HashMap<String, Vec<ProviderFunctionDef>> =
+        std::collections::HashMap::new();
+    for f in meta.functions {
+        let Some(signature) = f.signature.map(convert::fn_signature_from_pb) else {
+            continue;
+        };
+        by_provider
+            .entry(f.provider.clone())
+            .or_default()
+            .push(ProviderFunctionDef {
+                name: f.name.clone(),
+                signature,
+                doc: f.doc,
+                func: Arc::new(GuestRegisteredFn {
+                    reg: Arc::clone(&reg),
+                    provider: f.provider,
+                    name: f.name,
+                }),
+            });
+    }
+    let mut registry = ProviderFunctionRegistry::default();
+    for (provider_name, defs) in by_provider {
+        registry.insert_provider(&provider_name, defs);
+    }
+    provider.set_function_registry(Arc::new(registry));
+}
+
+impl StableMeta for StableProviderImpl {
+    extern "C" fn meta(&self, kind: u32) -> SVec<u8> {
+        match pb::ProviderMethod::try_from(kind as i32) {
+            Ok(pb::ProviderMethod::Config) => provider_config(&self.provider),
+            Ok(pb::ProviderMethod::Functions) => provider_functions(&self.provider),
+            Ok(pb::ProviderMethod::StateSchema) => provider_state_schema(&self.provider),
+            // Unknown sync metadatum: empty == "none", never a hard failure.
+            _ => SVec::new(),
+        }
+    }
+}
+
+impl StableProvider for StableProviderImpl {
+    extern "C" fn invoke<'a>(&'a self, method: u32, req: SVec<u8>) -> DynFuture<'a, SVec<u8>> {
         let provider = Arc::clone(&self.provider);
         stabby::boxed::Box::new(async move {
-            let req = pb::CallFunctionRequest::decode(&req[..]).unwrap_or_default();
-            // Re-derive the def each call (cheap; provider functions are static
-            // metadata). The handler is not transmissible, so it must be invoked
-            // here on the guest side.
-            let def = provider
-                .functions()
-                .into_iter()
-                .find(|d| d.name == req.name);
-            let Some(def) = def else {
-                return unary(err_body(format!(
-                    "unknown provider function `{}`",
-                    req.name
-                )));
-            };
-            let ctx = FnCallContext {
-                pkg: &req.pkg,
-                root: std::path::Path::new(&req.root),
-            };
-            let args = FnArgs {
-                positional: req
-                    .positional
-                    .into_iter()
-                    .map(convert::value_from_pb)
-                    .collect(),
-                named: req
-                    .named
-                    .into_iter()
-                    .map(|(k, v)| (k, convert::value_from_pb(v)))
-                    .collect(),
-            };
-            let body = match def.func.call(&ctx, args).await {
-                Ok(v) => Body::CallFunctionResp(pb::CallFunctionResponse {
-                    value: Some(convert::value_to_pb(&v)),
-                }),
-                Err(e) => err_body(format!("{e:#}")),
-            };
-            unary(body)
+            match pb::ProviderMethod::try_from(method as i32) {
+                Ok(pb::ProviderMethod::List) => provider_list(provider, req).await,
+                Ok(pb::ProviderMethod::ListPackages) => provider_list_packages(provider, req).await,
+                Ok(pb::ProviderMethod::Probe) => provider_probe(provider, req).await,
+                Ok(pb::ProviderMethod::CallFunction) => provider_call_function(provider, req).await,
+                _ => unimplemented(method),
+            }
         })
         .into()
     }
 
-    extern "C" fn state_schema(&self) -> SVec<u8> {
-        // Empty SVec == `None`; an encoded Schema == `Some` (see the ABI doc).
-        match self.provider.state_schema() {
-            Some(s) => SVec::from(convert::state_schema_to_pb(&s).encode_to_vec().as_slice()),
-            None => SVec::new(),
-        }
+    extern "C" fn invoke_exec<'a>(
+        &'a self,
+        method: u32,
+        req: SVec<u8>,
+        exec: DynExecutor,
+    ) -> DynFuture<'a, SVec<u8>> {
+        let provider = Arc::clone(&self.provider);
+        stabby::boxed::Box::new(async move {
+            match pb::ProviderMethod::try_from(method as i32) {
+                Ok(pb::ProviderMethod::Get) => provider_get(provider, req, exec).await,
+                _ => unimplemented(method),
+            }
+        })
+        .into()
     }
 
-    extern "C" fn set_function_registry(&self, metadata: SVec<u8>, reg: DynFunctionRegistry) {
-        let meta = pb::FunctionRegistry::decode(&metadata[..]).unwrap_or_default();
-        // Shared across every proxy handler — each dispatches back over the host
-        // callback to invoke the actual function.
-        let reg = Arc::new(reg);
-        let mut by_provider: std::collections::HashMap<String, Vec<ProviderFunctionDef>> =
-            std::collections::HashMap::new();
-        for f in meta.functions {
-            let Some(signature) = f.signature.map(convert::fn_signature_from_pb) else {
-                continue;
-            };
-            by_provider
-                .entry(f.provider.clone())
-                .or_default()
-                .push(ProviderFunctionDef {
-                    name: f.name.clone(),
-                    signature,
-                    doc: f.doc,
-                    func: Arc::new(GuestRegisteredFn {
-                        reg: Arc::clone(&reg),
-                        provider: f.provider,
-                        name: f.name,
-                    }),
-                });
+    extern "C" fn invoke_registry(&self, method: u32, req: SVec<u8>, reg: DynFunctionRegistry) {
+        // Only SetFunctionRegistry rides this slot today; an unknown id has no
+        // return channel, so the handle is simply dropped.
+        if let Ok(pb::ProviderMethod::SetFunctionRegistry) =
+            pb::ProviderMethod::try_from(method as i32)
+        {
+            provider_set_registry(&self.provider, req, reg);
         }
-        let mut registry = ProviderFunctionRegistry::default();
-        for (provider, defs) in by_provider {
-            registry.insert_provider(&provider, defs);
-        }
-        self.provider.set_function_registry(Arc::new(registry));
     }
 }
 
@@ -406,96 +449,127 @@ pub struct StableManagedDriverImpl {
     pub driver: Arc<dyn ManagedDriver>,
 }
 
+fn driver_config(driver: &Arc<dyn ManagedDriver>) -> SVec<u8> {
+    let name = driver
+        .config(DriverConfigRequest {})
+        .map(|r| r.name)
+        .unwrap_or_default();
+    SVec::from(pb::ConfigResponse { name }.encode_to_vec().as_slice())
+}
+
+fn driver_schema(driver: &Arc<dyn ManagedDriver>) -> SVec<u8> {
+    SVec::from(
+        convert::driver_schema_to_pb(&driver.schema())
+            .encode_to_vec()
+            .as_slice(),
+    )
+}
+
+async fn driver_parse(driver: Arc<dyn ManagedDriver>, req: SVec<u8>) -> SVec<u8> {
+    let req = pb::ParseRequest::decode(&req[..]).unwrap_or_default();
+    let tok = StdCancellationToken::new();
+    let preq = ParseRequest {
+        request_id: req.request_id,
+        target_spec: Arc::new(convert::target_spec_from_pb(
+            req.target_spec.unwrap_or_default(),
+        )),
+    };
+    let body = match driver.parse(preq, &tok).await {
+        Ok(resp) => match convert::target_def_to_pb(&resp.target_def) {
+            Ok(td) => Body::ParseResp(pb::ParseResponse {
+                target_def: Some(td),
+            }),
+            Err(e) => err_body(e.to_string()),
+        },
+        Err(e) => err_body(e.to_string()),
+    };
+    unary(body)
+}
+
+async fn driver_apply_transitive(driver: Arc<dyn ManagedDriver>, req: SVec<u8>) -> SVec<u8> {
+    let req = pb::ApplyTransitiveRequest::decode(&req[..]).unwrap_or_default();
+    let tok = StdCancellationToken::new();
+    let target_def = match convert::target_def_from_pb(req.target_def.unwrap_or_default()) {
+        Ok(td) => td,
+        Err(e) => return unary(err_body(e.to_string())),
+    };
+    let areq = ApplyTransitiveRequest {
+        request_id: req.request_id,
+        target_def,
+        sandbox: convert::sandbox_from_pb(req.sandbox.unwrap_or_default()),
+    };
+    let body = match driver.apply_transitive(areq, &tok).await {
+        Ok(resp) => match convert::target_def_to_pb(&resp.target_def) {
+            Ok(td) => Body::ApplyTransitiveResp(pb::ApplyTransitiveResponse {
+                target_def: Some(td),
+            }),
+            Err(e) => err_body(e.to_string()),
+        },
+        Err(e) => err_body(e.to_string()),
+    };
+    unary(body)
+}
+
+impl StableMeta for StableManagedDriverImpl {
+    extern "C" fn meta(&self, kind: u32) -> SVec<u8> {
+        match pb::DriverMethod::try_from(kind as i32) {
+            Ok(pb::DriverMethod::Config) => driver_config(&self.driver),
+            Ok(pb::DriverMethod::Schema) => driver_schema(&self.driver),
+            _ => SVec::new(),
+        }
+    }
+}
+
 impl StableManagedDriver for StableManagedDriverImpl {
-    extern "C" fn config(&self) -> SString {
-        self.driver
-            .config(DriverConfigRequest {})
-            .map(|r| r.name)
-            .unwrap_or_default()
-            .into()
-    }
-
-    extern "C" fn schema(&self) -> SVec<u8> {
-        SVec::from(
-            convert::driver_schema_to_pb(&self.driver.schema())
-                .encode_to_vec()
-                .as_slice(),
-        )
-    }
-
-    extern "C" fn parse<'a>(&'a self, req: SVec<u8>) -> DynFuture<'a, SVec<u8>> {
+    extern "C" fn invoke<'a>(&'a self, method: u32, req: SVec<u8>) -> DynFuture<'a, SVec<u8>> {
         let driver = Arc::clone(&self.driver);
         stabby::boxed::Box::new(async move {
-            let req = pb::ParseRequest::decode(&req[..]).unwrap_or_default();
-            let tok = StdCancellationToken::new();
-            let preq = ParseRequest {
-                request_id: req.request_id,
-                target_spec: Arc::new(convert::target_spec_from_pb(
-                    req.target_spec.unwrap_or_default(),
-                )),
-            };
-            let body = match driver.parse(preq, &tok).await {
-                Ok(resp) => match convert::target_def_to_pb(&resp.target_def) {
-                    Ok(td) => Body::ParseResp(pb::ParseResponse {
-                        target_def: Some(td),
-                    }),
-                    Err(e) => err_body(e.to_string()),
-                },
-                Err(e) => err_body(e.to_string()),
-            };
-            unary(body)
+            match pb::DriverMethod::try_from(method as i32) {
+                Ok(pb::DriverMethod::Parse) => driver_parse(driver, req).await,
+                Ok(pb::DriverMethod::ApplyTransitive) => {
+                    driver_apply_transitive(driver, req).await
+                }
+                _ => unimplemented(method),
+            }
         })
         .into()
     }
 
-    extern "C" fn apply_transitive<'a>(&'a self, req: SVec<u8>) -> DynFuture<'a, SVec<u8>> {
+    extern "C" fn invoke_io<'a>(
+        &'a self,
+        method: u32,
+        req: SVec<u8>,
+        // The native stdio rails. Frozen and accepted now; live stdin/stdout/stderr
+        // streaming will populate these (see RunIo). Today's `run` inherits stdio at
+        // spawn, so the handles are unused and dropped here.
+        _io: RunIo,
+    ) -> DynFuture<'a, SVec<u8>> {
         let driver = Arc::clone(&self.driver);
         stabby::boxed::Box::new(async move {
-            let req = pb::ApplyTransitiveRequest::decode(&req[..]).unwrap_or_default();
-            let tok = StdCancellationToken::new();
-            let target_def = match convert::target_def_from_pb(req.target_def.unwrap_or_default()) {
-                Ok(td) => td,
-                Err(e) => return unary(err_body(e.to_string())),
-            };
-            let areq = ApplyTransitiveRequest {
-                request_id: req.request_id,
-                target_def,
-                sandbox: convert::sandbox_from_pb(req.sandbox.unwrap_or_default()),
-            };
-            let body = match driver.apply_transitive(areq, &tok).await {
-                Ok(resp) => match convert::target_def_to_pb(&resp.target_def) {
-                    Ok(td) => Body::ApplyTransitiveResp(pb::ApplyTransitiveResponse {
-                        target_def: Some(td),
-                    }),
-                    Err(e) => err_body(e.to_string()),
-                },
-                Err(e) => err_body(e.to_string()),
-            };
-            unary(body)
-        })
-        .into()
-    }
-
-    extern "C" fn run<'a>(&'a self, req: SVec<u8>, shell: bool) -> DynFuture<'a, SVec<u8>> {
-        let driver = Arc::clone(&self.driver);
-        stabby::boxed::Box::new(async move {
-            // `run` shells out via the reactor — execute on the cdylib's own
-            // runtime, bridge the result back to the host's polling task.
-            let (tx, rx) = tokio::sync::oneshot::channel();
-            cdylib_runtime().spawn(async move {
-                // Receiver dropped only if the host gave up; ignore send failure.
-                drop(tx.send(run_impl(driver, req, shell).await));
-            });
-            rx.await
-                .unwrap_or_else(|_| unary(err_body("cdylib run task dropped".into())))
+            match pb::DriverMethod::try_from(method as i32) {
+                Ok(pb::DriverMethod::Run) => {
+                    // `run` shells out via the reactor — execute on the cdylib's own
+                    // runtime, bridge the result back to the host's polling task.
+                    let (tx, rx) = tokio::sync::oneshot::channel();
+                    cdylib_runtime().spawn(async move {
+                        // Receiver dropped only if the host gave up; ignore send failure.
+                        drop(tx.send(run_impl(driver, req).await));
+                    });
+                    rx.await
+                        .unwrap_or_else(|_| unary(err_body("cdylib run task dropped".into())))
+                }
+                _ => unimplemented(method),
+            }
         })
         .into()
     }
 }
 
-async fn run_impl(driver: Arc<dyn ManagedDriver>, req: SVec<u8>, shell: bool) -> SVec<u8> {
+async fn run_impl(driver: Arc<dyn ManagedDriver>, req: SVec<u8>) -> SVec<u8> {
     let req = pb::ManagedRunRequest::decode(&req[..]).unwrap_or_default();
     let tok = StdCancellationToken::new();
+    // `shell` selects run_shell over run; it rides the request now (not a slot arg).
+    let shell = req.shell;
     let target = match convert::target_def_from_pb(req.target.unwrap_or_default()) {
         Ok(t) => t,
         Err(e) => return unary(err_body(e.to_string())),
@@ -854,6 +928,28 @@ mod tests {
                     required: false,
                 }],
             })
+        }
+    }
+
+    // The additive-compat contract: a dispatch method id this plugin does not
+    // know (a newer host calling a method this build predates) returns
+    // Error{Unimplemented} rather than crashing. This is what lets the host add
+    // RPC methods without an ABI break — the frozen vtable still loads, and the
+    // old guest answers unknown ids gracefully.
+    #[test]
+    fn unknown_dispatch_method_is_unimplemented() {
+        use hplugin_stabby::abi::StableProviderDyn;
+
+        let dynp = make_dyn_provider(Arc::new(FnProvider) as Arc<dyn Provider>);
+        // 9999 is not a ProviderMethod value (none assigned).
+        let bytes = futures::executor::block_on(dynp.invoke(9999, SVec::new()));
+        match pb::Frame::decode(&bytes[..]).expect("frame").body {
+            Some(Body::Error(e)) => assert_eq!(
+                e.kind,
+                pb::error::Kind::Unimplemented as i32,
+                "unknown method must report Unimplemented"
+            ),
+            other => panic!("expected Unimplemented error, got {other:?}"),
         }
     }
 

--- a/crates/plugin-sdk/src/serve.rs
+++ b/crates/plugin-sdk/src/serve.rs
@@ -24,9 +24,11 @@ use hplugin::provider::{
     ProviderFunctionRegistry,
 };
 use hplugin_stabby::abi::{
-    DynExecutor, DynFunctionRegistry, DynItemStream, RunIo, StableFunctionRegistryDyn,
-    StableItemStream, StableManagedDriver, StableMeta, StableProvider,
+    DynExecutor, DynFunctionRegistry, DynItemStream, StableCancel, StableFunctionRegistryDyn,
+    StableItemStream, StableItemStreamDyn, StableManagedDriver, StableMeta, StableProvider,
 };
+use std::collections::{HashMap, HashSet};
+use std::sync::Mutex;
 use plugin_abi::convert;
 use plugin_abi::pb;
 use plugin_abi::pb::frame::Body;
@@ -171,19 +173,112 @@ fn get_error_kind(e: &anyhow::Error) -> pb::get_error::Kind {
 /// Wrap a real provider as an ABI-stable [`hplugin_stabby::abi::DynProvider`] handle
 /// (in-process; the cdylib entry produces the same handle across the boundary).
 pub fn make_dyn_provider(provider: Arc<dyn Provider>) -> hplugin_stabby::abi::DynProvider {
-    stabby::boxed::Box::new(StableProviderImpl { provider }).into()
+    stabby::boxed::Box::new(StableProviderImpl {
+        provider,
+        cancels: Arc::new(CancelRegistry::default()),
+    })
+    .into()
 }
 
 /// Wrap a real managed driver as an ABI-stable [`hplugin_stabby::abi::DynManagedDriver`].
 pub fn make_dyn_managed_driver(
     driver: Arc<dyn ManagedDriver>,
 ) -> hplugin_stabby::abi::DynManagedDriver {
-    stabby::boxed::Box::new(StableManagedDriverImpl { driver }).into()
+    stabby::boxed::Box::new(StableManagedDriverImpl {
+        driver,
+        cancels: Arc::new(CancelRegistry::default()),
+    })
+    .into()
+}
+
+/// In-flight calls keyed by `request_id`, so [`StableCancel::cancel`] can trip the
+/// token a running call handed the provider/driver. A cancel that races ahead of
+/// its call (arrives before the call registers) is parked in `precancelled` and
+/// applied when the call enters — so it is never lost.
+#[derive(Default)]
+struct CancelRegistry {
+    inflight: Mutex<HashMap<String, StdCancellationToken>>,
+    precancelled: Mutex<HashSet<String>>,
+}
+
+impl CancelRegistry {
+    /// Register a fresh token for `id` and return a guard that deregisters on drop.
+    /// An empty id (no cancellation wired for this call) is a no-op passthrough.
+    fn enter(self: &Arc<Self>, id: &str) -> CancelGuard {
+        let token = StdCancellationToken::new();
+        if !id.is_empty() {
+            if self
+                .precancelled
+                .lock()
+                .unwrap_or_else(|e| e.into_inner())
+                .remove(id)
+            {
+                token.cancel();
+            }
+            self.inflight
+                .lock()
+                .unwrap_or_else(|e| e.into_inner())
+                .insert(id.to_string(), token.clone());
+        }
+        CancelGuard {
+            reg: Arc::clone(self),
+            id: id.to_string(),
+            token,
+        }
+    }
+
+    fn cancel(&self, id: &str) {
+        if id.is_empty() {
+            return;
+        }
+        let map = self.inflight.lock().unwrap_or_else(|e| e.into_inner());
+        if let Some(t) = map.get(id) {
+            t.cancel();
+        } else {
+            drop(map);
+            self.precancelled
+                .lock()
+                .unwrap_or_else(|e| e.into_inner())
+                .insert(id.to_string());
+        }
+    }
+}
+
+/// Holds a call's cancellation token registered; deregisters on drop.
+struct CancelGuard {
+    reg: Arc<CancelRegistry>,
+    id: String,
+    token: StdCancellationToken,
+}
+
+impl CancelGuard {
+    fn token(&self) -> &StdCancellationToken {
+        &self.token
+    }
+}
+
+impl Drop for CancelGuard {
+    fn drop(&mut self) {
+        if !self.id.is_empty() {
+            self.reg
+                .inflight
+                .lock()
+                .unwrap_or_else(|e| e.into_inner())
+                .remove(&self.id);
+        }
+    }
 }
 
 /// Wraps an author `Provider` as a [`StableProvider`].
 pub struct StableProviderImpl {
     pub provider: Arc<dyn Provider>,
+    cancels: Arc<CancelRegistry>,
+}
+
+impl StableCancel for StableProviderImpl {
+    extern "C" fn cancel(&self, request_id: stabby::string::String) {
+        self.cancels.cancel(&request_id);
+    }
 }
 
 /// Unary reply for a dispatch method the plugin does not implement. A newer host
@@ -238,17 +333,22 @@ async fn provider_list_packages_stream(provider: Arc<dyn Provider>, req: SVec<u8
     }
 }
 
-async fn provider_get(provider: Arc<dyn Provider>, req: SVec<u8>, exec: DynExecutor) -> SVec<u8> {
+async fn provider_get(
+    provider: Arc<dyn Provider>,
+    req: SVec<u8>,
+    exec: DynExecutor,
+    cancels: Arc<CancelRegistry>,
+) -> SVec<u8> {
     let req = pb::GetRequest::decode(&req[..]).unwrap_or_default();
     let executor: Arc<dyn ProviderExecutor> = Arc::new(GuestExecutor::new(exec));
-    let tok = StdCancellationToken::new();
+    let guard = cancels.enter(&req.request_id);
     let greq = GetRequest {
         request_id: req.request_id,
         addr: convert::addr_from_pb(req.addr.unwrap_or_default()),
         states: req.states.into_iter().map(convert::state_from_pb).collect(),
         executor,
     };
-    let body = match provider.get(greq, &tok).await {
+    let body = match provider.get(greq, guard.token()).await {
         Ok(gr) => Body::GetResp(pb::GetResponse {
             target_spec: Some(convert::target_spec_to_pb(&gr.target_spec)),
         }),
@@ -264,14 +364,18 @@ async fn provider_get(provider: Arc<dyn Provider>, req: SVec<u8>, exec: DynExecu
     unary(body)
 }
 
-async fn provider_probe(provider: Arc<dyn Provider>, req: SVec<u8>) -> SVec<u8> {
+async fn provider_probe(
+    provider: Arc<dyn Provider>,
+    req: SVec<u8>,
+    cancels: Arc<CancelRegistry>,
+) -> SVec<u8> {
     let req = pb::ProbeRequest::decode(&req[..]).unwrap_or_default();
-    let tok = StdCancellationToken::new();
+    let guard = cancels.enter(&req.request_id);
     let preq = ProbeRequest {
         request_id: req.request_id,
         package: PkgBuf::from(req.package),
     };
-    let body = match provider.probe(preq, &tok).await {
+    let body = match provider.probe(preq, guard.token()).await {
         Ok(pr) => Body::ProbeResp(pb::ProbeResponse {
             states: pr.states.iter().map(convert::state_to_pb).collect(),
         }),
@@ -400,9 +504,10 @@ impl StableMeta for StableProviderImpl {
 impl StableProvider for StableProviderImpl {
     extern "C" fn invoke<'a>(&'a self, method: u32, req: SVec<u8>) -> DynFuture<'a, SVec<u8>> {
         let provider = Arc::clone(&self.provider);
+        let cancels = Arc::clone(&self.cancels);
         stabby::boxed::Box::new(async move {
             match pb::ProviderMethod::try_from(method as i32) {
-                Ok(pb::ProviderMethod::Probe) => provider_probe(provider, req).await,
+                Ok(pb::ProviderMethod::Probe) => provider_probe(provider, req, cancels).await,
                 Ok(pb::ProviderMethod::CallFunction) => provider_call_function(provider, req).await,
                 _ => unimplemented(method),
             }
@@ -452,9 +557,10 @@ impl StableProvider for StableProviderImpl {
         exec: DynExecutor,
     ) -> DynFuture<'a, SVec<u8>> {
         let provider = Arc::clone(&self.provider);
+        let cancels = Arc::clone(&self.cancels);
         stabby::boxed::Box::new(async move {
             match pb::ProviderMethod::try_from(method as i32) {
-                Ok(pb::ProviderMethod::Get) => provider_get(provider, req, exec).await,
+                Ok(pb::ProviderMethod::Get) => provider_get(provider, req, exec, cancels).await,
                 _ => unimplemented(method),
             }
         })
@@ -522,6 +628,13 @@ fn stream_err(message: String) -> Body {
 /// Wraps an author `ManagedDriver` as a [`StableManagedDriver`].
 pub struct StableManagedDriverImpl {
     pub driver: Arc<dyn ManagedDriver>,
+    cancels: Arc<CancelRegistry>,
+}
+
+impl StableCancel for StableManagedDriverImpl {
+    extern "C" fn cancel(&self, request_id: stabby::string::String) {
+        self.cancels.cancel(&request_id);
+    }
 }
 
 fn driver_config(driver: &Arc<dyn ManagedDriver>) -> SVec<u8> {
@@ -540,16 +653,20 @@ fn driver_schema(driver: &Arc<dyn ManagedDriver>) -> SVec<u8> {
     )
 }
 
-async fn driver_parse(driver: Arc<dyn ManagedDriver>, req: SVec<u8>) -> SVec<u8> {
+async fn driver_parse(
+    driver: Arc<dyn ManagedDriver>,
+    req: SVec<u8>,
+    cancels: Arc<CancelRegistry>,
+) -> SVec<u8> {
     let req = pb::ParseRequest::decode(&req[..]).unwrap_or_default();
-    let tok = StdCancellationToken::new();
+    let guard = cancels.enter(&req.request_id);
     let preq = ParseRequest {
         request_id: req.request_id,
         target_spec: Arc::new(convert::target_spec_from_pb(
             req.target_spec.unwrap_or_default(),
         )),
     };
-    let body = match driver.parse(preq, &tok).await {
+    let body = match driver.parse(preq, guard.token()).await {
         Ok(resp) => match convert::target_def_to_pb(&resp.target_def) {
             Ok(td) => Body::ParseResp(pb::ParseResponse {
                 target_def: Some(td),
@@ -561,9 +678,13 @@ async fn driver_parse(driver: Arc<dyn ManagedDriver>, req: SVec<u8>) -> SVec<u8>
     unary(body)
 }
 
-async fn driver_apply_transitive(driver: Arc<dyn ManagedDriver>, req: SVec<u8>) -> SVec<u8> {
+async fn driver_apply_transitive(
+    driver: Arc<dyn ManagedDriver>,
+    req: SVec<u8>,
+    cancels: Arc<CancelRegistry>,
+) -> SVec<u8> {
     let req = pb::ApplyTransitiveRequest::decode(&req[..]).unwrap_or_default();
-    let tok = StdCancellationToken::new();
+    let guard = cancels.enter(&req.request_id);
     let target_def = match convert::target_def_from_pb(req.target_def.unwrap_or_default()) {
         Ok(td) => td,
         Err(e) => return unary(err_body(e.to_string())),
@@ -573,7 +694,7 @@ async fn driver_apply_transitive(driver: Arc<dyn ManagedDriver>, req: SVec<u8>) 
         target_def,
         sandbox: convert::sandbox_from_pb(req.sandbox.unwrap_or_default()),
     };
-    let body = match driver.apply_transitive(areq, &tok).await {
+    let body = match driver.apply_transitive(areq, guard.token()).await {
         Ok(resp) => match convert::target_def_to_pb(&resp.target_def) {
             Ok(td) => Body::ApplyTransitiveResp(pb::ApplyTransitiveResponse {
                 target_def: Some(td),
@@ -598,11 +719,12 @@ impl StableMeta for StableManagedDriverImpl {
 impl StableManagedDriver for StableManagedDriverImpl {
     extern "C" fn invoke<'a>(&'a self, method: u32, req: SVec<u8>) -> DynFuture<'a, SVec<u8>> {
         let driver = Arc::clone(&self.driver);
+        let cancels = Arc::clone(&self.cancels);
         stabby::boxed::Box::new(async move {
             match pb::DriverMethod::try_from(method as i32) {
-                Ok(pb::DriverMethod::Parse) => driver_parse(driver, req).await,
+                Ok(pb::DriverMethod::Parse) => driver_parse(driver, req, cancels).await,
                 Ok(pb::DriverMethod::ApplyTransitive) => {
-                    driver_apply_transitive(driver, req).await
+                    driver_apply_transitive(driver, req, cancels).await
                 }
                 _ => unimplemented(method),
             }
@@ -610,8 +732,7 @@ impl StableManagedDriver for StableManagedDriverImpl {
         .into()
     }
 
-    // No streaming driver RPC yet; the cardinality slots are frozen and provisioned,
-    // answering Unimplemented until a method id rides them.
+    // No unary->stream or stream->unary driver RPC yet; provisioned, Unimplemented.
     extern "C" fn invoke_server_stream<'a>(
         &'a self,
         method: u32,
@@ -628,52 +749,100 @@ impl StableManagedDriver for StableManagedDriverImpl {
         stabby::boxed::Box::new(async move { unimplemented(method) }).into()
     }
 
+    // `run` is the one bidi RPC: request stream = RunInFrame (run request, then live
+    // stdin), response stream = RunOutFrame (live stdout/stderr, then the result).
     extern "C" fn invoke_bidi<'a>(
         &'a self,
         method: u32,
-        _req: DynItemStream,
+        req: DynItemStream,
     ) -> DynFuture<'a, DynItemStream> {
-        stabby::boxed::Box::new(async move { unimplemented_item_stream(method) }).into()
-    }
-
-    extern "C" fn invoke_io<'a>(
-        &'a self,
-        method: u32,
-        req: SVec<u8>,
-        // The native stdio rails. Frozen and accepted now; live stdin/stdout/stderr
-        // streaming will populate these (see RunIo). Today's `run` inherits stdio at
-        // spawn, so the handles are unused and dropped here.
-        _io: RunIo,
-    ) -> DynFuture<'a, SVec<u8>> {
         let driver = Arc::clone(&self.driver);
+        let cancels = Arc::clone(&self.cancels);
         stabby::boxed::Box::new(async move {
             match pb::DriverMethod::try_from(method as i32) {
-                Ok(pb::DriverMethod::Run) => {
-                    // `run` shells out via the reactor — execute on the cdylib's own
-                    // runtime, bridge the result back to the host's polling task.
-                    let (tx, rx) = tokio::sync::oneshot::channel();
-                    cdylib_runtime().spawn(async move {
-                        // Receiver dropped only if the host gave up; ignore send failure.
-                        drop(tx.send(run_impl(driver, req).await));
-                    });
-                    rx.await
-                        .unwrap_or_else(|_| unary(err_body("cdylib run task dropped".into())))
-                }
-                _ => unimplemented(method),
+                Ok(pb::DriverMethod::Run) => run_bidi(driver, req, cancels).await,
+                _ => unimplemented_item_stream(method),
             }
         })
         .into()
     }
 }
 
-async fn run_impl(driver: Arc<dyn ManagedDriver>, req: SVec<u8>) -> SVec<u8> {
-    let req = pb::ManagedRunRequest::decode(&req[..]).unwrap_or_default();
-    let tok = StdCancellationToken::new();
-    // `shell` selects run_shell over run; it rides the request now (not a slot arg).
+/// Guest-side response stream backed by an mpsc the run task feeds. `blocking_recv`
+/// is sound because the host drains run output on a blocking task (it cannot ride
+/// the host's async workers), matching how `run` already parks threads per chunk.
+struct ChannelItemStream {
+    rx: Mutex<tokio::sync::mpsc::Receiver<Vec<u8>>>,
+}
+
+impl StableItemStream for ChannelItemStream {
+    extern "C" fn next(&self) -> SVec<u8> {
+        let mut rx = self.rx.lock().unwrap_or_else(|e| e.into_inner());
+        match rx.blocking_recv() {
+            Some(bytes) => SVec::from(bytes.as_slice()),
+            None => SVec::new(),
+        }
+    }
+}
+
+fn make_channel_item_stream(rx: tokio::sync::mpsc::Receiver<Vec<u8>>) -> DynItemStream {
+    stabby::boxed::Box::new(ChannelItemStream { rx: Mutex::new(rx) }).into()
+}
+
+fn run_out_err(msg: String) -> pb::RunOutFrame {
+    pb::RunOutFrame {
+        msg: Some(pb::run_out_frame::Msg::Error(msg)),
+    }
+}
+
+/// A run response stream that fails immediately (one `RunOutFrame{error}`).
+fn run_error_stream(msg: String) -> DynItemStream {
+    make_item_stream(Box::new(std::iter::once(run_out_err(msg).encode_to_vec())))
+}
+
+/// Pull the first request-stream item: the run request (`RunInFrame{start}`).
+fn pull_run_start(req: &DynItemStream) -> Option<pb::ManagedRunRequest> {
+    let bytes = req.next();
+    if bytes.is_empty() {
+        return None;
+    }
+    match pb::RunInFrame::decode(&bytes[..]).ok()?.msg {
+        Some(pb::run_in_frame::Msg::Start(s)) => Some(s),
+        _ => None,
+    }
+}
+
+async fn run_bidi(
+    driver: Arc<dyn ManagedDriver>,
+    req: DynItemStream,
+    cancels: Arc<CancelRegistry>,
+) -> DynItemStream {
+    let Some(start) = pull_run_start(&req) else {
+        return run_error_stream("run: missing start frame".into());
+    };
+    // The run shells out via the reactor — execute on the cdylib's own runtime,
+    // feeding RunOutFrames into a channel the host drains. (Live stdin/stdout will
+    // ride `req` / the channel later; today only the terminal result is sent.)
+    let (tx, rx) = tokio::sync::mpsc::channel::<Vec<u8>>(16);
+    cdylib_runtime().spawn(async move {
+        let guard = cancels.enter(&start.request_id);
+        let out = run_once(driver, start, guard.token()).await;
+        // Host gone => receiver dropped; ignore send failure.
+        drop(tx.send(out.encode_to_vec()).await);
+    });
+    make_channel_item_stream(rx)
+}
+
+async fn run_once(
+    driver: Arc<dyn ManagedDriver>,
+    req: pb::ManagedRunRequest,
+    ct: &StdCancellationToken,
+) -> pb::RunOutFrame {
+    // `shell` selects run_shell over run; it rides the request.
     let shell = req.shell;
     let target = match convert::target_def_from_pb(req.target.unwrap_or_default()) {
         Ok(t) => t,
-        Err(e) => return unary(err_body(e.to_string())),
+        Err(e) => return run_out_err(e.to_string()),
     };
     let request_id = req.request_id;
     let hashin = req.hashin;
@@ -700,21 +869,22 @@ async fn run_impl(driver: Arc<dyn ManagedDriver>, req: SVec<u8>) -> SVec<u8> {
         inputs: managed_inputs,
     };
     let result = if shell {
-        driver.run_shell(mrr, &tok).await
+        driver.run_shell(mrr, ct).await
     } else {
-        driver.run(mrr, &tok).await
+        driver.run(mrr, ct).await
     };
-    let body = match result {
-        Ok(resp) => Body::ManagedRunResp(pb::ManagedRunResponse {
-            artifacts: resp
-                .artifacts
-                .iter()
-                .map(convert::output_artifact_to_pb)
-                .collect(),
-        }),
-        Err(e) => err_body(e.to_string()),
-    };
-    unary(body)
+    match result {
+        Ok(resp) => pb::RunOutFrame {
+            msg: Some(pb::run_out_frame::Msg::Response(pb::ManagedRunResponse {
+                artifacts: resp
+                    .artifacts
+                    .iter()
+                    .map(convert::output_artifact_to_pb)
+                    .collect(),
+            })),
+        },
+        Err(e) => run_out_err(e.to_string()),
+    }
 }
 
 fn run_input_from_pb(mi: &pb::ManagedRunInput) -> RunInput {
@@ -1054,6 +1224,82 @@ mod tests {
         }
     }
 
+    // Cancellation propagates host -> plugin: a `probe` that blocks until its token
+    // trips returns only once the host's request token is cancelled. The host wires
+    // `ct` -> StableCancel::cancel(request_id) -> the guest token the provider holds.
+    // (If the wiring were missing the provider would block forever and this hangs.)
+    #[test]
+    fn cancellation_propagates_to_plugin() {
+        use hcore::hasync::StdCancellationToken;
+        use hplugin_stabby::load_stable::StableRemoteProvider;
+
+        struct BlockingProbe;
+        impl Provider for BlockingProbe {
+            fn config(&self, _r: ConfigRequest) -> Result<ConfigResponse> {
+                Ok(ConfigResponse {
+                    name: "blocker".into(),
+                })
+            }
+            fn list<'a>(
+                &'a self,
+                _r: ListRequest,
+                _c: &'a (dyn Cancellable + Send + Sync),
+            ) -> futures::future::BoxFuture<
+                'a,
+                Result<Box<dyn Iterator<Item = Result<ListResponse>> + Send>>,
+            > {
+                Box::pin(async { Ok(Box::new(std::iter::empty()) as Box<_>) })
+            }
+            fn list_packages<'a>(
+                &'a self,
+                _r: ListPackagesRequest,
+                _c: &'a (dyn Cancellable + Send + Sync),
+            ) -> futures::future::BoxFuture<
+                'a,
+                Result<Box<dyn Iterator<Item = Result<ListPackageResponse>> + Send>>,
+            > {
+                Box::pin(async { Ok(Box::new(std::iter::empty()) as Box<_>) })
+            }
+            fn get<'a>(
+                &'a self,
+                _r: GetRequest,
+                _c: &'a (dyn Cancellable + Send + Sync),
+            ) -> futures::future::BoxFuture<'a, std::result::Result<GetResponse, GetError>>
+            {
+                Box::pin(async { Err(GetError::NotFound) })
+            }
+            // Blocks until the (guest) token trips, then returns — proving the host
+            // cancel reached the token this provider was handed.
+            fn probe<'a>(
+                &'a self,
+                _r: ProbeRequest,
+                ct: &'a (dyn Cancellable + Send + Sync),
+            ) -> futures::future::BoxFuture<'a, Result<ProbeResponse>> {
+                Box::pin(async move {
+                    ct.cancelled().await;
+                    Ok(ProbeResponse { states: vec![] })
+                })
+            }
+        }
+
+        let host =
+            StableRemoteProvider::new(make_dyn_provider(Arc::new(BlockingProbe)), "blocker");
+        let ct = StdCancellationToken::new();
+        let preq = ProbeRequest {
+            request_id: "rq-1".into(),
+            package: PkgBuf::from("p"),
+        };
+        // Drive the probe and the cancel concurrently; completing at all proves the
+        // cancel unblocked the provider.
+        let out = futures::executor::block_on(async {
+            let probe = host.probe(preq, &ct);
+            let cancel = async { ct.cancel() };
+            let (r, ()) = futures::future::join(probe, cancel).await;
+            r
+        });
+        out.expect("probe returns after cancellation");
+    }
+
     // A provider whose `list` yields a scripted sequence of items (Ok) and an
     // optional terminal error — used to prove server-streaming delivers every item
     // and surfaces a mid-stream error across the seam.
@@ -1153,6 +1399,95 @@ mod tests {
         assert!(got[0].is_ok());
         let err = got[1].as_ref().expect_err("second item is the error");
         assert!(err.to_string().contains("boom"));
+    }
+
+    // `run` over invoke_bidi: the request stream (RunInFrame) is consumed and the
+    // response stream yields exactly one terminal RunOutFrame. Proves the bidi
+    // plumbing — request pulled, run spawned, result delivered over the channel.
+    #[test]
+    fn run_bidi_yields_one_terminal_frame() {
+        use hcore::hasync::Cancellable;
+        use hdriver_support::driver_managed::{ManagedRunRequest, ManagedRunResponse};
+        use hplugin_stabby::abi::{StableItemStreamDyn, StableManagedDriverDyn};
+
+        struct NoopDriver;
+        #[async_trait::async_trait]
+        impl ManagedDriver for NoopDriver {
+            fn config(
+                &self,
+                _r: hplugin::driver::ConfigRequest,
+            ) -> Result<hplugin::driver::ConfigResponse> {
+                Ok(hplugin::driver::ConfigResponse {
+                    name: "noop".into(),
+                })
+            }
+            fn schema(&self) -> hplugin::driver::DriverSchema {
+                hplugin::driver::DriverSchema::default()
+            }
+            async fn parse(
+                &self,
+                _r: hplugin::driver::ParseRequest,
+                _c: &(dyn Cancellable + Send + Sync),
+            ) -> Result<hplugin::driver::ParseResponse> {
+                anyhow::bail!("unused")
+            }
+            async fn apply_transitive(
+                &self,
+                _r: hplugin::driver::ApplyTransitiveRequest,
+                _c: &(dyn Cancellable + Send + Sync),
+            ) -> Result<hplugin::driver::ApplyTransitiveResponse> {
+                anyhow::bail!("unused")
+            }
+            async fn run<'a, 'io>(
+                &self,
+                _r: ManagedRunRequest<'a, 'io>,
+                _c: &(dyn Cancellable + Send + Sync),
+            ) -> Result<ManagedRunResponse> {
+                Ok(ManagedRunResponse { artifacts: vec![] })
+            }
+        }
+
+        let dynd = make_dyn_managed_driver(Arc::new(NoopDriver) as Arc<dyn ManagedDriver>);
+        let start = pb::RunInFrame {
+            msg: Some(pb::run_in_frame::Msg::Start(pb::ManagedRunRequest {
+                request_id: "r".into(),
+                ..Default::default()
+            })),
+        }
+        .encode_to_vec();
+        let req_stream = make_item_stream(Box::new(std::iter::once(start)));
+
+        let resp = futures::executor::block_on(
+            dynd.invoke_bidi(pb::DriverMethod::Run as u32, req_stream),
+        );
+        // `next` blocks on the run task; drain on a thread.
+        let frames = std::thread::spawn(move || {
+            let mut out: Vec<Vec<u8>> = Vec::new();
+            loop {
+                let b = resp.next();
+                if b.is_empty() {
+                    break;
+                }
+                out.push(b.to_vec());
+            }
+            out
+        })
+        .join()
+        .expect("drain thread");
+
+        assert_eq!(frames.len(), 1, "exactly one terminal RunOutFrame then end");
+        let frame = pb::RunOutFrame::decode(&frames[0][..]).expect("decode RunOutFrame");
+        // A terminal frame (Response or Error) — proves the request was consumed and
+        // the run task's output crossed the response stream. (The default target
+        // fails conversion, so this run terminates as Error; the plumbing is the point.)
+        assert!(
+            matches!(
+                frame.msg,
+                Some(pb::run_out_frame::Msg::Response(_)) | Some(pb::run_out_frame::Msg::Error(_))
+            ),
+            "expected a terminal RunOutFrame, got {:?}",
+            frame.msg
+        );
     }
 
     // Provider functions survive the guest→host stable-ABI round trip: the host

--- a/crates/plugin-sdk/src/serve.rs
+++ b/crates/plugin-sdk/src/serve.rs
@@ -24,8 +24,8 @@ use hplugin::provider::{
     ProviderFunctionRegistry,
 };
 use hplugin_stabby::abi::{
-    DynExecutor, DynFunctionRegistry, RunIo, StableFunctionRegistryDyn, StableManagedDriver,
-    StableMeta, StableProvider,
+    DynExecutor, DynFunctionRegistry, DynItemStream, RunIo, StableFunctionRegistryDyn,
+    StableItemStream, StableManagedDriver, StableMeta, StableProvider,
 };
 use plugin_abi::convert;
 use plugin_abi::pb;
@@ -66,18 +66,85 @@ fn unary(body: Body) -> SVec<u8> {
     SVec::from(f.encode_to_vec().as_slice())
 }
 
-fn stream(bodies: Vec<Body>) -> SVec<u8> {
-    let mut buf = Vec::new();
-    for b in bodies {
-        let f = pb::Frame {
-            id: 0,
-            body: Some(b),
-        };
-        // Encoding into a growable Vec is infallible; bind the Result to satisfy
-        // #[must_use] without an explicit drop (the value is Copy).
-        let _encoded = f.encode_length_delimited(&mut buf);
+/// Encode one `pb::Frame` carrying `body` (one frame per stream `next`).
+fn frame_bytes(body: Body) -> Vec<u8> {
+    pb::Frame {
+        id: 0,
+        body: Some(body),
     }
-    SVec::from(buf.as_slice())
+    .encode_to_vec()
+}
+
+/// Guest-side response stream: pulls items from a provider iterator lazily and
+/// frames each on demand — nothing is buffered at the seam. `Mutex` (not `RefCell`
+/// like [`HostRead`]) so the handle is `Send + Sync`, since list results flow into
+/// the host engine, which requires `Send`.
+struct GuestItemStream {
+    frames: std::sync::Mutex<Box<dyn Iterator<Item = Vec<u8>> + Send>>,
+}
+
+impl StableItemStream for GuestItemStream {
+    extern "C" fn next(&self) -> SVec<u8> {
+        let mut frames = self.frames.lock().unwrap_or_else(|e| e.into_inner());
+        // Empty == stream exhausted; otherwise one encoded `pb::Frame`.
+        match frames.next() {
+            Some(bytes) => SVec::from(bytes.as_slice()),
+            None => SVec::new(),
+        }
+    }
+}
+
+fn make_item_stream(frames: Box<dyn Iterator<Item = Vec<u8>> + Send>) -> DynItemStream {
+    stabby::boxed::Box::new(GuestItemStream {
+        frames: std::sync::Mutex::new(frames),
+    })
+    .into()
+}
+
+/// Lazily map a provider's fallible item iterator into encoded `StreamItem` frames,
+/// terminating with a `StreamEnd{error}` frame if an item errors. A clean end emits
+/// no terminal frame (the empty `next` signals it).
+fn frame_iter<T: 'static>(
+    mut iter: Box<dyn Iterator<Item = Result<T>> + Send>,
+    encode_item: fn(T) -> Vec<u8>,
+) -> Box<dyn Iterator<Item = Vec<u8>> + Send> {
+    let mut done = false;
+    Box::new(std::iter::from_fn(move || {
+        if done {
+            return None;
+        }
+        match iter.next() {
+            Some(Ok(t)) => Some(frame_bytes(Body::StreamItem(pb::StreamItem {
+                item: encode_item(t).into(),
+            }))),
+            Some(Err(e)) => {
+                done = true;
+                Some(frame_bytes(stream_err(e.to_string())))
+            }
+            None => {
+                done = true;
+                None
+            }
+        }
+    }))
+}
+
+/// A response stream that fails immediately with `msg` (one `StreamEnd{error}`).
+fn error_item_stream(msg: String) -> DynItemStream {
+    make_item_stream(Box::new(std::iter::once(frame_bytes(stream_err(msg)))))
+}
+
+/// A response stream for an unimplemented streaming method — the stream-shaped
+/// counterpart of [`unimplemented`], carrying `Error{Unimplemented}` so a newer
+/// host falls back instead of failing hard.
+fn unimplemented_item_stream(method: u32) -> DynItemStream {
+    let body = Body::StreamEnd(pb::StreamEnd {
+        error: Some(pb::Error {
+            kind: pb::error::Kind::Unimplemented as i32,
+            message: format!("dispatch method {method} not implemented"),
+        }),
+    });
+    make_item_stream(Box::new(std::iter::once(frame_bytes(body))))
 }
 
 fn err_body(message: String) -> Body {
@@ -132,7 +199,10 @@ fn unimplemented(method: u32) -> SVec<u8> {
 // ---- Provider RPC bodies (moved verbatim out of the old per-method vtable slots
 // into helpers; the dispatch impls below route method ids to them) ----
 
-async fn provider_list(provider: Arc<dyn Provider>, req: SVec<u8>) -> SVec<u8> {
+// Server-streaming: the provider's iterator is pulled lazily across the seam (one
+// item per `StableItemStream::next`), never materialized into one blob.
+
+async fn provider_list_stream(provider: Arc<dyn Provider>, req: SVec<u8>) -> DynItemStream {
     let req = pb::ListRequest::decode(&req[..]).unwrap_or_default();
     let tok = StdCancellationToken::new();
     let lreq = ListRequest {
@@ -140,60 +210,32 @@ async fn provider_list(provider: Arc<dyn Provider>, req: SVec<u8>) -> SVec<u8> {
         package: PkgBuf::from(req.package),
         states: req.states.into_iter().map(convert::state_from_pb).collect(),
     };
-    let mut bodies = Vec::new();
     match provider.list(lreq, &tok).await {
-        Ok(iter) => {
-            for item in iter {
-                match item {
-                    Ok(lr) => bodies.push(Body::StreamItem(pb::StreamItem {
-                        item: pb::ListResponse {
-                            addr: Some(convert::addr_to_pb(&lr.addr)),
-                        }
-                        .encode_to_vec()
-                        .into(),
-                    })),
-                    Err(e) => {
-                        bodies.push(stream_err(e.to_string()));
-                        return stream(bodies);
-                    }
-                }
+        Ok(iter) => make_item_stream(frame_iter(iter, |lr| {
+            pb::ListResponse {
+                addr: Some(convert::addr_to_pb(&lr.addr)),
             }
-            bodies.push(Body::StreamEnd(pb::StreamEnd { error: None }));
-        }
-        Err(e) => bodies.push(stream_err(e.to_string())),
+            .encode_to_vec()
+        })),
+        Err(e) => error_item_stream(e.to_string()),
     }
-    stream(bodies)
 }
 
-async fn provider_list_packages(provider: Arc<dyn Provider>, req: SVec<u8>) -> SVec<u8> {
+async fn provider_list_packages_stream(provider: Arc<dyn Provider>, req: SVec<u8>) -> DynItemStream {
     let req = pb::ListPackagesRequest::decode(&req[..]).unwrap_or_default();
     let tok = StdCancellationToken::new();
     let lreq = ListPackagesRequest {
         prefix: PkgBuf::from(req.prefix),
     };
-    let mut bodies = Vec::new();
     match provider.list_packages(lreq, &tok).await {
-        Ok(iter) => {
-            for item in iter {
-                match item {
-                    Ok(lpr) => bodies.push(Body::StreamItem(pb::StreamItem {
-                        item: pb::ListPackageResponse {
-                            pkg: lpr.pkg.as_str().to_string(),
-                        }
-                        .encode_to_vec()
-                        .into(),
-                    })),
-                    Err(e) => {
-                        bodies.push(stream_err(e.to_string()));
-                        return stream(bodies);
-                    }
-                }
+        Ok(iter) => make_item_stream(frame_iter(iter, |lpr| {
+            pb::ListPackageResponse {
+                pkg: lpr.pkg.as_str().to_string(),
             }
-            bodies.push(Body::StreamEnd(pb::StreamEnd { error: None }));
-        }
-        Err(e) => bodies.push(stream_err(e.to_string())),
+            .encode_to_vec()
+        })),
+        Err(e) => error_item_stream(e.to_string()),
     }
-    stream(bodies)
 }
 
 async fn provider_get(provider: Arc<dyn Provider>, req: SVec<u8>, exec: DynExecutor) -> SVec<u8> {
@@ -360,14 +402,47 @@ impl StableProvider for StableProviderImpl {
         let provider = Arc::clone(&self.provider);
         stabby::boxed::Box::new(async move {
             match pb::ProviderMethod::try_from(method as i32) {
-                Ok(pb::ProviderMethod::List) => provider_list(provider, req).await,
-                Ok(pb::ProviderMethod::ListPackages) => provider_list_packages(provider, req).await,
                 Ok(pb::ProviderMethod::Probe) => provider_probe(provider, req).await,
                 Ok(pb::ProviderMethod::CallFunction) => provider_call_function(provider, req).await,
                 _ => unimplemented(method),
             }
         })
         .into()
+    }
+
+    extern "C" fn invoke_server_stream<'a>(
+        &'a self,
+        method: u32,
+        req: SVec<u8>,
+    ) -> DynFuture<'a, DynItemStream> {
+        let provider = Arc::clone(&self.provider);
+        stabby::boxed::Box::new(async move {
+            match pb::ProviderMethod::try_from(method as i32) {
+                Ok(pb::ProviderMethod::List) => provider_list_stream(provider, req).await,
+                Ok(pb::ProviderMethod::ListPackages) => {
+                    provider_list_packages_stream(provider, req).await
+                }
+                _ => unimplemented_item_stream(method),
+            }
+        })
+        .into()
+    }
+
+    extern "C" fn invoke_client_stream<'a>(
+        &'a self,
+        method: u32,
+        // No client-streaming provider RPC yet; the request stream is dropped.
+        _req: DynItemStream,
+    ) -> DynFuture<'a, SVec<u8>> {
+        stabby::boxed::Box::new(async move { unimplemented(method) }).into()
+    }
+
+    extern "C" fn invoke_bidi<'a>(
+        &'a self,
+        method: u32,
+        _req: DynItemStream,
+    ) -> DynFuture<'a, DynItemStream> {
+        stabby::boxed::Box::new(async move { unimplemented_item_stream(method) }).into()
     }
 
     extern "C" fn invoke_exec<'a>(
@@ -533,6 +608,32 @@ impl StableManagedDriver for StableManagedDriverImpl {
             }
         })
         .into()
+    }
+
+    // No streaming driver RPC yet; the cardinality slots are frozen and provisioned,
+    // answering Unimplemented until a method id rides them.
+    extern "C" fn invoke_server_stream<'a>(
+        &'a self,
+        method: u32,
+        _req: SVec<u8>,
+    ) -> DynFuture<'a, DynItemStream> {
+        stabby::boxed::Box::new(async move { unimplemented_item_stream(method) }).into()
+    }
+
+    extern "C" fn invoke_client_stream<'a>(
+        &'a self,
+        method: u32,
+        _req: DynItemStream,
+    ) -> DynFuture<'a, SVec<u8>> {
+        stabby::boxed::Box::new(async move { unimplemented(method) }).into()
+    }
+
+    extern "C" fn invoke_bidi<'a>(
+        &'a self,
+        method: u32,
+        _req: DynItemStream,
+    ) -> DynFuture<'a, DynItemStream> {
+        stabby::boxed::Box::new(async move { unimplemented_item_stream(method) }).into()
     }
 
     extern "C" fn invoke_io<'a>(
@@ -951,6 +1052,107 @@ mod tests {
             ),
             other => panic!("expected Unimplemented error, got {other:?}"),
         }
+    }
+
+    // A provider whose `list` yields a scripted sequence of items (Ok) and an
+    // optional terminal error — used to prove server-streaming delivers every item
+    // and surfaces a mid-stream error across the seam.
+    struct ListProvider {
+        items: Vec<std::result::Result<&'static str, &'static str>>,
+    }
+    impl Provider for ListProvider {
+        fn config(&self, _req: ConfigRequest) -> Result<ConfigResponse> {
+            Ok(ConfigResponse {
+                name: "lister".into(),
+            })
+        }
+        fn list<'a>(
+            &'a self,
+            _req: ListRequest,
+            _ct: &'a (dyn Cancellable + Send + Sync),
+        ) -> futures::future::BoxFuture<
+            'a,
+            Result<Box<dyn Iterator<Item = Result<ListResponse>> + Send>>,
+        > {
+            let items: Vec<Result<ListResponse>> = self
+                .items
+                .iter()
+                .map(|it| match it {
+                    Ok(name) => Ok(ListResponse {
+                        addr: convert::addr_from_pb(pb::Addr {
+                            package: "p".into(),
+                            name: (*name).into(),
+                            args: Default::default(),
+                        }),
+                    }),
+                    Err(msg) => Err(anyhow::anyhow!("{msg}")),
+                })
+                .collect();
+            Box::pin(async move { Ok(Box::new(items.into_iter()) as Box<_>) })
+        }
+        fn list_packages<'a>(
+            &'a self,
+            _req: ListPackagesRequest,
+            _ct: &'a (dyn Cancellable + Send + Sync),
+        ) -> futures::future::BoxFuture<
+            'a,
+            Result<Box<dyn Iterator<Item = Result<ListPackageResponse>> + Send>>,
+        > {
+            Box::pin(async { Ok(Box::new(std::iter::empty()) as Box<_>) })
+        }
+        fn get<'a>(
+            &'a self,
+            _req: GetRequest,
+            _ct: &'a (dyn Cancellable + Send + Sync),
+        ) -> futures::future::BoxFuture<'a, std::result::Result<GetResponse, GetError>> {
+            Box::pin(async { Err(GetError::NotFound) })
+        }
+        fn probe<'a>(
+            &'a self,
+            _req: ProbeRequest,
+            _ct: &'a (dyn Cancellable + Send + Sync),
+        ) -> futures::future::BoxFuture<'a, Result<ProbeResponse>> {
+            Box::pin(async { Ok(ProbeResponse { states: vec![] }) })
+        }
+    }
+
+    fn list_all(items: Vec<std::result::Result<&'static str, &'static str>>) -> Vec<Result<String>> {
+        use hcore::hasync::StdCancellationToken;
+        use hplugin_stabby::load_stable::StableRemoteProvider;
+
+        let dynp = make_dyn_provider(Arc::new(ListProvider { items }) as Arc<dyn Provider>);
+        let host = StableRemoteProvider::new(dynp, "lister");
+        let tok = StdCancellationToken::new();
+        let iter = futures::executor::block_on(host.list(
+            ListRequest {
+                request_id: String::new(),
+                package: PkgBuf::from("p"),
+                states: vec![],
+            },
+            &tok,
+        ))
+        .expect("list ok");
+        iter.map(|r| r.map(|lr| lr.addr.to_string())).collect()
+    }
+
+    // Server-streaming list delivers every item across the seam, in order.
+    #[test]
+    fn list_streams_all_items() {
+        let got = list_all(vec![Ok("x"), Ok("y"), Ok("z")]);
+        let names: Vec<String> = got.into_iter().map(|r| r.expect("item")).collect();
+        assert_eq!(names.len(), 3, "all three items must arrive");
+        assert!(names[0].ends_with("x"));
+        assert!(names[2].ends_with("z"));
+    }
+
+    // A mid-stream provider error surfaces as a failed item, and the stream ends.
+    #[test]
+    fn list_stream_propagates_midstream_error() {
+        let got = list_all(vec![Ok("x"), Err("boom")]);
+        assert_eq!(got.len(), 2, "the ok item then the error");
+        assert!(got[0].is_ok());
+        let err = got[1].as_ref().expect_err("second item is the error");
+        assert!(err.to_string().contains("boom"));
     }
 
     // Provider functions survive the guest→host stable-ABI round trip: the host

--- a/crates/plugin-sdk/src/serve.rs
+++ b/crates/plugin-sdk/src/serve.rs
@@ -27,17 +27,17 @@ use hplugin_stabby::abi::{
     DynExecutor, DynFunctionRegistry, DynItemStream, StableCancel, StableFunctionRegistryDyn,
     StableItemStream, StableItemStreamDyn, StableManagedDriver, StableMeta, StableProvider,
 };
-use std::collections::{HashMap, HashSet};
-use std::sync::Mutex;
 use plugin_abi::convert;
 use plugin_abi::pb;
 use plugin_abi::pb::frame::Body;
 use prost::Message;
 use stabby::future::DynFutureUnsync as DynFuture;
 use stabby::vec::Vec as SVec;
+use std::collections::{HashMap, HashSet};
 use std::io::Read;
 use std::path::PathBuf;
 use std::sync::Arc;
+use std::sync::Mutex;
 
 /// The cdylib's own tokio runtime. A loaded cdylib's statically-linked tokio is a
 /// separate instance from the host's, so async work that touches the reactor (a
@@ -316,7 +316,10 @@ async fn provider_list_stream(provider: Arc<dyn Provider>, req: SVec<u8>) -> Dyn
     }
 }
 
-async fn provider_list_packages_stream(provider: Arc<dyn Provider>, req: SVec<u8>) -> DynItemStream {
+async fn provider_list_packages_stream(
+    provider: Arc<dyn Provider>,
+    req: SVec<u8>,
+) -> DynItemStream {
     let req = pb::ListPackagesRequest::decode(&req[..]).unwrap_or_default();
     let tok = StdCancellationToken::new();
     let lreq = ListPackagesRequest {
@@ -394,7 +397,10 @@ async fn provider_call_function(provider: Arc<dyn Provider>, req: SVec<u8>) -> S
         .into_iter()
         .find(|d| d.name == req.name);
     let Some(def) = def else {
-        return unary(err_body(format!("unknown provider function `{}`", req.name)));
+        return unary(err_body(format!(
+            "unknown provider function `{}`",
+            req.name
+        )));
     };
     let ctx = FnCallContext {
         pkg: &req.pkg,
@@ -457,7 +463,11 @@ fn provider_state_schema(provider: &Arc<dyn Provider>) -> SVec<u8> {
     }
 }
 
-fn provider_set_registry(provider: &Arc<dyn Provider>, metadata: SVec<u8>, reg: DynFunctionRegistry) {
+fn provider_set_registry(
+    provider: &Arc<dyn Provider>,
+    metadata: SVec<u8>,
+    reg: DynFunctionRegistry,
+) {
     let meta = pb::FunctionRegistry::decode(&metadata[..]).unwrap_or_default();
     // Shared across every proxy handler — each dispatches back over the host
     // callback to invoke the actual function.
@@ -1282,8 +1292,7 @@ mod tests {
             }
         }
 
-        let host =
-            StableRemoteProvider::new(make_dyn_provider(Arc::new(BlockingProbe)), "blocker");
+        let host = StableRemoteProvider::new(make_dyn_provider(Arc::new(BlockingProbe)), "blocker");
         let ct = StdCancellationToken::new();
         let preq = ProbeRequest {
             request_id: "rq-1".into(),
@@ -1362,7 +1371,9 @@ mod tests {
         }
     }
 
-    fn list_all(items: Vec<std::result::Result<&'static str, &'static str>>) -> Vec<Result<String>> {
+    fn list_all(
+        items: Vec<std::result::Result<&'static str, &'static str>>,
+    ) -> Vec<Result<String>> {
         use hcore::hasync::StdCancellationToken;
         use hplugin_stabby::load_stable::StableRemoteProvider;
 
@@ -1457,9 +1468,8 @@ mod tests {
         .encode_to_vec();
         let req_stream = make_item_stream(Box::new(std::iter::once(start)));
 
-        let resp = futures::executor::block_on(
-            dynd.invoke_bidi(pb::DriverMethod::Run as u32, req_stream),
-        );
+        let resp =
+            futures::executor::block_on(dynd.invoke_bidi(pb::DriverMethod::Run as u32, req_stream));
         // `next` blocks on the run task; drain on a thread.
         let frames = std::thread::spawn(move || {
             let mut out: Vec<Vec<u8>> = Vec::new();

--- a/crates/plugin-stabby/src/abi.rs
+++ b/crates/plugin-stabby/src/abi.rs
@@ -125,60 +125,99 @@ pub trait StableFunctionRegistry {
 pub type DynFunctionRegistry =
     stabby::dynptr!(stabby::boxed::Box<dyn StableFunctionRegistry + Send + Sync>);
 
-/// The cold provider surface, called by the host. Direct stabby vtable dispatch —
-/// no async mux, no channels, no duplex (that machinery was the entire cold-path
-/// cost; see ai-docs/PERFORMANCE.md). Requests/responses cross as prost-encoded
-/// `pb::Frame` bytes (cheap, low-volume, lenient via protobuf); the host decodes
-/// the response `Body`. `get` additionally takes the native [`DynExecutor`] so the
-/// plugin's hot callbacks during resolution are direct calls.
+/// Static, request-less plugin metadata (config name, provider `functions` /
+/// `state_schema`, driver `schema`), kept in its OWN sync trait so the evolvable
+/// RPC dispatch surface ([`StableProvider`] / [`StableManagedDriver`]) stays
+/// purely the async method dispatch. Composed into both handle types. `kind` is a
+/// `pb::ProviderMethod` / `pb::DriverMethod` selecting which metadatum; the reply
+/// is that metadatum's prost bytes (an EMPTY `SVec` encodes "none", e.g. a
+/// provider with no `state_schema`). Sync because it is read once during registry
+/// wiring, never on a hot path. Same append-only contract as the async dispatch.
+#[stabby::stabby]
+pub trait StableMeta {
+    extern "C" fn meta(&self, kind: u32) -> SVec<u8>;
+}
+
+/// A streaming byte sink across the seam — the mirror of [`StableRead`]. The host
+/// owns the sink (e.g. a driver's stdout/stderr); the guest pushes chunks into it.
+/// `write_chunk` returns the bytes accepted; `0` means the sink is closed and the
+/// guest should stop writing.
+#[stabby::stabby]
+pub trait StableWrite {
+    extern "C" fn write_chunk(&self, buf: SVec<u8>) -> u64;
+}
+
+/// An owned, ABI-stable streaming sink handle. Not `Send` for the same reason as
+/// [`DynRead`]: opened and consumed on one thread.
+pub type DynWrite = stabby::dynptr!(stabby::boxed::Box<dyn StableWrite + Send + Sync>);
+
+/// The live stdio streams handed to a driver `run` as native streaming handles
+/// (same family as artifact streaming, NOT prost bytes — live IO can't be unary).
+/// Each is optional: `None` means the host did not wire that stream. Frozen at the
+/// three subprocess fds, so adding live stdin/stdout/stderr streaming later just
+/// populates these handles — an additive change needing no ABI bump.
+#[stabby::stabby]
+pub struct RunIo {
+    /// host -> driver (process stdin).
+    pub stdin: stabby::option::Option<DynRead>,
+    /// driver -> host (process stdout).
+    pub stdout: stabby::option::Option<DynWrite>,
+    /// driver -> host (process stderr).
+    pub stderr: stabby::option::Option<DynWrite>,
+}
+
+/// The cold provider surface as a FROZEN generic dispatch. The `method` id
+/// (`pb::ProviderMethod`) selects an RPC; request/response cross as prost-encoded
+/// `pb::Frame` bytes (cheap, low-volume, lenient via protobuf). Adding an RPC is a
+/// new method id + a new guest match arm — the vtable is UNTOUCHED, so an older
+/// plugin and a newer host still load (stabby's type report is unchanged) and the
+/// old plugin answers an unknown id with `Error{Unimplemented}`. THIS is what
+/// makes the cold surface evolvable without an ABI break (see ABI_VERSIONING.md).
 ///
-/// Stream methods (`list`, `list_packages`) return all items length-delimited:
-/// a sequence of prost length-delimited `pb::Frame`s (StreamItem… then StreamEnd).
+/// Three slots cover the call shapes; native handles cannot ride prost bytes, so a
+/// method that carries one gets its own (also frozen) slot:
+/// - [`invoke`](StableProvider::invoke) — plain prost in/out.
+/// - [`invoke_exec`](StableProvider::invoke_exec) — also passes the native
+///   [`DynExecutor`] (`get`, whose resolution makes hot callbacks).
+/// - [`invoke_registry`](StableProvider::invoke_registry) — also passes the native
+///   [`DynFunctionRegistry`] (`set_function_registry`).
+///
+/// Replies follow the prior contract: unary methods return one prost `pb::Frame`;
+/// stream methods (`list`, `list_packages`) return length-delimited `pb::Frame`s
+/// (StreamItem… then StreamEnd).
 #[stabby::stabby]
 pub trait StableProvider {
-    /// The provider's registered name.
-    extern "C" fn config(&self) -> SString;
-    extern "C" fn list<'a>(&'a self, req: SVec<u8>) -> DynFuture<'a, SVec<u8>>;
-    extern "C" fn list_packages<'a>(&'a self, req: SVec<u8>) -> DynFuture<'a, SVec<u8>>;
-    extern "C" fn get<'a>(&'a self, req: SVec<u8>, exec: DynExecutor) -> DynFuture<'a, SVec<u8>>;
-    extern "C" fn probe<'a>(&'a self, req: SVec<u8>) -> DynFuture<'a, SVec<u8>>;
-    /// The BUILD-file functions this provider exposes, as prost-encoded
-    /// `pb::FunctionsResponse` bytes (metadata only — handlers stay guest-side,
-    /// reached via `call_function`). Sync: it is provider-static metadata read
-    /// once during host registry wiring, not a per-request call.
-    extern "C" fn functions(&self) -> SVec<u8>;
-    /// Invoke one exposed function by name. `req` is raw `pb::CallFunctionRequest`
-    /// bytes; the reply is a `pb::Frame` carrying `CallFunctionResp` or `Error`.
-    extern "C" fn call_function<'a>(&'a self, req: SVec<u8>) -> DynFuture<'a, SVec<u8>>;
-    /// The provider's state schema (the kwargs of `provider_state(provider=…, …)`)
-    /// as prost-encoded `pb::Schema` bytes. An EMPTY `SVec` means the provider
-    /// declares no schema (`None`); an encoded (possibly fields-empty) `Schema`
-    /// means it does. Sync provider-static metadata, like `functions`.
-    extern "C" fn state_schema(&self) -> SVec<u8>;
-    /// Hand the provider the aggregate registry of every provider's functions:
-    /// `metadata` is prost `pb::FunctionRegistry` bytes (names/signatures/docs);
-    /// `reg` is the host callback used to actually invoke any of them. Called once
-    /// before the first dispatch, mirroring [`hplugin::provider::Provider::set_function_registry`].
-    extern "C" fn set_function_registry(&self, metadata: SVec<u8>, reg: DynFunctionRegistry);
+    extern "C" fn invoke<'a>(&'a self, method: u32, req: SVec<u8>) -> DynFuture<'a, SVec<u8>>;
+    extern "C" fn invoke_exec<'a>(
+        &'a self,
+        method: u32,
+        req: SVec<u8>,
+        exec: DynExecutor,
+    ) -> DynFuture<'a, SVec<u8>>;
+    extern "C" fn invoke_registry(&self, method: u32, req: SVec<u8>, reg: DynFunctionRegistry);
 }
 
-/// The cold managed-driver surface (same transport contract as [`StableProvider`]).
+/// The cold managed-driver surface, same frozen-dispatch contract as
+/// [`StableProvider`]. `method` is a `pb::DriverMethod`. `run` rides
+/// [`invoke_io`](StableManagedDriver::invoke_io), which additionally carries the
+/// native [`RunIo`] stdio handles.
 #[stabby::stabby]
 pub trait StableManagedDriver {
-    extern "C" fn config(&self) -> SString;
-    extern "C" fn parse<'a>(&'a self, req: SVec<u8>) -> DynFuture<'a, SVec<u8>>;
-    extern "C" fn apply_transitive<'a>(&'a self, req: SVec<u8>) -> DynFuture<'a, SVec<u8>>;
-    /// `shell` selects `run_shell` over `run`.
-    extern "C" fn run<'a>(&'a self, req: SVec<u8>, shell: bool) -> DynFuture<'a, SVec<u8>>;
-    /// The driver's config schema (the driver-specific kwargs of `target(...)`)
-    /// as prost-encoded `pb::Schema` bytes. Sync driver-static metadata.
-    extern "C" fn schema(&self) -> SVec<u8>;
+    extern "C" fn invoke<'a>(&'a self, method: u32, req: SVec<u8>) -> DynFuture<'a, SVec<u8>>;
+    extern "C" fn invoke_io<'a>(
+        &'a self,
+        method: u32,
+        req: SVec<u8>,
+        io: RunIo,
+    ) -> DynFuture<'a, SVec<u8>>;
 }
 
-/// Owned ABI-stable handles to a loaded plugin's components.
-pub type DynProvider = stabby::dynptr!(stabby::boxed::Box<dyn StableProvider + Send + Sync>);
+/// Owned ABI-stable handles to a loaded plugin's components. Each composes
+/// [`StableMeta`] (static metadata) alongside its dispatch surface.
+pub type DynProvider =
+    stabby::dynptr!(stabby::boxed::Box<dyn StableProvider + StableMeta + Send + Sync>);
 pub type DynManagedDriver =
-    stabby::dynptr!(stabby::boxed::Box<dyn StableManagedDriver + Send + Sync>);
+    stabby::dynptr!(stabby::boxed::Box<dyn StableManagedDriver + StableMeta + Send + Sync>);
 
 /// Config handed to a cdylib's create entry: the workspace root, the engine's
 /// home dir (where a plugin should keep its state/scratch — e.g. `<root>/.heph3`,

--- a/crates/plugin-stabby/src/abi.rs
+++ b/crates/plugin-stabby/src/abi.rs
@@ -60,6 +60,12 @@ pub trait StableArtifactContent {
     extern "C" fn hashout(&self) -> SString;
     /// Byte size hint; `u64::MAX` means unknown.
     extern "C" fn byte_size(&self) -> u64;
+    /// The artifact's on-disk path when it is a real local file (e.g. an on-disk
+    /// cache artifact). EMPTY means not file-backed (synthetic/in-memory). Since
+    /// host and guest share the process and filesystem, a non-empty path lets the
+    /// guest open the file directly instead of pulling its bytes chunk-by-chunk
+    /// through [`open`](StableArtifactContent::open) — no per-chunk vtable hop.
+    extern "C" fn path(&self) -> SString;
 }
 
 /// An owned, ABI-stable artifact handle.

--- a/crates/plugin-stabby/src/abi.rs
+++ b/crates/plugin-stabby/src/abi.rs
@@ -166,28 +166,62 @@ pub struct RunIo {
     pub stderr: stabby::option::Option<DynWrite>,
 }
 
+/// A pull stream of items across the seam (the streaming counterpart of the unary
+/// `SVec<u8>` reply). Each `next` yields one prost length-delimited `pb::Frame`
+/// (`StreamItem` for an item, or `StreamEnd{error}` to end with failure); an EMPTY
+/// `SVec` means the stream is exhausted cleanly. Used for BOTH directions — a
+/// request stream (host → plugin) and a response stream (plugin → host). `&self`
+/// (not `&mut`) so it dispatches over the stable vtable; implementors use interior
+/// mutability for the cursor. Unlike [`DynRead`], the handle is `Send + Sync`
+/// (`Mutex`-guarded cursor) because list results flow into the engine, which
+/// requires `Send` iterators.
+#[stabby::stabby]
+pub trait StableItemStream {
+    extern "C" fn next(&self) -> SVec<u8>;
+}
+
+/// An owned, ABI-stable item-stream handle (a request or response stream).
+pub type DynItemStream =
+    stabby::dynptr!(stabby::boxed::Box<dyn StableItemStream + Send + Sync>);
+
 /// The cold provider surface as a FROZEN generic dispatch. The `method` id
-/// (`pb::ProviderMethod`) selects an RPC; request/response cross as prost-encoded
+/// (`pb::ProviderMethod`) selects an RPC; payloads cross as prost-encoded
 /// `pb::Frame` bytes (cheap, low-volume, lenient via protobuf). Adding an RPC is a
 /// new method id + a new guest match arm — the vtable is UNTOUCHED, so an older
 /// plugin and a newer host still load (stabby's type report is unchanged) and the
 /// old plugin answers an unknown id with `Error{Unimplemented}`. THIS is what
 /// makes the cold surface evolvable without an ABI break (see ABI_VERSIONING.md).
 ///
-/// Three slots cover the call shapes; native handles cannot ride prost bytes, so a
-/// method that carries one gets its own (also frozen) slot:
-/// - [`invoke`](StableProvider::invoke) — plain prost in/out.
-/// - [`invoke_exec`](StableProvider::invoke_exec) — also passes the native
+/// The slots cover the four RPC cardinalities (request × response, each unary or
+/// streaming) plus the native-handle carriers (a `DynExecutor` / `DynFunctionRegistry`
+/// cannot ride prost bytes, so the method carrying one gets its own frozen slot):
+/// - [`invoke`](StableProvider::invoke) — unary → unary.
+/// - [`invoke_server_stream`](StableProvider::invoke_server_stream) — unary →
+///   stream (`list`, `list_packages`): the reply is pulled lazily, never buffered.
+/// - [`invoke_client_stream`](StableProvider::invoke_client_stream) — stream → unary.
+/// - [`invoke_bidi`](StableProvider::invoke_bidi) — stream → stream.
+/// - [`invoke_exec`](StableProvider::invoke_exec) — unary → unary + native
 ///   [`DynExecutor`] (`get`, whose resolution makes hot callbacks).
-/// - [`invoke_registry`](StableProvider::invoke_registry) — also passes the native
+/// - [`invoke_registry`](StableProvider::invoke_registry) — unary → void + native
 ///   [`DynFunctionRegistry`] (`set_function_registry`).
-///
-/// Replies follow the prior contract: unary methods return one prost `pb::Frame`;
-/// stream methods (`list`, `list_packages`) return length-delimited `pb::Frame`s
-/// (StreamItem… then StreamEnd).
 #[stabby::stabby]
 pub trait StableProvider {
     extern "C" fn invoke<'a>(&'a self, method: u32, req: SVec<u8>) -> DynFuture<'a, SVec<u8>>;
+    extern "C" fn invoke_server_stream<'a>(
+        &'a self,
+        method: u32,
+        req: SVec<u8>,
+    ) -> DynFuture<'a, DynItemStream>;
+    extern "C" fn invoke_client_stream<'a>(
+        &'a self,
+        method: u32,
+        req: DynItemStream,
+    ) -> DynFuture<'a, SVec<u8>>;
+    extern "C" fn invoke_bidi<'a>(
+        &'a self,
+        method: u32,
+        req: DynItemStream,
+    ) -> DynFuture<'a, DynItemStream>;
     extern "C" fn invoke_exec<'a>(
         &'a self,
         method: u32,
@@ -197,13 +231,28 @@ pub trait StableProvider {
     extern "C" fn invoke_registry(&self, method: u32, req: SVec<u8>, reg: DynFunctionRegistry);
 }
 
-/// The cold managed-driver surface, same frozen-dispatch contract as
-/// [`StableProvider`]. `method` is a `pb::DriverMethod`. `run` rides
-/// [`invoke_io`](StableManagedDriver::invoke_io), which additionally carries the
-/// native [`RunIo`] stdio handles.
+/// The cold managed-driver surface, same frozen-dispatch contract and the same
+/// four cardinalities as [`StableProvider`]. `method` is a `pb::DriverMethod`.
+/// `run` rides [`invoke_io`](StableManagedDriver::invoke_io), which additionally
+/// carries the native [`RunIo`] stdio handles.
 #[stabby::stabby]
 pub trait StableManagedDriver {
     extern "C" fn invoke<'a>(&'a self, method: u32, req: SVec<u8>) -> DynFuture<'a, SVec<u8>>;
+    extern "C" fn invoke_server_stream<'a>(
+        &'a self,
+        method: u32,
+        req: SVec<u8>,
+    ) -> DynFuture<'a, DynItemStream>;
+    extern "C" fn invoke_client_stream<'a>(
+        &'a self,
+        method: u32,
+        req: DynItemStream,
+    ) -> DynFuture<'a, SVec<u8>>;
+    extern "C" fn invoke_bidi<'a>(
+        &'a self,
+        method: u32,
+        req: DynItemStream,
+    ) -> DynFuture<'a, DynItemStream>;
     extern "C" fn invoke_io<'a>(
         &'a self,
         method: u32,

--- a/crates/plugin-stabby/src/abi.rs
+++ b/crates/plugin-stabby/src/abi.rs
@@ -251,18 +251,6 @@ pub type DynManagedDriver = stabby::dynptr!(
     stabby::boxed::Box<dyn StableManagedDriver + StableMeta + StableCancel + Send + Sync>
 );
 
-/// Config handed to a cdylib's create entry: the workspace root, the engine's
-/// home dir (where a plugin should keep its state/scratch — e.g. `<root>/.heph3`,
-/// configurable; never hardcode it), and the plugin's `options:` map (from config
-/// yaml) encoded as a `plugin-abi` `pb::Value` map (prost bytes). The plugin
-/// decodes the options and instantiates its provider + drivers from them.
-#[stabby::stabby]
-pub struct CreateConfig {
-    pub root: SString,
-    pub home: SString,
-    pub options: SVec<u8>,
-}
-
 /// A named managed driver in a plugin's component bundle.
 #[stabby::stabby]
 pub struct NamedDriver {
@@ -273,16 +261,25 @@ pub struct NamedDriver {
 /// What a cdylib's create entry returns: a provider + named drivers, all as owned
 /// ABI-stable handles that the host wraps with [`crate::load_stable`]. (plugin-go
 /// always exports a provider; driver-only bundles can carry an empty name.)
+///
+/// `meta` is reserved, prost-encoded return-side metadata (empty today). It exists
+/// so a plugin can later report additive descriptive data (capabilities, abi
+/// minor, …) without changing this struct's layout — a layout change would break
+/// loading of older plugins. The handle fields must stay stabby (they carry the
+/// live native vtables); only the data rides prost.
 #[stabby::stabby]
 pub struct PluginComponents {
     pub provider_name: SString,
     pub provider: DynProvider,
     pub drivers: SVec<NamedDriver>,
+    pub meta: SVec<u8>,
 }
 
 /// The cdylib create-entry symbol name (exported with `#[stabby::export]`,
 /// loaded host-side with `get_stabbied`).
 pub const CREATE_SYMBOL: &[u8] = b"heph_plugin_create";
 
-/// The create entry's function-pointer type.
-pub type CreateFn = extern "C" fn(CreateConfig) -> PluginComponents;
+/// The create entry's function-pointer type. The config crosses as prost-encoded
+/// `pb::CreateConfig` bytes (not a stabby struct), so adding config fields is an
+/// additive change that does not break older plugins.
+pub type CreateFn = extern "C" fn(SVec<u8>) -> PluginComponents;

--- a/crates/plugin-stabby/src/abi.rs
+++ b/crates/plugin-stabby/src/abi.rs
@@ -138,34 +138,6 @@ pub trait StableMeta {
     extern "C" fn meta(&self, kind: u32) -> SVec<u8>;
 }
 
-/// A streaming byte sink across the seam — the mirror of [`StableRead`]. The host
-/// owns the sink (e.g. a driver's stdout/stderr); the guest pushes chunks into it.
-/// `write_chunk` returns the bytes accepted; `0` means the sink is closed and the
-/// guest should stop writing.
-#[stabby::stabby]
-pub trait StableWrite {
-    extern "C" fn write_chunk(&self, buf: SVec<u8>) -> u64;
-}
-
-/// An owned, ABI-stable streaming sink handle. Not `Send` for the same reason as
-/// [`DynRead`]: opened and consumed on one thread.
-pub type DynWrite = stabby::dynptr!(stabby::boxed::Box<dyn StableWrite + Send + Sync>);
-
-/// The live stdio streams handed to a driver `run` as native streaming handles
-/// (same family as artifact streaming, NOT prost bytes — live IO can't be unary).
-/// Each is optional: `None` means the host did not wire that stream. Frozen at the
-/// three subprocess fds, so adding live stdin/stdout/stderr streaming later just
-/// populates these handles — an additive change needing no ABI bump.
-#[stabby::stabby]
-pub struct RunIo {
-    /// host -> driver (process stdin).
-    pub stdin: stabby::option::Option<DynRead>,
-    /// driver -> host (process stdout).
-    pub stdout: stabby::option::Option<DynWrite>,
-    /// driver -> host (process stderr).
-    pub stderr: stabby::option::Option<DynWrite>,
-}
-
 /// A pull stream of items across the seam (the streaming counterpart of the unary
 /// `SVec<u8>` reply). Each `next` yields one prost length-delimited `pb::Frame`
 /// (`StreamItem` for an item, or `StreamEnd{error}` to end with failure); an EMPTY
@@ -233,8 +205,11 @@ pub trait StableProvider {
 
 /// The cold managed-driver surface, same frozen-dispatch contract and the same
 /// four cardinalities as [`StableProvider`]. `method` is a `pb::DriverMethod`.
-/// `run` rides [`invoke_io`](StableManagedDriver::invoke_io), which additionally
-/// carries the native [`RunIo`] stdio handles.
+/// `run` rides [`invoke_bidi`](StableManagedDriver::invoke_bidi): the request
+/// stream carries the run request then live stdin (`pb::RunInFrame`), the response
+/// stream carries live stdout/stderr then the result (`pb::RunOutFrame`). No
+/// dedicated stdio slot — live IO is modeled as prost frames on the bidi stream,
+/// so wiring stdin/stdout/stderr later is additive (see ABI_VERSIONING.md).
 #[stabby::stabby]
 pub trait StableManagedDriver {
     extern "C" fn invoke<'a>(&'a self, method: u32, req: SVec<u8>) -> DynFuture<'a, SVec<u8>>;
@@ -253,20 +228,28 @@ pub trait StableManagedDriver {
         method: u32,
         req: DynItemStream,
     ) -> DynFuture<'a, DynItemStream>;
-    extern "C" fn invoke_io<'a>(
-        &'a self,
-        method: u32,
-        req: SVec<u8>,
-        io: RunIo,
-    ) -> DynFuture<'a, SVec<u8>>;
+}
+
+/// Cooperative cancellation, in its OWN trait (composed into both handles like
+/// [`StableMeta`]). The host calls `cancel(request_id)` when its own request token
+/// fires; the plugin looks up the in-flight call by `request_id` and trips the
+/// cancellation token it handed the provider/driver — so a long `get` or a running
+/// subprocess (`run`) stops, exactly as for an in-process target. `request_id` is
+/// the id carried in each request message; it must be unique per in-flight call.
+#[stabby::stabby]
+pub trait StableCancel {
+    extern "C" fn cancel(&self, request_id: SString);
 }
 
 /// Owned ABI-stable handles to a loaded plugin's components. Each composes
-/// [`StableMeta`] (static metadata) alongside its dispatch surface.
-pub type DynProvider =
-    stabby::dynptr!(stabby::boxed::Box<dyn StableProvider + StableMeta + Send + Sync>);
-pub type DynManagedDriver =
-    stabby::dynptr!(stabby::boxed::Box<dyn StableManagedDriver + StableMeta + Send + Sync>);
+/// [`StableMeta`] (static metadata) and [`StableCancel`] (cancellation) alongside
+/// its dispatch surface.
+pub type DynProvider = stabby::dynptr!(
+    stabby::boxed::Box<dyn StableProvider + StableMeta + StableCancel + Send + Sync>
+);
+pub type DynManagedDriver = stabby::dynptr!(
+    stabby::boxed::Box<dyn StableManagedDriver + StableMeta + StableCancel + Send + Sync>
+);
 
 /// Config handed to a cdylib's create entry: the workspace root, the engine's
 /// home dir (where a plugin should keep its state/scratch — e.g. `<root>/.heph3`,

--- a/crates/plugin-stabby/src/abi.rs
+++ b/crates/plugin-stabby/src/abi.rs
@@ -159,8 +159,7 @@ pub trait StableItemStream {
 }
 
 /// An owned, ABI-stable item-stream handle (a request or response stream).
-pub type DynItemStream =
-    stabby::dynptr!(stabby::boxed::Box<dyn StableItemStream + Send + Sync>);
+pub type DynItemStream = stabby::dynptr!(stabby::boxed::Box<dyn StableItemStream + Send + Sync>);
 
 /// The cold provider surface as a FROZEN generic dispatch. The `method` id
 /// (`pb::ProviderMethod`) selects an RPC; payloads cross as prost-encoded

--- a/crates/plugin-stabby/src/host.rs
+++ b/crates/plugin-stabby/src/host.rs
@@ -75,6 +75,15 @@ impl StableArtifactContent for HostArtifactContent {
     extern "C" fn byte_size(&self) -> u64 {
         self.content.byte_size().unwrap_or(u64::MAX)
     }
+
+    extern "C" fn path(&self) -> SString {
+        // Non-empty only when the content is a real on-disk file (e.g. cache
+        // artifact); the guest then reads it directly instead of streaming.
+        match self.content.file_path() {
+            Some(p) => SString::from(p.to_string_lossy().as_ref()),
+            None => SString::new(),
+        }
+    }
 }
 
 /// Encode a unary `pb::Frame` reply carrying `body`.

--- a/crates/plugin-stabby/src/load_stable.rs
+++ b/crates/plugin-stabby/src/load_stable.rs
@@ -6,8 +6,8 @@
 
 use crate::abi::{
     CREATE_SYMBOL, CreateConfig, CreateFn, DynExecutor, DynItemStream, DynManagedDriver,
-    DynProvider, RunIo, StableItemStreamDyn, StableManagedDriverDyn, StableMetaDyn,
-    StableProviderDyn,
+    DynProvider, StableCancelDyn, StableItemStream, StableItemStreamDyn, StableManagedDriverDyn,
+    StableMetaDyn, StableProviderDyn,
 };
 use crate::host::HostExecutor;
 use async_trait::async_trait;
@@ -173,6 +173,89 @@ fn decode_list_package_item(b: &[u8]) -> anyhow::Result<ListPackageResponse> {
     })
 }
 
+/// Host-side request stream: yields a fixed sequence of pre-encoded items (today a
+/// single `RunInFrame{start}`; live stdin would push more), empty == end.
+struct HostItemStream {
+    items: std::sync::Mutex<std::vec::IntoIter<Vec<u8>>>,
+}
+
+impl StableItemStream for HostItemStream {
+    extern "C" fn next(&self) -> stabby::vec::Vec<u8> {
+        let mut items = self.items.lock().unwrap_or_else(|e| e.into_inner());
+        match items.next() {
+            Some(b) => stabby::vec::Vec::from(b.as_slice()),
+            None => stabby::vec::Vec::new(),
+        }
+    }
+}
+
+fn host_item_stream(items: Vec<Vec<u8>>) -> DynItemStream {
+    stabby::boxed::Box::new(HostItemStream {
+        items: std::sync::Mutex::new(items.into_iter()),
+    })
+    .into()
+}
+
+/// Drain a bidi `run` response stream to its terminal result. Blocking (called on a
+/// blocking task) because the stream's `next` blocks on subprocess output. stdout/
+/// stderr chunks are reserved — routed to host stdio once live streaming is wired.
+fn drain_run(stream: DynItemStream) -> anyhow::Result<ManagedRunResponse> {
+    loop {
+        let bytes = stream.next();
+        if bytes.is_empty() {
+            anyhow::bail!("run stream ended without a result");
+        }
+        match pb::RunOutFrame::decode(&bytes[..])?.msg {
+            Some(pb::run_out_frame::Msg::Response(r)) => {
+                return Ok(ManagedRunResponse {
+                    artifacts: r
+                        .artifacts
+                        .into_iter()
+                        .map(convert::output_artifact_from_pb)
+                        .collect(),
+                });
+            }
+            Some(pb::run_out_frame::Msg::Error(e)) => anyhow::bail!("{e}"),
+            // stdout/stderr chunks: not yet surfaced; ignore and keep draining.
+            _ => {}
+        }
+    }
+}
+
+/// Await `fut`, but if `ct` fires first, run `on_cancel` (signal the plugin to
+/// cancel this request) and keep awaiting — the call then returns its cancelled
+/// result. The plugin trips the token it gave the provider/driver, so a long `get`
+/// or a running subprocess stops, exactly as for an in-process target.
+async fn await_with_cancel<T>(
+    ct: &(dyn Cancellable + Send + Sync),
+    on_cancel: impl FnOnce() + Send,
+    fut: impl std::future::Future<Output = T> + Send,
+) -> T {
+    use futures::future::Either;
+    futures::pin_mut!(fut);
+    match futures::future::select(fut, ct.cancelled()).await {
+        Either::Left((out, _)) => out,
+        Either::Right(((), fut)) => {
+            on_cancel();
+            fut.await
+        }
+    }
+}
+
+/// The cancel signal for a provider call: trip the plugin's in-flight `request_id`.
+fn provider_cancel(inner: &Arc<DynProvider>, request_id: &str) -> impl FnOnce() + Send {
+    let inner = Arc::clone(inner);
+    let id = request_id.to_string();
+    move || inner.cancel(id.into())
+}
+
+/// The cancel signal for a driver call.
+fn driver_cancel(inner: &Arc<DynManagedDriver>, request_id: &str) -> impl FnOnce() + Send {
+    let inner = Arc::clone(inner);
+    let id = request_id.to_string();
+    move || inner.cancel(id.into())
+}
+
 /// Host handle to a loaded plugin's provider. `Clone` (cheap — shares the loaded
 /// component) so the engine's provider factory can mint handles.
 #[derive(Clone)]
@@ -257,7 +340,7 @@ impl Provider for StableRemoteProvider {
     fn get<'a>(
         &'a self,
         req: GetRequest,
-        _ct: &'a (dyn Cancellable + Send + Sync),
+        ct: &'a (dyn Cancellable + Send + Sync),
     ) -> BoxFuture<'a, std::result::Result<GetResponse, GetError>> {
         Box::pin(async move {
             let pb_req = pb::GetRequest {
@@ -267,10 +350,11 @@ impl Provider for StableRemoteProvider {
             }
             .encode_to_vec();
             let exec: DynExecutor = HostExecutor::wrap(Arc::clone(&req.executor));
-            let bytes = self
+            let fut = self
                 .inner
-                .invoke_exec(pb::ProviderMethod::Get as u32, sv(&pb_req), exec)
-                .await;
+                .invoke_exec(pb::ProviderMethod::Get as u32, sv(&pb_req), exec);
+            let bytes =
+                await_with_cancel(ct, provider_cancel(&self.inner, &req.request_id), fut).await;
             let body = decode_unary(&bytes).map_err(GetError::Other)?;
             match body {
                 Body::GetResp(gr) => Ok(GetResponse {
@@ -301,18 +385,19 @@ impl Provider for StableRemoteProvider {
     fn probe<'a>(
         &'a self,
         req: ProbeRequest,
-        _ct: &'a (dyn Cancellable + Send + Sync),
+        ct: &'a (dyn Cancellable + Send + Sync),
     ) -> BoxFuture<'a, anyhow::Result<ProbeResponse>> {
         Box::pin(async move {
+            let request_id = req.request_id.clone();
             let pb_req = pb::ProbeRequest {
                 request_id: req.request_id,
                 package: req.package.as_str().to_string(),
             }
             .encode_to_vec();
-            let bytes = self
+            let fut = self
                 .inner
-                .invoke(pb::ProviderMethod::Probe as u32, sv(&pb_req))
-                .await;
+                .invoke(pb::ProviderMethod::Probe as u32, sv(&pb_req));
+            let bytes = await_with_cancel(ct, provider_cancel(&self.inner, &request_id), fut).await;
             match decode_unary(&bytes)? {
                 Body::ProbeResp(pr) => Ok(ProbeResponse {
                     states: pr.states.into_iter().map(convert::state_from_pb).collect(),
@@ -453,18 +538,19 @@ impl ManagedDriver for StableRemoteManagedDriver {
     async fn parse(
         &self,
         req: ParseRequest,
-        _ct: &(dyn Cancellable + Send + Sync),
+        ct: &(dyn Cancellable + Send + Sync),
     ) -> anyhow::Result<ParseResponse> {
+        let request_id = req.request_id.clone();
         let pb_req = pb::ParseRequest {
             request_id: req.request_id,
             target_spec: Some(convert::target_spec_to_pb(req.target_spec.as_ref())),
             driver: self.name.clone(),
         }
         .encode_to_vec();
-        let bytes = self
+        let fut = self
             .inner
-            .invoke(pb::DriverMethod::Parse as u32, sv(&pb_req))
-            .await;
+            .invoke(pb::DriverMethod::Parse as u32, sv(&pb_req));
+        let bytes = await_with_cancel(ct, driver_cancel(&self.inner, &request_id), fut).await;
         match decode_unary(&bytes)? {
             Body::ParseResp(pr) => Ok(ParseResponse {
                 target_def: convert::target_def_from_pb(pr.target_def.unwrap_or_default())?,
@@ -477,8 +563,9 @@ impl ManagedDriver for StableRemoteManagedDriver {
     async fn apply_transitive(
         &self,
         req: ApplyTransitiveRequest,
-        _ct: &(dyn Cancellable + Send + Sync),
+        ct: &(dyn Cancellable + Send + Sync),
     ) -> anyhow::Result<ApplyTransitiveResponse> {
+        let request_id = req.request_id.clone();
         let pb_req = pb::ApplyTransitiveRequest {
             request_id: req.request_id,
             target_def: Some(convert::target_def_to_pb(&req.target_def)?),
@@ -486,10 +573,10 @@ impl ManagedDriver for StableRemoteManagedDriver {
             driver: self.name.clone(),
         }
         .encode_to_vec();
-        let bytes = self
+        let fut = self
             .inner
-            .invoke(pb::DriverMethod::ApplyTransitive as u32, sv(&pb_req))
-            .await;
+            .invoke(pb::DriverMethod::ApplyTransitive as u32, sv(&pb_req));
+        let bytes = await_with_cancel(ct, driver_cancel(&self.inner, &request_id), fut).await;
         match decode_unary(&bytes)? {
             Body::ApplyTransitiveResp(r) => Ok(ApplyTransitiveResponse {
                 target_def: convert::target_def_from_pb(r.target_def.unwrap_or_default())?,
@@ -506,17 +593,17 @@ impl ManagedDriver for StableRemoteManagedDriver {
     async fn run<'a, 'io>(
         &self,
         req: ManagedRunRequest<'a, 'io>,
-        _ct: &(dyn Cancellable + Send + Sync),
+        ct: &(dyn Cancellable + Send + Sync),
     ) -> anyhow::Result<ManagedRunResponse> {
-        self.dispatch_run(req, false).await
+        self.dispatch_run(req, false, ct).await
     }
 
     async fn run_shell<'a, 'io>(
         &self,
         req: ManagedRunRequest<'a, 'io>,
-        _ct: &(dyn Cancellable + Send + Sync),
+        ct: &(dyn Cancellable + Send + Sync),
     ) -> anyhow::Result<ManagedRunResponse> {
-        self.dispatch_run(req, true).await
+        self.dispatch_run(req, true, ct).await
     }
 }
 
@@ -525,8 +612,10 @@ impl StableRemoteManagedDriver {
         &self,
         req: ManagedRunRequest<'_, '_>,
         shell: bool,
+        ct: &(dyn Cancellable + Send + Sync),
     ) -> anyhow::Result<ManagedRunResponse> {
-        let pb_req = pb::ManagedRunRequest {
+        let request_id = req.request.request_id.clone();
+        let pmrr = pb::ManagedRunRequest {
             request_id: req.request.request_id.clone(),
             target: Some(convert::target_def_to_pb(req.request.target)?),
             tree_root_path: req.request.tree_root_path.to_string_lossy().into_owned(),
@@ -537,29 +626,28 @@ impl StableRemoteManagedDriver {
             inputs: req.inputs.iter().map(managed_input_to_pb).collect(),
             shell,
             driver: self.name.clone(),
+        };
+        // `run` is bidi: the request stream carries the run request (RunInFrame),
+        // the response stream carries the result (RunOutFrame). `shell` rides pmrr.
+        let in_frame = pb::RunInFrame {
+            msg: Some(pb::run_in_frame::Msg::Start(pmrr)),
         }
         .encode_to_vec();
-        // stdio rails are frozen but unused today (the subprocess inherits stdio at
-        // spawn); pass all-None. `shell` already rides pb_req (set above).
-        let io = RunIo {
-            stdin: Default::default(),
-            stdout: Default::default(),
-            stderr: Default::default(),
-        };
-        let bytes = self
+        let resp_stream = self
             .inner
-            .invoke_io(pb::DriverMethod::Run as u32, sv(&pb_req), io)
+            .invoke_bidi(pb::DriverMethod::Run as u32, host_item_stream(vec![in_frame]))
             .await;
-        match decode_unary(&bytes)? {
-            Body::ManagedRunResp(r) => Ok(ManagedRunResponse {
-                artifacts: r
-                    .artifacts
-                    .into_iter()
-                    .map(convert::output_artifact_from_pb)
-                    .collect(),
-            }),
-            Body::Error(e) => anyhow::bail!("{}", e.message),
-            other => anyhow::bail!("unexpected managed run response: {other:?}"),
+        // The response stream's `next` blocks (on subprocess output), so drain it on
+        // a dedicated thread and bridge the result back — while watching `ct` so a
+        // cancel trips the plugin's run token (which stops the subprocess).
+        let (tx, rx) = futures::channel::oneshot::channel();
+        std::thread::spawn(move || {
+            // Receiver dropped only if the caller gave up; ignore send failure.
+            drop(tx.send(drain_run(resp_stream)));
+        });
+        match await_with_cancel(ct, driver_cancel(&self.inner, &request_id), rx).await {
+            Ok(result) => result,
+            Err(_canceled) => anyhow::bail!("run drain thread dropped"),
         }
     }
 }

--- a/crates/plugin-stabby/src/load_stable.rs
+++ b/crates/plugin-stabby/src/load_stable.rs
@@ -5,8 +5,8 @@
 //! executor across natively (`HostExecutor`) so callbacks are direct.
 
 use crate::abi::{
-    CREATE_SYMBOL, CreateConfig, CreateFn, DynExecutor, DynManagedDriver, DynProvider,
-    StableManagedDriverDyn, StableProviderDyn,
+    CREATE_SYMBOL, CreateConfig, CreateFn, DynExecutor, DynManagedDriver, DynProvider, RunIo,
+    StableManagedDriverDyn, StableMetaDyn, StableProviderDyn,
 };
 use crate::host::HostExecutor;
 use async_trait::async_trait;
@@ -163,7 +163,10 @@ impl Provider for StableRemoteProvider {
                 states: req.states.iter().map(convert::state_to_pb).collect(),
             }
             .encode_to_vec();
-            let bytes = self.inner.list(sv(&pb_req)).await;
+            let bytes = self
+                .inner
+                .invoke(pb::ProviderMethod::List as u32, sv(&pb_req))
+                .await;
             let mut out: Vec<anyhow::Result<ListResponse>> = Vec::new();
             for b in decode_stream(&bytes)? {
                 match b {
@@ -203,7 +206,10 @@ impl Provider for StableRemoteProvider {
                 prefix: req.prefix.as_str().to_string(),
             }
             .encode_to_vec();
-            let bytes = self.inner.list_packages(sv(&pb_req)).await;
+            let bytes = self
+                .inner
+                .invoke(pb::ProviderMethod::ListPackages as u32, sv(&pb_req))
+                .await;
             let mut out: Vec<anyhow::Result<ListPackageResponse>> = Vec::new();
             for b in decode_stream(&bytes)? {
                 match b {
@@ -243,7 +249,10 @@ impl Provider for StableRemoteProvider {
             }
             .encode_to_vec();
             let exec: DynExecutor = HostExecutor::wrap(Arc::clone(&req.executor));
-            let bytes = self.inner.get(sv(&pb_req), exec).await;
+            let bytes = self
+                .inner
+                .invoke_exec(pb::ProviderMethod::Get as u32, sv(&pb_req), exec)
+                .await;
             let body = decode_unary(&bytes).map_err(GetError::Other)?;
             match body {
                 Body::GetResp(gr) => Ok(GetResponse {
@@ -282,7 +291,10 @@ impl Provider for StableRemoteProvider {
                 package: req.package.as_str().to_string(),
             }
             .encode_to_vec();
-            let bytes = self.inner.probe(sv(&pb_req)).await;
+            let bytes = self
+                .inner
+                .invoke(pb::ProviderMethod::Probe as u32, sv(&pb_req))
+                .await;
             match decode_unary(&bytes)? {
                 Body::ProbeResp(pr) => Ok(ProbeResponse {
                     states: pr.states.into_iter().map(convert::state_from_pb).collect(),
@@ -296,7 +308,7 @@ impl Provider for StableRemoteProvider {
     fn functions(&self) -> Vec<ProviderFunctionDef> {
         // Sync metadata call across the seam; decode the plugin's function defs
         // and wrap each handler in a proxy that dispatches back over the ABI.
-        let bytes = self.inner.functions();
+        let bytes = self.inner.meta(pb::ProviderMethod::Functions as u32);
         let resp = match pb::FunctionsResponse::decode(&bytes[..]) {
             Ok(r) => r,
             // A decode failure here would be an ABI bug; surface no functions
@@ -322,7 +334,7 @@ impl Provider for StableRemoteProvider {
     fn state_schema(&self) -> Option<StateSchema> {
         // An empty SVec encodes `None`; any encoded `Schema` (even fields-empty)
         // encodes `Some`.
-        let bytes = self.inner.state_schema();
+        let bytes = self.inner.meta(pb::ProviderMethod::StateSchema as u32);
         if bytes.is_empty() {
             return None;
         }
@@ -345,7 +357,11 @@ impl Provider for StableRemoteProvider {
             .collect();
         let metadata = pb::FunctionRegistry { functions }.encode_to_vec();
         let cb = crate::host::HostFunctionRegistry::wrap(reg);
-        self.inner.set_function_registry(sv(&metadata), cb);
+        self.inner.invoke_registry(
+            pb::ProviderMethod::SetFunctionRegistry as u32,
+            sv(&metadata),
+            cb,
+        );
     }
 }
 
@@ -372,7 +388,10 @@ impl ProviderFn for StableRemoteFn {
                 .collect(),
         }
         .encode_to_vec();
-        let bytes = self.inner.call_function(sv(&pb_req)).await;
+        let bytes = self
+            .inner
+            .invoke(pb::ProviderMethod::CallFunction as u32, sv(&pb_req))
+            .await;
         match decode_unary(&bytes)? {
             Body::CallFunctionResp(r) => Ok(convert::value_from_pb(r.value.unwrap_or_default())),
             Body::Error(e) => anyhow::bail!("{}", e.message),
@@ -407,7 +426,7 @@ impl ManagedDriver for StableRemoteManagedDriver {
     }
 
     fn schema(&self) -> DriverSchema {
-        let bytes = self.inner.schema();
+        let bytes = self.inner.meta(pb::DriverMethod::Schema as u32);
         pb::Schema::decode(&bytes[..])
             .map(convert::driver_schema_from_pb)
             .unwrap_or_default()
@@ -424,7 +443,10 @@ impl ManagedDriver for StableRemoteManagedDriver {
             driver: self.name.clone(),
         }
         .encode_to_vec();
-        let bytes = self.inner.parse(sv(&pb_req)).await;
+        let bytes = self
+            .inner
+            .invoke(pb::DriverMethod::Parse as u32, sv(&pb_req))
+            .await;
         match decode_unary(&bytes)? {
             Body::ParseResp(pr) => Ok(ParseResponse {
                 target_def: convert::target_def_from_pb(pr.target_def.unwrap_or_default())?,
@@ -446,7 +468,10 @@ impl ManagedDriver for StableRemoteManagedDriver {
             driver: self.name.clone(),
         }
         .encode_to_vec();
-        let bytes = self.inner.apply_transitive(sv(&pb_req)).await;
+        let bytes = self
+            .inner
+            .invoke(pb::DriverMethod::ApplyTransitive as u32, sv(&pb_req))
+            .await;
         match decode_unary(&bytes)? {
             Body::ApplyTransitiveResp(r) => Ok(ApplyTransitiveResponse {
                 target_def: convert::target_def_from_pb(r.target_def.unwrap_or_default())?,
@@ -496,7 +521,17 @@ impl StableRemoteManagedDriver {
             driver: self.name.clone(),
         }
         .encode_to_vec();
-        let bytes = self.inner.run(sv(&pb_req), shell).await;
+        // stdio rails are frozen but unused today (the subprocess inherits stdio at
+        // spawn); pass all-None. `shell` already rides pb_req (set above).
+        let io = RunIo {
+            stdin: Default::default(),
+            stdout: Default::default(),
+            stderr: Default::default(),
+        };
+        let bytes = self
+            .inner
+            .invoke_io(pb::DriverMethod::Run as u32, sv(&pb_req), io)
+            .await;
         match decode_unary(&bytes)? {
             Body::ManagedRunResp(r) => Ok(ManagedRunResponse {
                 artifacts: r

--- a/crates/plugin-stabby/src/load_stable.rs
+++ b/crates/plugin-stabby/src/load_stable.rs
@@ -5,9 +5,9 @@
 //! executor across natively (`HostExecutor`) so callbacks are direct.
 
 use crate::abi::{
-    CREATE_SYMBOL, CreateConfig, CreateFn, DynExecutor, DynItemStream, DynManagedDriver,
-    DynProvider, StableCancelDyn, StableItemStream, StableItemStreamDyn, StableManagedDriverDyn,
-    StableMetaDyn, StableProviderDyn,
+    CREATE_SYMBOL, CreateFn, DynExecutor, DynItemStream, DynManagedDriver, DynProvider,
+    StableCancelDyn, StableItemStream, StableItemStreamDyn, StableManagedDriverDyn, StableMetaDyn,
+    StableProviderDyn,
 };
 use crate::host::HostExecutor;
 use async_trait::async_trait;
@@ -54,11 +54,20 @@ pub fn load(
     path: &std::path::Path,
     root: &str,
     home: &str,
-    options: &[u8],
+    options: std::collections::HashMap<String, pb::Value>,
 ) -> anyhow::Result<LoadedComponents> {
     use crate::abi::PluginComponents;
     use anyhow::Context;
     use stabby::libloading::StabbyLibrary;
+
+    // The create config crosses as prost bytes so its fields are additive; build it
+    // once here from the structured options (no nested encode).
+    let cfg = pb::CreateConfig {
+        root: root.to_string(),
+        home: home.to_string(),
+        options,
+    }
+    .encode_to_vec();
 
     // SAFETY: loading a plugin dylib runs its initializers; the path is operator-
     // controlled config. The ABI of what we call is checked below via get_stabbied.
@@ -71,11 +80,7 @@ pub fn load(
         // `CreateFn` before returning it; calling it is then ABI-sound.
         let create = unsafe { lib.get_stabbied::<CreateFn>(CREATE_SYMBOL) }
             .map_err(|e| anyhow::anyhow!("stabby ABI check failed for {}: {e}", path.display()))?;
-        create(CreateConfig {
-            root: root.into(),
-            home: home.into(),
-            options: stabby::vec::Vec::from(options),
-        })
+        create(sv(&cfg))
     };
     // Keep the dylib mapped for the process lifetime (the returned trait objects'
     // vtables point into its code); leaking the handle is intentional.
@@ -85,6 +90,8 @@ pub fn load(
         provider_name,
         provider,
         drivers,
+        // Reserved return-side metadata; nothing consumes it yet.
+        meta: _,
     } = comps;
     let pname = provider_name.to_string();
     let host_provider = if pname.is_empty() {

--- a/crates/plugin-stabby/src/load_stable.rs
+++ b/crates/plugin-stabby/src/load_stable.rs
@@ -314,7 +314,10 @@ impl Provider for StableRemoteProvider {
                 stream,
                 decode: decode_list_item,
                 done: false,
-            }) as Box<dyn Iterator<Item = anyhow::Result<ListResponse>> + Send>)
+            })
+                as Box<
+                    dyn Iterator<Item = anyhow::Result<ListResponse>> + Send,
+                >)
         })
     }
 
@@ -340,7 +343,9 @@ impl Provider for StableRemoteProvider {
                 decode: decode_list_package_item,
                 done: false,
             })
-                as Box<dyn Iterator<Item = anyhow::Result<ListPackageResponse>> + Send>)
+                as Box<
+                    dyn Iterator<Item = anyhow::Result<ListPackageResponse>> + Send,
+                >)
         })
     }
 
@@ -642,7 +647,10 @@ impl StableRemoteManagedDriver {
         .encode_to_vec();
         let resp_stream = self
             .inner
-            .invoke_bidi(pb::DriverMethod::Run as u32, host_item_stream(vec![in_frame]))
+            .invoke_bidi(
+                pb::DriverMethod::Run as u32,
+                host_item_stream(vec![in_frame]),
+            )
             .await;
         // The response stream's `next` blocks (on subprocess output), so drain it on
         // a dedicated thread and bridge the result back — while watching `ct` so a

--- a/crates/plugin-stabby/src/load_stable.rs
+++ b/crates/plugin-stabby/src/load_stable.rs
@@ -5,8 +5,9 @@
 //! executor across natively (`HostExecutor`) so callbacks are direct.
 
 use crate::abi::{
-    CREATE_SYMBOL, CreateConfig, CreateFn, DynExecutor, DynManagedDriver, DynProvider, RunIo,
-    StableManagedDriverDyn, StableMetaDyn, StableProviderDyn,
+    CREATE_SYMBOL, CreateConfig, CreateFn, DynExecutor, DynItemStream, DynManagedDriver,
+    DynProvider, RunIo, StableItemStreamDyn, StableManagedDriverDyn, StableMetaDyn,
+    StableProviderDyn,
 };
 use crate::host::HostExecutor;
 use async_trait::async_trait;
@@ -109,17 +110,67 @@ fn decode_unary(bytes: &[u8]) -> anyhow::Result<Body> {
         .ok_or_else(|| anyhow::anyhow!("empty stable response frame"))
 }
 
-fn decode_stream(bytes: &[u8]) -> anyhow::Result<Vec<Body>> {
-    use prost::bytes::Buf;
-    let mut cur = bytes;
-    let mut out = Vec::new();
-    while cur.has_remaining() {
-        let f = pb::Frame::decode_length_delimited(&mut cur)?;
-        if let Some(b) = f.body {
-            out.push(b);
+/// Host-side lazy adapter over a plugin response stream: each `next` pulls one
+/// frame across the seam (`StableItemStream::next`) and decodes it, so items flow
+/// incrementally and the full set is never buffered. `Send` (the stream handle is
+/// `Send + Sync`, `decode` is a fn pointer) so it satisfies the engine's `Provider`
+/// iterator bound.
+struct ItemStreamIter<T> {
+    stream: DynItemStream,
+    decode: fn(&[u8]) -> anyhow::Result<T>,
+    done: bool,
+}
+
+impl<T> Iterator for ItemStreamIter<T> {
+    type Item = anyhow::Result<T>;
+
+    fn next(&mut self) -> Option<Self::Item> {
+        if self.done {
+            return None;
+        }
+        let bytes = self.stream.next();
+        // Empty == the stream is exhausted cleanly.
+        if bytes.is_empty() {
+            self.done = true;
+            return None;
+        }
+        let frame = match pb::Frame::decode(&bytes[..]) {
+            Ok(f) => f,
+            Err(e) => {
+                self.done = true;
+                return Some(Err(anyhow::anyhow!("stream frame decode: {e}")));
+            }
+        };
+        match frame.body {
+            Some(Body::StreamItem(si)) => Some((self.decode)(&si.item)),
+            Some(Body::StreamEnd(se)) => {
+                self.done = true;
+                se.error.map(|e| Err(anyhow::anyhow!("{}", e.message)))
+            }
+            Some(Body::Error(e)) => {
+                self.done = true;
+                Some(Err(anyhow::anyhow!("{}", e.message)))
+            }
+            _ => {
+                self.done = true;
+                None
+            }
         }
     }
-    Ok(out)
+}
+
+fn decode_list_item(b: &[u8]) -> anyhow::Result<ListResponse> {
+    let lr = pb::ListResponse::decode(b)?;
+    Ok(ListResponse {
+        addr: convert::addr_from_pb(lr.addr.unwrap_or_default()),
+    })
+}
+
+fn decode_list_package_item(b: &[u8]) -> anyhow::Result<ListPackageResponse> {
+    let lpr = pb::ListPackageResponse::decode(b)?;
+    Ok(ListPackageResponse {
+        pkg: PkgBuf::from(lpr.pkg),
+    })
 }
 
 /// Host handle to a loaded plugin's provider. `Clone` (cheap — shares the loaded
@@ -163,33 +214,17 @@ impl Provider for StableRemoteProvider {
                 states: req.states.iter().map(convert::state_to_pb).collect(),
             }
             .encode_to_vec();
-            let bytes = self
+            // Server-streaming: pull items lazily across the seam — the whole list
+            // is never materialized on either side.
+            let stream = self
                 .inner
-                .invoke(pb::ProviderMethod::List as u32, sv(&pb_req))
+                .invoke_server_stream(pb::ProviderMethod::List as u32, sv(&pb_req))
                 .await;
-            let mut out: Vec<anyhow::Result<ListResponse>> = Vec::new();
-            for b in decode_stream(&bytes)? {
-                match b {
-                    Body::StreamItem(si) => {
-                        let lr = pb::ListResponse::decode(&si.item[..])?;
-                        out.push(Ok(ListResponse {
-                            addr: convert::addr_from_pb(lr.addr.unwrap_or_default()),
-                        }));
-                    }
-                    Body::StreamEnd(se) => {
-                        if let Some(e) = se.error {
-                            anyhow::bail!("{}", e.message);
-                        }
-                        break;
-                    }
-                    Body::Error(e) => anyhow::bail!("{}", e.message),
-                    _ => {}
-                }
-            }
-            Ok(Box::new(out.into_iter())
-                as Box<
-                    dyn Iterator<Item = anyhow::Result<ListResponse>> + Send,
-                >)
+            Ok(Box::new(ItemStreamIter {
+                stream,
+                decode: decode_list_item,
+                done: false,
+            }) as Box<dyn Iterator<Item = anyhow::Result<ListResponse>> + Send>)
         })
     }
 
@@ -206,33 +241,16 @@ impl Provider for StableRemoteProvider {
                 prefix: req.prefix.as_str().to_string(),
             }
             .encode_to_vec();
-            let bytes = self
+            let stream = self
                 .inner
-                .invoke(pb::ProviderMethod::ListPackages as u32, sv(&pb_req))
+                .invoke_server_stream(pb::ProviderMethod::ListPackages as u32, sv(&pb_req))
                 .await;
-            let mut out: Vec<anyhow::Result<ListPackageResponse>> = Vec::new();
-            for b in decode_stream(&bytes)? {
-                match b {
-                    Body::StreamItem(si) => {
-                        let lpr = pb::ListPackageResponse::decode(&si.item[..])?;
-                        out.push(Ok(ListPackageResponse {
-                            pkg: PkgBuf::from(lpr.pkg),
-                        }));
-                    }
-                    Body::StreamEnd(se) => {
-                        if let Some(e) = se.error {
-                            anyhow::bail!("{}", e.message);
-                        }
-                        break;
-                    }
-                    Body::Error(e) => anyhow::bail!("{}", e.message),
-                    _ => {}
-                }
-            }
-            Ok(Box::new(out.into_iter())
-                as Box<
-                    dyn Iterator<Item = anyhow::Result<ListPackageResponse>> + Send,
-                >)
+            Ok(Box::new(ItemStreamIter {
+                stream,
+                decode: decode_list_package_item,
+                done: false,
+            })
+                as Box<dyn Iterator<Item = anyhow::Result<ListPackageResponse>> + Send>)
         })
     }
 

--- a/example/.hephconfig2
+++ b/example/.hephconfig2
@@ -15,7 +15,7 @@ plugins:
   # ~/.heph by the `gen-example` script (which runs `install-go-plugin`).
   - path: ~/.heph/plugins/go/heph-go-plugin.json
     options:
-      go_bin: "//@heph/bin:go"
+      gotool: "//@heph/bin:go"
 #fuse:
 #  enabled: true
 # Remote (shared) caches. Each entry is keyed by a name and has a `uri` plus

--- a/proto/plugin/v1/common.proto
+++ b/proto/plugin/v1/common.proto
@@ -28,6 +28,17 @@ message Value {
   }
 }
 
+// Config handed to a cdylib's create entry (`heph_plugin_create`). Crosses as
+// prost bytes (not a stabby struct) so new config fields are additive — an older
+// plugin built against fewer fields still loads. `options` is the plugin's
+// `options:` map as structured data (no nested encode). `root` is the workspace
+// root; `home` is the engine's home dir for plugin state/scratch.
+message CreateConfig {
+  string root = 1;
+  string home = 2;
+  map<string, Value> options = 3;
+}
+
 // Target address. Mirrors hmodel::Addr (package //pkg : name @args).
 message Addr {
   string package = 1;

--- a/proto/plugin/v1/driver.proto
+++ b/proto/plugin/v1/driver.proto
@@ -8,6 +8,18 @@ import "plugin/v1/common.proto";
 import "plugin/v1/targetdef.proto";
 import "plugin/v1/callback.proto";
 
+// Selects which driver RPC the stable-ABI dispatch (`StableManagedDriver::invoke*`)
+// should run. Same append-only contract as ProviderMethod. RUN carries the
+// native stdio handles (invoke_io). See crates/plugin-stabby/ABI_VERSIONING.md.
+enum DriverMethod {
+  DRIVER_METHOD_UNSPECIFIED = 0;
+  DRIVER_METHOD_PARSE = 1;
+  DRIVER_METHOD_APPLY_TRANSITIVE = 2;
+  DRIVER_METHOD_RUN = 3; // carries the native stdio (invoke_io)
+  DRIVER_METHOD_SCHEMA = 4; // sync metadata (StableMeta::meta)
+  DRIVER_METHOD_CONFIG = 5; // sync metadata (StableMeta::meta)
+}
+
 message ParseRequest {
   string request_id = 1;
   TargetSpec target_spec = 2;

--- a/proto/plugin/v1/driver.proto
+++ b/proto/plugin/v1/driver.proto
@@ -113,3 +113,27 @@ message ManagedRunRequest {
 message ManagedRunResponse {
   repeated OutputArtifactRef artifacts = 1;
 }
+
+// ---- Bidi run streams (DriverMethod RUN over StableManagedDriver::invoke_bidi) ----
+//
+// A driver run is a bidirectional stream. The request stream (host -> driver)
+// carries the run request first, then live stdin; the response stream
+// (driver -> host) carries live stdout/stderr, then the terminal result. Each
+// rides one StreamItem (its `item` is an encoded RunInFrame / RunOutFrame). The
+// stdio variants are reserved — unused until live streaming is wired — so adding
+// them is an additive, prost-only change (no ABI break).
+message RunInFrame {
+  oneof msg {
+    ManagedRunRequest start = 1; // first item: the run request
+    bytes stdin_chunk = 2;       // live stdin bytes
+    bool stdin_close = 3;        // stdin EOF (value ignored)
+  }
+}
+message RunOutFrame {
+  oneof msg {
+    bytes stdout_chunk = 1;
+    bytes stderr_chunk = 2;
+    ManagedRunResponse response = 3; // terminal: artifacts
+    string error = 4;                // terminal: failure message
+  }
+}

--- a/proto/plugin/v1/envelope.proto
+++ b/proto/plugin/v1/envelope.proto
@@ -58,6 +58,11 @@ message Error {
     KIND_CANCELLED = 2;
     KIND_NOT_FOUND = 3;
     KIND_CYCLE = 4;
+    // The plugin does not implement the dispatched method id. Returned by a
+    // plugin built against an older ABI minor when a newer host calls a method
+    // it predates — the host treats it as "capability absent" and falls back,
+    // never a hard failure. This is what makes added dispatch methods additive.
+    KIND_UNIMPLEMENTED = 5;
   }
   Kind kind = 1;
   string message = 2;

--- a/proto/plugin/v1/provider.proto
+++ b/proto/plugin/v1/provider.proto
@@ -14,6 +14,24 @@ message ConfigResponse {
   string name = 1;
 }
 
+// Selects which provider RPC the stable-ABI dispatch (`StableProvider::invoke*`)
+// should run. The numeric value is the `method` argument crossing the dylib
+// seam. Append-only: a new RPC is a NEW value here + a NEW match arm guest-side;
+// the frozen vtable is untouched, so it is an additive (minor) ABI change. Never
+// renumber or reuse a value. See crates/plugin-stabby/ABI_VERSIONING.md.
+enum ProviderMethod {
+  PROVIDER_METHOD_UNSPECIFIED = 0;
+  PROVIDER_METHOD_LIST = 1;
+  PROVIDER_METHOD_LIST_PACKAGES = 2;
+  PROVIDER_METHOD_GET = 3; // carries the native executor (invoke_exec)
+  PROVIDER_METHOD_PROBE = 4;
+  PROVIDER_METHOD_FUNCTIONS = 5;
+  PROVIDER_METHOD_CALL_FUNCTION = 6;
+  PROVIDER_METHOD_STATE_SCHEMA = 7;
+  PROVIDER_METHOD_SET_FUNCTION_REGISTRY = 8; // carries the registry (invoke_registry)
+  PROVIDER_METHOD_CONFIG = 9; // sync metadata (StableMeta::meta)
+}
+
 message ListRequest {
   string request_id = 1;
   string package = 2;


### PR DESCRIPTION
## Why

The cold provider/driver ABI was **one stabby vtable slot per RPC** (11 on `StableProvider`, 5 on `StableManagedDriver`). stabby's `get_stabbied` verifies the full type report reachable from the create symbol at load, so **adding any RPC changed the report and broke loading** of a separately-built plugin. The hot callback path already pays its cost natively; the cold path was the one that needed to evolve and couldn't.

## What

Collapse each cold trait to a **frozen generic dispatch** keyed by a prost method id. Requests/responses keep crossing as prost bytes (the cold path was *already* prost → **no perf change**, just one added `u32` match), but the vtable never changes when an RPC is added:

```
StableMeta          { meta(kind) }                         // sync metadata
StableProvider      { invoke, invoke_exec, invoke_registry }
StableManagedDriver { invoke, invoke_io }
```

- **Adding an RPC** = a new `ProviderMethod`/`DriverMethod` enum value + a guest match arm. Type report unchanged → an older plugin and newer host still load; the old guest answers an unknown id with `Error{Unimplemented}` and the host falls back. **Additive (minor), no longer an ABI break.**
- **Native handles can't ride prost bytes**, so each gets its own frozen slot: `invoke_exec` (`DynExecutor`, for `get`), `invoke_registry` (`DynFunctionRegistry`, for `set_function_registry`).
- **`config` split out**: `config`/`functions`/`state_schema`/`schema` move to a separate sync `StableMeta` trait, off the async RPC surface.
- **Streaming rails provisioned now**: `StableWrite` (mirror of `StableRead`) + a frozen `RunIo { stdin, stdout, stderr }` carried by `invoke_io`. `run()` routes through it with all-`None` handles today; future live stdin/stdout/stderr streaming just populates them — additive, no future ABI break.
- Handles compose `StableMeta` via stabby multi-trait dynptr.

## Compatibility / version

Per discussion this stays at `ABI_SEMVER = 0.1.0` (pre-release, no deployed plugins; this redefines the 0.1.0 contract in place). The point of the change is that *future* additions won't need a bump.

## Tests

Existing guest↔host round-trip tests (`provider_functions_roundtrip`, `function_registry_injection_roundtrip`, `driver_schema_roundtrip`) now exercise `meta`/`invoke`/`invoke_registry` and stay green. New `unknown_dispatch_method_is_unimplemented` asserts the additive-compat contract. Full `--workspace --all-features` build + clippy `-D warnings` clean.

## Notes

- Separate from #92 (the ABI guard). The guard's `ABI_VERSIONING.md` describes the *old* "vtable add = major" model; once this lands it should be updated to mark prost-RPC additions as the additive/minor case. Follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)