### PR TITLE
feat(plugin-go): recursive provider state + link config

### DIFF
--- a/crates/plugin-go/src/plugingo/provider.rs
+++ b/crates/plugin-go/src/plugingo/provider.rs
@@ -800,7 +800,10 @@ fn pick_xtest_p_lib_name(pkg: &GoPackage) -> Option<&'static str> {
 /// `test = True` (or the struct form, which implies tests run) closer to the
 /// target re-enables tests even if a recursive ancestor disabled them.
 fn pick_test_skip(states: &[State], addr_pkg: &str) -> bool {
-    let Some(state) = applicable_states(states, addr_pkg, "test").into_iter().last() else {
+    let Some(state) = applicable_states(states, addr_pkg, "test")
+        .into_iter()
+        .last()
+    else {
         return false;
     };
     // Skip only when the closest `test` state is the bool `False`. `True` and the
@@ -4400,8 +4403,10 @@ golang.org/x/oauth2 v0.0.0-20200107190931-bf48bf16ab8d h1:pE8b58s1HRDMi8RDc79m0H
     }
 
     fn state_with_link_map(pkg: &str, entries: Vec<(&str, Value)>) -> State {
-        let link_map: HashMap<String, Value> =
-            entries.into_iter().map(|(k, v)| (k.to_string(), v)).collect();
+        let link_map: HashMap<String, Value> = entries
+            .into_iter()
+            .map(|(k, v)| (k.to_string(), v))
+            .collect();
         let mut m = HashMap::new();
         m.insert("link".to_string(), Value::Map(link_map));
         State {
@@ -4445,7 +4450,10 @@ golang.org/x/oauth2 v0.0.0-20200107190931-bf48bf16ab8d h1:pE8b58s1HRDMi8RDc79m0H
             "foo",
             vec![
                 ("flags", Value::List(vec![Value::String("-s".to_string())])),
-                ("deps", Value::List(vec![Value::String("//a:b".to_string())])),
+                (
+                    "deps",
+                    Value::List(vec![Value::String("//a:b".to_string())]),
+                ),
                 (
                     "runtime_deps",
                     Value::List(vec![Value::String("//c:d".to_string())]),
@@ -4490,7 +4498,10 @@ golang.org/x/oauth2 v0.0.0-20200107190931-bf48bf16ab8d h1:pE8b58s1HRDMi8RDc79m0H
 
     #[test]
     fn pick_link_errors_on_unknown_key() {
-        let states = vec![state_with_link_map("foo", vec![("bogus", Value::Bool(true))])];
+        let states = vec![state_with_link_map(
+            "foo",
+            vec![("bogus", Value::Bool(true))],
+        )];
         let err = pick_link(&states, "foo").unwrap_err();
         assert!(
             format!("{err:#}").contains("bogus"),

--- a/crates/plugin-go/src/plugingo/provider.rs
+++ b/crates/plugin-go/src/plugingo/provider.rs
@@ -413,12 +413,14 @@ impl ProviderTrait for Provider {
                 field(
                     "go_codegen_root",
                     ParamType::Bool,
-                    "Mark this package (and descendants) as a Go codegen root.",
+                    "Mark this package (and descendants) as a Go codegen root. Always applies \
+                     to descendants, independent of `recursive`.",
                 ),
                 field(
                     "go_codegen_deps",
                     ParamType::list(ParamType::String),
-                    "Extra dependencies (target addresses) injected into generated Go targets.",
+                    "Extra dependencies (target addresses) injected into generated Go targets. \
+                     Always applies to descendants, independent of `recursive`.",
                 ),
                 field(
                     "test",
@@ -432,8 +434,8 @@ impl ProviderTrait for Provider {
                             ("pre_run", ParamType::list(ParamType::String)),
                         ]),
                     ]),
-                    "Test settings for this package. `test = False` skips its tests \
-                     (inherited by descendants); `test = True` (or unset) runs them. \
+                    "Test settings for this package. `test = False` skips its tests, \
+                     `test = True` (or unset) runs them. \
                      The struct form configures the generated `test`/`xtest` run \
                      targets — `env`/`runtime_env` (map[string]) and \
                      `pass_env`/`runtime_pass_env` (list[string]) set env, and \
@@ -459,10 +461,10 @@ impl ProviderTrait for Provider {
                 field(
                     "recursive",
                     ParamType::Bool,
-                    "Apply this state's per-package config (the `test = {...}` struct \
-                     and `link = {...}`) to descendant packages, not just the exact \
-                     declaring package. The `test = False`/`True` toggle and \
-                     `go_codegen_*` settings always inherit regardless of this flag.",
+                    "Apply this state's config (the `test` toggle/struct and `link = {...}`) \
+                     to descendant packages, not just the exact declaring package. \
+                     `go_codegen_root`/`go_codegen_deps` are unaffected — they always \
+                     apply to descendants.",
                 ),
             ],
         })
@@ -617,7 +619,7 @@ impl ProviderInner {
                     // under a go.mod (decode_package guarantees that). Each
                     // variant is filtered at `get` time by inspecting the
                     // `_golist` result — no filesystem scan needed.
-                    let skip_tests = pick_test_skip(&req.states);
+                    let skip_tests = pick_test_skip(&req.states, req.package.as_str());
                     let names: &[&str] = if skip_tests {
                         &["_golist", "build_lib", "build", "embed"]
                     } else {
@@ -791,16 +793,14 @@ fn pick_xtest_p_lib_name(pkg: &GoPackage) -> Option<&'static str> {
     }
 }
 
-/// Return true if the closest (deepest) ancestor `provider_state(provider="go", ...)`
-/// disables tests via `test = False`. Deeper states fully override shallower ones —
-/// a `test = True` (or the struct form, which implies tests run) closer to the
-/// target re-enables tests even if a root-level state disabled them.
-fn pick_test_skip(states: &[State]) -> bool {
-    let Some(state) = states
-        .iter()
-        .filter(|s| s.state.contains_key("test"))
-        .max_by_key(|s| s.package.as_str().len())
-    else {
+/// Return true if the closest `test` state applying to `addr_pkg` disables tests
+/// via `test = False`. Like the other per-package knobs, a `test` state applies
+/// to its exact package by default and reaches descendants only when it carries
+/// `recursive = True`. Deeper states fully override shallower ones — a
+/// `test = True` (or the struct form, which implies tests run) closer to the
+/// target re-enables tests even if a recursive ancestor disabled them.
+fn pick_test_skip(states: &[State], addr_pkg: &str) -> bool {
+    let Some(state) = applicable_states(states, addr_pkg, "test").into_iter().last() else {
         return false;
     };
     // Skip only when the closest `test` state is the bool `False`. `True` and the
@@ -1151,7 +1151,7 @@ impl ProviderInner {
         // descendants) out of test-target generation. Gate every test variant
         // before the `_golist` resolve below so a skipped pkg never forces a
         // `go list` round-trip purely to learn there are no tests.
-        if is_test_target_name(&addr.name) && pick_test_skip(&req.states) {
+        if is_test_target_name(&addr.name) && pick_test_skip(&req.states, addr.package.as_str()) {
             return Err(GetError::NotFound);
         }
 
@@ -4163,31 +4163,45 @@ golang.org/x/oauth2 v0.0.0-20200107190931-bf48bf16ab8d h1:pE8b58s1HRDMi8RDc79m0H
 
     #[test]
     fn pick_test_skip_false_when_no_states() {
-        assert!(!pick_test_skip(&[]));
+        assert!(!pick_test_skip(&[], "foo"));
     }
 
     #[test]
-    fn pick_test_skip_true_when_root_state_sets_skip() {
+    fn pick_test_skip_true_when_state_sets_skip_for_own_package() {
         let states = vec![state_with_test_skip("", true)];
-        assert!(pick_test_skip(&states));
+        assert!(pick_test_skip(&states, ""));
     }
 
     #[test]
-    fn pick_test_skip_deeper_state_overrides_shallower() {
-        // Root says test=False (skip); deeper pkg says test=True → tests must run.
+    fn pick_test_skip_non_recursive_does_not_reach_descendants() {
+        // `test = False` at `foo` only disables `foo`'s own tests; `foo/bar` runs.
+        let states = vec![state_with_test_skip("foo", true)];
+        assert!(pick_test_skip(&states, "foo"));
+        assert!(!pick_test_skip(&states, "foo/bar"));
+    }
+
+    #[test]
+    fn pick_test_skip_recursive_reaches_descendants() {
+        let states = vec![with_recursive(state_with_test_skip("foo", true))];
+        assert!(pick_test_skip(&states, "foo/bar"));
+    }
+
+    #[test]
+    fn pick_test_skip_deeper_state_overrides_recursive_ancestor() {
+        // Recursive root says test=False (skip); deeper pkg says test=True → run.
         let states = vec![
-            state_with_test_skip("", true),
+            with_recursive(state_with_test_skip("", true)),
             state_with_test_skip("src/foo", false),
         ];
-        assert!(!pick_test_skip(&states));
+        assert!(!pick_test_skip(&states, "src/foo"));
     }
 
     #[test]
     fn pick_test_skip_struct_form_leaves_tests_enabled() {
         // A deeper struct-form `test = {env: ...}` re-enables tests even when a
-        // root state disabled them — the struct implies tests run.
+        // recursive root disabled them — the struct implies tests run.
         let states = vec![
-            state_with_test_skip("", true),
+            with_recursive(state_with_test_skip("", true)),
             state_with_test_map(
                 "src/foo",
                 vec![(
@@ -4199,7 +4213,7 @@ golang.org/x/oauth2 v0.0.0-20200107190931-bf48bf16ab8d h1:pE8b58s1HRDMi8RDc79m0H
                 )],
             ),
         ];
-        assert!(!pick_test_skip(&states));
+        assert!(!pick_test_skip(&states, "src/foo"));
     }
 
     #[test]
@@ -4211,7 +4225,7 @@ golang.org/x/oauth2 v0.0.0-20200107190931-bf48bf16ab8d h1:pE8b58s1HRDMi8RDc79m0H
             provider: "go".to_string(),
             state: m,
         }];
-        assert!(!pick_test_skip(&states));
+        assert!(!pick_test_skip(&states, ""));
     }
 
     fn test_env_is_empty(env: &target_test::TestEnv) -> bool {
@@ -4493,7 +4507,7 @@ golang.org/x/oauth2 v0.0.0-20200107190931-bf48bf16ab8d h1:pE8b58s1HRDMi8RDc79m0H
         let req = ListRequest {
             request_id: "test".to_string(),
             package: PkgBuf::from("pkg"),
-            states: vec![state_with_test_skip("", true)],
+            states: vec![with_recursive(state_with_test_skip("", true))],
         };
         let names: Vec<String> = p
             .list(req, &ctoken)
@@ -4522,7 +4536,7 @@ golang.org/x/oauth2 v0.0.0-20200107190931-bf48bf16ab8d h1:pE8b58s1HRDMi8RDc79m0H
             let req = GetRequest {
                 request_id: "test".to_string(),
                 addr: make_addr("pkg", name),
-                states: vec![state_with_test_skip("", true)],
+                states: vec![with_recursive(state_with_test_skip("", true))],
                 executor: test_executor(sandbox.path()),
             };
             let res = p.get(req, &ctoken).await;
@@ -4543,7 +4557,7 @@ golang.org/x/oauth2 v0.0.0-20200107190931-bf48bf16ab8d h1:pE8b58s1HRDMi8RDc79m0H
             request_id: "test".to_string(),
             addr: make_addr("pkg", "build_test"),
             states: vec![
-                state_with_test_skip("", true),
+                with_recursive(state_with_test_skip("", true)),
                 state_with_test_skip("pkg", false),
             ],
             executor: test_executor(sandbox.path()),

--- a/crates/plugin-go/src/plugingo/provider.rs
+++ b/crates/plugin-go/src/plugingo/provider.rs
@@ -438,8 +438,31 @@ impl ProviderTrait for Provider {
                      targets — `env`/`runtime_env` (map[string]) and \
                      `pass_env`/`runtime_pass_env` (list[string]) set env, and \
                      `pre_run` (list[string]) runs shell lines before the test binary \
-                     (switching the target to the bash driver) — and applies only \
-                     to this package.",
+                     (switching the target to the bash driver). By default applies \
+                     only to this package; set `recursive = True` to apply to \
+                     descendant packages too.",
+                ),
+                field(
+                    "link",
+                    ParamType::strukt(vec![
+                        ("flags", ParamType::list(ParamType::String)),
+                        ("deps", ParamType::list(ParamType::String)),
+                        ("runtime_deps", ParamType::list(ParamType::String)),
+                    ]),
+                    "Link settings for a `main` package's `build` (binary) target. \
+                     `flags` are passed verbatim to `go tool link`; `deps` are target \
+                     addresses staged into the link sandbox (hashed inputs) that the \
+                     flags can reference; `runtime_deps` travel with the binary at run \
+                     time only (not hashed). By default applies only to this package; \
+                     set `recursive = True` to apply to descendant packages too.",
+                ),
+                field(
+                    "recursive",
+                    ParamType::Bool,
+                    "Apply this state's per-package config (the `test = {...}` struct \
+                     and `link = {...}`) to descendant packages, not just the exact \
+                     declaring package. The `test = False`/`True` toggle and \
+                     `go_codegen_*` settings always inherit regardless of this flag.",
                 ),
             ],
         })
@@ -821,9 +844,35 @@ const TEST_STATE_KEYS: &[&str] = &[
     "pre_run",
 ];
 
+/// Whether a state opts its per-package config into descendant packages via
+/// `recursive = True`. Engine pre-filters states to ancestors-of-or-equal-to the
+/// target package, so a `recursive` state is always a valid ancestor (or self).
+fn state_is_recursive(state: &State) -> bool {
+    matches!(state.state.get("recursive"), Some(Value::Bool(true)))
+}
+
+/// Whether a state's per-package config (the `test = {...}` struct and
+/// `link = {...}`) applies to `addr_pkg`. By default config applies only to the
+/// exact declaring package; `recursive = True` extends it to all descendants.
+fn state_applies_to(state: &State, addr_pkg: &str) -> bool {
+    state.package.as_str() == addr_pkg || state_is_recursive(state)
+}
+
+/// Return the `states` that apply to `addr_pkg` (exact package, or `recursive`
+/// ancestors) and carry `key`, sorted shallow->deep so the closest declaration
+/// is applied last and wins on conflicting map keys.
+fn applicable_states<'a>(states: &'a [State], addr_pkg: &str, key: &str) -> Vec<&'a State> {
+    let mut out: Vec<&State> = states
+        .iter()
+        .filter(|s| state_applies_to(s, addr_pkg) && s.state.contains_key(key))
+        .collect();
+    out.sort_by_key(|s| s.package.as_str().len());
+    out
+}
+
 fn pick_test_env(states: &[State], addr_pkg: &str) -> anyhow::Result<target_test::TestEnv> {
     let mut out = target_test::TestEnv::default();
-    for state in states.iter().filter(|s| s.package.as_str() == addr_pkg) {
+    for state in applicable_states(states, addr_pkg, "test") {
         let Some(Value::Map(test_map)) = state.state.get("test") else {
             continue;
         };
@@ -860,6 +909,48 @@ fn pick_test_env(states: &[State], addr_pkg: &str) -> anyhow::Result<target_test
         if let Some(v) = test_map.get("pre_run") {
             out.pre_run
                 .extend(parse_strings(v).context("parsing test pre_run from go provider_state")?);
+        }
+    }
+    Ok(out)
+}
+
+/// Keys accepted inside a `link = {...}` go provider_state map. Rejects typos /
+/// unsupported knobs instead of silently dropping them.
+const LINK_STATE_KEYS: &[&str] = &["flags", "deps", "runtime_deps"];
+
+/// Collect the link knobs (`flags`, `deps`, `runtime_deps`) from `link = {...}`
+/// provider_states applying to the binary's package — its own package plus any
+/// `recursive` ancestor. Applicable states accumulate (shallow->deep), so a
+/// recursive ancestor's flags/deps combine with the package's own.
+fn pick_link(states: &[State], addr_pkg: &str) -> anyhow::Result<target_bin::LinkConfig> {
+    let mut out = target_bin::LinkConfig::default();
+    for state in applicable_states(states, addr_pkg, "link") {
+        let Some(Value::Map(link_map)) = state.state.get("link") else {
+            anyhow::bail!(
+                "go provider_state `link` must be a struct, got: {:?}",
+                state.state.get("link")
+            );
+        };
+        for key in link_map.keys() {
+            if !LINK_STATE_KEYS.contains(&key.as_str()) {
+                anyhow::bail!(
+                    "unknown key `{key}` in go provider_state `link` map (allowed: {})",
+                    LINK_STATE_KEYS.join(", "),
+                );
+            }
+        }
+        if let Some(v) = link_map.get("flags") {
+            out.flags
+                .extend(parse_strings(v).context("parsing link flags from go provider_state")?);
+        }
+        if let Some(v) = link_map.get("deps") {
+            out.deps
+                .extend(parse_strings(v).context("parsing link deps from go provider_state")?);
+        }
+        if let Some(v) = link_map.get("runtime_deps") {
+            out.runtime_deps.extend(
+                parse_strings(v).context("parsing link runtime_deps from go provider_state")?,
+            );
         }
     }
     Ok(out)
@@ -1187,11 +1278,14 @@ impl ProviderInner {
                     .libs
                     .insert(0, (import_path.clone(), own_lib_addr));
 
+                let link =
+                    pick_link(&req.states, addr.package.as_str()).map_err(GetError::Other)?;
                 let spec = target_bin::build_spec(
                     addr.clone(),
                     &import_path,
                     &factors,
                     &transitive.libs,
+                    &link,
                     &self.go_version,
                 );
                 Ok(GetResponse { target_spec: spec })
@@ -4272,6 +4366,122 @@ golang.org/x/oauth2 v0.0.0-20200107190931-bf48bf16ab8d h1:pE8b58s1HRDMi8RDc79m0H
             )],
         )];
         assert!(pick_test_env(&states, "foo").is_err());
+    }
+
+    /// Add `recursive = True` to an existing State.
+    fn with_recursive(mut s: State) -> State {
+        s.state.insert("recursive".to_string(), Value::Bool(true));
+        s
+    }
+
+    /// A `test` struct `env` knob carrying a single `key=val` pair.
+    fn env_entry(key: &str, val: &str) -> (&'static str, Value) {
+        (
+            "env",
+            Value::Map(HashMap::from([(
+                key.to_string(),
+                Value::String(val.to_string()),
+            )])),
+        )
+    }
+
+    fn state_with_link_map(pkg: &str, entries: Vec<(&str, Value)>) -> State {
+        let link_map: HashMap<String, Value> =
+            entries.into_iter().map(|(k, v)| (k.to_string(), v)).collect();
+        let mut m = HashMap::new();
+        m.insert("link".to_string(), Value::Map(link_map));
+        State {
+            package: PkgBuf::from(pkg),
+            provider: "go".to_string(),
+            state: m,
+        }
+    }
+
+    #[test]
+    fn pick_test_env_recursive_applies_to_descendants() {
+        // `recursive = True` at ancestor `foo` reaches `foo/bar`'s test target.
+        let states = vec![with_recursive(state_with_test_map(
+            "foo",
+            vec![env_entry("FOO", "1")],
+        ))];
+        let env = pick_test_env(&states, "foo/bar").unwrap();
+        assert_eq!(env.env.get("FOO").map(String::as_str), Some("1"));
+    }
+
+    #[test]
+    fn pick_test_env_deeper_package_overrides_recursive_ancestor() {
+        // Recursive ancestor sets FOO=1; the exact package overrides FOO=2.
+        let states = vec![
+            with_recursive(state_with_test_map("foo", vec![env_entry("FOO", "1")])),
+            state_with_test_map("foo/bar", vec![env_entry("FOO", "2")]),
+        ];
+        let env = pick_test_env(&states, "foo/bar").unwrap();
+        assert_eq!(env.env.get("FOO").map(String::as_str), Some("2"));
+    }
+
+    #[test]
+    fn pick_link_empty_when_no_states() {
+        let link = pick_link(&[], "foo").unwrap();
+        assert!(link.flags.is_empty() && link.deps.is_empty() && link.runtime_deps.is_empty());
+    }
+
+    #[test]
+    fn pick_link_reads_all_knobs() {
+        let states = vec![state_with_link_map(
+            "foo",
+            vec![
+                ("flags", Value::List(vec![Value::String("-s".to_string())])),
+                ("deps", Value::List(vec![Value::String("//a:b".to_string())])),
+                (
+                    "runtime_deps",
+                    Value::List(vec![Value::String("//c:d".to_string())]),
+                ),
+            ],
+        )];
+        let link = pick_link(&states, "foo").unwrap();
+        assert_eq!(link.flags, vec!["-s".to_string()]);
+        assert_eq!(link.deps, vec!["//a:b".to_string()]);
+        assert_eq!(link.runtime_deps, vec!["//c:d".to_string()]);
+    }
+
+    #[test]
+    fn pick_link_exact_package_only_by_default() {
+        let states = vec![state_with_link_map(
+            "foo",
+            vec![("flags", Value::List(vec![Value::String("-s".to_string())]))],
+        )];
+        let link = pick_link(&states, "foo/bar").unwrap();
+        assert!(
+            link.flags.is_empty(),
+            "non-recursive link must not leak to descendants"
+        );
+    }
+
+    #[test]
+    fn pick_link_recursive_accumulates_ancestor_and_self_flags() {
+        let states = vec![
+            with_recursive(state_with_link_map(
+                "foo",
+                vec![("flags", Value::List(vec![Value::String("-s".to_string())]))],
+            )),
+            state_with_link_map(
+                "foo/bar",
+                vec![("flags", Value::List(vec![Value::String("-w".to_string())]))],
+            ),
+        ];
+        let link = pick_link(&states, "foo/bar").unwrap();
+        // shallow->deep order: ancestor flag first, then the package's own.
+        assert_eq!(link.flags, vec!["-s".to_string(), "-w".to_string()]);
+    }
+
+    #[test]
+    fn pick_link_errors_on_unknown_key() {
+        let states = vec![state_with_link_map("foo", vec![("bogus", Value::Bool(true))])];
+        let err = pick_link(&states, "foo").unwrap_err();
+        assert!(
+            format!("{err:#}").contains("bogus"),
+            "error must name the bad key"
+        );
     }
 
     #[tokio::test]

--- a/crates/plugin-go/src/plugingo/target_bin.rs
+++ b/crates/plugin-go/src/plugingo/target_bin.rs
@@ -8,12 +8,28 @@ use hmodel::htaddr::Addr;
 use hplugin::provider::TargetSpec;
 use std::collections::{BTreeMap, HashMap};
 
+/// Extra link configuration plumbed onto the `build` (binary) target from a
+/// package's `provider_state(provider="go", link={...})`.
+///
+/// - `flags`: passed verbatim to `go tool link` (e.g. `-X main.version=...`).
+/// - `deps`: target addresses staged into the link sandbox (hashed inputs) so
+///   `flags` can reference their outputs.
+/// - `runtime_deps`: target addresses that travel with the binary at run time
+///   only (not hashed — they do not invalidate the link cache).
+#[derive(Debug, Default, Clone)]
+pub struct LinkConfig {
+    pub flags: Vec<String>,
+    pub deps: Vec<String>,
+    pub runtime_deps: Vec<String>,
+}
+
 pub fn build_spec(
     addr: Addr,
     import_path: &str,
     factors: &Factors,
     // All transitive libs including own build_lib at index 0
     transitive_libs: &[(String, Addr)],
+    link: &LinkConfig,
     go_version: &str,
 ) -> TargetSpec {
     let binary_name = import_path
@@ -27,6 +43,7 @@ pub fn build_spec(
         import_path,
         &binary_name,
         transitive_libs,
+        &link.flags,
     ));
 
     let mut deps: BTreeMap<String, Value> = transitive_libs
@@ -39,6 +56,14 @@ pub fn build_spec(
     if let Some((sdk_group, sdk_val)) = go_sdk_dep(go_version) {
         deps.insert(sdk_group, sdk_val);
     }
+    // Link deps from provider_state land in their own group so they never collide
+    // with the importcfg lib groups (stdlib/firstparty/thirdparty/sdk).
+    if !link.deps.is_empty() {
+        deps.insert(
+            "link_deps".to_string(),
+            Value::List(link.deps.iter().cloned().map(Value::String).collect()),
+        );
+    }
 
     let mut config: HashMap<String, Value> = HashMap::new();
     config.insert("run".to_string(), to_run_value(run));
@@ -46,6 +71,23 @@ pub fn build_spec(
         "deps".to_string(),
         Value::Map(deps.into_iter().collect::<HashMap<_, _>>()),
     );
+    // Runtime-only link deps: staged with the binary at run time, excluded from
+    // the link's def hash (pluginexec excludes runtime_deps from the hash).
+    if !link.runtime_deps.is_empty() {
+        config.insert(
+            "runtime_deps".to_string(),
+            Value::Map(HashMap::from([(
+                "link_runtime_deps".to_string(),
+                Value::List(
+                    link.runtime_deps
+                        .iter()
+                        .cloned()
+                        .map(Value::String)
+                        .collect(),
+                ),
+            )])),
+        );
+    }
     if let Some((ro_k, ro_v)) = go_sdk_read_only_config(go_version) {
         config.insert(ro_k, ro_v);
     }
@@ -83,16 +125,23 @@ fn generate_link_script(
     self_import_path: &str,
     binary_name: &str,
     transitive_libs: &[(String, Addr)],
+    link_flags: &[String],
 ) -> Vec<String> {
     // The main package is passed as a positional arg to the linker, not via importcfg.
     let mut lines = write_importcfg_script(transitive_libs, Some(self_import_path));
     let self_group = import_path_to_dep_group(self_import_path);
     let self_env_var = format!("SRC_{}", self_group.to_uppercase());
+    // User link flags from provider_state, inserted verbatim before `-o`.
+    let flags = if link_flags.is_empty() {
+        String::new()
+    } else {
+        format!(" {}", link_flags.join(" "))
+    };
     // -buildmode=pie matches Go's default on darwin/arm64 (and most modern
     // platforms). Libs were compiled with -shared, so the link must agree on
     // PIE — otherwise asm relocations from transitive deps fail to resolve.
     lines.push(format!(
-        "\"$GO\" tool link -importcfg \"$importcfg\" -buildmode=pie -o {} \"${}\"",
+        "\"$GO\" tool link -importcfg \"$importcfg\" -buildmode=pie{flags} -o {} \"${}\"",
         binary_name, self_env_var
     ));
     lines
@@ -143,7 +192,7 @@ mod tests {
 
     #[test]
     fn test_driver_is_bash() {
-        let spec = build_spec(test_addr(), "example.com/cmd", &test_factors(), &[], V);
+        let spec = build_spec(test_addr(), "example.com/cmd", &test_factors(), &[], &LinkConfig::default(), V);
         assert_eq!(spec.driver, "sh");
     }
 
@@ -154,6 +203,7 @@ mod tests {
             "example.com/myapp/cmd",
             &test_factors(),
             &[],
+            &LinkConfig::default(),
             V,
         );
         let out = match spec.config.get("out").unwrap() {
@@ -173,7 +223,7 @@ mod tests {
             ("example.com/cmd".to_string(), lib_addr("cmd")),
             ("fmt".to_string(), lib_addr("@heph/go/std/fmt")),
         ];
-        let spec = build_spec(test_addr(), "example.com/cmd", &test_factors(), &libs, V);
+        let spec = build_spec(test_addr(), "example.com/cmd", &test_factors(), &libs, &LinkConfig::default(), V);
         let run = run_str(&spec);
         assert!(run.contains("tool link"));
         assert!(run.contains("importcfg"));
@@ -181,7 +231,7 @@ mod tests {
 
     #[test]
     fn test_run_uses_hermetic_go() {
-        let spec = build_spec(test_addr(), "example.com/cmd", &test_factors(), &[], V);
+        let spec = build_spec(test_addr(), "example.com/cmd", &test_factors(), &[], &LinkConfig::default(), V);
         let run = run_str(&spec);
         assert!(
             run.contains("\"$GO\""),
@@ -202,7 +252,7 @@ mod tests {
 
     #[test]
     fn test_deps_include_hermetic_sdk() {
-        let spec = build_spec(test_addr(), "example.com/cmd", &test_factors(), &[], V);
+        let spec = build_spec(test_addr(), "example.com/cmd", &test_factors(), &[], &LinkConfig::default(), V);
         let deps = match spec.config.get("deps").unwrap() {
             Value::Map(m) => m,
             _ => panic!("expected map"),
@@ -219,7 +269,7 @@ mod tests {
 
     #[test]
     fn test_env_pins_cgo_disabled() {
-        let spec = build_spec(test_addr(), "example.com/cmd", &test_factors(), &[], V);
+        let spec = build_spec(test_addr(), "example.com/cmd", &test_factors(), &[], &LinkConfig::default(), V);
         let env = match spec.config.get("env").unwrap() {
             Value::Map(m) => m,
             _ => panic!("expected map"),
@@ -232,13 +282,97 @@ mod tests {
     }
 
     #[test]
+    fn test_link_flags_threaded_into_link_command() {
+        let link = LinkConfig {
+            flags: vec!["-X main.version=1.2.3".to_string(), "-s".to_string()],
+            ..Default::default()
+        };
+        let spec = build_spec(test_addr(), "example.com/cmd", &test_factors(), &[], &link, V);
+        let run = run_str(&spec);
+        let link_line = run
+            .lines()
+            .find(|l| l.contains("tool link"))
+            .expect("link line present");
+        assert!(
+            link_line.contains("-X main.version=1.2.3") && link_line.contains(" -s "),
+            "link flags must be threaded into the link command: {link_line}"
+        );
+        let flags_pos = link_line.find("-X main.version").unwrap();
+        let o_pos = link_line.find(" -o ").unwrap();
+        assert!(flags_pos < o_pos, "flags must precede -o: {link_line}");
+    }
+
+    #[test]
+    fn test_link_deps_added_to_deps_map() {
+        let link = LinkConfig {
+            deps: vec!["//some:target".to_string()],
+            ..Default::default()
+        };
+        let spec = build_spec(test_addr(), "example.com/cmd", &test_factors(), &[], &link, V);
+        let deps = match spec.config.get("deps").unwrap() {
+            Value::Map(m) => m,
+            _ => panic!("expected deps map"),
+        };
+        let group = match deps.get("link_deps").expect("link_deps group present") {
+            Value::List(v) => v,
+            _ => panic!("expected list"),
+        };
+        assert!(matches!(&group[0], Value::String(s) if s == "//some:target"));
+    }
+
+    #[test]
+    fn test_link_runtime_deps_added_to_runtime_deps_map() {
+        let link = LinkConfig {
+            runtime_deps: vec!["//some:rt".to_string()],
+            ..Default::default()
+        };
+        let spec = build_spec(test_addr(), "example.com/cmd", &test_factors(), &[], &link, V);
+        let rdeps = match spec.config.get("runtime_deps").expect("runtime_deps present") {
+            Value::Map(m) => m,
+            _ => panic!("expected runtime_deps map"),
+        };
+        let group = match rdeps
+            .get("link_runtime_deps")
+            .expect("link_runtime_deps group present")
+        {
+            Value::List(v) => v,
+            _ => panic!("expected list"),
+        };
+        assert!(matches!(&group[0], Value::String(s) if s == "//some:rt"));
+    }
+
+    #[test]
+    fn test_link_empty_omits_extra_keys() {
+        let spec = build_spec(
+            test_addr(),
+            "example.com/cmd",
+            &test_factors(),
+            &[],
+            &LinkConfig::default(),
+            V,
+        );
+        assert!(
+            !spec.config.contains_key("runtime_deps"),
+            "no runtime_deps key when link config empty"
+        );
+        let deps = match spec.config.get("deps").unwrap() {
+            Value::Map(m) => m,
+            _ => panic!(),
+        };
+        assert!(
+            !deps.contains_key("link_deps"),
+            "no link_deps group when link config empty"
+        );
+    }
+
+    #[test]
     fn test_run_self_not_in_importcfg() {
         // The main package is passed as a positional arg to the linker, not via importcfg.
         let libs = vec![
             ("example.com/cmd".to_string(), lib_addr("cmd")),
             ("fmt".to_string(), lib_addr("@heph/go/std/fmt")),
         ];
-        let spec = build_spec(test_addr(), "example.com/cmd", &test_factors(), &libs, V);
+        let spec = build_spec(test_addr(), "example.com/cmd", &test_factors(), &libs, &LinkConfig::default(), V);
         let run = run_str(&spec);
         assert!(
             !run.contains("packagefile example.com/cmd="),

--- a/crates/plugin-go/src/plugingo/target_bin.rs
+++ b/crates/plugin-go/src/plugingo/target_bin.rs
@@ -192,7 +192,14 @@ mod tests {
 
     #[test]
     fn test_driver_is_bash() {
-        let spec = build_spec(test_addr(), "example.com/cmd", &test_factors(), &[], &LinkConfig::default(), V);
+        let spec = build_spec(
+            test_addr(),
+            "example.com/cmd",
+            &test_factors(),
+            &[],
+            &LinkConfig::default(),
+            V,
+        );
         assert_eq!(spec.driver, "sh");
     }
 
@@ -223,7 +230,14 @@ mod tests {
             ("example.com/cmd".to_string(), lib_addr("cmd")),
             ("fmt".to_string(), lib_addr("@heph/go/std/fmt")),
         ];
-        let spec = build_spec(test_addr(), "example.com/cmd", &test_factors(), &libs, &LinkConfig::default(), V);
+        let spec = build_spec(
+            test_addr(),
+            "example.com/cmd",
+            &test_factors(),
+            &libs,
+            &LinkConfig::default(),
+            V,
+        );
         let run = run_str(&spec);
         assert!(run.contains("tool link"));
         assert!(run.contains("importcfg"));
@@ -231,7 +245,14 @@ mod tests {
 
     #[test]
     fn test_run_uses_hermetic_go() {
-        let spec = build_spec(test_addr(), "example.com/cmd", &test_factors(), &[], &LinkConfig::default(), V);
+        let spec = build_spec(
+            test_addr(),
+            "example.com/cmd",
+            &test_factors(),
+            &[],
+            &LinkConfig::default(),
+            V,
+        );
         let run = run_str(&spec);
         assert!(
             run.contains("\"$GO\""),
@@ -252,7 +273,14 @@ mod tests {
 
     #[test]
     fn test_deps_include_hermetic_sdk() {
-        let spec = build_spec(test_addr(), "example.com/cmd", &test_factors(), &[], &LinkConfig::default(), V);
+        let spec = build_spec(
+            test_addr(),
+            "example.com/cmd",
+            &test_factors(),
+            &[],
+            &LinkConfig::default(),
+            V,
+        );
         let deps = match spec.config.get("deps").unwrap() {
             Value::Map(m) => m,
             _ => panic!("expected map"),
@@ -269,7 +297,14 @@ mod tests {
 
     #[test]
     fn test_env_pins_cgo_disabled() {
-        let spec = build_spec(test_addr(), "example.com/cmd", &test_factors(), &[], &LinkConfig::default(), V);
+        let spec = build_spec(
+            test_addr(),
+            "example.com/cmd",
+            &test_factors(),
+            &[],
+            &LinkConfig::default(),
+            V,
+        );
         let env = match spec.config.get("env").unwrap() {
             Value::Map(m) => m,
             _ => panic!("expected map"),
@@ -287,7 +322,14 @@ mod tests {
             flags: vec!["-X main.version=1.2.3".to_string(), "-s".to_string()],
             ..Default::default()
         };
-        let spec = build_spec(test_addr(), "example.com/cmd", &test_factors(), &[], &link, V);
+        let spec = build_spec(
+            test_addr(),
+            "example.com/cmd",
+            &test_factors(),
+            &[],
+            &link,
+            V,
+        );
         let run = run_str(&spec);
         let link_line = run
             .lines()
@@ -308,7 +350,14 @@ mod tests {
             deps: vec!["//some:target".to_string()],
             ..Default::default()
         };
-        let spec = build_spec(test_addr(), "example.com/cmd", &test_factors(), &[], &link, V);
+        let spec = build_spec(
+            test_addr(),
+            "example.com/cmd",
+            &test_factors(),
+            &[],
+            &link,
+            V,
+        );
         let deps = match spec.config.get("deps").unwrap() {
             Value::Map(m) => m,
             _ => panic!("expected deps map"),
@@ -326,8 +375,19 @@ mod tests {
             runtime_deps: vec!["//some:rt".to_string()],
             ..Default::default()
         };
-        let spec = build_spec(test_addr(), "example.com/cmd", &test_factors(), &[], &link, V);
-        let rdeps = match spec.config.get("runtime_deps").expect("runtime_deps present") {
+        let spec = build_spec(
+            test_addr(),
+            "example.com/cmd",
+            &test_factors(),
+            &[],
+            &link,
+            V,
+        );
+        let rdeps = match spec
+            .config
+            .get("runtime_deps")
+            .expect("runtime_deps present")
+        {
             Value::Map(m) => m,
             _ => panic!("expected runtime_deps map"),
         };
@@ -372,7 +432,14 @@ mod tests {
             ("example.com/cmd".to_string(), lib_addr("cmd")),
             ("fmt".to_string(), lib_addr("@heph/go/std/fmt")),
         ];
-        let spec = build_spec(test_addr(), "example.com/cmd", &test_factors(), &libs, &LinkConfig::default(), V);
+        let spec = build_spec(
+            test_addr(),
+            "example.com/cmd",
+            &test_factors(),
+            &libs,
+            &LinkConfig::default(),
+            V,
+        );
         let run = run_str(&spec);
         assert!(
             !run.contains("packagefile example.com/cmd="),


### PR DESCRIPTION
## What

Two additions to the go `provider_state`:

### 1. `recursive` scoping knob
By default a state's config applies **only** to the exact declaring package. Setting `recursive = True` extends it to the package **and all descendant packages**.

- Governs the `test` toggle (`test = False`/`True`), the `test = {...}` env struct, and the new `link = {...}`.
- Implemented via `state_applies_to` / `applicable_states`: fold over the exact package plus any `recursive` ancestor (the engine already pre-filters states to ancestors of the target), sorted shallow→deep so the closest declaration wins on conflicts.
- A non-recursive `test = False` now disables **only that package's** tests — it no longer silently disables a whole subtree. Use `recursive = True` for subtree-wide disable.
- `go_codegen_root` / `go_codegen_deps` are **unaffected** — they always apply to descendants (noted on their own schema field docs).

### 2. `link = {...}` config for `main` packages' `build` (binary) target
- `flags` — passed verbatim to `go tool link` (inserted before `-o`).
- `deps` — target addresses staged into the link sandbox as **hashed** inputs (group `link_deps`) so `flags` can reference their outputs.
- `runtime_deps` — travel with the binary at run time only, **not hashed** (group `link_runtime_deps`).

`link` honors the same `recursive` scoping; `flags`/`deps`/`runtime_deps` accumulate across applicable states. Unknown keys in either map fail closed.

```python
provider_state(
    provider = "go",
    recursive = True,                       # apply test + link to descendants
    test = {"env": {"FOO": "bar"}},
    link = {
        "flags": ["-X main.version=1.2.3", "-s"],
        "deps": ["//some:asset"],
        "runtime_deps": ["//some:rt"],
    },
)
```

## Tests
`pick_link_*`, `pick_test_env_recursive_*`, `pick_test_skip_*` (recursive/non-recursive/override), and `test_link_*` cover the new paths. Go-gated integration tests (`list`/`get` test-skip) updated to use `recursive`. Full `plugin-go` suite green (297 passed); clippy `-D warnings` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)