### PR TITLE
perf(ci): build heph bin + both cdylibs in one cargo invocation

### DIFF
--- a/.github/workflows/heph.yml
+++ b/.github/workflows/heph.yml
@@ -128,14 +128,21 @@ jobs:
           # zigbuild cross-compiles cleanly. On macOS it links libfuse via the
           # devenv macfuse-stubs; zig mangles the nix `-L` path under its SDK
           # syslibroot and fails to find `-lfuse`, so the (native arm64) macOS
-          # runner uses plain `cargo build` — no cross needed there. The go plugin
-          # cdylib builds in a second invocation: `--bin heph` is a target filter
-          # that would exclude the cdylib's lib target, so it can't share the bin's
-          # command. The compile is still shared (deps are already built).
+          # runner uses plain `cargo build` — no cross needed there.
+          #
+          # The heph bin and the two plugin cdylibs build in ONE invocation. They
+          # share nearly the whole workspace dep graph, and under the release
+          # profile (thin-LTO + opt-level=3) each artifact's final codegen/LTO pass
+          # is heavy — splitting into separate `cargo build` calls serializes those
+          # three passes and pays cargo startup + freshness re-resolution each time.
+          # A single invocation lets cargo's jobserver overlap them (one artifact's
+          # link tail filling cores while the next codegens). `--bin heph` selects
+          # the binary; `--lib` adds every selected package's lib target — i.e. both
+          # cdylibs (heph's own lib is already built as the bin's dependency, so it
+          # costs nothing extra).
+          TARGETS="--bin heph --lib -p heph -p plugin-go-cdylib -p plugin-gha-cdylib"
           if [ "${{ matrix.os }}" = "darwin" ]; then
-            cargo build --release --locked --target ${{ matrix.target }} -p heph --bin heph
-            cargo build --release --locked --target ${{ matrix.target }} -p plugin-go-cdylib
-            cargo build --release --locked --target ${{ matrix.target }} -p plugin-gha-cdylib
+            cargo build --release --locked --target ${{ matrix.target }} $TARGETS
             lib="$OUT/libplugin_go_cdylib.dylib"
             gha_lib="$OUT/libplugin_gha_cdylib.dylib"
             # The nix toolchain hard-links libiconv against its /nix/store path,
@@ -145,9 +152,7 @@ jobs:
             bash scripts/macos-portable.sh "$lib"
             bash scripts/macos-portable.sh "$gha_lib"
           else
-            cargo zigbuild --release --locked --target ${{ matrix.target }} -p heph --bin heph
-            cargo zigbuild --release --locked --target ${{ matrix.target }} -p plugin-go-cdylib
-            cargo zigbuild --release --locked --target ${{ matrix.target }} -p plugin-gha-cdylib
+            cargo zigbuild --release --locked --target ${{ matrix.target }} $TARGETS
             lib="$OUT/libplugin_go_cdylib.so"
             gha_lib="$OUT/libplugin_gha_cdylib.so"
           fi


### PR DESCRIPTION
## What

The `build` job ran **three** sequential `cargo build` calls — `heph` bin, `plugin-go-cdylib`, `plugin-gha-cdylib`. Collapse them into one:

```
cargo build --release --locked --target $T --bin heph --lib \
  -p heph -p plugin-go-cdylib -p plugin-gha-cdylib
```

`--bin heph` selects the binary; `--lib` adds every selected package's lib target (both cdylibs). heph's own lib is already built as the bin's dependency, so it costs nothing extra.

## Why

The three crates share nearly the whole workspace dep graph, so deps already compiled once. But under the release profile (`lto = "thin"`, `opt-level = 3`) **each artifact's final codegen/LTO pass is heavy** — three separate invocations serialize those passes and re-pay cargo startup + freshness resolution each time. A single invocation lets cargo's jobserver overlap them: one artifact's link tail fills cores while the next codegens.

## Why not split into parallel jobs

The original question was whether splitting core CLI + the 2 plugins into separate parallel jobs would be faster. It would **not** in the common case: each runner would have to recompile the shared dep graph cold (sccache is restored at job *start*, so concurrent jobs don't see each other's fresh writes), trading the serialized-LTO tail for a duplicated dep compile plus per-job nix-setup + artifact-download overhead. A job split only pays off in the warm-sccache + dominant-LTO regime, and even then is overhead-gated — worth measuring separately, not assuming.

## Test

CI-only YAML change. Validated locally that cargo accepts the combined target selection and compiles all three targets (`--bin heph --lib -p heph -p plugin-go-cdylib -p plugin-gha-cdylib`). The build matrix on this PR exercises it end-to-end.

🤖 Generated with [Claude Code](https://claude.com/claude-code)