### PR TITLE
docs: open PR before running full test suite

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -24,6 +24,17 @@ gen                                  # regenerate protobuf bindings (runs buf ge
 
 The `gen` script is a devenv-provided alias, assume its present. It must be run at the beginning of all sessions, or after any `.proto` file changes before building.
 
+## Workflow
+
+Open the PR before running the full test suite — CI runs `tst` anyway, so running it locally first just delays the push.
+
+1. Make the change, with tests.
+2. Run `lint` and the tests relevant to the change (`cargo test <test_name>`).
+3. Commit, push, open the PR. CI takes it from there.
+4. Only then run `tst` locally if you want a faster signal than CI.
+
+Exception: for a major change — one touching the engine core, provider/driver traits, caching, or anything with wide blast radius — run the full `tst` suite locally *before* opening the PR. The cost of a broken PR is higher than the wait.
+
 @.claude/rust.md
 @.claude/testing.md
 @.claude/architecture.md

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -33,6 +33,8 @@ Open the PR before running the full test suite — CI runs `tst` anyway, so runn
 3. Commit, push, open the PR. CI takes it from there.
 4. Only then run `tst` locally if you want a faster signal than CI.
 
+The same applies to subsequent pushes on an open PR: push the fix and let CI run the suite, don't run `tst` locally first.
+
 Exception: for a major change — one touching the engine core, provider/driver traits, caching, or anything with wide blast radius — run the full `tst` suite locally *before* opening the PR. The cost of a broken PR is higher than the wait.
 
 @.claude/rust.md

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -26,16 +26,15 @@ The `gen` script is a devenv-provided alias, assume its present. It must be run 
 
 ## Workflow
 
-Open the PR before running the full test suite — CI runs `tst` anyway, so running it locally first just delays the push.
+Don't run the full test suite locally — CI runs `tst` on every push, so running it first only delays the push.
 
 1. Make the change, with tests.
 2. Run `lint` and the tests relevant to the change (`cargo test <test_name>`).
 3. Commit, push, open the PR. CI takes it from there.
-4. Only then run `tst` locally if you want a faster signal than CI.
 
-The same applies to subsequent pushes on an open PR: push the fix and let CI run the suite, don't run `tst` locally first.
+The same applies to subsequent pushes on an open PR: push the fix and let CI run the suite.
 
-Exception: for a major change — one touching the engine core, provider/driver traits, caching, or anything with wide blast radius — run the full `tst` suite locally *before* opening the PR. The cost of a broken PR is higher than the wait.
+Run the full `tst` suite locally only for a large blast radius change — one touching the engine core, provider/driver traits, or caching, where a break is likely to be wide rather than local. Run it before opening the PR: the cost of a broken PR there is higher than the wait.
 
 @.claude/rust.md
 @.claude/testing.md


### PR DESCRIPTION
## Summary

Adds a **Workflow** section to `CLAUDE.md` telling Claude to open the PR *before* running the full test suite.

CI runs `tst` on every push anyway, so running the full suite locally first only delays the push. The new guidance:

1. Make the change, with tests.
2. Run `lint` and the tests relevant to the change.
3. Commit, push, open the PR — CI takes over.
4. Run `tst` locally afterwards only if a faster signal than CI is wanted.

**Exception:** major changes (engine core, provider/driver traits, caching, or anything with wide blast radius) still run the full `tst` suite locally before opening the PR — a broken PR there costs more than the wait.

## Test plan

Docs-only change to `CLAUDE.md`; no code paths touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)