### PR TITLE
feat(plugin-go): test env via provider_state (bool | struct schema)

### DIFF
--- a/crates/core/src/htvalue/signature.rs
+++ b/crates/core/src/htvalue/signature.rs
@@ -27,6 +27,18 @@ pub enum ParamType {
     /// Accepts any one of several types, e.g. `cache` being `bool | map[bool]`.
     /// Rendered as the members joined by ` | `; matches if any member matches.
     Union(Vec<ParamType>),
+    /// A record with named, heterogeneously-typed fields. Unlike [`ParamType::Map`]
+    /// (homogeneous value type, arbitrary keys), a struct fixes a known set of
+    /// field names, each with its own type. All fields are optional: a value
+    /// matches if every present key names a known field of matching type.
+    Struct(Vec<StructField>),
+}
+
+/// One named field of a [`ParamType::Struct`].
+#[derive(Clone, Debug, PartialEq)]
+pub struct StructField {
+    pub name: String,
+    pub ty: ParamType,
 }
 
 impl ParamType {
@@ -45,6 +57,19 @@ impl ParamType {
         ParamType::Union(types)
     }
 
+    /// Convenience: a struct with the given `(name, type)` fields.
+    pub fn strukt(fields: Vec<(&str, ParamType)>) -> ParamType {
+        ParamType::Struct(
+            fields
+                .into_iter()
+                .map(|(name, ty)| StructField {
+                    name: name.to_string(),
+                    ty,
+                })
+                .collect(),
+        )
+    }
+
     /// Human-readable name used in rendered signatures and error messages.
     pub fn render(&self) -> String {
         match self {
@@ -61,6 +86,14 @@ impl ParamType {
                 .map(ParamType::render)
                 .collect::<Vec<_>>()
                 .join(" | "),
+            ParamType::Struct(fields) => {
+                let rendered = fields
+                    .iter()
+                    .map(|f| format!("{}: {}", f.name, f.ty.render()))
+                    .collect::<Vec<_>>()
+                    .join(", ");
+                format!("struct({rendered})")
+            }
         }
     }
 
@@ -79,6 +112,14 @@ impl ParamType {
             (ParamType::Null, Value::Null()) => true,
             (ParamType::List(inner), Value::List(items)) => items.iter().all(|e| inner.matches(e)),
             (ParamType::Map(value), Value::Map(m)) => m.values().all(|e| value.matches(e)),
+            // Every present key must name a known field whose type matches.
+            // Fields are optional, so missing keys are fine; unknown keys fail.
+            (ParamType::Struct(fields), Value::Map(m)) => m.iter().all(|(k, v)| {
+                fields
+                    .iter()
+                    .find(|f| &f.name == k)
+                    .is_some_and(|f| f.ty.matches(v))
+            }),
             _ => false,
         }
     }
@@ -294,6 +335,60 @@ mod tests {
             Value::Bool(true)
         )]))));
         assert!(!ty.matches(&Value::Int(3)));
+    }
+
+    #[test]
+    fn struct_renders_fields_in_order() {
+        let ty = ParamType::strukt(vec![
+            ("env", ParamType::map(ParamType::String)),
+            ("pass_env", ParamType::list(ParamType::String)),
+        ]);
+        assert_eq!(
+            ty.render(),
+            "struct(env: map[string], pass_env: list[string])"
+        );
+    }
+
+    #[test]
+    fn struct_matches_subset_of_known_fields_and_rejects_unknown() {
+        use std::collections::HashMap;
+        let ty = ParamType::strukt(vec![
+            ("env", ParamType::map(ParamType::String)),
+            ("pass_env", ParamType::list(ParamType::String)),
+        ]);
+        // Empty map and a subset both match (fields optional).
+        assert!(ty.matches(&Value::Map(HashMap::new())));
+        assert!(ty.matches(&Value::Map(HashMap::from([(
+            "pass_env".to_string(),
+            Value::List(vec![Value::String("HOME".to_string())])
+        )]))));
+        // Wrong value type for a known field fails.
+        assert!(!ty.matches(&Value::Map(HashMap::from([(
+            "env".to_string(),
+            Value::Bool(true)
+        )]))));
+        // Unknown key fails.
+        assert!(!ty.matches(&Value::Map(HashMap::from([(
+            "nope".to_string(),
+            Value::String("x".to_string())
+        )]))));
+    }
+
+    #[test]
+    fn bool_or_struct_union_accepts_both_forms() {
+        use std::collections::HashMap;
+        let ty = ParamType::union(vec![
+            ParamType::Bool,
+            ParamType::strukt(vec![("env", ParamType::map(ParamType::String))]),
+        ]);
+        assert!(ty.matches(&Value::Bool(false)));
+        assert!(ty.matches(&Value::Map(HashMap::from([(
+            "env".to_string(),
+            Value::Map(HashMap::from([(
+                "K".to_string(),
+                Value::String("v".to_string())
+            )]))
+        )]))));
     }
 
     #[test]

