### PR TITLE
fix(selfupdate): drop self-upgrade notice, only log on download

### DIFF
--- a/crates/selfupdate/src/lib.rs
+++ b/crates/selfupdate/src/lib.rs
@@ -107,7 +107,6 @@ pub fn maybe_self_upgrade() -> Result<(), SelfUpgradeError> {
             Ok(())
         }
         Decision::Upgrade { target } => {
-            tracing::info!(from = current, to = %target, "self-upgrading heph");
             let binary = imp::ensure_binary(&target)?;
             // Replaces the process image; only returns on failure.
             imp::exec_into(&binary)?;


### PR DESCRIPTION
## What

Remove the `self-upgrading heph` info line that printed on every pinned re-exec.

## Why

The upgrade path logged a notice unconditionally, even when the pinned binary was already cached (fast re-exec, nothing fetched). The `downloading heph {tag}` notice already fires only on a cache miss (`ensure_binary`, after both `dest.exists()` checks), so the user now sees output only when a binary is actually downloaded.

🤖 Generated with [Claude Code](https://claude.com/claude-code)