### PR TITLE
fix(engine): deliver emit_scope *End events to hooks, not just the channel

### DIFF
--- a/crates/engine/src/engine/event.rs
+++ b/crates/engine/src/engine/event.rs
@@ -6,8 +6,9 @@
 //! with a wall-clock timestamp at emit time (`at_unix_ms`), so elapsed times stay
 //! correct even when the client and server are split across a channel.
 
-use crate::engine::request_state::RequestState;
+use crate::engine::request_state::{RequestState, RequestStateData};
 use std::future::Future;
+use std::sync::Arc;
 
 // Event types moved to `heph-core::events` (shared by the TUI + telemetry
 // without an engine dep); re-exported so `engine::event::BuildEventKind` etc.
@@ -17,22 +18,25 @@ pub use hcore::events::{BuildEvent, BuildEventKind, EventReceiver, EventSender, 
 /// Internal drop-guard so the `*End` event fires on early-return (`?`) **and** on
 /// cancellation (the awaited future is dropped mid-flight). Once armed, the guard
 /// emits exactly one end event when dropped.
+///
+/// Holds the shared [`RequestStateData`] (not just the event channel) so the end
+/// event fans out to registered hooks too — an out-of-process hook (e.g. the GHA
+/// status plugin) must see `ResultEnd`/`ExecuteEnd`, or every count it tallies
+/// against paired scopes reads zero.
 struct EndGuard {
-    tx: Option<EventSender>,
+    data: Option<Arc<RequestStateData>>,
     make_end: Option<Box<dyn FnOnce(Option<String>) -> BuildEventKind + Send>>,
     error: Option<String>,
 }
 
 impl Drop for EndGuard {
     fn drop(&mut self) {
-        if let (Some(tx), Some(make_end)) = (self.tx.take(), self.make_end.take()) {
+        if let (Some(data), Some(make_end)) = (self.data.take(), self.make_end.take()) {
             let kind = make_end(self.error.take());
-            // A closed receiver (consumer gone, e.g. TUI shut down) is expected;
-            // dropping the send result is intentional, events are best-effort.
-            drop(tx.send(BuildEvent {
+            data.dispatch(BuildEvent {
                 at_unix_ms: now_unix_ms(),
                 kind,
-            }));
+            });
         }
     }
 }
@@ -51,7 +55,7 @@ pub async fn emit_scope<T>(
 ) -> anyhow::Result<T> {
     rs.emit(start);
     let mut guard = EndGuard {
-        tx: rs.events_sender(),
+        data: Some(rs.data()),
         make_end: Some(Box::new(make_end)),
         error: None,
     };

--- a/crates/engine/src/engine/request_state.rs
+++ b/crates/engine/src/engine/request_state.rs
@@ -343,15 +343,16 @@ impl RequestState {
             at_unix_ms: crate::engine::event::now_unix_ms(),
             kind,
         };
-        // Fan out to every registered hook (best-effort, sync push).
-        for hook in &self.data.hooks {
-            hook.on_event(&event);
-        }
-        if let Some(tx) = &self.data.events {
-            // A closed receiver (consumer gone) is expected; events are
-            // best-effort, so dropping the send result is intentional.
-            drop(tx.send(event));
-        }
+        self.data.dispatch(event);
+    }
+
+    /// The shared request data, for consumers that must fan an event out
+    /// themselves after `self` is no longer borrowable — notably
+    /// [`emit_scope`](crate::engine::event::emit_scope)'s end-of-scope drop guard,
+    /// which fires after the scoped future (which borrowed the `RequestState`)
+    /// has been dropped.
+    pub(crate) fn data(&self) -> Arc<RequestStateData> {
+        Arc::clone(&self.data)
     }
 
     /// Emit the `MaxWorkers` capacity event at most once per request. Safe to
@@ -455,6 +456,24 @@ impl RequestState {
             self.data.dep_dag.lock().add_dep(parent, addr)
         } else {
             Ok(())
+        }
+    }
+}
+
+impl RequestStateData {
+    /// Fan a fully-built event out to every registered hook and the event
+    /// channel (both best-effort). The single delivery path for a `BuildEvent`,
+    /// shared by [`RequestState::emit`] and [`emit_scope`](crate::engine::event::emit_scope)'s
+    /// drop guard so paired `*End` events reach hooks, not just the channel.
+    pub(crate) fn dispatch(&self, event: crate::engine::event::BuildEvent) {
+        // Fan out to every registered hook (best-effort, sync push).
+        for hook in &self.hooks {
+            hook.on_event(&event);
+        }
+        if let Some(tx) = &self.events {
+            // A closed receiver (consumer gone) is expected; events are
+            // best-effort, so dropping the send result is intentional.
+            drop(tx.send(event));
         }
     }
 }