--- a/crates/plugin-abi/src/convert.rs
+++ b/crates/plugin-abi/src/convert.rs
@@ -81,10 +81,10 @@ pub fn value_from_pb(v: pb::Value) -> Value {
 // `call_function`. The host reconstructs the `FnSignature` to enforce arity/type
 // and render it (`heph inspect functions`, LSP hover).
 
-use hcore::htvalue::signature::{FnSignature, Param, ParamType};
+use hcore::htvalue::signature::{FnSignature, Param, ParamType, StructField};
 
 pub fn param_type_to_pb(t: &ParamType) -> pb::ParamType {
-    use pb::param_type::{Kind, Scalar, Union};
+    use pb::param_type::{Kind, Scalar, Struct, Union, r#struct};
     let kind = match t {
         ParamType::String => Kind::Scalar(Scalar::String as i32),
         ParamType::Bool => Kind::Scalar(Scalar::Bool as i32),
@@ -96,6 +96,15 @@ pub fn param_type_to_pb(t: &ParamType) -> pb::ParamType {
         ParamType::Map(value) => Kind::Map(Box::new(param_type_to_pb(value))),
         ParamType::Union(types) => Kind::Union(Union {
             types: types.iter().map(param_type_to_pb).collect(),
+        }),
+        ParamType::Struct(fields) => Kind::Struct(Struct {
+            fields: fields
+                .iter()
+                .map(|f| r#struct::Field {
+                    name: f.name.clone(),
+                    ty: Some(param_type_to_pb(&f.ty)),
+                })
+                .collect(),
         }),
     };
     pb::ParamType { kind: Some(kind) }
@@ -117,6 +126,15 @@ pub fn param_type_from_pb(t: pb::ParamType) -> ParamType {
         Some(Kind::Union(u)) => {
             ParamType::union(u.types.into_iter().map(param_type_from_pb).collect())
         }
+        Some(Kind::Struct(s)) => ParamType::Struct(
+            s.fields
+                .into_iter()
+                .map(|f| StructField {
+                    name: f.name,
+                    ty: f.ty.map(param_type_from_pb).unwrap_or(ParamType::Null),
+                })
+                .collect(),
+        ),
         None => ParamType::Null,
     }
 }
@@ -811,6 +829,20 @@ mod tests {
             ),
         ]));
         assert_eq!(value_from_pb(value_to_pb(&v)), v);
+    }
+
+    #[test]
+    fn param_type_struct_roundtrip() {
+        // `bool | struct(env: map[string], pass_env: list[string])` — exercises
+        // the Struct wire kind and its nested ParamTypes.
+        let ty = ParamType::union(vec![
+            ParamType::Bool,
+            ParamType::strukt(vec![
+                ("env", ParamType::map(ParamType::String)),
+                ("pass_env", ParamType::list(ParamType::String)),
+            ]),
+        ]);
+        assert_eq!(param_type_from_pb(param_type_to_pb(&ty)), ty);
     }
 
     #[test]

--- a/crates/plugin-abi/src/lib.rs
+++ b/crates/plugin-abi/src/lib.rs
@@ -17,7 +17,7 @@ pub use hproto_gen::heph::plugin::v1 as pb;
 
 /// ABI semantic version. Major must match exactly between host and plugin;
 /// minor is negotiated to `min(host, plugin)` at handshake.
-pub const ABI_SEMVER: &str = "0.1.0";
+pub const ABI_SEMVER: &str = "0.2.0";
 
 #[cfg(feature = "convert")]
 pub mod convert;

