### PR TITLE
fix(plugin-go): stage cross-package asm headers for thirdparty libs

### DIFF
--- a/crates/plugin-go/src/plugingo/driver_golist.rs
+++ b/crates/plugin-go/src/plugingo/driver_golist.rs
@@ -398,7 +398,38 @@ impl ManagedDriver for GoGolistDriver {
             ),
             None => None,
         };
-        let addrs = resolve_package_addrs(&pkg, pkg_str, &source_map, download_addr.as_ref());
+        let mut addrs = resolve_package_addrs(&pkg, pkg_str, &source_map, download_addr.as_ref());
+
+        // circl-style asm `#include`s reach into sibling packages of the same
+        // module (`dh/x448` → `../../math/fp448/fp_amd64.h`). Those headers
+        // aren't in this package's HFiles, so scan the asm sources and stage the
+        // siblings via the module-root download target at their module-relative
+        // path — the path the `-I .` asm step resolves them against.
+        if let (Some(dl), false) = (download_addr.as_ref(), pkg.s_files.is_empty())
+            && let Some(pkg_dir) = pkg.dir.as_deref()
+        {
+            let module_ws_root = dl.package.as_str();
+            let subpath = pkg_str
+                .strip_prefix(module_ws_root)
+                .map(|s| s.trim_start_matches('/'))
+                .unwrap_or("");
+            addrs.extra_h_files = crate::plugingo::pkg_analysis::collect_cross_pkg_asm_headers(
+                pkg_dir,
+                subpath,
+                &pkg.s_files,
+            )
+            .into_iter()
+            .map(|rel| {
+                TargetAddr {
+                    r#ref: dl.clone(),
+                    output: None,
+                    filters: vec![format!("{module_ws_root}/{rel}")],
+                }
+                .to_string()
+            })
+            .collect();
+        }
+
         let addrs_bin = encode_package_addrs(&addrs).context("encode package_addrs.bin")?;
         std::fs::write(req.sandbox_pkg_dir.join("package_addrs.bin"), &addrs_bin)
             .context("write package_addrs.bin")?;

--- a/crates/plugin-go/src/plugingo/pkg_analysis.rs
+++ b/crates/plugin-go/src/plugingo/pkg_analysis.rs
@@ -5,8 +5,9 @@ use hmodel::htaddr::{Addr, parse_addr_with_base};
 use hmodel::htpkg::PkgBuf;
 use hplugin::driver::TargetAddr;
 use serde::{Deserialize, Serialize};
-use std::collections::HashMap;
+use std::collections::{BTreeSet, HashMap, HashSet, VecDeque};
 use std::io::Read;
