### PR TITLE
feat(run): add --copy-out and --output flags

### DIFF
--- a/crates/e2e/tests/engine_core.rs
+++ b/crates/e2e/tests/engine_core.rs
@@ -153,3 +153,53 @@ async fn test_failure_surfaces_process_log_tail() -> anyhow::Result<()> {
     );
     Ok(())
 }
+
+#[tokio::test]
+async fn test_output_selection_filters_to_named_output() -> anyhow::Result<()> {
+    // `heph run --output foo` resolves only the requested output group; the
+    // sibling output's artifact must not surface. Mirrors the OutputMatcher::Exact
+    // path the CLI takes.
+    let ws = Workspace::new();
+    ws.write_build_file(
+        "sel",
+        r#"
+target(
+    name = "t",
+    driver = "bash",
+    run = "printf 'FOO' > $OUT_FOO; printf 'BAR' > $OUT_BAR",
+    out = {"foo": ["foo.txt"], "bar": ["bar.txt"]},
+)
+"#,
+    );
+
+    let only_foo = ws.run_addr_outputs("//sel:t", &["foo"]).await?;
+    let paths = common::artifact_paths(&only_foo);
+    assert!(
+        paths.iter().any(|p| p.ends_with("foo.txt")),
+        "foo.txt must be present: {paths:?}"
+    );
+    assert!(
+        !paths.iter().any(|p| p.ends_with("bar.txt")),
+        "bar.txt must be filtered out: {paths:?}"
+    );
+    Ok(())
+}
+
+#[tokio::test]
+async fn test_output_selection_unknown_name_errors() -> anyhow::Result<()> {
+    // An output name the target does not declare must fail loudly, not silently
+    // resolve to an empty set.
+    let ws = Workspace::new();
+    ws.write_build_file(
+        "selerr",
+        r#"target(name = "t", driver = "bash", run = "printf 'X' > $OUT", out = "x.txt")"#,
+    );
+
+    let err = match ws.run_addr_outputs("//selerr:t", &["nope"]).await {
+        Ok(_) => panic!("unknown output must error"),
+        Err(e) => e,
+    };
+    let msg = format!("{err:#}");
+    assert!(msg.contains("output not found"), "got: {msg}");
+    Ok(())
+}