--- a/crates/plugin-buildfile/src/pluginbuildfile/run_file.rs
+++ b/crates/plugin-buildfile/src/pluginbuildfile/run_file.rs
@@ -133,6 +133,12 @@ pub(crate) fn param_type_to_ty(t: &ParamType) -> starlark::typing::Ty {
         ParamType::List(inner) => Ty::list(param_type_to_ty(inner)),
         ParamType::Map(value) => Ty::dict(Ty::string(), param_type_to_ty(value)),
         ParamType::Union(types) => Ty::unions(types.iter().map(param_type_to_ty).collect()),
+        // Starlark has no record type; model a struct as a string-keyed dict
+        // whose value type is the union of the field types.
+        ParamType::Struct(fields) => Ty::dict(
+            Ty::string(),
+            Ty::unions(fields.iter().map(|f| param_type_to_ty(&f.ty)).collect()),
+        ),
     }
 }
 

--- a/crates/plugin-go/src/plugingo/provider.rs
+++ b/crates/plugin-go/src/plugingo/provider.rs
@@ -464,8 +464,15 @@ impl ProviderTrait for Provider {
                 ),
                 field(
                     "test",
-                    ParamType::map(ParamType::Bool),
-                    "Test settings for this package, e.g. `{\"skip\": True}` to skip its tests.",
+                    ParamType::map(ParamType::union(vec![
+                        ParamType::Bool,
+                        ParamType::map(ParamType::String),
+                        ParamType::list(ParamType::String),
+                    ])),
+                    "Test settings for this package. `{\"skip\": True}` skips its tests \
+                     (inherited by descendants). `env`/`runtime_env` (map[string]) and \
+                     `pass_env`/`runtime_pass_env` (list[string]) are plumbed onto the \
+                     generated `test`/`xtest` run targets and apply only to this package.",
                 ),
             ],
         })
@@ -810,6 +817,59 @@ fn pick_test_skip(states: &[State]) -> bool {
         return false;
     };
     matches!(test_map.get("skip"), Some(Value::Bool(true)))
+}
+
+/// Parse a `map[string]string` Starlark value into a sorted map. Rejects
+/// non-string values so a typo (e.g. an int) surfaces as a clear error rather
+/// than being silently dropped.
+fn parse_str_map(v: &Value) -> anyhow::Result<BTreeMap<String, String>> {
+    let Value::Map(m) = v else {
+        anyhow::bail!("expected map[string], got: {v:?}");
+    };
+    m.iter()
+        .map(|(k, val)| match val {
+            Value::String(s) => Ok((k.clone(), s.clone())),
+            other => Err(anyhow::anyhow!(
+                "expected string value for key `{k}`, got: {other:?}"
+            )),
+        })
+        .collect()
+}
+
+/// Collect the test env knobs (`env`, `runtime_env`, `pass_env`,
+/// `runtime_pass_env`) from a `test = {...}` provider_state declared in the
+/// *exact* package of the target.
+///
+/// Unlike `skip` (which inherits down the package tree via [`pick_test_skip`]),
+/// these apply only to the package that declares them — a state at `//foo` does
+/// not leak into `//foo/bar`'s test targets. The engine pre-filters states by
+/// provider name, so callers only see Go states.
+fn pick_test_env(states: &[State], addr_pkg: &str) -> anyhow::Result<target_test::TestEnv> {
+    let mut out = target_test::TestEnv::default();
+    for state in states.iter().filter(|s| s.package.as_str() == addr_pkg) {
+        let Some(Value::Map(test_map)) = state.state.get("test") else {
+            continue;
+        };
+        if let Some(v) = test_map.get("env") {
+            out.env
+                .extend(parse_str_map(v).context("parsing test env from go provider_state")?);
+        }
+        if let Some(v) = test_map.get("runtime_env") {
+            out.runtime_env.extend(
+                parse_str_map(v).context("parsing test runtime_env from go provider_state")?,
+            );
+        }
+        if let Some(v) = test_map.get("pass_env") {
+            out.pass_env
+                .extend(parse_strings(v).context("parsing test pass_env from go provider_state")?);
+        }
+        if let Some(v) = test_map.get("runtime_pass_env") {
+            out.runtime_pass_env.extend(
+                parse_strings(v).context("parsing test runtime_pass_env from go provider_state")?,
+            );
+        }
+    }
+    Ok(out)
 }
 
 /// Pick the closest (deepest) ancestor state carrying `go_codegen_deps`.
