### PR TITLE
fix(plugin-stabby): serialize stabby vtable registration

### DIFF
--- a/crates/plugin-sdk/src/serve.rs
+++ b/crates/plugin-sdk/src/serve.rs
@@ -29,6 +29,7 @@ use hplugin_stabby::abi::{
     StableHook, StableItemStream, StableItemStreamDyn, StableManagedDriver, StableMeta,
     StableProvider,
 };
+use hplugin_stabby::vtable::dynify;
 use plugin_abi::convert;
 use plugin_abi::pb;
 use plugin_abi::pb::frame::Body;
@@ -99,10 +100,9 @@ impl StableItemStream for GuestItemStream {
 }
 
 fn make_item_stream(frames: Box<dyn Iterator<Item = Vec<u8>> + Send>) -> DynItemStream {
-    stabby::boxed::Box::new(GuestItemStream {
+    dynify(stabby::boxed::Box::new(GuestItemStream {
         frames: std::sync::Mutex::new(frames),
-    })
-    .into()
+    }))
 }
 
 /// Lazily map a provider's fallible item iterator into encoded `StreamItem` frames,
@@ -185,22 +185,20 @@ fn get_error_kind(e: &anyhow::Error) -> pb::get_error::Kind {
 /// Wrap a real provider as an ABI-stable [`hplugin_stabby::abi::DynProvider`] handle
 /// (in-process; the cdylib entry produces the same handle across the boundary).
 pub fn make_dyn_provider(provider: Arc<dyn Provider>) -> hplugin_stabby::abi::DynProvider {
-    stabby::boxed::Box::new(StableProviderImpl {
+    dynify(stabby::boxed::Box::new(StableProviderImpl {
         provider,
         cancels: Arc::new(CancelRegistry::default()),
-    })
-    .into()
+    }))
 }
 
 /// Wrap a real managed driver as an ABI-stable [`hplugin_stabby::abi::DynManagedDriver`].
 pub fn make_dyn_managed_driver(
     driver: Arc<dyn ManagedDriver>,
 ) -> hplugin_stabby::abi::DynManagedDriver {
-    stabby::boxed::Box::new(StableManagedDriverImpl {
+    dynify(stabby::boxed::Box::new(StableManagedDriverImpl {
         driver,
         cancels: Arc::new(CancelRegistry::default()),
-    })
-    .into()
+    }))
 }
 
 /// In-flight calls keyed by `request_id`, so [`StableCancel::cancel`] can trip the
@@ -527,14 +525,13 @@ impl StableProvider for StableProviderImpl {
     extern "C" fn invoke<'a>(&'a self, method: u32, req: SVec<u8>) -> DynFuture<'a, SVec<u8>> {
         let provider = Arc::clone(&self.provider);
         let cancels = Arc::clone(&self.cancels);
-        stabby::boxed::Box::new(async move {
+        dynify(stabby::boxed::Box::new(async move {
             match pb::ProviderMethod::try_from(method as i32) {
                 Ok(pb::ProviderMethod::Probe) => provider_probe(provider, req, cancels).await,
                 Ok(pb::ProviderMethod::CallFunction) => provider_call_function(provider, req).await,
                 _ => unimplemented(method),
             }
-        })
-        .into()
+        }))
     }
 
     extern "C" fn invoke_server_stream<'a>(
@@ -543,7 +540,7 @@ impl StableProvider for StableProviderImpl {
         req: SVec<u8>,
     ) -> DynFuture<'a, DynItemStream> {
         let provider = Arc::clone(&self.provider);
-        stabby::boxed::Box::new(async move {
+        dynify(stabby::boxed::Box::new(async move {
             match pb::ProviderMethod::try_from(method as i32) {
                 Ok(pb::ProviderMethod::List) => provider_list_stream(provider, req).await,
                 Ok(pb::ProviderMethod::ListPackages) => {
@@ -551,8 +548,7 @@ impl StableProvider for StableProviderImpl {
                 }
                 _ => unimplemented_item_stream(method),
             }
-        })
-        .into()
+        }))
     }
 
     extern "C" fn invoke_client_stream<'a>(