+use std::path::{Component, Path, PathBuf};
 
 #[derive(Debug, Clone, Default, Serialize, Deserialize, BorshSerialize, BorshDeserialize)]
 pub struct GoPackage {
@@ -71,6 +72,12 @@ pub struct PackageAddrs {
     /// `#include` directives.
     #[serde(rename = "HFiles", default)]
     pub h_files: Vec<String>,
+    /// Addrs for header files this package's asm `#include`s from sibling
+    /// packages in the same module (e.g. circl `dh/x448` → `math/fp448`). Not
+    /// in `HFiles` (they belong to other packages), discovered by scanning the
+    /// asm sources and staged via the module-root `download` target.
+    #[serde(rename = "ExtraHFiles", default)]
+    pub extra_h_files: Vec<String>,
     #[serde(rename = "TestGoFiles", default)]
     pub test_go_files: Vec<String>,
     #[serde(rename = "XTestGoFiles", default)]
@@ -150,12 +157,134 @@ pub fn resolve_package_addrs(
         go_files: resolve(&pkg.go_files),
         s_files: resolve(&pkg.s_files),
         h_files: resolve(&pkg.h_files),
+        // Cross-package asm headers need filesystem scanning; the golist driver
+        // fills this in after resolve (it can't be derived from `go list` JSON).
+        extra_h_files: Vec::new(),
         test_go_files: resolve(&pkg.test_go_files),
         xtest_go_files: resolve(&pkg.xtest_go_files),
         embed_files: resolve(&pkg.embed_files),
         test_embed_files: resolve(&pkg.test_embed_files),
         xtest_embed_files: resolve(&pkg.xtest_embed_files),
     }
+}
+
+/// Parse `#include "path"` directives out of Go assembly (or header) source.
+///
+/// Go's assembler only honours double-quoted includes; angle-bracket form is
+/// not used. Returns the quoted paths verbatim, in source order.
+pub fn parse_asm_includes(content: &str) -> impl Iterator<Item = &str> {
+    content.lines().filter_map(|line| {
+        let rest = line.trim_start().strip_prefix("#include")?.trim_start();
+        let rest = rest.strip_prefix('"')?;
+        rest.split_once('"').map(|(inc, _)| inc)
+    })
+}
+
+/// Resolve `.`/`..` components in `p` lexically (no filesystem access), keeping
+/// any root/prefix component intact so `..` can never climb above the root.
+fn lexical_normalize(p: &Path) -> PathBuf {
+    let mut out: Vec<std::ffi::OsString> = Vec::new();
+    let mut anchored = false;
+    for comp in p.components() {
+        match comp {
+            Component::CurDir => {}
+            Component::ParentDir => {
+                // Don't pop the root/prefix anchor or a leading `..`.
+                if out.len() > usize::from(anchored)
+                    && out.last().map(|s| s.as_os_str() != "..").unwrap_or(true)
+                {
+                    out.pop();
+                } else if !anchored {
+                    out.push("..".into());
+                }
+            }
+            Component::RootDir | Component::Prefix(_) => {
+                anchored = true;
+                out.push(comp.as_os_str().to_os_string());
+            }
+            Component::Normal(c) => out.push(c.to_os_string()),
+        }
+    }
+    out.iter().collect()
+}
+
+/// Discover header files that asm sources `#include` from *sibling packages* in
+/// the same module — files the package's own `HFiles` never lists, so nothing
+/// else stages them.
+///
+/// Example: cloudflare/circl's `dh/x448/curve_amd64.s` does
+/// `#include "../../math/fp448/fp_amd64.h"`. That header lives in the `math/
+/// fp448` package, not `dh/x448`, so the asm step fails with "no such file"
+/// unless it's staged at its module-relative path.
+///
+/// `pkg_dir` is the package's source directory (host GOMODCACHE path); `subpath`
+/// is its module-relative location (e.g. `dh/x448`), used to derive the module
+/// root. Returns module-root-relative, forward-slashed paths — deduped and
+/// sorted for deterministic output. Headers inside `pkg_dir` itself are skipped
+/// (already covered by `HFiles`); includes that don't resolve to a real file
+/// (std headers like `textflag.h` via `-I $GOROOT/pkg/include`, or generated
+/// `go_asm.h`) are skipped.
+pub fn collect_cross_pkg_asm_headers(
+    pkg_dir: &str,
+    subpath: &str,
+    s_files: &[String],
+) -> Vec<String> {
+    let pkg_dir = Path::new(pkg_dir);
+    // Strip the subpath components off pkg_dir to reach the module root.
+    let mut module_root = pkg_dir;
+    for _ in subpath.split('/').filter(|s| !s.is_empty()) {
+        module_root = match module_root.parent() {
+            Some(p) => p,
+            None => return Vec::new(),
+        };
+    }
+
+    let mut out: BTreeSet<String> = BTreeSet::new();
+    let mut visited: HashSet<PathBuf> = HashSet::new();
+    let mut queue: VecDeque<PathBuf> = VecDeque::new();
+
+    let enqueue = |from: &Path, inc: &str, queue: &mut VecDeque<PathBuf>| {
+        // Absolute includes would be non-hermetic; Go asm never uses them.
+        if inc.starts_with('/') {
+            return;
+        }
+        let base = from.parent().unwrap_or(module_root);
+        queue.push_back(lexical_normalize(&base.join(inc)));
+    };
+
+    for s in s_files {
+        let p = pkg_dir.join(s);
+        if let Ok(content) = std::fs::read_to_string(&p) {
+            for inc in parse_asm_includes(&content) {
+                enqueue(&p, inc, &mut queue);
+            }
+        }
+    }
+
+    while let Some(hdr) = queue.pop_front() {
+        if !visited.insert(hdr.clone()) {
+            continue;
+        }
+        // Never stage anything outside the module (or std headers absent here).
+        if !hdr.starts_with(module_root) {
+            continue;
+        }
+        let content = match std::fs::read_to_string(&hdr) {
+            Ok(c) => c,
+            Err(_) => continue,
+        };
+        // Record only siblings — headers in the origin package ship via HFiles.
+        if !hdr.starts_with(pkg_dir)
+            && let Ok(rel) = hdr.strip_prefix(module_root)
+        {
+            out.insert(rel.to_string_lossy().replace('\\', "/"));
+        }
+        for inc in parse_asm_includes(&content) {
+            enqueue(&hdr, inc, &mut queue);
+        }
+    }
+
+    out.into_iter().collect()
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, BorshSerialize, BorshDeserialize)]
@@ -664,5 +793,86 @@ golang.org/x/oauth2 v0.0.0-20200107190931-bf48bf16ab8d/go.mod h1:gOpvHmFTYa4Iltr
         assert!(pkg.go_files.is_empty());
         assert!(pkg.imports.is_empty());
         assert!(pkg.module.is_none());
