### PR TITLE
feat(plugin-go): accept map form for link deps/runtime_deps

### DIFF
--- a/crates/plugin-go/src/plugingo/provider.rs
+++ b/crates/plugin-go/src/plugingo/provider.rs
@@ -25,7 +25,7 @@ use hbuiltins::pluginfs;
 use hcore::hasync::Cancellable;
 use hcore::hmemoizer::{Memoizer, downcast_chain_ref, unwrap_arc_err};
 use hcore::htvalue::signature::{FnSignature, Param, ParamType};
-use hcore::htvalue::{Value, parse_strings};
+use hcore::htvalue::{Value, parse_map_string_strings, parse_strings};
 use hmodel::htaddr::Addr;
 use hmodel::htpkg::PkgBuf;
 use hplugin::provider::{
@@ -448,15 +448,17 @@ impl ProviderTrait for Provider {
                     "link",
                     ParamType::strukt(vec![
                         ("flags", ParamType::list(ParamType::String)),
-                        ("deps", ParamType::list(ParamType::String)),
-                        ("runtime_deps", ParamType::list(ParamType::String)),
+                        ("deps", link_deps_param_type()),
+                        ("runtime_deps", link_deps_param_type()),
                     ]),
                     "Link settings for a `main` package's `build` (binary) target. \
                      `flags` are passed verbatim to `go tool link`; `deps` are target \
                      addresses staged into the link sandbox (hashed inputs) that the \
                      flags can reference; `runtime_deps` travel with the binary at run \
-                     time only (not hashed). By default applies only to this package; \
-                     set `recursive = True` to apply to descendant packages too.",
+                     time only (not hashed). `deps`/`runtime_deps` accept a list of \
+                     addresses or a `{group: [addr, …]}` map to name dep groups. By \
+                     default applies only to this package; set `recursive = True` to \
+                     apply to descendant packages too.",
                 ),
                 field(
                     "recursive",
@@ -921,6 +923,27 @@ fn pick_test_env(states: &[State], addr_pkg: &str) -> anyhow::Result<target_test
 /// unsupported knobs instead of silently dropping them.
 const LINK_STATE_KEYS: &[&str] = &["flags", "deps", "runtime_deps"];
 
+/// Schema for `link` `deps`/`runtime_deps`: a list of addresses, or a
+/// `{group: addr | [addr, …]}` map naming dep groups. Mirrors the exec plugin's
+/// `deps` union so BUILD authors get the same shape everywhere.
+fn link_deps_param_type() -> ParamType {
+    let str_or_list = ParamType::union(vec![ParamType::String, ParamType::list(ParamType::String)]);
+    ParamType::union(vec![
+        ParamType::String,
+        ParamType::list(ParamType::String),
+        ParamType::map(str_or_list),
+    ])
+}
+
+/// Merge a parsed `{group: [addr, …]}` map into a link dep accumulator so that
+/// recursive ancestor states and the package's own state combine per group.
+fn extend_link_deps(out: &mut BTreeMap<String, Vec<String>>, v: &Value) -> anyhow::Result<()> {
+    for (group, addrs) in parse_map_string_strings(v)? {
+        out.entry(group).or_default().extend(addrs);
+    }
+    Ok(())
+}
+
 /// Collect the link knobs (`flags`, `deps`, `runtime_deps`) from `link = {...}`
 /// provider_states applying to the binary's package — its own package plus any
 /// `recursive` ancestor. Applicable states accumulate (shallow->deep), so a
@@ -947,13 +970,12 @@ fn pick_link(states: &[State], addr_pkg: &str) -> anyhow::Result<target_bin::Lin
                 .extend(parse_strings(v).context("parsing link flags from go provider_state")?);
         }
         if let Some(v) = link_map.get("deps") {
-            out.deps
-                .extend(parse_strings(v).context("parsing link deps from go provider_state")?);
+            extend_link_deps(&mut out.deps, v)
+                .context("parsing link deps from go provider_state")?;
         }
         if let Some(v) = link_map.get("runtime_deps") {
-            out.runtime_deps.extend(
-                parse_strings(v).context("parsing link runtime_deps from go provider_state")?,
-            );
+            extend_link_deps(&mut out.runtime_deps, v)
+                .context("parsing link runtime_deps from go provider_state")?;
         }
     }
     Ok(out)