@@ -561,7 +557,9 @@ impl StableProvider for StableProviderImpl {
         // No client-streaming provider RPC yet; the request stream is dropped.
         _req: DynItemStream,
     ) -> DynFuture<'a, SVec<u8>> {
-        stabby::boxed::Box::new(async move { unimplemented(method) }).into()
+        dynify(stabby::boxed::Box::new(
+            async move { unimplemented(method) },
+        ))
     }
 
     extern "C" fn invoke_bidi<'a>(
@@ -569,7 +567,9 @@ impl StableProvider for StableProviderImpl {
         method: u32,
         _req: DynItemStream,
     ) -> DynFuture<'a, DynItemStream> {
-        stabby::boxed::Box::new(async move { unimplemented_item_stream(method) }).into()
+        dynify(stabby::boxed::Box::new(async move {
+            unimplemented_item_stream(method)
+        }))
     }
 
     extern "C" fn invoke_exec<'a>(
@@ -580,13 +580,12 @@ impl StableProvider for StableProviderImpl {
     ) -> DynFuture<'a, SVec<u8>> {
         let provider = Arc::clone(&self.provider);
         let cancels = Arc::clone(&self.cancels);
-        stabby::boxed::Box::new(async move {
+        dynify(stabby::boxed::Box::new(async move {
             match pb::ProviderMethod::try_from(method as i32) {
                 Ok(pb::ProviderMethod::Get) => provider_get(provider, req, exec, cancels).await,
                 _ => unimplemented(method),
             }
-        })
-        .into()
+        }))
     }
 
     extern "C" fn invoke_registry(&self, method: u32, req: SVec<u8>, reg: DynFunctionRegistry) {
@@ -742,7 +741,7 @@ impl StableManagedDriver for StableManagedDriverImpl {
     extern "C" fn invoke<'a>(&'a self, method: u32, req: SVec<u8>) -> DynFuture<'a, SVec<u8>> {
         let driver = Arc::clone(&self.driver);
         let cancels = Arc::clone(&self.cancels);
-        stabby::boxed::Box::new(async move {
+        dynify(stabby::boxed::Box::new(async move {
             match pb::DriverMethod::try_from(method as i32) {
                 Ok(pb::DriverMethod::Parse) => driver_parse(driver, req, cancels).await,
                 Ok(pb::DriverMethod::ApplyTransitive) => {
@@ -750,8 +749,7 @@ impl StableManagedDriver for StableManagedDriverImpl {
                 }
                 _ => unimplemented(method),
             }
-        })
-        .into()
+        }))
     }
 
     // No unary->stream or stream->unary driver RPC yet; provisioned, Unimplemented.
@@ -760,7 +758,9 @@ impl StableManagedDriver for StableManagedDriverImpl {
         method: u32,
         _req: SVec<u8>,
     ) -> DynFuture<'a, DynItemStream> {
-        stabby::boxed::Box::new(async move { unimplemented_item_stream(method) }).into()
+        dynify(stabby::boxed::Box::new(async move {
+            unimplemented_item_stream(method)
+        }))
     }
 
     extern "C" fn invoke_client_stream<'a>(
@@ -768,7 +768,9 @@ impl StableManagedDriver for StableManagedDriverImpl {
         method: u32,
         _req: DynItemStream,
     ) -> DynFuture<'a, SVec<u8>> {
-        stabby::boxed::Box::new(async move { unimplemented(method) }).into()
+        dynify(stabby::boxed::Box::new(
+            async move { unimplemented(method) },
+        ))
     }
 
     // `run` is the one bidi RPC: request stream = RunInFrame (run request, then live
@@ -780,13 +782,12 @@ impl StableManagedDriver for StableManagedDriverImpl {
     ) -> DynFuture<'a, DynItemStream> {
         let driver = Arc::clone(&self.driver);
         let cancels = Arc::clone(&self.cancels);
-        stabby::boxed::Box::new(async move {
+        dynify(stabby::boxed::Box::new(async move {
             match pb::DriverMethod::try_from(method as i32) {
                 Ok(pb::DriverMethod::Run) => run_bidi(driver, req, cancels).await,
                 _ => unimplemented_item_stream(method),
             }
-        })
-        .into()
+        }))
     }
 }
 
