### PR TITLE
feat(plugin-go): support target-ref Go toolchain (host bin, nix)

### DIFF
--- a/crates/plugin-go/src/plugingo/addr_util.rs
+++ b/crates/plugin-go/src/plugingo/addr_util.rs
@@ -299,30 +299,34 @@ pub fn dep_group_env_var(group: &str) -> String {
 /// stage the SDK files into the sandbox.
 pub const GO_SDK_DEP_GROUP: &str = "gosdk";
 
-/// `(group, value)` dep entry staging the hermetic Go SDK for `go_version` into
-/// the sandbox at [`toolchain::staged_goroot`]. A single SDK output (the full
-/// tree, incl. `GOROOT/src`) serves every consumer: it is staged read-only and
-/// exposed via a directory symlink, so its size costs nothing per consumer.
-/// Pair with [`go_sdk_read_only_config`] on `sh`/exec targets.
+/// `(group, value)` dep entry staging the Go toolchain for `go_version` into the
+/// sandbox via the `gosdk` group. The dep address depends on the toolchain kind:
+/// a hermetic version deps the synthesized `//@heph/go/toolchain/<v>:go`
+/// download (staged at the deterministic [`toolchain::staged_goroot`]); a target
+/// ref (`//pkg:go`) deps that target verbatim (host `go` via hostbin, a nix-built
+/// `go`, …), staged at a path discovered from `$SRC_GOSDK` at runtime. Pair with
+/// [`go_sdk_read_only_config`] on `sh`/exec targets.
 ///
 /// Returns `None` for the host toolchain ([`toolchain::HOST`]) — the host `go`
 /// is read from the sandbox's `PATH`/`GOROOT`, not staged as a dep.
 pub fn go_sdk_dep(go_version: &str) -> Option<(String, Value)> {
-    if crate::plugingo::toolchain::is_host(go_version) {
-        return None;
-    }
+    use crate::plugingo::toolchain::{self, Toolchain};
+    let addr = match toolchain::classify(go_version) {
+        Toolchain::Host => return None,
+        Toolchain::Target(t) => t.to_string(),
+        Toolchain::Hermetic(v) => toolchain::toolchain_addr(v).format(),
+    };
     Some((
         GO_SDK_DEP_GROUP.to_string(),
-        Value::List(vec![Value::String(
-            crate::plugingo::toolchain::toolchain_addr(go_version).format(),
-        )]),
+        Value::List(vec![Value::String(addr)]),
     ))
 }
 
 /// `(key, value)` config entry marking the `gosdk` dep group for read-only
-/// staging on the `sh`/exec driver: the SDK is materialized once into the
-/// shared stage and exposed to each sandbox via a directory symlink instead of
-/// byte-copied per consumer. `None` for the host toolchain (no SDK dep to mark).
+/// staging on the `sh`/exec driver: the toolchain is materialized once into the
+/// shared stage and exposed to each sandbox via a symlink instead of byte-copied
+/// per consumer. Applies to both the hermetic SDK and a target-ref toolchain.
+/// `None` for the host toolchain (no SDK dep to mark).
 pub fn go_sdk_read_only_config(go_version: &str) -> Option<(String, Value)> {
     if crate::plugingo::toolchain::is_host(go_version) {
         return None;
@@ -333,12 +337,16 @@ pub fn go_sdk_read_only_config(go_version: &str) -> Option<(String, Value)> {
     ))
 }
 
-/// Host env vars to pass through (at runtime, unhashed) so the host toolchain
-/// works inside the sandbox: `PATH` to find `go`, plus the Go/module cache and
-/// proxy knobs `go` consults. Empty for a hermetic toolchain (reads nothing from
-/// the host). Insert the names under the exec `runtime_pass_env` config key.
+/// Env vars to pass through (at runtime, unhashed) so a non-hermetic toolchain
+/// works inside the sandbox: `PATH`, plus the Go/module cache and proxy knobs
+/// `go` consults. Passed for both the host toolchain and a target-ref toolchain
+/// (`//pkg:go`): the staged `go` still resolves thirdparty modules through the
+/// host module cache/proxy, and a hostbin/nix wrapper may consult `PATH`/`HOME`.
+/// Empty for a hermetic toolchain (reads nothing from the host). Insert the
+/// names under the exec `runtime_pass_env` config key.
 pub fn go_host_runtime_pass_env(go_version: &str) -> Vec<String> {
-    if crate::plugingo::toolchain::is_host(go_version) {
+    use crate::plugingo::toolchain::{is_host, is_target_ref};
+    if is_host(go_version) || is_target_ref(go_version) {
         [
             "PATH",
             "HOME",
@@ -375,28 +383,42 @@ pub fn go_host_pass_env_config(go_version: &str) -> Option<(String, Value)> {
 /// Prelude pointing `GOROOT` at the Go toolchain for `go_version` and exposing
 /// its `go` binary on `PATH` and as `$GO`.
 ///
-/// Hermetic: `GOROOT` is the staged SDK ([`toolchain::staged_goroot`]) — reads
-/// nothing from the host; pair with [`go_sdk_dep`]. Host ([`toolchain::HOST`]):
-/// `GOROOT` is resolved in-shell via the host `go env GOROOT` (so `go` must be
-/// on the passed-through `PATH`, see [`go_host_runtime_pass_env`]).
+/// - Hermetic: `GOROOT` is the staged SDK ([`toolchain::staged_goroot`]) — reads
+///   nothing from the host; pair with [`go_sdk_dep`].
+/// - Host ([`toolchain::HOST`]): `GOROOT` is resolved in-shell via the host
+///   `go env GOROOT` (so `go` must be on the passed-through `PATH`, see
+///   [`go_host_runtime_pass_env`]).
+/// - Target (`//pkg:go`): the toolchain target's single output is staged via the
+///   `gosdk` dep and surfaced as `$SRC_GOSDK`. Auto-detect a full GOROOT tree (a
+///   directory, whose `bin/go` we use) vs. a bare `go` binary (a file), then take
+///   `GOROOT` from whatever that `go` reports — a relocated tree, a host install,
+///   or a `/nix/store` path alike.
 pub fn go_goroot_prelude(go_version: &str) -> Vec<String> {
-    if crate::plugingo::toolchain::is_host(go_version) {
-        return vec![
+    use crate::plugingo::toolchain::{self, Toolchain};
+    match toolchain::classify(go_version) {
+        Toolchain::Host => vec![
             // Host `go` from PATH; pin GOROOT to its own report so `go tool`
             // invocations resolve the compiler/linker consistently.
             "export GOROOT=\"$(go env GOROOT)\"".to_string(),
             "export PATH=\"$GOROOT/bin:$PATH\"".to_string(),
             "GO=\"$GOROOT/bin/go\"".to_string(),
-        ];
+        ],
+        Toolchain::Target(_) => vec![
+            "GO=\"$SRC_GOSDK\"".to_string(),
+            // Directory output → a GOROOT tree; file output → the `go` binary.
+            "if [ -d \"$GO\" ]; then GO=\"$GO/bin/go\"; fi".to_string(),
+            "export GOROOT=\"$(\"$GO\" env GOROOT)\"".to_string(),
+            "export PATH=\"$GOROOT/bin:$PATH\"".to_string(),
+        ],
+        Toolchain::Hermetic(v) => vec![
+            format!(
+                "export GOROOT=\"$WORKSPACE_ROOT/{}\"",
+                toolchain::staged_goroot(v)
+            ),
+            "export PATH=\"$GOROOT/bin:$PATH\"".to_string(),
+            "GO=\"$GOROOT/bin/go\"".to_string(),
+        ],
     }
-    vec![
-        format!(
-            "export GOROOT=\"$WORKSPACE_ROOT/{}\"",
-            crate::plugingo::toolchain::staged_goroot(go_version)
-        ),
-        "export PATH=\"$GOROOT/bin:$PATH\"".to_string(),
-        "GO=\"$GOROOT/bin/go\"".to_string(),
-    ]
 }
 
 /// Shell prelude every Go *compile/link/list* script runs first:
@@ -636,6 +658,56 @@ mod tests {
             dep_group_env_var("lib_github_com_foo_bar"),
             "SRC_LIB_GITHUB_COM_FOO_BAR"
         );
+    }
+
+    #[test]
+    fn test_go_sdk_dep_per_toolchain_kind() {
+        // Host: no SDK dep.
+        assert!(go_sdk_dep("host").is_none());
+        // Hermetic: deps the synthesized toolchain download target.
+        let (group, val) = go_sdk_dep("1.26.4").expect("hermetic deps SDK");
+        assert_eq!(group, GO_SDK_DEP_GROUP);
+        match val {
+            Value::List(v) => match &v[0] {
+                Value::String(s) => assert!(s.contains("@heph/go/toolchain/1.26.4")),
+                _ => panic!("addr must be a string"),
+            },
+            _ => panic!("dep value must be a list"),
+        }
+        // Target ref: deps that target verbatim.
+        let (group, val) = go_sdk_dep("//@heph/bin:go").expect("target deps SDK");
+        assert_eq!(group, GO_SDK_DEP_GROUP);
+        match val {
+            Value::List(v) => assert_eq!(v, vec![Value::String("//@heph/bin:go".to_string())]),
+            _ => panic!("dep value must be a list"),
+        }
+    }
+
+    #[test]
+    fn test_target_ref_passes_host_env_and_marks_read_only() {
+        // A target-ref toolchain still consults the host module cache/proxy and
+        // is staged read-only like the hermetic SDK.
+        assert!(go_host_runtime_pass_env("//@heph/bin:go").contains(&"PATH".to_string()));
+        assert!(go_host_runtime_pass_env("//@heph/bin:go").contains(&"GOMODCACHE".to_string()));
+        assert!(go_sdk_read_only_config("//@heph/bin:go").is_some());
+        // Hermetic passes no host env; host passes the full set.
+        assert!(go_host_runtime_pass_env("1.26.4").is_empty());
+        assert!(go_host_runtime_pass_env("host").contains(&"PATH".to_string()));
+    }
+
+    #[test]
+    fn test_goroot_prelude_target_auto_detects_via_src_gosdk() {
+        let p = go_goroot_prelude("//some/pkg:go").join("\n");
+        // Resolves the toolchain from the staged `gosdk` dep, auto-detecting a
+        // directory (GOROOT tree) vs. a bare `go` binary, and derives GOROOT from
+        // the binary itself.
+        assert!(p.contains("$SRC_GOSDK"), "must read the staged dep: {p}");
+        assert!(p.contains("if [ -d"), "must auto-detect dir vs file: {p}");
+        assert!(p.contains("env GOROOT"), "must derive GOROOT: {p}");
+        // Hermetic instead points at the deterministic staged path.
+        let h = go_goroot_prelude("1.26.4").join("\n");
+        assert!(h.contains("$WORKSPACE_ROOT/@heph/go/toolchain/1.26.4/go"));
+        assert!(!h.contains("$SRC_GOSDK"));
     }
 
     #[test]

--- a/crates/plugin-go/src/plugingo/driver_compile.rs
+++ b/crates/plugin-go/src/plugingo/driver_compile.rs
@@ -321,24 +321,15 @@ impl ManagedDriver for GoCompileDriver {
         let pkg_dir = &req.sandbox_pkg_dir;
         let ws_root = req.sandbox_ws_dir.to_string_lossy().into_owned();
 
-        // GOROOT / go binary: hermetic staged SDK or host (mirrors go_golist).
-        let host = crate::plugingo::toolchain::is_host(&def.go_version);
-        let (goroot, go_bin) = if host {
-            let go_bin = crate::plugingo::toolchain::resolve_host_go()?;
-            let goroot = crate::plugingo::toolchain::host_goroot(&go_bin)?;
-            (goroot, go_bin)
-        } else {
-            let goroot = req
-                .sandbox_ws_dir
-                .join(crate::plugingo::toolchain::staged_goroot(&def.go_version));
-            let go_bin = goroot.join("bin").join("go");
-            if !go_bin.exists() {
-                anyhow::bail!(
-                    "go_compile: hermetic go binary missing at {go_bin:?} (gosdk dep not staged?)"
-                );
-            }
-            (goroot, go_bin)
-        };
+        // GOROOT / go binary for the selected toolchain — host, target-ref, or
+        // hermetic staged SDK (mirrors go_golist, see `resolve_toolchain_go`).
+        use crate::plugingo::toolchain::Toolchain;
+        let (goroot, go_bin) = crate::plugingo::toolchain::resolve_toolchain_go(
+            &def.go_version,
+            &req.inputs,
+            &req.sandbox_ws_dir,
+            "go_compile",
+        )?;
 
         let gocache = pkg_dir.join(".heph-gocache");
         std::fs::create_dir_all(&gocache)
@@ -355,7 +346,13 @@ impl ManagedDriver for GoCompileDriver {
         env.insert("GOTOOLCHAIN".to_string(), "local".to_string());
         env.insert("GOWORK".to_string(), "off".to_string());
         env.insert("CGO_ENABLED".to_string(), "0".to_string());
-        if host && let Ok(v) = std::env::var("PATH") {
+        // Non-hermetic toolchains (host, or a hostbin/nix target wrapper) may need
+        // PATH; hermetic mode omits it to stay PATH-independent.
+        if !matches!(
+            crate::plugingo::toolchain::classify(&def.go_version),
+            Toolchain::Hermetic(_)
+        ) && let Ok(v) = std::env::var("PATH")
+        {
             env.insert("PATH".to_string(), v);
         }
 

--- a/crates/plugin-go/src/plugingo/driver_golist.rs
+++ b/crates/plugin-go/src/plugingo/driver_golist.rs
@@ -240,26 +240,15 @@ impl ManagedDriver for GoGolistDriver {
     ) -> anyhow::Result<ManagedRunResponse> {
         let def = req.request.target.def_de::<GoGolistDef>();
 
-        // GOROOT and the `go` binary come from either the hermetic SDK staged
-        // into this sandbox by the `gosdk` dep, or — when the provider selects
-        // `gotool = "host"` — the host `go` resolved from this process's PATH.
-        let host = crate::plugingo::toolchain::is_host(&def.go_version);
-        let (goroot, go_bin) = if host {
-            let go_bin = crate::plugingo::toolchain::resolve_host_go()?;
-            let goroot = crate::plugingo::toolchain::host_goroot(&go_bin)?;
-            (goroot, go_bin)
-        } else {
-            let goroot = req
-                .sandbox_ws_dir
-                .join(crate::plugingo::toolchain::staged_goroot(&def.go_version));
-            let go_bin = goroot.join("bin").join("go");
-            if !go_bin.exists() {
-                anyhow::bail!(
-                    "go_golist: hermetic go binary missing at {go_bin:?} (gosdk dep not staged?)"
-                );
-            }
-            (goroot, go_bin)
-        };
+        // GOROOT and the `go` binary depend on the selected toolchain (host,
+        // target-ref, or hermetic) — see [`toolchain::resolve_toolchain_go`].
+        use crate::plugingo::toolchain::Toolchain;
+        let (goroot, go_bin) = crate::plugingo::toolchain::resolve_toolchain_go(
+            &def.go_version,
+            &req.inputs,
+            &req.sandbox_ws_dir,
+            "go_golist",
+        )?;
         // Sandbox-local build cache so `go list` neither reads nor writes the
         // host GOCACHE.
         let gocache = req.sandbox_pkg_dir.join(".heph-gocache");
@@ -301,10 +290,14 @@ impl ManagedDriver for GoGolistDriver {
                 env.insert(name.to_string(), v);
             }
         }
-        // Host toolchain: the `go` subprocess may need PATH (e.g. to locate
-        // ancillary tools). Hermetic mode deliberately omits it to stay
-        // PATH-independent.
-        if host && let Ok(v) = std::env::var("PATH") {
+        // Non-hermetic toolchains: the `go` subprocess (or a hostbin/nix wrapper)
+        // may need PATH — to locate ancillary tools, or for the wrapper itself.
+        // Hermetic mode deliberately omits it to stay PATH-independent.
+        if !matches!(
+            crate::plugingo::toolchain::classify(&def.go_version),
+            Toolchain::Hermetic(_)
+        ) && let Ok(v) = std::env::var("PATH")
+        {
             env.insert("PATH".to_string(), v);
         }
 

--- a/crates/plugin-go/src/plugingo/provider.rs
+++ b/crates/plugin-go/src/plugingo/provider.rs
@@ -231,9 +231,12 @@ impl Provider {
         // `gotool` selects the Go toolchain and is REQUIRED — there is no
         // implicit default. Set it to:
         //   - `"host"` → use the host `go` (read from PATH / `go env GOROOT`
-        //     inside the sandbox; non-hermetic, see [`toolchain::HOST`]), or
+        //     inside the sandbox; non-hermetic, see [`toolchain::HOST`]),
         //   - a pinned version like `"1.26.4"` → download + manage that SDK
-        //     hermetically (`//@heph/go/toolchain/<version>:go`).
+        //     hermetically (`//@heph/go/toolchain/<version>:go`), or
+        //   - a target address like `"//@heph/bin:go"` (host `go` via the hostbin
+        //     provider) or `"//some/pkg:go"` (e.g. a nix-built `go`) → use the
+        //     `go` produced by that target (see [`toolchain::is_target_ref`]).
         hplugin::config::deny_unknown(
             "go provider",
             opts,
@@ -242,8 +245,9 @@ impl Provider {
         let go_version: String = hplugin::config::decode_opt(opts, "go provider", "gotool")?
             .ok_or_else(|| {
                 anyhow::anyhow!(
-                    "go provider: `gotool` is required — set it to \"host\" (use the host go) \
-                     or a pinned version like \"{}\" (hermetic SDK download)",
+                    "go provider: `gotool` is required — set it to \"host\" (use the host go), \
+                     a pinned version like \"{}\" (hermetic SDK download), or a target address \
+                     like \"//@heph/bin:go\" (a target that produces the go toolchain)",
                     toolchain::DEFAULT_GO_VERSION
                 )
             })?;

--- a/crates/plugin-go/src/plugingo/toolchain.rs
+++ b/crates/plugin-go/src/plugingo/toolchain.rs
@@ -13,6 +13,15 @@
 //! (resolved from `PATH` / `go env GOROOT` inside the sandbox): no SDK target,
 //! no `gosdk` dep, host env passed through. Non-hermetic by construction.
 //!
+//! With `gotool = "//pkg:go"` ([`is_target_ref`]) the toolchain comes from
+//! another *target* — e.g. `//@heph/bin:go` (host `go` exposed by the hostbin
+//! provider) or a `//some/pkg:go` built by the nix driver. The build deps that
+//! target in the `gosdk` group exactly like the hermetic SDK, but its staged
+//! path is not known ahead of time, so `go`/`GOROOT` are resolved from the
+//! staged output at runtime (auto-detecting a GOROOT directory vs. a bare `go`
+//! binary; see [`addr_util::go_goroot_prelude`] and the golist driver). How
+//! hermetic the result is then depends entirely on what that target produces.
+//!
 //! The SDK is one cacheable output (the full tree: `go` + `pkg/tool` + `lib` +
 //! `src` + version/env metadata; `api/test/doc/misc` excluded — nothing reads
 //! them). Consumers don't copy it: it is staged read-only once and exposed to
@@ -30,7 +39,9 @@ use async_trait::async_trait;
 use hcore::debug_hash::DebugHasher;
 use hcore::hasync::Cancellable;
 use hcore::htvalue::Value;
-use hdriver_support::driver_managed::{ManagedDriver, ManagedRunRequest, ManagedRunResponse};
+use hdriver_support::driver_managed::{
+    ManagedDriver, ManagedRunInput, ManagedRunRequest, ManagedRunResponse,
+};
 use hmodel::htaddr::Addr;
 use hmodel::htpkg::PkgBuf;
 use hplugin::driver::targetdef::path::{CodegenMode, Content, Path};
@@ -66,6 +77,43 @@ pub const HOST: &str = "host";
 /// Whether `spec` selects the host toolchain (vs. a hermetic pinned version).
 pub fn is_host(spec: &str) -> bool {
     spec == HOST
+}
+
+/// Whether `spec` selects a **target** toolchain: an explicit target address
+/// providing the `go` toolchain, distinguished by a leading `//`. Examples:
+/// `//@heph/bin:go` (host `go` exposed by the hostbin provider) or
+/// `//some/pkg:go` (a `go` built by the nix driver). The build deps that target
+/// in the `gosdk` group, stages its single output, and resolves `go`/`GOROOT`
+/// from it at runtime — auto-detecting a full GOROOT tree (a directory whose
+/// `bin/go` is used) vs. a bare `go` binary (a file), with `GOROOT` taken from
+/// whatever that `go` reports.
+pub fn is_target_ref(spec: &str) -> bool {
+    spec.starts_with("//")
+}
+
+/// The three ways the required `gotool` provider option selects the toolchain.
+/// Threaded everywhere as the `go_version` string; classify with [`classify`].
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum Toolchain<'a> {
+    /// `gotool = "host"` — host `go` resolved from `PATH` / `go env GOROOT`.
+    Host,
+    /// `gotool = "//pkg:go"` — a target producing the toolchain (hostbin, nix, …).
+    Target(&'a str),
+    /// `gotool = "1.26.4"` — a pinned hermetic SDK downloaded from go.dev.
+    Hermetic(&'a str),
+}
+
+/// Classify a `gotool` value into the toolchain it selects. `"host"` →
+/// [`Toolchain::Host`]; anything starting with `//` → [`Toolchain::Target`];
+/// everything else is taken as a pinned hermetic version.
+pub fn classify(spec: &str) -> Toolchain<'_> {
+    if is_host(spec) {
+        Toolchain::Host
+    } else if is_target_ref(spec) {
+        Toolchain::Target(spec)
+    } else {
+        Toolchain::Hermetic(spec)
+    }
 }
 
 /// Base provider package for the hermetic toolchain. The concrete target lives
@@ -196,6 +244,90 @@ pub(crate) fn host_goroot(go_bin: &std::path::Path) -> anyhow::Result<std::path:
         anyhow::bail!("`{go_bin:?} env GOROOT` returned empty");
     }
     Ok(std::path::PathBuf::from(goroot))
+}
+
+/// Resolve the `go` binary from a target-ref toolchain (`gotool = "//pkg:go"`)
+/// staged into this sandbox via the `gosdk` dep. The dep's output is either a
+/// full GOROOT tree (we pick its `bin/go`) or a single `go` binary (a hostbin or
+/// nix wrapper); when both shapes appear, prefer a `.../bin/go`.
+pub(crate) fn resolve_target_go(inputs: &[ManagedRunInput]) -> anyhow::Result<std::path::PathBuf> {
+    let prefix = format!("dep|{}|", crate::plugingo::addr_util::GO_SDK_DEP_GROUP);
+    let gosdk = inputs
+        .iter()
+        .find(|m| m.input.origin_id.starts_with(&prefix))
+        .context("go toolchain: target `gosdk` dep not staged")?;
+
+    let mut candidates: Vec<std::path::PathBuf> = Vec::new();
+    for entry in gosdk
+        .input
+        .artifact
+        .content
+        .as_ref()
+        .walk()
+        .context("walk target toolchain output")?
+    {
+        let entry = entry.context("read target toolchain entry")?;
+        if entry.path.file_name().and_then(|n| n.to_str()) == Some("go") {
+            candidates.push(gosdk.unpack_root.join(&entry.path));
+        }
+    }
+
+    pick_go_binary(candidates).context("go toolchain: no `go` binary in target toolchain output")
+}
+
+/// Pick the `go` binary among the toolchain output's `go`-named entries,
+/// preferring a `.../bin/go` (a full GOROOT tree) over a bare `go` wrapper
+/// (hostbin/nix). Returns `None` when no candidate is present.
+pub(crate) fn pick_go_binary(
+    mut candidates: Vec<std::path::PathBuf>,
+) -> Option<std::path::PathBuf> {
+    // `false` (parent is `bin`) sorts before `true`. Stable so ties keep input order.
+    candidates.sort_by_key(|p| {
+        p.parent()
+            .and_then(|d| d.file_name())
+            .and_then(|n| n.to_str())
+            != Some("bin")
+    });
+    candidates.into_iter().next()
+}
+
+/// Resolve `(GOROOT, go binary)` for the toolchain selected by `version`, shared
+/// by every driver that runs a `go` subprocess (`go_golist`, `go_compile`, …):
+/// - **Host** (`gotool = "host"`): host `go` from `PATH`; GOROOT is what it reports.
+/// - **Target** (`gotool = "//pkg:go"`): the `go` staged by the `gosdk` dep at a
+///   path discovered from the dep's output; GOROOT is what it reports.
+/// - **Hermetic** (`gotool = "1.26.4"`): the SDK staged at the deterministic
+///   `staged_goroot` path under `sandbox_ws_dir`.
+///
+/// `driver` names the caller for the hermetic "not staged" error message.
+pub(crate) fn resolve_toolchain_go(
+    version: &str,
+    inputs: &[ManagedRunInput],
+    sandbox_ws_dir: &std::path::Path,
+    driver: &str,
+) -> anyhow::Result<(std::path::PathBuf, std::path::PathBuf)> {
+    match classify(version) {
+        Toolchain::Host => {
+            let go_bin = resolve_host_go()?;
+            let goroot = host_goroot(&go_bin)?;
+            Ok((goroot, go_bin))
+        }
+        Toolchain::Target(_) => {
+            let go_bin = resolve_target_go(inputs)?;
+            let goroot = host_goroot(&go_bin)?;
+            Ok((goroot, go_bin))
+        }
+        Toolchain::Hermetic(v) => {
+            let goroot = sandbox_ws_dir.join(staged_goroot(v));
+            let go_bin = goroot.join("bin").join("go");
+            if !go_bin.exists() {
+                anyhow::bail!(
+                    "{driver}: hermetic go binary missing at {go_bin:?} (gosdk dep not staged?)"
+                );
+            }
+            Ok((goroot, go_bin))
+        }
+    }
 }
 
 /// Build the `TargetSpec` for the toolchain download target for `version`.
@@ -519,6 +651,44 @@ mod tests {
         // Not a toolchain package, or nested.
         assert_eq!(version_from_pkg("mylib"), None);
         assert_eq!(version_from_pkg("@heph/go/toolchain/1.26.4/extra"), None);
+    }
+
+    #[test]
+    fn test_classify_distinguishes_host_target_hermetic() {
+        assert_eq!(classify("host"), Toolchain::Host);
+        assert_eq!(classify("1.26.4"), Toolchain::Hermetic("1.26.4"));
+        assert_eq!(
+            classify("//@heph/bin:go"),
+            Toolchain::Target("//@heph/bin:go")
+        );
+        assert_eq!(
+            classify("//some/pkg:go"),
+            Toolchain::Target("//some/pkg:go")
+        );
+        // A bare version is never mistaken for a target ref.
+        assert!(!is_target_ref("1.26.4"));
+        assert!(!is_target_ref("host"));
+        assert!(is_target_ref("//@heph/bin:go"));
+    }
+
+    #[test]
+    fn test_pick_go_binary_prefers_goroot_tree_bin_go() {
+        use std::path::PathBuf;
+        // hostbin wrapper only → use it.
+        assert_eq!(
+            pick_go_binary(vec![PathBuf::from("__heph/hostbin/go")]),
+            Some(PathBuf::from("__heph/hostbin/go"))
+        );
+        // Both a wrapper and a full tree → prefer the tree's bin/go.
+        assert_eq!(
+            pick_go_binary(vec![
+                PathBuf::from("ws/wrap/go"),
+                PathBuf::from("ws/sdk/go/bin/go"),
+            ]),
+            Some(PathBuf::from("ws/sdk/go/bin/go"))
+        );
+        // No candidates → None.
+        assert_eq!(pick_go_binary(vec![]), None);
     }
 
     #[test]


### PR DESCRIPTION
## What

`gotool` now accepts a **third** form besides `"host"` and a pinned version: a target address starting with `//` that produces the `go` toolchain.

| mode | `gotool` | source |
|------|----------|--------|
| self-installed | `"1.26.4"` | hermetic go.dev download (unchanged) |
| host bin | `"//@heph/bin:go"` | hostbin provider |
| nix | `"//some/pkg:go"` | nix driver |

## How

Classify `gotool` via `toolchain::classify` → `Toolchain::{Host, Target(&str), Hermetic(&str)}`.

In **target mode** the build deps that address in the `gosdk` group (read-only staged like the hermetic SDK) and passes the host module/cache env through (thirdparty modcache + wrapper `PATH`/`HOME`). The staged path isn't known ahead of time, so `go`/`GOROOT` are resolved from the staged output at runtime, **auto-detecting** a full GOROOT tree (a directory whose `bin/go` is used) vs. a bare `go` binary:

- **sh/exec targets** (`go_goroot_prelude`): prelude reads `$SRC_GOSDK`; dir → `$GOSDK/bin/go`, file → the `go` binary; then `GOROOT="$("$GO" env GOROOT)"`.
- **golist driver** (in-process, no shell): finds the `dep|gosdk|*` `ManagedRunInput`, walks its artifact for `go`-named entries, `pick_go_binary` prefers `.../bin/go` over a bare wrapper, then `go_env_goroot` queries `go env GOROOT` (renamed from `host_goroot`, now shared by host + target).

**Contract**: the target must expose exactly one output — a `go` binary file or a GOROOT directory containing `bin/go`.

## Files

- `toolchain.rs` — `Toolchain` enum, `classify`, `is_target_ref` + module docs.
- `addr_util.rs` — `go_sdk_dep` / `go_host_runtime_pass_env` / `go_goroot_prelude` handle all three kinds.
- `driver_golist.rs` — Target branch, `resolve_target_go`, `pick_go_binary`, `host_goroot`→`go_env_goroot`, PATH passthrough for non-hermetic.
- `provider.rs` — `gotool` docs + error message.

## Tests

279 plugin-go tests pass; production clippy clean. New unit tests cover classify, per-kind dep wiring, target env + read-only staging, prelude auto-detect, and `pick_go_binary` preference. No e2e (needs network + real nix/host go); coverage targets the pure logic.

## Caveat

Nix wrappers reference `/nix/store`; the go build sandbox must be allowed to read `/nix/store` at runtime. That's a sandbox-exposure concern outside this plugin's wiring.

🤖 Generated with [Claude Code](https://claude.com/claude-code)