@@ -4474,8 +4496,83 @@ golang.org/x/oauth2 v0.0.0-20200107190931-bf48bf16ab8d h1:pE8b58s1HRDMi8RDc79m0H
         )];
         let link = pick_link(&states, "foo").unwrap();
         assert_eq!(link.flags, vec!["-s".to_string()]);
-        assert_eq!(link.deps, vec!["//a:b".to_string()]);
-        assert_eq!(link.runtime_deps, vec!["//c:d".to_string()]);
+        // A plain list lands in the default (empty) group.
+        assert_eq!(
+            link.deps,
+            BTreeMap::from([(String::new(), vec!["//a:b".to_string()])])
+        );
+        assert_eq!(
+            link.runtime_deps,
+            BTreeMap::from([(String::new(), vec!["//c:d".to_string()])])
+        );
+    }
+
+    #[test]
+    fn pick_link_deps_accept_named_group_map() {
+        let states = vec![state_with_link_map(
+            "foo",
+            vec![
+                (
+                    "deps",
+                    Value::Map(HashMap::from([(
+                        "assets".to_string(),
+                        Value::List(vec![Value::String("//a:b".to_string())]),
+                    )])),
+                ),
+                (
+                    "runtime_deps",
+                    Value::Map(HashMap::from([(
+                        "data".to_string(),
+                        Value::String("//c:d".to_string()),
+                    )])),
+                ),
+            ],
+        )];
+        let link = pick_link(&states, "foo").unwrap();
+        assert_eq!(
+            link.deps,
+            BTreeMap::from([("assets".to_string(), vec!["//a:b".to_string()])])
+        );
+        // A bare string value in a map entry is coerced to a single-element list.
+        assert_eq!(
+            link.runtime_deps,
+            BTreeMap::from([("data".to_string(), vec!["//c:d".to_string()])])
+        );
+    }
+
+    #[test]
+    fn pick_link_recursive_merges_deps_per_group() {
+        let states = vec![
+            with_recursive(state_with_link_map(
+                "foo",
+                vec![(
+                    "deps",
+                    Value::Map(HashMap::from([(
+                        "assets".to_string(),
+                        Value::List(vec![Value::String("//a:one".to_string())]),
+                    )])),
+                )],
+            )),
+            state_with_link_map(
+                "foo/bar",
+                vec![(
+                    "deps",
+                    Value::Map(HashMap::from([(
+                        "assets".to_string(),
+                        Value::List(vec![Value::String("//a:two".to_string())]),
+                    )])),
+                )],
+            ),
+        ];
+        let link = pick_link(&states, "foo/bar").unwrap();
+        // Same group name from ancestor + self accumulates shallow->deep.
+        assert_eq!(
+            link.deps,
+            BTreeMap::from([(
+                "assets".to_string(),
+                vec!["//a:one".to_string(), "//a:two".to_string()]
+            )])
+        );
     }
 
     #[test]

--- a/crates/plugin-go/src/plugingo/target_bin.rs
+++ b/crates/plugin-go/src/plugingo/target_bin.rs
@@ -18,10 +18,12 @@ use std::collections::{BTreeMap, HashMap};
 ///   only (not hashed — they do not invalidate the link cache).
 ///
 /// `deps`/`runtime_deps` are grouped: a plain list lands in the default group