@@ -1558,7 +1618,14 @@ impl ProviderInner {
                 ))
                 .context("build go_test_data query addr")
                 .map_err(GetError::Other)?;
-                let spec = target_test::test_spec(addr.clone(), build_test_addr, &data_query_addr);
+                let test_env =
+                    pick_test_env(&req.states, addr.package.as_str()).map_err(GetError::Other)?;
+                let spec = target_test::test_spec(
+                    addr.clone(),
+                    build_test_addr,
+                    &data_query_addr,
+                    &test_env,
+                );
                 Ok(GetResponse { target_spec: spec })
             }
             // Run the EXTERNAL (xtest) test bin.
@@ -1575,7 +1642,14 @@ impl ProviderInner {
                 ))
                 .context("build go_test_data query addr")
                 .map_err(GetError::Other)?;
-                let spec = target_test::test_spec(addr.clone(), build_xtest_addr, &data_query_addr);
+                let test_env =
+                    pick_test_env(&req.states, addr.package.as_str()).map_err(GetError::Other)?;
+                let spec = target_test::test_spec(
+                    addr.clone(),
+                    build_xtest_addr,
+                    &data_query_addr,
+                    &test_env,
+                );
                 Ok(GetResponse { target_spec: spec })
             }
             "embed" => {
@@ -4060,6 +4134,98 @@ golang.org/x/oauth2 v0.0.0-20200107190931-bf48bf16ab8d h1:pE8b58s1HRDMi8RDc79m0H
             state: m,
         }];
         assert!(!pick_test_skip(&states));
+    }
+
+    fn test_env_is_empty(env: &target_test::TestEnv) -> bool {
+        env.env.is_empty()
+            && env.runtime_env.is_empty()
+            && env.pass_env.is_empty()
+            && env.runtime_pass_env.is_empty()
+    }
+
+    fn state_with_test_map(pkg: &str, entries: Vec<(&str, Value)>) -> State {
+        let test_map: HashMap<String, Value> = entries
+            .into_iter()
+            .map(|(k, v)| (k.to_string(), v))
+            .collect();
+        let mut m = HashMap::new();
+        m.insert("test".to_string(), Value::Map(test_map));
+        State {
+            package: PkgBuf::from(pkg),
+            provider: "go".to_string(),
+            state: m,
+        }
+    }
+
+    #[test]
+    fn pick_test_env_empty_when_no_states() {
+        let env = pick_test_env(&[], "foo").unwrap();
+        assert!(test_env_is_empty(&env));
+    }
+
+    #[test]
+    fn pick_test_env_reads_all_four_knobs() {
+        let states = vec![state_with_test_map(
+            "foo",
+            vec![
+                (
+                    "env",
+                    Value::Map(HashMap::from([(
+                        "FOO".to_string(),
+                        Value::String("1".to_string()),
+                    )])),
+                ),
+                (
+                    "runtime_env",
+                    Value::Map(HashMap::from([(
+                        "BAR".to_string(),
+                        Value::String("2".to_string()),
+                    )])),
+                ),
+                (
+                    "pass_env",
+                    Value::List(vec![Value::String("HOME".to_string())]),
+                ),
+                (
+                    "runtime_pass_env",
+                    Value::List(vec![Value::String("PATH".to_string())]),
+                ),
+            ],
+        )];
+        let env = pick_test_env(&states, "foo").unwrap();
+        assert_eq!(env.env.get("FOO").map(String::as_str), Some("1"));
+        assert_eq!(env.runtime_env.get("BAR").map(String::as_str), Some("2"));
+        assert_eq!(env.pass_env, vec!["HOME".to_string()]);
+        assert_eq!(env.runtime_pass_env, vec!["PATH".to_string()]);
+    }
+
+    #[test]
+    fn pick_test_env_applies_only_to_exact_package_not_ancestors() {
+        // State at ancestor `foo` must NOT leak into `foo/bar`'s test targets.
+        let states = vec![state_with_test_map(
+            "foo",
+            vec![(
+                "env",
+                Value::Map(HashMap::from([(
+                    "FOO".to_string(),
+                    Value::String("1".to_string()),
+                )])),
+            )],
+        )];
+        let env = pick_test_env(&states, "foo/bar").unwrap();
+        assert!(test_env_is_empty(&env));
+    }
+
+    #[test]
+    fn pick_test_env_errors_on_non_string_env_value() {
+        let states = vec![state_with_test_map(
+            "foo",
+            vec![(
+                "env",
+                Value::Map(HashMap::from([("FOO".to_string(), Value::Int(3))])),
+            )],
+        )];
+        assert!(pick_test_env(&states, "foo").is_err());
     }
 
     #[tokio::test]

