### PR TITLE
Add /pr-build-published skill to watch the upload_artifacts CI job

### DIFF
--- a/.claude/skills/pr-build-published/SKILL.md
+++ b/.claude/skills/pr-build-published/SKILL.md
@@ -1,0 +1,49 @@
+---
+name: pr-build-published
+description: >
+  Watch the current PR's "CI" GitHub Actions run and report the outcome of the
+  `upload_artifacts` job (display name "Pre-release"), which publishes the build
+  artifacts as a pre-release. Resolves the PR for the current branch, locates the
+  CI workflow run for its head commit, and polls that job until it reaches a
+  terminal state. Reports a positive outcome when the job completes successfully,
+  or a failure with the reason when it is skipped or fails.
+  Trigger when the user says "pr build published", "was the build published",
+  "did upload_artifacts pass", "check the pre-release job", or invokes
+  /pr-build-published.
+---
+
+# PR Build Published
+
+Goal: report whether the current PR's `upload_artifacts` job (which uploads/publishes
+the build artifacts as a pre-release) succeeded, was skipped, or failed.
+
+How it works: the `upload_artifacts` job in `.github/workflows/heph.yml` carries the
+display name **"Pre-release"** — that display name is what the GitHub Actions jobs API
+returns, so the script matches on it. The job has `if: always() && needs.gen.result == 'success'`,
+so it is **skipped** when the upstream `gen` codegen job does not succeed, and **fails**
+when a step (artifact download, manifest generation, or the release creation) errors. The
+script polls the job until it reaches a terminal state.
+
+## Run
+
+Execute this script. It resolves the PR, finds the `CI` run, and polls the `upload_artifacts`
+("Pre-release") job until it completes (default cap 45 min; override with `TIMEOUT_SECONDS`).
+
+```bash
+bash .claude/skills/pr-build-published/watch-upload-artifacts.sh
+```
+
+## After running
+
+- **Exit 0** (`ok`) → report a **positive outcome**: the `upload_artifacts` job completed and
+  the build was published. Share the run URL and PR URL, all clickable.
+- Non-zero → report a **failure with the reason** the script printed to stderr — do not retry
+  blindly:
+  - Exit 2 (`no PR`) → there is no open PR for the current branch; tell the user to open one.
+  - Exit 3 (`no CI run`) → the `CI` workflow has not started for the head commit yet.
+  - Exit 4 (`skipped`) → the job was skipped because an upstream dependency (the `gen` codegen
+    job) did not succeed; relay that reason and the run URL.
+  - Exit 5 (`failed`) → the job ran but concluded `failure`/`cancelled`/`timed_out`; relay the
+    failing step name(s) the script reported and the run URL.
+  - Exit 6 (`timeout`) → the job did not reach a terminal state within the deadline; share the
+    run URL so the user can inspect it (or re-run with a larger `TIMEOUT_SECONDS`).

