### PR TITLE
fix(unpack): make symlink creation idempotent on overlapping inputs

### DIFF
--- a/crates/core/src/hartifactcontent/unpack.rs
+++ b/crates/core/src/hartifactcontent/unpack.rs
@@ -126,14 +126,39 @@ pub fn unpack(
                 }
                 #[cfg(unix)]
                 {
-                    std::os::unix::fs::symlink(&*target, &dest).with_context(|| {
-                        format!(
-                            "create symlink {:?} -> {:?} (existing={})",
-                            dest,
-                            target,
-                            describe_existing(&dest),
-                        )
-                    })?;
+                    match std::os::unix::fs::symlink(&*target, &dest) {
+                        Ok(()) => {}
+                        // Inputs can overlap (multiple sources unpack into the
+                        // same ws). An identical symlink already in place is a
+                        // no-op; only a divergent target is an error.
+                        Err(e) if e.kind() == io::ErrorKind::AlreadyExists => {
+                            let existing = fs::read_link(&dest).with_context(|| {
+                                format!(
+                                    "read existing symlink {:?} while unpacking {:?} -> {:?}",
+                                    dest, entry.path, target,
+                                )
+                            })?;
+                            if existing != **target {
+                                anyhow::bail!(
+                                    "symlink {:?} already exists with divergent target: \
+                                     existing -> {:?}, unpacking -> {:?}",
+                                    dest,
+                                    existing,
+                                    target,
+                                );
+                            }
+                        }
+                        Err(e) => {
+                            return Err(e).with_context(|| {
+                                format!(
+                                    "create symlink {:?} -> {:?} (existing={})",
+                                    dest,
+                                    target,
+                                    describe_existing(&dest),
+                                )
+                            });
+                        }
+                    }
                 }
                 #[cfg(not(unix))]
                 {
@@ -281,6 +306,36 @@ mod tests {
             "script exited non-zero: {output:?}"
         );
         assert_eq!(String::from_utf8_lossy(&output.stdout), "ok\n");
+    }
+
+    #[test]
+    fn unpack_existing_identical_symlink_is_noop() {
+        // Overlapping inputs unpack into the same dir; re-creating an identical
+        // symlink must succeed (idempotent), not fail with EEXIST.
+        let buf = pack_with_symlink(false);
+        let content = TarBytes(buf);
+        let out = tempfile::tempdir().expect("out tempdir");
+
+        unpack(&content, out.path(), None, None).expect("first unpack");
+        unpack(&content, out.path(), None, None).expect("second unpack must be idempotent");
+
+        let link_path = out.path().join("link.txt");
+        let read_target = std::fs::read_link(&link_path).unwrap();
+        assert_eq!(read_target, PathBuf::from("target.txt"));
+    }
+
+    #[test]
+    fn unpack_existing_divergent_symlink_errors() {
+        let buf = pack_with_symlink(false);
+        let content = TarBytes(buf);
+        let out = tempfile::tempdir().expect("out tempdir");
+
+        // Pre-create link.txt pointing elsewhere; unpack must reject divergence.
+        symlink("other.txt", out.path().join("link.txt")).unwrap();
+
+        let err = unpack(&content, out.path(), None, None).expect_err("expected error");
+        let msg = format!("{err:#}");
+        assert!(msg.contains("divergent target"), "unexpected: {msg}");
     }
 
     #[test]


### PR DESCRIPTION
## Problem

When multiple inputs unpack into the same sandbox `ws` directory, an identical symlink already in place caused unpack to fail:

```
create symlink ".../node_modules/.bin/esparse" -> "../esprima/bin/esparse.js"
  (existing=symlink->../esprima/bin/esparse.js): File exists (os error 17)
```

`std::os::unix::fs::symlink` is not idempotent, so re-creating a symlink that already exists errors with `EEXIST`. File entries dodge this because `File::create` truncates an existing file.

## Fix

On `AlreadyExists`, read the existing link:
- identical target → no-op (overlapping inputs are legitimate)
- divergent target → error
- other errors keep the existing `describe_existing` context

## Tests

- `unpack_existing_identical_symlink_is_noop` — re-unpack succeeds
- `unpack_existing_divergent_symlink_errors` — divergence rejected

🤖 Generated with [Claude Code](https://claude.com/claude-code)