### PR TITLE
feat(telemetry): anonymous repo fingerprint attr

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5340,6 +5340,7 @@ dependencies = [
  "core",
  "plugin",
  "posthog-rs",
+ "reqwest 0.13.4",
  "rusqlite",
  "serde",
  "serde_json",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5343,6 +5343,7 @@ dependencies = [
  "rusqlite",
  "serde",
  "serde_json",
+ "sha2",
  "tempfile",
  "tokio",
  "tracing",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5338,6 +5338,7 @@ dependencies = [
  "chrono",
  "clap",
  "core",
+ "hex",
  "plugin",
  "posthog-rs",
  "reqwest 0.13.4",

--- a/crates/telemetry/Cargo.toml
+++ b/crates/telemetry/Cargo.toml
@@ -16,6 +16,7 @@ sha2 = "0.10"
 chrono = { version = "0.4", features = ["serde"] }
 uuid = { version = "1.23.3", features = ["v4"] }
 posthog-rs = "0.12.0"
+reqwest = { version = "0.13", default-features = false, features = ["blocking", "rustls"] }
 tracing = "0.1"
 clap = { version = "4.6.1", features = ["derive"] }
 rusqlite = { version = "0.39", features = ["bundled", "blob"] }

--- a/crates/telemetry/Cargo.toml
+++ b/crates/telemetry/Cargo.toml
@@ -12,6 +12,7 @@ hplugin = { package = "plugin", path = "../plugin" }
 anyhow = "1.0.102"
 serde = { version = "1", features = ["derive"] }
 serde_json = "1.0"
+sha2 = "0.10"
 chrono = { version = "0.4", features = ["serde"] }
 uuid = { version = "1.23.3", features = ["v4"] }
 posthog-rs = "0.12.0"

--- a/crates/telemetry/Cargo.toml
+++ b/crates/telemetry/Cargo.toml
@@ -13,6 +13,7 @@ anyhow = "1.0.102"
 serde = { version = "1", features = ["derive"] }
 serde_json = "1.0"
 sha2 = "0.10"
+hex = "0.4"
 chrono = { version = "0.4", features = ["serde"] }
 uuid = { version = "1.23.3", features = ["v4"] }
 posthog-rs = "0.12.0"

--- a/crates/telemetry/src/telemetry/mod.rs
+++ b/crates/telemetry/src/telemetry/mod.rs
@@ -216,6 +216,25 @@ fn distinct_id(dir: &std::path::Path) -> anyhow::Result<String> {
 /// CI (ephemeral, no next run) blocks to completion. The single entry point the
 /// CLI calls at exit; everything below is best-effort and never affects the
 /// command's outcome.
+/// Kick off background computation of the repo fingerprint so the exit path
+/// never runs git. Fire-and-forget: spawns a detached thread and returns at once.
+/// Call once at startup when telemetry is enabled; the result is cached and read
+/// back (best-effort) by [`record_invocation`]. If the command exits before the
+/// warmer finishes, the attr is simply absent this run and lands on the next.
+pub fn prewarm() {
+    let spawned = std::thread::Builder::new()
+        .name("heph-telemetry-warm".to_string())
+        .spawn(|| match config_dir() {
+            Ok(dir) => repo::prewarm(&dir),
+            Err(e) => tracing::debug!(error = %format!("{e:#}"), "telemetry prewarm skipped"),
+        });
+    // A failure to even spawn the warmer is ignored — strictly best-effort. The
+    // JoinHandle is intentionally dropped (detached); we never join it.
+    if let Err(e) = spawned {
+        tracing::debug!(error = %format!("{e:#}"), "telemetry prewarm thread not spawned");
+    }
+}
+
 pub fn record_invocation(matches: &ArgMatches, error: Option<&anyhow::Error>, took: Duration) {
     // Full subcommand path ("inspect deps", "tool gc"), plus the args set at
     // every nesting level.
@@ -320,9 +339,10 @@ fn try_enqueue(ctx: ReportContext<'_>) -> anyhow::Result<()> {
     let plugins = PLUGINS.get().cloned().unwrap_or_default();
 
     let dir = config_dir()?;
-    // Best-effort, cached repo fingerprint; absent when it can't be determined.
-    let fingerprint = repo::repo_fingerprint(&dir);
-    let props = build_props(&ctx, &stats, plugins, fingerprint.as_deref());
+    // Read-only: the startup warmer (see `prewarm`) does the git work off the hot
+    // path, so the exit path never blocks. Absent on a cold cache; lands next run.
+    let fingerprint = repo::cached(&dir);
+    let props = build_props(&ctx, &stats, plugins, fingerprint.as_ref());
 
     let event = SpooledEvent {
         uuid: uuid::Uuid::new_v4().to_string(),
@@ -340,7 +360,7 @@ fn build_props(
     ctx: &ReportContext<'_>,
     stats: &TelemetrySnapshot,
     plugins: Plugins,
-    repo_fingerprint: Option<&str>,
+    repo_fingerprint: Option<&repo::Fingerprint>,
 ) -> serde_json::Map<String, serde_json::Value> {
     let mut props = serde_json::Map::new();
     let mut put = |k: &str, v: serde_json::Value| drop(props.insert(k.to_string(), v));
@@ -368,11 +388,14 @@ fn build_props(
         }
     }
     put("ci", is_ci().into());
-    // Stable per-repo id (SHA-256 of the root commit), grouping events by project
-    // without identifying it. Absent when not in a git repo / git is unavailable
-    // / a shallow clone can't reach the root.
+    // Stable per-repo id grouping events by project without identifying it, plus
+    // the identity it was derived from (root commit vs CI repo id — kept distinct
+    // so the two namespaces aren't conflated). Absent when not in a git repo /
+    // git is unavailable / a shallow clone can't reach the root and there's no CI
+    // repo id.
     if let Some(fp) = repo_fingerprint {
-        put("repo_fingerprint", fp.into());
+        put("repo_fingerprint", fp.value.clone().into());
+        put("repo_fingerprint_source", fp.source.into());
     }
     // Command + selector shape + the set of flags used (names only).
     put("command", ctx.command.into());
@@ -565,7 +588,11 @@ mod tests {
             failure: None,
             duration_ms: 1,
         };
-        let props = build_props(&ctx, &snapshot, Plugins::default(), Some("deadbeef"));
+        let fp = repo::Fingerprint {
+            value: "deadbeef".to_string(),
+            source: "root_commit",
+        };
+        let props = build_props(&ctx, &snapshot, Plugins::default(), Some(&fp));
 
         // posthog-rs stamps `$os` / `$os_version` itself, so build_props must
         // not carry an `os` of its own (nor the `$`-prefixed keys).
@@ -577,14 +604,21 @@ mod tests {
             props.get("arch").and_then(|v| v.as_str()),
             Some(std::env::consts::ARCH)
         );
-        // The repo fingerprint is carried through when present.
+        // The repo fingerprint + its source are carried through when present.
         assert_eq!(
             props.get("repo_fingerprint").and_then(|v| v.as_str()),
             Some("deadbeef")
         );
+        assert_eq!(
+            props
+                .get("repo_fingerprint_source")
+                .and_then(|v| v.as_str()),
+            Some("root_commit")
+        );
         // ...and omitted entirely when it can't be determined.
         let absent = build_props(&ctx, &snapshot, Plugins::default(), None);
         assert!(!absent.contains_key("repo_fingerprint"));
+        assert!(!absent.contains_key("repo_fingerprint_source"));
     }
 
     #[test]

--- a/crates/telemetry/src/telemetry/mod.rs
+++ b/crates/telemetry/src/telemetry/mod.rs
@@ -3,9 +3,9 @@
 //! Reports coarse usage shape to PostHog (EU region) to guide development.
 //! Every event is *personless* (`$process_person_profile: false` — no person
 //! profile is ever created) and carries only os (`$os`/`$os_version`, stamped by
-//! posthog-rs), arch, and version plus aggregate run
-//! counters — never target addresses, labels, filesystem paths, or any user
-//! identifier. The `distinct_id` is a random per-install UUID stored in the
+//! posthog-rs), arch, version, an anonymous repo fingerprint (a one-way hash of
+//! the git root commit — see [`repo`]), plus aggregate run counters — never
+//! target addresses, labels, filesystem paths, or any user identifier. The `distinct_id` is a random per-install UUID stored in the
 //! machine's config dir (or the constant `"ci"` on CI runners, where ephemeral
 //! machines would otherwise mint a fake install per job); it identifies an
 //! installation, not a person.
@@ -25,6 +25,7 @@
 //! and never affects the command's exit.
 
 mod collector;
+mod repo;
 mod spool;
 
 pub use collector::{TelemetryCollector, TelemetrySnapshot};
@@ -317,9 +318,12 @@ struct ReportContext<'a> {
 fn try_enqueue(ctx: ReportContext<'_>) -> anyhow::Result<()> {
     let stats = COLLECTOR.snapshot();
     let plugins = PLUGINS.get().cloned().unwrap_or_default();
-    let props = build_props(&ctx, &stats, plugins);
 
     let dir = config_dir()?;
+    // Best-effort, cached repo fingerprint; absent when it can't be determined.
+    let fingerprint = repo::repo_fingerprint(&dir);
+    let props = build_props(&ctx, &stats, plugins, fingerprint.as_deref());
+
     let event = SpooledEvent {
         uuid: uuid::Uuid::new_v4().to_string(),
         distinct_id: distinct_id(&dir)?,
@@ -336,6 +340,7 @@ fn build_props(
     ctx: &ReportContext<'_>,
     stats: &TelemetrySnapshot,
     plugins: Plugins,
+    repo_fingerprint: Option<&str>,
 ) -> serde_json::Map<String, serde_json::Value> {
     let mut props = serde_json::Map::new();
     let mut put = |k: &str, v: serde_json::Value| drop(props.insert(k.to_string(), v));
@@ -363,6 +368,12 @@ fn build_props(
         }
     }
     put("ci", is_ci().into());
+    // Stable per-repo id (SHA-256 of the root commit), grouping events by project
+    // without identifying it. Absent when not in a git repo / git is unavailable
+    // / a shallow clone can't reach the root.
+    if let Some(fp) = repo_fingerprint {
+        put("repo_fingerprint", fp.into());
+    }
     // Command + selector shape + the set of flags used (names only).
     put("command", ctx.command.into());
     put("request_shape", ctx.request_shape.into());
@@ -554,7 +565,7 @@ mod tests {
             failure: None,
             duration_ms: 1,
         };
-        let props = build_props(&ctx, &snapshot, Plugins::default());
+        let props = build_props(&ctx, &snapshot, Plugins::default(), Some("deadbeef"));
 
         // posthog-rs stamps `$os` / `$os_version` itself, so build_props must
         // not carry an `os` of its own (nor the `$`-prefixed keys).
@@ -566,6 +577,14 @@ mod tests {
             props.get("arch").and_then(|v| v.as_str()),
             Some(std::env::consts::ARCH)
         );
+        // The repo fingerprint is carried through when present.
+        assert_eq!(
+            props.get("repo_fingerprint").and_then(|v| v.as_str()),
+            Some("deadbeef")
+        );
+        // ...and omitted entirely when it can't be determined.
+        let absent = build_props(&ctx, &snapshot, Plugins::default(), None);
+        assert!(!absent.contains_key("repo_fingerprint"));
     }
 
     #[test]

--- a/crates/telemetry/src/telemetry/mod.rs
+++ b/crates/telemetry/src/telemetry/mod.rs
@@ -339,10 +339,10 @@ fn try_enqueue(ctx: ReportContext<'_>) -> anyhow::Result<()> {
     let plugins = PLUGINS.get().cloned().unwrap_or_default();
 
     let dir = config_dir()?;
-    // Read-only: the startup warmer (see `prewarm`) does the git work off the hot
-    // path, so the exit path never blocks. Absent on a cold cache; lands next run.
+    // Read-only: the startup warmer (see `prewarm`) does the git/API work off the
+    // hot path, so the exit path never blocks. Absent on a cold cache; lands next.
     let fingerprint = repo::cached(&dir);
-    let props = build_props(&ctx, &stats, plugins, fingerprint.as_ref());
+    let props = build_props(&ctx, &stats, plugins, fingerprint.as_deref());
 
     let event = SpooledEvent {
         uuid: uuid::Uuid::new_v4().to_string(),
@@ -360,7 +360,7 @@ fn build_props(
     ctx: &ReportContext<'_>,
     stats: &TelemetrySnapshot,
     plugins: Plugins,
-    repo_fingerprint: Option<&repo::Fingerprint>,
+    repo_fingerprint: Option<&str>,
 ) -> serde_json::Map<String, serde_json::Value> {
     let mut props = serde_json::Map::new();
     let mut put = |k: &str, v: serde_json::Value| drop(props.insert(k.to_string(), v));
@@ -388,14 +388,12 @@ fn build_props(
         }
     }
     put("ci", is_ci().into());
-    // Stable per-repo id grouping events by project without identifying it, plus
-    // the identity it was derived from (root commit vs CI repo id — kept distinct
-    // so the two namespaces aren't conflated). Absent when not in a git repo /
-    // git is unavailable / a shallow clone can't reach the root and there's no CI
-    // repo id.
+    // Stable per-repo id (one-way hash of the git root commit) grouping events by
+    // project without identifying it. Absent when not in a git repo / git is
+    // unavailable / a shallow clone can't reach the root and the GitHub API
+    // fallback didn't apply.
     if let Some(fp) = repo_fingerprint {
-        put("repo_fingerprint", fp.value.clone().into());
-        put("repo_fingerprint_source", fp.source.into());
+        put("repo_fingerprint", fp.into());
     }
     // Command + selector shape + the set of flags used (names only).
     put("command", ctx.command.into());
@@ -588,11 +586,7 @@ mod tests {
             failure: None,
             duration_ms: 1,
         };
-        let fp = repo::Fingerprint {
-            value: "deadbeef".to_string(),
-            source: "root_commit",
-        };
-        let props = build_props(&ctx, &snapshot, Plugins::default(), Some(&fp));
+        let props = build_props(&ctx, &snapshot, Plugins::default(), Some("deadbeef"));
 
         // posthog-rs stamps `$os` / `$os_version` itself, so build_props must
         // not carry an `os` of its own (nor the `$`-prefixed keys).
@@ -604,21 +598,14 @@ mod tests {
             props.get("arch").and_then(|v| v.as_str()),
             Some(std::env::consts::ARCH)
         );
-        // The repo fingerprint + its source are carried through when present.
+        // The repo fingerprint is carried through when present.
         assert_eq!(
             props.get("repo_fingerprint").and_then(|v| v.as_str()),
             Some("deadbeef")
         );
-        assert_eq!(
-            props
-                .get("repo_fingerprint_source")
-                .and_then(|v| v.as_str()),
-            Some("root_commit")
-        );
         // ...and omitted entirely when it can't be determined.
         let absent = build_props(&ctx, &snapshot, Plugins::default(), None);
         assert!(!absent.contains_key("repo_fingerprint"));
-        assert!(!absent.contains_key("repo_fingerprint_source"));
     }
 
     #[test]

--- a/crates/telemetry/src/telemetry/repo.rs
+++ b/crates/telemetry/src/telemetry/repo.rs
@@ -10,16 +10,31 @@
 //! so the fingerprint is opaque: it cannot be reversed to look up the actual
 //! commit/repo, while still being deterministic across clones.
 //!
-//! Everything here is strictly best-effort. No git, not a repo, a shallow clone
-//! whose history doesn't reach the root, an unreadable cache — any of these just
-//! yields `None`, and the `repo_fingerprint` attr is omitted from the event.
+//! On a shallow clone whose history can't reach the root (the default depth-1
+//! GitHub Actions checkout), the root is unavailable, so we fall back to a hash
+//! of `GITHUB_REPOSITORY_ID` — GitHub's immutable numeric repo id (rename- and
+//! transfer-safe). That is a *different namespace* than the root-commit hash, so
+//! every fingerprint also carries a [`Fingerprint::source`] tag and the two are
+//! never conflated.
 //!
-//! The `git rev-list` walk (O(history)) runs at most once per repo per machine:
-//! the result is cached under the config dir, keyed by the working directory, so
-//! every subsequent invocation is a single file read.
+//! Everything here is strictly best-effort. No git, not a repo, an unreadable
+//! cache — any of these just yields `None`, and the attrs are omitted.
+//!
+//! The `git rev-list` walk is O(history) and never runs on the exit path: a
+//! startup warmer ([`prewarm`]) computes and caches it on a detached thread,
+//! while the exit path ([`cached`]) only ever reads the cache. A cold cache just
+//! omits the attr for that run; it lands on the next.
+//!
+//! Caching (under the config dir, keyed by the working directory):
+//! - A success is cached forever, so the walk runs at most once per repo per
+//!   machine.
+//! - A *failure* is cached too, with a timestamp and a [`NEGATIVE_TTL`]: a huge
+//!   monorepo whose root walk keeps hitting [`GIT_TIMEOUT`] would otherwise re-pay
+//!   the walk on every warm-up. The negative entry expires so a later full fetch
+//!   is eventually picked up.
 
 use sha2::{Digest, Sha256};
-use std::path::Path;
+use std::path::{Path, PathBuf};
 use std::process::{Command, Stdio};
 use std::time::{Duration, Instant};
 
@@ -28,44 +43,171 @@ use std::time::{Duration, Instant};
 /// bound it and give up rather than block.
 const GIT_TIMEOUT: Duration = Duration::from_secs(2);
 
-/// The repo fingerprint for the process's working directory: SHA-256 (hex) of
-/// the repository's root commit(s), or `None` when it can't be determined.
-/// Cached under `<config_dir>/repo-fingerprints/`.
-pub fn repo_fingerprint(config_dir: &Path) -> Option<String> {
-    let cwd = std::env::current_dir().ok()?;
-    fingerprint_in(config_dir, &cwd)
+/// How long a cached *failure* suppresses recomputation. Keeps a repo whose root
+/// walk keeps timing out from re-paying it every run, while still letting a later
+/// full fetch be picked up within a day.
+const NEGATIVE_TTL: Duration = Duration::from_secs(24 * 60 * 60);
+
+/// Where the fingerprint came from — recorded alongside the value so the two
+/// namespaces (root commit vs CI repo id) are never silently mixed in analysis.
+mod source {
+    /// SHA-256 of the git root commit(s). The portable, cross-machine identity.
+    pub const ROOT_COMMIT: &str = "root_commit";
+    /// SHA-256 of `GITHUB_REPOSITORY_ID`. Shallow-CI fallback only.
+    pub const GITHUB_REPO_ID: &str = "github_repo_id";
+
+    /// Whether `s` is a tag we wrote (guards against a corrupt cache file).
+    pub fn is_known(s: &str) -> bool {
+        s == ROOT_COMMIT || s == GITHUB_REPO_ID
+    }
 }
 
-/// Inner form taking the working directory explicitly (the public entry passes
-/// the process cwd). Split out so tests can target a specific repo without
-/// mutating global process state.
-fn fingerprint_in(config_dir: &Path, work_dir: &Path) -> Option<String> {
-    let cache_path = config_dir
+/// A computed fingerprint plus the kind of identity it was derived from.
+#[derive(Debug, Clone)]
+pub struct Fingerprint {
+    pub value: String,
+    pub source: &'static str,
+}
+
+/// Read-only lookup for the exit path: the cached fingerprint if one was already
+/// computed (by a prior run or this run's [`prewarm`]). Never runs git, never
+/// blocks — a cold cache just yields `None` and the attr is omitted this run,
+/// then appears once the warmer lands.
+pub fn cached(config_dir: &Path) -> Option<Fingerprint> {
+    let cwd = std::env::current_dir().ok()?;
+    match read_cache(&cache_path_for(config_dir, &cwd), now_ms()) {
+        Cached::Hit(fp) => Some(fp),
+        Cached::FreshMiss | Cached::Stale | Cached::Absent => None,
+    }
+}
+
+/// Compute the fingerprint for the process's working directory and cache it.
+/// Meant to run off the hot path (a startup warmer thread) so the exit path only
+/// ever reads the cache. Honors the cache, so it's free once warm. Reads
+/// `GITHUB_REPOSITORY_ID` for the shallow-CI fallback.
+pub fn prewarm(config_dir: &Path) {
+    let Ok(cwd) = std::env::current_dir() else {
+        return;
+    };
+    let ci_repo_id = std::env::var("GITHUB_REPOSITORY_ID").ok();
+    let _ = fingerprint_in(config_dir, &cwd, ci_repo_id.as_deref(), now_ms());
+}
+
+/// Inner form taking the working directory, the CI repo id, and the current time
+/// explicitly (the public entry supplies the process cwd / env / clock). Split
+/// out so tests can target a specific repo and clock without global state.
+fn fingerprint_in(
+    config_dir: &Path,
+    work_dir: &Path,
+    ci_repo_id: Option<&str>,
+    now: u64,
+) -> Option<Fingerprint> {
+    let cache_path = cache_path_for(config_dir, work_dir);
+
+    match read_cache(&cache_path, now) {
+        Cached::Hit(fp) => return Some(fp),
+        Cached::FreshMiss => return None,
+        Cached::Stale | Cached::Absent => {}
+    }
+
+    let computed = compute(work_dir, ci_repo_id);
+    write_cache(&cache_path, computed.as_ref(), now);
+    computed
+}
+
+/// Compute the fingerprint from scratch: the git root commit if reachable,
+/// otherwise the CI repo id, otherwise nothing.
+fn compute(work_dir: &Path, ci_repo_id: Option<&str>) -> Option<Fingerprint> {
+    if let Some(root) = root_commit(work_dir) {
+        return Some(Fingerprint {
+            value: hex(&Sha256::digest(root.as_bytes())),
+            source: source::ROOT_COMMIT,
+        });
+    }
+    // Shallow CI: the root is unreachable, so fall back to GitHub's immutable
+    // numeric repo id (a different namespace — tagged accordingly).
+    let id = ci_repo_id?.trim();
+    if id.is_empty() {
+        return None;
+    }
+    Some(Fingerprint {
+        value: hex(&Sha256::digest(id.as_bytes())),
+        source: source::GITHUB_REPO_ID,
+    })
+}
+
+/// The cache file for a working directory: `<config_dir>/repo-fingerprints/<h>`,
+/// where `h` is a hash of the directory path (so distinct checkouts don't
+/// collide and the path itself isn't stored).
+fn cache_path_for(config_dir: &Path, work_dir: &Path) -> PathBuf {
+    config_dir
         .join("repo-fingerprints")
         .join(hex(&Sha256::digest(
             work_dir.as_os_str().as_encoded_bytes(),
-        )));
+        )))
+}
 
-    if let Ok(cached) = std::fs::read_to_string(&cache_path) {
-        let cached = cached.trim();
-        if !cached.is_empty() {
-            return Some(cached.to_string());
+/// Outcome of consulting the on-disk cache.
+enum Cached {
+    /// A previously computed fingerprint.
+    Hit(Fingerprint),
+    /// A recent failure — still within the negative TTL, so don't recompute.
+    FreshMiss,
+    /// A failure older than the TTL — recompute.
+    Stale,
+    /// No (or unreadable) cache entry.
+    Absent,
+}
+
+/// Parse the cache file. Two record shapes, tab-separated:
+/// - `ok\t<source>\t<value>` — a computed fingerprint.
+/// - `none\t<unix_ms>` — a failure, stamped so it can expire.
+fn read_cache(path: &Path, now: u64) -> Cached {
+    let Ok(raw) = std::fs::read_to_string(path) else {
+        return Cached::Absent;
+    };
+    let line = raw.trim();
+    if let Some(rest) = line.strip_prefix("ok\t") {
+        if let Some((src, value)) = rest.split_once('\t')
+            && source::is_known(src)
+            && !value.is_empty()
+        {
+            let source = if src == source::ROOT_COMMIT {
+                source::ROOT_COMMIT
+            } else {
+                source::GITHUB_REPO_ID
+            };
+            return Cached::Hit(Fingerprint {
+                value: value.to_string(),
+                source,
+            });
         }
+        return Cached::Absent;
     }
+    if let Some(ts) = line.strip_prefix("none\t") {
+        return match ts.trim().parse::<u64>() {
+            Ok(stamped) if now.saturating_sub(stamped) < NEGATIVE_TTL.as_millis() as u64 => {
+                Cached::FreshMiss
+            }
+            Ok(_) => Cached::Stale,
+            Err(_) => Cached::Absent,
+        };
+    }
+    Cached::Absent
+}
 
-    let root = root_commit(work_dir)?;
-    let fingerprint = hex(&Sha256::digest(root.as_bytes()));
-
-    // Best-effort cache write — a failure here is fine, the next run recomputes.
-    // Only positive results are cached: a shallow checkout that can't reach the
-    // root returns `None` above, so a later full fetch is free to recompute.
-    if let Some(parent) = cache_path.parent()
+/// Persist the computation outcome. Best-effort — a failure here just means the
+/// next run recomputes.
+fn write_cache(path: &Path, computed: Option<&Fingerprint>, now: u64) {
+    let body = match computed {
+        Some(fp) => format!("ok\t{}\t{}", fp.source, fp.value),
+        None => format!("none\t{now}"),
+    };
+    if let Some(parent) = path.parent()
         && std::fs::create_dir_all(parent).is_ok()
     {
-        drop(std::fs::write(&cache_path, &fingerprint));
+        drop(std::fs::write(path, body));
     }
-
-    Some(fingerprint)
 }
 
 /// The repository's root commit id(s): the output of
@@ -73,12 +215,11 @@ fn fingerprint_in(config_dir: &Path, work_dir: &Path) -> Option<String> {
 /// several roots from merged histories — sorting keeps the value stable
 /// regardless of git's enumeration order).
 ///
-/// Shallow-aware for GitHub Actions: a default `actions/checkout` is a depth-1
-/// clone, where the grafted boundary commit *masquerades* as a root. Those
-/// grafts (listed in `.git/shallow`) are filtered out, so a shallow clone yields
-/// the true root only when its history actually reaches it — otherwise `None`,
-/// rather than a per-checkout value that would shatter one repo into thousands
-/// of fingerprints. A `fetch-depth: 0` checkout (full history) always works.
+/// Shallow-aware: a default `actions/checkout` is a depth-1 clone, where the
+/// grafted boundary commit *masquerades* as a root. Those grafts (listed in
+/// `.git/shallow`) are filtered out, so a shallow clone yields the true root only
+/// when its history actually reaches it — otherwise `None`, never a per-checkout
+/// value that would shatter one repo into thousands of fingerprints.
 fn root_commit(work_dir: &Path) -> Option<String> {
     let out = git(work_dir, &["rev-list", "--max-parents=0", "HEAD"])?;
     let mut roots: Vec<&str> = out
@@ -170,6 +311,11 @@ fn git(work_dir: &Path, args: &[&str]) -> Option<String> {
     Some(buf.trim().to_string())
 }
 
+/// Current wall-clock as unix milliseconds (for stamping negative cache entries).
+fn now_ms() -> u64 {
+    hcore::events::now_unix_ms()
+}
+
 /// Lowercase hex encoding of a byte slice.
 fn hex(bytes: &[u8]) -> String {
     // A single nibble (0..=15) as a lowercase hex digit. No indexing/Result, so
@@ -215,19 +361,22 @@ mod tests {
         }
     }
 
+    const T0: u64 = 1_000_000_000_000;
+
     #[test]
     fn fingerprint_is_stable_and_hashed() {
         let cfg = tempfile::tempdir().unwrap();
         let repo = tempfile::tempdir().unwrap();
         init_repo(repo.path(), 3);
 
-        let fp = fingerprint_in(cfg.path(), repo.path()).expect("fingerprint");
+        let fp = fingerprint_in(cfg.path(), repo.path(), None, T0).expect("fingerprint");
         // SHA-256 hex is 64 chars, and is *not* the raw 40-char commit hash.
-        assert_eq!(fp.len(), 64);
+        assert_eq!(fp.value.len(), 64);
+        assert_eq!(fp.source, source::ROOT_COMMIT);
 
         // Same answer on a repeat call (now served from cache).
-        let again = fingerprint_in(cfg.path(), repo.path()).expect("fingerprint");
-        assert_eq!(fp, again);
+        let again = fingerprint_in(cfg.path(), repo.path(), None, T0).expect("fingerprint");
+        assert_eq!(fp.value, again.value);
     }
 
     #[test]
@@ -249,9 +398,9 @@ mod tests {
             &["clone", "-q", origin.path().to_str().unwrap(), "."],
         );
 
-        let fa = fingerprint_in(cfg.path(), a.path()).expect("a");
-        let fb = fingerprint_in(cfg.path(), b.path()).expect("b");
-        assert_eq!(fa, fb);
+        let fa = fingerprint_in(cfg.path(), a.path(), None, T0).expect("a");
+        let fb = fingerprint_in(cfg.path(), b.path(), None, T0).expect("b");
+        assert_eq!(fa.value, fb.value);
     }
 
     #[test]
@@ -260,19 +409,19 @@ mod tests {
         let repo = tempfile::tempdir().unwrap();
         init_repo(repo.path(), 1);
 
-        let fp = fingerprint_in(cfg.path(), repo.path()).expect("fingerprint");
+        let fp = fingerprint_in(cfg.path(), repo.path(), None, T0).expect("fingerprint");
         // Destroy the repo: a non-cached path would now fail. The cache (keyed
         // by work dir) must still return the original value.
         std::fs::remove_dir_all(repo.path().join(".git")).unwrap();
-        let cached = fingerprint_in(cfg.path(), repo.path()).expect("cached");
-        assert_eq!(fp, cached);
+        let cached = fingerprint_in(cfg.path(), repo.path(), None, T0).expect("cached");
+        assert_eq!(fp.value, cached.value);
     }
 
     #[test]
     fn non_repo_yields_none() {
         let cfg = tempfile::tempdir().unwrap();
         let plain = tempfile::tempdir().unwrap();
-        assert!(fingerprint_in(cfg.path(), plain.path()).is_none());
+        assert!(fingerprint_in(cfg.path(), plain.path(), None, T0).is_none());
     }
 
     #[test]
@@ -298,6 +447,84 @@ mod tests {
         );
 
         assert!(is_shallow(shallow.path()), "expected a shallow clone");
-        assert!(fingerprint_in(cfg.path(), shallow.path()).is_none());
+        assert!(fingerprint_in(cfg.path(), shallow.path(), None, T0).is_none());
+    }
+
+    #[test]
+    fn shallow_clone_falls_back_to_github_repo_id() {
+        // When the root is unreachable but the CI repo id is present, fall back
+        // to it — tagged as a distinct source.
+        let cfg = tempfile::tempdir().unwrap();
+        let plain = tempfile::tempdir().unwrap(); // not a repo -> no root commit
+
+        let fp =
+            fingerprint_in(cfg.path(), plain.path(), Some("123456"), T0).expect("github fallback");
+        assert_eq!(fp.source, source::GITHUB_REPO_ID);
+        assert_eq!(fp.value, hex(&Sha256::digest(b"123456")));
+
+        // Same id anywhere -> same fingerprint (stable across CI runs).
+        let other = tempfile::tempdir().unwrap();
+        let fp2 = fingerprint_in(cfg.path(), other.path(), Some("123456"), T0).expect("again");
+        assert_eq!(fp.value, fp2.value);
+    }
+
+    #[test]
+    fn root_commit_wins_over_github_id() {
+        // A real root is the portable identity and takes precedence over the
+        // CI-only fallback even when both are available.
+        let cfg = tempfile::tempdir().unwrap();
+        let repo = tempfile::tempdir().unwrap();
+        init_repo(repo.path(), 1);
+
+        let fp = fingerprint_in(cfg.path(), repo.path(), Some("999"), T0).expect("root");
+        assert_eq!(fp.source, source::ROOT_COMMIT);
+    }
+
+    #[test]
+    fn negative_cache_skips_then_expires() {
+        let cfg = tempfile::tempdir().unwrap();
+        let repo = tempfile::tempdir().unwrap();
+        init_repo(repo.path(), 1);
+        let cache = cache_path_for(cfg.path(), repo.path());
+        std::fs::create_dir_all(cache.parent().unwrap()).unwrap();
+
+        // A *fresh* negative entry short-circuits computation: even though the
+        // repo has a perfectly good root, we honor the recent failure and skip.
+        std::fs::write(&cache, format!("none\t{T0}")).unwrap();
+        assert!(fingerprint_in(cfg.path(), repo.path(), None, T0).is_none());
+
+        // Past the TTL the entry is stale -> recompute, and now we get a value.
+        let later = T0 + NEGATIVE_TTL.as_millis() as u64 + 1;
+        let fp = fingerprint_in(cfg.path(), repo.path(), None, later).expect("recomputed");
+        assert_eq!(fp.source, source::ROOT_COMMIT);
+    }
+
+    #[test]
+    fn read_only_lookup_is_cold_until_warmed() {
+        // The exit path (`cached`) only reads; computation happens in `prewarm`.
+        let cfg = tempfile::tempdir().unwrap();
+        let repo = tempfile::tempdir().unwrap();
+        init_repo(repo.path(), 1);
+        let path = cache_path_for(cfg.path(), repo.path());
+
+        // Cold: nothing computed yet -> the read-only lookup misses.
+        assert!(matches!(read_cache(&path, T0), Cached::Absent));
+
+        // Warm it (the prewarm path), then the read-only lookup hits.
+        fingerprint_in(cfg.path(), repo.path(), None, T0).expect("warm");
+        assert!(matches!(read_cache(&path, T0), Cached::Hit(_)));
+    }
+
+    #[test]
+    fn failure_is_negatively_cached() {
+        let cfg = tempfile::tempdir().unwrap();
+        let plain = tempfile::tempdir().unwrap();
+        assert!(fingerprint_in(cfg.path(), plain.path(), None, T0).is_none());
+
+        // The miss is recorded so a giant repo that keeps timing out doesn't
+        // re-pay the walk every run.
+        let cache = cache_path_for(cfg.path(), plain.path());
+        let body = std::fs::read_to_string(&cache).expect("negative entry written");
+        assert!(body.starts_with("none\t"), "got: {body}");
     }
 }

--- a/crates/telemetry/src/telemetry/repo.rs
+++ b/crates/telemetry/src/telemetry/repo.rs
@@ -13,11 +13,13 @@
 //! Sources for the root commit, in order:
 //! 1. Local git: `git rev-list --max-parents=0 HEAD`.
 //! 2. On a shallow clone whose history can't reach the root (the default depth-1
-//!    GitHub Actions checkout), the GitHub REST API: ask for one commit, read the
-//!    `Link` header to jump to the last page, and read the first commit's SHA
-//!    from there. Because this yields the *same* root SHA a full clone would, the
-//!    fingerprint is identical to one computed locally — same namespace, no
-//!    special-casing downstream. Gated to GitHub Actions with a token present.
+//!    GitHub Actions checkout), the GitHub REST API: ask for one commit (starting
+//!    from `GITHUB_SHA`/HEAD so the walk follows HEAD's ancestry, matching local
+//!    git), read the `Link` header to jump to the last page, and read the first
+//!    commit's SHA from there. Because this yields the *same* root SHA a full
+//!    clone would, the fingerprint is identical to one computed locally — same
+//!    namespace, no special-casing downstream. Gated to GitHub Actions with a
+//!    token present.
 //!
 //! Everything here is strictly best-effort. No git, not a repo, no token, a
 //! failed API call, an unreadable cache — any of these just yields `None`, and
@@ -280,9 +282,10 @@ fn git(work_dir: &Path, args: &[&str]) -> Option<String> {
 /// fallback. Returns `None` unless we're in GitHub Actions with a token and a
 /// known `owner/repo`; every failure is logged at `trace` and swallowed.
 ///
-/// Two hops: GET one commit, read the `Link` header's `rel="last"` URL (the
-/// oldest commit's page), then GET that and read its SHA. A repo with a single
-/// page (≤1 commit) has no `Link` header, so the first response already holds it.
+/// Two hops: GET one commit (starting from `GITHUB_SHA`/HEAD when known), read
+/// the `Link` header's `rel="last"` URL (the oldest commit's page), then GET that
+/// and read its SHA. A repo with a single page (≤1 commit) has no `Link` header,
+/// so the first response already holds it.
 fn github_root_commit() -> Option<String> {
     if std::env::var("GITHUB_ACTIONS").ok().as_deref() != Some("true") {
         return None;
@@ -290,6 +293,10 @@ fn github_root_commit() -> Option<String> {
     let token = nonempty_env("GITHUB_TOKEN")?;
     let repo = nonempty_env("GITHUB_REPOSITORY")?; // "owner/name"
     let api = nonempty_env("GITHUB_API_URL").unwrap_or_else(|| API_DEFAULT.to_string());
+    // Walk HEAD's own ancestry (so the root matches local `rev-list HEAD`), not
+    // the default branch's. `GITHUB_SHA` is the checked-out commit; absent, the
+    // API defaults to the default branch.
+    let head = nonempty_env("GITHUB_SHA");
 
     // reqwest::blocking spins up its own runtime; we're already on a dedicated
     // warmer thread (never the async runtime), so this is safe.
@@ -304,7 +311,12 @@ fn github_root_commit() -> Option<String> {
         }
     };
 
-    root_via_api(|url| gh_get(&client, url, &token), &api, &repo)
+    root_via_api(
+        |url| gh_get(&client, url, &token),
+        &api,
+        &repo,
+        head.as_deref(),
+    )
 }
 
 /// A trimmed, non-empty env var, or `None`.
@@ -325,13 +337,23 @@ struct HttpResp {
 }
 
 /// Orchestrate the two-hop root-commit lookup over an injected fetcher (so the
-/// pagination/JSON logic is testable without the network).
-fn root_via_api(fetch: impl Fn(&str) -> Option<HttpResp>, api: &str, repo: &str) -> Option<String> {
-    let first_url = format!(
+/// pagination/JSON logic is testable without the network). When `head` is set,
+/// the listing starts from it (HEAD's ancestry) instead of the default branch.
+fn root_via_api(
+    fetch: impl Fn(&str) -> Option<HttpResp>,
+    api: &str,
+    repo: &str,
+    head: Option<&str>,
+) -> Option<String> {
+    let mut first_url = format!(
         "{}/repos/{}/commits?per_page=1",
         api.trim_end_matches('/'),
         repo
     );
+    if let Some(head) = head {
+        first_url.push_str("&sha=");
+        first_url.push_str(head);
+    }
     let first = fetch(&first_url)?;
     let body = match first.link.as_deref().and_then(parse_rel_last) {
         // Jump straight to the last page — its single commit is the root.
@@ -671,7 +693,7 @@ mod tests {
             }
         };
         assert_eq!(
-            root_via_api(fetch, "https://api.test", "o/r").as_deref(),
+            root_via_api(fetch, "https://api.test", "o/r", None).as_deref(),
             Some("rootsha")
         );
     }
@@ -686,8 +708,29 @@ mod tests {
             })
         };
         assert_eq!(
-            root_via_api(fetch, "https://api.test", "o/r").as_deref(),
+            root_via_api(fetch, "https://api.test", "o/r", None).as_deref(),
             Some("only")
         );
+    }
+
+    #[test]
+    fn root_via_api_pins_to_head_sha() {
+        // A HEAD ref is threaded into the listing as `&sha=`, so the walk follows
+        // HEAD's ancestry rather than the default branch.
+        let seen = Cell::new(false);
+        let fetch = |url: &str| {
+            if url.contains("&sha=headref") {
+                seen.set(true);
+            }
+            Some(HttpResp {
+                link: None,
+                body: r#"[{"sha":"root"}]"#.to_string(),
+            })
+        };
+        assert_eq!(
+            root_via_api(fetch, "https://api.test", "o/r", Some("headref")).as_deref(),
+            Some("root")
+        );
+        assert!(seen.get(), "request must pin to the HEAD sha");
     }
 }

--- a/crates/telemetry/src/telemetry/repo.rs
+++ b/crates/telemetry/src/telemetry/repo.rs
@@ -1,0 +1,303 @@
+//! Anonymous repository fingerprint.
+//!
+//! A stable, repo-level identifier that lets PostHog group events by *project*
+//! without learning which project it is. Two clones of the same repository — on
+//! any machine, under any name, hosted anywhere — produce the same fingerprint,
+//! because it is derived from the repository's **root commit** (the parentless
+//! initial commit). Different repos almost never share a root commit.
+//!
+//! The root commit hash is itself hashed (SHA-256) before it leaves the machine,
+//! so the fingerprint is opaque: it cannot be reversed to look up the actual
+//! commit/repo, while still being deterministic across clones.
+//!
+//! Everything here is strictly best-effort. No git, not a repo, a shallow clone
+//! whose history doesn't reach the root, an unreadable cache — any of these just
+//! yields `None`, and the `repo_fingerprint` attr is omitted from the event.
+//!
+//! The `git rev-list` walk (O(history)) runs at most once per repo per machine:
+//! the result is cached under the config dir, keyed by the working directory, so
+//! every subsequent invocation is a single file read.
+
+use sha2::{Digest, Sha256};
+use std::path::Path;
+use std::process::{Command, Stdio};
+use std::time::{Duration, Instant};
+
+/// Cap on a single git subprocess. Telemetry runs on the exit path and must not
+/// stall a real command — on a giant monorepo the root walk can be slow, so we
+/// bound it and give up rather than block.
+const GIT_TIMEOUT: Duration = Duration::from_secs(2);
+
+/// The repo fingerprint for the process's working directory: SHA-256 (hex) of
+/// the repository's root commit(s), or `None` when it can't be determined.
+/// Cached under `<config_dir>/repo-fingerprints/`.
+pub fn repo_fingerprint(config_dir: &Path) -> Option<String> {
+    let cwd = std::env::current_dir().ok()?;
+    fingerprint_in(config_dir, &cwd)
+}
+
+/// Inner form taking the working directory explicitly (the public entry passes
+/// the process cwd). Split out so tests can target a specific repo without
+/// mutating global process state.
+fn fingerprint_in(config_dir: &Path, work_dir: &Path) -> Option<String> {
+    let cache_path = config_dir
+        .join("repo-fingerprints")
+        .join(hex(&Sha256::digest(
+            work_dir.as_os_str().as_encoded_bytes(),
+        )));
+
+    if let Ok(cached) = std::fs::read_to_string(&cache_path) {
+        let cached = cached.trim();
+        if !cached.is_empty() {
+            return Some(cached.to_string());
+        }
+    }
+
+    let root = root_commit(work_dir)?;
+    let fingerprint = hex(&Sha256::digest(root.as_bytes()));
+
+    // Best-effort cache write — a failure here is fine, the next run recomputes.
+    // Only positive results are cached: a shallow checkout that can't reach the
+    // root returns `None` above, so a later full fetch is free to recompute.
+    if let Some(parent) = cache_path.parent()
+        && std::fs::create_dir_all(parent).is_ok()
+    {
+        drop(std::fs::write(&cache_path, &fingerprint));
+    }
+
+    Some(fingerprint)
+}
+
+/// The repository's root commit id(s): the output of
+/// `git rev-list --max-parents=0 HEAD`, sorted and joined (a repo can have
+/// several roots from merged histories — sorting keeps the value stable
+/// regardless of git's enumeration order).
+///
+/// Shallow-aware for GitHub Actions: a default `actions/checkout` is a depth-1
+/// clone, where the grafted boundary commit *masquerades* as a root. Those
+/// grafts (listed in `.git/shallow`) are filtered out, so a shallow clone yields
+/// the true root only when its history actually reaches it — otherwise `None`,
+/// rather than a per-checkout value that would shatter one repo into thousands
+/// of fingerprints. A `fetch-depth: 0` checkout (full history) always works.
+fn root_commit(work_dir: &Path) -> Option<String> {
+    let out = git(work_dir, &["rev-list", "--max-parents=0", "HEAD"])?;
+    let mut roots: Vec<&str> = out
+        .lines()
+        .map(str::trim)
+        .filter(|l| !l.is_empty())
+        .collect();
+
+    if is_shallow(work_dir) {
+        let grafts = shallow_grafts(work_dir);
+        roots.retain(|r| !grafts.iter().any(|g| g == r));
+    }
+
+    if roots.is_empty() {
+        return None;
+    }
+    roots.sort_unstable();
+    Some(roots.join("\n"))
+}
+
+/// Whether this is a shallow clone (`git rev-parse --is-shallow-repository`).
+fn is_shallow(work_dir: &Path) -> bool {
+    git(work_dir, &["rev-parse", "--is-shallow-repository"])
+        .map(|s| s.trim() == "true")
+        .unwrap_or(false)
+}
+
+/// The grafted boundary commits of a shallow clone: the lines of `.git/shallow`.
+/// These are commits whose parents were omitted, so they falsely report zero
+/// parents and must not be mistaken for the true root.
+fn shallow_grafts(work_dir: &Path) -> Vec<String> {
+    let Some(path) = git(work_dir, &["rev-parse", "--git-path", "shallow"]) else {
+        return Vec::new();
+    };
+    let path = Path::new(path.trim());
+    let path = if path.is_absolute() {
+        path.to_path_buf()
+    } else {
+        work_dir.join(path)
+    };
+    std::fs::read_to_string(path)
+        .map(|s| {
+            s.lines()
+                .map(str::trim)
+                .filter(|l| !l.is_empty())
+                .map(str::to_string)
+                .collect()
+        })
+        .unwrap_or_default()
+}
+
+/// Run `git <args>` in `work_dir`, returning trimmed stdout on a clean exit, or
+/// `None` on any failure (git missing, non-repo, non-zero exit, timeout).
+fn git(work_dir: &Path, args: &[&str]) -> Option<String> {
+    let mut child = Command::new("git")
+        .args(args)
+        .current_dir(work_dir)
+        .stdin(Stdio::null())
+        .stdout(Stdio::piped())
+        .stderr(Stdio::null())
+        .spawn()
+        .ok()?;
+
+    let started = Instant::now();
+    loop {
+        match child.try_wait() {
+            Ok(Some(status)) => {
+                if !status.success() {
+                    return None;
+                }
+                break;
+            }
+            Ok(None) => {
+                if started.elapsed() >= GIT_TIMEOUT {
+                    drop(child.kill());
+                    drop(child.wait());
+                    return None;
+                }
+                std::thread::sleep(Duration::from_millis(10));
+            }
+            Err(_) => return None,
+        }
+    }
+
+    use std::io::Read;
+    let mut stdout = child.stdout.take()?;
+    let mut buf = String::new();
+    stdout.read_to_string(&mut buf).ok()?;
+    Some(buf.trim().to_string())
+}
+
+/// Lowercase hex encoding of a byte slice.
+fn hex(bytes: &[u8]) -> String {
+    // A single nibble (0..=15) as a lowercase hex digit. No indexing/Result, so
+    // it trips neither the panic nor the must-use lints.
+    fn nibble(n: u8) -> char {
+        (if n < 10 { b'0' + n } else { b'a' + n - 10 }) as char
+    }
+    let mut s = String::with_capacity(bytes.len() * 2);
+    for &b in bytes {
+        s.push(nibble(b >> 4));
+        s.push(nibble(b & 0x0f));
+    }
+    s
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::process::Command;
+
+    fn run(dir: &Path, args: &[&str]) {
+        let status = Command::new("git")
+            .args(args)
+            .current_dir(dir)
+            .env("GIT_AUTHOR_NAME", "t")
+            .env("GIT_AUTHOR_EMAIL", "t@t")
+            .env("GIT_COMMITTER_NAME", "t")
+            .env("GIT_COMMITTER_EMAIL", "t@t")
+            .stdout(Stdio::null())
+            .stderr(Stdio::null())
+            .status()
+            .expect("run git");
+        assert!(status.success(), "git {args:?} failed");
+    }
+
+    /// Init a repo at `dir` with `n` commits on a fixed branch name.
+    fn init_repo(dir: &Path, n: usize) {
+        run(dir, &["init", "-q", "-b", "main"]);
+        for i in 0..n {
+            std::fs::write(dir.join(format!("f{i}")), format!("{i}")).unwrap();
+            run(dir, &["add", "."]);
+            run(dir, &["commit", "-q", "-m", &format!("c{i}")]);
+        }
+    }
+
+    #[test]
+    fn fingerprint_is_stable_and_hashed() {
+        let cfg = tempfile::tempdir().unwrap();
+        let repo = tempfile::tempdir().unwrap();
+        init_repo(repo.path(), 3);
+
+        let fp = fingerprint_in(cfg.path(), repo.path()).expect("fingerprint");
+        // SHA-256 hex is 64 chars, and is *not* the raw 40-char commit hash.
+        assert_eq!(fp.len(), 64);
+
+        // Same answer on a repeat call (now served from cache).
+        let again = fingerprint_in(cfg.path(), repo.path()).expect("fingerprint");
+        assert_eq!(fp, again);
+    }
+
+    #[test]
+    fn two_clones_share_a_fingerprint() {
+        // The whole point: same root commit -> same fingerprint, independent of
+        // path/name. Two independent clones must agree.
+        let cfg = tempfile::tempdir().unwrap();
+        let origin = tempfile::tempdir().unwrap();
+        init_repo(origin.path(), 2);
+
+        let a = tempfile::tempdir().unwrap();
+        let b = tempfile::tempdir().unwrap();
+        run(
+            a.path(),
+            &["clone", "-q", origin.path().to_str().unwrap(), "."],
+        );
+        run(
+            b.path(),
+            &["clone", "-q", origin.path().to_str().unwrap(), "."],
+        );
+
+        let fa = fingerprint_in(cfg.path(), a.path()).expect("a");
+        let fb = fingerprint_in(cfg.path(), b.path()).expect("b");
+        assert_eq!(fa, fb);
+    }
+
+    #[test]
+    fn cache_short_circuits_git() {
+        let cfg = tempfile::tempdir().unwrap();
+        let repo = tempfile::tempdir().unwrap();
+        init_repo(repo.path(), 1);
+
+        let fp = fingerprint_in(cfg.path(), repo.path()).expect("fingerprint");
+        // Destroy the repo: a non-cached path would now fail. The cache (keyed
+        // by work dir) must still return the original value.
+        std::fs::remove_dir_all(repo.path().join(".git")).unwrap();
+        let cached = fingerprint_in(cfg.path(), repo.path()).expect("cached");
+        assert_eq!(fp, cached);
+    }
+
+    #[test]
+    fn non_repo_yields_none() {
+        let cfg = tempfile::tempdir().unwrap();
+        let plain = tempfile::tempdir().unwrap();
+        assert!(fingerprint_in(cfg.path(), plain.path()).is_none());
+    }
+
+    #[test]
+    fn shallow_clone_without_root_yields_none() {
+        // A depth-1 clone (the GitHub Actions default) can't reach the root: the
+        // grafted boundary commit must not be reported as a fingerprint.
+        let cfg = tempfile::tempdir().unwrap();
+        let origin = tempfile::tempdir().unwrap();
+        init_repo(origin.path(), 5);
+
+        let shallow = tempfile::tempdir().unwrap();
+        // `--no-local` forces the real (graft-creating) shallow transport.
+        run(
+            shallow.path(),
+            &[
+                "clone",
+                "-q",
+                "--depth=1",
+                "--no-local",
+                &format!("file://{}", origin.path().display()),
+                ".",
+            ],
+        );
+
+        assert!(is_shallow(shallow.path()), "expected a shallow clone");
+        assert!(fingerprint_in(cfg.path(), shallow.path()).is_none());
+    }
+}

--- a/crates/telemetry/src/telemetry/repo.rs
+++ b/crates/telemetry/src/telemetry/repo.rs
@@ -109,7 +109,7 @@ fn fingerprint_in(
 /// git, or — when those are unreachable — from the GitHub API fallback.
 fn compute(work_dir: &Path, gh_root: impl FnOnce() -> Option<String>) -> Option<String> {
     let root = root_commit(work_dir).or_else(gh_root)?;
-    Some(hex(&Sha256::digest(root.as_bytes())))
+    Some(hex::encode(Sha256::digest(root.as_bytes())))
 }
 
 /// The cache file for a working directory: `<config_dir>/repo-fingerprints/<h>`,
@@ -118,7 +118,7 @@ fn compute(work_dir: &Path, gh_root: impl FnOnce() -> Option<String>) -> Option<
 fn cache_path_for(config_dir: &Path, work_dir: &Path) -> PathBuf {
     config_dir
         .join("repo-fingerprints")
-        .join(hex(&Sha256::digest(
+        .join(hex::encode(Sha256::digest(
             work_dir.as_os_str().as_encoded_bytes(),
         )))
 }
@@ -426,21 +426,6 @@ fn now_ms() -> u64 {
     hcore::events::now_unix_ms()
 }
 
-/// Lowercase hex encoding of a byte slice.
-fn hex(bytes: &[u8]) -> String {
-    // A single nibble (0..=15) as a lowercase hex digit. No indexing/Result, so
-    // it trips neither the panic nor the must-use lints.
-    fn nibble(n: u8) -> char {
-        (if n < 10 { b'0' + n } else { b'a' + n - 10 }) as char
-    }
-    let mut s = String::with_capacity(bytes.len() * 2);
-    for &b in bytes {
-        s.push(nibble(b >> 4));
-        s.push(nibble(b & 0x0f));
-    }
-    s
-}
-
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -576,7 +561,7 @@ mod tests {
 
         let fp = fingerprint_in(cfg.path(), plain.path(), || Some(api_sha.to_string()), T0)
             .expect("api fallback");
-        assert_eq!(fp, hex(&Sha256::digest(api_sha.as_bytes())));
+        assert_eq!(fp, hex::encode(Sha256::digest(api_sha.as_bytes())));
     }
 
     #[test]

--- a/crates/telemetry/src/telemetry/repo.rs
+++ b/crates/telemetry/src/telemetry/repo.rs
@@ -10,130 +10,104 @@
 //! so the fingerprint is opaque: it cannot be reversed to look up the actual
 //! commit/repo, while still being deterministic across clones.
 //!
-//! On a shallow clone whose history can't reach the root (the default depth-1
-//! GitHub Actions checkout), the root is unavailable, so we fall back to a hash
-//! of `GITHUB_REPOSITORY_ID` — GitHub's immutable numeric repo id (rename- and
-//! transfer-safe). That is a *different namespace* than the root-commit hash, so
-//! every fingerprint also carries a [`Fingerprint::source`] tag and the two are
-//! never conflated.
+//! Sources for the root commit, in order:
+//! 1. Local git: `git rev-list --max-parents=0 HEAD`.
+//! 2. On a shallow clone whose history can't reach the root (the default depth-1
+//!    GitHub Actions checkout), the GitHub REST API: ask for one commit, read the
+//!    `Link` header to jump to the last page, and read the first commit's SHA
+//!    from there. Because this yields the *same* root SHA a full clone would, the
+//!    fingerprint is identical to one computed locally — same namespace, no
+//!    special-casing downstream. Gated to GitHub Actions with a token present.
 //!
-//! Everything here is strictly best-effort. No git, not a repo, an unreadable
-//! cache — any of these just yields `None`, and the attrs are omitted.
+//! Everything here is strictly best-effort. No git, not a repo, no token, a
+//! failed API call, an unreadable cache — any of these just yields `None`, and
+//! the attr is omitted. API failures are logged at `trace`.
 //!
-//! The `git rev-list` walk is O(history) and never runs on the exit path: a
-//! startup warmer ([`prewarm`]) computes and caches it on a detached thread,
-//! while the exit path ([`cached`]) only ever reads the cache. A cold cache just
-//! omits the attr for that run; it lands on the next.
+//! The work never runs on the exit path: a startup warmer ([`prewarm`]) computes
+//! and caches the fingerprint on a detached thread, while the exit path
+//! ([`cached`]) only ever reads the cache. A cold cache just omits the attr for
+//! that run; it lands on the next.
 //!
 //! Caching (under the config dir, keyed by the working directory):
-//! - A success is cached forever, so the walk runs at most once per repo per
-//!   machine.
+//! - A success is cached forever, so the (O(history) git walk or two API hops)
+//!   runs at most once per repo per machine.
 //! - A *failure* is cached too, with a timestamp and a [`NEGATIVE_TTL`]: a huge
-//!   monorepo whose root walk keeps hitting [`GIT_TIMEOUT`] would otherwise re-pay
-//!   the walk on every warm-up. The negative entry expires so a later full fetch
-//!   is eventually picked up.
+//!   monorepo whose root walk keeps hitting [`GIT_TIMEOUT`], or a transient API
+//!   failure, would otherwise re-pay the cost on every warm-up. The negative
+//!   entry expires so a later full fetch / fixed token is eventually picked up.
 
 use sha2::{Digest, Sha256};
 use std::path::{Path, PathBuf};
 use std::process::{Command, Stdio};
 use std::time::{Duration, Instant};
 
-/// Cap on a single git subprocess. Telemetry runs on the exit path and must not
-/// stall a real command — on a giant monorepo the root walk can be slow, so we
-/// bound it and give up rather than block.
+/// Cap on a single git subprocess. On a giant monorepo the root walk can be slow,
+/// so we bound it and give up rather than block the warmer indefinitely.
 const GIT_TIMEOUT: Duration = Duration::from_secs(2);
 
+/// Cap on the GitHub API round-trips, so a hung endpoint can't pin the warmer.
+const API_TIMEOUT: Duration = Duration::from_secs(5);
+
 /// How long a cached *failure* suppresses recomputation. Keeps a repo whose root
-/// walk keeps timing out from re-paying it every run, while still letting a later
-/// full fetch be picked up within a day.
+/// walk keeps timing out (or whose API call keeps failing) from re-paying it
+/// every run, while still letting a later full fetch be picked up within a day.
 const NEGATIVE_TTL: Duration = Duration::from_secs(24 * 60 * 60);
 
-/// Where the fingerprint came from — recorded alongside the value so the two
-/// namespaces (root commit vs CI repo id) are never silently mixed in analysis.
-mod source {
-    /// SHA-256 of the git root commit(s). The portable, cross-machine identity.
-    pub const ROOT_COMMIT: &str = "root_commit";
-    /// SHA-256 of `GITHUB_REPOSITORY_ID`. Shallow-CI fallback only.
-    pub const GITHUB_REPO_ID: &str = "github_repo_id";
-
-    /// Whether `s` is a tag we wrote (guards against a corrupt cache file).
-    pub fn is_known(s: &str) -> bool {
-        s == ROOT_COMMIT || s == GITHUB_REPO_ID
-    }
-}
-
-/// A computed fingerprint plus the kind of identity it was derived from.
-#[derive(Debug, Clone)]
-pub struct Fingerprint {
-    pub value: String,
-    pub source: &'static str,
-}
+/// Default GitHub REST API host (overridden by `GITHUB_API_URL`, e.g. on GHES).
+const API_DEFAULT: &str = "https://api.github.com";
 
 /// Read-only lookup for the exit path: the cached fingerprint if one was already
-/// computed (by a prior run or this run's [`prewarm`]). Never runs git, never
-/// blocks — a cold cache just yields `None` and the attr is omitted this run,
-/// then appears once the warmer lands.
-pub fn cached(config_dir: &Path) -> Option<Fingerprint> {
+/// computed (by a prior run or this run's [`prewarm`]). Never runs git or the
+/// network, never blocks — a cold cache just yields `None` and the attr is
+/// omitted this run, then appears once the warmer lands.
+pub fn cached(config_dir: &Path) -> Option<String> {
     let cwd = std::env::current_dir().ok()?;
     match read_cache(&cache_path_for(config_dir, &cwd), now_ms()) {
-        Cached::Hit(fp) => Some(fp),
+        Cached::Hit(value) => Some(value),
         Cached::FreshMiss | Cached::Stale | Cached::Absent => None,
     }
 }
 
 /// Compute the fingerprint for the process's working directory and cache it.
 /// Meant to run off the hot path (a startup warmer thread) so the exit path only
-/// ever reads the cache. Honors the cache, so it's free once warm. Reads
-/// `GITHUB_REPOSITORY_ID` for the shallow-CI fallback.
+/// ever reads the cache. Honors the cache, so it's free once warm. Falls back to
+/// the GitHub API (see [`github_root_commit`]) only when local git can't reach
+/// the root.
 pub fn prewarm(config_dir: &Path) {
     let Ok(cwd) = std::env::current_dir() else {
         return;
     };
-    let ci_repo_id = std::env::var("GITHUB_REPOSITORY_ID").ok();
-    let _ = fingerprint_in(config_dir, &cwd, ci_repo_id.as_deref(), now_ms());
+    let _ = fingerprint_in(config_dir, &cwd, github_root_commit, now_ms());
 }
 
-/// Inner form taking the working directory, the CI repo id, and the current time
-/// explicitly (the public entry supplies the process cwd / env / clock). Split
-/// out so tests can target a specific repo and clock without global state.
+/// Inner form taking the working directory, a lazy GitHub-API fallback, and the
+/// current time explicitly (the public entries supply the process cwd / env /
+/// clock). Split out so tests can target a specific repo, fallback, and clock
+/// without global state. The fallback is invoked only when local git fails.
 fn fingerprint_in(
     config_dir: &Path,
     work_dir: &Path,
-    ci_repo_id: Option<&str>,
+    gh_root: impl FnOnce() -> Option<String>,
     now: u64,
-) -> Option<Fingerprint> {
+) -> Option<String> {
     let cache_path = cache_path_for(config_dir, work_dir);
 
     match read_cache(&cache_path, now) {
-        Cached::Hit(fp) => return Some(fp),
+        Cached::Hit(value) => return Some(value),
         Cached::FreshMiss => return None,
         Cached::Stale | Cached::Absent => {}
     }
 
-    let computed = compute(work_dir, ci_repo_id);
-    write_cache(&cache_path, computed.as_ref(), now);
+    let computed = compute(work_dir, gh_root);
+    write_cache(&cache_path, computed.as_deref(), now);
     computed
 }
 
-/// Compute the fingerprint from scratch: the git root commit if reachable,
-/// otherwise the CI repo id, otherwise nothing.
-fn compute(work_dir: &Path, ci_repo_id: Option<&str>) -> Option<Fingerprint> {
-    if let Some(root) = root_commit(work_dir) {
-        return Some(Fingerprint {
-            value: hex(&Sha256::digest(root.as_bytes())),
-            source: source::ROOT_COMMIT,
-        });
-    }
-    // Shallow CI: the root is unreachable, so fall back to GitHub's immutable
-    // numeric repo id (a different namespace — tagged accordingly).
-    let id = ci_repo_id?.trim();
-    if id.is_empty() {
-        return None;
-    }
-    Some(Fingerprint {
-        value: hex(&Sha256::digest(id.as_bytes())),
-        source: source::GITHUB_REPO_ID,
-    })
+/// Compute the fingerprint from scratch: hash the root commit id(s) from local
+/// git, or — when those are unreachable — from the GitHub API fallback.
+fn compute(work_dir: &Path, gh_root: impl FnOnce() -> Option<String>) -> Option<String> {
+    let root = root_commit(work_dir).or_else(gh_root)?;
+    Some(hex(&Sha256::digest(root.as_bytes())))
 }
 
 /// The cache file for a working directory: `<config_dir>/repo-fingerprints/<h>`,
@@ -150,7 +124,7 @@ fn cache_path_for(config_dir: &Path, work_dir: &Path) -> PathBuf {
 /// Outcome of consulting the on-disk cache.
 enum Cached {
     /// A previously computed fingerprint.
-    Hit(Fingerprint),
+    Hit(String),
     /// A recent failure — still within the negative TTL, so don't recompute.
     FreshMiss,
     /// A failure older than the TTL — recompute.
@@ -160,29 +134,20 @@ enum Cached {
 }
 
 /// Parse the cache file. Two record shapes, tab-separated:
-/// - `ok\t<source>\t<value>` — a computed fingerprint.
+/// - `ok\t<value>` — a computed fingerprint.
 /// - `none\t<unix_ms>` — a failure, stamped so it can expire.
 fn read_cache(path: &Path, now: u64) -> Cached {
     let Ok(raw) = std::fs::read_to_string(path) else {
         return Cached::Absent;
     };
     let line = raw.trim();
-    if let Some(rest) = line.strip_prefix("ok\t") {
-        if let Some((src, value)) = rest.split_once('\t')
-            && source::is_known(src)
-            && !value.is_empty()
-        {
-            let source = if src == source::ROOT_COMMIT {
-                source::ROOT_COMMIT
-            } else {
-                source::GITHUB_REPO_ID
-            };
-            return Cached::Hit(Fingerprint {
-                value: value.to_string(),
-                source,
-            });
-        }
-        return Cached::Absent;
+    if let Some(value) = line.strip_prefix("ok\t") {
+        let value = value.trim();
+        return if value.is_empty() {
+            Cached::Absent
+        } else {
+            Cached::Hit(value.to_string())
+        };
     }
     if let Some(ts) = line.strip_prefix("none\t") {
         return match ts.trim().parse::<u64>() {
@@ -197,10 +162,10 @@ fn read_cache(path: &Path, now: u64) -> Cached {
 }
 
 /// Persist the computation outcome. Best-effort — a failure here just means the
-/// next run recomputes.
-fn write_cache(path: &Path, computed: Option<&Fingerprint>, now: u64) {
-    let body = match computed {
-        Some(fp) => format!("ok\t{}\t{}", fp.source, fp.value),
+/// next warm-up recomputes.
+fn write_cache(path: &Path, value: Option<&str>, now: u64) {
+    let body = match value {
+        Some(v) => format!("ok\t{v}"),
         None => format!("none\t{now}"),
     };
     if let Some(parent) = path.parent()
@@ -218,8 +183,8 @@ fn write_cache(path: &Path, computed: Option<&Fingerprint>, now: u64) {
 /// Shallow-aware: a default `actions/checkout` is a depth-1 clone, where the
 /// grafted boundary commit *masquerades* as a root. Those grafts (listed in
 /// `.git/shallow`) are filtered out, so a shallow clone yields the true root only
-/// when its history actually reaches it — otherwise `None`, never a per-checkout
-/// value that would shatter one repo into thousands of fingerprints.
+/// when its history actually reaches it — otherwise `None`, and the caller falls
+/// back to the GitHub API.
 fn root_commit(work_dir: &Path) -> Option<String> {
     let out = git(work_dir, &["rev-list", "--max-parents=0", "HEAD"])?;
     let mut roots: Vec<&str> = out
@@ -311,6 +276,129 @@ fn git(work_dir: &Path, args: &[&str]) -> Option<String> {
     Some(buf.trim().to_string())
 }
 
+/// The repository's root commit SHA via the GitHub REST API — the shallow-CI
+/// fallback. Returns `None` unless we're in GitHub Actions with a token and a
+/// known `owner/repo`; every failure is logged at `trace` and swallowed.
+///
+/// Two hops: GET one commit, read the `Link` header's `rel="last"` URL (the
+/// oldest commit's page), then GET that and read its SHA. A repo with a single
+/// page (≤1 commit) has no `Link` header, so the first response already holds it.
+fn github_root_commit() -> Option<String> {
+    if std::env::var("GITHUB_ACTIONS").ok().as_deref() != Some("true") {
+        return None;
+    }
+    let token = nonempty_env("GITHUB_TOKEN")?;
+    let repo = nonempty_env("GITHUB_REPOSITORY")?; // "owner/name"
+    let api = nonempty_env("GITHUB_API_URL").unwrap_or_else(|| API_DEFAULT.to_string());
+
+    // reqwest::blocking spins up its own runtime; we're already on a dedicated
+    // warmer thread (never the async runtime), so this is safe.
+    let client = match reqwest::blocking::Client::builder()
+        .timeout(API_TIMEOUT)
+        .build()
+    {
+        Ok(c) => c,
+        Err(e) => {
+            tracing::trace!(error = %e, "telemetry: github api client build failed");
+            return None;
+        }
+    };
+
+    root_via_api(|url| gh_get(&client, url, &token), &api, &repo)
+}
+
+/// A trimmed, non-empty env var, or `None`.
+fn nonempty_env(name: &str) -> Option<String> {
+    let v = std::env::var(name).ok()?;
+    let v = v.trim();
+    if v.is_empty() {
+        None
+    } else {
+        Some(v.to_string())
+    }
+}
+
+/// The bits of an HTTP response we care about: the `Link` header and the body.
+struct HttpResp {
+    link: Option<String>,
+    body: String,
+}
+
+/// Orchestrate the two-hop root-commit lookup over an injected fetcher (so the
+/// pagination/JSON logic is testable without the network).
+fn root_via_api(fetch: impl Fn(&str) -> Option<HttpResp>, api: &str, repo: &str) -> Option<String> {
+    let first_url = format!(
+        "{}/repos/{}/commits?per_page=1",
+        api.trim_end_matches('/'),
+        repo
+    );
+    let first = fetch(&first_url)?;
+    let body = match first.link.as_deref().and_then(parse_rel_last) {
+        // Jump straight to the last page — its single commit is the root.
+        Some(last) => fetch(&last)?.body,
+        // No pagination => ≤1 commit total => the first page already holds it.
+        None => first.body,
+    };
+    first_sha(&body)
+}
+
+/// Perform one authenticated GitHub API GET. Logs failures at `trace`.
+fn gh_get(client: &reqwest::blocking::Client, url: &str, token: &str) -> Option<HttpResp> {
+    let resp = match client
+        .get(url)
+        .header(reqwest::header::USER_AGENT, "heph-telemetry")
+        .header(reqwest::header::ACCEPT, "application/vnd.github+json")
+        .header("X-GitHub-Api-Version", "2022-11-28")
+        .bearer_auth(token)
+        .send()
+    {
+        Ok(r) => r,
+        Err(e) => {
+            tracing::trace!(error = %e, url, "telemetry: github api request failed");
+            return None;
+        }
+    };
+    if !resp.status().is_success() {
+        tracing::trace!(status = %resp.status(), url, "telemetry: github api non-success");
+        return None;
+    }
+    let link = resp
+        .headers()
+        .get(reqwest::header::LINK)
+        .and_then(|v| v.to_str().ok())
+        .map(str::to_string);
+    match resp.text() {
+        Ok(body) => Some(HttpResp { link, body }),
+        Err(e) => {
+            tracing::trace!(error = %e, "telemetry: github api body read failed");
+            None
+        }
+    }
+}
+
+/// Extract the `rel="last"` URL from a GitHub `Link` header, if present.
+fn parse_rel_last(link: &str) -> Option<String> {
+    link.split(',')
+        .map(str::trim)
+        .find(|part| part.contains("rel=\"last\""))
+        .and_then(|part| {
+            let after = part.split_once('<')?.1;
+            let url = after.split_once('>')?.0;
+            Some(url.to_string())
+        })
+}
+
+/// The `sha` of the first commit in a GitHub commits-list JSON body.
+fn first_sha(body: &str) -> Option<String> {
+    let v: serde_json::Value = serde_json::from_str(body).ok()?;
+    let sha = v.as_array()?.first()?.get("sha")?.as_str()?;
+    if sha.is_empty() {
+        None
+    } else {
+        Some(sha.to_string())
+    }
+}
+
 /// Current wall-clock as unix milliseconds (for stamping negative cache entries).
 fn now_ms() -> u64 {
     hcore::events::now_unix_ms()
@@ -334,6 +422,7 @@ fn hex(bytes: &[u8]) -> String {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use std::cell::Cell;
     use std::process::Command;
 
     fn run(dir: &Path, args: &[&str]) {
@@ -363,20 +452,24 @@ mod tests {
 
     const T0: u64 = 1_000_000_000_000;
 
+    /// A gh fallback that must never be called.
+    fn no_gh() -> Option<String> {
+        None
+    }
+
     #[test]
     fn fingerprint_is_stable_and_hashed() {
         let cfg = tempfile::tempdir().unwrap();
         let repo = tempfile::tempdir().unwrap();
         init_repo(repo.path(), 3);
 
-        let fp = fingerprint_in(cfg.path(), repo.path(), None, T0).expect("fingerprint");
+        let fp = fingerprint_in(cfg.path(), repo.path(), no_gh, T0).expect("fingerprint");
         // SHA-256 hex is 64 chars, and is *not* the raw 40-char commit hash.
-        assert_eq!(fp.value.len(), 64);
-        assert_eq!(fp.source, source::ROOT_COMMIT);
+        assert_eq!(fp.len(), 64);
 
         // Same answer on a repeat call (now served from cache).
-        let again = fingerprint_in(cfg.path(), repo.path(), None, T0).expect("fingerprint");
-        assert_eq!(fp.value, again.value);
+        let again = fingerprint_in(cfg.path(), repo.path(), no_gh, T0).expect("fingerprint");
+        assert_eq!(fp, again);
     }
 
     #[test]
@@ -398,9 +491,9 @@ mod tests {
             &["clone", "-q", origin.path().to_str().unwrap(), "."],
         );
 
-        let fa = fingerprint_in(cfg.path(), a.path(), None, T0).expect("a");
-        let fb = fingerprint_in(cfg.path(), b.path(), None, T0).expect("b");
-        assert_eq!(fa.value, fb.value);
+        let fa = fingerprint_in(cfg.path(), a.path(), no_gh, T0).expect("a");
+        let fb = fingerprint_in(cfg.path(), b.path(), no_gh, T0).expect("b");
+        assert_eq!(fa, fb);
     }
 
     #[test]
@@ -409,25 +502,26 @@ mod tests {
         let repo = tempfile::tempdir().unwrap();
         init_repo(repo.path(), 1);
 
-        let fp = fingerprint_in(cfg.path(), repo.path(), None, T0).expect("fingerprint");
+        let fp = fingerprint_in(cfg.path(), repo.path(), no_gh, T0).expect("fingerprint");
         // Destroy the repo: a non-cached path would now fail. The cache (keyed
         // by work dir) must still return the original value.
         std::fs::remove_dir_all(repo.path().join(".git")).unwrap();
-        let cached = fingerprint_in(cfg.path(), repo.path(), None, T0).expect("cached");
-        assert_eq!(fp.value, cached.value);
+        let cached = fingerprint_in(cfg.path(), repo.path(), no_gh, T0).expect("cached");
+        assert_eq!(fp, cached);
     }
 
     #[test]
     fn non_repo_yields_none() {
         let cfg = tempfile::tempdir().unwrap();
         let plain = tempfile::tempdir().unwrap();
-        assert!(fingerprint_in(cfg.path(), plain.path(), None, T0).is_none());
+        assert!(fingerprint_in(cfg.path(), plain.path(), no_gh, T0).is_none());
     }
 
     #[test]
     fn shallow_clone_without_root_yields_none() {
         // A depth-1 clone (the GitHub Actions default) can't reach the root: the
-        // grafted boundary commit must not be reported as a fingerprint.
+        // grafted boundary commit must not be reported, and with no API fallback
+        // there is nothing to report.
         let cfg = tempfile::tempdir().unwrap();
         let origin = tempfile::tempdir().unwrap();
         init_repo(origin.path(), 5);
@@ -447,37 +541,42 @@ mod tests {
         );
 
         assert!(is_shallow(shallow.path()), "expected a shallow clone");
-        assert!(fingerprint_in(cfg.path(), shallow.path(), None, T0).is_none());
+        assert!(fingerprint_in(cfg.path(), shallow.path(), no_gh, T0).is_none());
     }
 
     #[test]
-    fn shallow_clone_falls_back_to_github_repo_id() {
-        // When the root is unreachable but the CI repo id is present, fall back
-        // to it — tagged as a distinct source.
+    fn github_api_root_used_when_local_git_fails() {
+        // No local root reachable -> the API fallback supplies the root SHA, and
+        // it hashes into the *same namespace* as a local clone would.
         let cfg = tempfile::tempdir().unwrap();
-        let plain = tempfile::tempdir().unwrap(); // not a repo -> no root commit
+        let plain = tempfile::tempdir().unwrap(); // not a repo
+        let api_sha = "e83c5163316f89bfbde7d9ab23ca2e25604af290";
 
-        let fp =
-            fingerprint_in(cfg.path(), plain.path(), Some("123456"), T0).expect("github fallback");
-        assert_eq!(fp.source, source::GITHUB_REPO_ID);
-        assert_eq!(fp.value, hex(&Sha256::digest(b"123456")));
-
-        // Same id anywhere -> same fingerprint (stable across CI runs).
-        let other = tempfile::tempdir().unwrap();
-        let fp2 = fingerprint_in(cfg.path(), other.path(), Some("123456"), T0).expect("again");
-        assert_eq!(fp.value, fp2.value);
+        let fp = fingerprint_in(cfg.path(), plain.path(), || Some(api_sha.to_string()), T0)
+            .expect("api fallback");
+        assert_eq!(fp, hex(&Sha256::digest(api_sha.as_bytes())));
     }
 
     #[test]
-    fn root_commit_wins_over_github_id() {
-        // A real root is the portable identity and takes precedence over the
-        // CI-only fallback even when both are available.
+    fn local_root_wins_and_skips_github() {
+        // A real local root takes precedence; the API fallback must not run.
         let cfg = tempfile::tempdir().unwrap();
         let repo = tempfile::tempdir().unwrap();
         init_repo(repo.path(), 1);
 
-        let fp = fingerprint_in(cfg.path(), repo.path(), Some("999"), T0).expect("root");
-        assert_eq!(fp.source, source::ROOT_COMMIT);
+        let called = Cell::new(false);
+        let fp = fingerprint_in(
+            cfg.path(),
+            repo.path(),
+            || {
+                called.set(true);
+                Some("unused".to_string())
+            },
+            T0,
+        )
+        .expect("local root");
+        assert!(!called.get(), "github fallback should not be consulted");
+        assert_eq!(fp.len(), 64);
     }
 
     #[test]
@@ -491,12 +590,12 @@ mod tests {
         // A *fresh* negative entry short-circuits computation: even though the
         // repo has a perfectly good root, we honor the recent failure and skip.
         std::fs::write(&cache, format!("none\t{T0}")).unwrap();
-        assert!(fingerprint_in(cfg.path(), repo.path(), None, T0).is_none());
+        assert!(fingerprint_in(cfg.path(), repo.path(), no_gh, T0).is_none());
 
         // Past the TTL the entry is stale -> recompute, and now we get a value.
         let later = T0 + NEGATIVE_TTL.as_millis() as u64 + 1;
-        let fp = fingerprint_in(cfg.path(), repo.path(), None, later).expect("recomputed");
-        assert_eq!(fp.source, source::ROOT_COMMIT);
+        let fp = fingerprint_in(cfg.path(), repo.path(), no_gh, later).expect("recomputed");
+        assert_eq!(fp.len(), 64);
     }
 
     #[test]
@@ -511,7 +610,7 @@ mod tests {
         assert!(matches!(read_cache(&path, T0), Cached::Absent));
 
         // Warm it (the prewarm path), then the read-only lookup hits.
-        fingerprint_in(cfg.path(), repo.path(), None, T0).expect("warm");
+        fingerprint_in(cfg.path(), repo.path(), no_gh, T0).expect("warm");
         assert!(matches!(read_cache(&path, T0), Cached::Hit(_)));
     }
 
@@ -519,12 +618,76 @@ mod tests {
     fn failure_is_negatively_cached() {
         let cfg = tempfile::tempdir().unwrap();
         let plain = tempfile::tempdir().unwrap();
-        assert!(fingerprint_in(cfg.path(), plain.path(), None, T0).is_none());
+        assert!(fingerprint_in(cfg.path(), plain.path(), no_gh, T0).is_none());
 
         // The miss is recorded so a giant repo that keeps timing out doesn't
         // re-pay the walk every run.
         let cache = cache_path_for(cfg.path(), plain.path());
         let body = std::fs::read_to_string(&cache).expect("negative entry written");
         assert!(body.starts_with("none\t"), "got: {body}");
+    }
+
+    #[test]
+    fn parse_rel_last_extracts_last_url() {
+        let header = "<https://api.github.com/repositories/123/commits?per_page=1&page=2>; \
+             rel=\"next\", \
+             <https://api.github.com/repositories/123/commits?per_page=1&page=845>; rel=\"last\"";
+        assert_eq!(
+            parse_rel_last(header).as_deref(),
+            Some("https://api.github.com/repositories/123/commits?per_page=1&page=845")
+        );
+        // No `last` relation (single page) -> nothing to jump to.
+        assert!(parse_rel_last("<https://x/y>; rel=\"self\"").is_none());
+    }
+
+    #[test]
+    fn first_sha_reads_array_head() {
+        assert_eq!(
+            first_sha(r#"[{"sha":"abc123","commit":{}}]"#).as_deref(),
+            Some("abc123")
+        );
+        assert!(first_sha("[]").is_none());
+        assert!(first_sha("not json").is_none());
+    }
+
+    #[test]
+    fn root_via_api_jumps_to_last_page() {
+        // Multi-page: the first hop yields a `last` link; the second hop's body
+        // carries the root commit.
+        let last_url = "https://api.test/repositories/9/commits?per_page=1&page=42";
+        let fetch = |url: &str| {
+            if url.ends_with("/repos/o/r/commits?per_page=1") {
+                Some(HttpResp {
+                    link: Some(format!("<{last_url}>; rel=\"last\"")),
+                    body: r#"[{"sha":"newest"}]"#.to_string(),
+                })
+            } else if url == last_url {
+                Some(HttpResp {
+                    link: None,
+                    body: r#"[{"sha":"rootsha"}]"#.to_string(),
+                })
+            } else {
+                None
+            }
+        };
+        assert_eq!(
+            root_via_api(fetch, "https://api.test", "o/r").as_deref(),
+            Some("rootsha")
+        );
+    }
+
+    #[test]
+    fn root_via_api_single_page_uses_first_body() {
+        // One-commit repo: no `Link` header, so the first response is the root.
+        let fetch = |_url: &str| {
+            Some(HttpResp {
+                link: None,
+                body: r#"[{"sha":"only"}]"#.to_string(),
+            })
+        };
+        assert_eq!(
+            root_via_api(fetch, "https://api.test", "o/r").as_deref(),
+            Some("only")
+        );
     }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -79,6 +79,11 @@ fn main() -> ExitCode {
     // spool — is ephemeral, so there is no "next run" to defer to.
     let telemetry_on =
         heph::telemetry::is_enabled(commands::bootstrap::telemetry_enabled_from_config());
+    // Warm the repo fingerprint off the hot path: the git root walk runs on a
+    // detached thread now so the exit-time flush only reads the cached result.
+    if telemetry_on {
+        heph::telemetry::prewarm();
+    }
     let started_at = std::time::Instant::now();
 
     let pprof_guard = if cli.global.pprof_cpu.is_some() {


### PR DESCRIPTION
## What

Adds a `repo_fingerprint` property to the PostHog `cli_command` event: a stable, repo-level id that groups events by *project* without revealing which project it is.

Derived from the repository's **root commit** — unique per repo, independent of name/remote/host. Two clones of the same repo share a root commit → share a fingerprint. The root commit is **SHA-256-hashed** before sending, so the value is one-way (can't be reversed to the real repo) but deterministic across clones.

## Sources for the root commit

1. **Local git**: `git rev-list --max-parents=0 HEAD`.
2. **GitHub API** (shallow-CI fallback): a default depth-1 `actions/checkout` can't reach the root locally. So we recover it over the REST API — GET one commit, follow the `Link` header's `rel="last"` to the oldest commit's page, read its SHA (a single-page repo has no `Link` header, so the first response already holds it). This returns the **same root SHA** a full clone would, so it hashes into the **same namespace** — same repo → same fingerprint on dev and CI, no downstream special-casing.

   Gated to GitHub Actions with a token: `GITHUB_ACTIONS=true` + `GITHUB_TOKEN` + `GITHUB_REPOSITORY` (`GITHUB_API_URL` honored for GHES). Runs only when local git can't reach the root. Every failure is best-effort and logged at `trace`.

## Never blocks the exit path

The git walk is O(history) (1–3s on a 1M-commit monorepo) and the API path is two network hops — neither runs on exit:

- **Warmed at startup.** When telemetry is enabled, `telemetry::prewarm()` does the work on a **detached thread**. The exit path only ever *reads* the cache (`repo::cached`). Cold cache → attr just absent that run, lands on the next.
- **Bounded**: 2s git timeout, 5s API timeout.
- **Cached.** Success cached forever (once per repo per machine). **Failure negatively cached with a 24h TTL** (covers a monorepo that keeps timing out and transient API failures), expiring so a later full fetch / fixed token is picked up.

Cache lives under the config dir (`<config_dir>/repo-fingerprints/`), keyed by a hash of the working directory.

## Optional / best-effort

No git, not a repo, no token, failed API call, unreadable cache, even a failed thread spawn → the attr is simply omitted. Never affects the command outcome.

## Tests (`crates/telemetry/src/telemetry/repo.rs`, 30 total)

- fingerprint is a 64-char SHA-256 hex (not raw commit), stable across calls; two independent clones → **same** fingerprint
- cache short-circuits git (returns cached value after `.git` deleted); non-repo → `None`; depth-1 `--no-local` shallow clone → `None` (no API)
- API fallback supplies the root when local git fails (hashes into same namespace); local root wins and skips the API
- `parse_rel_last` extracts the `rel="last"` URL; `first_sha` reads the array head; `root_via_api` jumps to the last page (multi-page) and uses the first body (single-page) over an injected fetcher
- negative cache skips recompute then expires past TTL; failures negatively cached; read-only lookup cold until warmed

`tst` / `lint` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)