+    }
+
+    #[test]
+    fn test_parse_asm_includes() {
+        let src = concat!(
+            "#include \"textflag.h\"\n",
+            "  #include \"../../math/fp448/fp_amd64.h\"\n",
+            "#include \"curve_amd64.h\"\n",
+            "// #include \"not_a_real_one.h\"\n",
+            "TEXT ·foo(SB), 0, $0\n",
+        );
+        let got: Vec<&str> = parse_asm_includes(src).collect();
+        assert_eq!(
+            got,
+            vec!["textflag.h", "../../math/fp448/fp_amd64.h", "curve_amd64.h",]
+        );
+    }
+
+    #[test]
+    fn test_collect_cross_pkg_asm_headers_circl_shape() {
+        // Lay out a circl-shaped module: dh/x448 asm `#include`s a sibling
+        // header in math/fp448, which itself pulls in a same-dir helper.
+        let dir = tempfile::tempdir().expect("tempdir");
+        let root = dir.path();
+        let x448 = root.join("dh/x448");
+        let fp448 = root.join("math/fp448");
+        std::fs::create_dir_all(&x448).unwrap();
+        std::fs::create_dir_all(&fp448).unwrap();
+
+        std::fs::write(
+            x448.join("curve_amd64.s"),
+            concat!(
+                "#include \"textflag.h\"\n",
+                "#include \"../../math/fp448/fp_amd64.h\"\n",
+                "#include \"curve_amd64.h\"\n",
+            ),
+        )
+        .unwrap();
+        // Same-package header — must NOT be reported (covered by HFiles).
+        std::fs::write(x448.join("curve_amd64.h"), "// macros\n").unwrap();
+        // Sibling header pulls a same-dir helper — both must be reported.
+        std::fs::write(fp448.join("fp_amd64.h"), "#include \"fp_amd64_helper.h\"\n").unwrap();
+        std::fs::write(fp448.join("fp_amd64_helper.h"), "// more macros\n").unwrap();
+
+        let got = collect_cross_pkg_asm_headers(
+            &x448.to_string_lossy(),
+            "dh/x448",
+            &["curve_amd64.s".to_string()],
+        );
+        assert_eq!(
+            got,
+            vec![
+                "math/fp448/fp_amd64.h".to_string(),
+                "math/fp448/fp_amd64_helper.h".to_string(),
+            ],
+            "must report sibling headers (transitively), module-relative, sorted; \
+             never the same-package header nor the std `textflag.h`"
+        );
+    }
+
+    #[test]
+    fn test_collect_cross_pkg_asm_headers_none_when_self_contained() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let pkg = dir.path().join("crypto/foo");
+        std::fs::create_dir_all(&pkg).unwrap();
+        std::fs::write(
+            pkg.join("impl_amd64.s"),
+            "#include \"textflag.h\"\n#include \"local.h\"\n",
+        )
+        .unwrap();
+        std::fs::write(pkg.join("local.h"), "// macros\n").unwrap();
+
+        let got = collect_cross_pkg_asm_headers(
+            &pkg.to_string_lossy(),
+            "crypto/foo",
+            &["impl_amd64.s".to_string()],
+        );
+        assert!(
+            got.is_empty(),
+            "self-contained asm must not stage any cross-package header: {got:?}"
+        );
     }
 }

