### PR TITLE
feat(remote-cache): support external_account GCS ADC via google-cloud-auth

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -416,7 +416,7 @@ dependencies = [
  "cc",
  "cfg-if",
  "constant_time_eq",
- "digest",
+ "digest 0.10.7",
  "rayon-core",
 ]
 
@@ -427,6 +427,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3078c7629b62d3f0439517fa394996acacc5cbc91c5a20d8c658e77abd503a71"
 dependencies = [
  "generic-array",
+]
+
+[[package]]
+name = "block-buffer"
+version = "0.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d2f6c7dbe95a6ed67ad9f18e57daf93a2f034c524b99fd2b76d18fdfeb6660aa"
+dependencies = [
+ "hybrid-array",
 ]
 
 [[package]]
@@ -460,6 +469,15 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 2.0.117",
+]
+
+[[package]]
+name = "bs58"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bf88ba1141d185c399bee5288d850d63b8369520c1eafc32a0430b5b6c287bf4"
+dependencies = [
+ "tinyvec",
 ]
 
 [[package]]
@@ -542,6 +560,9 @@ name = "bytes"
 version = "1.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1e748733b7cbc798e1434b6ac524f0c1ff2ab456fe201501e6497c8417a4fc33"
+dependencies = [
+ "serde",
+]
 
 [[package]]
 name = "castaway"
@@ -676,6 +697,12 @@ checksum = "c0f78a02292a74a88ac736019ab962ece0bc380e3f977bf72e376c5d78ff0678"
 dependencies = [
  "cc",
 ]
+
+[[package]]
+name = "cmov"
+version = "0.5.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0c9ea0ac24bc397ab3c98583a3c9ba74fa56b09a4449bbe172b9b1ddb016027a"
 
 [[package]]
 name = "cmp_any"
@@ -957,6 +984,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "crypto-common"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ce6e4c961d6cd6c9a86db418387425e8bdeaf05b3c8bc1411e6dca4c252f1453"
+dependencies = [
+ "hybrid-array",
+]
+
+[[package]]
 name = "csscolorparser"
 version = "0.6.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -974,6 +1010,15 @@ checksum = "01334b89b69ff726750c5ce5073fc8bd860e99aa9a8fc5ca11b04730e3aee97a"
 dependencies = [
  "link-section",
  "linktime-proc-macro",
+]
+
+[[package]]
+name = "ctutils"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7d5515a3834141de9eafb9717ad39eea8247b5674e6066c404e8c4b365d2a29e"
+dependencies = [
+ "cmov",
 ]
 
 [[package]]
@@ -1090,6 +1135,9 @@ name = "deranged"
 version = "0.5.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7cd812cc2bc1d69d4764bd80df88b4317eaef9e773c75226407d9bc0876b211c"
+dependencies = [
+ "serde_core",
+]
 
 [[package]]
 name = "derivative"
@@ -1183,9 +1231,20 @@ version = "0.10.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9ed9a281f7bc9b7576e61468ba615a66a5c8cfdff42420a70aa82701a3b1e292"
 dependencies = [
- "block-buffer",
- "crypto-common",
+ "block-buffer 0.10.4",
+ "crypto-common 0.1.7",
  "subtle",
+]
+
+[[package]]
+name = "digest"
+version = "0.11.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f1dd6dbb5841937940781866fa1281a1ff7bd3bf827091440879f9994983d5c2"
+dependencies = [
+ "block-buffer 0.12.1",
+ "crypto-common 0.2.2",
+ "ctutils",
 ]
 
 [[package]]