--- a/crates/e2e/tests/engine_sanity.rs
+++ b/crates/e2e/tests/engine_sanity.rs
@@ -88,7 +88,14 @@ async fn test_static_matcher_package_all_targets() -> anyhow::Result<()> {
     let e = ws.engine.clone();
     let rs = e.new_state();
     let matcher = Matcher::Package(PkgBuf::from("mypkg"));
-    let results = e.result(rs, &matcher, &ResultOptions::default()).await?;
+    let results = e
+        .result(
+            rs,
+            &matcher,
+            heph::engine::OutputMatcher::All,
+            &ResultOptions::default(),
+        )
+        .await?;
 
     assert_eq!(results.ok.len(), 2, "expected 2 targets in //mypkg");
     assert!(results.errors.is_empty());

--- a/crates/e2e/tests/plugin_buildfile.rs
+++ b/crates/e2e/tests/plugin_buildfile.rs
@@ -20,7 +20,12 @@ async fn test_result_matcher_eval_error_not_in_registry() -> anyhow::Result<()> 
     let rs = e.new_state();
     let matcher = Matcher::Package(PkgBuf::from("broken"));
     let res = e
-        .result(rs.clone(), &matcher, &ResultOptions::default())
+        .result(
+            rs.clone(),
+            &matcher,
+            heph::engine::OutputMatcher::All,
+            &ResultOptions::default(),
+        )
         .await;
 
     // The eval error surfaces as a returned `Err`...

--- a/crates/engine/src/engine/result.rs
+++ b/crates/engine/src/engine/result.rs
@@ -856,6 +856,7 @@ impl Engine {
         self: Arc<Self>,
         rs: Arc<RequestState>,
         matcher: &Matcher,
+        outputs: OutputMatcher,
         opts: &ResultOptions,
     ) -> anyhow::Result<BatchResult> {
         let mut opts = opts.clone();
@@ -903,8 +904,8 @@ impl Engine {
             }
             hcore::hmemoizer::join_set_spawn(
                 &mut set,
-                enclose!((self => engine, rs, opts, addr) async move {
-                    let r = engine.result_addr(rs, &addr, OutputMatcher::All, &opts).await;
+                enclose!((self => engine, rs, opts, addr, outputs) async move {
+                    let r = engine.result_addr(rs, &addr, outputs, &opts).await;
                     (addr, r)
                 }),
             );
@@ -3693,6 +3694,7 @@ mod tests {
             .result(
                 rs,
                 &Matcher::Package(PkgBuf::from("pkg")),
+                OutputMatcher::All,
                 &ResultOptions::default(),
             )
             .await;
@@ -3716,6 +3718,7 @@ mod tests {
             .result(
                 rs,
                 &Matcher::Package(PkgBuf::from("pkg")),
+                OutputMatcher::All,
                 &ResultOptions::default(),
             )
             .await
@@ -3747,6 +3750,7 @@ mod tests {
             .result(
                 rs,
                 &Matcher::Package(PkgBuf::from("pkg")),
+                OutputMatcher::All,
                 &ResultOptions::default(),
             )
             .await;
@@ -3774,6 +3778,7 @@ mod tests {
             .result(
                 rs,
                 &Matcher::Package(PkgBuf::from("pkg")),
+                OutputMatcher::All,
                 &ResultOptions::default(),
             )
             .await?;
@@ -4302,6 +4307,7 @@ mod tests {
             .result(
                 rs.clone(),
                 &Matcher::Package(PkgBuf::from("pkg")),
+                OutputMatcher::All,
                 &ResultOptions::default(),
             )
             .await?;
@@ -4350,6 +4356,7 @@ mod tests {
             .result(
                 rs.clone(),
                 &Matcher::Package(PkgBuf::from("pkg")),
+                OutputMatcher::All,
                 &ResultOptions::default(),
             )
             .await?;
@@ -4426,6 +4433,7 @@ mod tests {
             .result(
                 rs.clone(),
                 &Matcher::Package(PkgBuf::from("pkg")),
+                OutputMatcher::All,
                 &ResultOptions::default(),
             )
             .await?;
@@ -4439,6 +4447,7 @@ mod tests {
             .result(
                 rs.clone(),
                 &Matcher::Package(PkgBuf::from("pkg")),
+                OutputMatcher::All,
                 &ResultOptions::default(),
             )
             .await?;

--- a/crates/testkit/src/lib.rs
+++ b/crates/testkit/src/lib.rs
@@ -118,6 +118,23 @@ impl Workspace {
         self.run_addr(addr).await
     }
 
+    /// Resolve a single addr restricted to a subset of its outputs — the exact
+    /// path `heph run --output NAME` takes. Returns the engine error verbatim
+    /// (e.g. "output not found") without the failure-registry rewrite, so callers
+    /// can assert on validation failures.
+    pub async fn run_addr_outputs(
+        &self,
+        addr_str: &str,
+        outputs: &[&str],
+    ) -> anyhow::Result<Arc<EResult>> {
+        let addr = parse_addr(addr_str)?;
+        let e = self.engine.clone();
+        let rs = e.new_state();
+        let matcher = OutputMatcher::Exact(outputs.iter().map(|s| s.to_string()).collect());
+        e.result_addr(rs, &addr, matcher, &ResultOptions::default())
+            .await
+    }
+
     pub async fn run_addr(&self, addr: Addr) -> anyhow::Result<Arc<EResult>> {
         let e = self.engine.clone();
         let rs = e.new_state();
@@ -164,7 +181,9 @@ impl Workspace {
     ) -> anyhow::Result<Vec<Arc<EResult>>> {
         let e = self.engine.clone();
         let rs = e.new_state();
-        let batch = e.result(rs, matcher, &ResultOptions::default()).await?;
+        let batch = e
+            .result(rs, matcher, OutputMatcher::All, &ResultOptions::default())
+            .await?;
         if !batch.errors.is_empty() {
             let mut msg = String::new();
             for (addr, err) in &batch.errors {

--- a/src/commands/run.rs
+++ b/src/commands/run.rs
@@ -1,6 +1,7 @@
 use std::io;
 use std::sync::Arc;
 
+use anyhow::Context;
 use async_trait::async_trait;
 use clap::Args;
 use clap_complete::engine::ArgValueCompleter;
@@ -72,11 +73,19 @@ pub struct RunArgs {
     #[arg(long = "shell", num_args = 0..=1, require_equals = true, default_missing_value = "", value_name = "TARGET",)]
     pub shell: Option<String>,
     /// Print output artifacts to stdout
-    #[arg(long = "cat-out")]
+    #[arg(long = "cat-out", conflicts_with = "list_out")]
     pub cat_out: bool,
     /// Print output file list to stdout
     #[arg(long = "list-out")]
     pub list_out: bool,
+    /// Copy output artifacts into DIR (created if needed).
+    /// Relative paths resolve against the current directory.
+    #[arg(long = "copy-out", value_name = "DIR")]
+    pub copy_out: Option<String>,
+    /// Restrict --cat-out/--list-out/--copy-out to these output names
+    /// (repeatable). When omitted, all of the target's outputs are considered.
+    #[arg(long = "output", value_name = "NAME")]
+    pub output: Vec<String>,
     /// Fail if generated output differs from the tree (CI check)
     #[arg(long = "frozen")]
     pub frozen: bool,
@@ -164,17 +173,23 @@ impl App for RunApp {
         // `finalize!` paved road handles rendering and exit uniformly. The engine
         // already returns `Err` for cancellation and genuine top-level failures;
         // per-addr failures (default, fail-fast off) live in the request's failure registry.
+        let outputs = if self.args.output.is_empty() {
+            OutputMatcher::All
+        } else {
+            OutputMatcher::Exact(self.args.output.clone())
+        };
+
         let res = match self.matcher {
             Matcher::Addr(addr) => self
                 .engine
                 .clone()
-                .result_addr(rs.clone(), &addr, OutputMatcher::All, &opts)
+                .result_addr(rs.clone(), &addr, outputs, &opts)
                 .await
                 .map(|r| vec![r]),
             m => self
                 .engine
                 .clone()
-                .result(rs.clone(), &m, &opts)
+                .result(rs.clone(), &m, outputs, &opts)
                 .await
                 .map(|batch| batch.ok),
         };
@@ -201,6 +216,24 @@ impl App for RunApp {
                         for e in a.walk()? {
                             println!("{}", e?.path.display());
                         }
+                    }
+                }
+            }
+            if let Some(dir) = &self.args.copy_out {
+                let dst = std::path::Path::new(dir);
+                let dst = if dst.is_absolute() {
+                    dst.to_path_buf()
+                } else {
+                    std::env::current_dir()
+                        .context("resolve current directory for --copy-out")?
+                        .join(dst)
+                };
+                std::fs::create_dir_all(&dst)
+                    .with_context(|| format!("create --copy-out dir {:?}", dst))?;
+                for r in &result {
+                    for a in &r.artifacts {
+                        crate::hartifactcontent::unpack::unpack(a.as_ref(), &dst, None, None)
+                            .with_context(|| format!("copy output into {:?}", dst))?;
                     }
                 }
             }


### PR DESCRIPTION
## What

Two new `heph run` flags plus a small cleanup.

### `--copy-out=DIR`
Copies the resolved output artifacts into `DIR` (created if missing).
- Relative paths resolve against the current directory; absolute paths used as-is.
- Reuses the existing artifact `unpack`, so symlinks and exec bits are materialized the same way as sandbox staging.
- Copied tree mirrors the workspace-relative artifact paths (same paths `--list-out` prints).

### `--output=NAME` (repeatable)
Restricts which output groups are considered for `--cat-out` / `--list-out` / `--copy-out`. Omitted ⇒ all outputs.
- Maps to `OutputMatcher::Exact`, so an undeclared name **fails loudly** (`output not found: NAME`) instead of silently resolving to nothing.
- Works for named outputs (`out = {"foo": [...], "bar": [...]}`).

### `--cat-out` / `--list-out` now mutually exclusive.

### Engine
Threads `OutputMatcher` through `Engine::result` (batch path) so output selection applies to label/package queries too, not just single addresses.

## Tests
- `test_output_selection_filters_to_named_output` — selecting one of two named outputs surfaces only that artifact.
- `test_output_selection_unknown_name_errors` — undeclared output name errors with `output not found`.
- Added `Workspace::run_addr_outputs` testkit helper (the exact `OutputMatcher::Exact` path the CLI takes).
- Manually smoke-tested `--copy-out` (absolute, relative, forced, cached) against `example/`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)