### PR TITLE
fix(path): normalize package-relative path joins

### DIFF
--- a/crates/builtins/src/pluginfs/mod.rs
+++ b/crates/builtins/src/pluginfs/mod.rs
@@ -254,12 +254,8 @@ impl ProviderFn for GlobFn {
         // Arg shape is enforced by the declared signature before we get here.
         let pattern = str_arg("heph.fs.glob", &args)?;
 
-        let resolved = if ctx.pkg.is_empty() {
-            pattern.to_string()
-        } else {
-            format!("{}/{}", ctx.pkg, pattern)
-        };
-        let resolved = normalize_path(&resolved).context("heph.fs.glob: normalizing pattern")?;
+        let resolved = hmodel::htpkg::join_rel_checked(ctx.pkg, pattern)
+            .context("heph.fs.glob: normalizing pattern")?;
 
         // No user excludes, so `request_id` is irrelevant (the built-in exclude
         // path is taken). Reuses the driver's compiled glob + walk verbatim.

--- a/crates/model/src/htpkg/mod.rs
+++ b/crates/model/src/htpkg/mod.rs
@@ -2,4 +2,4 @@ mod parse;
 mod pkg;
 
 pub use parse::parse;
-pub use pkg::PkgBuf;
+pub use pkg::{PkgBuf, join_rel_checked};

--- a/crates/model/src/htpkg/pkg.rs
+++ b/crates/model/src/htpkg/pkg.rs
@@ -50,6 +50,54 @@ impl PkgBuf {
     }
 }
 
+/// Join a package-relative `rel` onto package `pkg`, returning a single
+/// workspace-root-relative path. The result is lexically normalized: empty and
+/// `.` segments are dropped and `..` segments are resolved against earlier
+/// components, so callers never emit smells like `pkg/./sub` or `pkg/a/../b`.
+/// Glob metacharacters in segments are preserved verbatim, and a single
+/// trailing slash is kept when `rel` had one (so directory paths stay
+/// distinguishable from file paths). Returns an error when a `..` segment would
+/// escape the workspace root — declaring a path outside the workspace is always
+/// a configuration mistake.
+pub fn join_rel_checked(pkg: &str, rel: &str) -> anyhow::Result<String> {
+    let joined = join_raw(pkg, rel);
+    let mut out: Vec<&str> = Vec::new();
+    for c in joined.split('/') {
+        match c {
+            "" | "." => {}
+            ".." => {
+                if out.pop().is_none() {
+                    anyhow::bail!("path '{joined}' escapes workspace root");
+                }
+            }
+            other => out.push(other),
+        }
+    }
+    Ok(finish(&out, &joined))
+}
+
+/// Concatenate `pkg` and `rel` with a single separator, skipping the separator
+/// when either side is empty (root package, or a bare package reference).
+fn join_raw(pkg: &str, rel: &str) -> String {
+    if pkg.is_empty() {
+        rel.to_string()
+    } else if rel.is_empty() {
+        pkg.to_string()
+    } else {
+        format!("{pkg}/{rel}")
+    }
+}
+
+/// Re-join normalized segments, restoring a single trailing slash when the
+/// pre-normalization `original` had one and the result is non-empty.
+fn finish(out: &[&str], original: &str) -> String {
+    let mut s = out.join("/");
+    if original.ends_with('/') && !s.is_empty() {
+        s.push('/');
+    }
+    s
+}
+
 impl fmt::Display for PkgBuf {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         f.write_str(&self.0)
@@ -145,6 +193,53 @@ mod tests {
             .map(|p| p.as_str().to_string())
             .collect();
         assert_eq!(got, vec![""]);
+    }
+
+    fn join(pkg: &str, rel: &str) -> String {
+        join_rel_checked(pkg, rel).expect("join should not escape root")
+    }
+
+    #[test]
+    fn join_rel_collapses_dot_and_empty_segments() {
+        // The bug that motivated this: a `./`-prefixed output declared in a BUILD
+        // file used to land in the path verbatim as `pkg/./sub/file`.
+        assert_eq!(
+            join("a/b/c", "./openapi/schemas/X.yaml"),
+            "a/b/c/openapi/schemas/X.yaml"
+        );
+        assert_eq!(join("a/b", "x//y"), "a/b/x/y");
+    }
+
+    #[test]
+    fn join_rel_resolves_dotdot() {
+        assert_eq!(join("a/b", "../c/file"), "a/c/file");
+    }
+
+    #[test]
+    fn join_rel_handles_empty_sides() {
+        assert_eq!(join("", "./x/y"), "x/y");
+        assert_eq!(join("a/b", ""), "a/b");
+        assert_eq!(join("", ""), "");
+    }
+
+    #[test]
+    fn join_rel_preserves_trailing_slash() {
+        assert_eq!(join("a/b", "gen/"), "a/b/gen/");
+        // `./` is a directory reference to the package itself — slash kept.
+        assert_eq!(join("a", "./"), "a/");
+        // A fully empty rel has no trailing slash to preserve.
+        assert_eq!(join("a", ""), "a");
+    }
+
+    #[test]
+    fn join_rel_preserves_glob_metachars() {
+        assert_eq!(join("a/b", "./gen/**/*.go"), "a/b/gen/**/*.go");
+    }
+
+    #[test]
+    fn join_rel_checked_errors_on_escape() {
+        let err = join_rel_checked("a", "../../x").unwrap_err();
+        assert!(err.to_string().contains("escapes workspace root"), "{err}");
     }
 
     #[test]

--- a/crates/plugin-buildfile/src/pluginbuildfile/run_file.rs
+++ b/crates/plugin-buildfile/src/pluginbuildfile/run_file.rs
@@ -581,23 +581,22 @@ fn starlark_to_rust(v: &Value) -> htvalue::Value {
     );
 }
 
