### PR TITLE
fix(remote-cache): drop backtrace from cache-failure warning

### DIFF
--- a/crates/engine/src/engine/remote_cache.rs
+++ b/crates/engine/src/engine/remote_cache.rs
@@ -140,9 +140,13 @@ impl ConfiguredCache {
     /// trip the breaker after [`FAILURE_THRESHOLD`] consecutive failures.
     fn note_err(&self, op: &str, e: &anyhow::Error) {
         if !self.health.warned.swap(true, Ordering::Relaxed) {
+            // `{e:#}` is anyhow's alternate Display: the cause chain on one line,
+            // no backtrace. (`{e:?}` would dump the full `Caused by:` ladder plus
+            // a process backtrace — useless noise for the user.)
             warn!(
-                cache = %self.def.name, op, error = ?e,
-                "remote cache error; further warnings for this cache are suppressed",
+                cache = %self.def.name,
+                op,
+                "remote cache unavailable, skipping it for {op}: {e:#}. Further errors for this cache are suppressed.",
             );
         }
         let n = self


### PR DESCRIPTION
## Problem

The first remote-cache error was logged with `error = ?e` (anyhow `Debug`) — full `Caused by:` ladder + a useless 30-frame `__mh_execute_header` backtrace:

```
WARN remote cache error ... error=open remote object .../manifest-v1.borsh
Caused by:
    0: Generic GCS error: ... invalid_grant ...
    ...
Stack backtrace:
   0: __mh_execute_header
   ... 30 frames ...
```

## Change

One-liner: use `{e:#}` (anyhow alternate Display) instead of `{e:?}`. Cause chain on a single line, no backtrace.

```
WARN remote cache unavailable, skipping it for manifest read: open remote object ...: Generic GCS error: ... invalid_grant .... Further errors for this cache are suppressed.
```

Covered by existing `failing_backend_is_best_effort_and_trips_breaker`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)