### PR TITLE
feat(run): add --log-lines flag and real log line numbers

### DIFF
--- a/crates/core/src/hartifactcontent/file.rs
+++ b/crates/core/src/hartifactcontent/file.rs
@@ -1,0 +1,93 @@
+use std::io;
+use std::path::{Path, PathBuf};
+
+use anyhow::Context;
+
+use super::{Content, ReadSeek, WalkEntry, WalkEntryKind};
+
+/// [`Content`] backed by a single on-disk file, opened lazily on each read.
+///
+/// Used to carry a handle to a target's process log inside a failure error
+/// without slurping the whole file into memory: the diagnostic reads only the
+/// trailing lines it renders, and only when it renders them. The file must
+/// outlive the read (process logs persist in the sandbox until the target's
+/// next run, so this holds through end-of-run rendering).
+#[derive(Debug, Clone)]
+pub struct FileContent {
+    path: PathBuf,
+}
+
+impl FileContent {
+    pub fn new(path: impl Into<PathBuf>) -> Self {
+        Self { path: path.into() }
+    }
+
+    pub fn path(&self) -> &Path {
+        &self.path
+    }
+
+    fn open(&self) -> anyhow::Result<std::fs::File> {
+        std::fs::File::open(&self.path).with_context(|| format!("opening {}", self.path.display()))
+    }
+}
+
+impl Content for FileContent {
+    fn reader(&self) -> anyhow::Result<Box<dyn io::Read>> {
+        Ok(Box::new(self.open()?))
+    }
+
+    fn walk(&self) -> anyhow::Result<Box<dyn Iterator<Item = anyhow::Result<WalkEntry>> + '_>> {
+        let name = self.path.file_name().map(PathBuf::from).unwrap_or_default();
+        let entry = WalkEntry {
+            path: name,
+            kind: WalkEntryKind::File {
+                data: self.reader()?,
+                x: false,
+            },
+        };
+        Ok(Box::new(std::iter::once(Ok(entry))))
+    }
+
+    fn hashout(&self) -> anyhow::Result<String> {
+        // Logs are never content-addressed; nothing reads this.
+        Ok(String::new())
+    }
+
+    fn seekable_reader(&self) -> anyhow::Result<Option<Box<dyn ReadSeek + Send>>> {
+        Ok(Some(Box::new(self.open()?)))
+    }
+
+    fn file_path(&self) -> Option<PathBuf> {
+        Some(self.path.clone())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::io::Read as _;
+
+    #[test]
+    fn reads_backing_file() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let path = dir.path().join("log.txt");
+        std::fs::write(&path, b"line1\nline2\n").expect("write");
+
+        let content = FileContent::new(&path);
+        assert_eq!(content.file_path().as_deref(), Some(path.as_path()));
+
+        let mut buf = String::new();
+        content
+            .reader()
+            .expect("reader")
+            .read_to_string(&mut buf)
+            .expect("read");
+        assert_eq!(buf, "line1\nline2\n");
+    }
+
+    #[test]
+    fn missing_file_errors_on_read() {
+        let content = FileContent::new("/no/such/log.txt");
+        assert!(content.reader().is_err());
+    }
+}

--- a/crates/core/src/hartifactcontent/mod.rs
+++ b/crates/core/src/hartifactcontent/mod.rs
@@ -1,6 +1,9 @@
+pub mod file;
 pub mod tar;
 pub mod tar_index;
 pub mod unpack;
+
+pub use file::FileContent;
 
 use std::io;
 use std::path::PathBuf;

--- a/crates/e2e/tests/engine_core.rs
+++ b/crates/e2e/tests/engine_core.rs
@@ -130,3 +130,26 @@ async fn test_failing_command_returns_error() -> anyhow::Result<()> {
     assert!(err.is_err(), "expected error from failing command");
     Ok(())
 }
