### PR TITLE
chore(log): silence per-request GCS token-fetch info log

### DIFF
--- a/src/log.rs
+++ b/src/log.rs
@@ -11,8 +11,15 @@ pub fn init() -> LogSink {
     // fuser is chatty at info!/warn! during mount lifecycle. Cap it at
     // error! by default so genuine failures surface but lifecycle noise
     // is silenced. User raises via `RUST_LOG=fuser=debug` for details.
-    let filter =
-        EnvFilter::try_from_default_env().unwrap_or_else(|_| EnvFilter::new("info,fuser=error"));
+    //
+    // object_store's GCS credential provider emits an info! per GCP token
+    // fetch ("fetching token from metadata server"); cap it at warn! so the
+    // remote cache doesn't spam a token line on every run. Genuine auth
+    // failures still surface; `RUST_LOG=object_store::gcp::credential=info`
+    // restores the detail.
+    let filter = EnvFilter::try_from_default_env().unwrap_or_else(|_| {
+        EnvFilter::new("info,fuser=error,object_store::gcp::credential=warn")
+    });
 
     // tracing_subscriber defaults ANSI on regardless of where the writer points.
     // Our writer is stderr, so gate color on stderr's capability — otherwise a


### PR DESCRIPTION
## Problem

`object_store`'s GCS credential provider emits `info!("fetching token from metadata server")` on every GCP token fetch (`object_store::gcp::credential`). With a GCS remote cache and heph's default `info` filter, that prints a token line per run / per token refresh — noise.

## Fix

Cap `object_store::gcp::credential` at `warn!` in the default `EnvFilter` in `src/log.rs`, mirroring the existing `fuser=error` treatment. Genuine auth failures (warn/error) still surface. `RUST_LOG=object_store::gcp::credential=info` restores the detail.

No heph code emits this message — it comes from the dependency — so a target-level filter directive is the correct lever.

🤖 Generated with [Claude Code](https://claude.com/claude-code)