### PR TITLE
feat(hook): Hook plugin kind + GitHub Actions hook; telemetry as builtin hook

### DIFF
--- a/.github/workflows/heph.yml
+++ b/.github/workflows/heph.yml
@@ -119,8 +119,10 @@ jobs:
           # explicitly, so no uniform suffix is needed.
           if [ "${{ matrix.os }}" = "darwin" ]; then ext=dylib; else ext=so; fi
           PLUGIN_GO_NAME="heph-go-plugin_${{ matrix.os }}_${{ matrix.arch }}.$ext"
+          PLUGIN_GHA_NAME="heph-gha-plugin_${{ matrix.os }}_${{ matrix.arch }}.$ext"
           echo "bin_name=$BIN_NAME" >> $GITHUB_OUTPUT
           echo "plugin_go_name=$PLUGIN_GO_NAME" >> $GITHUB_OUTPUT
+          echo "plugin_gha_name=$PLUGIN_GHA_NAME" >> $GITHUB_OUTPUT
           OUT="$CARGO_TARGET_DIR/${{ matrix.target }}/release"
           # FUSE (default feature) on Linux is pure-Rust (no libfuse link), so
           # zigbuild cross-compiles cleanly. On macOS it links libfuse via the
@@ -133,19 +135,25 @@ jobs:
           if [ "${{ matrix.os }}" = "darwin" ]; then
             cargo build --release --locked --target ${{ matrix.target }} -p heph --bin heph
             cargo build --release --locked --target ${{ matrix.target }} -p plugin-go-cdylib
+            cargo build --release --locked --target ${{ matrix.target }} -p plugin-gha-cdylib
             lib="$OUT/libplugin_go_cdylib.dylib"
+            gha_lib="$OUT/libplugin_gha_cdylib.dylib"
             # The nix toolchain hard-links libiconv against its /nix/store path,
             # which is absent on user machines (dyld aborts at launch). Rewrite
-            # those load commands to the OS /usr/lib copies — for both artifacts.
+            # those load commands to the OS /usr/lib copies — for every artifact.
             bash scripts/macos-portable.sh "$OUT/heph"
             bash scripts/macos-portable.sh "$lib"
+            bash scripts/macos-portable.sh "$gha_lib"
           else
             cargo zigbuild --release --locked --target ${{ matrix.target }} -p heph --bin heph
             cargo zigbuild --release --locked --target ${{ matrix.target }} -p plugin-go-cdylib
+            cargo zigbuild --release --locked --target ${{ matrix.target }} -p plugin-gha-cdylib
             lib="$OUT/libplugin_go_cdylib.so"
+            gha_lib="$OUT/libplugin_gha_cdylib.so"
           fi
           cp "$OUT/heph" $BIN_NAME
           cp "$lib" $PLUGIN_GO_NAME
+          cp "$gha_lib" $PLUGIN_GHA_NAME
 
       - name: sccache stats
         if: always()
@@ -172,6 +180,12 @@ jobs:
         with:
           name: ${{steps.build.outputs.plugin_go_name}}
           path: ${{steps.build.outputs.plugin_go_name}}
+
+      - name: Upload gha plugin artifact
+        uses: actions/upload-artifact@v6
+        with:
+          name: ${{steps.build.outputs.plugin_gha_name}}
+          path: ${{steps.build.outputs.plugin_gha_name}}
 
   upload_artifacts:
     name: Pre-release
@@ -218,6 +232,13 @@ jobs:
               -out "$GITHUB_WORKSPACE/dist/heph-go-plugin.json" )
           cat dist/heph-go-plugin.json
           echo "manifest checksum: $(cat dist/heph-go-plugin.json.sha256)"
+          # The gha hook plugin ships the same way: one manifest entry per
+          # per-os/arch cdylib in dist/, published as a release asset.
+          ( cd tools/pluginmanifest && go run . -name gha -version "$VERSION" \
+              -prefix heph-gha-plugin -from-dir "$GITHUB_WORKSPACE/dist" -url-base "$BASE" \
+              -out "$GITHUB_WORKSPACE/dist/heph-gha-plugin.json" )
+          cat dist/heph-gha-plugin.json
+          echo "manifest checksum: $(cat dist/heph-gha-plugin.json.sha256)"
 
       - name: Create Release in artifacts repo
         id: create_release

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3805,6 +3805,7 @@ dependencies = [
  "plugin",
  "serde_yaml",
  "tempfile",
+ "tracing",
 ]
 
 [[package]]
