### PR TITLE
ci(setup-nix): bump cache-nix-action v6 -> v7 for Node 24

### DIFF
--- a/.github/actions/setup-nix/action.yml
+++ b/.github/actions/setup-nix/action.yml
@@ -41,7 +41,7 @@ runs:
     # intermittently fails to fetch/realize a rust-overlay patch, forcing reruns.
     # Keyed on the devenv lock so a toolchain bump busts the cache.
     - name: Cache Nix store
-      uses: nix-community/cache-nix-action@v6
+      uses: nix-community/cache-nix-action@v7
       with:
         primary-key: nix-${{ runner.os }}-${{ hashFiles('devenv.lock', 'devenv.nix', 'devenv.yaml') }}
         restore-prefixes-first-match: nix-${{ runner.os }}-


### PR DESCRIPTION
## Why

`nix-community/cache-nix-action@v6` runs on the deprecated Node.js 20 runtime — GitHub Actions runners now force it onto Node 24 with a deprecation warning ([changelog](https://github.blog/changelog/2025-09-19-deprecation-of-node-20-on-github-actions-runners/)).

## What

Bump `v6` → `v7` in `.github/actions/setup-nix/action.yml`. v7 targets Node 24 natively. All inputs we use are unchanged: `primary-key`, `restore-prefixes-first-match`, `gc-max-store-size-linux`, `gc-max-store-size-macos`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)