@@ -808,7 +809,9 @@ impl StableItemStream for ChannelItemStream {
 }
 
 fn make_channel_item_stream(rx: tokio::sync::mpsc::Receiver<Vec<u8>>) -> DynItemStream {
-    stabby::boxed::Box::new(ChannelItemStream { rx: Mutex::new(rx) }).into()
+    dynify(stabby::boxed::Box::new(ChannelItemStream {
+        rx: Mutex::new(rx),
+    }))
 }
 
 fn run_out_err(msg: String) -> pb::RunOutFrame {
@@ -1060,7 +1063,7 @@ impl Content for DiskInputContent {
 
 /// Wrap an author `Hook` as an ABI-stable [`hplugin_stabby::abi::DynHook`].
 pub fn make_dyn_hook(hook: Arc<dyn Hook>) -> hplugin_stabby::abi::DynHook {
-    stabby::boxed::Box::new(StableHookImpl { hook }).into()
+    dynify(stabby::boxed::Box::new(StableHookImpl { hook }))
 }
 
 /// Wraps an author `Hook` as a [`StableHook`].
@@ -1091,13 +1094,12 @@ impl StableHook for StableHookImpl {
         req: DynItemStream,
     ) -> DynFuture<'a, SVec<u8>> {
         let hook = Arc::clone(&self.hook);
-        stabby::boxed::Box::new(async move {
+        dynify(stabby::boxed::Box::new(async move {
             match pb::HookMethod::try_from(method as i32) {
                 Ok(pb::HookMethod::OnEvents) => hook_on_events(hook, req).await,
                 _ => unimplemented(method),
             }
-        })
-        .into()
+        }))
     }
 }
 

--- a/crates/plugin-stabby/src/abi.rs
+++ b/crates/plugin-stabby/src/abi.rs
@@ -2,6 +2,10 @@
 //! cdylib boundary. Pure stabby — no domain deps — so both host and guest depend
 //! on the exact same layout. Conversions to/from the engine's native types live
 //! in [`crate::host`] / [`crate::guest`].
+//!
+//! Every `Dyn…` handle below must be built with [`crate::vtable::dynify`], never a
+//! bare `.into()`: stabby's process-global vtable registry corrupts if one thread
+//! registers a first-use vtable while another reads the registry.
 
 // Engine futures are `Send` but not `Sync` (BoxFuture), so the ABI returns the
 // Send-only stabby future (`DynFuture` would additionally require `Sync`).

--- a/crates/plugin-stabby/src/host.rs
+++ b/crates/plugin-stabby/src/host.rs
@@ -6,6 +6,7 @@ use crate::abi::{
     QueryOutcome, ResultOutcome, StableAddr, StableArtifactContent, StableExecutor,
     StableFunctionRegistry, StableLogSink, StableRead,
 };
+use crate::vtable::dynify;
 use hcore::hartifactcontent::Content;
 use hmodel::htaddr::Addr;
 use hmodel::htpkg::PkgBuf;
@@ -61,11 +62,10 @@ impl StableArtifactContent for HostArtifactContent {
             .content
             .reader()
             .unwrap_or_else(|_| Box::new(std::io::empty()));
-        stabby::boxed::Box::new(HostRead {
+        dynify(stabby::boxed::Box::new(HostRead {
             inner: std::cell::RefCell::new(inner),
             buf: std::cell::RefCell::new(vec![0u8; READ_CHUNK]),
-        })
-        .into()
+        }))
     }
 
     extern "C" fn hashout(&self) -> SString {
@@ -98,7 +98,7 @@ pub struct HostLogSink;
 impl HostLogSink {
     /// Wrap as an ABI-stable [`DynLogSink`] to pass over the seam.
     pub fn wrap() -> DynLogSink {
-        stabby::boxed::Box::new(HostLogSink).into()
+        dynify(stabby::boxed::Box::new(HostLogSink))
     }
 }
 
@@ -147,13 +147,13 @@ pub struct HostFunctionRegistry {
 impl HostFunctionRegistry {
     /// Wrap the aggregate registry as an ABI-stable [`DynFunctionRegistry`].
     pub fn wrap(inner: Arc<ProviderFunctionRegistry>) -> DynFunctionRegistry {
-        stabby::boxed::Box::new(HostFunctionRegistry { inner }).into()
+        dynify(stabby::boxed::Box::new(HostFunctionRegistry { inner }))
     }
 }
 
 impl StableFunctionRegistry for HostFunctionRegistry {
     extern "C" fn call_registered<'a>(&'a self, req: SVec<u8>) -> DynFuture<'a, SVec<u8>> {
-        stabby::boxed::Box::new(async move {
+        dynify(stabby::boxed::Box::new(async move {
             let req = match pb::CallRegisteredRequest::decode(&req[..]) {
                 Ok(r) => r,
                 Err(e) => return unary(err_body(format!("call_registered decode: {e}"))),
@@ -187,8 +187,7 @@ impl StableFunctionRegistry for HostFunctionRegistry {
                 })),
                 Err(e) => unary(err_body(format!("{e:#}"))),
             }
-        })
-        .into()
+        }))
     }
 }
 
