### PR TITLE
feat(inspect): support relative targets in addr subcommands

### DIFF
--- a/src/commands/inspect/def.rs
+++ b/src/commands/inspect/def.rs
@@ -82,8 +82,9 @@ pub fn execute(args: &Args, sink: LogSink, global: &GlobalOptions) -> anyhow::Re
 }
 
 async fn execute_async(args: Args, sink: LogSink, global: GlobalOptions) -> anyhow::Result<()> {
-    let addr =
-        htaddr::parse_addr(args.addr.as_ref()).with_context(|| format!("parse {}", args.addr))?;
+    let base = crate::engine::get_cwp()?;
+    let addr = htaddr::parse_addr_with_base(args.addr.as_ref(), &base)
+        .with_context(|| format!("parse {}", args.addr))?;
     let (engine, shutdown) = bootstrap::new_engine()?;
     let app = DefApp {
         engine,

--- a/src/commands/inspect/deps.rs
+++ b/src/commands/inspect/deps.rs
@@ -62,8 +62,9 @@ pub fn execute(args: &Args, sink: LogSink, global: &GlobalOptions) -> anyhow::Re
 }
 
 async fn execute_async(args: Args, sink: LogSink, global: GlobalOptions) -> anyhow::Result<()> {
-    let addr =
-        htaddr::parse_addr(args.addr.as_ref()).with_context(|| format!("parse {}", args.addr))?;
+    let base = crate::engine::get_cwp()?;
+    let addr = htaddr::parse_addr_with_base(args.addr.as_ref(), &base)
+        .with_context(|| format!("parse {}", args.addr))?;
     let (engine, shutdown) = bootstrap::new_engine()?;
     let interactive = tui::should_use_tui(global.no_tui);
 

--- a/src/commands/inspect/hashin.rs
+++ b/src/commands/inspect/hashin.rs
@@ -57,8 +57,9 @@ pub fn execute(args: &Args, sink: LogSink, global: &GlobalOptions) -> anyhow::Re
 }
 
 async fn execute_async(args: Args, sink: LogSink, global: GlobalOptions) -> anyhow::Result<()> {
-    let addr =
-        htaddr::parse_addr(args.addr.as_ref()).with_context(|| format!("parse {}", args.addr))?;
+    let base = crate::engine::get_cwp()?;
+    let addr = htaddr::parse_addr_with_base(args.addr.as_ref(), &base)
+        .with_context(|| format!("parse {}", args.addr))?;
     let (engine, shutdown) = bootstrap::new_engine()?;
     let app = HashinApp {
         engine,

--- a/src/commands/inspect/hashout.rs
+++ b/src/commands/inspect/hashout.rs
@@ -68,8 +68,9 @@ pub fn execute(args: &Args, sink: LogSink, global: &GlobalOptions) -> anyhow::Re
 }
 
 async fn execute_async(args: Args, sink: LogSink, global: GlobalOptions) -> anyhow::Result<()> {
-    let addr =
-        htaddr::parse_addr(args.addr.as_ref()).with_context(|| format!("parse {}", args.addr))?;
+    let base = crate::engine::get_cwp()?;
+    let addr = htaddr::parse_addr_with_base(args.addr.as_ref(), &base)
+        .with_context(|| format!("parse {}", args.addr))?;
     let (engine, shutdown) = bootstrap::new_engine()?;
     let app = HashoutApp {
         engine,

--- a/src/commands/inspect/spec.rs
+++ b/src/commands/inspect/spec.rs
@@ -58,8 +58,9 @@ pub fn execute(args: &Args, sink: LogSink, global: &GlobalOptions) -> anyhow::Re
 }
 
 async fn execute_async(args: Args, sink: LogSink, global: GlobalOptions) -> anyhow::Result<()> {
-    let addr =
-        htaddr::parse_addr(args.addr.as_ref()).with_context(|| format!("parse {}", args.addr))?;
+    let base = crate::engine::get_cwp()?;
+    let addr = htaddr::parse_addr_with_base(args.addr.as_ref(), &base)
+        .with_context(|| format!("parse {}", args.addr))?;
     let (engine, shutdown) = bootstrap::new_engine()?;
     let app = SpecApp {
         engine,


### PR DESCRIPTION
## What

`inspect hashin/hashout/spec/def/deps` parsed their `<addr>` arg with `parse_addr` — absolute `//pkg:name` only. Every other target-taking command (`run`, `query`, `validate`, `inspect packages`, gen-gitignore) already resolves relative forms against the current working package.

Routed the 5 inspect addr subcommands through `parse_addr_with_base(input, &get_cwp()?)`, matching the existing pattern. Now accept:

- `:name` — current package
- `./sub`, `./sub:name` — child package
- `../sib`, `../sib:name` — parent sibling
- `.`, `..` — current/parent package
- absolute `//pkg:name` (unchanged)

## Tests

Relative resolution lives entirely in `parse_addr_with_base`, already fully unit-tested (absolute / `:name` / `./` / `../` / escapes-root). This change only routes through that tested function — no new logic. `gen` + `cargo build --bin heph` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)