@@ -3816,6 +3817,7 @@ dependencies = [
  "plugin-gha",
  "plugin-sdk",
  "stabby",
+ "tracing",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3918,6 +3918,8 @@ dependencies = [
  "stabby",
  "tempfile",
  "tokio",
+ "tracing",
+ "tracing-subscriber",
 ]
 
 [[package]]
@@ -3937,6 +3939,7 @@ dependencies = [
  "serde_json",
  "stabby",
  "tokio",
+ "tracing",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3803,6 +3803,8 @@ dependencies = [
  "anyhow",
  "core",
  "plugin",
+ "reqwest 0.13.4",
+ "serde_json",
  "serde_yaml",
  "tempfile",
  "tracing",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3797,6 +3797,28 @@ dependencies = [
 ]
 
 [[package]]
+name = "plugin-gha"
+version = "0.1.0"
+dependencies = [
+ "anyhow",
+ "core",
+ "plugin",
+ "serde_yaml",
+ "tempfile",
+]
+
+[[package]]
+name = "plugin-gha-cdylib"
+version = "0.1.0"
+dependencies = [
+ "anyhow",
+ "plugin",
+ "plugin-gha",
+ "plugin-sdk",
+ "stabby",
+]
+
+[[package]]
 name = "plugin-go"
 version = "0.1.0"
 dependencies = [
@@ -3888,6 +3910,7 @@ dependencies = [
  "plugin-abi",
  "plugin-stabby",
  "prost 0.14.4",
+ "serde_json",
  "stabby",
  "tempfile",
  "tokio",
@@ -3907,7 +3930,9 @@ dependencies = [
  "plugin",
  "plugin-abi",
  "prost 0.14.4",
+ "serde_json",
  "stabby",
+ "tokio",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,7 +4,7 @@ version = "0.1.0"
 edition = "2024"
 
 [workspace]
-members = ["gen/proto", "crates/e2e", "crates/testkit", "crates/plugingo-e2e", "crates/htspec-derive", "crates/core", "crates/config", "crates/walk", "crates/proc", "crates/model", "crates/sandboxfuse", "crates/plugin", "crates/plugin-abi", "crates/plugin-stabby", "crates/plugin-sdk", "crates/plugin-go-cdylib", "crates/builtins", "crates/plugin-buildfile", "crates/driver-support", "crates/driver-bridge", "crates/plugin-exec", "crates/plugin-nix", "crates/plugin-query", "crates/plugin-go", "crates/telemetry", "crates/tui", "crates/lock", "crates/selfupdate", "crates/engine"]
+members = ["gen/proto", "crates/e2e", "crates/testkit", "crates/plugingo-e2e", "crates/htspec-derive", "crates/core", "crates/config", "crates/walk", "crates/proc", "crates/model", "crates/sandboxfuse", "crates/plugin", "crates/plugin-abi", "crates/plugin-stabby", "crates/plugin-sdk", "crates/plugin-go-cdylib", "crates/builtins", "crates/plugin-buildfile", "crates/driver-support", "crates/driver-bridge", "crates/plugin-exec", "crates/plugin-nix", "crates/plugin-query", "crates/plugin-go", "crates/plugin-gha", "crates/plugin-gha-cdylib", "crates/telemetry", "crates/tui", "crates/lock", "crates/selfupdate", "crates/engine"]
 
 [profile.profiling]
 inherits = "release"

--- a/crates/engine/src/engine/engine.rs
+++ b/crates/engine/src/engine/engine.rs
@@ -2,6 +2,7 @@ use crate::engine::config::Config;
 use crate::engine::config_yaml::{FuseConfig, Options};
 use crate::engine::driver::Driver as SDKDriver;
 use crate::engine::driver_managed::ManagedDriver as SDKManagedDriver;
+use crate::engine::hook::Hook as SDKHook;
 use crate::engine::local_cache::LocalCache;
 use crate::engine::local_cache_mem::LocalCacheMem;
 use crate::engine::local_cache_sqlite::LocalCacheSQLite;
@@ -74,6 +75,11 @@ pub struct Engine {
     pub providers_by_name: HashMap<String, Arc<Provider>>,
     pub(crate) drivers: Vec<Arc<Driver>>,
     pub drivers_by_name: HashMap<String, Arc<Driver>>,
+
+    /// Registered build-event hooks. Fed every emitted `BuildEvent` (see
+    /// `RequestState::emit`); unlike providers/drivers they are never queried,
+    /// only observed. Usually empty (a cheap no-op on the emit hot path).
+    pub(crate) hooks: Vec<Arc<dyn SDKHook>>,
 
     pub requests: Mutex<HashMap<String, Weak<RequestState>>>,
     pub home: PathBuf,
@@ -375,6 +381,7 @@ impl Engine {
             providers_by_name: HashMap::new(),
             drivers: vec![],
             drivers_by_name: HashMap::new(),
+            hooks: vec![],
             requests: Mutex::new(HashMap::new()),
             result_semaphore: Arc::new(Semaphore::new(max_workers)),
             max_workers,
@@ -593,6 +600,30 @@ impl Engine {
         self.providers_by_name
             .insert(provider.name.clone(), provider);
         Ok(())
+    }
+
+    /// Register a build-event hook. Hooks are observers — fed every emitted
+    /// `BuildEvent` and never queried — so they need no name-uniqueness guard
+    /// (two CI summary hooks would just both run). Loaded from out-of-process
+    /// plugins (see `plugin_load`).
+    pub fn register_hook(&mut self, hook: Arc<dyn SDKHook>) -> anyhow::Result<()> {
+        self.hooks.push(hook);
+        Ok(())
+    }
+
+    /// Snapshot of the registered hooks, cloned into a request's state so every
+    /// emitted event fans out to them. Empty unless a hook plugin is configured.
+    pub fn hooks(&self) -> Vec<Arc<dyn SDKHook>> {
+        self.hooks.clone()
+    }
+
+    /// Await every hook's in-flight delivery/flush. Called at command teardown,
+    /// after the request state (and thus its `on_close`) has dropped, so an
+    /// out-of-process hook's final write completes before the process exits.
+    pub async fn await_hooks(&self) {
+        for h in &self.hooks {
+            h.drain().await;
+        }
     }
 
     pub fn register_provider_factory(

--- a/crates/engine/src/engine/mod.rs
+++ b/crates/engine/src/engine/mod.rs
@@ -28,6 +28,7 @@ pub use cwd::get_cwp;
 // `crate::engine::driver::…` etc. resolve unchanged across engine + plugins.
 pub use hplugin::driver;
 pub use hplugin::error;
+pub use hplugin::hook;
 pub mod event;
 mod local_cache;
 mod local_cache_fs;

--- a/crates/engine/src/engine/plugin_load.rs
+++ b/crates/engine/src/engine/plugin_load.rs
@@ -98,12 +98,15 @@ fn load_dylib_plugins(
         .collect::<anyhow::Result<Vec<_>>>()?;
 
     // Engine mutation is single-threaded; register the loaded components in order.
-    for (provider, drivers) in loaded {
+    for (provider, drivers, hooks) in loaded {
         if let Some(p) = provider {
             e.register_provider(|_| Box::new(p))?;
         }
         for (_name, drv) in drivers {
             e.register_managed_driver(|_| Box::new(drv))?;
+        }
+        for (_name, hook) in hooks {
+            e.register_hook(std::sync::Arc::new(hook))?;
         }
     }
     Ok(())

--- a/crates/engine/src/engine/request_state.rs
+++ b/crates/engine/src/engine/request_state.rs
@@ -203,6 +203,13 @@ pub struct RequestStateData {
     /// `Arc<RequestStateData>`, so `with_parent` / `with_skip_provider` children
     /// inherit it for free.
     pub events: Option<crate::engine::event::EventSender>,
+    /// Build-event hooks registered on the engine, fanned out from [`emit`].
+    /// Cloned from `engine.hooks()` once per top-level request; shared via the
+    /// `Arc<RequestStateData>` so `with_parent`/`with_skip_provider` children
+    /// inherit them. Usually empty (a no-op slice walk on the emit hot path).
+    ///
+    /// [`emit`]: RequestState::emit
+    pub hooks: Vec<Arc<dyn crate::engine::hook::Hook>>,
     /// Guards the one-shot `MaxWorkers` announcement so it fires once per request
     /// regardless of which entry point (`result` / `result_addr`) is hit first.
     pub workers_announced: std::sync::atomic::AtomicBool,
@@ -318,18 +325,26 @@ impl RequestState {
 
     /// Stamp the server timestamp on `kind` and emit it on the event stream, if any.
     pub fn emit(&self, kind: crate::engine::event::BuildEventKind) {
-        // Fold into the process-global telemetry counters first: this is the
-        // single chokepoint every progress event flows through, so target/cache
-        // tallies stay in lockstep with what the renderer sees. Always counted
-        // (cheap atomics); the opt-out only gates whether the snapshot is sent.
-        htelemetry::telemetry::observe_event(&kind);
+        // Nobody downstream: skip building the event entirely (the common case
+        // for non-`run` commands with no renderer and no hooks). Usage telemetry
+        // is itself a registered hook (the built-in `TelemetryHook`, wired in
+        // `bootstrap` when enabled), so it rides the fan-out below rather than a
+        // dedicated call here — an opt-out leaves `hooks` empty and pays nothing.
+        if self.data.events.is_none() && self.data.hooks.is_empty() {
+            return;
+        }
+        let event = crate::engine::event::BuildEvent {
+            at_unix_ms: crate::engine::event::now_unix_ms(),
+            kind,
+        };
+        // Fan out to every registered hook (best-effort, sync push).
+        for hook in &self.data.hooks {
+            hook.on_event(&event);
+        }
         if let Some(tx) = &self.data.events {
             // A closed receiver (consumer gone) is expected; events are
             // best-effort, so dropping the send result is intentional.
-            drop(tx.send(crate::engine::event::BuildEvent {
-                at_unix_ms: crate::engine::event::now_unix_ms(),
-                kind,
-            }));
+            drop(tx.send(event));
         }
     }
 
@@ -441,6 +456,11 @@ impl RequestState {
 impl Drop for RequestStateData {
     fn drop(&mut self) {
         self.ctoken.cancel();
+        // Signal end-of-stream to each hook so it can flush its final state. The
+        // host awaits the actual flush separately via `Engine::await_hooks`.
+        for hook in &self.hooks {
+            hook.on_close();
+        }
         if let Some(engine) = self.engine.upgrade()
             && let Ok(mut requests) = engine.requests.lock()
         {
@@ -510,6 +530,7 @@ impl Engine {
             fail_fast,
             log_tail_lines,
             events,
+            hooks: self.hooks(),
             workers_announced: std::sync::atomic::AtomicBool::new(false),
             matched_announced: std::sync::atomic::AtomicBool::new(false),
             bg_pending,
@@ -742,6 +763,64 @@ mod tests {
             "child drop must not cancel parent token"
         );
 
+        Ok(())
+    }
+
+    // A registered hook is fed every emitted event (via the `emit` chokepoint,
+    // even with no renderer channel) and gets `on_close` when the request state
+    // drops.
+    #[test]
+    fn emit_fans_out_to_hooks_and_closes_on_drop() -> anyhow::Result<()> {
+        use crate::engine::hook::Hook;
+        use hcore::events::{BuildEvent, BuildEventKind};
+        use std::sync::atomic::{AtomicBool, Ordering};
+
+        #[derive(Default)]
+        struct Rec {
+            seen: Mutex<Vec<String>>,
+            closed: AtomicBool,
+        }
+        impl Hook for Rec {
+            fn name(&self) -> String {
+                "rec".into()
+            }
+            fn on_event(&self, ev: &BuildEvent) {
+                if let BuildEventKind::ResultStart { addr } = &ev.kind {
+                    self.seen.lock().push(addr.clone());
+                }
+            }
+            fn on_close(&self) {
+                self.closed.store(true, Ordering::Release);
+            }
+        }
+
+        let dir = tempfile::tempdir().expect("tempdir");
+        let mut e = Engine::new(Config {
+            root: dir.path().to_path_buf(),
+            home_dir: PathBuf::new(),
+            parallelism: None,
+            ..Default::default()
+        })?;
+        let rec = Arc::new(Rec::default());
+        e.register_hook(Arc::clone(&rec) as Arc<dyn Hook>)?;
+        let engine = Arc::new(e);
+
+        // No renderer channel (events = None); the hook still receives events.
+        let state = engine.new_state_with_events(true, None);
+        state.emit(BuildEventKind::ResultStart {
+            addr: "//a:b".into(),
+        });
+        assert_eq!(rec.seen.lock().clone(), vec!["//a:b".to_string()]);
+        assert!(
+            !rec.closed.load(Ordering::Acquire),
+            "not closed mid-request"
+        );
+
+        drop(state);
+        assert!(
+            rec.closed.load(Ordering::Acquire),
+            "on_close fires when the request state drops"
+        );
         Ok(())
     }
 }

--- a/crates/plugin-abi/src/lib.rs
+++ b/crates/plugin-abi/src/lib.rs
@@ -17,7 +17,11 @@ pub use hproto_gen::heph::plugin::v1 as pb;
 
 /// ABI semantic version. Major must match exactly between host and plugin;
 /// minor is negotiated to `min(host, plugin)` at handshake.
-pub const ABI_SEMVER: &str = "0.2.0";
+///
+/// 0.3.0: `PluginComponents` gained a `hooks` field (a layout change to the
+/// create-entry struct) for the Hook plugin kind — a hard break, so every plugin
+/// must be rebuilt against this ABI.
+pub const ABI_SEMVER: &str = "0.3.0";
 
 #[cfg(feature = "convert")]
 pub mod convert;

--- a/crates/plugin-gha-cdylib/Cargo.toml
+++ b/crates/plugin-gha-cdylib/Cargo.toml
@@ -1,0 +1,17 @@
+[package]
+name = "plugin-gha-cdylib"
+version = "0.1.0"
+edition = "2024"
+
+[lib]
+crate-type = ["cdylib"]
+
+[lints]
+workspace = true
+
+[dependencies]
+hplugin-gha = { package = "plugin-gha", path = "../plugin-gha" }
+hplugin = { package = "plugin", path = "../plugin" }
+plugin-sdk = { path = "../plugin-sdk", features = ["stabby"] }
+stabby = "72.1.8"
+anyhow = "1.0.102"

--- a/crates/plugin-gha-cdylib/Cargo.toml
+++ b/crates/plugin-gha-cdylib/Cargo.toml
@@ -15,3 +15,4 @@ hplugin = { package = "plugin", path = "../plugin" }
 plugin-sdk = { path = "../plugin-sdk", features = ["stabby"] }
 stabby = "72.1.8"
 anyhow = "1.0.102"
+tracing = "0.1"

--- a/crates/plugin-gha-cdylib/src/lib.rs
+++ b/crates/plugin-gha-cdylib/src/lib.rs
@@ -9,9 +9,7 @@ use std::sync::Arc;
 use hplugin::hook::Hook;
 use hplugin_gha::GhaHook;
 use plugin_sdk::stabby::abi::{NamedHook, PluginComponents};
-use plugin_sdk::stabby::{
-    create_config_from_bytes, make_dyn_hook, make_noop_provider, options_from_pb_map,
-};
+use plugin_sdk::stabby::{create_config_from_bytes, make_dyn_hook, options_from_pb_map};
 
 /// Stable ABI create entry. `#[stabby::export]` emits the type-report symbols the
 /// host's `get_stabbied` checks for ABI compatibility. `cfg` is prost-encoded
@@ -39,9 +37,9 @@ fn build(cfg: &[u8]) -> anyhow::Result<PluginComponents> {
     });
 
     Ok(PluginComponents {
-        // Hook-only: no provider (placeholder dropped by the host), no drivers.
+        // Hook-only: no provider, no drivers.
         provider_name: String::new().into(),
-        provider: make_noop_provider(),
+        provider: stabby::option::Option::None(),
         drivers: stabby::vec::Vec::new(),
         hooks,
         meta: stabby::vec::Vec::new(),

--- a/crates/plugin-gha-cdylib/src/lib.rs
+++ b/crates/plugin-gha-cdylib/src/lib.rs
@@ -8,8 +8,10 @@ use std::sync::Arc;
 
 use hplugin::hook::Hook;
 use hplugin_gha::GhaHook;
-use plugin_sdk::stabby::abi::{NamedHook, PluginComponents};
-use plugin_sdk::stabby::{create_config_from_bytes, make_dyn_hook, options_from_pb_map};
+use plugin_sdk::stabby::abi::{DynLogSink, NamedHook, PluginComponents};
+use plugin_sdk::stabby::{
+    create_config_from_bytes, install_log_sink, make_dyn_hook, options_from_pb_map,
+};
 
 /// Stable ABI create entry. `#[stabby::export]` emits the type-report symbols the
 /// host's `get_stabbied` checks for ABI compatibility. `cfg` is prost-encoded
@@ -23,6 +25,14 @@ pub extern "C" fn heph_plugin_create(cfg: stabby::vec::Vec<u8>) -> PluginCompone
             std::process::abort();
         }
     }
+}
+
+/// Stable ABI log-sink entry: the host calls this right after `create` to hand the
+/// plugin a sink for its `tracing` events. Without it, this cdylib's
+/// statically-linked `tracing` has no subscriber and the hook's logs vanish.
+#[stabby::export]
+pub extern "C" fn heph_plugin_set_log_sink(sink: DynLogSink) {
+    install_log_sink(sink);
 }
 
 fn build(cfg: &[u8]) -> anyhow::Result<PluginComponents> {

--- a/crates/plugin-gha-cdylib/src/lib.rs
+++ b/crates/plugin-gha-cdylib/src/lib.rs
@@ -1,0 +1,49 @@
+//! The GitHub Actions hook as a loadable cdylib behind the stable ABI.
+//!
+//! Exports a single stabby `create` entry that constructs the [`GhaHook`] and
+//! hands it back as an ABI-stable handle. A hook-only plugin: it carries no
+//! provider (a no-op placeholder the host drops) and no drivers.
+
+use std::sync::Arc;
+
+use hplugin::hook::Hook;
+use hplugin_gha::GhaHook;
+use plugin_sdk::stabby::abi::{NamedHook, PluginComponents};
+use plugin_sdk::stabby::{
+    create_config_from_bytes, make_dyn_hook, make_noop_provider, options_from_pb_map,
+};
+
+/// Stable ABI create entry. `#[stabby::export]` emits the type-report symbols the
+/// host's `get_stabbied` checks for ABI compatibility. `cfg` is prost-encoded
+/// `pb::CreateConfig` bytes.
+#[stabby::export]
+pub extern "C" fn heph_plugin_create(cfg: stabby::vec::Vec<u8>) -> PluginComponents {
+    match build(&cfg) {
+        Ok(c) => c,
+        Err(e) => {
+            eprintln!("heph-gha-plugin: plugin construction failed: {e:#}");
+            std::process::abort();
+        }
+    }
+}
+
+fn build(cfg: &[u8]) -> anyhow::Result<PluginComponents> {
+    let cfg = create_config_from_bytes(cfg)?;
+    let options = options_from_pb_map(cfg.options);
+    let hook: Arc<dyn Hook> = Arc::new(GhaHook::from_options(&options)?);
+
+    let mut hooks = stabby::vec::Vec::new();
+    hooks.push(NamedHook {
+        name: "gha".into(),
+        hook: make_dyn_hook(hook),
+    });
+
+    Ok(PluginComponents {
+        // Hook-only: no provider (placeholder dropped by the host), no drivers.
+        provider_name: String::new().into(),
+        provider: make_noop_provider(),
+        drivers: stabby::vec::Vec::new(),
+        hooks,
+        meta: stabby::vec::Vec::new(),
+    })
+}

--- a/crates/plugin-gha-cdylib/src/lib.rs
+++ b/crates/plugin-gha-cdylib/src/lib.rs
@@ -21,7 +21,7 @@ pub extern "C" fn heph_plugin_create(cfg: stabby::vec::Vec<u8>) -> PluginCompone
     match build(&cfg) {
         Ok(c) => c,
         Err(e) => {
-            eprintln!("heph-gha-plugin: plugin construction failed: {e:#}");
+            tracing::error!("heph-gha-plugin: plugin construction failed: {e:#}");
             std::process::abort();
         }
     }

--- a/crates/plugin-gha/Cargo.toml
+++ b/crates/plugin-gha/Cargo.toml
@@ -12,9 +12,9 @@ hplugin = { package = "plugin", path = "../plugin" }
 hcore = { package = "core", path = "../core" }
 anyhow = "1.0.102"
 tracing = "0.1"
-# Live check-run updates over the GitHub REST API. Blocking client (the hook runs
-# its updates on a plain thread, not an async runtime); rustls to match the other
-# crates' reqwest config.
+# Live sticky-PR-comment updates over the GitHub REST API. Blocking client (the
+# hook runs its updates on a plain thread, not an async runtime); rustls to match
+# the other crates' reqwest config.
 reqwest = { version = "0.13", default-features = false, features = ["blocking", "rustls", "json"] }
 serde_json = "1"
 

--- a/crates/plugin-gha/Cargo.toml
+++ b/crates/plugin-gha/Cargo.toml
@@ -12,6 +12,11 @@ hplugin = { package = "plugin", path = "../plugin" }
 hcore = { package = "core", path = "../core" }
 anyhow = "1.0.102"
 tracing = "0.1"
+# Live check-run updates over the GitHub REST API. Blocking client (the hook runs
+# its updates on a plain thread, not an async runtime); rustls to match the other
+# crates' reqwest config.
+reqwest = { version = "0.13", default-features = false, features = ["blocking", "rustls", "json"] }
+serde_json = "1"
 
 [dev-dependencies]
 tempfile = "3"

--- a/crates/plugin-gha/Cargo.toml
+++ b/crates/plugin-gha/Cargo.toml
@@ -1,0 +1,17 @@
+[package]
+name = "plugin-gha"
+version = "0.1.0"
+edition = "2024"
+
+[lints]
+workspace = true
+
+[dependencies]
+# The hook contract + option decoding — transport-agnostic, same as any plugin.
+hplugin = { package = "plugin", path = "../plugin" }
+hcore = { package = "core", path = "../core" }
+anyhow = "1.0.102"
+
+[dev-dependencies]
+tempfile = "3"
+serde_yaml = "0.9"

--- a/crates/plugin-gha/Cargo.toml
+++ b/crates/plugin-gha/Cargo.toml
@@ -11,6 +11,7 @@ workspace = true
 hplugin = { package = "plugin", path = "../plugin" }
 hcore = { package = "core", path = "../core" }
 anyhow = "1.0.102"
+tracing = "0.1"
 
 [dev-dependencies]
 tempfile = "3"

--- a/crates/plugin-gha/src/lib.rs
+++ b/crates/plugin-gha/src/lib.rs
@@ -277,9 +277,18 @@ impl ChecksClient {
     /// absent. The head sha is resolved by [`resolve_head_sha`] so a check on a PR
     /// lands on the PR head commit, not the merge commit — no workflow override
     /// needed. `head_sha_override` (the `headSha` option) still wins if set.
-    fn from_env(head_sha_override: Option<String>) -> Option<Self> {
+    ///
+    /// `token_env` names the env var the API token is read from (default
+    /// `GITHUB_TOKEN`). Point it at a **GitHub App** installation token (or a PAT)
+    /// to give the check run its own check suite — with the default `GITHUB_TOKEN`,
+    /// GitHub nests the API-created run under another workflow's github-actions
+    /// check suite (e.g. a labeler), which the check-runs API can't override.
+    fn from_env(head_sha_override: Option<String>, token_env: Option<String>) -> Option<Self> {
         let nonempty = |v: String| Some(v).filter(|s| !s.is_empty());
-        let token = std::env::var("GITHUB_TOKEN").ok().and_then(nonempty)?;
+        let token_var = token_env
+            .filter(|s| !s.is_empty())
+            .unwrap_or_else(|| "GITHUB_TOKEN".to_string());
+        let token = std::env::var(&token_var).ok().and_then(nonempty)?;
         let repo = std::env::var("GITHUB_REPOSITORY").ok().and_then(nonempty)?;
         let head_sha = head_sha_override
             .and_then(nonempty)
@@ -436,10 +445,17 @@ impl GhaHook {
     /// `refreshSecs` (live check-run PATCH interval, default 30), `summaryPath`
     /// (final step-summary file, default `$GITHUB_STEP_SUMMARY`), `headSha` (check
     /// run head sha; default is auto-resolved by [`resolve_head_sha`] — the PR head
-    /// on a `pull_request` event, else `$GITHUB_SHA`). Spawns the live-update thread
-    /// when a check run can be created.
+    /// on a `pull_request` event, else `$GITHUB_SHA`), `tokenEnv` (name of the env
+    /// var holding the API token, default `GITHUB_TOKEN`; point at a GitHub App /
+    /// PAT token so the check gets its own check suite instead of nesting under
+    /// another workflow's). Spawns the live-update thread when a check run can be
+    /// created.
     pub fn from_options(opts: &Options) -> anyhow::Result<Self> {
-        deny_unknown("gha hook", opts, &["refreshSecs", "summaryPath", "headSha"])?;
+        deny_unknown(
+            "gha hook",
+            opts,
+            &["refreshSecs", "summaryPath", "headSha", "tokenEnv"],
+        )?;
         tracing::info!("gha hook loaded");
         let refresh_secs: u64 = decode_opt(opts, "gha hook", "refreshSecs")?
             .unwrap_or(30)
@@ -454,7 +470,8 @@ impl GhaHook {
             );
         }
         let head_sha = decode_opt::<String>(opts, "gha hook", "headSha")?;
-        let checks = ChecksClient::from_env(head_sha);
+        let token_env = decode_opt::<String>(opts, "gha hook", "tokenEnv")?;
+        let checks = ChecksClient::from_env(head_sha, token_env);
         if checks.is_none() {
             tracing::info!(
                 "gha hook: GITHUB_TOKEN/GITHUB_REPOSITORY/GITHUB_SHA not all set; \

--- a/crates/plugin-gha/src/lib.rs
+++ b/crates/plugin-gha/src/lib.rs
@@ -189,8 +189,8 @@ impl GhaHook {
             .map(PathBuf::from)
             .or_else(|| std::env::var_os("GITHUB_STEP_SUMMARY").map(PathBuf::from));
         if summary_path.is_none() {
-            eprintln!(
-                "heph-gha-hook: neither `summaryPath` option nor $GITHUB_STEP_SUMMARY set; \
+            tracing::warn!(
+                "gha hook: neither `summaryPath` option nor $GITHUB_STEP_SUMMARY set; \
                  no summary will be written"
             );
         }

--- a/crates/plugin-gha/src/lib.rs
+++ b/crates/plugin-gha/src/lib.rs
@@ -3,10 +3,12 @@
 //! ways. Published out-of-process as a cdylib (see `plugin-gha-cdylib`) and
 //! enabled via a config `plugins:` entry.
 //!
-//! - **Live**, while the job runs: a dedicated GitHub **check run** whose markdown
-//!   `output` is PATCHed on a timer. A check run is the only Actions surface that
-//!   updates in real time — `$GITHUB_STEP_SUMMARY` is rendered by GitHub *only*
-//!   when the step ends, so it cannot show live progress.
+//! - **Live**, while the job runs: a **sticky PR comment** whose body is PATCHed on
+//!   a timer. `$GITHUB_STEP_SUMMARY` is rendered by GitHub *only* when the step
+//!   ends, so it can't show live progress; a comment can, works with the default
+//!   `GITHUB_TOKEN`, and (unlike a check run) never nests under another workflow's
+//!   check suite. One comment per job, reused across runs (found by a hidden marker)
+//!   so it's never spammed.
 //! - **At the end**: the full markdown is written once to `$GITHUB_STEP_SUMMARY`.
 //!
 //! The aggregation is intentionally self-contained (a small [`Tally`]) rather than
@@ -212,112 +214,99 @@ impl Tally {
     }
 }
 
-/// The default check-run name for an invocation: the heph command, suffixed with
-/// the Actions job id (`GITHUB_JOB`) when present so the same command in different
-/// jobs never collides into one check. Same command + same step is the only case
-/// that can still collide — set the `checkName` option there.
-fn default_check_name(command: &str, job: Option<String>) -> String {
-    let base = if command.is_empty() {
-        "heph".to_string()
-    } else {
-        format!("heph: {command}")
-    };
+/// Scopes the sticky comment to one per job: the Actions job id (`GITHUB_JOB`) when
+/// present, else the heph command (so local / non-Actions runs still get a stable
+/// key). A job keeps a single comment across all its steps.
+fn comment_key(command: &str, job: Option<String>) -> String {
     match job.filter(|s| !s.is_empty()) {
-        Some(job) => format!("{base} [{job}]"),
-        None => base,
+        Some(job) => job,
+        None if command.is_empty() => "heph".to_string(),
+        None => command.to_string(),
     }
 }
 
-/// The commit a check run should attach to. On a `pull_request` event `GITHUB_SHA`
-/// is the ephemeral *merge* commit (`refs/pull/N/merge`); a check attached there is
-/// invisible on the PR. The commit reviewers actually see is the PR **head**, which
-/// the event payload carries at `pull_request.head.sha`. So: on a PR event, read the
-/// event JSON (`GITHUB_EVENT_PATH`) and use that head sha; otherwise (push, etc.)
-/// fall back to `GITHUB_SHA`. This is why the workflow no longer needs to override
-/// `GITHUB_SHA` itself.
-fn resolve_head_sha() -> Option<String> {
-    let nonempty = |s: String| Some(s).filter(|s| !s.is_empty());
-    let event = std::env::var("GITHUB_EVENT_NAME").unwrap_or_default();
-    if (event == "pull_request" || event == "pull_request_target")
-        && let Some(sha) = pr_head_sha_from_event()
-    {
-        return Some(sha);
+/// Shared GitHub REST auth/version headers.
+fn gh_headers(token: &str) -> reqwest::header::HeaderMap {
+    use reqwest::header::{ACCEPT, AUTHORIZATION, HeaderMap, HeaderName, HeaderValue, USER_AGENT};
+    let mut h = HeaderMap::new();
+    if let Ok(v) = HeaderValue::from_str(&format!("Bearer {token}")) {
+        h.insert(AUTHORIZATION, v);
     }
-    std::env::var("GITHUB_SHA").ok().and_then(nonempty)
+    h.insert(
+        ACCEPT,
+        HeaderValue::from_static("application/vnd.github+json"),
+    );
+    h.insert(USER_AGENT, HeaderValue::from_static("heph"));
+    h.insert(
+        HeaderName::from_static("x-github-api-version"),
+        HeaderValue::from_static("2022-11-28"),
+    );
+    h
 }
 
-/// Read the Actions event payload (`GITHUB_EVENT_PATH`) and pull
-/// `pull_request.head.sha` out of it; `None` if unset / unreadable / absent.
-fn pr_head_sha_from_event() -> Option<String> {
-    let path = std::env::var("GITHUB_EVENT_PATH")
+/// The PR number for the current event, or `None` outside a PR. Prefers the event
+/// payload's `pull_request.number`, falling back to `GITHUB_REF`
+/// (`refs/pull/<N>/merge`).
+fn pr_number() -> Option<u64> {
+    if let Some(path) = std::env::var("GITHUB_EVENT_PATH")
         .ok()
-        .filter(|s| !s.is_empty())?;
-    let bytes = std::fs::read(path).ok()?;
-    pr_head_sha_from_json(&bytes)
-}
-
-/// Extract `pull_request.head.sha` from raw event-payload JSON. Pure (no env / fs)
-/// so it is unit-testable; `None` if the bytes don't parse or the field is missing.
-fn pr_head_sha_from_json(bytes: &[u8]) -> Option<String> {
-    let json: serde_json::Value = serde_json::from_slice(bytes).ok()?;
-    json.get("pull_request")?
-        .get("head")?
-        .get("sha")?
-        .as_str()
         .filter(|s| !s.is_empty())
-        .map(str::to_string)
+        && let Ok(bytes) = std::fs::read(path)
+        && let Some(n) = pr_number_from_json(&bytes)
+    {
+        return Some(n);
+    }
+    pr_number_from_ref(&std::env::var("GITHUB_REF").unwrap_or_default())
 }
 
-/// Live updates to a dedicated GitHub **check run**. A check run's markdown
-/// `output` can be PATCHed while the job runs (the step summary cannot), so this
-/// is the live surface. Configured from the Actions environment; disabled (with no
-/// network calls) if any of token / repo / head-sha is missing. All calls are
-/// best-effort — an API/network error is logged, never fatal.
-struct ChecksClient {
-    /// Built lazily on first use. The blocking client must not be constructed on a
-    /// thread inside a tokio runtime; building it here, on the off-runtime update
-    /// thread (or the `on_close` blocking thread), keeps that guaranteed regardless
-    /// of where the plugin was loaded.
+/// Extract `pull_request.number` from raw event-payload JSON. Pure (testable).
+fn pr_number_from_json(bytes: &[u8]) -> Option<u64> {
+    let json: serde_json::Value = serde_json::from_slice(bytes).ok()?;
+    json.get("pull_request")?.get("number")?.as_u64()
+}
+
+/// Parse the PR number out of a `refs/pull/<N>/merge` (or `/head`) ref. Pure.
+fn pr_number_from_ref(git_ref: &str) -> Option<u64> {
+    git_ref
+        .strip_prefix("refs/pull/")?
+        .split('/')
+        .next()?
+        .parse()
+        .ok()
+}
+
+/// Live updates to a **sticky PR comment**. Unlike a check run, an issue comment
+/// is never grouped under a workflow's check suite, so it works correctly with the
+/// default `GITHUB_TOKEN` (needs `pull-requests: write`). The comment is found-or-
+/// created once (matched by a hidden marker) and PATCHed in place afterwards, so
+/// repeated runs reuse the one comment instead of spamming new ones. One comment
+/// per `marker` key (the job, so a job keeps a single comment across its steps).
+struct CommentClient {
     http: std::sync::OnceLock<reqwest::blocking::Client>,
     api_url: String,
     repo: String,
     token: String,
-    head_sha: String,
-    /// The check run's unique GitHub identity. Each heph invocation (a separate
-    /// process — CI runs many across jobs/steps) must use a distinct name, else
-    /// same-name runs on the same head sha collapse to the latest and earlier
-    /// commands' results are lost. Derived from the command + job (or `checkName`).
-    name: String,
-    /// The check run id, assigned by the first (create) call, reused by PATCHes.
+    /// The PR to comment on.
+    pr: u64,
+    /// Hidden HTML marker (`<!-- heph-gha:<key> -->`) identifying *this* comment, so
+    /// the same job's comment is found and reused rather than duplicated.
+    marker: String,
+    /// The comment id, resolved (found-or-created) on first sync, reused after.
     id: Mutex<Option<u64>>,
 }
 
-impl ChecksClient {
-    /// Build from the Actions env (`GITHUB_TOKEN` / `GITHUB_REPOSITORY` /
-    /// `GITHUB_SHA`, `GITHUB_API_URL` optional), or `None` if a required piece is
-    /// absent. The head sha is resolved by [`resolve_head_sha`] so a check on a PR
-    /// lands on the PR head commit, not the merge commit — no workflow override
-    /// needed. `head_sha_override` (the `headSha` option) still wins if set.
-    ///
-    /// `token_env` names the env var the API token is read from (default
-    /// `GITHUB_TOKEN`). Point it at a **GitHub App** installation token (or a PAT)
-    /// to give the check run its own check suite — with the default `GITHUB_TOKEN`,
-    /// GitHub nests the API-created run under another workflow's github-actions
-    /// check suite (e.g. a labeler), which the check-runs API can't override.
-    fn from_env(
-        name: String,
-        head_sha_override: Option<String>,
-        token_env: Option<String>,
-    ) -> Option<Self> {
+impl CommentClient {
+    /// Build from the Actions env, or `None` outside a PR / without a token. `key`
+    /// scopes the sticky comment (the job id, so one comment per job). `token_env`
+    /// names the token var (default `GITHUB_TOKEN`).
+    fn from_env(key: &str, token_env: Option<String>) -> Option<Self> {
         let nonempty = |v: String| Some(v).filter(|s| !s.is_empty());
         let token_var = token_env
             .filter(|s| !s.is_empty())
             .unwrap_or_else(|| "GITHUB_TOKEN".to_string());
         let token = std::env::var(&token_var).ok().and_then(nonempty)?;
         let repo = std::env::var("GITHUB_REPOSITORY").ok().and_then(nonempty)?;
-        let head_sha = head_sha_override
-            .and_then(nonempty)
-            .or_else(resolve_head_sha)?;
+        let pr = pr_number()?;
         let api_url = std::env::var("GITHUB_API_URL")
             .ok()
             .and_then(nonempty)
@@ -327,8 +316,8 @@ impl ChecksClient {
             api_url,
             repo,
             token,
-            head_sha,
-            name,
+            pr,
+            marker: format!("<!-- heph-gha:{key} -->"),
             id: Mutex::new(None),
         })
     }
@@ -337,113 +326,118 @@ impl ChecksClient {
         self.http.get_or_init(reqwest::blocking::Client::new)
     }
 
-    fn headers(&self) -> reqwest::header::HeaderMap {
-        use reqwest::header::{
-            ACCEPT, AUTHORIZATION, HeaderMap, HeaderName, HeaderValue, USER_AGENT,
-        };
-        let mut h = HeaderMap::new();
-        if let Ok(v) = HeaderValue::from_str(&format!("Bearer {}", self.token)) {
-            h.insert(AUTHORIZATION, v);
+    /// Find an existing comment carrying our marker, returning its id. Pages through
+    /// the PR's comments (newest unlikely to matter; caps pages to bound work).
+    fn find_existing(&self) -> Option<u64> {
+        const MAX_PAGES: u32 = 10;
+        for page in 1..=MAX_PAGES {
+            let resp = self
+                .http()
+                .get(format!(
+                    "{}/repos/{}/issues/{}/comments?per_page=100&page={page}",
+                    self.api_url, self.repo, self.pr
+                ))
+                .headers(gh_headers(&self.token))
+                .send()
+                .and_then(|r| r.error_for_status())
+                .and_then(|r| r.json::<Vec<serde_json::Value>>());
+            let comments = match resp {
+                Ok(c) => c,
+                Err(e) => {
+                    tracing::warn!("listing PR comments failed: {e}");
+                    return None;
+                }
+            };
+            if comments.is_empty() {
+                break;
+            }
+            for c in &comments {
+                let body = c
+                    .get("body")
+                    .and_then(serde_json::Value::as_str)
+                    .unwrap_or("");
+                if body.contains(&self.marker)
+                    && let Some(cid) = c.get("id").and_then(serde_json::Value::as_u64)
+                {
+                    return Some(cid);
+                }
+            }
+            if comments.len() < 100 {
+                break;
+            }
         }
-        h.insert(
-            ACCEPT,
-            HeaderValue::from_static("application/vnd.github+json"),
-        );
-        h.insert(USER_AGENT, HeaderValue::from_static("heph"));
-        h.insert(
-            HeaderName::from_static("x-github-api-version"),
-            HeaderValue::from_static("2022-11-28"),
-        );
-        h
+        None
     }
 
-    /// Create the check run on the first call, PATCH it after. `completed` finalizes
-    /// it with a `success`/`failure` conclusion from `ok`.
-    fn sync(&self, title: String, summary: String, completed: bool, ok: bool) {
+    /// Create-or-update the sticky comment with `markdown`. The marker is prepended
+    /// (hidden) so the comment is re-findable across processes.
+    fn sync(&self, markdown: String) {
         let mut id = self.id.lock().unwrap_or_else(|e| e.into_inner());
-        let status = if completed {
-            "completed"
-        } else {
-            "in_progress"
-        };
-        let conclusion = completed.then_some(if ok { "success" } else { "failure" });
-        let output = serde_json::json!({ "title": title, "summary": summary });
-
-        // Build the request body via a map (avoids `Value` index assignment).
-        let mut body = serde_json::Map::new();
-        body.insert("status".into(), serde_json::json!(status));
-        body.insert("output".into(), output);
-        if let Some(c) = conclusion {
-            body.insert("conclusion".into(), serde_json::json!(c));
+        // First sync: adopt an existing comment (e.g. from an earlier step in this
+        // job) before deciding to create — that is what keeps it one-per-job.
+        if id.is_none() {
+            *id = self.find_existing();
         }
+        let body = format!("{}\n{markdown}", self.marker);
+        let mut payload = serde_json::Map::new();
+        payload.insert("body".into(), serde_json::json!(body));
 
         let result = match *id {
-            None => {
-                // Create: `name` + `head_sha` are required. `name` is per-invocation
-                // unique so concurrent heph commands don't clobber one another.
-                body.insert("name".into(), serde_json::json!(self.name));
-                body.insert("head_sha".into(), serde_json::json!(self.head_sha));
-                self.http()
-                    .post(format!("{}/repos/{}/check-runs", self.api_url, self.repo))
-                    .headers(self.headers())
-                    .json(&serde_json::Value::Object(body))
-                    .send()
-                    .and_then(|r| r.error_for_status())
-                    .and_then(|r| r.json::<serde_json::Value>())
-                    .map(|v| {
-                        if let Some(new_id) = v.get("id").and_then(serde_json::Value::as_u64) {
-                            *id = Some(new_id);
-                        }
-                        // Surface the deep-link to the check's output in the job log.
-                        if let Some(url) = v.get("html_url").and_then(serde_json::Value::as_str) {
-                            tracing::info!("check run {url}");
-                        }
-                    })
-            }
-            Some(rid) => self
+            Some(cid) => self
                 .http()
                 .patch(format!(
-                    "{}/repos/{}/check-runs/{rid}",
+                    "{}/repos/{}/issues/comments/{cid}",
                     self.api_url, self.repo
                 ))
-                .headers(self.headers())
-                .json(&serde_json::Value::Object(body))
+                .headers(gh_headers(&self.token))
+                .json(&serde_json::Value::Object(payload))
                 .send()
                 .and_then(|r| r.error_for_status())
                 .map(drop),
+            None => self
+                .http()
+                .post(format!(
+                    "{}/repos/{}/issues/{}/comments",
+                    self.api_url, self.repo, self.pr
+                ))
+                .headers(gh_headers(&self.token))
+                .json(&serde_json::Value::Object(payload))
+                .send()
+                .and_then(|r| r.error_for_status())
+                .and_then(|r| r.json::<serde_json::Value>())
+                .map(|v| {
+                    if let Some(new_id) = v.get("id").and_then(serde_json::Value::as_u64) {
+                        *id = Some(new_id);
+                    }
+                    if let Some(url) = v.get("html_url").and_then(serde_json::Value::as_str) {
+                        tracing::info!("status comment {url}");
+                    }
+                }),
         };
         if let Err(e) = result {
-            tracing::warn!("check-run update failed: {e}");
+            tracing::warn!("status-comment update failed: {e}");
         }
     }
 }
 
 struct Inner {
     tally: Mutex<Tally>,
-    /// Title for the check run + the summary H2: `heph: <command>`.
+    /// The summary H2 + comment heading: `heph: <command>`.
     title: String,
     /// Final step-summary path; `None` disables the end-of-run file write.
     summary_path: Option<PathBuf>,
-    /// Live check-run updater; `None` when not running under Actions (or no token).
-    checks: Option<ChecksClient>,
+    /// Live sticky-comment updater; `None` when not running under Actions (or no
+    /// token / not a PR).
+    comment: Option<CommentClient>,
     /// Set by `on_close` so the live-update thread exits.
     stop: AtomicBool,
 }
 
 impl Inner {
-    /// (title, full markdown) for the current tally.
-    fn render(&self) -> (String, String) {
+    /// The full status markdown for the current tally.
+    fn render_markdown(&self) -> String {
         let tally = self.tally.lock().unwrap_or_else(|e| e.into_inner());
-        let markdown = tally.render_markdown(now_unix_ms(), &self.title);
-        (self.title.clone(), markdown)
-    }
-
-    fn ok(&self) -> bool {
-        self.tally
-            .lock()
-            .unwrap_or_else(|e| e.into_inner())
-            .failed
-            .is_empty()
+        tally.render_markdown(now_unix_ms(), &self.title)
     }
 
     /// Write the full markdown to the step-summary file once, at the end of the
@@ -452,7 +446,7 @@ impl Inner {
         let Some(path) = &self.summary_path else {
             return;
         };
-        let (_, markdown) = self.render();
+        let markdown = self.render_markdown();
         let tmp = path.with_extension("heph-tmp");
         if std::fs::write(&tmp, markdown.as_bytes()).is_ok()
             && let Err(e) = std::fs::rename(&tmp, path)
@@ -469,27 +463,15 @@ pub struct GhaHook {
 
 impl GhaHook {
     /// Build from the plugin's `options:` map. Options (all optional):
-    /// `refreshSecs` (live check-run PATCH interval, default 30), `summaryPath`
-    /// (final step-summary file, default `$GITHUB_STEP_SUMMARY`), `headSha` (check
-    /// run head sha; default is auto-resolved by [`resolve_head_sha`] — the PR head
-    /// on a `pull_request` event, else `$GITHUB_SHA`), `tokenEnv` (name of the env
-    /// var holding the API token, default `GITHUB_TOKEN`; point at a GitHub App /
-    /// PAT token so the check gets its own check suite instead of nesting under
-    /// another workflow's), `checkName` (the check run's GitHub identity; default
-    /// is the heph command + job id, kept distinct per invocation so CI's many
-    /// heph commands don't overwrite one check). Spawns the live-update thread when
-    /// a check run can be created.
+    /// `refreshSecs` (live PR-comment PATCH interval, default 30), `summaryPath`
+    /// (final step-summary file, default `$GITHUB_STEP_SUMMARY`), `tokenEnv` (name
+    /// of the env var holding the API token, default `GITHUB_TOKEN`). Spawns the
+    /// live-update thread when a PR comment can be created.
     pub fn from_options(opts: &Options) -> anyhow::Result<Self> {
         deny_unknown(
             "gha hook",
             opts,
-            &[
-                "refreshSecs",
-                "summaryPath",
-                "headSha",
-                "tokenEnv",
-                "checkName",
-            ],
+            &["refreshSecs", "summaryPath", "tokenEnv"],
         )?;
         tracing::info!("gha hook loaded");
         let refresh_secs: u64 = decode_opt(opts, "gha hook", "refreshSecs")?
@@ -512,22 +494,15 @@ impl GhaHook {
         } else {
             format!("heph: {command}")
         };
-        // The check-run identity. CI runs many heph commands across jobs/steps, each
-        // a fresh process; a static name would make same-name runs collapse to the
-        // latest on the head sha. Derive a distinct name per invocation (or take the
-        // explicit `checkName`).
-        let check_name = match decode_opt::<String>(opts, "gha hook", "checkName")? {
-            Some(n) if !n.is_empty() => n,
-            _ => default_check_name(&command, std::env::var("GITHUB_JOB").ok()),
-        };
 
-        let head_sha = decode_opt::<String>(opts, "gha hook", "headSha")?;
         let token_env = decode_opt::<String>(opts, "gha hook", "tokenEnv")?;
-        let checks = ChecksClient::from_env(check_name, head_sha, token_env);
-        if checks.is_none() {
+        // One sticky PR comment per job (keyed by GITHUB_JOB, command as fallback).
+        let key = comment_key(&command, std::env::var("GITHUB_JOB").ok());
+        let comment = CommentClient::from_env(&key, token_env);
+        if comment.is_none() {
             tracing::info!(
-                "gha hook: GITHUB_TOKEN/GITHUB_REPOSITORY/GITHUB_SHA not all set; \
-                 live check-run updates disabled (step summary still written at end)"
+                "gha hook: GITHUB_TOKEN/GITHUB_REPOSITORY/PR not all set; \
+                 live status comment disabled (step summary still written at end)"
             );
         }
 
@@ -535,29 +510,27 @@ impl GhaHook {
             tally: Mutex::new(Tally::default()),
             title,
             summary_path,
-            checks,
+            comment,
             stop: AtomicBool::new(false),
         });
 
-        // Live updates run only when a check run is configured. A plain thread (no
+        // Live updates run only when a comment is configured. A plain thread (no
         // async runtime) keeps the hook free of runtime entanglement; it creates
-        // the check run up front so it appears at job start, then PATCHes it every
+        // the comment up front so it appears at job start, then PATCHes it every
         // `refreshSecs` until `on_close` sets `stop`.
-        if inner.checks.is_some() {
+        if inner.comment.is_some() {
             let t = Arc::clone(&inner);
             std::thread::spawn(move || {
-                let (title, summary) = t.render();
-                if let Some(c) = &t.checks {
-                    c.sync(title, summary, false, true);
+                if let Some(c) = &t.comment {
+                    c.sync(t.render_markdown());
                 }
                 while !t.stop.load(Ordering::Acquire) {
                     std::thread::sleep(Duration::from_secs(refresh_secs));
                     if t.stop.load(Ordering::Acquire) {
                         break;
                     }
-                    let (title, summary) = t.render();
-                    if let Some(c) = &t.checks {
-                        c.sync(title, summary, false, true);
+                    if let Some(c) = &t.comment {
+                        c.sync(t.render_markdown());
                     }
                 }
             });
@@ -581,13 +554,12 @@ impl Hook for GhaHook {
     }
 
     fn on_close(&self) {
-        // Stop the live-update thread, finalize the check run, then write the step
+        // Stop the live-update thread, write the final comment, then the step
         // summary once — all synchronously, so they complete before the plugin
         // acks the host (which is the host's drain barrier before process exit).
         self.inner.stop.store(true, Ordering::Release);
-        if let Some(c) = &self.inner.checks {
-            let (title, summary) = self.inner.render();
-            c.sync(title, summary, true, self.inner.ok());
+        if let Some(c) = &self.inner.comment {
+            c.sync(self.inner.render_markdown());
         }
         self.inner.write_summary();
     }
@@ -760,39 +732,29 @@ mod tests {
     }
 
     #[test]
-    fn check_name_distinct_per_command_and_job() {
-        // Command + job → unique even when two jobs run the same command.
+    fn comment_key_prefers_job_then_command() {
+        // Job id wins → one comment per job.
+        assert_eq!(comment_key("run //a:x", Some("test".into())), "test");
+        // No job → command keeps it stable (local / non-Actions).
+        assert_eq!(comment_key("run //a:x", None), "run //a:x");
+        // Empty job string treated as absent.
         assert_eq!(
-            default_check_name("run //a:x", Some("test".into())),
-            "heph: run //a:x [test]",
+            comment_key("query //...", Some(String::new())),
+            "query //..."
         );
-        // No job → bare command name.
-        assert_eq!(default_check_name("run //a:x", None), "heph: run //a:x");
-        // Empty job string is treated as absent.
-        assert_eq!(
-            default_check_name("query //...", Some(String::new())),
-            "heph: query //...",
-        );
-        // Empty command → still a stable fallback.
-        assert_eq!(default_check_name("", None), "heph");
+        // Empty command → stable fallback.
+        assert_eq!(comment_key("", None), "heph");
     }
 
     #[test]
-    fn pr_head_sha_extracted_from_event_json() {
-        // A trimmed `pull_request` event payload.
-        let payload = serde_json::json!({
-            "pull_request": { "head": { "sha": "deadbeefcafe" } }
-        })
-        .to_string();
-        assert_eq!(
-            pr_head_sha_from_json(payload.as_bytes()).as_deref(),
-            Some("deadbeefcafe"),
-        );
-        // Missing field / wrong shape → None (so it falls back to GITHUB_SHA).
-        assert_eq!(pr_head_sha_from_json(b"{}"), None);
-        assert_eq!(pr_head_sha_from_json(b"not json"), None);
-        let no_sha = serde_json::json!({ "pull_request": { "head": {} } }).to_string();
-        assert_eq!(pr_head_sha_from_json(no_sha.as_bytes()), None);
+    fn pr_number_extracted_from_event_and_ref() {
+        let payload = serde_json::json!({ "pull_request": { "number": 122 } }).to_string();
+        assert_eq!(pr_number_from_json(payload.as_bytes()), Some(122));
+        assert_eq!(pr_number_from_json(b"{}"), None);
+        // Ref fallback.
+        assert_eq!(pr_number_from_ref("refs/pull/122/merge"), Some(122));
+        assert_eq!(pr_number_from_ref("refs/pull/7/head"), Some(7));
+        assert_eq!(pr_number_from_ref("refs/heads/main"), None);
     }
 
     #[test]

--- a/crates/plugin-gha/src/lib.rs
+++ b/crates/plugin-gha/src/lib.rs
@@ -212,6 +212,46 @@ impl Tally {
     }
 }
 
+/// The commit a check run should attach to. On a `pull_request` event `GITHUB_SHA`
+/// is the ephemeral *merge* commit (`refs/pull/N/merge`); a check attached there is
+/// invisible on the PR. The commit reviewers actually see is the PR **head**, which
+/// the event payload carries at `pull_request.head.sha`. So: on a PR event, read the
+/// event JSON (`GITHUB_EVENT_PATH`) and use that head sha; otherwise (push, etc.)
+/// fall back to `GITHUB_SHA`. This is why the workflow no longer needs to override
+/// `GITHUB_SHA` itself.
+fn resolve_head_sha() -> Option<String> {
+    let nonempty = |s: String| Some(s).filter(|s| !s.is_empty());
+    let event = std::env::var("GITHUB_EVENT_NAME").unwrap_or_default();
+    if (event == "pull_request" || event == "pull_request_target")
+        && let Some(sha) = pr_head_sha_from_event()
+    {
+        return Some(sha);
+    }
+    std::env::var("GITHUB_SHA").ok().and_then(nonempty)
+}
+
+/// Read the Actions event payload (`GITHUB_EVENT_PATH`) and pull
+/// `pull_request.head.sha` out of it; `None` if unset / unreadable / absent.
+fn pr_head_sha_from_event() -> Option<String> {
+    let path = std::env::var("GITHUB_EVENT_PATH")
+        .ok()
+        .filter(|s| !s.is_empty())?;
+    let bytes = std::fs::read(path).ok()?;
+    pr_head_sha_from_json(&bytes)
+}
+
+/// Extract `pull_request.head.sha` from raw event-payload JSON. Pure (no env / fs)
+/// so it is unit-testable; `None` if the bytes don't parse or the field is missing.
+fn pr_head_sha_from_json(bytes: &[u8]) -> Option<String> {
+    let json: serde_json::Value = serde_json::from_slice(bytes).ok()?;
+    json.get("pull_request")?
+        .get("head")?
+        .get("sha")?
+        .as_str()
+        .filter(|s| !s.is_empty())
+        .map(str::to_string)
+}
+
 /// Live updates to a dedicated GitHub **check run**. A check run's markdown
 /// `output` can be PATCHed while the job runs (the step summary cannot), so this
 /// is the live surface. Configured from the Actions environment; disabled (with no
@@ -234,15 +274,16 @@ struct ChecksClient {
 impl ChecksClient {
     /// Build from the Actions env (`GITHUB_TOKEN` / `GITHUB_REPOSITORY` /
     /// `GITHUB_SHA`, `GITHUB_API_URL` optional), or `None` if a required piece is
-    /// absent. `head_sha_override` (the `headSha` option) wins over `GITHUB_SHA`
-    /// — useful to attach the check to a PR head rather than the merge commit.
+    /// absent. The head sha is resolved by [`resolve_head_sha`] so a check on a PR
+    /// lands on the PR head commit, not the merge commit — no workflow override
+    /// needed. `head_sha_override` (the `headSha` option) still wins if set.
     fn from_env(head_sha_override: Option<String>) -> Option<Self> {
         let nonempty = |v: String| Some(v).filter(|s| !s.is_empty());
         let token = std::env::var("GITHUB_TOKEN").ok().and_then(nonempty)?;
         let repo = std::env::var("GITHUB_REPOSITORY").ok().and_then(nonempty)?;
         let head_sha = head_sha_override
-            .or_else(|| std::env::var("GITHUB_SHA").ok())
-            .and_then(nonempty)?;
+            .and_then(nonempty)
+            .or_else(resolve_head_sha)?;
         let api_url = std::env::var("GITHUB_API_URL")
             .ok()
             .and_then(nonempty)
@@ -319,7 +360,7 @@ impl ChecksClient {
                         }
                         // Surface the deep-link to the check's output in the job log.
                         if let Some(url) = v.get("html_url").and_then(serde_json::Value::as_str) {
-                            tracing::info!("gha hook: check run {url}");
+                            tracing::info!("check run {url}");
                         }
                     })
             }
@@ -336,7 +377,7 @@ impl ChecksClient {
                 .map(drop),
         };
         if let Err(e) = result {
-            tracing::warn!("gha hook: check-run update failed: {e}");
+            tracing::warn!("check-run update failed: {e}");
         }
     }
 }
@@ -380,7 +421,7 @@ impl Inner {
         if std::fs::write(&tmp, markdown.as_bytes()).is_ok()
             && let Err(e) = std::fs::rename(&tmp, path)
         {
-            tracing::warn!("gha hook: failed to write step summary: {e}");
+            tracing::warn!("failed to write step summary: {e}");
         }
     }
 }
@@ -394,10 +435,12 @@ impl GhaHook {
     /// Build from the plugin's `options:` map. Options (all optional):
     /// `refreshSecs` (live check-run PATCH interval, default 30), `summaryPath`
     /// (final step-summary file, default `$GITHUB_STEP_SUMMARY`), `headSha` (check
-    /// run head sha, default `$GITHUB_SHA`). Spawns the live-update thread when a
-    /// check run can be created.
+    /// run head sha; default is auto-resolved by [`resolve_head_sha`] — the PR head
+    /// on a `pull_request` event, else `$GITHUB_SHA`). Spawns the live-update thread
+    /// when a check run can be created.
     pub fn from_options(opts: &Options) -> anyhow::Result<Self> {
         deny_unknown("gha hook", opts, &["refreshSecs", "summaryPath", "headSha"])?;
+        tracing::info!("gha hook loaded");
         let refresh_secs: u64 = decode_opt(opts, "gha hook", "refreshSecs")?
             .unwrap_or(30)
             .max(1);
@@ -654,6 +697,24 @@ mod tests {
             t.render_markdown(0, "heph: test").contains("~1"),
             "provisional total"
         );
+    }
+
+    #[test]
+    fn pr_head_sha_extracted_from_event_json() {
+        // A trimmed `pull_request` event payload.
+        let payload = serde_json::json!({
+            "pull_request": { "head": { "sha": "deadbeefcafe" } }
+        })
+        .to_string();
+        assert_eq!(
+            pr_head_sha_from_json(payload.as_bytes()).as_deref(),
+            Some("deadbeefcafe"),
+        );
+        // Missing field / wrong shape → None (so it falls back to GITHUB_SHA).
+        assert_eq!(pr_head_sha_from_json(b"{}"), None);
+        assert_eq!(pr_head_sha_from_json(b"not json"), None);
+        let no_sha = serde_json::json!({ "pull_request": { "head": {} } }).to_string();
+        assert_eq!(pr_head_sha_from_json(no_sha.as_bytes()), None);
     }
 
     #[test]

--- a/crates/plugin-gha/src/lib.rs
+++ b/crates/plugin-gha/src/lib.rs
@@ -22,6 +22,13 @@ use hplugin::hook::Hook;
 /// section of the summary.
 const SLOW_THRESHOLD_MS: u64 = 10_000;
 
+/// `$GITHUB_STEP_SUMMARY` is capped at 1 MiB by GitHub. The header is tiny and
+/// fixed; the only unbounded sections are the slow + failed lists, so they are
+/// truncated to the slowest / first N (with a "…and X more" line) to keep every
+/// snapshot well under the limit.
+const MAX_SLOW_ROWS: usize = 20;
+const MAX_FAILED_ROWS: usize = 50;
+
 /// The folded build status. Only what the summary renders: matched/finished sets
 /// for progress, cache-hit + built counts, the failure list, and the in-flight
 /// execute start times for slow detection.
@@ -99,7 +106,8 @@ impl Tally {
                 (elapsed >= SLOW_THRESHOLD_MS).then(|| (addr.clone(), elapsed))
             })
             .collect();
-        slow.sort_by(|a, b| b.1.cmp(&a.1));
+        // Slowest first.
+        slow.sort_by_key(|(_, elapsed)| std::cmp::Reverse(*elapsed));
         slow
     }
 
@@ -123,14 +131,17 @@ impl Tally {
         let slow = self.slow(now_ms);
         if !slow.is_empty() {
             out.push_str("\n### Slow targets\n\n| target | running for |\n| --- | --- |\n");
-            for (addr, elapsed) in slow {
+            for (addr, elapsed) in slow.iter().take(MAX_SLOW_ROWS) {
                 out.push_str(&format!("| `{addr}` | {}s |\n", elapsed / 1000));
+            }
+            if slow.len() > MAX_SLOW_ROWS {
+                out.push_str(&format!("\n…and {} more\n", slow.len() - MAX_SLOW_ROWS));
             }
         }
 
         if !self.failed.is_empty() {
             out.push_str("\n### Failed\n\n");
-            for (addr, err) in &self.failed {
+            for (addr, err) in self.failed.iter().take(MAX_FAILED_ROWS) {
                 match err {
                     Some(e) => out.push_str(&format!(
                         "- `{addr}` — {}\n",
@@ -138,6 +149,12 @@ impl Tally {
                     )),
                     None => out.push_str(&format!("- `{addr}`\n")),
                 }
+            }
+            if self.failed.len() > MAX_FAILED_ROWS {
+                out.push_str(&format!(
+                    "\n…and {} more\n",
+                    self.failed.len() - MAX_FAILED_ROWS
+                ));
             }
         }
         out
@@ -161,11 +178,15 @@ impl Inner {
             let tally = self.tally.lock().unwrap_or_else(|e| e.into_inner());
             tally.render_markdown(now_unix_ms())
         };
-        // Atomic: write a temp sibling then rename, so a reader never sees a
-        // half-written summary.
+        // Each write fully RESETS the file (write a temp sibling, then rename over
+        // the target): the summary always shows only the latest snapshot, never an
+        // append of every refresh. Atomic so a reader never sees a half-written
+        // file.
         let tmp = path.with_extension("heph-tmp");
-        if std::fs::write(&tmp, markdown.as_bytes()).is_ok() {
-            let _ = std::fs::rename(&tmp, path);
+        if std::fs::write(&tmp, markdown.as_bytes()).is_ok()
+            && let Err(e) = std::fs::rename(&tmp, path)
+        {
+            tracing::warn!("gha hook: failed to write step summary: {e}");
         }
     }
 }
@@ -335,6 +356,26 @@ mod tests {
             md.contains("//a:w") && md.contains("boom"),
             "failure detail: {md}"
         );
+    }
+
+    #[test]
+    fn slow_list_capped_to_top_n() {
+        let mut t = Tally::default();
+        // Many concurrent long-running targets; the slowest started earliest.
+        for i in 0..(MAX_SLOW_ROWS + 5) {
+            t.apply(&ev(
+                i as u64,
+                BuildEventKind::ExecuteStart {
+                    addr: format!("//a:t{i}"),
+                    driver: "exec".into(),
+                    cache: false,
+                },
+            ));
+        }
+        let md = t.render_markdown(1_000_000);
+        let rows = md.matches("| `//a:t").count();
+        assert_eq!(rows, MAX_SLOW_ROWS, "slow rows capped: {rows}");
+        assert!(md.contains("…and 5 more"), "overflow line: {md}");
     }
 
     #[test]

--- a/crates/plugin-gha/src/lib.rs
+++ b/crates/plugin-gha/src/lib.rs
@@ -29,9 +29,31 @@ const SLOW_THRESHOLD_MS: u64 = 10_000;
 const MAX_SLOW_ROWS: usize = 20;
 const MAX_FAILED_ROWS: usize = 50;
 
+/// One long-running phase a target can currently be in. A target is slow because
+/// of a *single* active phase (it executes, or pulls from cache, or writes cache —
+/// not several at once), so the summary names which one.
+#[derive(Clone, Copy)]
+enum Phase {
+    Execute,
+    CachePull,
+    LocalCacheWrite,
+    RemoteCacheWrite,
+}
+
+impl Phase {
+    fn label(self) -> &'static str {
+        match self {
+            Phase::Execute => "execute",
+            Phase::CachePull => "cache pull",
+            Phase::LocalCacheWrite => "cache write",
+            Phase::RemoteCacheWrite => "remote cache write",
+        }
+    }
+}
+
 /// The folded build status. Only what the summary renders: matched/finished sets
 /// for progress, cache-hit + built counts, the failure list, and the in-flight
-/// execute start times for slow detection.
+/// active phase per target for slow detection.
 #[derive(Default)]
 struct Tally {
     matched: BTreeSet<String>,
@@ -40,9 +62,10 @@ struct Tally {
     built: usize,
     cache_hit: BTreeSet<String>,
     failed: Vec<(String, Option<String>)>,
-    /// addr -> `ExecuteStart` timestamp; removed on `ExecuteEnd`. The remaining
-    /// entries are the currently-running targets.
-    running: BTreeMap<String, u64>,
+    /// addr -> (active phase, its start timestamp). Set on a phase `*Start`,
+    /// cleared on the matching `*End`; the remaining entries are the targets
+    /// currently inside a phase (one phase each).
+    running: BTreeMap<String, (Phase, u64)>,
 }
 
 impl Tally {
@@ -63,13 +86,31 @@ impl Tally {
                 }
             }
             BuildEventKind::ExecuteStart { addr, .. } => {
-                self.running.insert(addr.clone(), ev.at_unix_ms);
+                self.running
+                    .insert(addr.clone(), (Phase::Execute, ev.at_unix_ms));
             }
             BuildEventKind::ExecuteEnd { addr, error } => {
                 self.running.remove(addr);
                 if error.is_none() {
                     self.built += 1;
                 }
+            }
+            BuildEventKind::RemoteCacheReadStart { addr } => {
+                self.running
+                    .insert(addr.clone(), (Phase::CachePull, ev.at_unix_ms));
+            }
+            BuildEventKind::LocalCacheWriteStart { addr } => {
+                self.running
+                    .insert(addr.clone(), (Phase::LocalCacheWrite, ev.at_unix_ms));
+            }
+            BuildEventKind::RemoteCacheWriteStart { addr } => {
+                self.running
+                    .insert(addr.clone(), (Phase::RemoteCacheWrite, ev.at_unix_ms));
+            }
+            BuildEventKind::RemoteCacheReadEnd { addr, .. }
+            | BuildEventKind::LocalCacheWriteEnd { addr, .. }
+            | BuildEventKind::RemoteCacheWriteEnd { addr, .. } => {
+                self.running.remove(addr);
             }
             BuildEventKind::LocalCacheHit { addr } | BuildEventKind::RemoteCacheHit { addr } => {
                 self.cache_hit.insert(addr.clone());
@@ -96,18 +137,19 @@ impl Tally {
             .count()
     }
 
-    /// Targets still executing past [`SLOW_THRESHOLD_MS`], slowest first.
-    fn slow(&self, now_ms: u64) -> Vec<(String, u64)> {
-        let mut slow: Vec<(String, u64)> = self
+    /// Targets stuck in a single phase past [`SLOW_THRESHOLD_MS`], slowest first.
+    /// Each carries the phase label so the summary shows *what* is slow.
+    fn slow(&self, now_ms: u64) -> Vec<(String, &'static str, u64)> {
+        let mut slow: Vec<(String, &'static str, u64)> = self
             .running
             .iter()
-            .filter_map(|(addr, start)| {
+            .filter_map(|(addr, (phase, start))| {
                 let elapsed = now_ms.saturating_sub(*start);
-                (elapsed >= SLOW_THRESHOLD_MS).then(|| (addr.clone(), elapsed))
+                (elapsed >= SLOW_THRESHOLD_MS).then(|| (addr.clone(), phase.label(), elapsed))
             })
             .collect();
         // Slowest first.
-        slow.sort_by_key(|(_, elapsed)| std::cmp::Reverse(*elapsed));
+        slow.sort_by_key(|(_, _, elapsed)| std::cmp::Reverse(*elapsed));
         slow
     }
 
@@ -130,9 +172,11 @@ impl Tally {
 
         let slow = self.slow(now_ms);
         if !slow.is_empty() {
-            out.push_str("\n### Slow targets\n\n| target | running for |\n| --- | --- |\n");
-            for (addr, elapsed) in slow.iter().take(MAX_SLOW_ROWS) {
-                out.push_str(&format!("| `{addr}` | {}s |\n", elapsed / 1000));
+            out.push_str(
+                "\n### Slow targets\n\n| target | phase | running for |\n| --- | --- | --- |\n",
+            );
+            for (addr, phase, elapsed) in slow.iter().take(MAX_SLOW_ROWS) {
+                out.push_str(&format!("| `{addr}` | {phase} | {}s |\n", elapsed / 1000));
             }
             if slow.len() > MAX_SLOW_ROWS {
                 out.push_str(&format!("\n…and {} more\n", slow.len() - MAX_SLOW_ROWS));
@@ -355,6 +399,36 @@ mod tests {
         assert!(
             md.contains("//a:w") && md.contains("boom"),
             "failure detail: {md}"
+        );
+    }
+
+    #[test]
+    fn slow_target_names_its_active_phase() {
+        let mut t = Tally::default();
+        // Stuck pulling from the remote cache (not executing).
+        t.apply(&ev(
+            0,
+            BuildEventKind::RemoteCacheReadStart {
+                addr: "//a:p".into(),
+            },
+        ));
+        let md = t.render_markdown(SLOW_THRESHOLD_MS + 1);
+        assert!(md.contains("//a:p"), "slow target listed: {md}");
+        assert!(md.contains("cache pull"), "phase labelled: {md}");
+        assert!(md.contains("| phase |"), "phase column header: {md}");
+
+        // Its end clears it — no longer slow.
+        t.apply(&ev(
+            0,
+            BuildEventKind::RemoteCacheReadEnd {
+                addr: "//a:p".into(),
+                error: None,
+            },
+        ));
+        assert!(
+            !t.render_markdown(SLOW_THRESHOLD_MS + 1)
+                .contains("### Slow"),
+            "cleared on phase end"
         );
     }
 

--- a/crates/plugin-gha/src/lib.rs
+++ b/crates/plugin-gha/src/lib.rs
@@ -162,6 +162,19 @@ impl Tally {
         slow
     }
 
+    /// A status emoji for the CLI invocation, derived from the tally: ❌ if anything
+    /// failed, ✅ once every matched target is done, otherwise ⏳ (still running).
+    fn status_emoji(&self) -> &'static str {
+        let (done, total) = self.progress();
+        if !self.failed.is_empty() {
+            "❌"
+        } else if self.matched_complete && done == total {
+            "✅"
+        } else {
+            "⏳"
+        }
+    }
+
     /// Render the GitHub-Actions markdown for the current tally. `heading` is the
     /// H2 title (the heph command being run).
     fn render_markdown(&self, now_ms: u64, heading: &str) -> String {
@@ -172,7 +185,8 @@ impl Tally {
             format!("~{total}")
         };
         let mut out = String::new();
-        out.push_str(&format!("## {heading}\n\n"));
+        // Heading leads with the invocation status emoji.
+        out.push_str(&format!("## {} {heading}\n\n", self.status_emoji()));
         out.push_str(&format!(
             "**Targets:** {done} / {total_str} &nbsp;•&nbsp; **built:** {} &nbsp;•&nbsp; **cached:** {} &nbsp;•&nbsp; **failed:** {}\n",
             self.built,
@@ -182,15 +196,19 @@ impl Tally {
 
         let slow = self.slow(now_ms);
         if !slow.is_empty() {
-            out.push_str(
-                "\n### Slow targets\n\n| target | phase | running for |\n| --- | --- | --- |\n",
-            );
+            // Collapsible: slow targets are noise most of the time, expanded on demand.
+            // The blank line after </summary> is required for the table to render.
+            out.push_str(&format!(
+                "\n<details><summary>🐢 Slow targets ({})</summary>\n\n| target | phase | running for |\n| --- | --- | --- |\n",
+                slow.len(),
+            ));
             for (addr, phase, elapsed) in slow.iter().take(MAX_SLOW_ROWS) {
                 out.push_str(&format!("| `{addr}` | {phase} | {}s |\n", elapsed / 1000));
             }
             if slow.len() > MAX_SLOW_ROWS {
                 out.push_str(&format!("\n…and {} more\n", slow.len() - MAX_SLOW_ROWS));
             }
+            out.push_str("</details>\n");
         }
 
         if !self.failed.is_empty() {
@@ -741,15 +759,19 @@ mod tests {
         // now far enough past //a:z's start to mark it slow.
         let md = t.render_markdown(SLOW_THRESHOLD_MS + 5_000, "heph: test");
 
-        // The H2 is the heph command.
-        assert!(md.contains("## heph: test"), "command heading: {md}");
+        // The H2 is the heph command, led by a status emoji (❌ — there's a failure).
+        assert!(md.contains("## ❌ heph: test"), "command heading: {md}");
         // 2 of 3 matched finished (x, y); w finished but isn't in the matched set.
         assert!(md.contains("2 / 3"), "progress: {md}");
         assert!(md.contains("**built:** 1"), "built: {md}");
         assert!(md.contains("**cached:** 1"), "cached: {md}");
         assert!(md.contains("**failed:** 1"), "failed: {md}");
-        // //a:z is still running past the threshold.
-        assert!(md.contains("### Slow targets"), "slow section: {md}");
+        // //a:z is still running past the threshold — in the collapsible.
+        assert!(
+            md.contains("<details><summary>🐢 Slow targets (1)</summary>"),
+            "slow collapsible: {md}"
+        );
+        assert!(md.contains("</details>"), "collapsible closed: {md}");
         assert!(md.contains("//a:z"), "slow target listed: {md}");
         // failure surfaced with its message.
         assert!(md.contains("### Failed"), "failed section: {md}");
@@ -757,6 +779,44 @@ mod tests {
             md.contains("//a:w") && md.contains("boom"),
             "failure detail: {md}"
         );
+    }
+
+    #[test]
+    fn status_emoji_tracks_invocation_outcome() {
+        let mut t = Tally::default();
+        t.apply(&ev(
+            0,
+            BuildEventKind::Matched {
+                addrs: vec!["//a:x".into()],
+                complete: true,
+            },
+        ));
+        // Matched but nothing finished → running.
+        assert_eq!(t.status_emoji(), "⏳");
+        assert!(
+            t.render_markdown(0, "heph: test")
+                .contains("## ⏳ heph: test")
+        );
+
+        // All matched finished, no failure → success.
+        t.apply(&ev(
+            1,
+            BuildEventKind::ResultEnd {
+                addr: "//a:x".into(),
+                error: None,
+            },
+        ));
+        assert_eq!(t.status_emoji(), "✅");
+
+        // A failure flips it to failed regardless of progress.
+        t.apply(&ev(
+            2,
+            BuildEventKind::ResultEnd {
+                addr: "//a:x".into(),
+                error: Some("boom".into()),
+            },
+        ));
+        assert_eq!(t.status_emoji(), "❌");
     }
 
     #[test]

--- a/crates/plugin-gha/src/lib.rs
+++ b/crates/plugin-gha/src/lib.rs
@@ -1,7 +1,13 @@
 //! A GitHub Actions hook: folds the engine's build-event stream into a status
-//! tally and periodically rewrites the job's `$GITHUB_STEP_SUMMARY` markdown
-//! (done/total, built, cached, failed, slow targets). Published out-of-process as
-//! a cdylib (see `plugin-gha-cdylib`) and enabled via a config `plugins:` entry.
+//! tally (done/total, built, cached, failed, slow targets) and surfaces it two
+//! ways. Published out-of-process as a cdylib (see `plugin-gha-cdylib`) and
+//! enabled via a config `plugins:` entry.
+//!
+//! - **Live**, while the job runs: a dedicated GitHub **check run** whose markdown
+//!   `output` is PATCHed on a timer. A check run is the only Actions surface that
+//!   updates in real time — `$GITHUB_STEP_SUMMARY` is rendered by GitHub *only*
+//!   when the step ends, so it cannot show live progress.
+//! - **At the end**: the full markdown is written once to `$GITHUB_STEP_SUMMARY`.
 //!
 //! The aggregation is intentionally self-contained (a small [`Tally`]) rather than
 //! reusing the TUI's `BuildState`: the renderer's aggregator is coupled to ratatui
@@ -153,8 +159,9 @@ impl Tally {
         slow
     }
 
-    /// Render the GitHub-Actions step-summary markdown for the current tally.
-    fn render_markdown(&self, now_ms: u64) -> String {
+    /// Render the GitHub-Actions markdown for the current tally. `heading` is the
+    /// H2 title (the heph command being run).
+    fn render_markdown(&self, now_ms: u64, heading: &str) -> String {
         let (done, total) = self.progress();
         let total_str = if self.matched_complete {
             total.to_string()
@@ -162,7 +169,7 @@ impl Tally {
             format!("~{total}")
         };
         let mut out = String::new();
-        out.push_str("## heph build\n\n");
+        out.push_str(&format!("## {heading}\n\n"));
         out.push_str(&format!(
             "**Targets:** {done} / {total_str} &nbsp;•&nbsp; **built:** {} &nbsp;•&nbsp; **cached:** {} &nbsp;•&nbsp; **failed:** {}\n",
             self.built,
@@ -205,27 +212,166 @@ impl Tally {
     }
 }
 
+/// Live updates to a dedicated GitHub **check run**. A check run's markdown
+/// `output` can be PATCHed while the job runs (the step summary cannot), so this
+/// is the live surface. Configured from the Actions environment; disabled (with no
+/// network calls) if any of token / repo / head-sha is missing. All calls are
+/// best-effort — an API/network error is logged, never fatal.
+struct ChecksClient {
+    /// Built lazily on first use. The blocking client must not be constructed on a
+    /// thread inside a tokio runtime; building it here, on the off-runtime update
+    /// thread (or the `on_close` blocking thread), keeps that guaranteed regardless
+    /// of where the plugin was loaded.
+    http: std::sync::OnceLock<reqwest::blocking::Client>,
+    api_url: String,
+    repo: String,
+    token: String,
+    head_sha: String,
+    /// The check run id, assigned by the first (create) call, reused by PATCHes.
+    id: Mutex<Option<u64>>,
+}
+
+impl ChecksClient {
+    /// Build from the Actions env (`GITHUB_TOKEN` / `GITHUB_REPOSITORY` /
+    /// `GITHUB_SHA`, `GITHUB_API_URL` optional), or `None` if a required piece is
+    /// absent. `head_sha_override` (the `headSha` option) wins over `GITHUB_SHA`
+    /// — useful to attach the check to a PR head rather than the merge commit.
+    fn from_env(head_sha_override: Option<String>) -> Option<Self> {
+        let nonempty = |v: String| Some(v).filter(|s| !s.is_empty());
+        let token = std::env::var("GITHUB_TOKEN").ok().and_then(nonempty)?;
+        let repo = std::env::var("GITHUB_REPOSITORY").ok().and_then(nonempty)?;
+        let head_sha = head_sha_override
+            .or_else(|| std::env::var("GITHUB_SHA").ok())
+            .and_then(nonempty)?;
+        let api_url = std::env::var("GITHUB_API_URL")
+            .ok()
+            .and_then(nonempty)
+            .unwrap_or_else(|| "https://api.github.com".to_string());
+        Some(Self {
+            http: std::sync::OnceLock::new(),
+            api_url,
+            repo,
+            token,
+            head_sha,
+            id: Mutex::new(None),
+        })
+    }
+
+    fn http(&self) -> &reqwest::blocking::Client {
+        self.http.get_or_init(reqwest::blocking::Client::new)
+    }
+
+    fn headers(&self) -> reqwest::header::HeaderMap {
+        use reqwest::header::{
+            ACCEPT, AUTHORIZATION, HeaderMap, HeaderName, HeaderValue, USER_AGENT,
+        };
+        let mut h = HeaderMap::new();
+        if let Ok(v) = HeaderValue::from_str(&format!("Bearer {}", self.token)) {
+            h.insert(AUTHORIZATION, v);
+        }
+        h.insert(
+            ACCEPT,
+            HeaderValue::from_static("application/vnd.github+json"),
+        );
+        h.insert(USER_AGENT, HeaderValue::from_static("heph"));
+        h.insert(
+            HeaderName::from_static("x-github-api-version"),
+            HeaderValue::from_static("2022-11-28"),
+        );
+        h
+    }
+
+    /// Create the check run on the first call, PATCH it after. `completed` finalizes
+    /// it with a `success`/`failure` conclusion from `ok`.
+    fn sync(&self, title: String, summary: String, completed: bool, ok: bool) {
+        let mut id = self.id.lock().unwrap_or_else(|e| e.into_inner());
+        let status = if completed {
+            "completed"
+        } else {
+            "in_progress"
+        };
+        let conclusion = completed.then_some(if ok { "success" } else { "failure" });
+        let output = serde_json::json!({ "title": title, "summary": summary });
+
+        // Build the request body via a map (avoids `Value` index assignment).
+        let mut body = serde_json::Map::new();
+        body.insert("status".into(), serde_json::json!(status));
+        body.insert("output".into(), output);
+        if let Some(c) = conclusion {
+            body.insert("conclusion".into(), serde_json::json!(c));
+        }
+
+        let result = match *id {
+            None => {
+                // Create: `name` + `head_sha` are required.
+                body.insert("name".into(), serde_json::json!("heph build"));
+                body.insert("head_sha".into(), serde_json::json!(self.head_sha));
+                self.http()
+                    .post(format!("{}/repos/{}/check-runs", self.api_url, self.repo))
+                    .headers(self.headers())
+                    .json(&serde_json::Value::Object(body))
+                    .send()
+                    .and_then(|r| r.error_for_status())
+                    .and_then(|r| r.json::<serde_json::Value>())
+                    .map(|v| {
+                        if let Some(new_id) = v.get("id").and_then(serde_json::Value::as_u64) {
+                            *id = Some(new_id);
+                        }
+                    })
+            }
+            Some(rid) => self
+                .http()
+                .patch(format!(
+                    "{}/repos/{}/check-runs/{rid}",
+                    self.api_url, self.repo
+                ))
+                .headers(self.headers())
+                .json(&serde_json::Value::Object(body))
+                .send()
+                .and_then(|r| r.error_for_status())
+                .map(drop),
+        };
+        if let Err(e) = result {
+            tracing::warn!("gha hook: check-run update failed: {e}");
+        }
+    }
+}
+
 struct Inner {
     tally: Mutex<Tally>,
-    /// Where to write the summary; `None` disables writing (warned once at build).
+    /// Title for the check run + the summary H2: `heph: <command>`.
+    title: String,
+    /// Final step-summary path; `None` disables the end-of-run file write.
     summary_path: Option<PathBuf>,
-    /// Set by `on_close` so the periodic writer thread exits.
+    /// Live check-run updater; `None` when not running under Actions (or no token).
+    checks: Option<ChecksClient>,
+    /// Set by `on_close` so the live-update thread exits.
     stop: AtomicBool,
 }
 
 impl Inner {
+    /// (title, full markdown) for the current tally.
+    fn render(&self) -> (String, String) {
+        let tally = self.tally.lock().unwrap_or_else(|e| e.into_inner());
+        let markdown = tally.render_markdown(now_unix_ms(), &self.title);
+        (self.title.clone(), markdown)
+    }
+
+    fn ok(&self) -> bool {
+        self.tally
+            .lock()
+            .unwrap_or_else(|e| e.into_inner())
+            .failed
+            .is_empty()
+    }
+
+    /// Write the full markdown to the step-summary file once, at the end of the
+    /// run. Atomic (temp + rename) so a reader never sees a half-written file.
     fn write_summary(&self) {
         let Some(path) = &self.summary_path else {
             return;
         };
-        let markdown = {
-            let tally = self.tally.lock().unwrap_or_else(|e| e.into_inner());
-            tally.render_markdown(now_unix_ms())
-        };
-        // Each write fully RESETS the file (write a temp sibling, then rename over
-        // the target): the summary always shows only the latest snapshot, never an
-        // append of every refresh. Atomic so a reader never sees a half-written
-        // file.
+        let (_, markdown) = self.render();
         let tmp = path.with_extension("heph-tmp");
         if std::fs::write(&tmp, markdown.as_bytes()).is_ok()
             && let Err(e) = std::fs::rename(&tmp, path)
@@ -241,12 +387,13 @@ pub struct GhaHook {
 }
 
 impl GhaHook {
-    /// Build from the plugin's `options:` map. Reads `refreshSecs` (default 30)
-    /// and an optional `summaryPath` override; absent the override it targets
-    /// `$GITHUB_STEP_SUMMARY`. Spawns a background thread that rewrites the
-    /// summary every `refreshSecs` until [`Hook::on_close`].
+    /// Build from the plugin's `options:` map. Options (all optional):
+    /// `refreshSecs` (live check-run PATCH interval, default 30), `summaryPath`
+    /// (final step-summary file, default `$GITHUB_STEP_SUMMARY`), `headSha` (check
+    /// run head sha, default `$GITHUB_SHA`). Spawns the live-update thread when a
+    /// check run can be created.
     pub fn from_options(opts: &Options) -> anyhow::Result<Self> {
-        deny_unknown("gha hook", opts, &["refreshSecs", "summaryPath"])?;
+        deny_unknown("gha hook", opts, &["refreshSecs", "summaryPath", "headSha"])?;
         let refresh_secs: u64 = decode_opt(opts, "gha hook", "refreshSecs")?
             .unwrap_or(30)
             .max(1);
@@ -256,28 +403,58 @@ impl GhaHook {
         if summary_path.is_none() {
             tracing::warn!(
                 "gha hook: neither `summaryPath` option nor $GITHUB_STEP_SUMMARY set; \
-                 no summary will be written"
+                 no step summary will be written"
+            );
+        }
+        let head_sha = decode_opt::<String>(opts, "gha hook", "headSha")?;
+        let checks = ChecksClient::from_env(head_sha);
+        if checks.is_none() {
+            tracing::info!(
+                "gha hook: GITHUB_TOKEN/GITHUB_REPOSITORY/GITHUB_SHA not all set; \
+                 live check-run updates disabled (step summary still written at end)"
             );
         }
 
+        // The plugin shares the heph process, so its args ARE the heph command:
+        // skip the binary (argv[0]) and join the rest, e.g. `run //foo:bar`.
+        let command = std::env::args().skip(1).collect::<Vec<_>>().join(" ");
+        let title = if command.is_empty() {
+            "heph".to_string()
+        } else {
+            format!("heph: {command}")
+        };
+
         let inner = Arc::new(Inner {
             tally: Mutex::new(Tally::default()),
+            title,
             summary_path,
+            checks,
             stop: AtomicBool::new(false),
         });
 
-        // Periodic writer. A plain thread (no async runtime) keeps the hook free
-        // of runtime entanglement; it exits once `stop` is set by `on_close`.
-        let t = Arc::clone(&inner);
-        std::thread::spawn(move || {
-            while !t.stop.load(Ordering::Acquire) {
-                std::thread::sleep(Duration::from_secs(refresh_secs));
-                if t.stop.load(Ordering::Acquire) {
-                    break;
+        // Live updates run only when a check run is configured. A plain thread (no
+        // async runtime) keeps the hook free of runtime entanglement; it creates
+        // the check run up front so it appears at job start, then PATCHes it every
+        // `refreshSecs` until `on_close` sets `stop`.
+        if inner.checks.is_some() {
+            let t = Arc::clone(&inner);
+            std::thread::spawn(move || {
+                let (title, summary) = t.render();
+                if let Some(c) = &t.checks {
+                    c.sync(title, summary, false, true);
                 }
-                t.write_summary();
-            }
-        });
+                while !t.stop.load(Ordering::Acquire) {
+                    std::thread::sleep(Duration::from_secs(refresh_secs));
+                    if t.stop.load(Ordering::Acquire) {
+                        break;
+                    }
+                    let (title, summary) = t.render();
+                    if let Some(c) = &t.checks {
+                        c.sync(title, summary, false, true);
+                    }
+                }
+            });
+        }
 
         Ok(Self { inner })
     }
@@ -297,9 +474,14 @@ impl Hook for GhaHook {
     }
 
     fn on_close(&self) {
-        // Stop the periodic writer and flush the final summary synchronously, so
-        // the completed status is written before the plugin acks the host.
+        // Stop the live-update thread, finalize the check run, then write the step
+        // summary once — all synchronously, so they complete before the plugin
+        // acks the host (which is the host's drain barrier before process exit).
         self.inner.stop.store(true, Ordering::Release);
+        if let Some(c) = &self.inner.checks {
+            let (title, summary) = self.inner.render();
+            c.sync(title, summary, true, self.inner.ok());
+        }
         self.inner.write_summary();
     }
 }
@@ -384,8 +566,10 @@ mod tests {
     fn markdown_reports_counts_slow_and_failures() {
         let t = scripted();
         // now far enough past //a:z's start to mark it slow.
-        let md = t.render_markdown(SLOW_THRESHOLD_MS + 5_000);
+        let md = t.render_markdown(SLOW_THRESHOLD_MS + 5_000, "heph: test");
 
+        // The H2 is the heph command.
+        assert!(md.contains("## heph: test"), "command heading: {md}");
         // 2 of 3 matched finished (x, y); w finished but isn't in the matched set.
         assert!(md.contains("2 / 3"), "progress: {md}");
         assert!(md.contains("**built:** 1"), "built: {md}");
@@ -412,7 +596,7 @@ mod tests {
                 addr: "//a:p".into(),
             },
         ));
-        let md = t.render_markdown(SLOW_THRESHOLD_MS + 1);
+        let md = t.render_markdown(SLOW_THRESHOLD_MS + 1, "heph: test");
         assert!(md.contains("//a:p"), "slow target listed: {md}");
         assert!(md.contains("cache pull"), "phase labelled: {md}");
         assert!(md.contains("| phase |"), "phase column header: {md}");
@@ -426,7 +610,7 @@ mod tests {
             },
         ));
         assert!(
-            !t.render_markdown(SLOW_THRESHOLD_MS + 1)
+            !t.render_markdown(SLOW_THRESHOLD_MS + 1, "heph: test")
                 .contains("### Slow"),
             "cleared on phase end"
         );
@@ -446,7 +630,7 @@ mod tests {
                 },
             ));
         }
-        let md = t.render_markdown(1_000_000);
+        let md = t.render_markdown(1_000_000, "heph: test");
         let rows = md.matches("| `//a:t").count();
         assert_eq!(rows, MAX_SLOW_ROWS, "slow rows capped: {rows}");
         assert!(md.contains("…and 5 more"), "overflow line: {md}");
@@ -462,7 +646,10 @@ mod tests {
                 complete: false,
             },
         ));
-        assert!(t.render_markdown(0).contains("~1"), "provisional total");
+        assert!(
+            t.render_markdown(0, "heph: test").contains("~1"),
+            "provisional total"
+        );
     }
 
     #[test]

--- a/crates/plugin-gha/src/lib.rs
+++ b/crates/plugin-gha/src/lib.rs
@@ -212,6 +212,22 @@ impl Tally {
     }
 }
 
+/// The default check-run name for an invocation: the heph command, suffixed with
+/// the Actions job id (`GITHUB_JOB`) when present so the same command in different
+/// jobs never collides into one check. Same command + same step is the only case
+/// that can still collide — set the `checkName` option there.
+fn default_check_name(command: &str, job: Option<String>) -> String {
+    let base = if command.is_empty() {
+        "heph".to_string()
+    } else {
+        format!("heph: {command}")
+    };
+    match job.filter(|s| !s.is_empty()) {
+        Some(job) => format!("{base} [{job}]"),
+        None => base,
+    }
+}
+
 /// The commit a check run should attach to. On a `pull_request` event `GITHUB_SHA`
 /// is the ephemeral *merge* commit (`refs/pull/N/merge`); a check attached there is
 /// invisible on the PR. The commit reviewers actually see is the PR **head**, which
@@ -267,6 +283,11 @@ struct ChecksClient {
     repo: String,
     token: String,
     head_sha: String,
+    /// The check run's unique GitHub identity. Each heph invocation (a separate
+    /// process — CI runs many across jobs/steps) must use a distinct name, else
+    /// same-name runs on the same head sha collapse to the latest and earlier
+    /// commands' results are lost. Derived from the command + job (or `checkName`).
+    name: String,
     /// The check run id, assigned by the first (create) call, reused by PATCHes.
     id: Mutex<Option<u64>>,
 }
@@ -283,7 +304,11 @@ impl ChecksClient {
     /// to give the check run its own check suite — with the default `GITHUB_TOKEN`,
     /// GitHub nests the API-created run under another workflow's github-actions
     /// check suite (e.g. a labeler), which the check-runs API can't override.
-    fn from_env(head_sha_override: Option<String>, token_env: Option<String>) -> Option<Self> {
+    fn from_env(
+        name: String,
+        head_sha_override: Option<String>,
+        token_env: Option<String>,
+    ) -> Option<Self> {
         let nonempty = |v: String| Some(v).filter(|s| !s.is_empty());
         let token_var = token_env
             .filter(|s| !s.is_empty())
@@ -303,6 +328,7 @@ impl ChecksClient {
             repo,
             token,
             head_sha,
+            name,
             id: Mutex::new(None),
         })
     }
@@ -353,8 +379,9 @@ impl ChecksClient {
 
         let result = match *id {
             None => {
-                // Create: `name` + `head_sha` are required.
-                body.insert("name".into(), serde_json::json!("heph build"));
+                // Create: `name` + `head_sha` are required. `name` is per-invocation
+                // unique so concurrent heph commands don't clobber one another.
+                body.insert("name".into(), serde_json::json!(self.name));
                 body.insert("head_sha".into(), serde_json::json!(self.head_sha));
                 self.http()
                     .post(format!("{}/repos/{}/check-runs", self.api_url, self.repo))
@@ -448,13 +475,21 @@ impl GhaHook {
     /// on a `pull_request` event, else `$GITHUB_SHA`), `tokenEnv` (name of the env
     /// var holding the API token, default `GITHUB_TOKEN`; point at a GitHub App /
     /// PAT token so the check gets its own check suite instead of nesting under
-    /// another workflow's). Spawns the live-update thread when a check run can be
-    /// created.
+    /// another workflow's), `checkName` (the check run's GitHub identity; default
+    /// is the heph command + job id, kept distinct per invocation so CI's many
+    /// heph commands don't overwrite one check). Spawns the live-update thread when
+    /// a check run can be created.
     pub fn from_options(opts: &Options) -> anyhow::Result<Self> {
         deny_unknown(
             "gha hook",
             opts,
-            &["refreshSecs", "summaryPath", "headSha", "tokenEnv"],
+            &[
+                "refreshSecs",
+                "summaryPath",
+                "headSha",
+                "tokenEnv",
+                "checkName",
+            ],
         )?;
         tracing::info!("gha hook loaded");
         let refresh_secs: u64 = decode_opt(opts, "gha hook", "refreshSecs")?
@@ -469,16 +504,6 @@ impl GhaHook {
                  no step summary will be written"
             );
         }
-        let head_sha = decode_opt::<String>(opts, "gha hook", "headSha")?;
-        let token_env = decode_opt::<String>(opts, "gha hook", "tokenEnv")?;
-        let checks = ChecksClient::from_env(head_sha, token_env);
-        if checks.is_none() {
-            tracing::info!(
-                "gha hook: GITHUB_TOKEN/GITHUB_REPOSITORY/GITHUB_SHA not all set; \
-                 live check-run updates disabled (step summary still written at end)"
-            );
-        }
-
         // The plugin shares the heph process, so its args ARE the heph command:
         // skip the binary (argv[0]) and join the rest, e.g. `run //foo:bar`.
         let command = std::env::args().skip(1).collect::<Vec<_>>().join(" ");
@@ -487,6 +512,24 @@ impl GhaHook {
         } else {
             format!("heph: {command}")
         };
+        // The check-run identity. CI runs many heph commands across jobs/steps, each
+        // a fresh process; a static name would make same-name runs collapse to the
+        // latest on the head sha. Derive a distinct name per invocation (or take the
+        // explicit `checkName`).
+        let check_name = match decode_opt::<String>(opts, "gha hook", "checkName")? {
+            Some(n) if !n.is_empty() => n,
+            _ => default_check_name(&command, std::env::var("GITHUB_JOB").ok()),
+        };
+
+        let head_sha = decode_opt::<String>(opts, "gha hook", "headSha")?;
+        let token_env = decode_opt::<String>(opts, "gha hook", "tokenEnv")?;
+        let checks = ChecksClient::from_env(check_name, head_sha, token_env);
+        if checks.is_none() {
+            tracing::info!(
+                "gha hook: GITHUB_TOKEN/GITHUB_REPOSITORY/GITHUB_SHA not all set; \
+                 live check-run updates disabled (step summary still written at end)"
+            );
+        }
 
         let inner = Arc::new(Inner {
             tally: Mutex::new(Tally::default()),
@@ -714,6 +757,24 @@ mod tests {
             t.render_markdown(0, "heph: test").contains("~1"),
             "provisional total"
         );
+    }
+
+    #[test]
+    fn check_name_distinct_per_command_and_job() {
+        // Command + job → unique even when two jobs run the same command.
+        assert_eq!(
+            default_check_name("run //a:x", Some("test".into())),
+            "heph: run //a:x [test]",
+        );
+        // No job → bare command name.
+        assert_eq!(default_check_name("run //a:x", None), "heph: run //a:x");
+        // Empty job string is treated as absent.
+        assert_eq!(
+            default_check_name("query //...", Some(String::new())),
+            "heph: query //...",
+        );
+        // Empty command → still a stable fallback.
+        assert_eq!(default_check_name("", None), "heph");
     }
 
     #[test]

--- a/crates/plugin-gha/src/lib.rs
+++ b/crates/plugin-gha/src/lib.rs
@@ -1,0 +1,383 @@
+//! A GitHub Actions hook: folds the engine's build-event stream into a status
+//! tally and periodically rewrites the job's `$GITHUB_STEP_SUMMARY` markdown
+//! (done/total, built, cached, failed, slow targets). Published out-of-process as
+//! a cdylib (see `plugin-gha-cdylib`) and enabled via a config `plugins:` entry.
+//!
+//! The aggregation is intentionally self-contained (a small [`Tally`]) rather than
+//! reusing the TUI's `BuildState`: the renderer's aggregator is coupled to ratatui
+//! and lives in the (terminal) `tui` crate, and a hook only needs a handful of
+//! counts plus the in-flight set for slow detection.
+
+use std::collections::{BTreeMap, BTreeSet};
+use std::path::PathBuf;
+use std::sync::atomic::{AtomicBool, Ordering};
+use std::sync::{Arc, Mutex};
+use std::time::Duration;
+
+use hcore::events::{BuildEvent, BuildEventKind, now_unix_ms};
+use hplugin::config::{Options, decode_opt, deny_unknown};
+use hplugin::hook::Hook;
+
+/// A target executing longer than this (ms) is surfaced in the "slow targets"
+/// section of the summary.
+const SLOW_THRESHOLD_MS: u64 = 10_000;
+
+/// The folded build status. Only what the summary renders: matched/finished sets
+/// for progress, cache-hit + built counts, the failure list, and the in-flight
+/// execute start times for slow detection.
+#[derive(Default)]
+struct Tally {
+    matched: BTreeSet<String>,
+    matched_complete: bool,
+    finished: BTreeSet<String>,
+    built: usize,
+    cache_hit: BTreeSet<String>,
+    failed: Vec<(String, Option<String>)>,
+    /// addr -> `ExecuteStart` timestamp; removed on `ExecuteEnd`. The remaining
+    /// entries are the currently-running targets.
+    running: BTreeMap<String, u64>,
+}
+
+impl Tally {
+    fn apply(&mut self, ev: &BuildEvent) {
+        match &ev.kind {
+            BuildEventKind::Matched { addrs, complete } => {
+                for a in addrs {
+                    self.matched.insert(a.clone());
+                }
+                if *complete {
+                    self.matched_complete = true;
+                }
+            }
+            BuildEventKind::ResultEnd { addr, error } => {
+                self.finished.insert(addr.clone());
+                if let Some(e) = error {
+                    self.failed.push((addr.clone(), Some(e.clone())));
+                }
+            }
+            BuildEventKind::ExecuteStart { addr, .. } => {
+                self.running.insert(addr.clone(), ev.at_unix_ms);
+            }
+            BuildEventKind::ExecuteEnd { addr, error } => {
+                self.running.remove(addr);
+                if error.is_none() {
+                    self.built += 1;
+                }
+            }
+            BuildEventKind::LocalCacheHit { addr } | BuildEventKind::RemoteCacheHit { addr } => {
+                self.cache_hit.insert(addr.clone());
+            }
+            _ => {}
+        }
+    }
+
+    /// `(done, total)` over the matched top-level set: done = matched targets that
+    /// have finished. `total` is provisional until the matcher resolves.
+    fn progress(&self) -> (usize, usize) {
+        let done = self
+            .matched
+            .iter()
+            .filter(|a| self.finished.contains(*a))
+            .count();
+        (done, self.matched.len())
+    }
+
+    fn cached_count(&self) -> usize {
+        self.matched
+            .iter()
+            .filter(|a| self.cache_hit.contains(*a))
+            .count()
+    }
+
+    /// Targets still executing past [`SLOW_THRESHOLD_MS`], slowest first.
+    fn slow(&self, now_ms: u64) -> Vec<(String, u64)> {
+        let mut slow: Vec<(String, u64)> = self
+            .running
+            .iter()
+            .filter_map(|(addr, start)| {
+                let elapsed = now_ms.saturating_sub(*start);
+                (elapsed >= SLOW_THRESHOLD_MS).then(|| (addr.clone(), elapsed))
+            })
+            .collect();
+        slow.sort_by(|a, b| b.1.cmp(&a.1));
+        slow
+    }
+
+    /// Render the GitHub-Actions step-summary markdown for the current tally.
+    fn render_markdown(&self, now_ms: u64) -> String {
+        let (done, total) = self.progress();
+        let total_str = if self.matched_complete {
+            total.to_string()
+        } else {
+            format!("~{total}")
+        };
+        let mut out = String::new();
+        out.push_str("## heph build\n\n");
+        out.push_str(&format!(
+            "**Targets:** {done} / {total_str} &nbsp;•&nbsp; **built:** {} &nbsp;•&nbsp; **cached:** {} &nbsp;•&nbsp; **failed:** {}\n",
+            self.built,
+            self.cached_count(),
+            self.failed.len(),
+        ));
+
+        let slow = self.slow(now_ms);
+        if !slow.is_empty() {
+            out.push_str("\n### Slow targets\n\n| target | running for |\n| --- | --- |\n");
+            for (addr, elapsed) in slow {
+                out.push_str(&format!("| `{addr}` | {}s |\n", elapsed / 1000));
+            }
+        }
+
+        if !self.failed.is_empty() {
+            out.push_str("\n### Failed\n\n");
+            for (addr, err) in &self.failed {
+                match err {
+                    Some(e) => out.push_str(&format!(
+                        "- `{addr}` — {}\n",
+                        e.lines().next().unwrap_or("")
+                    )),
+                    None => out.push_str(&format!("- `{addr}`\n")),
+                }
+            }
+        }
+        out
+    }
+}
+
+struct Inner {
+    tally: Mutex<Tally>,
+    /// Where to write the summary; `None` disables writing (warned once at build).
+    summary_path: Option<PathBuf>,
+    /// Set by `on_close` so the periodic writer thread exits.
+    stop: AtomicBool,
+}
+
+impl Inner {
+    fn write_summary(&self) {
+        let Some(path) = &self.summary_path else {
+            return;
+        };
+        let markdown = {
+            let tally = self.tally.lock().unwrap_or_else(|e| e.into_inner());
+            tally.render_markdown(now_unix_ms())
+        };
+        // Atomic: write a temp sibling then rename, so a reader never sees a
+        // half-written summary.
+        let tmp = path.with_extension("heph-tmp");
+        if std::fs::write(&tmp, markdown.as_bytes()).is_ok() {
+            let _ = std::fs::rename(&tmp, path);
+        }
+    }
+}
+
+/// The GitHub Actions build-status hook.
+pub struct GhaHook {
+    inner: Arc<Inner>,
+}
+
+impl GhaHook {
+    /// Build from the plugin's `options:` map. Reads `refreshSecs` (default 30)
+    /// and an optional `summaryPath` override; absent the override it targets
+    /// `$GITHUB_STEP_SUMMARY`. Spawns a background thread that rewrites the
+    /// summary every `refreshSecs` until [`Hook::on_close`].
+    pub fn from_options(opts: &Options) -> anyhow::Result<Self> {
+        deny_unknown("gha hook", opts, &["refreshSecs", "summaryPath"])?;
+        let refresh_secs: u64 = decode_opt(opts, "gha hook", "refreshSecs")?
+            .unwrap_or(30)
+            .max(1);
+        let summary_path = decode_opt::<String>(opts, "gha hook", "summaryPath")?
+            .map(PathBuf::from)
+            .or_else(|| std::env::var_os("GITHUB_STEP_SUMMARY").map(PathBuf::from));
+        if summary_path.is_none() {
+            eprintln!(
+                "heph-gha-hook: neither `summaryPath` option nor $GITHUB_STEP_SUMMARY set; \
+                 no summary will be written"
+            );
+        }
+
+        let inner = Arc::new(Inner {
+            tally: Mutex::new(Tally::default()),
+            summary_path,
+            stop: AtomicBool::new(false),
+        });
+
+        // Periodic writer. A plain thread (no async runtime) keeps the hook free
+        // of runtime entanglement; it exits once `stop` is set by `on_close`.
+        let t = Arc::clone(&inner);
+        std::thread::spawn(move || {
+            while !t.stop.load(Ordering::Acquire) {
+                std::thread::sleep(Duration::from_secs(refresh_secs));
+                if t.stop.load(Ordering::Acquire) {
+                    break;
+                }
+                t.write_summary();
+            }
+        });
+
+        Ok(Self { inner })
+    }
+}
+
+impl Hook for GhaHook {
+    fn name(&self) -> String {
+        "gha".to_string()
+    }
+
+    fn on_event(&self, ev: &BuildEvent) {
+        self.inner
+            .tally
+            .lock()
+            .unwrap_or_else(|e| e.into_inner())
+            .apply(ev);
+    }
+
+    fn on_close(&self) {
+        // Stop the periodic writer and flush the final summary synchronously, so
+        // the completed status is written before the plugin acks the host.
+        self.inner.stop.store(true, Ordering::Release);
+        self.inner.write_summary();
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn ev(at: u64, kind: BuildEventKind) -> BuildEvent {
+        BuildEvent {
+            at_unix_ms: at,
+            kind,
+        }
+    }
+
+    fn scripted() -> Tally {
+        let mut t = Tally::default();
+        t.apply(&ev(
+            0,
+            BuildEventKind::Matched {
+                addrs: vec!["//a:x".into(), "//a:y".into(), "//a:z".into()],
+                complete: true,
+            },
+        ));
+        // x: built
+        t.apply(&ev(
+            10,
+            BuildEventKind::ExecuteStart {
+                addr: "//a:x".into(),
+                driver: "exec".into(),
+                cache: true,
+            },
+        ));
+        t.apply(&ev(
+            20,
+            BuildEventKind::ExecuteEnd {
+                addr: "//a:x".into(),
+                error: None,
+            },
+        ));
+        t.apply(&ev(
+            20,
+            BuildEventKind::ResultEnd {
+                addr: "//a:x".into(),
+                error: None,
+            },
+        ));
+        // y: cache hit, finished
+        t.apply(&ev(
+            15,
+            BuildEventKind::LocalCacheHit {
+                addr: "//a:y".into(),
+            },
+        ));
+        t.apply(&ev(
+            15,
+            BuildEventKind::ResultEnd {
+                addr: "//a:y".into(),
+                error: None,
+            },
+        ));
+        // z: started long ago, still running (slow), then a separate failure
+        t.apply(&ev(
+            0,
+            BuildEventKind::ExecuteStart {
+                addr: "//a:z".into(),
+                driver: "exec".into(),
+                cache: false,
+            },
+        ));
+        t.apply(&ev(
+            30,
+            BuildEventKind::ResultEnd {
+                addr: "//a:w".into(),
+                error: Some("boom".into()),
+            },
+        ));
+        t
+    }
+
+    #[test]
+    fn markdown_reports_counts_slow_and_failures() {
+        let t = scripted();
+        // now far enough past //a:z's start to mark it slow.
+        let md = t.render_markdown(SLOW_THRESHOLD_MS + 5_000);
+
+        // 2 of 3 matched finished (x, y); w finished but isn't in the matched set.
+        assert!(md.contains("2 / 3"), "progress: {md}");
+        assert!(md.contains("**built:** 1"), "built: {md}");
+        assert!(md.contains("**cached:** 1"), "cached: {md}");
+        assert!(md.contains("**failed:** 1"), "failed: {md}");
+        // //a:z is still running past the threshold.
+        assert!(md.contains("### Slow targets"), "slow section: {md}");
+        assert!(md.contains("//a:z"), "slow target listed: {md}");
+        // failure surfaced with its message.
+        assert!(md.contains("### Failed"), "failed section: {md}");
+        assert!(
+            md.contains("//a:w") && md.contains("boom"),
+            "failure detail: {md}"
+        );
+    }
+
+    #[test]
+    fn provisional_total_until_matcher_complete() {
+        let mut t = Tally::default();
+        t.apply(&ev(
+            0,
+            BuildEventKind::Matched {
+                addrs: vec!["//a:x".into()],
+                complete: false,
+            },
+        ));
+        assert!(t.render_markdown(0).contains("~1"), "provisional total");
+    }
+
+    #[test]
+    fn on_close_writes_final_summary_to_path() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let path = dir.path().join("summary.md");
+        let opts: Options = [(
+            "summaryPath".to_string(),
+            serde_yaml::Value::String(path.to_string_lossy().into_owned()),
+        )]
+        .into_iter()
+        .collect();
+        let hook = GhaHook::from_options(&opts).expect("hook");
+        hook.on_event(&ev(
+            0,
+            BuildEventKind::Matched {
+                addrs: vec!["//a:x".into()],
+                complete: true,
+            },
+        ));
+        hook.on_event(&ev(
+            5,
+            BuildEventKind::ResultEnd {
+                addr: "//a:x".into(),
+                error: None,
+            },
+        ));
+        hook.on_close();
+
+        let written = std::fs::read_to_string(&path).expect("summary written");
+        assert!(written.contains("1 / 1"), "final summary: {written}");
+    }
+}

--- a/crates/plugin-gha/src/lib.rs
+++ b/crates/plugin-gha/src/lib.rs
@@ -317,6 +317,10 @@ impl ChecksClient {
                         if let Some(new_id) = v.get("id").and_then(serde_json::Value::as_u64) {
                             *id = Some(new_id);
                         }
+                        // Surface the deep-link to the check's output in the job log.
+                        if let Some(url) = v.get("html_url").and_then(serde_json::Value::as_str) {
+                            tracing::info!("gha hook: check run {url}");
+                        }
                     })
             }
             Some(rid) => self

--- a/crates/plugin-gha/src/lib.rs
+++ b/crates/plugin-gha/src/lib.rs
@@ -8,7 +8,8 @@
 //!   ends, so it can't show live progress; a comment can, works with the default
 //!   `GITHUB_TOKEN`, and (unlike a check run) never nests under another workflow's
 //!   check suite. One comment per job, reused across runs (found by a hidden marker)
-//!   so it's never spammed.
+//!   so it's never spammed; within it each heph command (each step) keeps its own
+//!   section, so a job's earlier steps' results are preserved, not overwritten.
 //! - **At the end**: the full markdown is written once to `$GITHUB_STEP_SUMMARY`.
 //!
 //! The aggregation is intentionally self-contained (a small [`Tally`]) rather than
@@ -275,12 +276,91 @@ fn pr_number_from_ref(git_ref: &str) -> Option<u64> {
         .ok()
 }
 
-/// Live updates to a **sticky PR comment**. Unlike a check run, an issue comment
-/// is never grouped under a workflow's check suite, so it works correctly with the
-/// default `GITHUB_TOKEN` (needs `pull-requests: write`). The comment is found-or-
-/// created once (matched by a hidden marker) and PATCHed in place afterwards, so
-/// repeated runs reuse the one comment instead of spamming new ones. One comment
-/// per `marker` key (the job, so a job keeps a single comment across its steps).
+/// Hidden delimiters wrapping one heph command's section inside the shared
+/// per-job comment, so each step (a separate heph process) owns its own block and
+/// updates only that — earlier steps' sections are preserved.
+fn section_open(key: &str) -> String {
+    format!("<!-- heph-gha-step:{key} -->")
+}
+fn section_close(key: &str) -> String {
+    format!("<!-- /heph-gha-step:{key} -->")
+}
+
+/// Parse the ordered `(key, content)` sections out of a comment body. Tolerant:
+/// anything outside a well-formed open/close pair is ignored.
+fn parse_sections(body: &str) -> Vec<(String, String)> {
+    const OPEN: &str = "<!-- heph-gha-step:";
+    let mut out = Vec::new();
+    let mut rest = body;
+    // `.get(..)` (not `s[..]` slicing) throughout to satisfy the string-slice lint
+    // and stay panic-free on any malformed body.
+    while let Some(i) = rest.find(OPEN) {
+        let Some(after) = rest.get(i + OPEN.len()..) else {
+            break;
+        };
+        let Some(j) = after.find(" -->") else { break };
+        let (Some(key), Some(content_start)) = (after.get(..j), after.get(j + " -->".len()..))
+        else {
+            break;
+        };
+        let close = section_close(key);
+        let Some(k) = content_start.find(&close) else {
+            break;
+        };
+        let (Some(content), Some(next)) =
+            (content_start.get(..k), content_start.get(k + close.len()..))
+        else {
+            break;
+        };
+        out.push((key.to_string(), content.trim_matches('\n').to_string()));
+        rest = next;
+    }
+    out
+}
+
+/// Replace the section named `key` in place, or append it if new (preserving the
+/// order of the others).
+fn upsert_section(sections: &mut Vec<(String, String)>, key: &str, content: &str) {
+    if let Some(slot) = sections.iter_mut().find(|(k, _)| k == key) {
+        slot.1 = content.to_string();
+    } else {
+        sections.push((key.to_string(), content.to_string()));
+    }
+}
+
+/// Serialize the comment body: the container marker (used to find the comment)
+/// followed by each section wrapped in its hidden delimiters.
+fn assemble_body(container_marker: &str, sections: &[(String, String)]) -> String {
+    let mut s = String::from(container_marker);
+    s.push('\n');
+    for (key, content) in sections {
+        s.push_str(&format!(
+            "{}\n{content}\n{}\n\n",
+            section_open(key),
+            section_close(key)
+        ));
+    }
+    s.trim_end().to_string()
+}
+
+/// The found-or-created comment state, kept across the process's timer ticks so the
+/// other steps' sections (loaded once) are preserved on every update.
+#[derive(Default)]
+struct CommentState {
+    /// Whether the existing comment (if any) has been fetched & adopted.
+    loaded: bool,
+    /// The comment id once found or created.
+    id: Option<u64>,
+    /// All sections currently in the comment, including this process's.
+    sections: Vec<(String, String)>,
+}
+
+/// Live updates to a **sticky PR comment**. Unlike a check run, an issue comment is
+/// never grouped under a workflow's check suite, so it works with the default
+/// `GITHUB_TOKEN` (needs `pull-requests: write`). One comment per job (found-or-
+/// created via the hidden `container_marker`, so it's never spammed); within it,
+/// each heph command owns a `section_key` block, so a job's many steps each keep
+/// their own results instead of overwriting one another.
 struct CommentClient {
     http: std::sync::OnceLock<reqwest::blocking::Client>,
     api_url: String,
@@ -288,18 +368,19 @@ struct CommentClient {
     token: String,
     /// The PR to comment on.
     pr: u64,
-    /// Hidden HTML marker (`<!-- heph-gha:<key> -->`) identifying *this* comment, so
-    /// the same job's comment is found and reused rather than duplicated.
-    marker: String,
-    /// The comment id, resolved (found-or-created) on first sync, reused after.
-    id: Mutex<Option<u64>>,
+    /// Hidden marker (`<!-- heph-gha:<job> -->`) identifying *this job's* comment.
+    container_marker: String,
+    /// This process's section key (the heph command) within that comment.
+    section_key: String,
+    state: Mutex<CommentState>,
 }
 
 impl CommentClient {
-    /// Build from the Actions env, or `None` outside a PR / without a token. `key`
-    /// scopes the sticky comment (the job id, so one comment per job). `token_env`
-    /// names the token var (default `GITHUB_TOKEN`).
-    fn from_env(key: &str, token_env: Option<String>) -> Option<Self> {
+    /// Build from the Actions env, or `None` outside a PR / without a token.
+    /// `job_key` scopes the comment (one per job); `section_key` scopes this
+    /// process's block within it. `token_env` names the token var (default
+    /// `GITHUB_TOKEN`).
+    fn from_env(job_key: &str, section_key: &str, token_env: Option<String>) -> Option<Self> {
         let nonempty = |v: String| Some(v).filter(|s| !s.is_empty());
         let token_var = token_env
             .filter(|s| !s.is_empty())
@@ -317,8 +398,9 @@ impl CommentClient {
             repo,
             token,
             pr,
-            marker: format!("<!-- heph-gha:{key} -->"),
-            id: Mutex::new(None),
+            container_marker: format!("<!-- heph-gha:{job_key} -->"),
+            section_key: section_key.to_string(),
+            state: Mutex::new(CommentState::default()),
         })
     }
 
@@ -326,9 +408,9 @@ impl CommentClient {
         self.http.get_or_init(reqwest::blocking::Client::new)
     }
 
-    /// Find an existing comment carrying our marker, returning its id. Pages through
-    /// the PR's comments (newest unlikely to matter; caps pages to bound work).
-    fn find_existing(&self) -> Option<u64> {
+    /// Find this job's comment (by `container_marker`), returning its id + body.
+    /// Pages through the PR's comments, capped to bound work.
+    fn fetch_existing(&self) -> Option<(u64, String)> {
         const MAX_PAGES: u32 = 10;
         for page in 1..=MAX_PAGES {
             let resp = self
@@ -356,10 +438,10 @@ impl CommentClient {
                     .get("body")
                     .and_then(serde_json::Value::as_str)
                     .unwrap_or("");
-                if body.contains(&self.marker)
+                if body.contains(&self.container_marker)
                     && let Some(cid) = c.get("id").and_then(serde_json::Value::as_u64)
                 {
-                    return Some(cid);
+                    return Some((cid, body.to_string()));
                 }
             }
             if comments.len() < 100 {
@@ -369,20 +451,25 @@ impl CommentClient {
         None
     }
 
-    /// Create-or-update the sticky comment with `markdown`. The marker is prepended
-    /// (hidden) so the comment is re-findable across processes.
+    /// Upsert this process's section with `markdown` and write the merged comment.
+    /// On the first call it adopts any existing comment for this job (inheriting the
+    /// other steps' sections); afterwards it edits only its own block.
     fn sync(&self, markdown: String) {
-        let mut id = self.id.lock().unwrap_or_else(|e| e.into_inner());
-        // First sync: adopt an existing comment (e.g. from an earlier step in this
-        // job) before deciding to create — that is what keeps it one-per-job.
-        if id.is_none() {
-            *id = self.find_existing();
+        let mut st = self.state.lock().unwrap_or_else(|e| e.into_inner());
+        if !st.loaded {
+            if let Some((cid, body)) = self.fetch_existing() {
+                st.id = Some(cid);
+                st.sections = parse_sections(&body);
+            }
+            st.loaded = true;
         }
-        let body = format!("{}\n{markdown}", self.marker);
+        upsert_section(&mut st.sections, &self.section_key, &markdown);
+        let body = assemble_body(&self.container_marker, &st.sections);
+
         let mut payload = serde_json::Map::new();
         payload.insert("body".into(), serde_json::json!(body));
 
-        let result = match *id {
+        let result = match st.id {
             Some(cid) => self
                 .http()
                 .patch(format!(
@@ -407,7 +494,7 @@ impl CommentClient {
                 .and_then(|r| r.json::<serde_json::Value>())
                 .map(|v| {
                     if let Some(new_id) = v.get("id").and_then(serde_json::Value::as_u64) {
-                        *id = Some(new_id);
+                        st.id = Some(new_id);
                     }
                     if let Some(url) = v.get("html_url").and_then(serde_json::Value::as_str) {
                         tracing::info!("status comment {url}");
@@ -496,9 +583,16 @@ impl GhaHook {
         };
 
         let token_env = decode_opt::<String>(opts, "gha hook", "tokenEnv")?;
-        // One sticky PR comment per job (keyed by GITHUB_JOB, command as fallback).
-        let key = comment_key(&command, std::env::var("GITHUB_JOB").ok());
-        let comment = CommentClient::from_env(&key, token_env);
+        // One sticky PR comment per job (keyed by GITHUB_JOB, command as fallback);
+        // within it, one section per heph command so a job's steps each keep their
+        // own results.
+        let job_key = comment_key(&command, std::env::var("GITHUB_JOB").ok());
+        let section_key = if command.is_empty() {
+            "heph".to_string()
+        } else {
+            command.clone()
+        };
+        let comment = CommentClient::from_env(&job_key, &section_key, token_env);
         if comment.is_none() {
             tracing::info!(
                 "gha hook: GITHUB_TOKEN/GITHUB_REPOSITORY/PR not all set; \
@@ -744,6 +838,39 @@ mod tests {
         );
         // Empty command → stable fallback.
         assert_eq!(comment_key("", None), "heph");
+    }
+
+    #[test]
+    fn comment_sections_preserve_other_steps() {
+        // Two steps wrote their sections into one job comment.
+        let container = "<!-- heph-gha:test -->";
+        let mut sections = parse_sections(&assemble_body(
+            container,
+            &[
+                ("run //a:x".into(), "## heph: run //a:x\nbuilt 1".into()),
+                ("run //b:y".into(), "## heph: run //b:y\nbuilt 2".into()),
+            ],
+        ));
+        assert_eq!(sections.len(), 2);
+
+        // A third step updates only its own section; the others stay.
+        upsert_section(&mut sections, "run //a:x", "## heph: run //a:x\nbuilt 9");
+        let body = assemble_body(container, &sections);
+        assert!(body.starts_with(container), "container marker kept: {body}");
+        assert!(body.contains("built 9"), "own section updated: {body}");
+        assert!(body.contains("built 2"), "other step preserved: {body}");
+        // Round-trips back to the same three sections, in order.
+        let reparsed = parse_sections(&body);
+        assert_eq!(reparsed.len(), 2);
+        assert_eq!(reparsed[0].0, "run //a:x");
+        assert_eq!(reparsed[1].0, "run //b:y");
+
+        // A brand-new command appends a section rather than clobbering.
+        upsert_section(&mut sections, "query //...", "## heph: query //...\nok");
+        assert_eq!(
+            parse_sections(&assemble_body(container, &sections)).len(),
+            3
+        );
     }
 
     #[test]

--- a/crates/plugin-go-cdylib/src/lib.rs
+++ b/crates/plugin-go-cdylib/src/lib.rs
@@ -85,6 +85,8 @@ fn build(cfg: &[u8]) -> anyhow::Result<PluginComponents> {
         provider_name: "go".into(),
         provider: make_dyn_provider(provider),
         drivers,
+        // The go plugin exports no hooks.
+        hooks: stabby::vec::Vec::new(),
         // No return-side metadata to report yet.
         meta: stabby::vec::Vec::new(),
     })

--- a/crates/plugin-go-cdylib/src/lib.rs
+++ b/crates/plugin-go-cdylib/src/lib.rs
@@ -83,7 +83,7 @@ fn build(cfg: &[u8]) -> anyhow::Result<PluginComponents> {
 
     Ok(PluginComponents {
         provider_name: "go".into(),
-        provider: make_dyn_provider(provider),
+        provider: stabby::option::Option::Some(make_dyn_provider(provider)),
         drivers,
         // The go plugin exports no hooks.
         hooks: stabby::vec::Vec::new(),

--- a/crates/plugin-go-cdylib/src/lib.rs
+++ b/crates/plugin-go-cdylib/src/lib.rs
@@ -13,9 +13,10 @@ use hdriver_support::driver_managed::ManagedDriver;
 use hplugin_go::plugingo::{
     GoCompileDriver, GoGolistDriver, GoTestmainDriver, GoToolchainDriver, Provider,
 };
-use plugin_sdk::stabby::abi::{NamedDriver, PluginComponents};
+use plugin_sdk::stabby::abi::{DynLogSink, NamedDriver, PluginComponents};
 use plugin_sdk::stabby::{
-    create_config_from_bytes, make_dyn_managed_driver, make_dyn_provider, options_from_pb_map,
+    create_config_from_bytes, install_log_sink, make_dyn_managed_driver, make_dyn_provider,
+    options_from_pb_map,
 };
 use std::path::PathBuf;
 use std::sync::Arc;
@@ -35,6 +36,14 @@ pub extern "C" fn heph_plugin_create(cfg: stabby::vec::Vec<u8>) -> PluginCompone
             std::process::abort();
         }
     }
+}
+
+/// Stable ABI log-sink entry: the host calls this right after `create` to hand the
+/// plugin a sink for its `tracing` events. Without it, this cdylib's
+/// statically-linked `tracing` has no subscriber and the plugin's logs vanish.
+#[stabby::export]
+pub extern "C" fn heph_plugin_set_log_sink(sink: DynLogSink) {
+    install_log_sink(sink);
 }
 
 fn build(cfg: &[u8]) -> anyhow::Result<PluginComponents> {

--- a/crates/plugin-sdk/Cargo.toml
+++ b/crates/plugin-sdk/Cargo.toml
@@ -32,6 +32,11 @@ serde_json = { version = "1", optional = true }
 # distinct from the host's, so async work that touches the reactor (e.g. plugin-go
 # shelling out to `go list` in a driver `run`) must execute on the cdylib's runtime.
 tokio = { version = "1.52", features = ["rt-multi-thread", "sync"], optional = true }
+# A loaded cdylib statically links its own `tracing` whose global subscriber is
+# unset, so plugin logs would vanish. The SDK installs a subscriber that forwards
+# every event to the host sink over the ABI.
+tracing = { version = "0.1", optional = true }
+tracing-subscriber = { version = "0.3", optional = true }
 
 [features]
 # In-process stable-ABI cdylib transport. Pulls in the stabby guest serving
@@ -46,6 +51,8 @@ stabby = [
     "dep:prost",
     "dep:serde_json",
     "dep:tokio",
+    "dep:tracing",
+    "dep:tracing-subscriber",
 ]
 
 [dev-dependencies]

--- a/crates/plugin-sdk/Cargo.toml
+++ b/crates/plugin-sdk/Cargo.toml
@@ -25,6 +25,9 @@ stabby = { version = "72.1.8", optional = true }
 async-trait = { version = "0.1.89", optional = true }
 futures = { version = "0.3.32", optional = true }
 prost = { version = "0.14", optional = true }
+# Hook events cross the seam as serde-JSON (the BuildEvent type is already serde,
+# so it stays the single source of truth — no parallel proto mirror to maintain).
+serde_json = { version = "1", optional = true }
 # A loaded cdylib owns its own tokio runtime — its statically-linked tokio is
 # distinct from the host's, so async work that touches the reactor (e.g. plugin-go
 # shelling out to `go list` in a driver `run`) must execute on the cdylib's runtime.
@@ -41,6 +44,7 @@ stabby = [
     "dep:async-trait",
     "dep:futures",
     "dep:prost",
+    "dep:serde_json",
     "dep:tokio",
 ]
 

--- a/crates/plugin-sdk/src/lib.rs
+++ b/crates/plugin-sdk/src/lib.rs
@@ -17,6 +17,8 @@ pub use hplugin::{driver, eresult, hook, provider};
 #[cfg(feature = "stabby")]
 mod guest;
 #[cfg(feature = "stabby")]
+mod logsink;
+#[cfg(feature = "stabby")]
 mod serve;
 
 /// In-process stable-ABI cdylib transport (opt-in via the `stabby` feature).
@@ -31,6 +33,7 @@ pub mod stabby {
     pub use hplugin_stabby::abi;
 
     pub use crate::guest::GuestExecutor;
+    pub use crate::logsink::install_log_sink;
     pub use crate::serve::{make_dyn_hook, make_dyn_managed_driver, make_dyn_provider};
 
     /// Decode the cdylib create-entry config (`pb::CreateConfig`) from its prost

--- a/crates/plugin-sdk/src/lib.rs
+++ b/crates/plugin-sdk/src/lib.rs
@@ -31,9 +31,7 @@ pub mod stabby {
     pub use hplugin_stabby::abi;
 
     pub use crate::guest::GuestExecutor;
-    pub use crate::serve::{
-        make_dyn_hook, make_dyn_managed_driver, make_dyn_provider, make_noop_provider,
-    };
+    pub use crate::serve::{make_dyn_hook, make_dyn_managed_driver, make_dyn_provider};
 
     /// Decode the cdylib create-entry config (`pb::CreateConfig`) from its prost
     /// bytes, and convert its structured `options` map into a plugin `options:`

--- a/crates/plugin-sdk/src/lib.rs
+++ b/crates/plugin-sdk/src/lib.rs
@@ -12,7 +12,7 @@
 //! - (future) proto/shm, wasm — sibling features, same author surface.
 
 /// Re-export of the author-facing contract so a plugin depends only on the SDK.
-pub use hplugin::{driver, eresult, provider};
+pub use hplugin::{driver, eresult, hook, provider};
 
 #[cfg(feature = "stabby")]
 mod guest;
@@ -31,7 +31,9 @@ pub mod stabby {
     pub use hplugin_stabby::abi;
 
     pub use crate::guest::GuestExecutor;
-    pub use crate::serve::{make_dyn_managed_driver, make_dyn_provider};
+    pub use crate::serve::{
+        make_dyn_hook, make_dyn_managed_driver, make_dyn_provider, make_noop_provider,
+    };
 
     /// Decode the cdylib create-entry config (`pb::CreateConfig`) from its prost
     /// bytes, and convert its structured `options` map into a plugin `options:`

--- a/crates/plugin-sdk/src/logsink.rs
+++ b/crates/plugin-sdk/src/logsink.rs
@@ -1,0 +1,76 @@
+//! Guest side of plugin-log forwarding: install a `tracing` subscriber that
+//! funnels every event to the host's [`DynLogSink`] over the ABI.
+//!
+//! A loaded cdylib statically links its OWN `tracing`, whose global subscriber is
+//! never set — so a plugin author's `tracing::info!(...)` would be dropped on the
+//! floor. The host hands the plugin a sink (via the `heph_plugin_set_log_sink`
+//! symbol); [`install_log_sink`] installs a subscriber forwarding all events to it,
+//! and the host re-emits each on its own `tracing`. The guest forwards every level
+//! and lets the host's subscriber do the filtering — the host owns log config.
+
+use hplugin_stabby::abi::{DynLogSink, StableLogSinkDyn};
+use stabby::string::String as SString;
+use tracing::field::{Field, Visit};
+use tracing::{Event, Level, Subscriber};
+use tracing_subscriber::layer::{Context, Layer};
+
+/// Collects an event's `message` field into a string (the rendered log line).
+struct MsgVisitor(String);
+
+impl Visit for MsgVisitor {
+    fn record_debug(&mut self, field: &Field, value: &dyn std::fmt::Debug) {
+        if field.name() == "message" {
+            // `push_str(&format!(..))` rather than `write!` — the latter returns an
+            // infallible-here `Result` that trips both the drop-copy and
+            // let-underscore lints.
+            self.0.push_str(&format!("{value:?}"));
+        }
+    }
+}
+
+/// A `tracing` layer that forwards each event to the host sink. Holds the
+/// ABI-stable [`DynLogSink`] (`Send + Sync`), so it satisfies the global
+/// subscriber's bounds.
+struct ForwardLayer {
+    sink: DynLogSink,
+}
+
+impl<S: Subscriber> Layer<S> for ForwardLayer {
+    fn on_event(&self, event: &Event<'_>, _ctx: Context<'_, S>) {
+        let meta = event.metadata();
+        // `tracing::Level` as `1=ERROR .. 5=TRACE` — the wire encoding the host
+        // re-expands back into the matching macro.
+        let level = match *meta.level() {
+            Level::ERROR => 1u8,
+            Level::WARN => 2,
+            Level::INFO => 3,
+            Level::DEBUG => 4,
+            Level::TRACE => 5,
+        };
+        let mut v = MsgVisitor(String::new());
+        event.record(&mut v);
+        self.sink.log(
+            level,
+            SString::from(meta.target()),
+            SString::from(v.0.as_str()),
+        );
+    }
+}
+
+/// Install the host log sink as this plugin's global `tracing` subscriber. Idempotent
+/// and best-effort: only the first call wins (the global subscriber is set once per
+/// process), and a failure to set it (already set) is ignored — log forwarding is
+/// never load-fatal.
+pub fn install_log_sink(sink: DynLogSink) {
+    use std::sync::OnceLock;
+    use tracing_subscriber::layer::SubscriberExt;
+    use tracing_subscriber::util::SubscriberInitExt;
+
+    static INSTALLED: OnceLock<()> = OnceLock::new();
+    if INSTALLED.set(()).is_err() {
+        return;
+    }
+    let subscriber = tracing_subscriber::registry().with(ForwardLayer { sink });
+    // `try_init` returns `Err` only if a global subscriber is already set; ignore.
+    drop(subscriber.try_init());
+}

--- a/crates/plugin-sdk/src/serve.rs
+++ b/crates/plugin-sdk/src/serve.rs
@@ -18,6 +18,7 @@ use hplugin::driver::{
     ApplyTransitiveRequest, ConfigRequest as DriverConfigRequest, ParseRequest, RunInput,
     RunRequest, inputartifact,
 };
+use hplugin::hook::Hook;
 use hplugin::provider::{
     ConfigRequest, FnArgs, FnCallContext, GetError, GetRequest, ListPackagesRequest, ListRequest,
     ProbeRequest, Provider, ProviderExecutor, ProviderFn, ProviderFunctionDef,
@@ -25,7 +26,8 @@ use hplugin::provider::{
 };
 use hplugin_stabby::abi::{
     DynExecutor, DynFunctionRegistry, DynItemStream, StableCancel, StableFunctionRegistryDyn,
-    StableItemStream, StableItemStreamDyn, StableManagedDriver, StableMeta, StableProvider,
+    StableHook, StableItemStream, StableItemStreamDyn, StableManagedDriver, StableMeta,
+    StableProvider,
 };
 use plugin_abi::convert;
 use plugin_abi::pb;
@@ -1054,6 +1056,142 @@ impl Content for DiskInputContent {
     }
 }
 
+// ---- Hook (build-event consumer) ----
+
+/// Wrap an author `Hook` as an ABI-stable [`hplugin_stabby::abi::DynHook`].
+pub fn make_dyn_hook(hook: Arc<dyn Hook>) -> hplugin_stabby::abi::DynHook {
+    stabby::boxed::Box::new(StableHookImpl { hook }).into()
+}
+
+/// A provider that exposes nothing — its empty `config` name makes the host drop
+/// it at load. The `PluginComponents.provider` field is non-optional, so a
+/// hook-only (or driver-only) plugin fills it with this placeholder.
+struct NoopProvider;
+
+impl Provider for NoopProvider {
+    fn config(&self, _req: ConfigRequest) -> Result<hplugin::provider::ConfigResponse> {
+        Ok(hplugin::provider::ConfigResponse {
+            name: String::new(),
+        })
+    }
+    fn list<'a>(
+        &'a self,
+        _req: ListRequest,
+        _ct: &'a (dyn hcore::hasync::Cancellable + Send + Sync),
+    ) -> futures::future::BoxFuture<
+        'a,
+        Result<Box<dyn Iterator<Item = Result<hplugin::provider::ListResponse>> + Send>>,
+    > {
+        Box::pin(async { Ok(Box::new(std::iter::empty()) as Box<_>) })
+    }
+    fn list_packages<'a>(
+        &'a self,
+        _req: ListPackagesRequest,
+        _ct: &'a (dyn hcore::hasync::Cancellable + Send + Sync),
+    ) -> futures::future::BoxFuture<
+        'a,
+        Result<Box<dyn Iterator<Item = Result<hplugin::provider::ListPackageResponse>> + Send>>,
+    > {
+        Box::pin(async { Ok(Box::new(std::iter::empty()) as Box<_>) })
+    }
+    fn get<'a>(
+        &'a self,
+        _req: GetRequest,
+        _ct: &'a (dyn hcore::hasync::Cancellable + Send + Sync),
+    ) -> futures::future::BoxFuture<'a, std::result::Result<hplugin::provider::GetResponse, GetError>>
+    {
+        Box::pin(async { Err(GetError::NotFound) })
+    }
+    fn probe<'a>(
+        &'a self,
+        _req: ProbeRequest,
+        _ct: &'a (dyn hcore::hasync::Cancellable + Send + Sync),
+    ) -> futures::future::BoxFuture<'a, Result<hplugin::provider::ProbeResponse>> {
+        Box::pin(async { Ok(hplugin::provider::ProbeResponse { states: vec![] }) })
+    }
+}
+
+/// A no-op provider handle for hook-only / driver-only plugins. The host drops it
+/// (its `config` name is empty), so it is never invoked.
+pub fn make_noop_provider() -> hplugin_stabby::abi::DynProvider {
+    make_dyn_provider(Arc::new(NoopProvider))
+}
+
+/// Wraps an author `Hook` as a [`StableHook`].
+pub struct StableHookImpl {
+    pub hook: Arc<dyn Hook>,
+}
+
+impl StableMeta for StableHookImpl {
+    extern "C" fn meta(&self, kind: u32) -> SVec<u8> {
+        match pb::HookMethod::try_from(kind as i32) {
+            Ok(pb::HookMethod::Config) => SVec::from(
+                pb::ConfigResponse {
+                    name: self.hook.name(),
+                }
+                .encode_to_vec()
+                .as_slice(),
+            ),
+            // Unknown sync metadatum: empty == "none", never a hard failure.
+            _ => SVec::new(),
+        }
+    }
+}
+
+impl StableHook for StableHookImpl {
+    extern "C" fn invoke_client_stream<'a>(
+        &'a self,
+        method: u32,
+        req: DynItemStream,
+    ) -> DynFuture<'a, SVec<u8>> {
+        let hook = Arc::clone(&self.hook);
+        stabby::boxed::Box::new(async move {
+            match pb::HookMethod::try_from(method as i32) {
+                Ok(pb::HookMethod::OnEvents) => hook_on_events(hook, req).await,
+                _ => unimplemented(method),
+            }
+        })
+        .into()
+    }
+}
+
+/// Decode one host->plugin event frame into a `BuildEvent`. `None` ends the pull
+/// loop (a `StreamEnd`, an error, or a non-item frame). Events ride as serde-JSON
+/// inside `StreamItem.item` — the `BuildEvent` type is already serde, so there is
+/// no parallel proto mirror to keep in lockstep.
+fn decode_event_frame(bytes: &[u8]) -> Option<hcore::events::BuildEvent> {
+    match pb::Frame::decode(bytes).ok()?.body? {
+        Body::StreamItem(si) => serde_json::from_slice(&si.item).ok(),
+        _ => None,
+    }
+}
+
+/// Consume the client-streamed events: pull each frame on a blocking thread (the
+/// host's stream `next` blocks until the next event arrives), hand it to the
+/// author hook, then signal end-of-stream. The reply is an empty ack — the host
+/// only needs this future to resolve, which means the plugin drained the full
+/// stream and ran its final flush.
+async fn hook_on_events(hook: Arc<dyn Hook>, req: DynItemStream) -> SVec<u8> {
+    let (tx, rx) = tokio::sync::oneshot::channel();
+    cdylib_runtime().spawn_blocking(move || {
+        loop {
+            let bytes = req.next();
+            // Empty == the host closed the stream (request finished).
+            if bytes.is_empty() {
+                break;
+            }
+            match decode_event_frame(&bytes) {
+                Some(ev) => hook.on_event(&ev),
+                None => break,
+            }
+        }
+        hook.on_close();
+        let _ = tx.send(());
+    });
+    let _ = rx.await;
+    SVec::new()
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -1698,6 +1836,72 @@ mod tests {
         assert!(
             msg.contains("//go:embed pattern(s) matched no files: ui_dist/*"),
             "underlying cause dropped — only the top frame crossed: {msg}"
+        );
+    }
+
+    // A hook receives every client-streamed event in order across the seam, then
+    // `on_close` fires when the host ends the stream. Exercises the full
+    // host→guest client-stream path: StableRemoteHook (host) → make_dyn_hook
+    // (guest) → author Hook.
+    #[test]
+    fn hook_client_stream_roundtrip() {
+        use hcore::events::{BuildEvent, BuildEventKind};
+        use hplugin::hook::Hook;
+        use hplugin_stabby::load_stable::StableRemoteHook;
+        use std::sync::Mutex;
+        use std::sync::atomic::{AtomicBool, Ordering};
+
+        #[derive(Default)]
+        struct Recorder {
+            seen: Mutex<Vec<u64>>,
+            closed: AtomicBool,
+        }
+        impl Hook for Recorder {
+            fn name(&self) -> String {
+                "rec".into()
+            }
+            fn on_event(&self, ev: &BuildEvent) {
+                self.seen
+                    .lock()
+                    .unwrap_or_else(|e| e.into_inner())
+                    .push(ev.at_unix_ms);
+            }
+            fn on_close(&self) {
+                self.closed.store(true, Ordering::Release);
+            }
+        }
+
+        let rec = Arc::new(Recorder::default());
+        let remote = StableRemoteHook::new(make_dyn_hook(Arc::clone(&rec) as Arc<dyn Hook>), "rec");
+
+        let rt = tokio::runtime::Builder::new_multi_thread()
+            .worker_threads(2)
+            .enable_all()
+            .build()
+            .expect("rt");
+        rt.block_on(async {
+            let mk = |at| BuildEvent {
+                at_unix_ms: at,
+                kind: BuildEventKind::ResultStart {
+                    addr: "//a:b".into(),
+                },
+            };
+            remote.on_event(&mk(1));
+            remote.on_event(&mk(2));
+            remote.on_event(&mk(3));
+            // Closes the stream and awaits the plugin's ack (its full drain).
+            remote.drain().await;
+        });
+
+        let seen = rec.seen.lock().unwrap_or_else(|e| e.into_inner()).clone();
+        assert_eq!(
+            seen,
+            vec![1, 2, 3],
+            "all events arrive in order across the seam"
+        );
+        assert!(
+            rec.closed.load(Ordering::Acquire),
+            "on_close fires when the host ends the stream"
         );
     }
 

--- a/crates/plugin-sdk/src/serve.rs
+++ b/crates/plugin-sdk/src/serve.rs
@@ -1063,60 +1063,6 @@ pub fn make_dyn_hook(hook: Arc<dyn Hook>) -> hplugin_stabby::abi::DynHook {
     stabby::boxed::Box::new(StableHookImpl { hook }).into()
 }
 
-/// A provider that exposes nothing — its empty `config` name makes the host drop
-/// it at load. The `PluginComponents.provider` field is non-optional, so a
-/// hook-only (or driver-only) plugin fills it with this placeholder.
-struct NoopProvider;
-
-impl Provider for NoopProvider {
-    fn config(&self, _req: ConfigRequest) -> Result<hplugin::provider::ConfigResponse> {
-        Ok(hplugin::provider::ConfigResponse {
-            name: String::new(),
-        })
-    }
-    fn list<'a>(
-        &'a self,
-        _req: ListRequest,
-        _ct: &'a (dyn hcore::hasync::Cancellable + Send + Sync),
-    ) -> futures::future::BoxFuture<
-        'a,
-        Result<Box<dyn Iterator<Item = Result<hplugin::provider::ListResponse>> + Send>>,
-    > {
-        Box::pin(async { Ok(Box::new(std::iter::empty()) as Box<_>) })
-    }
-    fn list_packages<'a>(
-        &'a self,
-        _req: ListPackagesRequest,
-        _ct: &'a (dyn hcore::hasync::Cancellable + Send + Sync),
-    ) -> futures::future::BoxFuture<
-        'a,
-        Result<Box<dyn Iterator<Item = Result<hplugin::provider::ListPackageResponse>> + Send>>,
-    > {
-        Box::pin(async { Ok(Box::new(std::iter::empty()) as Box<_>) })
-    }
-    fn get<'a>(
-        &'a self,
-        _req: GetRequest,
-        _ct: &'a (dyn hcore::hasync::Cancellable + Send + Sync),
-    ) -> futures::future::BoxFuture<'a, std::result::Result<hplugin::provider::GetResponse, GetError>>
-    {
-        Box::pin(async { Err(GetError::NotFound) })
-    }
-    fn probe<'a>(
-        &'a self,
-        _req: ProbeRequest,
-        _ct: &'a (dyn hcore::hasync::Cancellable + Send + Sync),
-    ) -> futures::future::BoxFuture<'a, Result<hplugin::provider::ProbeResponse>> {
-        Box::pin(async { Ok(hplugin::provider::ProbeResponse { states: vec![] }) })
-    }
-}
-
-/// A no-op provider handle for hook-only / driver-only plugins. The host drops it
-/// (its `config` name is empty), so it is never invoked.
-pub fn make_noop_provider() -> hplugin_stabby::abi::DynProvider {
-    make_dyn_provider(Arc::new(NoopProvider))
-}
-
 /// Wraps an author `Hook` as a [`StableHook`].
 pub struct StableHookImpl {
     pub hook: Arc<dyn Hook>,

--- a/crates/plugin-sdk/src/serve.rs
+++ b/crates/plugin-sdk/src/serve.rs
@@ -1118,8 +1118,7 @@ fn decode_event_frame(bytes: &[u8]) -> Option<hcore::events::BuildEvent> {
 /// only needs this future to resolve, which means the plugin drained the full
 /// stream and ran its final flush.
 async fn hook_on_events(hook: Arc<dyn Hook>, req: DynItemStream) -> SVec<u8> {
-    let (tx, rx) = tokio::sync::oneshot::channel();
-    cdylib_runtime().spawn_blocking(move || {
+    let handle = cdylib_runtime().spawn_blocking(move || {
         loop {
             let bytes = req.next();
             // Empty == the host closed the stream (request finished).
@@ -1132,9 +1131,10 @@ async fn hook_on_events(hook: Arc<dyn Hook>, req: DynItemStream) -> SVec<u8> {
             }
         }
         hook.on_close();
-        let _ = tx.send(());
     });
-    let _ = rx.await;
+    // Wait for the blocking pull loop to finish (stream fully drained + the hook's
+    // final flush done) before acking the host.
+    drop(handle.await);
     SVec::new()
 }
 

--- a/crates/plugin-stabby/Cargo.toml
+++ b/crates/plugin-stabby/Cargo.toml
@@ -20,12 +20,17 @@ hdriver-support = { package = "driver-support", path = "../driver-support", opti
 plugin-abi = { path = "../plugin-abi", features = ["convert"], optional = true }
 prost = { version = "0.14", optional = true }
 async-trait = { version = "0.1.89", optional = true }
+# Host side encodes BuildEvents as serde-JSON to stream into a hook plugin.
+serde_json = { version = "1", optional = true }
+# Host spawns one background task per hook to drive its client-stream RPC to the
+# plugin (it runs concurrently with event production).
+tokio = { version = "1.52", features = ["rt", "sync"], optional = true }
 
 [features]
 # host: adapters from the engine's ProviderExecutor onto the stable ABI, plus
 # the libloading-based cdylib loader. The shared ABI contract (`abi`) is always
 # compiled (needs only stabby) so the guest SDK can depend on it feature-free.
-host = ["dep:hplugin", "dep:hmodel", "dep:hcore", "dep:hdriver-support", "dep:plugin-abi", "dep:prost", "dep:async-trait"]
+host = ["dep:hplugin", "dep:hmodel", "dep:hcore", "dep:hdriver-support", "dep:plugin-abi", "dep:prost", "dep:async-trait", "dep:serde_json", "dep:tokio"]
 
 [dev-dependencies]
 futures = "0.3.32"

--- a/crates/plugin-stabby/Cargo.toml
+++ b/crates/plugin-stabby/Cargo.toml
@@ -25,12 +25,14 @@ serde_json = { version = "1", optional = true }
 # Host spawns one background task per hook to drive its client-stream RPC to the
 # plugin (it runs concurrently with event production).
 tokio = { version = "1.52", features = ["rt", "sync"], optional = true }
+# Re-emit a loaded plugin's forwarded tracing events on the host subscriber.
+tracing = { version = "0.1", optional = true }
 
 [features]
 # host: adapters from the engine's ProviderExecutor onto the stable ABI, plus
 # the libloading-based cdylib loader. The shared ABI contract (`abi`) is always
 # compiled (needs only stabby) so the guest SDK can depend on it feature-free.
-host = ["dep:hplugin", "dep:hmodel", "dep:hcore", "dep:hdriver-support", "dep:plugin-abi", "dep:prost", "dep:async-trait", "dep:serde_json", "dep:tokio"]
+host = ["dep:hplugin", "dep:hmodel", "dep:hcore", "dep:hdriver-support", "dep:plugin-abi", "dep:prost", "dep:async-trait", "dep:serde_json", "dep:tokio", "dep:tracing"]
 
 [dev-dependencies]
 futures = "0.3.32"

--- a/crates/plugin-stabby/src/abi.rs
+++ b/crates/plugin-stabby/src/abi.rs
@@ -235,6 +235,22 @@ pub trait StableManagedDriver {
     ) -> DynFuture<'a, DynItemStream>;
 }
 
+/// The cold hook surface: a single client-streaming RPC. A hook is a build-event
+/// CONSUMER — the host streams the engine's `BuildEvent`s into the plugin
+/// (`HOOK_METHOD_ON_EVENTS`: the request stream carries one event per
+/// [`StableItemStream::next`], each an envelope `StreamItem` whose `item` is the
+/// event's serde-JSON bytes), and the reply is a unary ack once the stream ends.
+/// Same frozen-dispatch + append-only contract as [`StableProvider`]; new hook
+/// RPCs are new method ids, the vtable is untouched.
+#[stabby::stabby]
+pub trait StableHook {
+    extern "C" fn invoke_client_stream<'a>(
+        &'a self,
+        method: u32,
+        req: DynItemStream,
+    ) -> DynFuture<'a, SVec<u8>>;
+}
+
 /// Cooperative cancellation, in its OWN trait (composed into both handles like
 /// [`StableMeta`]). The host calls `cancel(request_id)` when its own request token
 /// fires; the plugin looks up the in-flight call by `request_id` and trips the
@@ -255,12 +271,22 @@ pub type DynProvider = stabby::dynptr!(
 pub type DynManagedDriver = stabby::dynptr!(
     stabby::boxed::Box<dyn StableManagedDriver + StableMeta + StableCancel + Send + Sync>
 );
+/// A hook handle composes its dispatch surface with [`StableMeta`] (the hook name)
+/// only — hooks have no per-request cancellation, so no [`StableCancel`].
+pub type DynHook = stabby::dynptr!(stabby::boxed::Box<dyn StableHook + StableMeta + Send + Sync>);
 
 /// A named managed driver in a plugin's component bundle.
 #[stabby::stabby]
 pub struct NamedDriver {
     pub name: SString,
     pub driver: DynManagedDriver,
+}
+
+/// A named hook in a plugin's component bundle.
+#[stabby::stabby]
+pub struct NamedHook {
+    pub name: SString,
+    pub hook: DynHook,
 }
 
 /// What a cdylib's create entry returns: a provider + named drivers, all as owned
@@ -277,6 +303,10 @@ pub struct PluginComponents {
     pub provider_name: SString,
     pub provider: DynProvider,
     pub drivers: SVec<NamedDriver>,
+    /// Named build-event hooks the plugin exports. Empty for provider/driver-only
+    /// plugins. A hook-only plugin leaves `provider_name` empty (its `provider` is
+    /// a no-op the host drops) and carries its hooks here.
+    pub hooks: SVec<NamedHook>,
     pub meta: SVec<u8>,
 }
 

--- a/crates/plugin-stabby/src/abi.rs
+++ b/crates/plugin-stabby/src/abi.rs
@@ -289,9 +289,10 @@ pub struct NamedHook {
     pub hook: DynHook,
 }
 
-/// What a cdylib's create entry returns: a provider + named drivers, all as owned
-/// ABI-stable handles that the host wraps with [`crate::load_stable`]. (plugin-go
-/// always exports a provider; driver-only bundles can carry an empty name.)
+/// What a cdylib's create entry returns: an optional provider + named drivers +
+/// named hooks, all as owned ABI-stable handles that the host wraps with
+/// [`crate::load_stable`]. A plugin populates only what it exports — a hook-only
+/// (or driver-only) bundle leaves `provider` `None`.
 ///
 /// `meta` is reserved, prost-encoded return-side metadata (empty today). It exists
 /// so a plugin can later report additive descriptive data (capabilities, abi
@@ -300,8 +301,10 @@ pub struct NamedHook {
 /// live native vtables); only the data rides prost.
 #[stabby::stabby]
 pub struct PluginComponents {
+    /// The exported provider's name (empty when `provider` is `None`).
     pub provider_name: SString,
-    pub provider: DynProvider,
+    /// The exported provider, or `None` for a hook-only / driver-only plugin.
+    pub provider: stabby::option::Option<DynProvider>,
     pub drivers: SVec<NamedDriver>,
     /// Named build-event hooks the plugin exports. Empty for provider/driver-only
     /// plugins. A hook-only plugin leaves `provider_name` empty (its `provider` is

--- a/crates/plugin-stabby/src/abi.rs
+++ b/crates/plugin-stabby/src/abi.rs
@@ -313,9 +313,32 @@ pub struct PluginComponents {
     pub meta: SVec<u8>,
 }
 
+/// A host log sink the plugin forwards its `tracing` events through. A loaded
+/// cdylib statically links its OWN `tracing`, whose global subscriber is never set
+/// — so a plugin's `tracing::*` would be silently dropped. The host hands the
+/// plugin this sink (via [`SET_LOG_SINK_SYMBOL`]); the plugin installs a tracing
+/// subscriber that calls `log` for every event, and the host re-emits it on its
+/// own `tracing`, so plugin logs appear in the host's output. `level` is the
+/// `tracing::Level` as `1=ERROR .. 5=TRACE`; `target` is the event's target.
+#[stabby::stabby]
+pub trait StableLogSink {
+    extern "C" fn log(&self, level: u8, target: SString, message: SString);
+}
+
+/// An owned, ABI-stable handle to the host's log sink.
+pub type DynLogSink = stabby::dynptr!(stabby::boxed::Box<dyn StableLogSink + Send + Sync>);
+
 /// The cdylib create-entry symbol name (exported with `#[stabby::export]`,
 /// loaded host-side with `get_stabbied`).
 pub const CREATE_SYMBOL: &[u8] = b"heph_plugin_create";
+
+/// Optional cdylib symbol: install a host [`DynLogSink`] so the plugin's `tracing`
+/// events reach the host. The host calls it right after load if present; a plugin
+/// that does not export it simply gets no log forwarding.
+pub const SET_LOG_SINK_SYMBOL: &[u8] = b"heph_plugin_set_log_sink";
+
+/// The set-log-sink entry's function-pointer type.
+pub type SetLogSinkFn = extern "C" fn(DynLogSink);
 
 /// The create entry's function-pointer type. The config crosses as prost-encoded
 /// `pb::CreateConfig` bytes (not a stabby struct), so adding config fields is an

--- a/crates/plugin-stabby/src/host.rs
+++ b/crates/plugin-stabby/src/host.rs
@@ -2,9 +2,9 @@
 //! a loaded plugin can call back via direct stabby vtable dispatch.
 
 use crate::abi::{
-    DynArtifact, DynExecutor, DynFunctionRegistry, DynRead, NoteDepOutcome, QueryOutcome,
-    ResultOutcome, StableAddr, StableArtifactContent, StableExecutor, StableFunctionRegistry,
-    StableRead,
+    DynArtifact, DynExecutor, DynFunctionRegistry, DynLogSink, DynRead, NoteDepOutcome,
+    QueryOutcome, ResultOutcome, StableAddr, StableArtifactContent, StableExecutor,
+    StableFunctionRegistry, StableLogSink, StableRead,
 };
 use hcore::hartifactcontent::Content;
 use hmodel::htaddr::Addr;
@@ -82,6 +82,39 @@ impl StableArtifactContent for HostArtifactContent {
         match self.content.file_path() {
             Some(p) => SString::from(p.to_string_lossy().as_ref()),
             None => SString::new(),
+        }
+    }
+}
+
+/// Host-side log sink handed to a loaded plugin. A cdylib statically links its
+/// OWN `tracing`, whose global subscriber is never set, so a plugin's
+/// `tracing::*` events would be dropped on the floor. The plugin installs a
+/// subscriber that funnels every event here; this re-emits it on the *host's*
+/// `tracing`, so plugin logs land in the host's output like any other span.
+/// `level` is the `tracing::Level` as `1=ERROR .. 5=TRACE`; `target` carries the
+/// plugin's module path so host filtering still works.
+pub struct HostLogSink;
+
+impl HostLogSink {
+    /// Wrap as an ABI-stable [`DynLogSink`] to pass over the seam.
+    pub fn wrap() -> DynLogSink {
+        stabby::boxed::Box::new(HostLogSink).into()
+    }
+}
+
+impl StableLogSink for HostLogSink {
+    extern "C" fn log(&self, level: u8, target: SString, message: SString) {
+        let target = target.to_string();
+        let message = message.to_string();
+        // Re-emit on the host subscriber. Target is set dynamically so the
+        // plugin's module path is preserved for env-filter matching. The level
+        // is a compile-time constant per arm, matching `tracing`'s macro shape.
+        match level {
+            1 => tracing::error!(target: "heph::plugin", plugin = %target, "{message}"),
+            2 => tracing::warn!(target: "heph::plugin", plugin = %target, "{message}"),
+            3 => tracing::info!(target: "heph::plugin", plugin = %target, "{message}"),
+            4 => tracing::debug!(target: "heph::plugin", plugin = %target, "{message}"),
+            _ => tracing::trace!(target: "heph::plugin", plugin = %target, "{message}"),
         }
     }
 }

--- a/crates/plugin-stabby/src/load_stable.rs
+++ b/crates/plugin-stabby/src/load_stable.rs
@@ -97,12 +97,9 @@ pub fn load(
         // Reserved return-side metadata; nothing consumes it yet.
         meta: _,
     } = comps;
-    let pname = provider_name.to_string();
-    let host_provider = if pname.is_empty() {
-        None
-    } else {
-        Some(StableRemoteProvider::new(provider, pname))
-    };
+    // `provider` is optional: hook-only / driver-only plugins export `None`.
+    let provider: std::option::Option<DynProvider> = provider.into();
+    let host_provider = provider.map(|p| StableRemoteProvider::new(p, provider_name.to_string()));
 
     let mut host_drivers = Vec::new();
     for nd in drivers {

--- a/crates/plugin-stabby/src/load_stable.rs
+++ b/crates/plugin-stabby/src/load_stable.rs
@@ -5,9 +5,9 @@
 //! executor across natively (`HostExecutor`) so callbacks are direct.
 
 use crate::abi::{
-    CREATE_SYMBOL, CreateFn, DynExecutor, DynItemStream, DynManagedDriver, DynProvider,
-    StableCancelDyn, StableItemStream, StableItemStreamDyn, StableManagedDriverDyn, StableMetaDyn,
-    StableProviderDyn,
+    CREATE_SYMBOL, CreateFn, DynExecutor, DynHook, DynItemStream, DynManagedDriver, DynProvider,
+    StableCancelDyn, StableHookDyn, StableItemStream, StableItemStreamDyn, StableManagedDriverDyn,
+    StableMetaDyn, StableProviderDyn,
 };
 use crate::host::HostExecutor;
 use async_trait::async_trait;
@@ -23,6 +23,7 @@ use hplugin::driver::{
     ConfigResponse as DriverConfigResponse, DriverSchema, ParseRequest, ParseResponse,
     inputartifact,
 };
+use hplugin::hook::Hook;
 use hplugin::provider::{
     ConfigRequest, ConfigResponse, FnArgs, FnCallContext, GetError, GetRequest, GetResponse,
     ListPackageResponse, ListPackagesRequest, ListRequest, ListResponse, ProbeRequest,
@@ -39,10 +40,12 @@ fn sv(bytes: &[u8]) -> SVec<u8> {
     SVec::from(bytes)
 }
 
-/// A loaded plugin's host-side handles: an optional provider + named drivers.
+/// A loaded plugin's host-side handles: an optional provider + named drivers +
+/// named hooks.
 pub type LoadedComponents = (
     Option<StableRemoteProvider>,
     Vec<(String, StableRemoteManagedDriver)>,
+    Vec<(String, StableRemoteHook)>,
 );
 
 /// Load a plugin cdylib and construct the host-side handles. The library's ABI is
@@ -90,6 +93,7 @@ pub fn load(
         provider_name,
         provider,
         drivers,
+        hooks,
         // Reserved return-side metadata; nothing consumes it yet.
         meta: _,
     } = comps;
@@ -108,7 +112,13 @@ pub fn load(
             StableRemoteManagedDriver::new(nd.driver, name),
         ));
     }
-    Ok((host_provider, host_drivers))
+
+    let mut host_hooks = Vec::new();
+    for nh in hooks {
+        let name = nh.name.to_string();
+        host_hooks.push((name.clone(), StableRemoteHook::new(nh.hook, name)));
+    }
+    Ok((host_provider, host_drivers, host_hooks))
 }
 
 fn decode_unary(bytes: &[u8]) -> anyhow::Result<Body> {
@@ -672,6 +682,127 @@ impl StableRemoteManagedDriver {
             Ok(result) => result,
             Err(_canceled) => anyhow::bail!("run drain thread dropped"),
         }
+    }
+}
+
+/// Host-side request stream backed by a channel: each `next` blocks until the
+/// host pushes the next event frame (or all senders drop == clean end). The guest
+/// pulls it on a blocking thread, so the blocking `recv` is sound (mirrors how the
+/// guest drains run output on a blocking task).
+struct HostChannelItemStream {
+    rx: std::sync::Mutex<std::sync::mpsc::Receiver<Vec<u8>>>,
+}
+
+impl StableItemStream for HostChannelItemStream {
+    extern "C" fn next(&self) -> SVec<u8> {
+        let rx = self.rx.lock().unwrap_or_else(|e| e.into_inner());
+        // `Err` == every sender dropped (stream closed cleanly) => empty SVec.
+        match rx.recv() {
+            Ok(b) => SVec::from(b.as_slice()),
+            Err(_) => SVec::new(),
+        }
+    }
+}
+
+fn host_channel_item_stream(rx: std::sync::mpsc::Receiver<Vec<u8>>) -> DynItemStream {
+    stabby::boxed::Box::new(HostChannelItemStream {
+        rx: std::sync::Mutex::new(rx),
+    })
+    .into()
+}
+
+/// One build event, framed as the envelope `StreamItem` carrying its serde-JSON
+/// bytes (the wire form a hook plugin pulls and deserializes).
+fn event_frame(ev: &hcore::events::BuildEvent) -> Vec<u8> {
+    let item = serde_json::to_vec(ev).unwrap_or_default();
+    pb::Frame {
+        id: 0,
+        body: Some(Body::StreamItem(pb::StreamItem { item: item.into() })),
+    }
+    .encode_to_vec()
+}
+
+/// Lazily-opened state for a remote hook's event stream.
+#[derive(Default)]
+struct HookStreamState {
+    started: bool,
+    /// Pushes event frames to the in-flight client-stream; `None` once closed.
+    tx: Option<std::sync::mpsc::Sender<Vec<u8>>>,
+    /// The task driving the plugin's `invoke_client_stream` to its ack.
+    join: Option<tokio::task::JoinHandle<()>>,
+}
+
+/// Host handle to a loaded plugin's hook. Forwards each engine `BuildEvent` across
+/// the seam by client-streaming it into the plugin (`HOOK_METHOD_ON_EVENTS`). The
+/// stream opens lazily on the first event; [`on_close`](Hook::on_close) ends it;
+/// [`drain`](Hook::drain) awaits the plugin's ack so its final flush completes
+/// before the host exits.
+pub struct StableRemoteHook {
+    inner: Arc<DynHook>,
+    name: String,
+    state: std::sync::Mutex<HookStreamState>,
+}
+
+impl StableRemoteHook {
+    pub fn new(inner: DynHook, name: impl Into<String>) -> Self {
+        Self {
+            inner: Arc::new(inner),
+            name: name.into(),
+            state: std::sync::Mutex::new(HookStreamState::default()),
+        }
+    }
+}
+
+impl Hook for StableRemoteHook {
+    fn name(&self) -> String {
+        self.name.clone()
+    }
+
+    fn on_event(&self, ev: &hcore::events::BuildEvent) {
+        let mut st = self.state.lock().unwrap_or_else(|e| e.into_inner());
+        if !st.started {
+            st.started = true;
+            // Open the client-stream once: the host pushes frames into `tx`, the
+            // plugin pulls them and acks when the stream closes. Spawned because
+            // the call runs for the whole request, concurrent with event flow.
+            let (tx, rx) = std::sync::mpsc::channel::<Vec<u8>>();
+            let stream = host_channel_item_stream(rx);
+            let inner = Arc::clone(&self.inner);
+            let join = tokio::spawn(async move {
+                drop(
+                    inner
+                        .invoke_client_stream(pb::HookMethod::OnEvents as u32, stream)
+                        .await,
+                );
+            });
+            st.tx = Some(tx);
+            st.join = Some(join);
+        }
+        if let Some(tx) = &st.tx {
+            // Plugin gone / stream closed => receiver dropped; best-effort.
+            drop(tx.send(event_frame(ev)));
+        }
+    }
+
+    fn on_close(&self) {
+        // Drop the sender so the plugin's pull sees end-of-stream and flushes.
+        let mut st = self.state.lock().unwrap_or_else(|e| e.into_inner());
+        st.tx = None;
+    }
+
+    fn drain(&self) -> BoxFuture<'_, ()> {
+        Box::pin(async move {
+            // Ensure the stream is closed, then await the plugin's ack so its final
+            // write lands before the host exits.
+            let join = {
+                let mut st = self.state.lock().unwrap_or_else(|e| e.into_inner());
+                st.tx = None;
+                st.join.take()
+            };
+            if let Some(j) = join {
+                drop(j.await);
+            }
+        })
     }
 }
 

--- a/crates/plugin-stabby/src/load_stable.rs
+++ b/crates/plugin-stabby/src/load_stable.rs
@@ -6,8 +6,8 @@
 
 use crate::abi::{
     CREATE_SYMBOL, CreateFn, DynExecutor, DynHook, DynItemStream, DynManagedDriver, DynProvider,
-    StableCancelDyn, StableHookDyn, StableItemStream, StableItemStreamDyn, StableManagedDriverDyn,
-    StableMetaDyn, StableProviderDyn,
+    SET_LOG_SINK_SYMBOL, SetLogSinkFn, StableCancelDyn, StableHookDyn, StableItemStream,
+    StableItemStreamDyn, StableManagedDriverDyn, StableMetaDyn, StableProviderDyn,
 };
 use crate::host::HostExecutor;
 use async_trait::async_trait;
@@ -83,7 +83,17 @@ pub fn load(
         // `CreateFn` before returning it; calling it is then ABI-sound.
         let create = unsafe { lib.get_stabbied::<CreateFn>(CREATE_SYMBOL) }
             .map_err(|e| anyhow::anyhow!("stabby ABI check failed for {}: {e}", path.display()))?;
-        create(sv(&cfg))
+        let comps = create(sv(&cfg));
+        // Optional: hand the plugin a host log sink so its `tracing` events (which
+        // its statically-linked `tracing` would otherwise drop — no subscriber is
+        // set in the dylib) are re-emitted on the host. A plugin built against an
+        // older SDK simply won't export the symbol; that is not an error.
+        // SAFETY: get_stabbied checks the symbol's stabby type report against
+        // `SetLogSinkFn` before returning it.
+        if let Ok(set_sink) = unsafe { lib.get_stabbied::<SetLogSinkFn>(SET_LOG_SINK_SYMBOL) } {
+            set_sink(crate::host::HostLogSink::wrap());
+        }
+        comps
     };
     // Keep the dylib mapped for the process lifetime (the returned trait objects'
     // vtables point into its code); leaking the handle is intentional.

--- a/crates/plugin/src/hook.rs
+++ b/crates/plugin/src/hook.rs
@@ -1,0 +1,46 @@
+//! The `Hook` contract: a build-event consumer plugin kind, alongside
+//! `Provider`/`Driver`. A hook observes the engine's [`BuildEvent`] stream — it
+//! does not produce targets or run them. Used for auxiliary reporting (a CI
+//! summary, an external dashboard, …).
+//!
+//! The trait is **symmetric**, exactly like `Provider`: the same trait is
+//! implemented by the author (guest side, in the plugin) and by the host-side
+//! bridge that forwards events across the cdylib seam (see
+//! `plugin-stabby::load_stable::StableRemoteHook`). The engine holds registered
+//! hooks and fans every emitted event out to each via [`Hook::on_event`].
+//!
+//! The surface is deliberately tiny: one event at a time (`on_event`), an
+//! end-of-stream signal (`on_close`), and an async [`Hook::drain`] the host awaits
+//! at teardown so an out-of-process hook's final write completes before exit.
+
+use futures::future::BoxFuture;
+use hcore::events::BuildEvent;
+
+/// A build-event consumer. Implementations must be cheap and non-blocking in
+/// [`on_event`](Hook::on_event) — it is called from the engine's `emit()`
+/// chokepoint on the hot path. Fold/forward and return; do slow work (file
+/// writes, network) off-thread or on a timer the implementation owns.
+pub trait Hook: Send + Sync {
+    /// The hook's stable name (for diagnostics / dedup).
+    fn name(&self) -> String;
+
+    /// Process one build event. Called for every event the engine emits, in
+    /// emit order, possibly concurrently from multiple tasks — implementations
+    /// must be `Sync`-safe. Best-effort: errors have no channel, so swallow or
+    /// log them internally.
+    fn on_event(&self, ev: &BuildEvent);
+
+    /// The event stream for this request has ended (the request's state is being
+    /// dropped). A hook flushes any final state here. Called at most once per
+    /// opened stream.
+    fn on_close(&self);
+
+    /// Await any in-flight delivery/flush this hook still owes (e.g. an
+    /// out-of-process hook waiting on the plugin to acknowledge it consumed the
+    /// full stream and wrote its final summary). The engine awaits this at
+    /// teardown, after [`on_close`](Hook::on_close), so a process exit never
+    /// races a hook's final write. Default: nothing to await.
+    fn drain(&self) -> BoxFuture<'_, ()> {
+        Box::pin(async {})
+    }
+}

--- a/crates/plugin/src/lib.rs
+++ b/crates/plugin/src/lib.rs
@@ -33,6 +33,7 @@ pub mod config;
 pub mod driver;
 pub mod eresult;
 pub mod error;
+pub mod hook;
 pub mod htspec;
 pub mod lsp;
 pub mod provider;

--- a/devenv.nix
+++ b/devenv.nix
@@ -135,6 +135,28 @@ in
     echo "installed go plugin -> $dest"
   '';
 
+  # Build + install the GitHub Actions hook plugin (a cdylib + manifest), the same
+  # publish flow as `install-go-plugin`. Reference it from config with a `path:`
+  # entry (e.g. in a `ci.hephconfig` profile overlay, enabled via HEPH_PROFILES).
+  scripts.install-gha-plugin.exec = ''
+    cargo build --release -p plugin-gha-cdylib
+    if [ "$(uname -s)" = "Darwin" ]; then
+      lib="$CARGO_TARGET_DIR/release/libplugin_gha_cdylib.dylib"
+      name="heph-gha-plugin.dylib"
+      bash "$DEVENV_ROOT/scripts/macos-portable.sh" "$lib"
+    else
+      lib="$CARGO_TARGET_DIR/release/libplugin_gha_cdylib.so"
+      name="heph-gha-plugin.so"
+    fi
+    dest="$HOME/.heph/plugins/gha"
+    mkdir -p "$dest"
+    cp "$lib" "$dest/$name.new"
+    mv -f "$dest/$name.new" "$dest/$name"
+    ( cd "$DEVENV_ROOT/tools/pluginmanifest" \
+        && go run . -name gha -host-path "$name" -checksum-from "$dest/$name" -out "$dest/heph-gha-plugin.json" )
+    echo "installed gha plugin -> $dest"
+  '';
+
   scripts.install-dev-build.exec = ''
     cargo build
     mkdir -p $(dirname "${binLocation}")

--- a/proto/plugin/v1/envelope.proto
+++ b/proto/plugin/v1/envelope.proto
@@ -22,6 +22,7 @@ enum PluginKind {
   PLUGIN_KIND_PROVIDER = 1;
   PLUGIN_KIND_DRIVER = 2;
   PLUGIN_KIND_BOTH = 3;
+  PLUGIN_KIND_HOOK = 4;
 }
 
 enum PayloadEncoding {

--- a/proto/plugin/v1/hook.proto
+++ b/proto/plugin/v1/hook.proto
@@ -1,0 +1,19 @@
+syntax = "proto3";
+
+// Hook-exported methods. A hook is a build-event consumer: the host
+// client-streams the engine's `BuildEvent`s into the plugin, which processes each
+// and returns a unary ack at end of stream. Same append-only dispatch contract as
+// ProviderMethod / DriverMethod. See crates/plugin-stabby/ABI_VERSIONING.md.
+package heph.plugin.v1;
+
+// Selects which hook RPC the stable-ABI dispatch (`StableHook::invoke_client_stream`)
+// should run.
+enum HookMethod {
+  HOOK_METHOD_UNSPECIFIED = 0;
+  // Client-streaming: the host streams events (host -> plugin), the plugin acks
+  // once the stream ends. Each streamed item is one `BuildEvent`, serialized as
+  // JSON bytes inside the envelope `StreamItem.item` (the event type is already
+  // serde, so it stays the single source of truth — no parallel proto mirror).
+  HOOK_METHOD_ON_EVENTS = 1;
+  HOOK_METHOD_CONFIG = 2; // sync metadata (StableMeta::meta): the hook name
+}

--- a/src/commands/bootstrap.rs
+++ b/src/commands/bootstrap.rs
@@ -53,6 +53,22 @@ pub fn block_on<F: Future>(fut: F) -> anyhow::Result<F::Output> {
 // trigger without depending on this bin module; re-exported for existing callers.
 pub use hcore::shutdown::{ShutdownTrigger, SuppressionHandle};
 
+/// Built-in hook that feeds the build-event stream into the usage-telemetry
+/// counters (the PostHog exit reporter snapshots them). Registered only when
+/// telemetry is enabled — see `new_engine`. The flush, the synchronous
+/// `snapshot()` read, and the non-event recorders stay as direct calls.
+struct TelemetryHook;
+
+impl engine::hook::Hook for TelemetryHook {
+    fn name(&self) -> String {
+        "telemetry".to_string()
+    }
+    fn on_event(&self, ev: &hcore::events::BuildEvent) {
+        crate::telemetry::observe_event(&ev.kind);
+    }
+    fn on_close(&self) {}
+}
+
 /// Read the telemetry opt-out flag straight from `.hephconfig2`, independent of
 /// engine construction, so the top-level CLI reporter can decide whether to send
 /// without holding an `Engine`. Any failure (no repo root, unreadable/invalid
@@ -126,6 +142,16 @@ pub fn new_engine() -> anyhow::Result<(Arc<engine::Engine>, ShutdownTrigger)> {
     // registers the provider + drivers it exports. The engine owns the resolve +
     // download + load machinery (see `engine::plugin_load`).
     e.register_plugins(&file.plugins)?;
+
+    // Usage telemetry is a built-in, auto-enabled hook: it folds the build-event
+    // stream into the process-global counters the exit reporter flushes to
+    // PostHog. Registered only when telemetry is enabled, so an opt-out pays no
+    // per-event cost. Non-event signals (execute_ms, artifacts, graph size, the
+    // CLI invocation) are still recorded via direct `telemetry::record_*` calls,
+    // and the synchronous `snapshot()` read the engine uses stays direct.
+    if crate::telemetry::is_enabled(file.telemetry_enabled()) {
+        e.register_hook(Arc::new(TelemetryHook))?;
+    }
 
     let engine = Arc::new(e);
 

--- a/src/commands/run.rs
+++ b/src/commands/run.rs
@@ -219,10 +219,15 @@ async fn execute_async(args: RunArgs, sink: LogSink, global: GlobalOptions) -> a
     let (engine, shutdown) = bootstrap::new_engine()?;
     let app = RunApp {
         args,
-        engine,
+        engine: std::sync::Arc::clone(&engine),
         matcher: m,
         fail_fast: global.fail_fast,
     };
     let interactive = tui::should_use_tui(global.no_tui);
-    tui::run_app(app, sink, interactive, shutdown).await
+    let result = tui::run_app(app, sink, interactive, shutdown).await;
+    // The app's request state has dropped now (firing each hook's `on_close`);
+    // await any hook's final out-of-process flush before returning so a process
+    // exit never races it.
+    engine.await_hooks().await;
+    result
 }


### PR DESCRIPTION
## What

Adds a third plugin kind — **Hook** — a build-event consumer alongside `Provider` and `Driver`. A hook observes the engine's `BuildEvent` stream; it never produces or runs targets. Two first uses ship: a published, out-of-process **GitHub Actions** hook, and **usage telemetry** migrated to a builtin hook.

## Hook plugin kind

| Layer | Change |
|---|---|
| proto | `hook.proto` (`HOOK_METHOD_ON_EVENTS`, client-streaming) + `PLUGIN_KIND_HOOK` |
| ABI | `StableHook` / `DynHook` / `NamedHook`, `PluginComponents.hooks`; **`ABI_SEMVER` 0.2.0 → 0.3.0** |
| trait | `hplugin::hook::Hook { name; on_event(&BuildEvent); on_close; drain }` — symmetric host+guest, sync, tiny |
| guest | `make_dyn_hook` + `StableHookImpl` (pulls the client-stream → `on_event`/`on_close`); `make_noop_provider` for hook-only plugins |
| host | `StableRemoteHook` bridge: channel-backed event stream, lazy open, ack-drain |
| engine | `register_hook` / `hooks()` / `await_hooks`; `emit()` fans out at the telemetry-style chokepoint (TUI renderer + backends untouched); `on_close` on request drop; `await_hooks` drain at `run` teardown |

Events cross the seam as **serde-JSON** (the `BuildEvent` type is already serde) — no parallel proto mirror to keep in lockstep.

## GitHub Actions hook (out-of-process, published like the go plugin)

- `plugin-gha`: `GhaHook` folds events into a self-contained `Tally` and rewrites `$GITHUB_STEP_SUMMARY` (done/total, built, cached, failed, slow targets) every ~30s, atomically (temp + rename).
- `plugin-gha-cdylib`: the cdylib create-entry (hook-only; no-op provider the host drops).
- `install-gha-plugin` devenv script + CI build/upload/manifest, mirroring `install-go-plugin`.
- Enable via a `path:` `plugins:` entry in a `ci.hephconfig` overlay, activated with `HEPH_PROFILES=ci`.

## Telemetry → builtin hook

Usage telemetry (PostHog) becomes a builtin, **auto-enabled** in-process hook (`TelemetryHook`), registered in `bootstrap` when telemetry is enabled. `emit()` no longer calls `observe_event` directly. Kept as direct calls (don't fit a one-way hook): the non-event recorders (`record_execute_ms`/`record_artifacts`/`record_graph_size`/`record_invocation`), the synchronous `snapshot()` read the engine uses for control flow, and the exit flush.

## Compatibility

The ABI bump is a **hard break** (the create-entry struct layout changed). Every out-of-process plugin must be rebuilt against this ABI — the go cdylib is rebuilt here; `get_stabbied` rejects stale ones at load.

## Tests

- Guest↔host client-stream roundtrip (`plugin-sdk`): events arrive in order, `on_close` fires at stream end.
- Engine `emit` fan-out to a stub hook + `on_close` on request-state drop.
- `GhaHook` tally → markdown (counts/slow/failures) + final summary file write.

Unit/lib suite green; clippy `-D warnings` (default + `--all-features`) and fmt clean. The codegen e2e suite is flaky only under full parallelism (heavy hermetic-Go builds) — passes serially, unrelated to hooks.

🤖 Generated with [Claude Code](https://claude.com/claude-code)