@@ -200,7 +199,7 @@ pub struct HostExecutor {
 impl HostExecutor {
     /// Wrap a per-request engine executor as an ABI-stable [`DynExecutor`].
     pub fn wrap(inner: Arc<dyn ProviderExecutor>) -> DynExecutor {
-        stabby::boxed::Box::new(HostExecutor { inner }).into()
+        dynify(stabby::boxed::Box::new(HostExecutor { inner }))
     }
 }
 
@@ -242,7 +241,7 @@ impl StableExecutor for HostExecutor {
     }
 
     extern "C" fn result<'a>(&'a self, addr: StableAddr) -> DynFuture<'a, ResultOutcome> {
-        stabby::boxed::Box::new(async move {
+        dynify(stabby::boxed::Box::new(async move {
             let parsed = addr_from_stable(&addr);
             match self.inner.result(&parsed).await {
                 Ok(eres) => {
@@ -252,10 +251,10 @@ impl StableExecutor for HostExecutor {
                     // guest. Nothing is buffered whole here.
                     let mut artifacts: SVec<DynArtifact> = SVec::new();
                     for art in eres.artifacts.iter() {
-                        let handle: DynArtifact = stabby::boxed::Box::new(HostArtifactContent {
-                            content: Arc::clone(art),
-                        })
-                        .into();
+                        let handle: DynArtifact =
+                            dynify(stabby::boxed::Box::new(HostArtifactContent {
+                                content: Arc::clone(art),
+                            }));
                         artifacts.push(handle);
                     }
                     ResultOutcome {
@@ -274,8 +273,7 @@ impl StableExecutor for HostExecutor {
                     artifacts: SVec::new(),
                 },
             }
-        })
-        .into()
+        }))
     }
 
     extern "C" fn query<'a>(
@@ -283,7 +281,7 @@ impl StableExecutor for HostExecutor {
         matcher_pb: SVec<u8>,
         extra_skip: SVec<SString>,
     ) -> DynFuture<'a, QueryOutcome> {
-        stabby::boxed::Box::new(async move {
+        dynify(stabby::boxed::Box::new(async move {
             let matcher = match plugin_abi::pb::Matcher::decode(&matcher_pb[..]) {
                 Ok(m) => plugin_abi::convert::matcher_from_pb(m),
                 Err(e) => {
@@ -307,7 +305,6 @@ impl StableExecutor for HostExecutor {
                     addrs: SVec::new(),
                 },
             }
-        })
-        .into()
+        }))
     }
 }

--- a/crates/plugin-stabby/src/lib.rs
+++ b/crates/plugin-stabby/src/lib.rs
@@ -26,6 +26,7 @@
 )]
 
 pub mod abi;
+pub mod vtable;
 
 #[cfg(feature = "host")]
 pub mod host;

--- a/crates/plugin-stabby/src/load_stable.rs
+++ b/crates/plugin-stabby/src/load_stable.rs
@@ -10,6 +10,7 @@ use crate::abi::{
     StableItemStreamDyn, StableManagedDriverDyn, StableMetaDyn, StableProviderDyn,
 };
 use crate::host::HostExecutor;
+use crate::vtable::dynify;
 use async_trait::async_trait;
 use futures::future::BoxFuture;
 use hcore::hasync::Cancellable;
