### PR TITLE
feat(skill): pr-build-version — read CI "Build Version" annotation

### DIFF
--- a/.claude/skills/pr-build-version/SKILL.md
+++ b/.claude/skills/pr-build-version/SKILL.md
@@ -22,7 +22,7 @@ step runs, so poll until present (cap 5 min).
 ## Run
 
 Execute this script. It resolves the PR, finds the `CI` run, polls annotations for 5 minutes, and
-prints the version + run URL (or a clear failure).
+prints the version + run URL + PR URL (or a clear failure).
 
 ```bash
 bash .claude/skills/pr-build-version/find-build-version.sh
@@ -30,7 +30,7 @@ bash .claude/skills/pr-build-version/find-build-version.sh
 
 ## After running
 
-- On success: report the version and the run URL to the user, both clickable.
+- On success: report the version, the run URL, and the PR URL to the user, all clickable.
 - If the script exits non-zero, relay the exact error it printed — do not retry blindly:
   - `no PR` → there is no open PR for the current branch; tell the user to open one.
   - `no CI run` → the `CI` workflow has not started for the head commit yet.

--- a/.claude/skills/pr-build-version/SKILL.md
+++ b/.claude/skills/pr-build-version/SKILL.md
@@ -1,0 +1,38 @@
+---
+name: pr-build-version
+description: >
+  Find the "Build Version" annotation on the current PR's "CI" GitHub Actions run and print
+  the version plus a link to the run. Resolves the PR for the current branch, locates the CI
+  workflow run for its head commit, and reads the GHA annotations. The annotation is published
+  late in CI, so this polls for up to 5 minutes until it appears.
+  Trigger when user says "build version", "pr build version", "get the CI build version",
+  or invokes /pr-build-version.
+---
+
+# PR Build Version
+
+Goal: read the `Build Version` annotation from the current PR's `CI` Actions run, print version + run link.
+
+How it works: GitHub annotations live on **check-runs**. An Actions workflow run's jobs *are* check-runs
+(job id == check-run id), so the annotations endpoint is
+`repos/{repo}/check-runs/{job_id}/annotations`. The `Build Version` annotation's `title` is
+`Build Version`; its `message` carries the version string. The annotation appears only after the build
+step runs, so poll until present (cap 5 min).
+
+## Run
+
+Execute this script. It resolves the PR, finds the `CI` run, polls annotations for 5 minutes, and
+prints the version + run URL (or a clear failure).
+
+```bash
+bash .claude/skills/pr-build-version/find-build-version.sh
+```
+
+## After running
+
+- On success: report the version and the run URL to the user, both clickable.
+- If the script exits non-zero, relay the exact error it printed — do not retry blindly:
+  - `no PR` → there is no open PR for the current branch; tell the user to open one.
+  - `no CI run` → the `CI` workflow has not started for the head commit yet.
+  - `timeout` → CI ran but the `Build Version` annotation never appeared within 5 min; share the run
+    URL so the user can inspect it.

--- a/.claude/skills/pr-build-version/find-build-version.sh
+++ b/.claude/skills/pr-build-version/find-build-version.sh
@@ -10,8 +10,10 @@ POLL_INTERVAL=10
 
 repo=$(gh repo view --json nameWithOwner -q .nameWithOwner)
 
-# Resolve the PR for the current branch -> head commit SHA.
-sha=$(gh pr view --json headRefOid -q .headRefOid 2>/dev/null || true)
+# Resolve the PR for the current branch -> head commit SHA + PR url.
+pr_json=$(gh pr view --json headRefOid,url 2>/dev/null || true)
+sha=$(echo "$pr_json" | jq -r '.headRefOid // empty')
+pr_url=$(echo "$pr_json" | jq -r '.url // empty')
 if [ -z "${sha:-}" ]; then
   echo "error: no PR found for the current branch" >&2
   exit 2
@@ -34,7 +36,7 @@ while :; do
       version=$(gh api "repos/$repo/check-runs/$jid/annotations" \
         -q ".[] | select(.title == \"$ANNOTATION_TITLE\") | .message" 2>/dev/null | head -n1 || true)
       if [ -n "${version:-}" ]; then
-        printf '%s\n%s\n' "$version" "$run_url"
+        printf '%s\n%s\n%s\n' "$version" "$run_url" "$pr_url"
         exit 0
       fi
     done

--- a/.claude/skills/pr-build-version/find-build-version.sh
+++ b/.claude/skills/pr-build-version/find-build-version.sh
@@ -1,0 +1,54 @@
+#!/usr/bin/env bash
+# Find the "Build Version" annotation on the current PR's "CI" Actions run.
+# Prints: "<version>\n<run_url>" on success. Polls up to 5 min for the annotation.
+set -euo pipefail
+
+ANNOTATION_TITLE="Build Version"
+WORKFLOW="CI"
+DEADLINE=$(( $(date +%s) + 300 ))   # 5 minutes
+POLL_INTERVAL=10
+
+repo=$(gh repo view --json nameWithOwner -q .nameWithOwner)
+
+# Resolve the PR for the current branch -> head commit SHA.
+sha=$(gh pr view --json headRefOid -q .headRefOid 2>/dev/null || true)
+if [ -z "${sha:-}" ]; then
+  echo "error: no PR found for the current branch" >&2
+  exit 2
+fi
+
+found_run_url=""
+
+while :; do
+  # Find the CI workflow run for this exact head commit.
+  run_json=$(gh run list --repo "$repo" --workflow "$WORKFLOW" --commit "$sha" \
+    --limit 1 --json databaseId,url 2>/dev/null || echo '[]')
+  run_id=$(echo "$run_json" | jq -r '.[0].databaseId // empty')
+  run_url=$(echo "$run_json" | jq -r '.[0].url // empty')
+
+  if [ -n "$run_id" ]; then
+    found_run_url="$run_url"
+    # Job ids are check-run ids; scan each job's annotations for the title.
+    job_ids=$(gh api --paginate "repos/$repo/actions/runs/$run_id/jobs" -q '.jobs[].id' 2>/dev/null || true)
+    for jid in $job_ids; do
+      version=$(gh api "repos/$repo/check-runs/$jid/annotations" \
+        -q ".[] | select(.title == \"$ANNOTATION_TITLE\") | .message" 2>/dev/null | head -n1 || true)
+      if [ -n "${version:-}" ]; then
+        printf '%s\n%s\n' "$version" "$run_url"
+        exit 0
+      fi
+    done
+  fi
+
+  if [ "$(date +%s)" -ge "$DEADLINE" ]; then
+    if [ -z "$found_run_url" ]; then
+      echo "error: no CI run found for commit $sha within 5 min" >&2
+      exit 3
+    fi
+    echo "error: timeout - '$ANNOTATION_TITLE' annotation not found within 5 min" >&2
+    echo "run: $found_run_url" >&2
+    exit 4
+  fi
+
+  sleep "$POLL_INTERVAL"
+done


### PR DESCRIPTION
## What

Adds a `/pr-build-version` skill that prints the **Build Version** for the current PR.

## How

1. Resolve the current branch's PR → head commit SHA.
2. `gh run list --workflow CI --commit <sha>` → run id + URL.
3. Actions job ids are check-run ids → `GET repos/{repo}/check-runs/{id}/annotations`, filter `title == "Build Version"`, read `.message` as the version.
4. Poll every 10s, cap 5 min (annotation publishes late in CI).
5. Print version + run URL; clear non-zero exits for no-PR / no-CI-run / timeout.

`gh` has no annotation command, so this goes through the REST annotations endpoint; Actions jobs are check-runs, which is what carries annotations.

## Files

- `.claude/skills/pr-build-version/SKILL.md` — trigger + instructions
- `.claude/skills/pr-build-version/find-build-version.sh` — poll loop

## Note

Not live-tested — no open PR existed on the source branch at authoring time. Bash syntax verified. Confirm your CI annotation's `title`/`message` shape matches once this PR's own CI runs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)