### PR TITLE
fix(plugin-go): bump GO_GOLIST_FORMAT_VERSION for extra_h_files field

### DIFF
--- a/crates/plugin-go/src/plugingo/driver_golist.rs
+++ b/crates/plugin-go/src/plugingo/driver_golist.rs
@@ -82,7 +82,7 @@ struct GoGolistDef {
 
 /// Bump to invalidate every cached `_golist` artifact whenever the driver's
 /// output format (package.bin layout, package_addrs.bin schema, …) changes.
-const GO_GOLIST_FORMAT_VERSION: u32 = 13;
+const GO_GOLIST_FORMAT_VERSION: u32 = 14;
 
 impl Hash for GoGolistDef {
     fn hash<H: Hasher>(&self, state: &mut H) {

--- a/crates/plugin-go/src/plugingo/pkg_analysis.rs
+++ b/crates/plugin-go/src/plugingo/pkg_analysis.rs
@@ -875,4 +875,33 @@ golang.org/x/oauth2 v0.0.0-20200107190931-bf48bf16ab8d/go.mod h1:gOpvHmFTYa4Iltr
             "self-contained asm must not stage any cross-package header: {got:?}"
         );
     }
+
+    /// Borsh is not self-describing: adding/removing/reordering a `PackageAddrs`
+    /// field silently breaks decode of artifacts cached under the old layout
+    /// ("Unexpected length of input"). This golden locks the on-disk layout — if
+    /// it fails, the struct changed and `GO_GOLIST_FORMAT_VERSION`
+    /// (driver_golist.rs) MUST be bumped to invalidate stale `_golist` caches.
+    #[test]
+    fn test_package_addrs_borsh_layout_is_frozen() {
+        // One marker entry per Vec field; each field encodes to
+        // u32(len=1) + [ u32(len=1) + b"x" ] = 01 00 00 00 01 00 00 00 78.
+        let addrs = PackageAddrs {
+            go_files: vec!["x".to_string()],
+            s_files: vec!["x".to_string()],
+            h_files: vec!["x".to_string()],
+            extra_h_files: vec!["x".to_string()],
+            test_go_files: vec!["x".to_string()],
+            xtest_go_files: vec!["x".to_string()],
+            embed_files: vec!["x".to_string()],
+            test_embed_files: vec!["x".to_string()],
+            xtest_embed_files: vec!["x".to_string()],
+        };
+        let field = [0x01, 0x00, 0x00, 0x00, 0x01, 0x00, 0x00, 0x00, 0x78];
+        let golden: Vec<u8> = std::iter::repeat(field).take(9).flatten().collect();
+        let got = encode_package_addrs(&addrs).expect("encode");
+        assert_eq!(
+            got, golden,
+            "PackageAddrs borsh layout changed — bump GO_GOLIST_FORMAT_VERSION in driver_golist.rs"
+        );
+    }
 }

--- a/crates/plugin-go/src/plugingo/pkg_analysis.rs
+++ b/crates/plugin-go/src/plugingo/pkg_analysis.rs
@@ -62,6 +62,12 @@ pub struct GoPackage {
 
 /// Per-file Addr strings derived from a `GoPackage` by the golist driver.
 /// Each entry mirrors the same-name field in `GoPackage`, preserving order.
+///
+/// Serialized to `package_addrs.bin` via borsh, which is NOT self-describing:
+/// adding/removing/reordering a field breaks decode of artifacts cached under
+/// the old layout ("Unexpected length of input"). Any change here MUST bump
+/// `GO_GOLIST_FORMAT_VERSION` (driver_golist.rs) to invalidate stale `_golist`
+/// caches. `test_package_addrs_borsh_layout_is_frozen` guards this.
 #[derive(Debug, Clone, Default, Serialize, Deserialize, BorshSerialize, BorshDeserialize)]
 pub struct PackageAddrs {
     #[serde(rename = "GoFiles", default)]


### PR DESCRIPTION
## Problem

Runs fail with `× borsh decode PackageAddrs: Unexpected length of input`.

The error is **correct** — it's a stale-cache problem, not a decode bug. #110 added the `extra_h_files` field to the borsh `PackageAddrs` struct but did not bump `GO_GOLIST_FORMAT_VERSION`. borsh is not self-describing: `_golist` artifacts cached before #110 hold 8 `Vec` fields, and the new 9-field struct reads past the end on decode.

## Fix

- Bump `GO_GOLIST_FORMAT_VERSION` 13 → 14 (driver_golist.rs). This is the existing mechanism for exactly this case — it invalidates every cached `_golist` artifact so they regenerate with the new layout.
- Add a golden-bytes test freezing the `PackageAddrs` borsh layout. Any future field add/remove/reorder fails the test with a message pointing at `GO_GOLIST_FORMAT_VERSION`, so the bump isn't forgotten again.

## Note

Replaces the earlier approach in this PR (lenient decode → empty addrs), which masked the real issue and would have silently produced broken builds from stale caches.