### PR TITLE
feat(plugin-http): default http_fetch to local+remote cache with a knob

### DIFF
--- a/crates/plugin-exec/src/pluginexec/mod.rs
+++ b/crates/plugin-exec/src/pluginexec/mod.rs
@@ -9,9 +9,7 @@ use hcore::hasync::Cancellable;
 use hdriver_support::driver_managed::{ManagedRunRequest, ManagedRunResponse};
 use hplugin::driver::sandbox::EnvValue;
 use hplugin::driver::targetdef::path::{CodegenMode, Content, Path};
-use hplugin::driver::targetdef::{
-    CacheConfig, Input, InputMode, Output, TargetDef as EngineTargetDef,
-};
+use hplugin::driver::targetdef::{Input, InputMode, Output, TargetDef as EngineTargetDef};
 use hplugin::driver::{
     ApplyTransitiveRequest, ApplyTransitiveResponse, ConfigRequest, ConfigResponse, ParseRequest,
     ParseResponse, TargetAddr, outputartifact,
@@ -658,11 +656,7 @@ impl hdriver_support::driver_managed::ManagedDriver for Driver {
                     .collect(),
                 outputs,
                 support_files,
-                cache: CacheConfig {
-                    enabled: spec.cache.local,
-                    remote_enabled: spec.cache.remote,
-                    history: spec.cache.history,
-                },
+                cache: spec.cache.into(),
                 pty: true,
                 hash,
                 transparent: false,
@@ -1393,6 +1387,7 @@ mod tests {
     use hdriver_support::driver_managed::ManagedDriver;
     use hmodel::htaddr::Addr;
     use hplugin::driver::RunRequest;
+    use hplugin::driver::targetdef::CacheConfig;
 
     #[test]
     fn env_key_segment_sanitizes_invalid_chars() {

--- a/crates/plugin-exec/src/pluginexec/spec.rs
+++ b/crates/plugin-exec/src/pluginexec/spec.rs
@@ -1,15 +1,13 @@
-use anyhow::Context;
-use hcore::htvalue::Value;
-use hcore::htvalue::signature::ParamType;
 use hplugin::driver::targetdef::path::CodegenMode;
-use hplugin::htspec::{FromSpecValue, Spec, SpecStruct};
+use hplugin::htspec::{Spec, TargetSpecCache};
 use std::collections::HashMap;
 
 /// Exec-driver target config. `#[derive(Spec)]` generates `TargetSpec::from`
 /// (parser) and `TargetSpec::schema` (LSP schema) from these fields, so the two
 /// can never drift; doc comments below become the schema docs. `codegen` is a
-/// [`SpecEnum`](hplugin::htspec::SpecEnum); `cache` is a bool shorthand or a
-/// [`SpecStruct`] dict ([`CacheDict`]).
+/// [`SpecEnum`](hplugin::htspec::SpecEnum); `cache` is the shared
+/// [`TargetSpecCache`] knob (a bool shorthand or a `{enabled, remote, history}`
+/// dict).
 #[derive(Spec)]
 pub(crate) struct TargetSpec {
     /// Command to execute, as an argv list. `$OUT`, `$SRC_<group>`, `$TOOL_<group>` and declared env vars are available.
@@ -47,86 +45,11 @@ pub(crate) struct TargetSpec {
     pub runtime_env: HashMap<String, String>,
 }
 
-pub(crate) struct TargetSpecCache {
-    pub local: bool,
-    pub remote: bool,
-    /// How many cache revisions to retain for this target. Default 1.
-    pub history: u32,
-}
-
-impl Default for TargetSpecCache {
-    fn default() -> Self {
-        TargetSpecCache {
-            local: true,
-            remote: true,
-            history: 1,
-        }
-    }
-}
-
-/// The dict form of `cache`: `{"enabled": bool, "remote": bool, "history": int}`,
-/// each key optional and defaulting (enabled/remote true, history 1). The
-/// `SpecStruct` derive parses the map and rejects unknown keys.
-#[derive(SpecStruct)]
-struct CacheDict {
-    #[spec(rename = "enabled", default = true)]
-    local: bool,
-    #[spec(default = true)]
-    remote: bool,
-    #[spec(default = 1u32, parse = parse_cache_history)]
-    history: u32,
-}
-
-impl From<CacheDict> for TargetSpecCache {
-    fn from(d: CacheDict) -> Self {
-        TargetSpecCache {
-            local: d.local,
-            remote: d.remote,
-            history: d.history,
-        }
-    }
-}
-
-/// The `cache` attribute accepts either a bare bool (legacy: `cache =
-/// True/False` toggles both local and remote, history 1) or the [`CacheDict`]
-/// form. This is shape-dispatch (not `SpecUnion`): a map *commits* to the dict
-/// arm so its specific parse errors (unknown key, bad `history`) surface,
-/// rather than being masked by a generic "expected bool | map" union error.
-impl FromSpecValue for TargetSpecCache {
-    fn from_spec_value(v: &Value) -> anyhow::Result<Self> {
-        match v {
-            // A bare bool toggles both local and remote; history stays at 1.
-            Value::Bool(b) => Ok(TargetSpecCache {
-                local: *b,
-                remote: *b,
-                history: 1,
-            }),
-            Value::Map(_) => CacheDict::from_spec_value(v).map(TargetSpecCache::from),
-            _ => anyhow::bail!("`cache` must be a bool or a dict"),
-        }
-    }
-
-    fn spec_param_type() -> ParamType {
-        ParamType::union(vec![ParamType::Bool, CacheDict::spec_param_type()])
-    }
-}
-
-fn parse_cache_history(v: &Value) -> anyhow::Result<u32> {
-    let n: i64 = match v {
-        Value::Int(i) => *i,
-        Value::Uint(u) => i64::try_from(*u).context("`cache.history` too large")?,
-        _ => anyhow::bail!("`cache.history` must be an integer"),
-    };
-    if n < 1 {
-        anyhow::bail!("`cache.history` must be >= 1, got {n}");
-    }
-    u32::try_from(n).context("`cache.history` too large")
-}
-
 #[cfg(test)]
 mod tests {
     use super::*;
     use hcore::htvalue::Value;
+    use hcore::htvalue::signature::ParamType;
     use hplugin::driver::DriverField;
 
     fn make_spec(

--- a/crates/plugin-http/src/pluginhttp/mod.rs
+++ b/crates/plugin-http/src/pluginhttp/mod.rs
@@ -25,12 +25,12 @@ use hcore::hasync::Cancellable;
 use hcore::htvalue::signature::ParamType;
 use hdriver_support::driver_managed::{ManagedDriver, ManagedRunRequest, ManagedRunResponse};
 use hplugin::driver::targetdef::path::{CodegenMode, Content, Path};
-use hplugin::driver::targetdef::{CacheConfig, Output, TargetDef};
+use hplugin::driver::targetdef::{Output, TargetDef};
 use hplugin::driver::{
     ApplyTransitiveRequest, ApplyTransitiveResponse, ConfigRequest, ConfigResponse, ParseRequest,
     ParseResponse,
 };
-use hplugin::htspec::Spec;
+use hplugin::htspec::{Spec, TargetSpecCache};
 use sha2::{Digest, Sha256};
 use std::collections::BTreeMap;
 use std::hash::{Hash, Hasher};
@@ -59,6 +59,12 @@ struct HttpFetchSpec {
     out: Option<String>,
     /// Mark the fetched file executable (a downloaded tool binary).
     executable: bool,
+    /// Caching for the fetched file. Defaults to on for both the local and
+    /// remote cache — a fetch is content-addressed (pinned by `sha256`), so it
+    /// is safe to share. `cache = False` disables both tiers; the dict form
+    /// `{enabled, remote, history}` toggles them independently (e.g.
+    /// `cache = {"remote": False}` keeps the fetch local-only).
+    cache: TargetSpecCache,
 }
 
 #[derive(Clone, serde::Serialize, serde::Deserialize)]
@@ -156,7 +162,7 @@ impl ManagedDriver for Driver {
                     }],
                 }],
                 support_files: vec![],
-                cache: CacheConfig::on(true),
+                cache: spec.cache.into(),
                 pty: false,
                 hash,
                 transparent: false,
@@ -573,6 +579,77 @@ mod tests {
             .expect("parse darwin");
 
         assert_ne!(linux.target_def.hash, darwin.target_def.hash);
+    }
+
+    /// A fetch defaults to caching in both the local and remote tiers: the
+    /// bytes are content-addressed, so they are safe to share.
+    #[tokio::test]
+    async fn parse_defaults_to_local_and_remote_cache() {
+        let config = HashMap::from([(
+            "url".to_string(),
+            Value::String("https://x/tool".to_string()),
+        )]);
+        let resp = Driver
+            .parse(
+                parse_req("//tools/dl:tool", config),
+                &StdCancellationToken::new(),
+            )
+            .await
+            .expect("parse");
+
+        let cache = resp.target_def.cache;
+        assert!(cache.enabled, "local cache on by default");
+        assert!(cache.remote_enabled, "remote cache on by default");
+    }
+
+    /// `cache = False` turns off both tiers.
+    #[tokio::test]
+    async fn parse_cache_false_disables_both_tiers() {
+        let config = HashMap::from([
+            (
+                "url".to_string(),
+                Value::String("https://x/tool".to_string()),
+            ),
+            ("cache".to_string(), Value::Bool(false)),
+        ]);
+        let resp = Driver
+            .parse(
+                parse_req("//tools/dl:tool", config),
+                &StdCancellationToken::new(),
+            )
+            .await
+            .expect("parse");
+
+        let cache = resp.target_def.cache;
+        assert!(!cache.enabled);
+        assert!(!cache.remote_enabled);
+    }
+
+    /// The dict form toggles the tiers independently: keep the fetch local but
+    /// off the remote cache.
+    #[tokio::test]
+    async fn parse_cache_dict_can_disable_remote_only() {
+        let config = HashMap::from([
+            (
+                "url".to_string(),
+                Value::String("https://x/tool".to_string()),
+            ),
+            (
+                "cache".to_string(),
+                Value::Map(HashMap::from([("remote".to_string(), Value::Bool(false))])),
+            ),
+        ]);
+        let resp = Driver
+            .parse(
+                parse_req("//tools/dl:tool", config),
+                &StdCancellationToken::new(),
+            )
+            .await
+            .expect("parse");
+
+        let cache = resp.target_def.cache;
+        assert!(cache.enabled, "local stays on");
+        assert!(!cache.remote_enabled, "remote disabled");
     }
 
     #[tokio::test]

--- a/crates/plugin/src/htspec/cache.rs
+++ b/crates/plugin/src/htspec/cache.rs
@@ -1,0 +1,187 @@
+//! The shared `cache` target attribute.
+//!
+//! Any driver that lets a target configure its own caching exposes a `cache`
+//! field of type [`TargetSpecCache`]. It accepts either a bare bool (`cache =
+//! True/False`, toggling local **and** remote) or a `{enabled, remote, history}`
+//! dict, and lowers into the engine's [`CacheConfig`]. Defined once here so
+//! `exec`, `http_fetch`, and every future driver parse the knob identically.
+
+use anyhow::Context as _;
+use hcore::htvalue::Value;
+use hcore::htvalue::signature::ParamType;
+
+use crate::driver::targetdef::CacheConfig;
+use crate::htspec::{FromSpecValue, SpecStruct};
+
+/// A parsed `cache` attribute. `local`/`remote` gate the two cache tiers;
+/// `history` is how many cache revisions to retain. Defaults to both tiers on
+/// with history 1 — the same as an absent `cache`.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct TargetSpecCache {
+    pub local: bool,
+    pub remote: bool,
+    /// How many cache revisions to retain for this target. Default 1.
+    pub history: u32,
+}
+
+impl Default for TargetSpecCache {
+    fn default() -> Self {
+        TargetSpecCache {
+            local: true,
+            remote: true,
+            history: 1,
+        }
+    }
+}
+
+impl From<TargetSpecCache> for CacheConfig {
+    fn from(c: TargetSpecCache) -> Self {
+        CacheConfig {
+            enabled: c.local,
+            remote_enabled: c.remote,
+            history: c.history,
+        }
+    }
+}
+
+/// The dict form of `cache`: `{"enabled": bool, "remote": bool, "history": int}`,
+/// each key optional and defaulting (enabled/remote true, history 1). The
+/// `SpecStruct` derive parses the map and rejects unknown keys.
+#[derive(SpecStruct)]
+struct CacheDict {
+    #[spec(rename = "enabled", default = true)]
+    local: bool,
+    #[spec(default = true)]
+    remote: bool,
+    #[spec(default = 1u32, parse = parse_cache_history)]
+    history: u32,
+}
+
+impl From<CacheDict> for TargetSpecCache {
+    fn from(d: CacheDict) -> Self {
+        TargetSpecCache {
+            local: d.local,
+            remote: d.remote,
+            history: d.history,
+        }
+    }
+}
+
+/// The `cache` attribute accepts either a bare bool (`cache = True/False`
+/// toggles both local and remote, history 1) or the [`CacheDict`] form. This is
+/// shape-dispatch (not `SpecUnion`): a map *commits* to the dict arm so its
+/// specific parse errors (unknown key, bad `history`) surface, rather than being
+/// masked by a generic "expected bool | map" union error.
+impl FromSpecValue for TargetSpecCache {
+    fn from_spec_value(v: &Value) -> anyhow::Result<Self> {
+        match v {
+            // A bare bool toggles both local and remote; history stays at 1.
+            Value::Bool(b) => Ok(TargetSpecCache {
+                local: *b,
+                remote: *b,
+                history: 1,
+            }),
+            Value::Map(_) => CacheDict::from_spec_value(v).map(TargetSpecCache::from),
+            _ => anyhow::bail!("`cache` must be a bool or a dict"),
+        }
+    }
+
+    fn spec_param_type() -> ParamType {
+        ParamType::union(vec![ParamType::Bool, CacheDict::spec_param_type()])
+    }
+}
+
+fn parse_cache_history(v: &Value) -> anyhow::Result<u32> {
+    let n: i64 = match v {
+        Value::Int(i) => *i,
+        Value::Uint(u) => i64::try_from(*u).context("`cache.history` too large")?,
+        _ => anyhow::bail!("`cache.history` must be an integer"),
+    };
+    if n < 1 {
+        anyhow::bail!("`cache.history` must be >= 1, got {n}");
+    }
+    u32::try_from(n).context("`cache.history` too large")
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn parse(v: Value) -> anyhow::Result<TargetSpecCache> {
+        TargetSpecCache::from_spec_value(&v)
+    }
+
+    fn dict(pairs: impl IntoIterator<Item = (&'static str, Value)>) -> Value {
+        Value::Map(pairs.into_iter().map(|(k, v)| (k.to_string(), v)).collect())
+    }
+
+    #[test]
+    fn default_is_both_tiers_on() {
+        let c = TargetSpecCache::default();
+        assert!(c.local && c.remote);
+        assert_eq!(c.history, 1);
+    }
+
+    #[test]
+    fn bool_true_toggles_both() {
+        let c = parse(Value::Bool(true)).expect("parse");
+        assert!(c.local && c.remote);
+        assert_eq!(c.history, 1);
+    }
+
+    #[test]
+    fn bool_false_disables_both() {
+        let c = parse(Value::Bool(false)).expect("parse");
+        assert!(!c.local && !c.remote);
+    }
+
+    #[test]
+    fn dict_partial_keys_default_the_rest() {
+        // Only `remote` set → local defaults on, remote honored off.
+        let c = parse(dict([("remote", Value::Bool(false))])).expect("parse");
+        assert!(c.local, "enabled defaults to true");
+        assert!(!c.remote);
+        assert_eq!(c.history, 1);
+    }
+
+    #[test]
+    fn dict_history_honored() {
+        let c = parse(dict([("history", Value::Int(5))])).expect("parse");
+        assert_eq!(c.history, 5);
+        assert!(c.local && c.remote);
+    }
+
+    #[test]
+    fn dict_zero_history_errors() {
+        let err = parse(dict([("history", Value::Int(0))])).expect_err("zero");
+        assert!(format!("{err:#}").contains(">= 1"), "got: {err:#}");
+    }
+
+    #[test]
+    fn dict_unknown_key_errors() {
+        let err = parse(dict([("nope", Value::Bool(true))])).expect_err("unknown");
+        assert!(format!("{err:#}").contains("unknown"), "got: {err:#}");
+    }
+
+    #[test]
+    fn non_bool_non_map_errors() {
+        let err = parse(Value::Int(1)).expect_err("bad type");
+        assert!(
+            format!("{err:#}").contains("bool or a dict"),
+            "got: {err:#}"
+        );
+    }
+
+    #[test]
+    fn lowers_into_cache_config() {
+        let cfg: CacheConfig = TargetSpecCache {
+            local: true,
+            remote: false,
+            history: 3,
+        }
+        .into();
+        assert!(cfg.enabled);
+        assert!(!cfg.remote_enabled);
+        assert_eq!(cfg.history, 3);
+    }
+}

--- a/crates/plugin/src/htspec/mod.rs
+++ b/crates/plugin/src/htspec/mod.rs
@@ -15,8 +15,8 @@
 //!     (`map[...]`);
 //!   * `#[derive(SpecEnum)]` — a string-valued enum;
 //!   * `#[derive(SpecUnion)]` — a value accepting one of several shapes; or a
-//!     hand-written impl for a bespoke shape (see `TargetSpecCache` in
-//!     `pluginexec::spec`).
+//!     hand-written impl for a bespoke shape (see [`TargetSpecCache`], the
+//!     shared `cache` attribute).
 
 use hcore::htvalue::signature::ParamType;
 use hcore::htvalue::{
@@ -25,6 +25,9 @@ use hcore::htvalue::{
 };
 
 pub use htspec_derive::{Spec, SpecEnum, SpecStruct, SpecUnion};
+
+mod cache;
+pub use cache::TargetSpecCache;
 
 // The `Spec` derive macro emits `crate::htspec::DriverField` / `DriverSchema`
 // (portable across the monolith re-export and this crate). Re-export them here


### PR DESCRIPTION
## What

`http_fetch` targets hardcoded `CacheConfig::on(true)` — always cached locally + remotely, no user control. Add a `cache` attribute so a target can opt out or tune caching.

## Behavior

| `cache` | result |
|---|---|
| absent | both tiers on — unchanged default (a fetch is content-addressed, safe to share) |
| `cache = False` | local + remote off |
| `cache = {"remote": False}` | local-only |
| `cache = {"enabled": ..., "remote": ..., "history": N}` | per-tier + revision count |

## How

The `cache` knob (bool-or-dict parse + shape-dispatch errors + lowering into `CacheConfig`) already existed privately in the exec driver. Promoted it to shared `hplugin::htspec::TargetSpecCache` and reused it from both drivers rather than duplicating.

- `crates/plugin/src/htspec/cache.rs` (new) — shared `TargetSpecCache`, `From<_> for CacheConfig`, tests
- `plugin-exec` — deleted local copy, uses shared type; `cache: spec.cache.into()`
- `plugin-http` — new `cache` field + `spec.cache.into()`; 3 parse tests (default, `False`, remote-only)

go-plugin's programmatic `http_fetch` spec (`govet.rs`) is unaffected — omitted `cache` defaults to both-on, same as before. No proto change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)