@@ -831,6 +850,66 @@ mod tests {
         assert!(
             rec.closed.load(Ordering::Acquire),
             "on_close fires when the request state drops"
+        );
+        Ok(())
+    }
+
+    // The `*End` event of an `emit_scope` fans out to registered hooks — not just
+    // the renderer channel. Regression: the end-of-scope drop guard used to emit
+    // via the event sender only, so an out-of-process hook (e.g. the GHA status
+    // plugin) saw every `*Start` but no `*End`, tallying `done`/`built` as zero.
+    // Exercised with no renderer channel (events = None), the exact failing case.
+    #[tokio::test]
+    async fn emit_scope_end_reaches_hooks_without_renderer() -> anyhow::Result<()> {
+        use crate::engine::hook::Hook;
+        use hcore::events::{BuildEvent, BuildEventKind};
+
+        #[derive(Default)]
+        struct Rec {
+            ends: Mutex<Vec<String>>,
+        }
+        impl Hook for Rec {
+            fn name(&self) -> String {
+                "rec".into()
+            }
+            fn on_event(&self, ev: &BuildEvent) {
+                if let BuildEventKind::ResultEnd { addr, .. } = &ev.kind {
+                    self.ends.lock().push(addr.clone());
+                }
+            }
+            fn on_close(&self) {}
+        }
+
+        let dir = tempfile::tempdir().expect("tempdir");
+        let mut e = Engine::new(Config {
+            root: dir.path().to_path_buf(),
+            home_dir: PathBuf::new(),
+            parallelism: None,
+            ..Default::default()
+        })?;
+        let rec = Arc::new(Rec::default());
+        e.register_hook(Arc::clone(&rec) as Arc<dyn Hook>)?;
+        let engine = Arc::new(e);
+
+        // No renderer channel (events = None): the hook is the only consumer.
+        let state = engine.new_state_with_events(true, None);
+        crate::engine::event::emit_scope(
+            &state,
+            BuildEventKind::ResultStart {
+                addr: "//a:b".into(),
+            },
+            |error| BuildEventKind::ResultEnd {
+                addr: "//a:b".into(),
+                error,
+            },
+            async { anyhow::Ok(()) },
+        )
+        .await?;
+
+        assert_eq!(
+            rec.ends.lock().clone(),
+            vec!["//a:b".to_string()],
+            "the *End event must reach the hook even with no renderer channel"
         );
         Ok(())
     }


### PR DESCRIPTION
## Problem

The GHA status plugin's step summary printed all-zero counts at the end of a **successful** run:

```
Targets: 0 / 1240  •  built: 0  •  cached: 0  •  failed: 0
```

…with a green ✅. The total (`1240`) was right, but `done`/`built` were stuck at zero regardless of what the build did.

## Root cause

`emit_scope`'s end-of-scope drop guard (`crates/engine/src/engine/event.rs`) emitted the `*End` event through `RequestState::events_sender()` — the renderer mpsc channel **only** — bypassing every registered `Hook`.

The paired `*Start` goes through `rs.emit()`, which fans out to hooks **and** the channel. So a hook (like the out-of-process GHA plugin) saw `ResultStart`/`ExecuteStart` but never the matching `ResultEnd`/`ExecuteEnd`. Every count the GHA `Tally` measures against a paired scope (`done` = `matched ∩ finished`, `built` = `ExecuteEnd` counter, `failed`) therefore read zero. `Matched` and `LocalCacheHit` are plain `rs.emit()` calls, which is why the total and cache line still populated.

Worse, on CI there is often no renderer channel at all (hook present, no TUI) — so `events_sender()` was `None` and the guard silently dropped the end event entirely.

## Fix

Route both `RequestState::emit` and the drop guard through a single `RequestStateData::dispatch`, so `*End` events fan out to hooks and the channel alike. The guard now holds the shared `RequestStateData` (via `rs.data()`) instead of a lone sender, so it works even with no renderer channel.

This strictly *adds* the previously-missing end events to hooks; the TUI channel still receives exactly one end event, so existing consumers are unchanged.

## Test

`emit_scope_end_reaches_hooks_without_renderer` registers a hook with `events = None` and asserts the `ResultEnd` from an `emit_scope` reaches it. Fails before the fix (guard's `tx` was `None`), passes after.

🤖 Generated with [Claude Code](https://claude.com/claude-code)