### PR TITLE
ci: silence go module cache warning in Pre-release job

### DIFF
--- a/.github/workflows/heph.yml
+++ b/.github/workflows/heph.yml
@@ -208,6 +208,9 @@ jobs:
       - uses: actions/setup-go@v5
         with:
           go-version: "1.25"
+          # No go.mod at repo root (Rust project); disable module caching to
+          # avoid the "Dependencies file is not found" restore-cache warning.
+          cache: false
 
       - name: Download all artifacts
         uses: actions/download-artifact@v7


### PR DESCRIPTION
## What

`actions/setup-go@v5` caches Go modules by default and looks for a `go.mod` at the repo root. heph is a Rust project with no root `go.mod`, so the `upload_artifacts` (Pre-release) job logged this warning on every run:

```
Restore cache failed: Dependencies file is not found in /home/runner/work/heph/heph. Supported file pattern: go.mod
```

## Fix

Set `cache: false` on the `setup-go` step in that job — it only needs the Go toolchain to build the plugin manifest generator, not module caching.

🤖 Generated with [Claude Code](https://claude.com/claude-code)