--- a/.claude/skills/pr-build-published/watch-upload-artifacts.sh
+++ b/.claude/skills/pr-build-published/watch-upload-artifacts.sh
@@ -1,0 +1,87 @@
+#!/usr/bin/env bash
+# Watch the current PR's "CI" run for the `upload_artifacts` job (display name
+# "Pre-release") and report its terminal outcome.
+#
+# On success, prints:   ok\n<run_url>\n<pr_url>
+# On skip/failure, prints (to stderr) the reason and exits non-zero:
+#   3 -> no CI run found for the head commit within the deadline
+#   4 -> job was skipped
+#   5 -> job failed / cancelled / timed_out (reason = failed step names)
+#   6 -> deadline reached before the job completed
+# Polls until the job reaches a terminal state (default cap 45 min).
+set -euo pipefail
+
+JOB_NAME="${JOB_NAME:-Pre-release}"   # display name of the `upload_artifacts` job
+WORKFLOW="CI"
+DEADLINE=$(( $(date +%s) + ${TIMEOUT_SECONDS:-2700} ))   # default 45 minutes
+POLL_INTERVAL="${POLL_INTERVAL:-15}"
+
+repo=$(gh repo view --json nameWithOwner -q .nameWithOwner)
+
+# Resolve the PR for the current branch -> head commit SHA + PR url.
+pr_json=$(gh pr view --json headRefOid,url 2>/dev/null || true)
+sha=$(echo "$pr_json" | jq -r '.headRefOid // empty')
+pr_url=$(echo "$pr_json" | jq -r '.url // empty')
+if [ -z "${sha:-}" ]; then
+  echo "error: no PR found for the current branch" >&2
+  exit 2
+fi
+
+found_run_url=""
+
+while :; do
+  # Find the CI workflow run for this exact head commit.
+  run_json=$(gh run list --repo "$repo" --workflow "$WORKFLOW" --commit "$sha" \
+    --limit 1 --json databaseId,url 2>/dev/null || echo '[]')
+  run_id=$(echo "$run_json" | jq -r '.[0].databaseId // empty')
+  run_url=$(echo "$run_json" | jq -r '.[0].url // empty')
+
+  if [ -n "$run_id" ]; then
+    found_run_url="$run_url"
+    # Fetch the target job for this run by its display name.
+    job=$(gh api --paginate "repos/$repo/actions/runs/$run_id/jobs" \
+      -q ".jobs[] | select(.name == \"$JOB_NAME\")" 2>/dev/null | jq -s '.[0] // empty')
+
+    if [ -n "$job" ] && [ "$job" != "null" ]; then
+      status=$(echo "$job" | jq -r '.status // empty')
+      conclusion=$(echo "$job" | jq -r '.conclusion // empty')
+
+      if [ "$status" = "completed" ]; then
+        case "$conclusion" in
+          success)
+            printf 'ok\n%s\n%s\n' "$run_url" "$pr_url"
+            exit 0
+            ;;
+          skipped)
+            echo "error: '$JOB_NAME' (upload_artifacts) was skipped" >&2
+            echo "reason: an upstream dependency did not succeed (the job runs only when the 'gen' codegen job succeeds)" >&2
+            echo "run: $run_url" >&2
+            exit 4
+            ;;
+          *)
+            failed_steps=$(echo "$job" | jq -r \
+              '[.steps[]? | select(.conclusion == "failure" or .conclusion == "cancelled" or .conclusion == "timed_out") | .name] | join(", ")')
+            echo "error: '$JOB_NAME' (upload_artifacts) concluded '$conclusion'" >&2
+            if [ -n "$failed_steps" ]; then
+              echo "reason: failing step(s): $failed_steps" >&2
+            fi
+            echo "run: $run_url" >&2
+            exit 5
+            ;;
+        esac
+      fi
+    fi
+  fi
+
+  if [ "$(date +%s)" -ge "$DEADLINE" ]; then
+    if [ -z "$found_run_url" ]; then
+      echo "error: no CI run found for commit $sha within the deadline" >&2
+      exit 3
+    fi
+    echo "error: timeout - '$JOB_NAME' (upload_artifacts) did not complete within the deadline" >&2
+    echo "run: $found_run_url" >&2
+    exit 6
+  fi
+
+  sleep "$POLL_INTERVAL"
+done


### PR DESCRIPTION
## Summary

Adds a new `/pr-build-published` skill that watches the current PR's `CI` GitHub Actions run and reports the outcome of the `upload_artifacts` job — the job that publishes the build artifacts as a pre-release.

The `upload_artifacts` job carries the display name **"Pre-release"** (which is what the Actions jobs API returns), and runs with `if: always() && needs.gen.result == 'success'`, so it can be **skipped** (when the upstream `gen` codegen job does not succeed) or **fail** (artifact download, manifest generation, or release creation). The skill polls the job until it reaches a terminal state and reports:

- **success** → a positive outcome, with the run and PR URLs
- **skipped / failed** → a failure with the reason (upstream dependency, or the failing step name)

## Contents

- `.claude/skills/pr-build-published/SKILL.md` — skill definition and post-run reporting guidance
- `.claude/skills/pr-build-published/watch-upload-artifacts.sh` — polls the CI run's `upload_artifacts` ("Pre-release") job and exits with a distinct code per outcome (success / no PR / no run / skipped / failed / timeout)

Modeled on the existing `pr-build-version` skill.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018tZXu6iYG6e64UTDf9rVtG

---
_Generated by [Claude Code](https://claude.ai/code/session_018tZXu6iYG6e64UTDf9rVtG)_