--- a/crates/plugin-go/src/plugingo/provider.rs
+++ b/crates/plugin-go/src/plugingo/provider.rs
@@ -464,15 +464,21 @@ impl ProviderTrait for Provider {
                 ),
                 field(
                     "test",
-                    ParamType::map(ParamType::union(vec![
+                    ParamType::union(vec![
                         ParamType::Bool,
-                        ParamType::map(ParamType::String),
-                        ParamType::list(ParamType::String),
-                    ])),
-                    "Test settings for this package. `{\"skip\": True}` skips its tests \
-                     (inherited by descendants). `env`/`runtime_env` (map[string]) and \
-                     `pass_env`/`runtime_pass_env` (list[string]) are plumbed onto the \
-                     generated `test`/`xtest` run targets and apply only to this package.",
+                        ParamType::strukt(vec![
+                            ("env", ParamType::map(ParamType::String)),
+                            ("pass_env", ParamType::list(ParamType::String)),
+                            ("runtime_env", ParamType::map(ParamType::String)),
+                            ("runtime_pass_env", ParamType::list(ParamType::String)),
+                        ]),
+                    ]),
+                    "Test settings for this package. `test = False` skips its tests \
+                     (inherited by descendants); `test = True` (or unset) runs them. \
+                     The struct form sets env on the generated `test`/`xtest` run \
+                     targets — `env`/`runtime_env` (map[string]) and \
+                     `pass_env`/`runtime_pass_env` (list[string]) — and applies only \
+                     to this package.",
                 ),
             ],
         })
@@ -802,9 +808,9 @@ fn pick_xtest_p_lib_name(pkg: &GoPackage) -> Option<&'static str> {
 }
 
 /// Return true if the closest (deepest) ancestor `provider_state(provider="go", ...)`
-/// that carries a `test = {...}` map sets `skip = True`. Deeper states fully
-/// override shallower ones — a `test = {"skip": False}` closer to the target
-/// re-enables tests even if a root-level state disabled them.
+/// disables tests via `test = False`. Deeper states fully override shallower ones —
+/// a `test = True` (or the struct form, which implies tests run) closer to the
+/// target re-enables tests even if a root-level state disabled them.
 fn pick_test_skip(states: &[State]) -> bool {
     let Some(state) = states
         .iter()
@@ -813,10 +819,9 @@ fn pick_test_skip(states: &[State]) -> bool {
     else {
         return false;
     };
-    let Some(Value::Map(test_map)) = state.state.get("test") else {
-        return false;
-    };
-    matches!(test_map.get("skip"), Some(Value::Bool(true)))
+    // Skip only when the closest `test` state is the bool `False`. `True` and the
+    // struct form (env config) both leave tests enabled.
+    matches!(state.state.get("test"), Some(Value::Bool(false)))
 }
 
 /// Parse a `map[string]string` Starlark value into a sorted map. Rejects
@@ -1028,10 +1033,10 @@ impl ProviderInner {
             return Err(GetError::NotFound);
         }
 
-        // provider_state(provider="go", test={"skip": True}) opts the package
-        // (and all descendants) out of test-target generation. Gate every test
-        // variant before the `_golist` resolve below so a skipped pkg never
-        // forces a `go list` round-trip purely to learn there are no tests.
+        // provider_state(provider="go", test=False) opts the package (and all
+        // descendants) out of test-target generation. Gate every test variant
+        // before the `_golist` resolve below so a skipped pkg never forces a
+        // `go list` round-trip purely to learn there are no tests.
         if is_test_target_name(&addr.name) && pick_test_skip(&req.states) {
             return Err(GetError::NotFound);
         }
@@ -4091,11 +4096,10 @@ golang.org/x/oauth2 v0.0.0-20200107190931-bf48bf16ab8d h1:pE8b58s1HRDMi8RDc79m0H
         assert_eq!(picked.package.as_str(), "");
     }
 