@@ -1293,6 +1352,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "dyn-clone"
+version = "1.0.20"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d0881ea181b1df73ff77ffaaf9c7544ecc11e82fba9b5f27b262a3c73a332555"
+
+[[package]]
 name = "e2e"
 version = "0.1.0"
 dependencies = [
@@ -1354,9 +1419,10 @@ dependencies = [
  "flate2",
  "futures",
  "glob",
+ "google-cloud-auth",
  "hex",
  "humantime",
- "indexmap",
+ "indexmap 2.14.0",
  "libc",
  "lock",
  "memoize",
@@ -1377,12 +1443,13 @@ dependencies = [
  "reqwest 0.13.4",
  "rusqlite",
  "rustc-hash",
+ "rustls",
  "sandboxfuse",
  "serde",
  "serde-jsonlines",
  "serde_json",
  "serde_yaml",
- "sha2",
+ "sha2 0.10.9",
  "similar",
  "smart-default",
  "stacker",
@@ -1475,7 +1542,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -1833,6 +1900,81 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0cc23270f6e1808e30a928bdc84dea0b9b4136a8bc82338574f23baf47bbd280"
 
 [[package]]
+name = "google-cloud-auth"
+version = "1.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a300d4011cb53573eafe2419630d303ced54aab6c194a6d9e4156de375800372"
+dependencies = [
+ "async-trait",
+ "base64 0.22.1",
+ "bytes",
+ "chrono",
+ "google-cloud-gax",
+ "hex",
+ "hmac",
+ "http",
+ "reqwest 0.13.4",
+ "rustc_version",
+ "rustls",
+ "rustls-pki-types",
+ "serde",
+ "serde_json",
+ "sha2 0.11.0",
+ "thiserror 2.0.18",
+ "time",
+ "tokio",
+ "url",
+]
+
+[[package]]
+name = "google-cloud-gax"
+version = "1.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4f60f45dd97ff91cedfcb6b2b9f860d3d84739386c3557027687c52cc0e698fd"
+dependencies = [
+ "bytes",
+ "futures",
+ "google-cloud-rpc",
+ "google-cloud-wkt",
+ "http",
+ "pin-project",
+ "rand 0.10.1",
+ "serde",
+ "serde_json",
+ "thiserror 2.0.18",
+ "tokio",
+]
+
+[[package]]
+name = "google-cloud-rpc"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "10b177796075b7bfc02bf2e405db665ee850a924fa44cedfc5282b473c5ab203"
+dependencies = [
+ "bytes",
+ "google-cloud-wkt",
+ "serde",
+ "serde_json",
+ "serde_with",
+]
+
+[[package]]
+name = "google-cloud-wkt"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "88e0186e2221bf82c5296500251b4650b111172c324984159a0de9f6bcaa18a5"
+dependencies = [
+ "base64 0.22.1",
+ "bytes",
+ "serde",
+ "serde_json",
+ "serde_with",
+ "thiserror 2.0.18",
+ "time",
+ "url",
+]
+
+[[package]]
 name = "h2"
 version = "0.4.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1844,7 +1986,7 @@ dependencies = [
  "futures-core",
  "futures-sink",
  "http",
- "indexmap",
+ "indexmap 2.14.0",
  "slab",
  "tokio",
  "tokio-util",
@@ -1962,7 +2104,7 @@ dependencies = [
  "glob",
  "htspec-derive",
  "humantime",
- "indexmap",
+ "indexmap 2.14.0",
  "itertools 0.14.0",
  "libc",
  "lock",
@@ -2022,6 +2164,15 @@ name = "hex"
 version = "0.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7f24254aa9a54b5c858eaee2f5bccdb46aaf0e486a595ed5fd8f86ba55232a70"
+
+[[package]]
+name = "hmac"
+version = "0.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6303bc9732ae41b04cb554b844a762b4115a61bfaa81e3e83050991eeb56863f"
+dependencies = [
+ "digest 0.11.3",
+]
 
 [[package]]
 name = "home"
@@ -2085,6 +2236,15 @@ name = "humantime"
 version = "2.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "135b12329e5e3ce057a9f972339ea52bc954fe1e9358ef27f95e89716fbc5424"
+
+[[package]]
+name = "hybrid-array"
+version = "0.4.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9155a582abd142abc056962c29e3ce5ff2ad5469f4246b537ed42c5deba857da"
+dependencies = [
+ "typenum",
+]
 
 [[package]]
 name = "hyper"
@@ -2290,6 +2450,17 @@ name = "indenter"
 version = "0.3.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "964de6e86d545b246d84badc0fef527924ace5134f30641c203ef52ba83f58d5"
+
+[[package]]
+name = "indexmap"
+version = "1.9.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bd070e393353796e801d209ad339e89596eb4c8d430d18ede6a1cced8fafbd99"
+dependencies = [
+ "autocfg",
+ "hashbrown 0.12.3",
+ "serde",
+]
 
 [[package]]
 name = "indexmap"
@@ -2722,7 +2893,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d89e7ee0cfbedfc4da3340218492196241d89eefb6dab27de5df917a6d2e78cf"
 dependencies = [
  "cfg-if",
- "digest",
+ "digest 0.10.7",
 ]
 
 [[package]]
@@ -2934,7 +3105,7 @@ version = "0.50.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7957b9740744892f114936ab4a57b3f487491bbeafaf8083688b16841a4240e5"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -3287,7 +3458,7 @@ dependencies = [
  "either",
  "erased-serde 0.4.10",
  "fancy-regex 0.16.2",
- "indexmap",
+ "indexmap 2.14.0",
  "inventory",
  "num-bigint",
  "once_cell",
@@ -3437,7 +3608,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "89815c69d36021a140146f26659a81d6c2afa33d216d736dd4be5381a7362220"
 dependencies = [
  "pest",
- "sha2",
+ "sha2 0.10.9",
 ]
 
 [[package]]
@@ -3447,7 +3618,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b4c5cc86750666a3ed20bdaf5ca2a0344f9c67674cae0515bec2da16fbaa47db"
 dependencies = [
  "fixedbitset",
- "indexmap",
+ "indexmap 2.14.0",
 ]
 
 [[package]]
@@ -3500,6 +3671,26 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "67eabc2ef2a60eb7faa00097bd1ffdb5bd28e62bf39990626a582201b7a754e5"
 dependencies = [
  "siphasher",
+]
+
+[[package]]
+name = "pin-project"
+version = "1.1.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2466b2336ed02bcdca6b294417127b90ec92038d1d5c4fbeac971a922e0e0924"
+dependencies = [
+ "pin-project-internal",
+]
+
+[[package]]
+name = "pin-project-internal"
+version = "1.1.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c96395f0a926bc13b1c17622aaddda1ecb55d49c8f1bf9777e4d877800a43f8b"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -3628,7 +3819,7 @@ dependencies = [
  "reqwest 0.13.4",
  "serde",
  "serde_json",
- "sha2",
+ "sha2 0.10.9",
  "tar",
  "tempfile",
  "tokio",
@@ -3814,7 +4005,7 @@ dependencies = [
  "prost 0.12.6",
  "prost-build",
  "prost-derive 0.12.6",
- "sha2",
+ "sha2 0.10.9",
  "smallvec",
  "spin 0.10.0",
  "symbolic-demangle",
@@ -4062,7 +4253,7 @@ dependencies = [
  "once_cell",
  "socket2",
  "tracing",
- "windows-sys 0.60.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -4427,6 +4618,7 @@ dependencies = [
  "rustls-platform-verifier",
  "serde",
  "serde_json",
+ "serde_urlencoded",
  "sync_wrapper",
  "tokio",
  "tokio-rustls",
@@ -4509,7 +4701,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys",
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -4519,6 +4711,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ef86cd5876211988985292b91c96a8f2d298df24e75989a43a3c73f2d4d8168b"
 dependencies = [
  "aws-lc-rs",
+ "log",
  "once_cell",
  "ring",
  "rustls-pki-types",
@@ -4567,7 +4760,7 @@ dependencies = [
  "security-framework",
  "security-framework-sys",
  "webpki-root-certs",
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -4706,6 +4899,30 @@ dependencies = [
 ]
 
 [[package]]
+name = "schemars"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4cd191f9397d57d581cddd31014772520aa448f65ef991055d7f61582c65165f"
+dependencies = [
+ "dyn-clone",
+ "ref-cast",
+ "serde",
+ "serde_json",
+]
+
+[[package]]
+name = "schemars"
+version = "1.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a2b42f36aa1cd011945615b92222f6bf73c599a102a300334cd7f8dbeec726cc"
+dependencies = [
+ "dyn-clone",
+ "ref-cast",
+ "serde",
+ "serde_json",
+]
+
+[[package]]
 name = "scopeguard"
 version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4837,12 +5054,44 @@ dependencies = [
 ]
 
 [[package]]
+name = "serde_with"
+version = "3.21.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "76a5c54c7310e7b8b9577c286d7e399ddd876c3e12b3ed917a8aabc4b96e9e8c"
+dependencies = [
+ "base64 0.22.1",
+ "bs58",
+ "chrono",
+ "hex",
+ "indexmap 1.9.3",
+ "indexmap 2.14.0",
+ "schemars 0.9.0",
+ "schemars 1.2.1",
+ "serde_core",
+ "serde_json",
+ "serde_with_macros",
+ "time",
+]
+
+[[package]]
+name = "serde_with_macros"
+version = "3.21.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "84d57bc0c8b9a17920c178daa6bb924850d54a9c97ab45194bb8c17ad66bb660"
+dependencies = [
+ "darling 0.23.0",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+]
+
+[[package]]
 name = "serde_yaml"
 version = "0.9.34+deprecated"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6a8b1a1a2ebf674015cc02edccce75287f1a0130d394307b36743c2f5d504b47"
 dependencies = [
- "indexmap",
+ "indexmap 2.14.0",
  "itoa",
  "ryu",
  "serde",
@@ -4857,7 +5106,7 @@ checksum = "e3bf829a2d51ab4a5ddf1352d8470c140cadc8301b2ae1789db023f01cedd6ba"
 dependencies = [
  "cfg-if",
  "cpufeatures 0.2.17",
- "digest",
+ "digest 0.10.7",
 ]
 
 [[package]]
@@ -4868,7 +5117,18 @@ checksum = "a7507d819769d01a365ab707794a4084392c824f54a7a6a7862f8c3d0892b283"
 dependencies = [
  "cfg-if",
  "cpufeatures 0.2.17",
- "digest",
+ "digest 0.10.7",
+]
+
+[[package]]
+name = "sha2"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "446ba717509524cb3f22f17ecc096f10f4822d76ab5c0b9822c5f9c284e825f4"
+dependencies = [
+ "cfg-if",
+ "cpufeatures 0.3.0",
+ "digest 0.11.3",
 ]
 
 [[package]]
@@ -5113,7 +5373,7 @@ dependencies = [
  "either",
  "erased-serde 0.3.31",
  "hashbrown 0.16.1",
- "indexmap",
+ "indexmap 2.14.0",
  "inventory",
  "itertools 0.14.0",
  "maplit",
@@ -5382,7 +5642,7 @@ dependencies = [
  "rusqlite",
  "serde",
  "serde_json",
- "sha2",
+ "sha2 0.10.9",
  "tempfile",
  "tokio",
  "tracing",
@@ -5399,7 +5659,7 @@ dependencies = [
  "getrandom 0.4.2",
  "once_cell",
  "rustix",
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -5458,7 +5718,7 @@ dependencies = [
  "pest",
  "pest_derive",
  "phf",
- "sha2",
+ "sha2 0.10.9",
  "signal-hook",
  "siphasher",
  "terminfo",
@@ -5556,6 +5816,7 @@ dependencies = [
  "powerfmt",
  "serde_core",
  "time-core",
+ "time-macros",
 ]
 
 [[package]]
@@ -5563,6 +5824,16 @@ name = "time-core"
 version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9e1c906769ad99c88eaa54e728060edef082f8e358ff32030cb7c7d315e81109"
+
+[[package]]
+name = "time-macros"
+version = "0.2.29"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "71c652a3727a9cbb9a02f707f530b618ce00d0ccd762009c8c23bd191df3c17d"
+dependencies = [
+ "num-conv",
+ "time-core",
+]
 
 [[package]]
 name = "tinystr"
@@ -5655,7 +5926,7 @@ version = "0.25.12+spec-1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d2153edc6955a6c354fad8f5efd38b6a8769bdccf9fe50f8e1329f81b0baa5d7"
 dependencies = [
- "indexmap",
+ "indexmap 2.14.0",
  "toml_datetime",
  "toml_parser",
  "winnow",
@@ -6106,7 +6377,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bb0e353e6a2fbdc176932bbaab493762eb1255a7900fe0fea1a2f96c296cc909"
 dependencies = [
  "anyhow",
- "indexmap",
+ "indexmap 2.14.0",
  "wasm-encoder",
  "wasmparser",
 ]
@@ -6132,7 +6403,7 @@ checksum = "47b807c72e1bac69382b3a6fb3dbe8ea4c0ed87ff5629b8685ae6b9a611028fe"
 dependencies = [
  "bitflags 2.13.0",
  "hashbrown 0.15.5",
- "indexmap",
+ "indexmap 2.14.0",
  "semver",
 ]
 
@@ -6198,7 +6469,7 @@ checksum = "692daff6d93d94e29e4114544ef6d5c942a7ed998b37abdc19b17136ea428eb7"
 dependencies = [
  "getrandom 0.3.4",
  "mac_address",
- "sha2",
+ "sha2 0.10.9",
  "thiserror 1.0.69",
  "uuid",
 ]
@@ -6283,7 +6554,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -6559,7 +6830,7 @@ checksum = "b7c566e0f4b284dd6561c786d9cb0142da491f46a9fbed79ea69cdad5db17f21"
 dependencies = [
  "anyhow",
  "heck",
- "indexmap",
+ "indexmap 2.14.0",
  "prettyplease",
  "syn 2.0.117",
  "wasm-metadata",
@@ -6590,7 +6861,7 @@ checksum = "9d66ea20e9553b30172b5e831994e35fbde2d165325bec84fc43dbf6f4eb9cb2"
 dependencies = [
  "anyhow",
  "bitflags 2.13.0",
- "indexmap",
+ "indexmap 2.14.0",
  "log",
  "serde",
  "serde_derive",
@@ -6609,7 +6880,7 @@ checksum = "ecc8ac4bc1dc3381b7f59c34f00b67e18f910c2c0f50015669dde7def656a736"
 dependencies = [
  "anyhow",
  "id-arena",
- "indexmap",
+ "indexmap 2.14.0",
  "log",
  "semver",
  "serde",

--- a/crates/engine/Cargo.toml
+++ b/crates/engine/Cargo.toml
@@ -34,6 +34,13 @@ enclose = "1"
 flate2 = "1.1.9"
 futures = "0.3.32"
 glob = "0.3"
+# GCP auth that understands `external_account` ADC (workload identity
+# federation), which object_store's GCS builder cannot decode. Used only to mint
+# a bearer token for `gs://` caches whose ADC is external_account; every other
+# credential type stays on object_store's native path. `default-features = false`
+# drops the id-token backend (pulls aws-lc C build) we don't need; we install the
+# ring rustls provider ourselves (see `ensure_rustls_provider_installed`).
+google-cloud-auth = { version = "1.13", default-features = false }
 indexmap = "2"
 memoize = "0.6.0"
 object_store = { version = "0.13.2", features = ["aws", "gcp", "azure", "http", "tokio"] }
@@ -48,6 +55,10 @@ rayon = "1.12.0"
 reqwest = { version = "0.13", default-features = false, features = ["blocking", "rustls"] }
 rusqlite = { version = "0.39", features = ["bundled", "blob"] }
 rustc-hash = "2"
+# Needed only to install a process-wide rustls crypto provider for
+# `google-cloud-auth` (its reqwest uses `rustls-no-provider`). `ring` keeps us
+# off the aws-lc C toolchain.
+rustls = { version = "0.23", features = ["ring"] }
 serde = { version = "1", features = ["derive"] }
 serde_json = "1.0"
 sha2 = "0.10"

--- a/crates/engine/src/engine/remote_cache_objstore.rs
+++ b/crates/engine/src/engine/remote_cache_objstore.rs
@@ -8,19 +8,39 @@
 //! All transfers are streamed: reads expose the object's byte stream as an
 //! [`AsyncRead`], and writes go through object_store's multipart [`BufWriter`],
 //! so a blob is never held whole in memory.
+//!
+//! One credential type needs special handling. object_store's GCS builder reads
+//! Application Default Credentials itself and only decodes `service_account` and
+//! `authorized_user` files — an `external_account` ADC (GCP workload identity
+//! federation, e.g. what `google-github-actions/auth` writes in CI) fails to
+//! parse before any request is made. For that case only, we mint a bearer token
+//! out-of-band with `google-cloud-auth` (which does the STS token exchange and
+//! service-account impersonation in-process) and hand it to the GCS builder via
+//! [`object_store::gcp::GoogleCloudStorageBuilder::with_credentials`], which then
+//! skips ADC parsing entirely. Every other scheme and credential type is left on
+//! object_store's native path.
 
 use crate::engine::remote_cache::RemoteCacheBackend;
 use anyhow::Context;
 use async_trait::async_trait;
 use futures::TryStreamExt;
+use google_cloud_auth::credentials::{AccessTokenCredentials, Builder as AdcBuilder};
 use object_store::buffered::BufWriter;
+use object_store::gcp::{GcpCredential, GcpCredentialProvider, GoogleCloudStorageBuilder};
 use object_store::limit::LimitStore;
-use object_store::{ObjectStore, ObjectStoreExt, parse_url_opts, path::Path as ObjPath};
+use object_store::{
+    CredentialProvider, ObjectStore, ObjectStoreExt, parse_url_opts, path::Path as ObjPath,
+};
+use std::path::{Path, PathBuf};
 use std::pin::Pin;
 use std::sync::Arc;
 use tokio::io::{AsyncRead, AsyncWrite};
+use tokio::sync::OnceCell;
 use tokio_util::io::StreamReader;
 use url::Url;
+
+/// OAuth scope for read/write access to GCS objects — what a remote cache needs.
+const GCS_SCOPE: &str = "https://www.googleapis.com/auth/devstorage.read_write";
 
 /// One remote object store plus the path prefix carved out of its URI. Object
 /// keys handed to [`RemoteCacheBackend`] are joined under `prefix`, so two
@@ -41,10 +61,35 @@ impl ObjStoreBackend {
     /// simultaneous connections.
     pub fn from_uri(uri: &str, max_concurrency: usize) -> anyhow::Result<Self> {
         let url = Url::parse(uri).with_context(|| format!("parse remote cache uri {uri}"))?;
-        // Pass the environment through so s3/gcs/azure builders pick up
-        // credentials exactly as their `from_env` constructors would.
-        let (store, prefix) = parse_url_opts(&url, std::env::vars())
-            .with_context(|| format!("open remote cache store for {uri}"))?;
+        let (store, prefix): (Box<dyn ObjectStore>, ObjPath) =
+            if url.scheme() == "gs" && adc_is_external_account() {
+                // object_store can't decode an external_account ADC. Inject a
+                // `google-cloud-auth`-backed bearer provider so the GCS builder
+                // skips ADC parsing; the federation handshake happens lazily on
+                // the first request inside the provider.
+                let provider: GcpCredentialProvider =
+                    Arc::new(ExternalAccountCredentialProvider::new());
+                let store = GoogleCloudStorageBuilder::from_env()
+                    .with_url(uri)
+                    .with_credentials(provider)
+                    .build()
+                    .with_context(|| {
+                        format!(
+                            "build GCS store for {uri} (external_account ADC via google-cloud-auth)"
+                        )
+                    })?;
+                // The builder consumes only the bucket from the URL; derive the
+                // key prefix exactly as `parse_url_opts` would (path minus the
+                // leading slash, percent-decoded).
+                let prefix = ObjPath::from_url_path(url.path())
+                    .with_context(|| format!("parse object prefix from {uri}"))?;
+                (Box::new(store), prefix)
+            } else {
+                // Pass the environment through so s3/gcs/azure builders pick up
+                // credentials exactly as their `from_env` constructors would.
+                parse_url_opts(&url, std::env::vars())
+                    .with_context(|| format!("open remote cache store for {uri}"))?
+            };
         let store: Arc<dyn ObjectStore> = Arc::new(LimitStore::new(store, max_concurrency));
         Ok(Self { store, prefix })
     }
@@ -92,6 +137,110 @@ impl RemoteCacheBackend for ObjStoreBackend {
     }
 }
 
+/// Mints GCS bearer tokens from an `external_account` ADC via `google-cloud-auth`.
+///
+/// object_store calls [`get_credential`](CredentialProvider::get_credential) on
+/// every request; the underlying [`AccessTokenCredentials`] caches the token and
+/// refreshes it near expiry, so the expensive STS exchange happens once per token
+/// lifetime, not once per request. Construction is deferred to the first call
+/// (and memoized via [`OnceCell`]) so `from_uri` stays synchronous and a
+/// misconfigured cache never blocks engine startup on a network handshake.
+struct ExternalAccountCredentialProvider {
+    creds: OnceCell<AccessTokenCredentials>,
+}
+
+impl ExternalAccountCredentialProvider {
+    fn new() -> Self {
+        Self {
+            creds: OnceCell::new(),
+        }
+    }
+}
+
+impl std::fmt::Debug for ExternalAccountCredentialProvider {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("ExternalAccountCredentialProvider")
+            .field("initialized", &self.creds.initialized())
+            .finish()
+    }
+}
+
+#[async_trait]
+impl CredentialProvider for ExternalAccountCredentialProvider {
+    type Credential = GcpCredential;
+
+    async fn get_credential(&self) -> object_store::Result<Arc<GcpCredential>> {
+        let creds = self
+            .creds
+            .get_or_try_init(|| async {
+                ensure_rustls_provider_installed();
+                AdcBuilder::default()
+                    .with_scopes([GCS_SCOPE])
+                    .build_access_token_credentials()
+            })
+            .await
+            .map_err(|e| object_store::Error::Generic {
+                store: "GCS",
+                source: Box::new(e),
+            })?;
+        let token = creds
+            .access_token()
+            .await
+            .map_err(|e| object_store::Error::Generic {
+                store: "GCS",
+                source: Box::new(e),
+            })?;
+        Ok(Arc::new(GcpCredential {
+            bearer: token.token,
+        }))
+    }
+}
+
+/// True when the active GCP Application Default Credentials are an
+/// `external_account` file (workload identity federation) — the one ADC shape
+/// object_store's GCS builder refuses to decode.
+fn adc_is_external_account() -> bool {
+    adc_credential_path()
+        .as_deref()
+        .and_then(read_adc_type)
+        .as_deref()
+        == Some("external_account")
+}
+
+/// Resolve the ADC file the GCS builder would read: `GOOGLE_APPLICATION_CREDENTIALS`
+/// if set, else the gcloud well-known location under `$HOME`. Mirrors
+/// object_store's own resolution so detection matches what would actually load.
+fn adc_credential_path() -> Option<PathBuf> {
+    if let Some(p) = std::env::var_os("GOOGLE_APPLICATION_CREDENTIALS") {
+        return Some(PathBuf::from(p));
+    }
+    let home = std::env::var_os("HOME")?;
+    let path = Path::new(&home).join(".config/gcloud/application_default_credentials.json");
+    path.exists().then_some(path)
+}
+
+/// Read the `type` field of an ADC JSON file. Returns `None` if the file is
+/// missing or unparseable — detection then falls through to object_store, which
+/// surfaces its own error.
+fn read_adc_type(path: &Path) -> Option<String> {
+    let bytes = std::fs::read(path).ok()?;
+    let json: serde_json::Value = serde_json::from_slice(&bytes).ok()?;
+    json.get("type")?.as_str().map(str::to_owned)
+}
+
+/// Install the ring rustls crypto provider as the process-wide default, once.
+/// `google-cloud-auth`'s reqwest is built with `rustls-no-provider`, so the
+/// first TLS handshake panics unless a default provider is installed. Idempotent:
+/// `install_default` errors if one is already set, which we ignore.
+fn ensure_rustls_provider_installed() {
+    use std::sync::Once;
+    static ONCE: Once = Once::new();
+    ONCE.call_once(|| {
+        // Err means another provider was already installed — equally fine.
+        let _already_installed = rustls::crypto::ring::default_provider().install_default();
+    });
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -129,5 +278,43 @@ mod tests {
         let backend = ObjStoreBackend::from_uri(&uri, 10).expect("backend");
         put(&backend, "a/b/c", b"payload").await;
         assert_eq!(get(&backend, "a/b/c").await.expect("present"), b"payload");
+    }
+
+    fn write_adc(dir: &std::path::Path, body: &str) -> PathBuf {
+        let path = dir.join("adc.json");
+        std::fs::write(&path, body).expect("write adc");
+        path
+    }
+
+    #[test]
+    fn read_adc_type_classifies_external_account() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        // Minified, single-line — the exact shape google-github-actions/auth
+        // writes and that object_store fails to decode.
+        let path = write_adc(
+            dir.path(),
+            r#"{"type":"external_account","audience":"//iam.googleapis.com/x","token_url":"https://sts.googleapis.com/v1/token"}"#,
+        );
+        assert_eq!(read_adc_type(&path).as_deref(), Some("external_account"));
+    }
+
+    #[test]
+    fn read_adc_type_classifies_authorized_user() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let path = write_adc(
+            dir.path(),
+            r#"{"type": "authorized_user", "client_id": "x", "refresh_token": "y"}"#,
+        );
+        assert_eq!(read_adc_type(&path).as_deref(), Some("authorized_user"));
+    }
+
+    #[test]
+    fn read_adc_type_none_on_missing_or_garbage() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        assert_eq!(read_adc_type(&dir.path().join("nope.json")), None);
+        let garbage = write_adc(dir.path(), "not json at all");
+        assert_eq!(read_adc_type(&garbage), None);
+        let no_type = write_adc(dir.path(), r#"{"audience": "x"}"#);
+        assert_eq!(read_adc_type(&no_type), None);
     }
 }


### PR DESCRIPTION
## Problem

`object_store`'s GCS builder decodes only `service_account` and `authorized_user` Application Default Credentials. An **`external_account`** ADC — GCP workload identity federation, e.g. what `google-github-actions/auth@v2` (with `create_credentials_file: true` + `workload_identity_provider`) writes in CI — fails to parse *before any request is made*:

```
configure remote cache `master`: open remote cache store for gs://…:
Generic GCS error: Unable to decode service account file:
unknown variant `external_account`, expected `service_account` or `authorized_user`
```

So `gs://` remote caches are unusable in GHA workload-identity setups. There is no env-only workaround — object_store has no bearer-token config key and no external_account/STS support.

## Fix

When (and only when) a `gs://` cache's ADC `type` is `external_account`, mint a bearer token out-of-band with [`google-cloud-auth`](https://github.com/googleapis/google-cloud-rust) (STS token exchange + service-account impersonation, fully **in-process — no gcloud shell-out**) and inject it via `GoogleCloudStorageBuilder::with_credentials`, which then skips ADC parsing entirely.

- **Surgical**: gated on `scheme == gs` *and* detected `external_account`. Every other scheme and credential type stays on object_store's native path → no regression to existing s3/azure/gcs setups.
- **Lazy**: provider construction is deferred via `OnceCell`, so `from_uri` stays synchronous and a misconfigured cache never blocks startup on a network handshake. `AccessTokenCredentials` caches/refreshes the token internally → one STS exchange per token lifetime, not per request.
- Installs the ring rustls crypto provider once (the SDK's reqwest uses `rustls-no-provider`).

Same approach Vector adopted for the identical problem ([vectordotdev/vector#25454](https://github.com/vectordotdev/vector/pull/25454)).

## Deps

- `google-cloud-auth = "1.9"` (`default-features = false` → drops the id-token backend's aws-lc C build)
- `rustls` (`ring`) — only to install the process-wide crypto provider

## Tests

`read_adc_type` classification: external_account / authorized_user / missing-or-garbage.

## CI / usage note

Existing `auth@v2` workflows work unchanged. `setup-gcloud` is no longer needed for cache auth (federation is in-process now).

🤖 Generated with [Claude Code](https://claude.com/claude-code)