@@ -214,10 +215,9 @@ impl StableItemStream for HostItemStream {
 }
 
 fn host_item_stream(items: Vec<Vec<u8>>) -> DynItemStream {
-    stabby::boxed::Box::new(HostItemStream {
+    dynify(stabby::boxed::Box::new(HostItemStream {
         items: std::sync::Mutex::new(items.into_iter()),
-    })
-    .into()
+    }))
 }
 
 /// Drain a bidi `run` response stream to its terminal result. Blocking (called on a
@@ -712,10 +712,9 @@ impl StableItemStream for HostChannelItemStream {
 }
 
 fn host_channel_item_stream(rx: std::sync::mpsc::Receiver<Vec<u8>>) -> DynItemStream {
-    stabby::boxed::Box::new(HostChannelItemStream {
+    dynify(stabby::boxed::Box::new(HostChannelItemStream {
         rx: std::sync::Mutex::new(rx),
-    })
-    .into()
+    }))
 }
 
 /// One build event, framed as the envelope `StreamItem` carrying its serde-JSON

--- a/crates/plugin-stabby/src/vtable.rs
+++ b/crates/plugin-stabby/src/vtable.rs
@@ -1,0 +1,100 @@
+//! Safe construction of stabby dyn handles.
+//!
+//! On stable Rust, stabby cannot hold a dyn-object's vtable in a `const` (see
+//! `stabby_abi::vtable::IConstConstructor`), so every `Box<T>` → `Dyn…`
+//! conversion looks that type's vtable up in a process-global registry
+//! (`stabby_abi::vtable::VTABLES`, an `AtomicArc`-rooted btree) and inserts it on
+//! first use. The registry's read path loads the root pointer and only THEN
+//! clones the root `Arc` — nothing keeps the pointee alive across that window, so
+//! a concurrent first-time insert (which compare-exchanges a new root in and
+//! drops the old one) frees the node the reader is about to clone. The reader
+//! walks freed memory and can come back with a null vtable slice, aborting the
+//! process in `NonNull::new_unchecked` (`stabby-abi-72.1.8/src/vtable/mod.rs:170`,
+//! "unsafe precondition(s) violated") or segfault outright. 72.1.8 is the latest
+//! release, so there is no version to upgrade to.
+//!
+//! Registry lookups only race against registry MUTATION, and every mutation in
+//! this process comes from a dyn construction in this workspace — so serializing
+//! our constructions behind one process-global lock closes the window: while a
+//! first-use insert is swapping the root, no other thread is reading it.
+//!
+//! This is off the hot path. It costs one uncontended lock per handle
+//! construction (a per-RPC boxed future, a per-call executor handle); every
+//! *method call* on an existing handle — `note_dep`, `next`, `read_chunk` — is a
+//! direct vtable dispatch that never touches the registry.
+//!
+//! The host binary and each loaded cdylib statically link their own copy of
+//! stabby, hence their own `VTABLES` — and their own copy of this lock, which
+//! guards exactly the registry its side constructs into.
+
+use std::sync::Mutex;
+
+/// Guards `stabby_abi::vtable::VTABLES` against concurrent insert-vs-lookup.
+static VTABLE_REGISTRY: Mutex<()> = Mutex::new(());
+
+/// Build a stabby dyn handle (`stabby::boxed::Box<T>` → `Dyn…`) with the vtable
+/// registry locked.
+///
+/// EVERY stabby dyn construction in the workspace must go through this instead of
+/// a bare `.into()` — a single unguarded construction can free the registry root
+/// under another thread and abort the process.
+pub fn dynify<T, D: From<T>>(value: T) -> D {
+    // The lock only spans stabby's registry insert — never user code — so a poison
+    // flag carries no broken invariant of ours: take the guard and continue.
+    let _guard = VTABLE_REGISTRY
+        .lock()
+        .unwrap_or_else(|poisoned| poisoned.into_inner());
+    D::from(value)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::dynify;
+    use crate::abi::{DynRead, StableRead, StableReadDyn};
+    use stabby::vec::Vec as SVec;
+
+    /// A distinct `StableRead` implementor per `N` — each monomorphization is a
+    /// distinct source type, so it gets its OWN vtable and its own first-use
+    /// insert into the registry. One type would be inserted once and every later
+    /// construction would take the read-only path; many types keep the registry
+    /// mutating while other threads read it, which is the racy window.
+    struct Reader<const N: usize>;
+
+    impl<const N: usize> StableRead for Reader<N> {
+        extern "C" fn read_chunk(&self) -> SVec<u8> {
+            SVec::from([N as u8].as_slice())
+        }
+    }
+
+    /// Construct one handle per type and call through each, so a vtable that came
+    /// back corrupted shows up as a wrong answer rather than passing silently.
+    macro_rules! build_all {
+        ($($n:literal),* $(,)?) => {
+            $({
+                let handle: DynRead = dynify(stabby::boxed::Box::new(Reader::<$n>));
+                let got = handle.read_chunk();
+                assert_eq!(got.as_slice(), [$n as u8], "vtable dispatched to the wrong impl");
+            })*
+        };
+    }
+
+    /// Many threads registering many first-use vtables at once must not corrupt
+    /// the registry. Pre-fix this aborts the process (non-unwinding panic in
+    /// `NonNull::new_unchecked`) once a reader clones a root another thread just
+    /// freed; a plain `.into()` here is enough to trip it.
+    #[test]
+    fn concurrent_first_use_vtable_registration_is_sound() {
+        std::thread::scope(|scope| {
+            for _ in 0..16 {
+                scope.spawn(|| {
+                    build_all!(
+                        0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20,
+                        21, 22, 23, 24, 25, 26, 27, 28, 29, 30, 31, 32, 33, 34, 35, 36, 37, 38, 39,
+                        40, 41, 42, 43, 44, 45, 46, 47, 48, 49, 50, 51, 52, 53, 54, 55, 56, 57, 58,
+                        59, 60, 61, 62, 63,
+                    );
+                });
+            }
+        });
+    }
+}