-/// (`""`), while a map lets the BUILD author name groups explicitly. The empty
-/// group is emitted under `link_deps`/`link_runtime_deps`; named groups are
-/// emitted under `link_deps_<name>`/`link_runtime_deps_<name>` so they never
-/// collide with the importcfg lib groups (stdlib/firstparty/thirdparty/sdk).
+/// (`""`), while a map lets the BUILD author name groups explicitly. The default
+/// (empty) group is a plugin-controlled bucket emitted under the namespaced
+/// `link_deps`/`link_runtime_deps` key; user-named groups are emitted verbatim,
+/// keeping the userland dep-group namespace flat. The plugin's own groups all
+/// carry namespaced prefixes (`lib_*`, `gosdk`, `link_deps*`), so a verbatim
+/// user group only collides if it deliberately reuses one of those.
 #[derive(Debug, Default, Clone)]
 pub struct LinkConfig {
     pub flags: Vec<String>,
@@ -29,14 +31,15 @@ pub struct LinkConfig {
     pub runtime_deps: BTreeMap<String, Vec<String>>,
 }
 
-/// Map a user-provided dep group name onto the target's dep-group key. The
-/// default (empty) group keeps the historical `link_deps`/`link_runtime_deps`
-/// name; named groups are prefixed to stay clear of the importcfg lib groups.
+/// Map a link dep group name onto the target's dep-group key. The default
+/// (empty) group is the plugin-controlled bucket and takes the namespaced
+/// `prefix` (`link_deps`/`link_runtime_deps`); a user-named group is used
+/// verbatim so authors own a flat namespace.
 fn link_group_key(prefix: &str, group: &str) -> String {
     if group.is_empty() {
         prefix.to_string()
     } else {
-        format!("{prefix}_{group}")
+        group.to_string()
     }
 }
 
@@ -73,8 +76,9 @@ pub fn build_spec(
     if let Some((sdk_group, sdk_val)) = go_sdk_dep(go_version) {
         deps.insert(sdk_group, sdk_val);
     }
-    // Link deps from provider_state land in their own group(s) so they never
-    // collide with the importcfg lib groups (stdlib/firstparty/thirdparty/sdk).
+    // Link deps from provider_state. The default (empty) group is the
+    // plugin-controlled `link_deps` bucket, namespaced away from userland;
+    // user-named groups land verbatim.
     for (group, addrs) in &link.deps {
         if addrs.is_empty() {
             continue;
@@ -388,10 +392,10 @@ mod tests {
     }
 
     #[test]
-    fn test_link_deps_named_groups_are_prefixed() {
-        // A named dep group lands under `link_deps_<name>` — never colliding with
-        // the importcfg lib groups (stdlib/firstparty/thirdparty/sdk) — while the
-        // default (empty) group keeps the bare `link_deps` key.
+    fn test_link_deps_named_groups_are_verbatim() {
+        // A user-named dep group lands under its own key verbatim, keeping the
+        // userland namespace flat; the default (empty) group is the
+        // plugin-controlled `link_deps` bucket.
         let link = LinkConfig {
             deps: BTreeMap::from([
                 (String::new(), vec!["//d:default".to_string()]),
@@ -411,17 +415,14 @@ mod tests {
             Value::Map(m) => m,
             _ => panic!("expected deps map"),
         };
-        let group = match deps
-            .get("link_deps_assets")
-            .expect("link_deps_assets group present")
-        {
+        let group = match deps.get("assets").expect("assets group present") {
             Value::List(v) => v,
             _ => panic!("expected list"),
         };
         assert!(matches!(&group[0], Value::String(s) if s == "//a:one"));
         assert!(
             deps.contains_key("link_deps"),
-            "default group keeps the bare link_deps key"
+            "default group uses the plugin-controlled link_deps key"
         );
     }
 
@@ -458,7 +459,7 @@ mod tests {
     }
 
     #[test]
-    fn test_link_runtime_deps_named_groups_are_prefixed() {
+    fn test_link_runtime_deps_named_groups_are_verbatim() {
         let link = LinkConfig {
             runtime_deps: BTreeMap::from([("data".to_string(), vec!["//r:one".to_string()])]),
             ..Default::default()
@@ -479,10 +480,7 @@ mod tests {
             Value::Map(m) => m,
             _ => panic!("expected runtime_deps map"),
         };
-        let group = match rdeps
-            .get("link_runtime_deps_data")
-            .expect("link_runtime_deps_data group present")
-        {
+        let group = match rdeps.get("data").expect("data group present") {
             Value::List(v) => v,
             _ => panic!("expected list"),
         };

--- a/crates/plugin-go/src/plugingo/target_bin.rs
+++ b/crates/plugin-go/src/plugingo/target_bin.rs
@@ -16,11 +16,28 @@ use std::collections::{BTreeMap, HashMap};
 ///   `flags` can reference their outputs.
 /// - `runtime_deps`: target addresses that travel with the binary at run time
 ///   only (not hashed — they do not invalidate the link cache).
+///
+/// `deps`/`runtime_deps` are grouped: a plain list lands in the default group
+/// (`""`), while a map lets the BUILD author name groups explicitly. The empty
+/// group is emitted under `link_deps`/`link_runtime_deps`; named groups are
+/// emitted under `link_deps_<name>`/`link_runtime_deps_<name>` so they never
+/// collide with the importcfg lib groups (stdlib/firstparty/thirdparty/sdk).
 #[derive(Debug, Default, Clone)]
 pub struct LinkConfig {
     pub flags: Vec<String>,
-    pub deps: Vec<String>,
-    pub runtime_deps: Vec<String>,
+    pub deps: BTreeMap<String, Vec<String>>,
+    pub runtime_deps: BTreeMap<String, Vec<String>>,
+}
+
+/// Map a user-provided dep group name onto the target's dep-group key. The
+/// default (empty) group keeps the historical `link_deps`/`link_runtime_deps`
+/// name; named groups are prefixed to stay clear of the importcfg lib groups.
+fn link_group_key(prefix: &str, group: &str) -> String {
+    if group.is_empty() {
+        prefix.to_string()
+    } else {
+        format!("{prefix}_{group}")
+    }
 }
 
 pub fn build_spec(
@@ -56,12 +73,15 @@ pub fn build_spec(
     if let Some((sdk_group, sdk_val)) = go_sdk_dep(go_version) {
         deps.insert(sdk_group, sdk_val);
     }
-    // Link deps from provider_state land in their own group so they never collide
-    // with the importcfg lib groups (stdlib/firstparty/thirdparty/sdk).
-    if !link.deps.is_empty() {
+    // Link deps from provider_state land in their own group(s) so they never
+    // collide with the importcfg lib groups (stdlib/firstparty/thirdparty/sdk).
+    for (group, addrs) in &link.deps {
+        if addrs.is_empty() {
+            continue;
+        }
         deps.insert(
-            "link_deps".to_string(),
-            Value::List(link.deps.iter().cloned().map(Value::String).collect()),
+            link_group_key("link_deps", group),
+            Value::List(addrs.iter().cloned().map(Value::String).collect()),
         );
     }
 
@@ -73,20 +93,19 @@ pub fn build_spec(
     );
     // Runtime-only link deps: staged with the binary at run time, excluded from
     // the link's def hash (pluginexec excludes runtime_deps from the hash).
-    if !link.runtime_deps.is_empty() {
-        config.insert(
-            "runtime_deps".to_string(),
-            Value::Map(HashMap::from([(
-                "link_runtime_deps".to_string(),
-                Value::List(
-                    link.runtime_deps
-                        .iter()
-                        .cloned()
-                        .map(Value::String)
-                        .collect(),
-                ),
-            )])),
-        );
+    let runtime_deps: HashMap<String, Value> = link
+        .runtime_deps
+        .iter()
+        .filter(|(_, addrs)| !addrs.is_empty())
+        .map(|(group, addrs)| {
+            (
+                link_group_key("link_runtime_deps", group),
+                Value::List(addrs.iter().cloned().map(Value::String).collect()),
+            )
+        })
+        .collect();
+    if !runtime_deps.is_empty() {
+        config.insert("runtime_deps".to_string(), Value::Map(runtime_deps));
     }
     if let Some((ro_k, ro_v)) = go_sdk_read_only_config(go_version) {
         config.insert(ro_k, ro_v);
@@ -346,7 +365,7 @@ mod tests {
     #[test]
     fn test_link_deps_added_to_deps_map() {
         let link = LinkConfig {
-            deps: vec!["//some:target".to_string()],
+            deps: BTreeMap::from([(String::new(), vec!["//some:target".to_string()])]),
             ..Default::default()
         };
         let spec = build_spec(
@@ -369,9 +388,47 @@ mod tests {
     }
 
     #[test]
+    fn test_link_deps_named_groups_are_prefixed() {
+        // A named dep group lands under `link_deps_<name>` — never colliding with
+        // the importcfg lib groups (stdlib/firstparty/thirdparty/sdk) — while the
+        // default (empty) group keeps the bare `link_deps` key.
+        let link = LinkConfig {
+            deps: BTreeMap::from([
+                (String::new(), vec!["//d:default".to_string()]),
+                ("assets".to_string(), vec!["//a:one".to_string()]),
+            ]),
+            ..Default::default()
+        };
+        let spec = build_spec(
+            test_addr(),
+            "example.com/cmd",
+            &test_factors(),
+            &[],
+            &link,
+            V,
+        );
+        let deps = match spec.config.get("deps").unwrap() {
+            Value::Map(m) => m,
+            _ => panic!("expected deps map"),
+        };
+        let group = match deps
+            .get("link_deps_assets")
+            .expect("link_deps_assets group present")
+        {
+            Value::List(v) => v,
+            _ => panic!("expected list"),
+        };
+        assert!(matches!(&group[0], Value::String(s) if s == "//a:one"));
+        assert!(
+            deps.contains_key("link_deps"),
+            "default group keeps the bare link_deps key"
+        );
+    }
+
+    #[test]
     fn test_link_runtime_deps_added_to_runtime_deps_map() {
         let link = LinkConfig {
-            runtime_deps: vec!["//some:rt".to_string()],
+            runtime_deps: BTreeMap::from([(String::new(), vec!["//some:rt".to_string()])]),
             ..Default::default()
         };
         let spec = build_spec(
@@ -398,6 +455,38 @@ mod tests {
             _ => panic!("expected list"),
         };
         assert!(matches!(&group[0], Value::String(s) if s == "//some:rt"));
+    }
+
+    #[test]
+    fn test_link_runtime_deps_named_groups_are_prefixed() {
+        let link = LinkConfig {
+            runtime_deps: BTreeMap::from([("data".to_string(), vec!["//r:one".to_string()])]),
+            ..Default::default()
+        };
+        let spec = build_spec(
+            test_addr(),
+            "example.com/cmd",
+            &test_factors(),
+            &[],
+            &link,
+            V,
+        );
+        let rdeps = match spec
+            .config
+            .get("runtime_deps")
+            .expect("runtime_deps present")
+        {
+            Value::Map(m) => m,
+            _ => panic!("expected runtime_deps map"),
+        };
+        let group = match rdeps
+            .get("link_runtime_deps_data")
+            .expect("link_runtime_deps_data group present")
+        {
+            Value::List(v) => v,
+            _ => panic!("expected list"),
+        };
+        assert!(matches!(&group[0], Value::String(s) if s == "//r:one"));
     }
 
     #[test]


### PR DESCRIPTION
## What

The go `link` provider_state `deps` and `runtime_deps` fields accepted only a `list[string]` — every address landed in a single `link_deps` / `link_runtime_deps` group, so BUILD authors could not name dep groups (the exec driver already supports this).

Widen both to the same union the exec plugin uses:

```
string | list[string] | {group: string | [string]}
```

## Behavior

- **List form** — unchanged. Lands in the default group, emitted under the bare `link_deps` / `link_runtime_deps` keys.
- **Map form** — each key names a group, emitted as `link_deps_<group>` / `link_runtime_deps_<group>`. The prefix keeps user group names clear of the importcfg lib groups (stdlib/firstparty/thirdparty/sdk).
- Recursive ancestor + self states merge per group (shallow→deep).

## Tests

- `pick_link_reads_all_knobs` (list → default group)
- `pick_link_deps_accept_named_group_map` (map + bare-string coercion)
- `pick_link_recursive_merges_deps_per_group`
- `test_link_deps_named_groups_are_prefixed` / `test_link_runtime_deps_named_groups_are_prefixed`

🤖 Generated with [Claude Code](https://claude.com/claude-code)