-/// Returns `path` prefixed with the current package (e.g. `"src/main.rs"` from pkg
-/// `"foo/bar"` becomes `"foo/bar/src/main.rs"`). If `abs` is true, or the current
-/// package is empty (workspace root), returns `path` unchanged.
-fn resolve_fs_path(eval: &Evaluator, path: &str, abs: bool) -> String {
+/// Returns `path` prefixed with the current package and lexically normalized
+/// (e.g. `"./src/main.rs"` from pkg `"foo/bar"` becomes `"foo/bar/src/main.rs"`).
+/// If `abs` is true, returns `path` unchanged; at the workspace root the package
+/// prefix is empty but the path is still normalized. Errors when a `..` segment
+/// would escape the workspace root.
+fn resolve_fs_path(eval: &Evaluator, path: &str, abs: bool) -> anyhow::Result<String> {
     if abs {
-        return path.to_string();
+        return Ok(path.to_string());
     }
     let extra = eval
         .extra
         .expect("evaluator extra must be set")
         .downcast_ref::<Extra>()
         .expect("evaluator extra must be of type Extra");
-    if extra.pkg.is_empty() {
-        path.to_string()
-    } else {
-        format!("{}/{}", extra.pkg, path)
-    }
+    hmodel::htpkg::join_rel_checked(extra.pkg, path)
+        .with_context(|| format!("resolving fs path {path:?} in package {}", extra.pkg))
 }
 
 /// Snapshot the Starlark call stack at the moment `target()` runs into a chain of
@@ -761,7 +760,7 @@ fn starlark_module(builder: &mut GlobalsBuilder) {
         path: &str,
         #[starlark(require = named, default = false)] abs: bool,
     ) -> starlark::Result<String> {
-        let resolved = resolve_fs_path(eval, path, abs);
+        let resolved = resolve_fs_path(eval, path, abs)?;
         Ok(hbuiltins::pluginfs::file_addr(&resolved).format())
     }
 
@@ -774,7 +773,7 @@ fn starlark_module(builder: &mut GlobalsBuilder) {
         exclude: Option<Value<'v>>,
         #[starlark(require = named, default = false)] abs: bool,
     ) -> starlark::Result<String> {
-        let resolved = resolve_fs_path(eval, pattern, abs);
+        let resolved = resolve_fs_path(eval, pattern, abs)?;
         let excludes: Vec<String> = match exclude {
             Some(v) => {
                 if let Some(s) = v.unpack_str() {

--- a/crates/plugin-exec/src/pluginexec/mod.rs
+++ b/crates/plugin-exec/src/pluginexec/mod.rs
@@ -310,12 +310,13 @@ impl Driver {
     }
 }
 
-fn spec_path_to_target_path(raw: &str, pkg: &hmodel::htpkg::PkgBuf, codegen: &CodegenMode) -> Path {
-    let path = if pkg.is_empty() {
-        raw.to_string()
-    } else {
-        format!("{}/{}", pkg, raw)
-    };
+fn spec_path_to_target_path(
+    raw: &str,
+    pkg: &hmodel::htpkg::PkgBuf,
+    codegen: &CodegenMode,
+) -> anyhow::Result<Path> {
+    let path = hmodel::htpkg::join_rel_checked(pkg.as_str(), raw)
+        .with_context(|| format!("resolving output path {raw:?} in package {pkg}"))?;
     let content = if ["*", "?", "["].iter().any(|&p| path.contains(p)) {
         Content::Glob(path)
     } else if path.ends_with('/') {
@@ -323,11 +324,11 @@ fn spec_path_to_target_path(raw: &str, pkg: &hmodel::htpkg::PkgBuf, codegen: &Co
     } else {
         Content::FilePath(path)
     };
-    Path {
+    Ok(Path {
         content,
         codegen_tree: codegen.clone(),
         collect: true,
-    }
+    })
 }
 
 fn decode_path(opts: &hplugin::config::Options) -> anyhow::Result<Vec<String>> {
@@ -604,6 +605,26 @@ impl hdriver_support::driver_managed::ManagedDriver for Driver {
             format!("{:x}", h.finish()).into_bytes()
         };
 
+        let outputs = spec
+            .outputs
+            .iter()
+            .map(|(k, v)| {
+                Ok(Output {
+                    group: k.clone(),
+                    paths: v
+                        .iter()
+                        .map(|p| spec_path_to_target_path(p, &pkg, &spec.codegen))
+                        .collect::<anyhow::Result<Vec<_>>>()?,
+                })
+            })
+            .collect::<anyhow::Result<Vec<_>>>()?;
+
+        let support_files = spec
+            .support_files
+            .iter()
+            .map(|p| spec_path_to_target_path(p, &pkg, &CodegenMode::None))
+            .collect::<anyhow::Result<Vec<_>>>()?;
+
         Ok(ParseResponse {
             target_def: EngineTargetDef {
                 addr: req.target_spec.addr.clone(),
@@ -616,22 +637,8 @@ impl hdriver_support::driver_managed::ManagedDriver for Driver {
                     .chain(runtime_dep_inputs.into_iter().map(|(_, v)| v))
                     .chain(tool_inputs.into_iter().map(|(_, v)| v))
                     .collect(),
-                outputs: spec
-                    .outputs
-                    .iter()
-                    .map(|(k, v)| Output {
-                        group: k.clone(),
-                        paths: v
-                            .iter()
-                            .map(|p| spec_path_to_target_path(p, &pkg, &spec.codegen))
-                            .collect(),
-                    })
-                    .collect(),
-                support_files: spec
-                    .support_files
-                    .iter()
-                    .map(|p| spec_path_to_target_path(p, &pkg, &CodegenMode::None))
-                    .collect(),
+                outputs,
+                support_files,
                 cache: CacheConfig {
                     enabled: spec.cache.local,
                     remote_enabled: spec.cache.remote,
@@ -1364,6 +1371,47 @@ mod tests {
     use hdriver_support::driver_managed::ManagedDriver;
     use hmodel::htaddr::Addr;
     use hplugin::driver::RunRequest;
+
+    #[test]
+    fn spec_path_to_target_path_normalizes_and_classifies() {
+        use hmodel::htpkg::PkgBuf;
+
+        let pkg = PkgBuf::from("a/b/rest");
+
+        // `./`-prefixed output path no longer leaks a `pkg/./sub` smell.
+        let file = spec_path_to_target_path("./openapi/X.yaml", &pkg, &CodegenMode::Copy).unwrap();
+        assert!(
+            matches!(&file.content, Content::FilePath(p) if p == "a/b/rest/openapi/X.yaml"),
+            "got {}",
+            file.content
+        );
+        assert_eq!(file.codegen_tree, CodegenMode::Copy);
+
+        // Trailing slash classifies as a directory output.
+        let dir = spec_path_to_target_path("./gen/", &pkg, &CodegenMode::None).unwrap();
+        assert!(
+            matches!(&dir.content, Content::DirPath(p) if p == "a/b/rest/gen/"),
+            "got {}",
+            dir.content
+        );
+
+        // Glob metacharacters survive normalization.
+        let glob = spec_path_to_target_path("./gen/**/*.go", &pkg, &CodegenMode::None).unwrap();
+        assert!(
+            matches!(&glob.content, Content::Glob(p) if p == "a/b/rest/gen/**/*.go"),
+            "got {}",
+            glob.content
+        );
+
+        // A `..` that escapes the workspace root (more `..` than path depth) is a
+        // hard error.
+        let err = spec_path_to_target_path("../../../../etc/passwd", &pkg, &CodegenMode::None)
+            .unwrap_err();
+        assert!(
+            err.to_string().contains("resolving output path"),
+            "got {err}"
+        );
+    }
 
     fn make_req<'a, 'io>(request: RunRequest<'a, 'io>) -> ManagedRunRequest<'a, 'io> {
         let path = request.sandbox_dir.clone();

--- a/crates/plugin/src/driver.rs
+++ b/crates/plugin/src/driver.rs
@@ -695,14 +695,14 @@ pub mod targetdef {
         use serde::Serialize;
         use std::fmt::Display;
 
-        #[derive(Clone, Serialize)]
+        #[derive(Clone, Debug, Serialize)]
         pub struct Path {
             pub content: Content,
             pub codegen_tree: CodegenMode,
             pub collect: bool,
         }
 
-        #[derive(Clone, Serialize)]
+        #[derive(Clone, Debug, Serialize)]
         pub enum Content {
             FilePath(String),
             DirPath(String),


### PR DESCRIPTION
## Problem

Spotted in a generated `.gitignore`:

```
/some/./path.yaml # //some:gen
```

The stray `./` mid-path is a path-normalization smell. Root cause is **not** gitignore-specific: package-relative paths were joined with a bare `format!("{pkg}/{rel}")` that left `.`/`..` segments intact. A `./openapi/...` output declared in a BUILD file became `pkg/./openapi/...` and flowed straight through to every consumer (gitignore just rendered it visibly).

## Fix

Single normalizing join helper in `hmodel::htpkg`:

- `join_rel_checked(pkg, rel)` — lexically normalizes (drop `.`/empty, resolve `..`), preserves a trailing slash (DirPath classification) and glob metacharacters, and **hard-errors when a `..` escapes the workspace root**.

Routed all three package-relative join sites through it:

- `plugin-exec` `spec_path_to_target_path` — the output/support-path producer (the reported bug)
- `plugin-buildfile` `resolve_fs_path` — `heph.file` / `heph.glob`
- `builtins` `heph.fs.glob` — replaces its local `format!` + `normalize_path`

Declaring a path outside the workspace root is now a hard error at every site, rather than a silently-mangled path.

Also derives `Debug` on the public `path::Path` / `Content` types (per the Debug-on-public-types guideline; needed for `Result` assertions in tests).

## Tests

- `hmodel::htpkg` unit tests: `.`/empty collapse, `..` resolution, trailing-slash + glob-metachar preservation, root-escape error.
- `plugin-exec` test freezing `spec_path_to_target_path` normalization, File/Dir/Glob classification, and the escape hard-error.

All touched-crate tests pass; `cargo clippy -- -D warnings` clean; full workspace builds.

🤖 Generated with [Claude Code](https://claude.com/claude-code)