### PR DESCRIPTION
## Problem

`cargo test -p plugin-sdk --features stabby` aborted on ~1 in 6 runs, inside the pre-existing test `serve::tests::list_stream_propagates_midstream_error`:

```
panicked at stabby-abi-72.1.8/src/vtable/mod.rs:170:41:
unsafe precondition(s) violated: NonNull::new_unchecked requires that the pointer is non-null
thread caused non-unwinding panic. aborting.
```

## Root cause

Not the test — stabby.

On stable Rust, stabby cannot hold a dyn object's vtable in a `const` (see `stabby_abi::vtable::IConstConstructor`), so every `Box<T>` → `Dyn…` conversion looks that type's vtable up in a process-global registry (`stabby_abi::vtable::VTABLES`, an `AtomicArc`-rooted btree) and inserts it on first use.

That registry's read path loads the root pointer and **only then** clones the root `Arc` — nothing keeps the pointee alive across that window. A concurrent first-use insert compare-exchanges a new root in and drops the old one right there, so the reader clones freed memory and can walk out with a null vtable slice: abort in `NonNull::new_unchecked`, or an outright segfault.

`list_stream_propagates_midstream_error` was just the unlucky test — it builds a `DynProvider` and a `DynItemStream` while other test threads build their own handles. 72.1.8 is the latest stabby release, so there is no version to upgrade to.

## Fix

Registry lookups only race against registry **mutation**, and every mutation in the process comes from a dyn construction in this workspace — so one process-global lock around each construction closes the window.

Adds `hplugin_stabby::vtable::dynify` and routes all 20 construction sites (`host.rs`, `load_stable.rs`, `serve.rs`) through it instead of a bare `.into()`.

This stays off the hot path: it costs one uncontended lock per *handle construction* (a per-RPC boxed future, a per-call executor handle). Every *method call* on an existing handle — `note_dep`, `next`, `read_chunk` — is a direct vtable dispatch that never touches the registry.

## Test

`concurrent_first_use_vtable_registration_is_sound`: 16 threads × 64 distinct first-use vtables, calling through each handle so a corrupted vtable surfaces as a wrong answer rather than passing silently.

- lock removed → **46/100 runs crash** (SIGSEGV)
- lock in place → **150/150 clean**
- `plugin-sdk --features stabby` → clean over 120 consecutive runs

`cargo test --all` and `lint` pass. (`plugingo-e2e` could not run locally — the dev machine's disk is full and the Go SDK unpack fails with ENOSPC; unrelated to this change, leaving it to CI.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)