### PR TITLE
fix(log): silence object_store metadata-server token info log

### DIFF
--- a/src/log.rs
+++ b/src/log.rs
@@ -10,9 +10,12 @@ pub fn init() -> LogSink {
 
     // fuser is chatty at info!/warn! during mount lifecycle. Cap it at
     // error! by default so genuine failures surface but lifecycle noise
-    // is silenced. User raises via `RUST_LOG=fuser=debug` for details.
-    let filter =
-        EnvFilter::try_from_default_env().unwrap_or_else(|_| EnvFilter::new("info,fuser=error"));
+    // is silenced. object_store emits an info! ("fetching token from
+    // metadata server") on every GCS token fetch — cap it at warn! so the
+    // noise is silenced but real credential failures surface. Users raise
+    // either via `RUST_LOG=fuser=debug` / `RUST_LOG=object_store=info`.
+    let filter = EnvFilter::try_from_default_env()
+        .unwrap_or_else(|_| EnvFilter::new("info,fuser=error,object_store=warn"));
 
     // tracing_subscriber defaults ANSI on regardless of where the writer points.
     // Our writer is stderr, so gate color on stderr's capability — otherwise a


### PR DESCRIPTION
## What

`object_store` emits `info!("fetching token from metadata server")` on every GCS token fetch. Shows up as ` INFO fetching token from metadata server` on normal runs — pure noise.

## Change

Add `object_store=warn` to the default `EnvFilter` in `src/log.rs`, same pattern as the existing `fuser=error`. Real credential failures (`warn!`/`error!`) still surface. `RUST_LOG=object_store=info` restores it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)