--- a/crates/plugin-go/src/plugingo/provider.rs
+++ b/crates/plugin-go/src/plugingo/provider.rs
@@ -1135,6 +1135,7 @@ impl ProviderInner {
                         &pkg_addrs.go_files,
                         &pkg_addrs.s_files,
                         &pkg_addrs.h_files,
+                        &pkg_addrs.extra_h_files,
                         embed_addr.as_ref(),
                         &pkg_addrs.embed_files,
                         &self.go_version,

--- a/crates/plugin-go/src/plugingo/thirdparty.rs
+++ b/crates/plugin-go/src/plugingo/thirdparty.rs
@@ -131,6 +131,7 @@ pub fn build_lib_spec(
     src_addrs: &[String],
     s_file_addrs: &[String],
     h_file_addrs: &[String],
+    extra_h_file_addrs: &[String],
     embed_addr: Option<&Addr>,
     embed_file_addrs: &[String],
     go_version: &str,
@@ -178,18 +179,17 @@ pub fn build_lib_spec(
                     .collect(),
             ),
         );
-        // .h headers next to .s files (e.g. purego ships its own abi_arm64.h).
-        // Staged so asm `-I .` can resolve `#include "abi_arm64.h"`.
-        if !h_file_addrs.is_empty() {
-            deps.insert(
-                "hdr".to_string(),
-                Value::List(
-                    h_file_addrs
-                        .iter()
-                        .map(|s| Value::String(s.clone()))
-                        .collect(),
-                ),
-            );
+        // .h headers next to .s files (e.g. purego ships its own abi_arm64.h),
+        // plus sibling-package headers the asm `#include`s across the module
+        // (circl `dh/x448` → `math/fp448/fp_amd64.h`). Both stage at their
+        // module-relative path so asm `-I .` / relative `#include` resolve.
+        let hdrs: Vec<Value> = h_file_addrs
+            .iter()
+            .chain(extra_h_file_addrs.iter())
+            .map(|s| Value::String(s.clone()))
+            .collect();
+        if !hdrs.is_empty() {
+            deps.insert("hdr".to_string(), Value::List(hdrs));
         }
     }
     if let Some(e) = embed_addr {
@@ -516,6 +516,7 @@ mod tests {
             &[filter_src_addr("logr.go")],
             &[],
             &[],
+            &[],
             None,
             &[],
             V,
@@ -541,6 +542,7 @@ mod tests {
             &[filter_src_addr("logr.go")],
             &[],
             &[],
+            &[],
             None,
             &[],
             V,
@@ -556,6 +558,7 @@ mod tests {
             &test_factors(),
             &[],
             &[filter_src_addr("logr.go")],
+            &[],
             &[],
             &[],
             None,
@@ -577,6 +580,7 @@ mod tests {
             &test_factors(),
             &[],
             &[filter_src_addr("logr.go")],
+            &[],
             &[],
             &[],
             None,
@@ -602,6 +606,7 @@ mod tests {
             &test_factors(),
             &[],
             &[filter_src_addr("logr.go")],
+            &[],
             &[],
             &[],
             None,
@@ -631,6 +636,7 @@ mod tests {
             &[src.clone()],
             &[],
             &[],
+            &[],
             None,
             &[],
             V,
@@ -654,6 +660,7 @@ mod tests {
             &test_factors(),
             &[],
             &[filter_src_addr("logr.go")],
+            &[],
             &[],
             &[],
             None,
@@ -687,6 +694,7 @@ mod tests {
             &[filter_src_addr("main.go")],
             &[],
             &[],
+            &[],
             None,
             &[],
             V,
@@ -706,6 +714,7 @@ mod tests {
             &test_factors(),
             &[],
             &[filter_src_addr("logr.go")],
+            &[],
             &[],
             &[],
             None,
@@ -735,6 +744,7 @@ mod tests {
             &[filter_src_addr("logr.go")],
             &[],
             &[],
+            &[],
             None,
             &[],
             V,
@@ -761,6 +771,7 @@ mod tests {
             &[filter_src_addr("logr.go")],
             &[],
             &[],
+            &[],
             None,
             &[],
             V,
@@ -783,6 +794,7 @@ mod tests {
             &[],
             &[filter_src_addr("impl.go")],
             &s_addrs,
+            &[],
             &[],
             None,
             &[],
@@ -833,6 +845,47 @@ mod tests {
     }
 
     #[test]
+    fn test_build_lib_extra_h_files_join_hdr_group() {
+        // circl shape: x448 asm `#include`s a sibling-package header, surfaced
+        // as extra_h_file_addrs. It must land in the `hdr` group (staged into
+        // the sandbox) alongside any same-package headers.
+        let pkg = test_pkg_with_asm(
+            vec!["impl.go".to_string()],
+            vec!["curve_amd64.s".to_string()],
+        );
+        let extra = vec![
+            "//@heph/go/thirdparty/github.com/go-logr/logr@v1.4.2:download[@heph/go/thirdparty/github.com/go-logr/logr@v1.4.2/math/fp448/fp_amd64.h]"
+                .to_string(),
+        ];
+        let spec = build_lib_spec(
+            test_addr(),
+            &pkg,
+            &test_factors(),
+            &[],
+            &[filter_src_addr("impl.go")],
+            &[filter_src_addr("curve_amd64.s")],
+            &[], // no same-package headers
+            &extra,
+            None,
+            &[],
+            V,
+        );
+        let deps = match spec.config.get("deps").unwrap() {
+            Value::Map(m) => m,
+            _ => panic!("expected map"),
+        };
+        let hdr = match deps.get("hdr").expect("extra headers must form hdr group") {
+            Value::List(v) => v,
+            _ => panic!("hdr group must be a list"),
+        };
+        assert!(
+            hdr.iter()
+                .any(|e| matches!(e, Value::String(s) if s == &extra[0])),
+            "hdr group must carry the cross-package header addr: {hdr:?}"
+        );
+    }
+
+    #[test]
     fn test_build_lib_no_s_files_no_asm_steps() {
         let spec = build_lib_spec(
             test_addr(),
@@ -840,6 +893,7 @@ mod tests {
             &test_factors(),
             &[],
             &[filter_src_addr("logr.go")],
+            &[],
             &[],
             &[],
             None,
@@ -865,6 +919,7 @@ mod tests {
             &test_factors(),
             &[],
             &[filter_src_addr("logr.go")],
+            &[],
             &[],
             &[],
             Some(&embed),
@@ -898,6 +953,7 @@ mod tests {
             &test_factors(),
             &[],
             &[filter_src_addr("logr.go")],
+            &[],
             &[],
             &[],
             Some(&embed),


### PR DESCRIPTION
## Problem

circl-style thirdparty packages ship `.s` files that `#include` headers from **sibling packages** in the same module. Example: `dh/x448/curve_amd64.s` does `#include "../../math/fp448/fp_amd64.h"`. That header belongs to the `math/fp448` package, so it isn't in x448's `go list HFiles` — the hermetic sandbox never staged it, and the asm step failed:

```
./curve_amd64.s:8: #include: open .../go/math/fp448/fp_amd64.h: no such file or directory
```

The `-I .` lookup missed (file absent), fell through to `-I $GOROOT/pkg/include`, and reported the bogus `$GOROOT/math/fp448/...` path. Not arch-specific — `linux/amd64` just hits the `_amd64.s` variant.

## Fix

Discover the sibling headers by scanning the asm sources, and stage them at the path the asm step resolves against.

- **`pkg_analysis.rs`**
  - `parse_asm_includes` — extract `#include "..."` directives.
  - `collect_cross_pkg_asm_headers` — BFS over `.s` includes (transitive, follows sibling-header includes too); returns module-relative paths for headers **outside** the package but **inside** the module. Skips same-package headers (covered by `HFiles`) and std/generated headers (`textflag.h`, `go_asm.h` — not on disk → not staged). Deterministic: sorted, deduped, lexical `..` normalize, no host paths in output.
  - New `PackageAddrs.extra_h_files`.
- **`driver_golist.rs`** — after `resolve_package_addrs`, scan the package's asm sources (host GOMODCACHE `Dir`, same source `go list` reads) and emit `download`-filtered addrs at each header's module-relative ws path.
- **`thirdparty.rs`** — fold `extra_h_files` into the existing `hdr` dep group; they stage at the module-relative path so `-I .` / the relative `#include` resolve (CWD = package dir).

Covers all circl-style modules (x448→fp448, x25519→fp25519, etc.).

## Tests

- `parse_asm_includes`
- `collect_cross_pkg_asm_headers_circl_shape` — transitive sibling + same-dir helper; excludes same-package and std headers
- `collect_cross_pkg_asm_headers_none_when_self_contained`
- `build_lib_extra_h_files_join_hdr_group`

Full crate suite green, clippy clean via pinned `lint`.

> Did not run the real circl build end-to-end (no Go module fetch in this env) — verified via unit/spec tests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)