+    /// `skip = true` → `test = False` (disabled); `skip = false` → `test = True`.
     fn state_with_test_skip(pkg: &str, skip: bool) -> State {
-        let mut test_map = HashMap::new();
-        test_map.insert("skip".to_string(), Value::Bool(skip));
         let mut m = HashMap::new();
-        m.insert("test".to_string(), Value::Map(test_map));
+        m.insert("test".to_string(), Value::Bool(!skip));
         State {
             package: PkgBuf::from(pkg),
             provider: "go".to_string(),
@@ -4116,10 +4120,30 @@ golang.org/x/oauth2 v0.0.0-20200107190931-bf48bf16ab8d h1:pE8b58s1HRDMi8RDc79m0H
 
     #[test]
     fn pick_test_skip_deeper_state_overrides_shallower() {
-        // Root says skip=True; deeper pkg says skip=False → tests must run.
+        // Root says test=False (skip); deeper pkg says test=True → tests must run.
         let states = vec![
             state_with_test_skip("", true),
             state_with_test_skip("src/foo", false),
+        ];
+        assert!(!pick_test_skip(&states));
+    }
+
+    #[test]
+    fn pick_test_skip_struct_form_leaves_tests_enabled() {
+        // A deeper struct-form `test = {env: ...}` re-enables tests even when a
+        // root state disabled them — the struct implies tests run.
+        let states = vec![
+            state_with_test_skip("", true),
+            state_with_test_map(
+                "src/foo",
+                vec![(
+                    "env",
+                    Value::Map(HashMap::from([(
+                        "FOO".to_string(),
+                        Value::String("1".to_string()),
+                    )])),
+                )],
+            ),
         ];
         assert!(!pick_test_skip(&states));
     }

--- a/crates/plugin-go/src/plugingo/target_test.rs
+++ b/crates/plugin-go/src/plugingo/target_test.rs
@@ -13,6 +13,18 @@ pub struct GoEnv<'a> {
     pub gocache: &'a str,
 }
 
+/// Extra environment configuration plumbed onto the `test`/`xtest` run targets
+/// from a package's `provider_state(provider="go", test={...})`. Mirrors the
+/// exec driver's env knobs: `env`/`pass_env` are hashed (affect cache),
+/// `runtime_env`/`runtime_pass_env` are runtime-only (not hashed).
+#[derive(Debug, Default, Clone)]
+pub struct TestEnv {
+    pub env: BTreeMap<String, String>,
+    pub runtime_env: BTreeMap<String, String>,
+    pub pass_env: Vec<String>,
+    pub runtime_pass_env: Vec<String>,
+}
+
 /// Compile the test package (GoFiles + TestGoFiles) with `go tool compile` in test mode.
 ///
 /// Output: `<pkgname>_test.a`
@@ -229,7 +241,12 @@ pub fn build_test_spec(
 /// `data_query_addr` is a `@heph/query` addr selecting sibling targets labeled
 /// `go_test_data`. The engine expands the query lazily, so this provider does
 /// not need to scan the package itself.
-pub fn test_spec(addr: Addr, build_test_addr: Addr, data_query_addr: &Addr) -> TargetSpec {
+pub fn test_spec(
+    addr: Addr,
+    build_test_addr: Addr,
+    data_query_addr: &Addr,
+    test_env: &TestEnv,
+) -> TargetSpec {
     // exec driver passes argv literally — no shell expansion. The engine
     // stages dep outputs at <pkg>/<file> under ws_dir, and the process cwd
     // is the target's package dir (engine/driver_managed_os.rs:78). The
@@ -256,6 +273,28 @@ pub fn test_spec(addr: Addr, build_test_addr: Addr, data_query_addr: &Addr) -> T
     config.insert("run".to_string(), Value::List(run));
     config.insert("deps".to_string(), Value::Map(deps_map));
     config.insert("out".to_string(), Value::Map(HashMap::new()));
+
+    // Plumb package-scoped test env from provider_state. Omitted keys keep the
+    // spec minimal so cache fingerprints are unchanged for the common case.
+    if !test_env.env.is_empty() {
+        config.insert("env".to_string(), str_map_value(&test_env.env));
+    }
+    if !test_env.runtime_env.is_empty() {
+        config.insert(
+            "runtime_env".to_string(),
+            str_map_value(&test_env.runtime_env),
+        );
+    }
+    if !test_env.pass_env.is_empty() {
+        config.insert("pass_env".to_string(), str_list_value(&test_env.pass_env));
+    }
+    if !test_env.runtime_pass_env.is_empty() {
+        config.insert(
+            "runtime_pass_env".to_string(),
+            str_list_value(&test_env.runtime_pass_env),
+        );
+    }
+
     TargetSpec {
         addr,
         driver: "exec".to_string(),
@@ -266,6 +305,18 @@ pub fn test_spec(addr: Addr, build_test_addr: Addr, data_query_addr: &Addr) -> T
 }
 
 // ---- helpers ----
+
+fn str_map_value(m: &BTreeMap<String, String>) -> Value {
+    Value::Map(
+        m.iter()
+            .map(|(k, v)| (k.clone(), Value::String(v.clone())))
+            .collect(),
+    )
+}
+
+fn str_list_value(v: &[String]) -> Value {
+    Value::List(v.iter().cloned().map(Value::String).collect())
+}
 
 fn compile_run_script(
     p_flag: &str,
@@ -783,6 +834,7 @@ mod tests {
             mk_addr("mypkg", "test"),
             build_addr.clone(),
             &query_addr("mypkg"),
+            &TestEnv::default(),
         );
         let deps = match spec.config.get("deps").unwrap() {
             Value::Map(m) => m.clone(),
@@ -802,6 +854,7 @@ mod tests {
             mk_addr("mypkg", "test"),
             mk_addr("mypkg", "build_test"),
             &query_addr("mypkg"),
+            &TestEnv::default(),
         );
         assert_eq!(spec.driver, "exec");
         let run = match spec.config.get("run").expect("run present") {
@@ -819,6 +872,64 @@ mod tests {
             argv,
             vec!["./test_binary".to_string(), "-test.v".to_string()]
         );
+    }
+
+    #[test]
+    fn test_test_spec_omits_env_keys_when_test_env_empty() {
+        let spec = test_spec(
+            mk_addr("mypkg", "test"),
+            mk_addr("mypkg", "build_test"),
+            &query_addr("mypkg"),
+            &TestEnv::default(),
+        );
+        assert!(!spec.config.contains_key("env"));
+        assert!(!spec.config.contains_key("runtime_env"));
+        assert!(!spec.config.contains_key("pass_env"));
+        assert!(!spec.config.contains_key("runtime_pass_env"));
+    }
+
+    #[test]
+    fn test_test_spec_plumbs_all_env_knobs() {
+        let test_env = TestEnv {
+            env: BTreeMap::from([("FOO".to_string(), "1".to_string())]),
+            runtime_env: BTreeMap::from([("BAR".to_string(), "2".to_string())]),
+            pass_env: vec!["HOME".to_string()],
+            runtime_pass_env: vec!["PATH".to_string()],
+        };
+        let spec = test_spec(
+            mk_addr("mypkg", "test"),
+            mk_addr("mypkg", "build_test"),
+            &query_addr("mypkg"),
+            &test_env,
+        );
+
+        let env = match spec.config.get("env").expect("env present") {
+            Value::Map(m) => m.clone(),
+            _ => panic!("env must be a map"),
+        };
+        assert!(matches!(env.get("FOO"), Some(Value::String(s)) if s == "1"));
+
+        let renv = match spec.config.get("runtime_env").expect("runtime_env present") {
+            Value::Map(m) => m.clone(),
+            _ => panic!("runtime_env must be a map"),
+        };
+        assert!(matches!(renv.get("BAR"), Some(Value::String(s)) if s == "2"));
+
+        let pass = match spec.config.get("pass_env").expect("pass_env present") {
+            Value::List(v) => v.clone(),
+            _ => panic!("pass_env must be a list"),
+        };
+        assert!(matches!(&pass[0], Value::String(s) if s == "HOME"));
+
+        let rpass = match spec
+            .config
+            .get("runtime_pass_env")
+            .expect("runtime_pass_env present")
+        {
+            Value::List(v) => v.clone(),
+            _ => panic!("runtime_pass_env must be a list"),
+        };
+        assert!(matches!(&rpass[0], Value::String(s) if s == "PATH"));
     }
 
     #[test]
@@ -890,6 +1001,7 @@ mod tests {
             mk_addr("mypkg", "test"),
             mk_addr("mypkg", "build_test"),
             &query_addr("mypkg"),
+            &TestEnv::default(),
         );
         assert!(spec.labels.contains(&"test".to_string()));
         assert!(spec.labels.contains(&"go-test".to_string()));
@@ -902,6 +1014,7 @@ mod tests {
             mk_addr("mypkg", "test"),
             mk_addr("mypkg", "build_test"),
             &qa,
+            &TestEnv::default(),
         );
         let deps = match spec.config.get("deps").unwrap() {
             Value::Map(m) => m.clone(),

--- a/proto/plugin/v1/provider.proto
+++ b/proto/plugin/v1/provider.proto
@@ -99,11 +99,21 @@ message ParamType {
   message Union {
     repeated ParamType types = 1;
   }
+  // A record with named, heterogeneously-typed fields (e.g. `test`'s struct
+  // form). Distinct from `map` (which is homogeneous and arbitrary-keyed).
+  message Struct {
+    message Field {
+      string name = 1;
+      ParamType ty = 2;
+    }
+    repeated Field fields = 1;
+  }
   oneof kind {
     Scalar scalar = 1;
     ParamType list = 2; // homogeneous list element type
     ParamType map = 3;  // string-keyed map value type
     Union union = 4;
+    Struct struct = 5;  // named heterogeneous fields
   }
 }
 


### PR DESCRIPTION
## What

Add test environment options to the **go provider** via `provider_state`, and model the `test` field as **`bool | struct`**:

```python
# Disable a package's tests (inherited by descendants):
provider_state(provider = "go", test = False)

# Configure the test run environment (this package only):
provider_state(
    provider = "go",
    test = {
        "env": {"FOO": "1"},
        "runtime_env": {"BAR": "2"},
        "pass_env": ["HOME"],
        "runtime_pass_env": ["PATH"],
    },
)
```

The struct's four knobs are plumbed onto the generated `test`/`xtest` run targets (exec driver).

## Semantics

- **`test = False`** skips the package's tests; `test = True` / unset runs them. Inherited down the package tree (deeper state wins). Replaces the old `{"skip": True}` map form.
- **Struct form** sets env on the test run targets and is **package-scoped only** — a state at `//foo` does not leak into `//foo/bar` (`pick_test_env` filters by exact package). A deeper struct re-enables tests even if a root state disabled them.
- `env` / `pass_env` are hashed (affect cache); `runtime_env` / `runtime_pass_env` are runtime-only. Omitted keys keep specs minimal, so existing cache fingerprints are unchanged.

## Schema: new `ParamType::Struct`

To express `bool | struct(...)` faithfully, a `Struct(Vec<StructField>)` variant — named, heterogeneously-typed fields — was threaded through:

- `core` signature type (`render`, `matches`, `strukt` ctor)
- proto mirror: `ParamType.Struct` (additive `oneof` tag 5)
- ABI convert layer (`param_type_to_pb` / `from_pb`)
- Starlark `Ty` mapping (modeled as a string-keyed dict of the field-type union)
- **ABI_SEMVER 0.1.0 → 0.2.0** for the new wire field

## Tests

- `core`: struct render, subset/unknown-key matching, `bool | struct` union.
- `plugin-abi`: `bool | struct` wire round-trip.
- `plugin-go`: `pick_test_env` (all knobs, exact-package-only, bad-value errors); `pick_test_skip` (bool polarity, deeper-overrides, struct-form leaves enabled); `test_spec` env injection. Full `plugin-go` lib suite green (261 passed).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