+
+#[tokio::test]
+async fn test_failure_surfaces_process_log_tail() -> anyhow::Result<()> {
+    // The failure diagnostic reads the last log lines lazily from the on-disk
+    // log (the sandbox of a failed target survives until its next run), so the
+    // captured output must reach the recorded failure end-to-end.
+    let ws = Workspace::new();
+    ws.write_build_file(
+        "fail",
+        r#"target(name = "t", driver = "bash", run = "echo distinctive-marker-line; exit 3")"#,
+    );
+
+    let err = match ws.run("//fail:t").await {
+        Ok(_) => panic!("expected error from failing command"),
+        Err(e) => e,
+    };
+    let msg = format!("{err:#}");
+    assert!(
+        msg.contains("distinctive-marker-line"),
+        "log tail must surface the process output, got: {msg}"
+    );
+    Ok(())
+}

--- a/crates/engine/src/engine/gc.rs
+++ b/crates/engine/src/engine/gc.rs
@@ -271,7 +271,12 @@ impl Engine {
         self: Arc<Self>,
         rs: &Arc<RequestState>,
     ) -> Vec<(Addr, Decision)> {
-        let resolve_rs = self.new_state_full(false, rs.events_sender(), rs.bg_pending());
+        let resolve_rs = self.new_state_full(
+            false,
+            rs.events_sender(),
+            rs.bg_pending(),
+            Self::DEFAULT_LOG_TAIL_LINES,
+        );
         let targets = match self.local_cache.list_targets() {
             Ok(t) => t,
             Err(e) => {

--- a/crates/engine/src/engine/request_state.rs
+++ b/crates/engine/src/engine/request_state.rs
@@ -195,6 +195,10 @@ pub struct RequestStateData {
     /// short-circuiting on the first error; errors are aggregated into a
     /// `MultiError`. Defaults to true (current behavior).
     pub fail_fast: bool,
+    /// How many trailing lines of a failing target's process log to show in its
+    /// diagnostic box (`heph run --log-lines`). The full log is always saved as
+    /// the `log.txt` artifact; this only bounds the rendered tail.
+    pub log_tail_lines: usize,
     /// Optional one-way build-progress event stream. Lives in the shared
     /// `Arc<RequestStateData>`, so `with_parent` / `with_skip_provider` children
     /// inherit it for free.
@@ -264,6 +268,12 @@ impl RequestState {
 
     pub fn fail_fast(&self) -> bool {
         self.data.fail_fast
+    }
+
+    /// Trailing process-log lines to render in a failure box (see
+    /// [`RequestStateData::log_tail_lines`]).
+    pub fn log_tail_lines(&self) -> usize {
+        self.data.log_tail_lines
     }
 
     /// The request's in-flight sandbox-cleanup counter. Clone to hand to
@@ -444,6 +454,10 @@ impl Engine {
         self.new_state_with_fail_fast(true)
     }
 
+    /// Default number of trailing process-log lines shown in a failure box when a
+    /// caller (e.g. `gc`, non-`run` commands) does not override it.
+    pub const DEFAULT_LOG_TAIL_LINES: usize = 10;
+
     pub fn new_state_with_fail_fast(self: &Arc<Self>, fail_fast: bool) -> Arc<RequestState> {
         self.new_state_with_events(fail_fast, None)
     }
@@ -457,6 +471,7 @@ impl Engine {
             fail_fast,
             events,
             Arc::new(std::sync::atomic::AtomicUsize::new(0)),
+            Self::DEFAULT_LOG_TAIL_LINES,
         )
     }
 
@@ -468,6 +483,7 @@ impl Engine {
         fail_fast: bool,
         events: Option<crate::engine::event::EventSender>,
         bg_pending: crate::engine::sandbox_cleaner::PendingCounter,
+        log_tail_lines: usize,
     ) -> Arc<RequestState> {
         // Unique per top-level request. `with_parent`/`with_skip_provider`
         // children share this `RequestStateData` (and thus this id), so a request
@@ -492,6 +508,7 @@ impl Engine {
             mem_probe: Memoizer::with_tag("probe"),
             mem_probe_inner: Memoizer::with_tag("probe_inner"),
             fail_fast,
+            log_tail_lines,
             events,
             workers_announced: std::sync::atomic::AtomicBool::new(false),
             matched_announced: std::sync::atomic::AtomicBool::new(false),

--- a/crates/engine/src/engine/result.rs
+++ b/crates/engine/src/engine/result.rs
@@ -455,7 +455,7 @@ fn classify_failure(
     let log_tail = if interactive {
         None
     } else {
-        extract_log_tail(&e)
+        extract_log_tail(&e, rs.log_tail_lines())
     };
     rs.record_failure(
         addr.clone(),
@@ -464,10 +464,17 @@ fn classify_failure(
     UpstreamFailed { root: addr.clone() }.into()
 }
 
-/// Pull the captured log tail out of a `ProcessFailed` anywhere in the chain so
-/// the recorded `TargetFailure` can surface it in its diagnostic.
-fn extract_log_tail(e: &anyhow::Error) -> Option<String> {
-    downcast_chain_ref::<ProcessFailed>(e).map(|pf| pf.log_tail.clone())
+/// Read the last `n` lines of a `ProcessFailed`'s log (anywhere in the chain) so
+/// the recorded `TargetFailure` can surface them in its diagnostic, tagged with
+/// the real starting line number. Best-effort: a log file that can't be read
+/// (e.g. already reclaimed) yields no tail rather than masking the failure.
+fn extract_log_tail(e: &anyhow::Error, n: usize) -> Option<hplugin::error::LogTail> {
+    use std::io::Read as _;
+    let pf = downcast_chain_ref::<ProcessFailed>(e)?;
+    let mut buf = String::new();
+    pf.log.reader().ok()?.read_to_string(&mut buf).ok()?;
+    let (text, start_line) = hplugin::error::last_n_lines_with_start(&buf, n);
+    Some(hplugin::error::LogTail { text, start_line })
 }
 
 /// At the outermost `result_addr` frame (the directly-requested target, with no
@@ -3579,15 +3586,21 @@ mod tests {
         // suite covers the live path). `last_n_lines` itself is unit-tested in
         // `engine::error`.
         use crate::engine::error::{ProcessFailed, UpstreamFailed};
+        use std::sync::Arc;
 
         let engine = engine_with(vec![static_target("//pkg:a", &[], &[])])?;
         let rs = engine.new_state();
         let addr = hmodel::htaddr::parse_addr("//pkg:a")?;
 
-        let tail = "line6\nline7\nline8\nline9\nline10";
+        // A 12-line log, default tail of 10 → lines 3..=12 with start_line 3.
+        let dir = tempfile::tempdir().expect("tempdir");
+        let log_path = dir.path().join("log.txt");
+        let full: String = (1..=12).map(|i| format!("line{i}\n")).collect();
+        std::fs::write(&log_path, &full)?;
+
         let e = anyhow::Error::new(ProcessFailed {
             status: "exit status: 1".to_string(),
-            log_tail: tail.to_string(),
+            log: Arc::new(hcore::hartifactcontent::FileContent::new(&log_path)),
         })
         .context("driver run")
         .context("execute //pkg:a");
@@ -3595,9 +3608,15 @@ mod tests {
         let out = classify_failure(&rs, &addr, false, e);
         // Own failure → cheap marker propagated upward.
         assert!(downcast_chain_ref::<UpstreamFailed>(&out).is_some());
-        // …and the rich record carries the log tail pulled from ProcessFailed.
+        // …and the rich record carries the last 10 lines read from the log file,
+        // tagged with the real starting line number.
         let recorded = rs.get_failure(&addr).expect("failure must be recorded");
-        assert_eq!(recorded.log_tail.as_deref(), Some(tail));
+        let tail = recorded.log_tail.as_ref().expect("log tail");
+        assert_eq!(
+            tail.text,
+            "line3\nline4\nline5\nline6\nline7\nline8\nline9\nline10\nline11\nline12"
+        );
+        assert_eq!(tail.start_line, 3);
         Ok(())
     }
 
@@ -3606,14 +3625,19 @@ mod tests {
         // Interactive targets stream their output live to the user's terminal, so
         // the captured log tail must NOT be re-rendered in the failure box.
         use crate::engine::error::ProcessFailed;
+        use std::sync::Arc;
 
         let engine = engine_with(vec![static_target("//pkg:a", &[], &[])])?;
         let rs = engine.new_state();
         let addr = hmodel::htaddr::parse_addr("//pkg:a")?;
 
+        let dir = tempfile::tempdir().expect("tempdir");
+        let log_path = dir.path().join("log.txt");
+        std::fs::write(&log_path, "line9\nline10\n")?;
+
         let e = anyhow::Error::new(ProcessFailed {
             status: "exit status: 1".to_string(),
-            log_tail: "line9\nline10".to_string(),
+            log: Arc::new(hcore::hartifactcontent::FileContent::new(&log_path)),
         })
         .context("execute //pkg:a");
 

--- a/crates/plugin-exec/src/pluginexec/mod.rs
+++ b/crates/plugin-exec/src/pluginexec/mod.rs
@@ -1322,10 +1322,16 @@ impl Driver {
             .context("wait task panicked")?
             .context("wait for child process")?;
         if !status.success() {
-            let log = std::fs::read_to_string(&output_log_path).unwrap_or_default();
+            // Carry a lazy handle to the log file rather than its bytes; the
+            // diagnostic reads only the last N lines (the request's `--log-lines`)
+            // at classification time. The file outlives the read — a failed
+            // target's sandbox is reclaimed only at its next run.
+            let log: std::sync::Arc<dyn hcore::hartifactcontent::Content> = std::sync::Arc::new(
+                hcore::hartifactcontent::FileContent::new(output_log_path.clone()),
+            );
             return Err(hplugin::error::ProcessFailed {
                 status: status.to_string(),
-                log_tail: hplugin::error::last_n_lines(&log, 10),
+                log,
             }
             .into());
         }

--- a/crates/plugin/src/error.rs
+++ b/crates/plugin/src/error.rs
@@ -1,5 +1,7 @@
+use hcore::hartifactcontent::Content;
 use hmodel::htaddr::Addr;
 use std::fmt;
+use std::sync::Arc;
 
 #[derive(Debug, Clone)]
 pub struct TargetNotFoundError {
@@ -90,12 +92,16 @@ impl fmt::Display for UpstreamFailed {
 impl std::error::Error for UpstreamFailed {}
 
 /// A target's own process exited non-zero. Carries the exit status string and a
-/// bounded tail of the process log (the full log is still saved as the `log.txt`
-/// artifact). Surfaced as the `source` of a `TargetFailure`.
+/// lazy [`Content`] handle to the full process log, rather than the log bytes:
+/// the diagnostic reads only the last N lines on demand (see
+/// [`last_n_lines_with_start`]), where N is the request's `--log-lines`. The log
+/// file persists in the sandbox until the target's next run, so the handle stays
+/// readable through end-of-run rendering. Surfaced as the `source` of a
+/// [`TargetFailure`].
 #[derive(Debug, Clone)]
 pub struct ProcessFailed {
     pub status: String,
-    pub log_tail: String,
+    pub log: Arc<dyn Content>,
 }
 
 impl fmt::Display for ProcessFailed {
@@ -118,13 +124,14 @@ impl std::error::Error for ProcessFailed {}
 pub struct TargetFailure {
     pub addr: Addr,
     /// The last lines of the target's process log (the full log is still saved
-    /// as the `log.txt` artifact). Rendered as a framed `log` box.
-    pub log_tail: Option<String>,
+    /// as the `log.txt` artifact), with the real starting line number so the box
+    /// renders true file positions. Rendered as a framed `log` box.
+    pub log_tail: Option<LogTail>,
     pub source: std::sync::Arc<anyhow::Error>,
 }
 
 impl TargetFailure {
-    pub fn new(addr: Addr, log_tail: Option<String>, source: anyhow::Error) -> Self {
+    pub fn new(addr: Addr, log_tail: Option<LogTail>, source: anyhow::Error) -> Self {
         Self {
             addr,
             log_tail,
@@ -168,12 +175,31 @@ impl fmt::Display for FrozenCheckError {
 
 impl std::error::Error for FrozenCheckError {}
 
+/// A bounded slice of a process log prepared for display: the last lines of the
+/// full log, plus the real 1-based line number its first line had in the full log
+/// so the renderer can show true file positions (e.g. 91–100 for the last 10 of a
+/// 100-line log) instead of renumbering from 1.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct LogTail {
+    pub text: String,
+    /// 1-based line number of `text`'s first line within the full log.
+    pub start_line: usize,
+}
+
 /// Returns the last `n` lines of `s`, joined with `\n`. A trailing newline does
 /// not count as an extra empty line (`str::lines` already drops it).
 pub fn last_n_lines(s: &str, n: usize) -> String {
+    last_n_lines_with_start(s, n).0
+}
+
+/// Like [`last_n_lines`] but also returns the 1-based line number of the first
+/// returned line within `s`, so callers can render real file positions rather
+/// than renumbering the tail from 1.
+pub fn last_n_lines_with_start(s: &str, n: usize) -> (String, usize) {
     let lines: Vec<&str> = s.lines().collect();
     let start = lines.len().saturating_sub(n);
-    lines.get(start..).unwrap_or(&[]).join("\n")
+    let text = lines.get(start..).unwrap_or(&[]).join("\n");
+    (text, start + 1)
 }
 
 #[cfg(test)]
@@ -199,5 +225,24 @@ mod tests {
     fn last_n_lines_trailing_newline() {
         // The trailing newline is dropped by `lines()`, so the last real line wins.
         assert_eq!(last_n_lines("a\nb\nc\n", 2), "b\nc");
+    }
+
+    #[test]
+    fn last_n_lines_with_start_reports_real_first_line() {
+        // 5 lines, last 3 → first shown line is line 3 (1-based).
+        assert_eq!(
+            last_n_lines_with_start("a\nb\nc\nd\ne", 3),
+            ("c\nd\ne".to_string(), 3)
+        );
+    }
+
+    #[test]
+    fn last_n_lines_with_start_fewer_than_n_starts_at_one() {
+        assert_eq!(last_n_lines_with_start("a\nb", 10), ("a\nb".to_string(), 1));
+    }
+
+    #[test]
+    fn last_n_lines_with_start_empty_starts_at_one() {
+        assert_eq!(last_n_lines_with_start("", 10), (String::new(), 1));
     }
 }

--- a/crates/testkit/src/lib.rs
+++ b/crates/testkit/src/lib.rs
@@ -144,7 +144,7 @@ impl Workspace {
                 for f in &failures {
                     msg.push_str(&format!("{}: {:#}", f.addr.format(), f.source));
                     if let Some(tail) = &f.log_tail {
-                        msg.push_str(&format!("\nlast log lines:\n{tail}"));
+                        msg.push_str(&format!("\nlast log lines:\n{}", tail.text));
                     }
                     msg.push('\n');
                 }

--- a/src/commands/errors.rs
+++ b/src/commands/errors.rs
@@ -24,16 +24,20 @@ fn cause_chain(source: &anyhow::Error, addr: &str) -> String {
 
 /// Render the log tail inside a framed box, indented two spaces. The `▶` of the
 /// header sits in the same column as the `│` gutter bar so they connect. With
-/// `color`: border + `[log]` white, line numbers dim.
+/// `color`: border + `[log]` white, line numbers dim. Line numbers start at
+/// `start_line` — the real position of the first shown line in the full log — so
+/// the last 10 lines of a 100-line log read 91–100, not 1–10.
 /// ```text
 ///   ╭─▶[log]
-///   1 │  line one
-///   2 │  line two
+///   91 │  line one
+///   92 │  line two
 ///   ╰────
 /// ```
-fn render_log_box(out: &mut String, log: &str, color: bool) {
+fn render_log_box(out: &mut String, log: &str, start_line: usize, color: bool) {
     let lines: Vec<&str> = log.lines().collect();
-    let width = lines.len().to_string().len();
+    // Width is driven by the largest (last) line number, not the line count.
+    let last_no = start_line + lines.len().saturating_sub(1);
+    let width = last_no.to_string().len();
     // The line-number gutter sits OUTSIDE the box; the box corners/border line up
     // one column past it (number field + the separating space).
     let pad = " ".repeat(width + 1);
@@ -44,7 +48,7 @@ fn render_log_box(out: &mut String, log: &str, color: bool) {
         out.push_str(&format!("  {pad}╭─[log]\n"));
     }
     for (i, line) in lines.iter().enumerate() {
-        let num = format!("{:>width$}", i + 1, width = width);
+        let num = format!("{:>width$}", start_line + i, width = width);
         if color {
             out.push_str(&format!("  {} {} {line}\n", num.dim(), "│".white()));
         } else {
@@ -133,7 +137,7 @@ fn render_target_failure(f: &TargetFailure, color: bool) -> String {
         out.push_str(&format!("{arrow} {cause}\n"));
     }
     if let Some(log) = &f.log_tail {
-        render_log_box(&mut out, log, color);
+        render_log_box(&mut out, &log.text, log.start_line, color);
     }
     out
 }
@@ -277,8 +281,18 @@ pub fn render_anyhow(e: &anyhow::Error) -> bool {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::engine::error::ProcessFailed;
+    use crate::engine::error::{LogTail, ProcessFailed};
     use anyhow::Context as _;
+    use std::sync::Arc;
+
+    /// A `ProcessFailed` whose log handle is never read (tests that only exercise
+    /// the cause chain / rendering, not log extraction).
+    fn dummy_process_failed() -> ProcessFailed {
+        ProcessFailed {
+            status: "exit status: 1".to_string(),
+            log: Arc::new(hcore::hartifactcontent::FileContent::new("/dev/null")),
+        }
+    }
 
     #[test]
     fn is_cancelled_detects_cancellation_in_chain() {
@@ -317,15 +331,19 @@ mod tests {
     #[test]
     fn renders_target_failure_with_log_box() {
         let addr = crate::htaddr::parse_addr("//simple_fail:d1").unwrap();
-        let source = anyhow::Error::new(ProcessFailed {
-            status: "exit status: 1".to_string(),
-            log_tail: String::new(),
-        })
-        .context("driver run")
-        .context("run")
-        .context("execute //simple_fail:d1");
+        let source = anyhow::Error::new(dummy_process_failed())
+            .context("driver run")
+            .context("run")
+            .context("execute //simple_fail:d1");
         let log = "stuff\nstuff\nstuff\nstuff\nstuff\nstuff\nstuff\nstuff\nnot gucci";
-        let f = TargetFailure::new(addr, Some(log.to_string()), source);
+        let f = TargetFailure::new(
+            addr,
+            Some(LogTail {
+                text: log.to_string(),
+                start_line: 1,
+            }),
+            source,
+        );
 
         let rendered = render_target_failure(&f, false);
         let expected = "\
@@ -342,6 +360,32 @@ mod tests {
   8 │ stuff
   9 │ not gucci
     ╰────
+";
+        assert_eq!(rendered, expected);
+    }
+
+    #[test]
+    fn log_box_numbers_reflect_real_file_positions() {
+        // The last 3 lines of a 100-line log render with numbers 98–100, not 1–3,
+        // and the gutter widens to fit the largest number.
+        let addr = crate::htaddr::parse_addr("//simple_fail:d1").unwrap();
+        let f = TargetFailure::new(
+            addr,
+            Some(LogTail {
+                text: "line98\nline99\nboom".to_string(),
+                start_line: 98,
+            }),
+            anyhow::anyhow!("boom"),
+        );
+        let rendered = render_target_failure(&f, false);
+        let expected = "\
+× target failed: //simple_fail:d1
+╰─▶ boom
+      ╭─[log]
+   98 │ line98
+   99 │ line99
+  100 │ boom
+      ╰────
 ";
         assert_eq!(rendered, expected);
     }
@@ -416,7 +460,14 @@ mod tests {
     #[test]
     fn color_styles_markers_red_border_white_numbers_dim() {
         let addr = crate::htaddr::parse_addr("//pkg:a").unwrap();
-        let f = TargetFailure::new(addr, Some("oops".to_string()), anyhow::anyhow!("boom"));
+        let f = TargetFailure::new(
+            addr,
+            Some(LogTail {
+                text: "oops".to_string(),
+                start_line: 1,
+            }),
+            anyhow::anyhow!("boom"),
+        );
         let rendered = render_target_failure(&f, true);
         // × and ╰─▶ markers red.
         assert!(rendered.contains(&format!("{}", "×".red())));

--- a/src/commands/run.rs
+++ b/src/commands/run.rs
@@ -80,6 +80,10 @@ pub struct RunArgs {
     /// Fail if generated output differs from the tree (CI check)
     #[arg(long = "frozen")]
     pub frozen: bool,
+    /// Number of trailing process-log lines to show in a failing target's
+    /// diagnostic box. The full log is always saved as the `log.txt` artifact.
+    #[arg(long = "log-lines", value_name = "N", default_value_t = 10)]
+    pub log_lines: usize,
 }
 
 struct RunApp {
@@ -149,9 +153,12 @@ impl App for RunApp {
             interactive,
             frozen: self.args.frozen,
         };
-        let rs = self
-            .engine
-            .new_state_full(self.fail_fast, ctx.event_sender(), ctx.bg_pending());
+        let rs = self.engine.new_state_full(
+            self.fail_fast,
+            ctx.event_sender(),
+            ctx.bg_pending(),
+            self.args.log_lines,
+        );
 
         // Fold both matcher paths into a single `res: Result<Vec<_>>` so the
         // `finalize!` paved road handles rendering and exit uniformly. The engine


### PR DESCRIPTION
## What

- **`heph run --log-lines N`** (default `10`) — controls how many trailing process-log lines a failing target's diagnostic box shows. Scoped to `run` only.
- **Real line numbers** — the failure log box now numbers lines by their true position in the full log (the last 10 of a 100-line log read `91`–`100`), instead of renumbering from `1`.
- **Lazy log handle** — `ProcessFailed` no longer carries the full log string. It holds an `Arc<dyn Content>` handle (new `FileContent`) to the on-disk log and reads only the rendered tail on demand.

## How it fits together

- `--log-lines` → `RunArgs.log_lines` → `RequestState.log_tail_lines` (via `new_state_full`). Non-`run` callers (`gc`, internal) use `DEFAULT_LOG_TAIL_LINES = 10`.
- `classify_failure` reads `rs.log_tail_lines()` of the log via the lazy handle, producing a `LogTail { text, start_line }` recorded on `TargetFailure`.
- `render_log_box` numbers from `start_line` and sizes the gutter to the largest number.
- A failed target's sandbox is reclaimed only at its *next* run, so the log file stays readable through end-of-run rendering — the lazy read never races cleanup.

## Tests

- `last_n_lines_with_start` unit tests (real start line, fewer-than-N, empty).
- `FileContent` reads backing file / errors on missing file.
- `classify_*` tests rewritten to drive a real on-disk log file through the handle (12-line log → tail `3`–`12`, `start_line = 3`).
- `log_box_numbers_reflect_real_file_positions` renders `98`–`100` with a widened gutter.
- e2e `test_failure_surfaces_process_log_tail` — a real failing target's output reaches the recorded failure end-to-end.

🤖 Generated with [Claude Code](https://claude.com/claude-code)