### PR TITLE
feat(plugin-go): replace goos/goarch args with named build variants

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3975,8 +3975,11 @@ name = "plugingo-e2e"
 version = "0.1.0"
 dependencies = [
  "anyhow",
+ "core",
  "futures",
  "heph",
+ "model",
+ "plugin",
  "plugin-go",
  "tempfile",
  "testkit",

--- a/crates/builtins/src/pluginhostbin/mod.rs
+++ b/crates/builtins/src/pluginhostbin/mod.rs
@@ -287,6 +287,7 @@ mod tests {
                     request_id: "test".to_string(),
                     package: PkgBuf::from(PKG),
                     states: vec![],
+                    executor: std::sync::Arc::new(hplugin::provider::NoopExecutor),
                 },
                 &ctoken,
             )

--- a/crates/e2e/tests/codegen_in_place.rs
+++ b/crates/e2e/tests/codegen_in_place.rs
@@ -1,0 +1,90 @@
+//! `codegen = "in_place"` write-back: a target that rewrites the very files it
+//! took as inputs (a formatter, a lint fixer).
+
+mod common;
+
+use common::Workspace;
+
+/// A target that uppercases its own source in place.
+///
+/// `mutate` is bash spliced in after the transform: the test uses it to move the
+/// tree *while the target runs*, standing in for the editor save / `git checkout`
+/// / concurrent run that the write-back guard exists to catch.
+fn build_file(mutate: &str) -> String {
+    format!(
+        r#"
+target(
+    name = "upper",
+    driver = "bash",
+    deps = [file("src.txt")],
+    out = "src.txt",
+    codegen = "in_place",
+    run = "up=$(tr a-z A-Z < src.txt); printf '%s' \"$up\" > $OUT; {mutate}",
+)
+"#
+    )
+}
+
+/// The happy path: a settled tree is transformed and written back, and running
+/// again over the already-transformed tree is a clean no-op. The second run is
+/// what proves the guard doesn't false-positive on the write-back's *own*
+/// change to the tree.
+#[tokio::test]
+async fn in_place_writes_back_and_reruns_clean() -> anyhow::Result<()> {
+    let ws = Workspace::new();
+    ws.write_build_file("fix", &build_file("true"));
+    ws.write_file("fix/src.txt", "hello");
+
+    ws.run("//fix:upper").await?;
+    let src = ws.dir.path().join("fix/src.txt");
+    assert_eq!(
+        std::fs::read_to_string(&src)?,
+        "HELLO",
+        "the transformed bytes must land on the tracked source file"
+    );
+
+    ws.run("//fix:upper").await?;
+    assert_eq!(
+        std::fs::read_to_string(&src)?,
+        "HELLO",
+        "a re-run over the already-transformed tree must change nothing"
+    );
+    Ok(())
+}
+
+/// The guard: when the source moves between being hashed and being written back,
+/// the transform is stale — it was computed from the older bytes. Writing it
+/// would silently discard the newer ones, so the run fails and the tree is left
+/// exactly as the concurrent writer left it.
+#[tokio::test]
+async fn in_place_refuses_to_write_back_over_a_changed_source() -> anyhow::Result<()> {
+    let ws = Workspace::new();
+    let src = ws.dir.path().join("fix/src.txt");
+    // Absolute path: this write deliberately escapes the sandbox to model an
+    // *external* edit landing mid-run, which is exactly what the guard watches
+    // for. No ordinary target may do this.
+    ws.write_build_file(
+        "fix",
+        &build_file(&format!(
+            "printf 'edited by someone else' > {}",
+            src.display()
+        )),
+    );
+    ws.write_file("fix/src.txt", "hello");
+
+    let msg = match ws.run("//fix:upper").await {
+        Err(e) => format!("{e:#}"),
+        Ok(_) => panic!("a stale in-place write-back must fail, not clobber"),
+    };
+    assert!(
+        msg.contains("changed while it ran"),
+        "error must name the staleness, got: {msg}"
+    );
+
+    assert_eq!(
+        std::fs::read_to_string(&src)?,
+        "edited by someone else",
+        "the newer bytes must survive: nothing is written back"
+    );
+    Ok(())
+}

--- a/crates/engine/src/engine/query.rs
+++ b/crates/engine/src/engine/query.rs
@@ -28,6 +28,12 @@ impl Engine {
             // Multiple providers can surface the same addr (or the same package
             // from `packages()`), so dedup before yielding.
             let mut seen: FxHashSet<Addr> = FxHashSet::default();
+            // Callback surface handed to each `list` so a provider can gather
+            // config beyond the package ancestry (e.g. the go module variant
+            // universe via `states_under`).
+            let executor: Arc<dyn hplugin::provider::ProviderExecutor> = Arc::new(
+                crate::engine::result::EngineProviderExecutor::new(Arc::downgrade(&self), rs.clone()),
+            );
             for pkg_result in self.packages(m, &rs).await? {
                 let pkg = PkgBuf::from(pkg_result?);
 
@@ -42,6 +48,7 @@ impl Engine {
                             .filter(|s| s.provider == provider.name)
                             .cloned()
                             .collect(),
+                        executor: Arc::clone(&executor),
                     }, rs.ctoken()).await?;
 
                     for item in it {

--- a/crates/engine/src/engine/request_state.rs
+++ b/crates/engine/src/engine/request_state.rs
@@ -198,6 +198,12 @@ pub struct RequestStateData {
     /// Inner memoizer for `Engine::probe_segments`. Keyed by `(provider_name, pkg)`
     /// so a given provider's probe of a given package runs at most once per request.
     pub mem_probe_inner: Memoizer<(String, PkgBuf), ProbeStatesResult>,
+    /// Memoizer for `ProviderExecutor::states_under`. Keyed by the subtree prefix,
+    /// so the (potentially whole-workspace) package walk + probes for a given
+    /// prefix run at most once per request — a `list` that calls it repeatedly
+    /// (e.g. the go go_src query listing many packages) pays the walk once, not
+    /// once per package.
+    pub mem_states_under: Memoizer<PkgBuf, ProbeStatesResult>,
     /// When false, fanout sites await every concurrent child instead of
     /// short-circuiting on the first error; errors are aggregated into a
     /// `MultiError`. Defaults to true (current behavior).
@@ -563,6 +569,7 @@ impl Engine {
             mem_packages: Memoizer::with_tag("packages"),
             mem_probe: Memoizer::with_tag("probe"),
             mem_probe_inner: Memoizer::with_tag("probe_inner"),
+            mem_states_under: Memoizer::with_tag("states_under"),
             fail_fast,
             log_tail_lines,
             events,

--- a/crates/engine/src/engine/result.rs
+++ b/crates/engine/src/engine/result.rs
@@ -82,6 +82,22 @@ impl ProviderExecutor for EngineProviderExecutor {
         Box::pin(async move { self.rs.track_dep(addr).map_err(anyhow::Error::new) })
     }
 
+    fn states<'a>(
+        &'a self,
+        pkg: &'a PkgBuf,
+    ) -> futures::future::BoxFuture<'a, anyhow::Result<Vec<State>>> {
+        Box::pin(async move {
+            let engine = self
+                .engine
+                .upgrade()
+                .ok_or_else(|| anyhow::anyhow!("engine dropped"))?;
+            // Memoized per-package walk of the ancestry; registers no DepDag edge
+            // (states are config, not a build dependency).
+            let states = Arc::clone(&engine).probe_segments(&self.rs, pkg).await?;
+            Ok(states.as_ref().clone())
+        })
+    }
+
     fn query<'a>(
         &'a self,
         m: &'a Matcher,

--- a/crates/engine/src/engine/result.rs
+++ b/crates/engine/src/engine/result.rs
@@ -1327,17 +1327,26 @@ impl Engine {
             }
         };
 
+        // Guard the write-back against a tree that moved under us — an in_place
+        // target is about to overwrite the very files it hashed as inputs.
+        self.clone().check_in_place_inputs_unchanged(opts).await?;
         // Codegen tree write-back: is_top-gated, idempotent, runs on every path
         // (a cache hit on an in_place fmt must still materialize). Uses this
         // caller's `cached`, so the is_top requester must have asked for the
         // codegen output groups — exactly as before the single-flight split.
-        self.materialize_codegen(opts.is_top, opts.def, &cached, opts.frozen)
+        let wrote = self
+            .materialize_codegen(opts.is_top, opts.def, &cached, opts.frozen)
             .await?;
         // Fixpoint registration only on the cacheable path (force/shell never
         // cache a fixpoint). Idempotent across hit/miss; a no-op unless this is a
-        // top-level in_place codegen target whose tree just moved.
+        // top-level in_place codegen target whose tree just moved — and when the
+        // write-back moved nothing, the guard above already established that the
+        // tree hashes to `opts.hashin`, so the fixpoint would recompute that same
+        // key and early-return. Skip it and save a full input re-hash on the
+        // steady-state path (an already-formatted tree), where it is the common
+        // case.
         let can_cache = !opts.force && opts.def.target.cache.enabled && !opts.shell;
-        if can_cache {
+        if can_cache && wrote {
             self.clone().maybe_store_fixpoint(&rs, opts).await?;
         }
 
@@ -1683,13 +1692,13 @@ impl Engine {
         def: &LinkedTargetDef,
         cached: &[ResultArtifact],
         frozen: bool,
-    ) -> anyhow::Result<()> {
+    ) -> anyhow::Result<bool> {
         use crate::engine::driver::targetdef::path::CodegenMode;
 
         // Gate: only the top-level requested target writes its tree back, and
         // only when it actually declares a codegen output path.
         if !is_top {
-            return Ok(());
+            return Ok(false);
         }
         let has_codegen = def.target.outputs.iter().any(|o| {
             o.paths
@@ -1697,9 +1706,15 @@ impl Engine {
                 .any(|p| !matches!(p.codegen_tree, CodegenMode::None))
         });
         if !has_codegen {
-            return Ok(());
+            return Ok(false);
         }
 
+        // Whether anything about the tree actually moved. Content writes, exec-bit
+        // reconciles and symlink recreates all count; the codegen xattr does not
+        // (it is metadata, outside the `@heph/fs` content+exec-bit hash). `false`
+        // therefore means the tree still hashes exactly as it did before this
+        // call — which is what lets the caller skip the fixpoint recompute.
+        let mut wrote = false;
         let root = &self.cfg.root;
         let mut frozen_diff = String::new();
 
@@ -1854,6 +1869,7 @@ impl Engine {
                                 }
                                 std::fs::write(&dest, &new_bytes)
                                     .with_context(|| format!("write codegen file {:?}", dest))?;
+                                wrote = true;
                             }
                             // The exec bit is part of the `@heph/fs` (content,
                             // exec-bit) input hash, so reconcile it to the
@@ -1878,6 +1894,7 @@ impl Engine {
                                         .with_context(
                                             || format!("reconcile exec bit on {:?}", dest),
                                         )?;
+                                        wrote = true;
                                     }
                                 }
                             }
@@ -1917,6 +1934,7 @@ impl Engine {
                                     std::os::unix::fs::symlink(&target, &dest).with_context(
                                         || format!("symlink {:?} -> {:?}", dest, target),
                                     )?;
+                                    wrote = true;
                                 }
                                 // Stamp Copy symlink outputs too, so a later fs
                                 // glob excludes them like regular Copy files.
@@ -1937,7 +1955,7 @@ impl Engine {
             }));
         }
 
-        Ok(())
+        Ok(wrote)
     }
 
     // Memoized by addr:hashin — at most one execute+cache cycle runs per target per request,
@@ -2100,6 +2118,72 @@ impl Engine {
             )
             .await
             .map_err(unwrap_arc_err)
+    }
+
+    /// Refuse to write an in_place target's tree back when the sources moved
+    /// under it.
+    ///
+    /// An in_place target (a formatter, a lint fixer) rewrites the very files it
+    /// took as inputs, and the rewrite is derived from the bytes those inputs
+    /// held when the run hashed them. Everything between that hash and this
+    /// write-back — resolving deps, staging, executing, reading the cache — is a
+    /// window in which the tree can move: an editor save, a `git checkout`, a
+    /// concurrent run. `materialize_codegen` writes unconditionally, so without
+    /// this check the newer bytes are silently replaced by (stale bytes +
+    /// transform), with no error and no diff.
+    ///
+    /// Recomputing the target's `hashin` against the *current* tree on a fresh
+    /// request re-reads the `@heph/fs` inputs (cache-off, memoized per request),
+    /// so an unchanged tree reproduces this run's `hashin` exactly — the same
+    /// property [`Self::maybe_store_fixpoint`] relies on after the write. Any
+    /// difference means an input this target is about to overwrite is no longer
+    /// what it transformed.
+    ///
+    /// Gated exactly like the write-back it guards: top-level only (nothing else
+    /// writes), in_place only (nothing else overwrites its own inputs), and never
+    /// on a frozen run (which writes nothing at all).
+    ///
+    /// A failure to recompute is *not* waved through: not being able to confirm
+    /// the tree is precisely the case where overwriting it is unsafe.
+    async fn check_in_place_inputs_unchanged(
+        self: Arc<Self>,
+        opts: &ExecuteOptions<'_>,
+    ) -> anyhow::Result<()> {
+        use crate::engine::driver::targetdef::path::CodegenMode;
+
+        if opts.frozen || !opts.is_top {
+            return Ok(());
+        }
+        let is_in_place = opts.def.target.outputs.iter().any(|o| {
+            o.paths
+                .iter()
+                .any(|p| matches!(p.codegen_tree, CodegenMode::InPlace))
+        });
+        if !is_in_place {
+            return Ok(());
+        }
+
+        let addr = &opts.def.target.addr;
+        let current = Arc::clone(&self)
+            .meta(self.new_state(), addr)
+            .await
+            .with_context(|| {
+                format!(
+                    "re-reading the sources of {addr} to confirm they still match what it \
+                     transformed, before writing its in-place output back over them"
+                )
+            })?
+            .hashin;
+        if current != *opts.hashin {
+            anyhow::bail!(
+                "{addr} rewrites its own sources in place, and they changed while it ran \
+                 (input hash {} → {current}). Its output was computed from the older bytes, \
+                 so writing it back would discard the newer ones — nothing was written. \
+                 Re-run once the tree is settled.",
+                opts.hashin,
+            );
+        }
+        Ok(())
     }
 
     /// Register the just-executed in_place target's cache entry under the key a

--- a/crates/engine/src/engine/result.rs
+++ b/crates/engine/src/engine/result.rs
@@ -99,43 +99,57 @@ impl ProviderExecutor for EngineProviderExecutor {
                 .ok_or_else(|| anyhow::anyhow!("engine dropped"))?;
             let rs = self.rs.clone();
 
-            // Enumerate every package at or under `prefix`, then union each
-            // package's own `provider_state`s (all providers). Per-package probes
-            // are memoized (`mem_probe_inner`), so repeated subtree gathers are
-            // cheap. Registers no DepDag edge — states are config, not a dep.
-            let matcher = Matcher::PackagePrefix(prefix.clone());
-            let pkg_iter = engine.packages(&matcher, &rs).await?;
-            let pkgs: Vec<String> = pkg_iter.collect::<anyhow::Result<_>>()?;
+            // Memoize the whole subtree gather per prefix: a `list` that calls
+            // `states_under` for many packages (e.g. the go go_src query) then pays
+            // the package walk + probes once, not once per package — which would
+            // otherwise flood the blocking pool with concurrent `list_packages`
+            // walks. Registers no DepDag edge — states are config, not a dep.
+            let states = rs
+                .data
+                .mem_states_under
+                .once(
+                    prefix.clone(),
+                    enclose!((engine, rs, prefix.clone() => prefix) move || async move {
+                        // Enumerate every package at or under `prefix`, then union
+                        // each package's own `provider_state`s (all providers).
+                        let matcher = Matcher::PackagePrefix(prefix);
+                        let pkg_iter = engine.packages(&matcher, &rs).await?;
+                        let pkgs: Vec<String> = pkg_iter.collect::<anyhow::Result<_>>()?;
 
-            let mut acc: Vec<State> = Vec::new();
-            for pkg_str in pkgs {
-                let pkg = PkgBuf::from(pkg_str.as_str());
-                for provider in engine.providers.iter() {
-                    let inner = rs
-                        .data
-                        .mem_probe_inner
-                        .once(
-                            (provider.name.clone(), pkg.clone()),
-                            enclose!((provider, rs, pkg) move || async move {
-                                let res = provider
-                                    .provider
-                                    .probe(
-                                        ProbeRequest {
-                                            request_id: rs.request_id().to_string(),
-                                            package: pkg,
-                                        },
-                                        rs.ctoken(),
+                        let mut acc: Vec<State> = Vec::new();
+                        for pkg_str in pkgs {
+                            let pkg = PkgBuf::from(pkg_str.as_str());
+                            for provider in engine.providers.iter() {
+                                let inner = rs
+                                    .data
+                                    .mem_probe_inner
+                                    .once(
+                                        (provider.name.clone(), pkg.clone()),
+                                        enclose!((provider, rs, pkg) move || async move {
+                                            let res = provider
+                                                .provider
+                                                .probe(
+                                                    ProbeRequest {
+                                                        request_id: rs.request_id().to_string(),
+                                                        package: pkg,
+                                                    },
+                                                    rs.ctoken(),
+                                                )
+                                                .await?;
+                                            Ok(Arc::new(res.states))
+                                        }),
                                     )
-                                    .await?;
-                                Ok(Arc::new(res.states))
-                            }),
-                        )
-                        .await
-                        .map_err(unwrap_arc_err)?;
-                    acc.extend(inner.iter().cloned());
-                }
-            }
-            Ok(acc)
+                                    .await
+                                    .map_err(unwrap_arc_err)?;
+                                acc.extend(inner.iter().cloned());
+                            }
+                        }
+                        Ok(Arc::new(acc))
+                    }),
+                )
+                .await
+                .map_err(unwrap_arc_err)?;
+            Ok(states.as_ref().clone())
         })
     }
 

--- a/crates/engine/src/engine/result.rs
+++ b/crates/engine/src/engine/result.rs
@@ -47,9 +47,15 @@ type BoxedResultFuture<'a> =
 
 /// rs carries the parent addr (set by result_addr via with_parent) so the executor
 /// does not need to store it separately.
-struct EngineProviderExecutor {
+pub(crate) struct EngineProviderExecutor {
     engine: Weak<Engine>,
     rs: Arc<RequestState>,
+}
+
+impl EngineProviderExecutor {
+    pub(crate) fn new(engine: Weak<Engine>, rs: Arc<RequestState>) -> Self {
+        Self { engine, rs }
+    }
 }
 
 impl ProviderExecutor for EngineProviderExecutor {
@@ -82,19 +88,54 @@ impl ProviderExecutor for EngineProviderExecutor {
         Box::pin(async move { self.rs.track_dep(addr).map_err(anyhow::Error::new) })
     }
 
-    fn states<'a>(
+    fn states_under<'a>(
         &'a self,
-        pkg: &'a PkgBuf,
+        prefix: &'a PkgBuf,
     ) -> futures::future::BoxFuture<'a, anyhow::Result<Vec<State>>> {
         Box::pin(async move {
             let engine = self
                 .engine
                 .upgrade()
                 .ok_or_else(|| anyhow::anyhow!("engine dropped"))?;
-            // Memoized per-package walk of the ancestry; registers no DepDag edge
-            // (states are config, not a build dependency).
-            let states = Arc::clone(&engine).probe_segments(&self.rs, pkg).await?;
-            Ok(states.as_ref().clone())
+            let rs = self.rs.clone();
+
+            // Enumerate every package at or under `prefix`, then union each
+            // package's own `provider_state`s (all providers). Per-package probes
+            // are memoized (`mem_probe_inner`), so repeated subtree gathers are
+            // cheap. Registers no DepDag edge — states are config, not a dep.
+            let matcher = Matcher::PackagePrefix(prefix.clone());
+            let pkg_iter = engine.packages(&matcher, &rs).await?;
+            let pkgs: Vec<String> = pkg_iter.collect::<anyhow::Result<_>>()?;
+
+            let mut acc: Vec<State> = Vec::new();
+            for pkg_str in pkgs {
+                let pkg = PkgBuf::from(pkg_str.as_str());
+                for provider in engine.providers.iter() {
+                    let inner = rs
+                        .data
+                        .mem_probe_inner
+                        .once(
+                            (provider.name.clone(), pkg.clone()),
+                            enclose!((provider, rs, pkg) move || async move {
+                                let res = provider
+                                    .provider
+                                    .probe(
+                                        ProbeRequest {
+                                            request_id: rs.request_id().to_string(),
+                                            package: pkg,
+                                        },
+                                        rs.ctoken(),
+                                    )
+                                    .await?;
+                                Ok(Arc::new(res.states))
+                            }),
+                        )
+                        .await
+                        .map_err(unwrap_arc_err)?;
+                    acc.extend(inner.iter().cloned());
+                }
+            }
+            Ok(acc)
         })
     }
 
@@ -139,6 +180,10 @@ impl ProviderExecutor for EngineProviderExecutor {
                                     .filter(|s| s.provider == provider.name)
                                     .cloned()
                                     .collect(),
+                                executor: Arc::new(EngineProviderExecutor::new(
+                                    Arc::downgrade(&engine),
+                                    rs.clone(),
+                                )),
                             },
                             rs.ctoken(),
                         )

--- a/crates/plugin-abi/src/lib.rs
+++ b/crates/plugin-abi/src/lib.rs
@@ -18,6 +18,11 @@ pub use hproto_gen::heph::plugin::v1 as pb;
 /// ABI semantic version. Major must match exactly between host and plugin;
 /// minor is negotiated to `min(host, plugin)` at handshake.
 ///
+/// 0.5.0: `StableExecutor` gained a `states` method (fetch a package's provider
+/// states for cross-subtree config resolution — the go variant `vp` lookup). A
+/// new method on a `#[stabby::stabby]` vtable trait changes its type-report, so
+/// this is a hard break: every plugin must be rebuilt against this ABI.
+///
 /// 0.4.0: new optional `heph_plugin_set_supervisor` entry (`StableSupervisor` /
 /// `DynSupervisor`) so a plugin's children register with the host's process
 /// supervisor. Additive: no existing vtable or struct changed, and the host
@@ -27,7 +32,7 @@ pub use hproto_gen::heph::plugin::v1 as pb;
 /// 0.3.0: `PluginComponents` gained a `hooks` field (a layout change to the
 /// create-entry struct) for the Hook plugin kind — a hard break, so every plugin
 /// must be rebuilt against this ABI.
-pub const ABI_SEMVER: &str = "0.4.0";
+pub const ABI_SEMVER: &str = "0.5.0";
 
 #[cfg(feature = "convert")]
 pub mod convert;

--- a/crates/plugin-buildfile/src/pluginbuildfile/lsp/context.rs
+++ b/crates/plugin-buildfile/src/pluginbuildfile/lsp/context.rs
@@ -144,6 +144,7 @@ impl HephLspContext {
                 request_id: "lsp".to_string(),
                 package: PkgBuf::from(package),
                 states: vec![],
+                executor: std::sync::Arc::new(hplugin::provider::NoopExecutor),
             },
             &ctoken,
         );

--- a/crates/plugin-buildfile/src/pluginbuildfile/provider.rs
+++ b/crates/plugin-buildfile/src/pluginbuildfile/provider.rs
@@ -881,6 +881,7 @@ mod tests {
                     request_id: "test".to_string(),
                     package: PkgBuf::from("vendor/dep"),
                     states: vec![],
+                    executor: std::sync::Arc::new(hplugin::provider::NoopExecutor),
                 },
                 &ctoken,
             )

--- a/crates/plugin-go/src/plugingo/addr_util.rs
+++ b/crates/plugin-go/src/plugingo/addr_util.rs
@@ -1,4 +1,4 @@
-use crate::plugingo::factors::Factors;
+use crate::plugingo::factors::VariantRef;
 use hcore::htvalue::Value;
 use hmodel::htaddr::Addr;
 use hmodel::htpkg::PkgBuf;
@@ -198,11 +198,11 @@ fn parse_thirdparty(rest: &str, module_root: PathBuf) -> Option<GoPackageKind> {
 }
 
 /// Encode a stdlib import path as a heph Addr for build_lib.
-pub fn encode_stdlib(import_path: &str, factors: &Factors) -> Addr {
+pub fn encode_stdlib(import_path: &str, vref: &VariantRef) -> Addr {
     Addr::new(
         PkgBuf::from(format!("{}{}", STD_PREFIX, import_path)),
         "build_lib".to_string(),
-        factors_to_args(factors),
+        vref.to_args(),
     )
 }
 
@@ -214,7 +214,7 @@ pub fn encode_thirdparty(
     version: &str,
     subpath: &str,
     base_pkg: &str,
-    factors: &Factors,
+    vref: &VariantRef,
 ) -> Addr {
     let thirdparty_part = if subpath.is_empty() {
         format!("{}{}@{}", THIRD_PREFIX, module, version)
@@ -228,11 +228,7 @@ pub fn encode_thirdparty(
         format!("{}/{}", base_pkg, thirdparty_part)
     };
 
-    Addr::new(
-        PkgBuf::from(pkg),
-        "build_lib".to_string(),
-        factors_to_args(factors),
-    )
+    Addr::new(PkgBuf::from(pkg), "build_lib".to_string(), vref.to_args())
 }
 
 /// Encode the module-root `download` target Addr for a thirdparty module.
@@ -252,23 +248,13 @@ pub fn encode_thirdparty_download(module: &str, version: &str, base_pkg: &str) -
 }
 
 /// Encode a first-party package (relative to workspace root) as a heph Addr for build_lib.
-pub fn encode_firstparty(src_dir: &Path, workspace_root: &Path, factors: &Factors) -> Addr {
+pub fn encode_firstparty(src_dir: &Path, workspace_root: &Path, vref: &VariantRef) -> Addr {
     let rel = src_dir.strip_prefix(workspace_root).unwrap_or(src_dir);
     Addr::new(
         PkgBuf::from(rel.to_string_lossy().as_ref()),
         "build_lib".to_string(),
-        factors_to_args(factors),
+        vref.to_args(),
     )
-}
-
-pub fn factors_to_args(factors: &Factors) -> BTreeMap<String, String> {
-    let mut args = BTreeMap::new();
-    args.insert("goos".to_string(), factors.goos.clone());
-    args.insert("goarch".to_string(), factors.goarch.clone());
-    if !factors.build_tags.is_empty() {
-        args.insert("tags".to_string(), factors.build_tags.join(","));
-    }
-    args
 }
 
 /// Convert an import path to a dep group name.
@@ -712,24 +698,16 @@ mod tests {
 
     #[test]
     fn test_encode_stdlib() {
-        let factors = Factors {
-            goos: "linux".into(),
-            goarch: "amd64".into(),
-            build_tags: vec![],
-        };
-        let addr = encode_stdlib("fmt", &factors);
+        let vref = VariantRef::new("dev", "");
+        let addr = encode_stdlib("fmt", &vref);
         assert_eq!(addr.package.as_str(), "@heph/go/std/fmt");
         assert_eq!(addr.name, "build_lib");
     }
 
     #[test]
     fn test_encode_thirdparty_with_subpath() {
-        let factors = Factors {
-            goos: "linux".into(),
-            goarch: "amd64".into(),
-            build_tags: vec![],
-        };
-        let addr = encode_thirdparty("github.com/foo/bar", "v1.2.3", "pkg", "", &factors);
+        let vref = VariantRef::new("dev", "");
+        let addr = encode_thirdparty("github.com/foo/bar", "v1.2.3", "pkg", "", &vref);
         assert_eq!(
             addr.package.as_str(),
             "@heph/go/thirdparty/github.com/foo/bar@v1.2.3/pkg"
@@ -738,12 +716,8 @@ mod tests {
 
     #[test]
     fn test_encode_thirdparty_no_subpath() {
-        let factors = Factors {
-            goos: "linux".into(),
-            goarch: "amd64".into(),
-            build_tags: vec![],
-        };
-        let addr = encode_thirdparty("github.com/foo/bar", "v1.0.0", "", "", &factors);
+        let vref = VariantRef::new("dev", "");
+        let addr = encode_thirdparty("github.com/foo/bar", "v1.0.0", "", "", &vref);
         assert_eq!(
             addr.package.as_str(),
             "@heph/go/thirdparty/github.com/foo/bar@v1.0.0"
@@ -752,12 +726,8 @@ mod tests {
 
     #[test]
     fn test_encode_thirdparty_with_base_pkg() {
-        let factors = Factors {
-            goos: "linux".into(),
-            goarch: "amd64".into(),
-            build_tags: vec![],
-        };
-        let addr = encode_thirdparty("github.com/foo/bar", "v1.2.3", "pkg", "go", &factors);
+        let vref = VariantRef::new("dev", "");
+        let addr = encode_thirdparty("github.com/foo/bar", "v1.2.3", "pkg", "go", &vref);
         assert_eq!(
             addr.package.as_str(),
             "go/@heph/go/thirdparty/github.com/foo/bar@v1.2.3/pkg"
@@ -803,17 +773,13 @@ mod tests {
 
     #[test]
     fn test_encode_thirdparty_roundtrip_with_base_pkg() {
-        let factors = Factors {
-            goos: "linux".into(),
-            goarch: "amd64".into(),
-            build_tags: vec![],
-        };
+        let vref = VariantRef::new("dev", "");
         let addr = encode_thirdparty(
             "k8s.io/apimachinery",
             "v0.32.1",
             "pkg/util/sets",
             "go",
-            &factors,
+            &vref,
         );
         let ws = Path::new("/workspace");
         let kind = decode_package(&addr.package, ws).unwrap();
@@ -833,15 +799,12 @@ mod tests {
         let ws = tempfile::tempdir().unwrap();
         let src = ws.path().join("mylib");
         std::fs::create_dir_all(&src).unwrap();
-        let factors = Factors {
-            goos: "linux".into(),
-            goarch: "amd64".into(),
-            build_tags: vec![],
-        };
-        let addr = encode_firstparty(&src, ws.path(), &factors);
+        let vref = VariantRef::new("dev", "");
+        let addr = encode_firstparty(&src, ws.path(), &vref);
         assert_eq!(addr.package.as_str(), "mylib");
         assert_eq!(addr.name, "build_lib");
-        assert_eq!(addr.args.get("goos").map(|s| s.as_str()), Some("linux"));
+        assert_eq!(addr.args.get("v").map(|s| s.as_str()), Some("dev"));
+        assert_eq!(addr.args.get("vp").map(|s| s.as_str()), Some(""));
     }
 
     #[test]

--- a/crates/plugin-go/src/plugingo/driver_compile.rs
+++ b/crates/plugin-go/src/plugingo/driver_compile.rs
@@ -100,9 +100,6 @@ struct GoCompileSpec {
     goexperiment: Vec<String>,
     /// Extra flags passed verbatim to `go tool compile` (the variant's gcflags).
     gcflags: Vec<String>,
-    /// `CGO_ENABLED` from the variant (`"0"`/`"1"`).
-    #[spec(required)]
-    cgo_enabled: String,
     /// Import paths of the transitive libs, in deterministic order — each maps to
     /// a `lib_<sanitized>` dep group carrying that archive, used to build
     /// importcfg.
@@ -127,7 +124,6 @@ struct GoCompileDef {
     go_version: String,
     goexperiment: Vec<String>,
     gcflags: Vec<String>,
-    cgo_enabled: String,
     import_paths: Vec<String>,
     s_files: Vec<String>,
     embed_variant: Option<EmbedVariant>,
@@ -154,7 +150,6 @@ impl Hash for GoCompileDef {
         // `gcflags` order is semantically meaningful, so hash as-is.
         self.goexperiment.hash(state);
         self.gcflags.hash(state);
-        self.cgo_enabled.hash(state);
         // `import_paths` order is not semantically meaningful — it comes from a
         // closure walk that dedups through a per-process-randomized `HashSet`,
         // and `run()` re-sorts before writing importcfg, so the archive is
@@ -262,7 +257,6 @@ impl ManagedDriver for GoCompileDriver {
             go_version: spec.go_version,
             goexperiment: spec.goexperiment,
             gcflags: spec.gcflags,
-            cgo_enabled: spec.cgo_enabled,
             import_paths: spec.import_paths,
             s_files: spec.s_files,
             embed_variant,
@@ -364,7 +358,7 @@ impl ManagedDriver for GoCompileDriver {
         );
         env.insert("GOTOOLCHAIN".to_string(), "local".to_string());
         env.insert("GOWORK".to_string(), "off".to_string());
-        env.insert("CGO_ENABLED".to_string(), def.cgo_enabled.clone());
+        env.insert("CGO_ENABLED".to_string(), "0".to_string());
         if !def.goexperiment.is_empty() {
             env.insert("GOEXPERIMENT".to_string(), def.goexperiment.join(","));
         }
@@ -827,10 +821,6 @@ pub fn build_compile_spec(p: CompileParams) -> TargetSpec {
         str_list(&p.factors.goexperiment),
     );
     config.insert("gcflags".to_string(), str_list(&p.factors.gcflags));
-    config.insert(
-        "cgo_enabled".to_string(),
-        Value::String(p.factors.cgo_enabled_env().to_string()),
-    );
     config.insert("import_paths".to_string(), Value::List(import_paths));
     config.insert("s_files".to_string(), str_list(p.s_files));
     config.insert(
@@ -1115,7 +1105,6 @@ mod driver_tests {
             go_version: "1.26.4".to_string(),
             goexperiment: vec![],
             gcflags: vec![],
-            cgo_enabled: "0".to_string(),
             import_paths: ips.iter().map(|s| s.to_string()).collect(),
             s_files: vec![],
             embed_variant: None,

--- a/crates/plugin-go/src/plugingo/driver_compile.rs
+++ b/crates/plugin-go/src/plugingo/driver_compile.rs
@@ -96,6 +96,13 @@ struct GoCompileSpec {
     /// Go release whose staged hermetic SDK provides GOROOT + the `go` binary.
     #[spec(required)]
     go_version: String,
+    /// `GOEXPERIMENT` values from the variant (sorted). Empty → unset.
+    goexperiment: Vec<String>,
+    /// Extra flags passed verbatim to `go tool compile` (the variant's gcflags).
+    gcflags: Vec<String>,
+    /// `CGO_ENABLED` from the variant (`"0"`/`"1"`).
+    #[spec(required)]
+    cgo_enabled: String,
     /// Import paths of the transitive libs, in deterministic order — each maps to
     /// a `lib_<sanitized>` dep group carrying that archive, used to build
     /// importcfg.
@@ -118,6 +125,9 @@ struct GoCompileDef {
     goos: String,
     goarch: String,
     go_version: String,
+    goexperiment: Vec<String>,
+    gcflags: Vec<String>,
+    cgo_enabled: String,
     import_paths: Vec<String>,
     s_files: Vec<String>,
     embed_variant: Option<EmbedVariant>,
@@ -129,7 +139,7 @@ struct GoCompileDef {
 
 /// Bump to invalidate every cached `go_compile` archive whenever the compile
 /// command shape or embed resolution semantics change.
-const GO_COMPILE_FORMAT_VERSION: u32 = 2;
+const GO_COMPILE_FORMAT_VERSION: u32 = 3;
 
 impl Hash for GoCompileDef {
     fn hash<H: Hasher>(&self, state: &mut H) {
@@ -139,6 +149,12 @@ impl Hash for GoCompileDef {
         self.goos.hash(state);
         self.goarch.hash(state);
         self.go_version.hash(state);
+        // Variant toolchain knobs — each changes compiler output, so each must
+        // key the cache. `goexperiment` is already sorted at variant-parse time;
+        // `gcflags` order is semantically meaningful, so hash as-is.
+        self.goexperiment.hash(state);
+        self.gcflags.hash(state);
+        self.cgo_enabled.hash(state);
         // `import_paths` order is not semantically meaningful — it comes from a
         // closure walk that dedups through a per-process-randomized `HashSet`,
         // and `run()` re-sorts before writing importcfg, so the archive is
@@ -244,6 +260,9 @@ impl ManagedDriver for GoCompileDriver {
             goos: spec.goos,
             goarch: spec.goarch,
             go_version: spec.go_version,
+            goexperiment: spec.goexperiment,
+            gcflags: spec.gcflags,
+            cgo_enabled: spec.cgo_enabled,
             import_paths: spec.import_paths,
             s_files: spec.s_files,
             embed_variant,
@@ -345,7 +364,10 @@ impl ManagedDriver for GoCompileDriver {
         );
         env.insert("GOTOOLCHAIN".to_string(), "local".to_string());
         env.insert("GOWORK".to_string(), "off".to_string());
-        env.insert("CGO_ENABLED".to_string(), "0".to_string());
+        env.insert("CGO_ENABLED".to_string(), def.cgo_enabled.clone());
+        if !def.goexperiment.is_empty() {
+            env.insert("GOEXPERIMENT".to_string(), def.goexperiment.join(","));
+        }
         // Non-hermetic toolchains (host, or a hostbin/nix target wrapper) may need
         // PATH; hermetic mode omits it to stay PATH-independent.
         if !matches!(
@@ -442,6 +464,9 @@ impl ManagedDriver for GoCompileDriver {
             "-importcfg".to_string(),
             importcfg_path.to_string_lossy().into_owned(),
         ];
+        // Variant gcflags — raw `go tool compile` flags (what `-gcflags` forwards),
+        // in declared order, before the source responses.
+        cargs.extend(def.gcflags.iter().cloned());
         if has_asm {
             cargs.push("-symabis".to_string());
             cargs.push("symabis".to_string());
@@ -797,6 +822,15 @@ pub fn build_compile_spec(p: CompileParams) -> TargetSpec {
         "go_version".to_string(),
         Value::String(p.go_version.to_string()),
     );
+    config.insert(
+        "goexperiment".to_string(),
+        str_list(&p.factors.goexperiment),
+    );
+    config.insert("gcflags".to_string(), str_list(&p.factors.gcflags));
+    config.insert(
+        "cgo_enabled".to_string(),
+        Value::String(p.factors.cgo_enabled_env().to_string()),
+    );
     config.insert("import_paths".to_string(), Value::List(import_paths));
     config.insert("s_files".to_string(), str_list(p.s_files));
     config.insert(
@@ -862,6 +896,7 @@ mod driver_tests {
             goos: "linux".into(),
             goarch: "amd64".into(),
             build_tags: vec![],
+            ..Default::default()
         }
     }
 
@@ -1078,6 +1113,9 @@ mod driver_tests {
             goos: "linux".to_string(),
             goarch: "amd64".to_string(),
             go_version: "1.26.4".to_string(),
+            goexperiment: vec![],
+            gcflags: vec![],
+            cgo_enabled: "0".to_string(),
             import_paths: ips.iter().map(|s| s.to_string()).collect(),
             s_files: vec![],
             embed_variant: None,

--- a/crates/plugin-go/src/plugingo/driver_golist.rs
+++ b/crates/plugin-go/src/plugingo/driver_golist.rs
@@ -43,6 +43,12 @@ struct GoGolistSpec {
     go_version: String,
     /// Go build tags.
     build_tags: Vec<String>,
+    /// `GOEXPERIMENT` values from the variant (sorted). Empty → unset.
+    goexperiment: Vec<String>,
+    /// `CGO_ENABLED` from the variant (`"0"`/`"1"`). Affects `go list` file
+    /// selection (cgo files).
+    #[spec(required)]
+    cgo_enabled: String,
     /// For thirdparty packages: the `download` target whose filtered outputs are
     /// staged into consumers' sandboxes.
     #[spec(ty = ParamType::String)]
@@ -72,6 +78,8 @@ struct GoGolistDef {
     goarch: String,
     go_version: String,
     build_tags: Vec<String>,
+    goexperiment: Vec<String>,
+    cgo_enabled: String,
     dep_inputs: Vec<Input>,
     /// For thirdparty packages: the `download` target whose filtered outputs
     /// will be staged into consumers' sandboxes. Threaded through so
@@ -87,7 +95,7 @@ struct GoGolistDef {
 /// `go_compile`; cached `_golist` artifacts from intermediate builds of that
 /// work could carry empty `EmbedFiles` for a now-resolvable embed, surfacing as
 /// `compute embedcfg: //go:embed pattern(s) matched no files` until evicted.
-const GO_GOLIST_FORMAT_VERSION: u32 = 15;
+const GO_GOLIST_FORMAT_VERSION: u32 = 16;
 
 impl Hash for GoGolistDef {
     fn hash<H: Hasher>(&self, state: &mut H) {
@@ -97,6 +105,8 @@ impl Hash for GoGolistDef {
         self.goarch.hash(state);
         self.go_version.hash(state);
         self.build_tags.hash(state);
+        self.goexperiment.hash(state);
+        self.cgo_enabled.hash(state);
         self.dep_inputs.hash(state);
         self.thirdparty_download_addr.hash(state);
         // The hermetic SDK arrives via dep_inputs (group `gosdk`); the engine
@@ -171,6 +181,8 @@ impl ManagedDriver for GoGolistDriver {
             goarch: spec.goarch,
             go_version: spec.go_version,
             build_tags: spec.build_tags,
+            goexperiment: spec.goexperiment,
+            cgo_enabled: spec.cgo_enabled,
             dep_inputs: dep_inputs.clone(),
             thirdparty_download_addr: spec.thirdparty_download_addr,
         };
@@ -267,12 +279,15 @@ impl ManagedDriver for GoGolistDriver {
         // resolution is reproducible regardless of host config.
         env.insert("GOTOOLCHAIN".to_string(), "local".to_string());
         env.insert("GOWORK".to_string(), "off".to_string());
-        // Pin CGO_ENABLED=0 to keep this list call's view of transitive deps
-        // consistent with the bash-driven compile/link sandboxes. Letting Go
-        // autodetect produces drift across hosts (PATH-dependent) — e.g. an
-        // Ubuntu host with gcc on PATH pulls runtime/cgo here but later link
-        // steps run without it, breaking importcfg.
-        env.insert("CGO_ENABLED".to_string(), "0".to_string());
+        // Pin CGO_ENABLED to the variant's value (default off) to keep this list
+        // call's view of transitive deps consistent with the bash-driven
+        // compile/link sandboxes. Letting Go autodetect produces drift across
+        // hosts (PATH-dependent) — e.g. an Ubuntu host with gcc on PATH pulls
+        // runtime/cgo here but later link steps run without it, breaking importcfg.
+        env.insert("CGO_ENABLED".to_string(), def.cgo_enabled.clone());
+        if !def.goexperiment.is_empty() {
+            env.insert("GOEXPERIMENT".to_string(), def.goexperiment.join(","));
+        }
         // Thirdparty module *metadata* listing still consults the host module
         // cache / proxy (modules are content-addressed and verified by go.sum),
         // matching the v1 plugin; first-party and stdlib reads stay fully
@@ -493,6 +508,7 @@ mod tests {
         );
         config.insert("goos".to_string(), Value::String("linux".to_string()));
         config.insert("goarch".to_string(), Value::String("amd64".to_string()));
+        config.insert("cgo_enabled".to_string(), Value::String("0".to_string()));
         config.insert(
             "go_version".to_string(),
             Value::String(crate::plugingo::toolchain::DEFAULT_GO_VERSION.to_string()),

--- a/crates/plugin-go/src/plugingo/driver_golist.rs
+++ b/crates/plugin-go/src/plugingo/driver_golist.rs
@@ -45,10 +45,6 @@ struct GoGolistSpec {
     build_tags: Vec<String>,
     /// `GOEXPERIMENT` values from the variant (sorted). Empty → unset.
     goexperiment: Vec<String>,
-    /// `CGO_ENABLED` from the variant (`"0"`/`"1"`). Affects `go list` file
-    /// selection (cgo files).
-    #[spec(required)]
-    cgo_enabled: String,
     /// For thirdparty packages: the `download` target whose filtered outputs are
     /// staged into consumers' sandboxes.
     #[spec(ty = ParamType::String)]
@@ -79,7 +75,6 @@ struct GoGolistDef {
     go_version: String,
     build_tags: Vec<String>,
     goexperiment: Vec<String>,
-    cgo_enabled: String,
     dep_inputs: Vec<Input>,
     /// For thirdparty packages: the `download` target whose filtered outputs
     /// will be staged into consumers' sandboxes. Threaded through so
@@ -106,7 +101,6 @@ impl Hash for GoGolistDef {
         self.go_version.hash(state);
         self.build_tags.hash(state);
         self.goexperiment.hash(state);
-        self.cgo_enabled.hash(state);
         self.dep_inputs.hash(state);
         self.thirdparty_download_addr.hash(state);
         // The hermetic SDK arrives via dep_inputs (group `gosdk`); the engine
@@ -182,7 +176,6 @@ impl ManagedDriver for GoGolistDriver {
             go_version: spec.go_version,
             build_tags: spec.build_tags,
             goexperiment: spec.goexperiment,
-            cgo_enabled: spec.cgo_enabled,
             dep_inputs: dep_inputs.clone(),
             thirdparty_download_addr: spec.thirdparty_download_addr,
         };
@@ -279,12 +272,12 @@ impl ManagedDriver for GoGolistDriver {
         // resolution is reproducible regardless of host config.
         env.insert("GOTOOLCHAIN".to_string(), "local".to_string());
         env.insert("GOWORK".to_string(), "off".to_string());
-        // Pin CGO_ENABLED to the variant's value (default off) to keep this list
-        // call's view of transitive deps consistent with the bash-driven
-        // compile/link sandboxes. Letting Go autodetect produces drift across
-        // hosts (PATH-dependent) — e.g. an Ubuntu host with gcc on PATH pulls
-        // runtime/cgo here but later link steps run without it, breaking importcfg.
-        env.insert("CGO_ENABLED".to_string(), def.cgo_enabled.clone());
+        // Pin CGO_ENABLED=0 to keep this list call's view of transitive deps
+        // consistent with the bash-driven compile/link sandboxes. Letting Go
+        // autodetect produces drift across hosts (PATH-dependent) — e.g. an
+        // Ubuntu host with gcc on PATH pulls runtime/cgo here but later link
+        // steps run without it, breaking importcfg.
+        env.insert("CGO_ENABLED".to_string(), "0".to_string());
         if !def.goexperiment.is_empty() {
             env.insert("GOEXPERIMENT".to_string(), def.goexperiment.join(","));
         }
@@ -508,7 +501,6 @@ mod tests {
         );
         config.insert("goos".to_string(), Value::String("linux".to_string()));
         config.insert("goarch".to_string(), Value::String("amd64".to_string()));
-        config.insert("cgo_enabled".to_string(), Value::String("0".to_string()));
         config.insert(
             "go_version".to_string(),
             Value::String(crate::plugingo::toolchain::DEFAULT_GO_VERSION.to_string()),

--- a/crates/plugin-go/src/plugingo/driver_lint.rs
+++ b/crates/plugin-go/src/plugingo/driver_lint.rs
@@ -52,6 +52,22 @@ use xxhash_rust::xxh3::Xxh3Default;
 const LINT_FACTS: &str = "lint.facts";
 const LINT_REPORT: &str = "lint-report.json";
 
+/// Per-input `unpack_root` for the `report` dep group.
+///
+/// The gate and the fixer consume one `_lint-analyze` report **per variant**, and
+/// every one of those targets lives in the *same package* and names its output
+/// `lint-report.json` — so they all resolve to the same sandbox path and
+/// `detect_output_collisions` (correctly) rejects the target. Give each report
+/// its own unpack root so they land side by side instead. Both drivers read the
+/// staged paths out of the per-input list file, so where they land is immaterial
+/// to them.
+///
+/// (The `facts_*` groups don't need this: those reports come from *different*
+/// packages, so their paths already differ.)
+fn report_unpack_root(i: usize) -> String {
+    format!("lint_report_{i}")
+}
+
 /// Dep group carrying the `heph-govet` unitchecker binary.
 const GOVET_TOOL_GROUP: &str = "govet_tool";
 
@@ -708,7 +724,15 @@ impl ManagedDriver for GoLintGateDriver {
                         .with_context(|| format!("parse dep addr {addr_str}"))?,
                     mode: InputMode::Standard,
                     origin_id: format!("dep|{group}|{i}"),
-                    annotations: BTreeMap::new(),
+                    // One unpack root per report: every variant's analyze target
+                    // is in this same package and emits `lint-report.json`, so
+                    // they would otherwise all claim one sandbox path (see
+                    // `report_unpack_root`).
+                    annotations: if group.as_str() == "report" {
+                        BTreeMap::from([("unpack_root".to_string(), report_unpack_root(i))])
+                    } else {
+                        BTreeMap::new()
+                    },
                     hashed: true,
                     // The golangci config is a hash-only input: it re-keys the
                     // target on any `.golangci.yml` change without staging the
@@ -1049,7 +1073,15 @@ impl ManagedDriver for GoLintFixDriver {
                         .with_context(|| format!("parse dep addr {addr_str}"))?,
                     mode: InputMode::Standard,
                     origin_id: format!("dep|{group}|{i}"),
-                    annotations: BTreeMap::new(),
+                    // One unpack root per report: every variant's analyze target
+                    // is in this same package and emits `lint-report.json`, so
+                    // they would otherwise all claim one sandbox path (see
+                    // `report_unpack_root`).
+                    annotations: if group.as_str() == "report" {
+                        BTreeMap::from([("unpack_root".to_string(), report_unpack_root(i))])
+                    } else {
+                        BTreeMap::new()
+                    },
                     hashed: true,
                     // The golangci config is a hash-only input: it re-keys the
                     // target on any `.golangci.yml` change without staging the
@@ -1868,6 +1900,85 @@ mod tests {
         let a = edits.get("a.go").unwrap();
         assert_eq!(a.len(), 1, "only the first fix's edits are taken");
         assert_eq!(a[0].new, "A");
+    }
+
+    /// Every variant's `_lint-analyze` sits in the *same package* and names its
+    /// output `lint-report.json`. Staged into one root they would all claim the
+    /// same sandbox path and `detect_output_collisions` would reject the target
+    /// ("lint-report.json is produced by two different targets"), so each report
+    /// input must carry its own `unpack_root`.
+    #[tokio::test]
+    async fn per_variant_reports_get_distinct_unpack_roots() {
+        let analyze: Vec<Addr> = ["host", "win"]
+            .iter()
+            .map(|v| {
+                Addr::new(
+                    PkgBuf::from("mylib"),
+                    "_lint-analyze".to_string(),
+                    std::collections::BTreeMap::from([
+                        ("v".to_string(), (*v).to_string()),
+                        ("vp".to_string(), String::new()),
+                    ]),
+                )
+            })
+            .collect();
+        let token = hcore::hasync::StdCancellationToken::new();
+
+        let gate = GoLintGateDriver
+            .parse(
+                ParseRequest {
+                    request_id: "t".to_string(),
+                    target_spec: Arc::new(build_lint_gate_spec(addr("lint-check"), &analyze, None)),
+                },
+                &token,
+            )
+            .await
+            .unwrap();
+        let fix = GoLintFixDriver::new()
+            .parse(
+                ParseRequest {
+                    request_id: "t".to_string(),
+                    target_spec: Arc::new(build_lint_fix_spec(
+                        addr("lint"),
+                        &analyze,
+                        &["//mylib:a.go".to_string()],
+                        &["a.go".to_string()],
+                        None,
+                    )),
+                },
+                &token,
+            )
+            .await
+            .unwrap();
+
+        for (what, def) in [("gate", &gate.target_def), ("fix", &fix.target_def)] {
+            let roots: Vec<&String> = def
+                .inputs
+                .iter()
+                .filter(|i| i.origin_id.starts_with("dep|report|"))
+                .map(|i| {
+                    i.annotations
+                        .get("unpack_root")
+                        .unwrap_or_else(|| panic!("{what}: report input has no unpack_root"))
+                })
+                .collect();
+            assert_eq!(roots.len(), 2, "{what}: one input per variant report");
+            assert_ne!(
+                roots[0], roots[1],
+                "{what}: two same-package reports must not share an unpack root"
+            );
+        }
+
+        // The fixer's sources stay at the workspace root — they are its
+        // `codegen = in_place` outputs and must land where the tree expects them.
+        assert!(
+            fix.target_def
+                .inputs
+                .iter()
+                .filter(|i| i.origin_id.starts_with("dep||"))
+                .all(|i| !i.annotations.contains_key("unpack_root")),
+            "fixer sources must not be relocated"
+        );
     }
 
     // The gate is the union across variants: a finding only one variant's build

--- a/crates/plugin-go/src/plugingo/driver_lint.rs
+++ b/crates/plugin-go/src/plugingo/driver_lint.rs
@@ -100,6 +100,13 @@ struct GoLintSpec {
     /// Go release whose semantics drive the analysis (cfg `GoVersion`).
     #[spec(required)]
     go_version: String,
+    /// Variant build tags (affect which files are analyzed).
+    build_tags: Vec<String>,
+    /// Variant `GOEXPERIMENT` values (sorted).
+    goexperiment: Vec<String>,
+    /// Variant `CGO_ENABLED` (`"0"`/`"1"`).
+    #[spec(required)]
+    cgo_enabled: String,
     /// Import paths of the transitive libs, deterministic order — each maps to a
     /// `lib_<sanitized>` dep group (archive, for type info) and, when the dep is
     /// itself linted, a `facts_<sanitized>` group (its serialized facts).
@@ -116,6 +123,9 @@ struct GoLintDef {
     goos: String,
     goarch: String,
     go_version: String,
+    build_tags: Vec<String>,
+    goexperiment: Vec<String>,
+    cgo_enabled: String,
     import_paths: Vec<String>,
 }
 
@@ -131,6 +141,9 @@ impl Hash for GoLintDef {
         self.goos.hash(state);
         self.goarch.hash(state);
         self.go_version.hash(state);
+        self.build_tags.hash(state);
+        self.goexperiment.hash(state);
+        self.cgo_enabled.hash(state);
         // Order-invariant, exactly as `go_compile` does: the closure walk dedups
         // through a per-process-randomized HashSet, so hash a sorted view or the
         // cache key flips every run.
@@ -234,6 +247,9 @@ impl ManagedDriver for GoLintDriver {
             goos: spec.goos,
             goarch: spec.goarch,
             go_version: spec.go_version,
+            build_tags: spec.build_tags,
+            goexperiment: spec.goexperiment,
+            cgo_enabled: spec.cgo_enabled,
             import_paths: spec.import_paths,
         };
 
@@ -1169,6 +1185,34 @@ pub fn build_lint_spec(p: LintParams) -> TargetSpec {
         "go_version".to_string(),
         Value::String(p.go_version.to_string()),
     );
+    if !p.factors.build_tags.is_empty() {
+        config.insert(
+            "build_tags".to_string(),
+            Value::List(
+                p.factors
+                    .build_tags
+                    .iter()
+                    .map(|t| Value::String(t.clone()))
+                    .collect(),
+            ),
+        );
+    }
+    if !p.factors.goexperiment.is_empty() {
+        config.insert(
+            "goexperiment".to_string(),
+            Value::List(
+                p.factors
+                    .goexperiment
+                    .iter()
+                    .map(|t| Value::String(t.clone()))
+                    .collect(),
+            ),
+        );
+    }
+    config.insert(
+        "cgo_enabled".to_string(),
+        Value::String(p.factors.cgo_enabled_env().to_string()),
+    );
     config.insert("import_paths".to_string(), Value::List(import_paths));
     config.insert("deps".to_string(), Value::Map(deps.into_iter().collect()));
     config.insert(
@@ -1308,6 +1352,7 @@ mod tests {
             goos: "linux".into(),
             goarch: "amd64".into(),
             build_tags: vec![],
+            ..Default::default()
         }
     }
 

--- a/crates/plugin-go/src/plugingo/driver_lint.rs
+++ b/crates/plugin-go/src/plugingo/driver_lint.rs
@@ -104,9 +104,6 @@ struct GoLintSpec {
     build_tags: Vec<String>,
     /// Variant `GOEXPERIMENT` values (sorted).
     goexperiment: Vec<String>,
-    /// Variant `CGO_ENABLED` (`"0"`/`"1"`).
-    #[spec(required)]
-    cgo_enabled: String,
     /// Import paths of the transitive libs, deterministic order — each maps to a
     /// `lib_<sanitized>` dep group (archive, for type info) and, when the dep is
     /// itself linted, a `facts_<sanitized>` group (its serialized facts).
@@ -125,7 +122,6 @@ struct GoLintDef {
     go_version: String,
     build_tags: Vec<String>,
     goexperiment: Vec<String>,
-    cgo_enabled: String,
     import_paths: Vec<String>,
 }
 
@@ -143,7 +139,6 @@ impl Hash for GoLintDef {
         self.go_version.hash(state);
         self.build_tags.hash(state);
         self.goexperiment.hash(state);
-        self.cgo_enabled.hash(state);
         // Order-invariant, exactly as `go_compile` does: the closure walk dedups
         // through a per-process-randomized HashSet, so hash a sorted view or the
         // cache key flips every run.
@@ -249,7 +244,6 @@ impl ManagedDriver for GoLintDriver {
             go_version: spec.go_version,
             build_tags: spec.build_tags,
             goexperiment: spec.goexperiment,
-            cgo_enabled: spec.cgo_enabled,
             import_paths: spec.import_paths,
         };
 
@@ -1209,10 +1203,6 @@ pub fn build_lint_spec(p: LintParams) -> TargetSpec {
             ),
         );
     }
-    config.insert(
-        "cgo_enabled".to_string(),
-        Value::String(p.factors.cgo_enabled_env().to_string()),
-    );
     config.insert("import_paths".to_string(), Value::List(import_paths));
     config.insert("deps".to_string(), Value::Map(deps.into_iter().collect()));
     config.insert(

--- a/crates/plugin-go/src/plugingo/driver_lint.rs
+++ b/crates/plugin-go/src/plugingo/driver_lint.rs
@@ -663,6 +663,20 @@ fn report_findings(json: &[u8]) -> anyhow::Result<Vec<String>> {
     Ok(out)
 }
 
+/// Union the per-variant reports' findings: a finding in *any* variant fails the
+/// gate. A file every variant compiles yields the same finding in each, so
+/// identical findings collapse; sorting keeps the failure message independent of
+/// the order the reports happened to be staged in.
+fn merge_report_findings(reports: &[Vec<u8>]) -> anyhow::Result<Vec<String>> {
+    let mut findings: Vec<String> = Vec::new();
+    for report in reports {
+        findings.extend(report_findings(report)?);
+    }
+    findings.sort();
+    findings.dedup();
+    Ok(findings)
+}
+
 #[async_trait]
 impl ManagedDriver for GoLintGateDriver {
     fn config(&self, _req: ConfigRequest) -> anyhow::Result<ConfigResponse> {
@@ -744,28 +758,19 @@ impl ManagedDriver for GoLintGateDriver {
         req: ManagedRunRequest<'a, 'io>,
         _ctoken: &(dyn Cancellable + Send + Sync),
     ) -> anyhow::Result<ManagedRunResponse> {
-        // Single staged report file (origin `dep|report|*`).
-        let mut report_path: Option<String> = None;
-        for m in &req.inputs {
-            if !m.input.origin_id.starts_with("dep|report|") {
-                continue;
-            }
-            if let Ok(list_path) = m.require_list_path()
-                && let Ok(f) = std::fs::File::open(list_path)
-            {
-                for line in std::io::BufReader::new(f).lines().map_while(Result::ok) {
-                    if !line.is_empty() {
-                        report_path = Some(line);
-                        break;
-                    }
-                }
-            }
+        // One staged report per variant (origin `dep|report|*`). The gate is the
+        // union: a finding in any variant fails. A file both variants compile
+        // yields the same finding in each, so dedupe — and sort, so the message
+        // doesn't depend on staging order.
+        let report_paths = staged_paths_in_group(&req, "report");
+        if report_paths.is_empty() {
+            anyhow::bail!("go_lint_gate: no lint report staged");
         }
-        let report_path =
-            report_path.ok_or_else(|| anyhow::anyhow!("go_lint_gate: no lint report staged"))?;
-        let bytes = std::fs::read(&report_path)
-            .with_context(|| format!("read lint report {report_path}"))?;
-        let findings = report_findings(&bytes)?;
+        let reports = report_paths
+            .iter()
+            .map(|p| std::fs::read(p).with_context(|| format!("read lint report {p}")))
+            .collect::<anyhow::Result<Vec<_>>>()?;
+        let findings = merge_report_findings(&reports)?;
         if !findings.is_empty() {
             anyhow::bail!(
                 "lint found {} issue(s):\n{}",
@@ -792,6 +797,7 @@ impl ManagedDriver for GoLintGateDriver {
 /// (basename) with `new`. `start`/`end` are 0-based byte offsets into the file
 /// as the analyzer parsed it; `_lint-analyze` and `lint` stage byte-identical
 /// sources, so the offsets line up.
+#[derive(Debug)]
 struct FixEdit {
     start: usize,
     end: usize,
@@ -861,6 +867,60 @@ fn report_edits(json: &[u8]) -> anyhow::Result<HashMap<String, Vec<FixEdit>>> {
                         new: new.to_string(),
                     });
                 }
+            }
+        }
+    }
+    Ok(out)
+}
+
+/// Merge the per-variant reports into one edit set per source file.
+///
+/// Within a single report, overlapping edits are left alone — [`apply_edits`]
+/// resolves those with go/analysis' own earliest-wins rule. *Across* reports the
+/// situation is different: a file every variant compiles produces the same
+/// diagnostic in each, so byte-identical edits are deduped; but two variants
+/// proposing *different* rewrites of the same bytes is a genuine ambiguity with
+/// no basis to prefer either, so it fails rather than silently applying whichever
+/// report happened to be staged first.
+fn merge_report_edits(reports: &[Vec<u8>]) -> anyhow::Result<HashMap<String, Vec<FixEdit>>> {
+    /// Same span, same replacement — the same diagnostic seen by another variant.
+    fn is_same(a: &FixEdit, b: &FixEdit) -> bool {
+        a.start == b.start && a.end == b.end && a.new == b.new
+    }
+    /// Spans that can't both be applied: they overlap, or they are the same span
+    /// (which covers two insertions at one offset, where `start == end` makes the
+    /// overlap test vacuous).
+    fn collides(a: &FixEdit, b: &FixEdit) -> bool {
+        (a.start < b.end && b.start < a.end) || (a.start == b.start && a.end == b.end)
+    }
+
+    let mut out: HashMap<String, Vec<FixEdit>> = HashMap::new();
+    for report in reports {
+        for (file, edits) in report_edits(report)? {
+            let merged = out.entry(file.clone()).or_default();
+            // Only edits contributed by *earlier* reports are compared against;
+            // this report's own overlaps stay for `apply_edits` to arbitrate.
+            let prior = merged.len();
+            for e in edits {
+                if merged[..prior].iter().any(|x| is_same(x, &e)) {
+                    continue;
+                }
+                if let Some((start, end, new)) = merged[..prior]
+                    .iter()
+                    .find(|x| collides(x, &e))
+                    .map(|x| (x.start, x.end, x.new.clone()))
+                {
+                    anyhow::bail!(
+                        "go_lint_fix: build variants disagree on how to fix {file}: \
+                         bytes [{start}, {end}) → {new:?} vs bytes [{}, {}) → {:?}. \
+                         Nothing can pick a winner — fix the diagnostic by hand, or \
+                         narrow the variant set the package is linted under.",
+                        e.start,
+                        e.end,
+                        e.new,
+                    );
+                }
+                merged.push(e);
             }
         }
     }
@@ -1064,14 +1124,17 @@ impl ManagedDriver for GoLintFixDriver {
         req: ManagedRunRequest<'a, 'io>,
         _ctoken: &(dyn Cancellable + Send + Sync),
     ) -> anyhow::Result<ManagedRunResponse> {
-        // The analyze target's `-json` report (single staged file, dep|report|*).
-        let report_path = staged_paths_in_group(&req, "report")
-            .into_iter()
-            .next()
-            .ok_or_else(|| anyhow::anyhow!("go_lint_fix: no lint report staged"))?;
-        let report = std::fs::read(&report_path)
-            .with_context(|| format!("read lint report {report_path}"))?;
-        let mut edits_by_file = report_edits(&report)?;
+        // One `-json` report per variant (dep|report|*), merged into a single
+        // edit set per file — see `merge_report_edits`.
+        let report_paths = staged_paths_in_group(&req, "report");
+        if report_paths.is_empty() {
+            anyhow::bail!("go_lint_fix: no lint report staged");
+        }
+        let reports = report_paths
+            .iter()
+            .map(|p| std::fs::read(p).with_context(|| format!("read lint report {p}")))
+            .collect::<anyhow::Result<Vec<_>>>()?;
+        let mut edits_by_file = merge_report_edits(&reports)?;
 
         // Apply the edits to each staged source, rewriting it in place. The
         // default (`""`) group is staged as a plain writable copy (not read-only,
@@ -1240,15 +1303,17 @@ pub fn build_lint_spec(p: LintParams) -> TargetSpec {
 /// through `_lint-analyze`'s report.
 pub fn build_lint_gate_spec(
     addr: Addr,
-    analyze_addr: &Addr,
+    analyze_addrs: &[Addr],
     config_addr: Option<&Addr>,
 ) -> TargetSpec {
     let mut deps = BTreeMap::from([(
         "report".to_string(),
-        Value::List(vec![Value::String(format!(
-            "{}|report",
-            analyze_addr.format()
-        ))]),
+        Value::List(
+            analyze_addrs
+                .iter()
+                .map(|a| Value::String(format!("{}|report", a.format())))
+                .collect(),
+        ),
     )]);
     if let Some(cfg) = config_addr {
         deps.insert(
@@ -1272,16 +1337,19 @@ pub fn build_lint_gate_spec(
     }
 }
 
-/// Build the user-facing `lint` (fixer) spec. Depends on the `report` output of the
-/// analyze target (`_lint-analyze`) plus the package's own `.go` sources, applies each
-/// diagnostic's suggested fix, and rewrites the sources in place (codegen).
+/// Build the user-facing `lint` (fixer) spec. Depends on the `report` output of
+/// every per-variant analyze target (`_lint-analyze`) plus the package's own
+/// `.go` sources, applies each diagnostic's suggested fix, and rewrites the
+/// sources in place (codegen).
 ///
 /// `src_addrs` are the source file target addresses (the `""` dep group, staged
 /// writable and rewritten); `go_files` are their basenames (the declared
 /// `in_place` outputs). The two are the same files viewed as addr vs. filename.
+/// Both are the *union* across variants, so a file only one variant's build
+/// constraints admit is still fixable.
 pub fn build_lint_fix_spec(
     addr: Addr,
-    analyze_addr: &Addr,
+    analyze_addrs: &[Addr],
     src_addrs: &[String],
     go_files: &[String],
     config_addr: Option<&Addr>,
@@ -1289,10 +1357,12 @@ pub fn build_lint_fix_spec(
     let mut deps = BTreeMap::from([
         (
             "report".to_string(),
-            Value::List(vec![Value::String(format!(
-                "{}|report",
-                analyze_addr.format()
-            ))]),
+            Value::List(
+                analyze_addrs
+                    .iter()
+                    .map(|a| Value::String(format!("{}|report", a.format())))
+                    .collect(),
+            ),
         ),
         (
             String::new(),
@@ -1515,12 +1585,12 @@ mod tests {
             "_lint-analyze".to_string(),
             Default::default(),
         );
-        let check = build_lint_gate_spec(addr("lint-check"), &analyze, None);
+        let check = build_lint_gate_spec(addr("lint-check"), std::slice::from_ref(&analyze), None);
         assert_eq!(check.labels, vec!["go-lint-check", "lint-check"]);
 
         let fix = build_lint_fix_spec(
             addr("lint"),
-            &analyze,
+            std::slice::from_ref(&analyze),
             &["//mylib:a.go".to_string()],
             &["a.go".to_string()],
             None,
@@ -1679,7 +1749,7 @@ mod tests {
             "_lint-analyze".to_string(),
             Default::default(),
         );
-        let s = build_lint_gate_spec(addr("lint-check"), &analyze, None);
+        let s = build_lint_gate_spec(addr("lint-check"), std::slice::from_ref(&analyze), None);
         assert_eq!(s.driver, "go_lint_gate");
         let deps = match s.config.get("deps").unwrap() {
             Value::Map(m) => m,
@@ -1707,18 +1777,23 @@ mod tests {
         );
         let cfg = Addr::new(PkgBuf::from(""), "file".to_string(), Default::default());
 
-        let gate = build_lint_gate_spec(addr("lint-check"), &analyze, Some(&cfg));
+        let gate = build_lint_gate_spec(
+            addr("lint-check"),
+            std::slice::from_ref(&analyze),
+            Some(&cfg),
+        );
         assert!(
             deps_map(&gate).contains_key("config"),
             "gate must depend on the golangci config so a config change re-keys it"
         );
         // Without a config addr, no config dep (keeps the no-config path clean).
-        let gate_none = build_lint_gate_spec(addr("lint-check"), &analyze, None);
+        let gate_none =
+            build_lint_gate_spec(addr("lint-check"), std::slice::from_ref(&analyze), None);
         assert!(!deps_map(&gate_none).contains_key("config"));
 
         let fix = build_lint_fix_spec(
             addr("lint"),
-            &analyze,
+            std::slice::from_ref(&analyze),
             &["//mylib:a.go".to_string()],
             &["a.go".to_string()],
             Some(&cfg),
@@ -1795,6 +1870,107 @@ mod tests {
         assert_eq!(a[0].new, "A");
     }
 
+    // The gate is the union across variants: a finding only one variant's build
+    // constraints expose still fails, and a finding every variant reports is
+    // listed once, not N times.
+    #[test]
+    fn gate_unions_and_dedupes_findings_across_variants() {
+        let shared = br#"{"m": {"printf": [{"posn": "a.go:1:1", "message": "shared"}]}}"#;
+        let win_only = br#"{"m": {"printf": [
+            {"posn": "a.go:1:1", "message": "shared"},
+            {"posn": "only_windows.go:2:2", "message": "windows only"}
+        ]}}"#;
+        let findings = merge_report_findings(&[shared.to_vec(), win_only.to_vec()]).unwrap();
+        assert_eq!(findings.len(), 2, "shared finding deduped: {findings:?}");
+        assert!(
+            findings.iter().any(|f| f.contains("only_windows.go")),
+            "a finding from one variant alone must still fail the gate: {findings:?}"
+        );
+    }
+
+    /// A `-json` report with one suggested fix over `[start, end)` of `a.go`.
+    fn one_fix_report(start: usize, end: usize, new: &str) -> Vec<u8> {
+        format!(
+            r#"{{"m": {{"l": [{{"posn": "a.go:1:1", "message": "x",
+              "suggested_fixes": [{{"message": "f", "edits": [
+                {{"filename": "a.go", "start": {start}, "end": {end}, "new": "{new}"}}
+              ]}}]}}]}}}}"#
+        )
+        .into_bytes()
+    }
+
+    // Every variant that compiles a file reports the same diagnostic on it, so
+    // merging N reports must not apply the same rewrite N times.
+    #[test]
+    fn merge_dedupes_the_same_edit_seen_by_several_variants() {
+        let reports = vec![
+            one_fix_report(0, 5, "A"),
+            one_fix_report(0, 5, "A"),
+            one_fix_report(0, 5, "A"),
+        ];
+        let merged = merge_report_edits(&reports).unwrap();
+        let a = merged.get("a.go").expect("keyed by basename");
+        assert_eq!(
+            a.len(),
+            1,
+            "identical cross-variant edits collapse: {}",
+            a.len()
+        );
+        assert_eq!(a[0].new, "A");
+    }
+
+    // Edits from different variants that don't touch each other all apply.
+    #[test]
+    fn merge_keeps_disjoint_edits_from_different_variants() {
+        let merged =
+            merge_report_edits(&[one_fix_report(0, 2, "A"), one_fix_report(4, 6, "B")]).unwrap();
+        assert_eq!(merged.get("a.go").unwrap().len(), 2);
+    }
+
+    // Two variants proposing different rewrites of the same bytes is a real
+    // ambiguity — nothing here can pick a winner, so it must fail rather than
+    // apply whichever report was staged first.
+    #[test]
+    fn merge_fails_when_variants_disagree_on_a_rewrite() {
+        let err = merge_report_edits(&[one_fix_report(0, 5, "A"), one_fix_report(3, 8, "B")])
+            .expect_err("overlapping, differing edits must not silently resolve");
+        let msg = format!("{err:#}");
+        assert!(
+            msg.contains("disagree") && msg.contains("a.go"),
+            "error must name the file and the disagreement: {msg}"
+        );
+    }
+
+    // Same span, different replacement — the overlap test alone misses this for
+    // zero-length insertions, so it is checked explicitly.
+    #[test]
+    fn merge_fails_on_conflicting_insertions_at_one_offset() {
+        let err = merge_report_edits(&[one_fix_report(3, 3, "A"), one_fix_report(3, 3, "B")])
+            .expect_err("two different insertions at one offset must not silently resolve");
+        assert!(format!("{err:#}").contains("disagree"));
+    }
+
+    // Within ONE report, overlapping edits stay go/analysis' problem:
+    // `apply_edits` drops the later one (earliest wins). Merging must not turn
+    // that long-standing behavior into a hard failure.
+    #[test]
+    fn merge_leaves_intra_report_overlaps_to_apply_edits() {
+        let json = br#"{"m": {"l": [
+            {"posn": "a.go:1:1", "message": "x", "suggested_fixes": [{"message": "f", "edits": [
+              {"filename": "a.go", "start": 0, "end": 5, "new": "A"}]}]},
+            {"posn": "a.go:2:1", "message": "y", "suggested_fixes": [{"message": "f", "edits": [
+              {"filename": "a.go", "start": 3, "end": 8, "new": "B"}]}]}
+        ]}}"#;
+        let merged = merge_report_edits(std::slice::from_ref(&json.to_vec())).unwrap();
+        let mut a = merged.into_values().next().unwrap();
+        assert_eq!(a.len(), 2, "both kept; apply_edits arbitrates");
+        assert_eq!(
+            apply_edits(b"0123456789", &mut a).unwrap(),
+            b"A56789",
+            "earliest edit wins, the overlapping one is dropped"
+        );
+    }
+
     #[test]
     fn apply_edits_splices_in_offset_order() {
         let src = b"hello world";
@@ -1869,7 +2045,7 @@ mod tests {
         );
         let s = build_lint_fix_spec(
             addr("lint"),
-            &analyze,
+            std::slice::from_ref(&analyze),
             &["//mylib:a.go".to_string()],
             &["a.go".to_string()],
             None,
@@ -1920,7 +2096,7 @@ mod tests {
         );
         let spec = build_lint_fix_spec(
             addr("lint"),
-            &analyze,
+            std::slice::from_ref(&analyze),
             &["//mylib:a.go".to_string()],
             &["a.go".to_string()],
             None,

--- a/crates/plugin-go/src/plugingo/factors.rs
+++ b/crates/plugin-go/src/plugingo/factors.rs
@@ -1,43 +1,82 @@
-use hmodel::htaddr::Addr;
+use std::collections::BTreeMap;
 
-#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+/// Resolved build variant: the concrete set of Go toolchain factors a target
+/// compiles/links under. Produced by resolving a [`VariantRef`] (`v`/`vp` addr
+/// args) against the `variants` provider_state (see
+/// [`crate::plugingo::variant`]).
+///
+/// **Cache correctness:** every field here affects build output, so every field
+/// must be reflected in the compile/golist/lint cache keys (the `Go*Def::hash`
+/// functions). GOOS/GOARCH/GOEXPERIMENT/CGO are set as process env in the driver
+/// `run()` (never as hashed config keys), so they are hashed via those `Def`s;
+/// gcflags land on the `go tool compile` command line; ldflags land on the link
+/// script (hashed transitively by the exec driver's run-script hash).
+#[derive(Debug, Clone, PartialEq, Eq, Hash, Default)]
 pub struct Factors {
     pub goos: String,
     pub goarch: String,
+    /// `-tags` build tags (file selection). Sorted for determinism.
     pub build_tags: Vec<String>,
+    /// `GOEXPERIMENT` values. Sorted for determinism.
+    pub goexperiment: Vec<String>,
+    /// Flags passed verbatim to `go tool compile` (the `-gcflags` equivalent).
+    /// Order preserved — flag semantics can be order-sensitive.
+    pub gcflags: Vec<String>,
+    /// Flags passed verbatim to `go tool link` (the `-ldflags` equivalent).
+    /// Order preserved.
+    pub ldflags: Vec<String>,
+    /// `CGO_ENABLED`. Defaults to false — heph Go builds are cgo-off unless a
+    /// variant opts in.
+    pub cgo_enabled: bool,
 }
 
 impl Factors {
-    pub fn from_addr(addr: &Addr) -> Self {
-        let mut tags: Vec<String> = addr
-            .args
-            .get("tags")
-            .map(|t| {
-                t.split(',')
-                    .filter(|s| !s.is_empty())
-                    .map(String::from)
-                    .collect()
-            })
-            .unwrap_or_default();
-        tags.sort();
-        Self {
-            goos: addr.args.get("goos").cloned().unwrap_or_else(current_goos),
-            goarch: addr
-                .args
-                .get("goarch")
-                .cloned()
-                .unwrap_or_else(current_goarch),
-            build_tags: tags,
+    /// `GOEXPERIMENT` env value (`"a,b"`), or `None` when no experiments are set.
+    pub fn goexperiment_env(&self) -> Option<String> {
+        if self.goexperiment.is_empty() {
+            None
+        } else {
+            Some(self.goexperiment.join(","))
         }
     }
 
-    #[cfg(test)]
-    pub fn go_list_flags(&self) -> Vec<String> {
-        if self.build_tags.is_empty() {
-            vec![]
-        } else {
-            vec!["-tags".to_string(), self.build_tags.join(",")]
+    /// `CGO_ENABLED` env value (`"0"`/`"1"`).
+    pub fn cgo_enabled_env(&self) -> &'static str {
+        if self.cgo_enabled { "1" } else { "0" }
+    }
+}
+
+/// The variant coordinate carried on a target address: the variant `name` (`v`
+/// arg) plus the `pkg` that defines it (`vp` arg; `""` = workspace root).
+///
+/// User-facing targets are addressed with `v` only; the provider resolves the
+/// closest ancestor package defining that variant to fill in `pkg`. Every
+/// internal / dependency target the provider emits carries the full `{v, vp}`
+/// pair so the variant resolves identically no matter which subtree the target
+/// lives in (see [`crate::plugingo::variant::resolve`]). `vp` threads verbatim
+/// down the whole dependency graph so the entire binary shares one factor set.
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+pub struct VariantRef {
+    pub name: String,
+    pub pkg: String,
+}
+
+impl VariantRef {
+    pub fn new(name: impl Into<String>, pkg: impl Into<String>) -> Self {
+        Self {
+            name: name.into(),
+            pkg: pkg.into(),
         }
+    }
+
+    /// Encode as addr args `{v, vp}`. `vp` is always emitted (even empty, for the
+    /// root package) so a present `vp` key unambiguously marks a fully-resolved
+    /// internal address vs. a bare user `@v=` address.
+    pub fn to_args(&self) -> BTreeMap<String, String> {
+        let mut args = BTreeMap::new();
+        args.insert("v".to_string(), self.name.clone());
+        args.insert("vp".to_string(), self.pkg.clone());
+        args
     }
 }
 
@@ -54,54 +93,35 @@ pub fn current_goarch() -> String {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use hmodel::htaddr::Addr;
-    use hmodel::htpkg::PkgBuf;
 
-    fn addr_with_args(args: &[(&str, &str)]) -> Addr {
-        Addr::new(
-            PkgBuf::from(""),
-            String::new(),
-            args.iter()
-                .map(|(k, v)| (k.to_string(), v.to_string()))
-                .collect(),
-        )
+    #[test]
+    fn test_variant_ref_to_args() {
+        let vref = VariantRef::new("release", "app");
+        let args = vref.to_args();
+        assert_eq!(args.get("v").map(String::as_str), Some("release"));
+        assert_eq!(args.get("vp").map(String::as_str), Some("app"));
     }
 
     #[test]
-    fn test_from_addr_explicit() {
-        let addr = addr_with_args(&[("goos", "linux"), ("goarch", "amd64"), ("tags", "foo,bar")]);
-        let f = Factors::from_addr(&addr);
-        assert_eq!(f.goos, "linux");
-        assert_eq!(f.goarch, "amd64");
-        assert_eq!(f.build_tags, vec!["bar", "foo"]); // sorted
+    fn test_variant_ref_root_pkg_emits_empty_vp() {
+        let vref = VariantRef::new("release", "");
+        let args = vref.to_args();
+        assert_eq!(args.get("vp").map(String::as_str), Some(""));
     }
 
     #[test]
-    fn test_from_addr_defaults() {
-        let addr = Addr::default();
-        let f = Factors::from_addr(&addr);
-        assert!(!f.goos.is_empty());
-        assert!(!f.goarch.is_empty());
-        assert!(f.build_tags.is_empty());
+    fn test_goexperiment_env() {
+        let mut f = Factors::default();
+        assert_eq!(f.goexperiment_env(), None);
+        f.goexperiment = vec!["arenas".into(), "loopvar".into()];
+        assert_eq!(f.goexperiment_env(), Some("arenas,loopvar".to_string()));
     }
 
     #[test]
-    fn test_go_list_flags_empty_tags() {
-        let f = Factors {
-            goos: "linux".into(),
-            goarch: "amd64".into(),
-            build_tags: vec![],
-        };
-        assert!(f.go_list_flags().is_empty());
-    }
-
-    #[test]
-    fn test_go_list_flags_with_tags() {
-        let f = Factors {
-            goos: "linux".into(),
-            goarch: "amd64".into(),
-            build_tags: vec!["foo".into(), "bar".into()],
-        };
-        assert_eq!(f.go_list_flags(), vec!["-tags", "foo,bar"]);
+    fn test_cgo_enabled_env() {
+        let mut f = Factors::default();
+        assert_eq!(f.cgo_enabled_env(), "0");
+        f.cgo_enabled = true;
+        assert_eq!(f.cgo_enabled_env(), "1");
     }
 }

--- a/crates/plugin-go/src/plugingo/factors.rs
+++ b/crates/plugin-go/src/plugingo/factors.rs
@@ -25,9 +25,6 @@ pub struct Factors {
     /// Flags passed verbatim to `go tool link` (the `-ldflags` equivalent).
     /// Order preserved.
     pub ldflags: Vec<String>,
-    /// `CGO_ENABLED`. Defaults to false — heph Go builds are cgo-off unless a
-    /// variant opts in.
-    pub cgo_enabled: bool,
 }
 
 impl Factors {
@@ -38,11 +35,6 @@ impl Factors {
         } else {
             Some(self.goexperiment.join(","))
         }
-    }
-
-    /// `CGO_ENABLED` env value (`"0"`/`"1"`).
-    pub fn cgo_enabled_env(&self) -> &'static str {
-        if self.cgo_enabled { "1" } else { "0" }
     }
 }
 
@@ -115,13 +107,5 @@ mod tests {
         assert_eq!(f.goexperiment_env(), None);
         f.goexperiment = vec!["arenas".into(), "loopvar".into()];
         assert_eq!(f.goexperiment_env(), Some("arenas,loopvar".to_string()));
-    }
-
-    #[test]
-    fn test_cgo_enabled_env() {
-        let mut f = Factors::default();
-        assert_eq!(f.cgo_enabled_env(), "0");
-        f.cgo_enabled = true;
-        assert_eq!(f.cgo_enabled_env(), "1");
     }
 }

--- a/crates/plugin-go/src/plugingo/mod.rs
+++ b/crates/plugin-go/src/plugingo/mod.rs
@@ -19,6 +19,7 @@ mod target_std;
 mod target_test;
 mod thirdparty;
 mod toolchain;
+mod variant;
 
 pub use driver_compile::GoCompileDriver;
 pub use driver_format::{GoFormatCheckDriver, GoFormatDriver};

--- a/crates/plugin-go/src/plugingo/pkg_analysis.rs
+++ b/crates/plugin-go/src/plugingo/pkg_analysis.rs
@@ -486,7 +486,7 @@ pub(crate) async fn run_go_list(
         .current_dir(module_root)
         .env("GOOS", &factors.goos)
         .env("GOARCH", &factors.goarch)
-        .env("CGO_ENABLED", factors.cgo_enabled_env())
+        .env("CGO_ENABLED", "0")
         .env_remove("GOFLAGS");
 
     for var in &["GOROOT", "GOPATH", "GOMODCACHE", "HOME", "PATH", "GOCACHE"] {

--- a/crates/plugin-go/src/plugingo/pkg_analysis.rs
+++ b/crates/plugin-go/src/plugingo/pkg_analysis.rs
@@ -478,16 +478,15 @@ pub(crate) async fn run_go_list(
     module_root: &std::path::Path,
 ) -> anyhow::Result<HashMap<String, GoPackage>> {
     let mut cmd = tokio::process::Command::new("go");
-    cmd.arg("list")
-        .arg("-json")
-        .arg("-e")
-        .arg("-test")
-        .args(factors.go_list_flags())
-        .arg(import_path)
+    cmd.arg("list").arg("-json").arg("-e").arg("-test");
+    if !factors.build_tags.is_empty() {
+        cmd.arg("-tags").arg(factors.build_tags.join(","));
+    }
+    cmd.arg(import_path)
         .current_dir(module_root)
         .env("GOOS", &factors.goos)
         .env("GOARCH", &factors.goarch)
-        .env("CGO_ENABLED", "0")
+        .env("CGO_ENABLED", factors.cgo_enabled_env())
         .env_remove("GOFLAGS");
 
     for var in &["GOROOT", "GOPATH", "GOMODCACHE", "HOME", "PATH", "GOCACHE"] {

--- a/crates/plugin-go/src/plugingo/provider.rs
+++ b/crates/plugin-go/src/plugingo/provider.rs
@@ -630,15 +630,7 @@ impl ProviderInner {
             //     forms a cross-subtree consumer pins with `vp`.
             // A package with no variants in scope lists no build targets — there is
             // no implicit default variant.
-            let module_root = match &*kind {
-                GoPackageKind::FirstParty { module_root, .. }
-                | GoPackageKind::ThirdParty { module_root, .. } => module_root
-                    .strip_prefix(&self.workspace_root)
-                    .unwrap_or(module_root)
-                    .to_string_lossy()
-                    .into_owned(),
-                GoPackageKind::Stdlib { .. } => String::new(),
-            };
+            let module_root = module_root_rel(&kind, &self.workspace_root);
             let ancestry_pairs = variant::ancestry_variants_with_factors(&req.states, &module_root);
             let ancestry: Vec<VariantRef> = ancestry_pairs.iter().map(|(v, _)| v.clone()).collect();
             // Runnable `test`/`xtest` targets execute the built binary, so they
@@ -656,10 +648,20 @@ impl ProviderInner {
             // (rarely listed directly, and always consumed with a `vp` pin) fall
             // back to ancestry.
             let universe = if matches!(&*kind, GoPackageKind::FirstParty { .. }) {
-                let module_states = req
+                // `states_under` walks the whole subtree by path prefix, so it
+                // also returns states from *nested* submodules under this
+                // package. Keep only states in this target's own module — a
+                // nested submodule's variants are a different module's targets
+                // and must not be enumerated here.
+                let module_states: Vec<State> = req
                     .executor
                     .states_under(&hmodel::htpkg::PkgBuf::from(module_root.as_str()))
-                    .await?;
+                    .await?
+                    .into_iter()
+                    .filter(|s| {
+                        pkg_in_module(s.package.as_str(), &module_root, &self.workspace_root)
+                    })
+                    .collect();
                 variant::universe_variants(&module_states)?
             } else {
                 ancestry.clone()
@@ -861,6 +863,34 @@ fn is_entry_target_name(name: &str) -> bool {
 /// built for another platform can't run here.
 fn is_run_test_target_name(name: &str) -> bool {
     matches!(name, "test" | "xtest")
+}
+
+/// Workspace-relative go.mod directory of a decoded package (`""` for a root
+/// module, `"go"` for `go/go.mod`, etc.). Two packages belong to the *same* Go
+/// module iff this matches — the real module-membership test (a plain path
+/// prefix is wrong: a package can prefix-match a module root while living inside
+/// a *nested* submodule with its own `go.mod`).
+fn module_root_rel(kind: &GoPackageKind, workspace_root: &Path) -> String {
+    match kind {
+        GoPackageKind::FirstParty { module_root, .. }
+        | GoPackageKind::ThirdParty { module_root, .. } => module_root
+            .strip_prefix(workspace_root)
+            .unwrap_or(module_root)
+            .to_string_lossy()
+            .into_owned(),
+        GoPackageKind::Stdlib { .. } => String::new(),
+    }
+}
+
+/// Whether `pkg` (a Go import package) belongs to the module rooted at
+/// `target_module_root` (workspace-relative). The real nearest-`go.mod` check —
+/// used to bound `vp` honoring and library-variant enumeration to the target's
+/// own module, so a nested submodule's variants never leak across the boundary.
+fn pkg_in_module(pkg: &str, target_module_root: &str, workspace_root: &Path) -> bool {
+    match decode_package(&hmodel::htpkg::PkgBuf::from(pkg), workspace_root) {
+        Some(kind) => module_root_rel(&kind, workspace_root) == target_module_root,
+        None => false,
+    }
 }
 
 /// Spec for the magic host-default `build` (bare `//pkg:build`): a `group` target
@@ -1394,10 +1424,13 @@ impl ProviderInner {
         // resolve the variant here.
         if addr.package.as_str() == target_std::STD_PKG && addr.name == "install" {
             // std:install is always internal (carries `vp`), so it takes the
-            // library/universe branch — `module_root` is unused.
-            let (factors, _vref) = variant::resolve(addr, &req.states, "", req.executor.as_ref())
-                .await
-                .map_err(GetError::Other)?;
+            // library/universe branch — `module_root` is unused. std belongs to
+            // no user module; its `vp` (the consumer's declaring package) is
+            // always honored so std builds with the consumer's variant factors.
+            let (factors, _vref) =
+                variant::resolve(addr, &req.states, "", req.executor.as_ref(), true)
+                    .await
+                    .map_err(GetError::Other)?;
             let spec = target_std::install_spec(addr.clone(), &factors, &self.go_version);
             return Ok(GetResponse { target_spec: spec });
         }
@@ -1492,15 +1525,7 @@ impl ProviderInner {
         //
         // `module_root` bounds ancestry resolution at the go.mod dir (not repo
         // root); it is unused for the `vp` (library) branch.
-        let module_root = match &*kind {
-            GoPackageKind::FirstParty { module_root, .. }
-            | GoPackageKind::ThirdParty { module_root, .. } => module_root
-                .strip_prefix(&self.workspace_root)
-                .unwrap_or(module_root)
-                .to_string_lossy()
-                .into_owned(),
-            GoPackageKind::Stdlib { .. } => String::new(),
-        };
+        let module_root = module_root_rel(&kind, &self.workspace_root);
 
         // Magic host-default `build`: a *truly bare* `//pkg:build` (no addr args at
         // all) is served as a `group` target forwarding to `build@v=<variant>` for
@@ -1572,10 +1597,23 @@ impl ProviderInner {
             )));
         }
 
-        let (factors, vref) =
-            variant::resolve(addr, &req.states, &module_root, req.executor.as_ref())
-                .await
-                .map_err(GetError::Other)?;
+        // Honor `vp` only when it names a package in *this* target's own go
+        // module (a real nearest-`go.mod` check, not a path prefix). A `vp`
+        // threaded from a consumer in a different module is a cross-module dep
+        // pin and must be ignored so the foreign module's variant can't leak in.
+        let vp_same_module = addr
+            .args
+            .get("vp")
+            .is_some_and(|vp| pkg_in_module(vp, &module_root, &self.workspace_root));
+        let (factors, vref) = variant::resolve(
+            addr,
+            &req.states,
+            &module_root,
+            req.executor.as_ref(),
+            vp_same_module,
+        )
+        .await
+        .map_err(GetError::Other)?;
 
         // _golist — generate spec without executing go list (before stdlib check so
         // stdlib packages can also expose a _golist target for cached dep resolution)
@@ -4842,6 +4880,99 @@ golang.org/x/oauth2 v0.0.0-20200107190931-bf48bf16ab8d h1:pE8b58s1HRDMi8RDc79m0H
         assert!(
             !addrs.iter().any(|a| a.name == "build"),
             "entry target must not list a variant absent from ancestry: {addrs:?}"
+        );
+    }
+
+    /// Module-bounding: `states_under` walks by path prefix, so a variant
+    /// declared inside a **nested submodule** (its own `go.mod`) is returned too.
+    /// The root module's `list` must NOT enumerate it — that variant is a
+    /// different module's target. Only the same-module (root) variant is listed.
+    #[tokio::test]
+    async fn list_library_excludes_nested_submodule_variant() {
+        let ws = tempfile::tempdir().unwrap();
+        std::fs::write(
+            ws.path().join("go.mod"),
+            "module example.com/root\ngo 1.22\n",
+        )
+        .unwrap();
+        std::fs::create_dir(ws.path().join("nested")).unwrap();
+        std::fs::write(
+            ws.path().join("nested/go.mod"),
+            "module example.com/nested\ngo 1.22\n",
+        )
+        .unwrap();
+        let p = Provider::new(ws.path().to_path_buf()).unwrap();
+
+        // `release` declared at the root module ("") AND at the nested submodule
+        // ("nested"). `states_under("")` returns both by prefix.
+        struct NestedUniverse;
+        impl ProviderExecutor for NestedUniverse {
+            fn result<'a>(
+                &'a self,
+                _addr: &'a Addr,
+            ) -> BoxFuture<'a, anyhow::Result<Arc<EResult>>> {
+                unimplemented!("list must not resolve results")
+            }
+            fn query<'a>(
+                &'a self,
+                _m: &'a hmodel::htmatcher::Matcher,
+                _s: &'a [String],
+            ) -> BoxFuture<'a, anyhow::Result<Vec<Addr>>> {
+                unimplemented!("list must not query")
+            }
+            fn states_under<'a>(
+                &'a self,
+                prefix: &'a PkgBuf,
+            ) -> BoxFuture<'a, anyhow::Result<Vec<State>>> {
+                let variant = || {
+                    Value::Map(HashMap::from([
+                        ("goos".to_string(), Value::String("linux".into())),
+                        ("goarch".to_string(), Value::String("amd64".into())),
+                    ]))
+                };
+                let go_state = |pkg: &str| State {
+                    package: PkgBuf::from(pkg),
+                    provider: "go".to_string(),
+                    state: HashMap::from([(
+                        "variants".to_string(),
+                        Value::Map(HashMap::from([("release".to_string(), variant())])),
+                    )]),
+                };
+                let states = if prefix.as_str().is_empty() {
+                    vec![go_state(""), go_state("nested")]
+                } else {
+                    vec![]
+                };
+                Box::pin(async move { Ok(states) })
+            }
+        }
+
+        let req = ListRequest {
+            request_id: "test".to_string(),
+            package: PkgBuf::from(""),
+            states: vec![],
+            executor: Arc::new(NestedUniverse),
+        };
+        let addrs: Vec<Addr> = p
+            .list(req, &StdCancellationToken::new())
+            .await
+            .unwrap()
+            .map(|r| r.unwrap().addr)
+            .collect();
+
+        // The root-module variant is listed (vp="").
+        assert!(
+            addrs
+                .iter()
+                .any(|a| a.name == "build_lib" && a.args.get("vp").map(String::as_str) == Some("")),
+            "root-module variant must be listed: {addrs:?}"
+        );
+        // The nested submodule's variant must NOT be — it's a different module.
+        assert!(
+            !addrs
+                .iter()
+                .any(|a| a.args.get("vp").map(String::as_str) == Some("nested")),
+            "nested submodule variant must not cross the module boundary: {addrs:?}"
         );
     }
 

--- a/crates/plugin-go/src/plugingo/provider.rs
+++ b/crates/plugin-go/src/plugingo/provider.rs
@@ -1401,6 +1401,17 @@ impl ProviderInner {
             return Err(GetError::NotFound);
         }
 
+        // A name this provider doesn't own can't be a variant target — decline so
+        // the engine falls through to the owning provider. `foreign_name_guard`
+        // above is the on-by-default fast path (before `decode_package`); this
+        // unconditional check covers the guard-off case, where a foreign name (e.g.
+        // a buildfile codegen target sharing a Go package dir, spec-resolved via a
+        // go-first registration) must decline rather than error out of variant
+        // resolution below.
+        if !is_known_go_target_name(&addr.name) {
+            return Err(GetError::NotFound);
+        }
+
         // Everything below is variant-parameterized. Resolve the addr's variant —
         // a bare `@v` (binary/entry target) resolves by module-bounded ancestry;
         // `@v,vp` (library / dependency target) resolves `(name, vp)` against the

--- a/crates/plugin-go/src/plugingo/provider.rs
+++ b/crates/plugin-go/src/plugingo/provider.rs
@@ -1597,14 +1597,24 @@ impl ProviderInner {
             )));
         }
 
-        // Honor `vp` only when it names a package in *this* target's own go
-        // module (a real nearest-`go.mod` check, not a path prefix). A `vp`
-        // threaded from a consumer in a different module is a cross-module dep
-        // pin and must be ignored so the foreign module's variant can't leak in.
-        let vp_same_module = addr
-            .args
-            .get("vp")
-            .is_some_and(|vp| pkg_in_module(vp, &module_root, &self.workspace_root));
+        // Decide whether to honor the addr's `vp`:
+        //   - std / thirdparty belong to *no* user module — they carry no
+        //     variant declarations of their own and are only ever reached as a
+        //     dependency. Their factors ARE the consumer's, threaded via `vp`, so
+        //     always honor it (module-bounding them would strand them with an
+        //     empty ancestry and fail).
+        //   - first-party: honor `vp` only when it names a package in *this*
+        //     target's own go module (a real nearest-`go.mod` check, not a path
+        //     prefix). A `vp` threaded from a consumer in a different module is a
+        //     cross-module dep pin; ignoring it keeps the foreign module's
+        //     variant declaration from leaking across the boundary.
+        let vp_same_module = match &*kind {
+            GoPackageKind::Stdlib { .. } | GoPackageKind::ThirdParty { .. } => true,
+            GoPackageKind::FirstParty { .. } => addr
+                .args
+                .get("vp")
+                .is_some_and(|vp| pkg_in_module(vp, &module_root, &self.workspace_root)),
+        };
         let (factors, vref) = variant::resolve(
             addr,
             &req.states,

--- a/crates/plugin-go/src/plugingo/provider.rs
+++ b/crates/plugin-go/src/plugingo/provider.rs
@@ -1502,15 +1502,22 @@ impl ProviderInner {
             GoPackageKind::Stdlib { .. } => String::new(),
         };
 
-        // Magic host-default `build`: a bare `//pkg:build` (no `@v`) is served as a
-        // `group` target forwarding to `build@v=<variant>` for the first ancestry
-        // variant matching this machine's goos/goarch. It gives `//pkg:build` an
-        // ergonomic host default without an implicit variant on the real per-variant
-        // build. Intercept before `variant::resolve`, which requires an explicit `v`.
-        // First-party only — `build` (and thus its host-default) exists solely for
-        // first-party packages, matching what `list` emits.
+        // Magic host-default `build`: a *truly bare* `//pkg:build` (no addr args at
+        // all) is served as a `group` target forwarding to `build@v=<variant>` for
+        // the first ancestry variant matching this machine's goos/goarch. It gives
+        // `//pkg:build` an ergonomic host default without an implicit variant on the
+        // real per-variant build. First-party only — `build` (and thus its
+        // host-default) exists solely for first-party packages, matching what `list`
+        // emits.
+        //
+        // Gate on `args.is_empty()`, NOT merely "no `v`": a `build` carrying stray
+        // args — e.g. a legacy `build@goos=linux,goarch=amd64` from a pre-variant
+        // BUILD file — must fall through to `variant::resolve`, which reports a clear
+        // "requires `@v=NAME`" migration error, rather than being silently treated as
+        // the host-default (which would forward to the host variant and confusingly
+        // NotFound for a target-platform-only package).
         if addr.name == "build"
-            && !addr.args.contains_key("v")
+            && addr.args.is_empty()
             && matches!(&*kind, GoPackageKind::FirstParty { .. })
         {
             let (host_goos, host_goarch) = (current_goos(), current_goarch());
@@ -1548,6 +1555,21 @@ impl ProviderInner {
             return Ok(GetResponse {
                 target_spec: magic_build_group_spec(addr.clone(), &target),
             });
+        }
+
+        // Strict addr args: every variant-parameterized go target accepts only `v`
+        // (entry) and `vp` (library/dep pin). Reject anything else rather than
+        // silently ignoring it — notably a legacy `goos`/`goarch` from a pre-variant
+        // BUILD file, which must surface as an actionable error, not resolve to the
+        // wrong thing. (The host-keyed toolchain/govet targets, which do carry
+        // `goos`/`goarch`, are handled earlier and never reach here.)
+        if let Some(bad) = addr.args.keys().find(|k| !matches!(k.as_str(), "v" | "vp")) {
+            return Err(GetError::Other(anyhow::anyhow!(
+                "unknown addr arg `{bad}` on go target `:{}` (allowed: v, vp); \
+                 select a build variant with `@v=NAME` — `goos`/`goarch` are no \
+                 longer addr args, declare a variant instead",
+                addr.name,
+            )));
         }
 
         let (factors, vref) =
@@ -5893,6 +5915,61 @@ golang.org/x/oauth2 v0.0.0-20200107190931-bf48bf16ab8d h1:pE8b58s1HRDMi8RDc79m0H
         assert!(
             matches!(res, Err(GetError::NotFound)),
             "magic build on a non-main package must NotFound"
+        );
+    }
+
+    /// Unknown addr args are rejected. A legacy `build@goos=…,goarch=…` (a
+    /// pre-variant BUILD dep) must NOT be hijacked by the magic host-default nor
+    /// silently ignored — it errors naming the offending arg, pointing at `@v=`.
+    #[tokio::test]
+    async fn unknown_build_addr_arg_is_rejected() {
+        let sandbox = copy_fixture("with_dep");
+        let p = Provider::new(sandbox.path().to_path_buf()).unwrap();
+        let addr = Addr::new(
+            PkgBuf::from("cmd"),
+            "build".to_string(),
+            std::collections::BTreeMap::from([
+                ("goos".to_string(), "linux".to_string()),
+                ("goarch".to_string(), "amd64".to_string()),
+            ]),
+        );
+        let err = match provider_get(&p, addr).await {
+            Err(GetError::Other(e)) => e,
+            Err(GetError::NotFound) => panic!("expected an unknown-arg error, got NotFound"),
+            Ok(_) => panic!("expected an error, got Ok"),
+        };
+        let msg = format!("{err:#}");
+        // Args iterate sorted, so `goarch` (the first offending key) is named.
+        assert!(
+            msg.contains("unknown addr arg `goarch`") && msg.contains("@v="),
+            "error must name the bad arg and point at @v=: {msg}"
+        );
+    }
+
+    /// Unknown args are rejected on non-`build` targets too (the check is general,
+    /// not build-specific).
+    #[tokio::test]
+    async fn unknown_addr_arg_rejected_on_build_lib() {
+        let sandbox = copy_fixture("with_dep");
+        let p = Provider::new(sandbox.path().to_path_buf()).unwrap();
+        let addr = Addr::new(
+            PkgBuf::from("lib"),
+            "build_lib".to_string(),
+            std::collections::BTreeMap::from([
+                ("v".to_string(), "host".to_string()),
+                ("bogus".to_string(), "x".to_string()),
+            ]),
+        );
+        let err = match provider_get(&p, addr).await {
+            Err(GetError::Other(e)) => e,
+            other => {
+                let _ = other;
+                panic!("expected an unknown-arg error")
+            }
+        };
+        assert!(
+            format!("{err:#}").contains("unknown addr arg `bogus`"),
+            "{err:#}"
         );
     }
 

--- a/crates/plugin-go/src/plugingo/provider.rs
+++ b/crates/plugin-go/src/plugingo/provider.rs
@@ -594,35 +594,66 @@ impl ProviderInner {
                 return empty();
             }
 
-            // Every build/list target is variant-parameterized: list one copy per
-            // variant applicable to this package (each pinned to its defining
-            // package via `vp`). A package with no variants declared in scope lists
-            // no build targets — there is no implicit default variant.
-            let variants = variant::applicable(&req.states);
+            // Every build/list target is variant-parameterized. Two enumeration
+            // scopes:
+            //   - **entry / binary** targets (`build`, `test`, `lint`, …) list the
+            //     module-bounded *ancestry* variants — the ones a user can select
+            //     at this package.
+            //   - **library / intermediate** targets (`build_lib`, `_golist`, …)
+            //     list the whole module *universe* (fetched via `states_under`), so
+            //     a variant declared at a sibling package is still enumerated — the
+            //     forms a cross-subtree consumer pins with `vp`.
+            // A package with no variants in scope lists no build targets — there is
+            // no implicit default variant.
+            let module_root = match &*kind {
+                GoPackageKind::FirstParty { module_root, .. }
+                | GoPackageKind::ThirdParty { module_root, .. } => module_root
+                    .strip_prefix(&self.workspace_root)
+                    .unwrap_or(module_root)
+                    .to_string_lossy()
+                    .into_owned(),
+                GoPackageKind::Stdlib { .. } => String::new(),
+            };
+            let ancestry = variant::ancestry_variants(&req.states, &module_root);
+            // First-party libs enumerate the module universe; stdlib/thirdparty
+            // (rarely listed directly, and always consumed with a `vp` pin) fall
+            // back to ancestry.
+            let universe = if matches!(&*kind, GoPackageKind::FirstParty { .. }) {
+                let module_states = req
+                    .executor
+                    .states_under(&hmodel::htpkg::PkgBuf::from(module_root.as_str()))
+                    .await?;
+                variant::universe_variants(&module_states)?
+            } else {
+                ancestry.clone()
+            };
+            let vrefs_for = |name: &str| -> &[VariantRef] {
+                if is_entry_target_name(name) {
+                    &ancestry
+                } else {
+                    &universe
+                }
+            };
+
+            let push_names = |addrs: &mut Vec<Addr>, names: &[&str]| {
+                for name in names {
+                    for vref in vrefs_for(name) {
+                        addrs.push(Addr::new(
+                            req.package.clone(),
+                            (*name).to_string(),
+                            vref.to_args(),
+                        ));
+                    }
+                }
+            };
 
             let mut addrs: Vec<Addr> = Vec::new();
             match &*kind {
                 GoPackageKind::Stdlib { .. } => {
-                    for vref in &variants {
-                        for name in ["_golist", "build_lib"] {
-                            addrs.push(Addr::new(
-                                req.package.clone(),
-                                name.to_string(),
-                                vref.to_args(),
-                            ));
-                        }
-                    }
+                    push_names(&mut addrs, &["_golist", "build_lib"]);
                 }
                 GoPackageKind::ThirdParty { subpath, .. } => {
-                    for vref in &variants {
-                        for name in ["_golist", "build_lib"] {
-                            addrs.push(Addr::new(
-                                req.package.clone(),
-                                name.to_string(),
-                                vref.to_args(),
-                            ));
-                        }
-                    }
+                    push_names(&mut addrs, &["_golist", "build_lib"]);
                     // The `download` target lives at the module root only and is
                     // variant-independent (one per module@version).
                     if subpath.is_empty() {
@@ -634,37 +665,24 @@ impl ProviderInner {
                     }
                 }
                 GoPackageKind::FirstParty { module_root, .. } => {
-                    // Emit the full candidate set unconditionally for any dir
-                    // under a go.mod (decode_package guarantees that). Each target
-                    // is filtered at `get` time by inspecting the `_golist` result.
-                    //
-                    // Lint/format targets are the exception: they exist only for
-                    // modules that opt in with a golangci config at the go.mod
-                    // root, so gate them here (matching the `get`-time gate) to
-                    // avoid advertising targets that would resolve to NotFound.
+                    // Lint/format targets exist only for modules that opt in with a
+                    // golangci config at the go.mod root, so gate them here
+                    // (matching the `get`-time gate) to avoid advertising targets
+                    // that would resolve to NotFound.
                     let lint_enabled = self.golangci_config_addr(module_root).is_some();
                     let skip_tests = pick_test_skip(&req.states, req.package.as_str());
-                    let mut names: Vec<&str> = vec!["_golist", "build_lib", "build", "embed"];
+                    push_names(&mut addrs, &["_golist", "build_lib", "build", "embed"]);
                     if lint_enabled {
-                        names.extend_from_slice(&["lint-check", "lint", "format-check", "format"]);
+                        push_names(
+                            &mut addrs,
+                            &["lint-check", "lint", "format-check", "format"],
+                        );
                     }
                     if !skip_tests {
-                        names.extend_from_slice(&[
-                            "embed_xtest",
-                            "build_test",
-                            "test",
-                            "build_xtest",
-                            "xtest",
-                        ]);
-                    }
-                    for vref in &variants {
-                        for name in &names {
-                            addrs.push(Addr::new(
-                                req.package.clone(),
-                                (*name).to_string(),
-                                vref.to_args(),
-                            ));
-                        }
+                        push_names(
+                            &mut addrs,
+                            &["embed_xtest", "build_test", "test", "build_xtest", "xtest"],
+                        );
                     }
                 }
             }
@@ -774,6 +792,18 @@ const TEST_TARGET_NAMES: &[&str] = &[
 
 fn is_test_target_name(name: &str) -> bool {
     TEST_TARGET_NAMES.contains(&name)
+}
+
+/// User-facing **entry / binary** target names — the ones a user selects a
+/// variant on directly (bare `@v`, resolved by module-bounded ancestry). Every
+/// other target is a **library / intermediate** (carries `vp`, resolved against
+/// the module universe). Used by `list` to choose the enumeration scope
+/// (ancestry vs universe) per target name.
+fn is_entry_target_name(name: &str) -> bool {
+    matches!(
+        name,
+        "build" | "test" | "xtest" | "lint-check" | "lint" | "format-check" | "format"
+    )
 }
 
 /// Targets handled by `handle_get` *before* the `_golist` resolve (no go list
@@ -1290,7 +1320,9 @@ impl ProviderInner {
         // is variant-parameterized (std is compiled with the variant's factors), so
         // resolve the variant here.
         if addr.package.as_str() == target_std::STD_PKG && addr.name == "install" {
-            let (factors, _vref) = variant::resolve(addr, &req.states, req.executor.as_ref())
+            // std:install is always internal (carries `vp`), so it takes the
+            // library/universe branch — `module_root` is unused.
+            let (factors, _vref) = variant::resolve(addr, &req.states, "", req.executor.as_ref())
                 .await
                 .map_err(GetError::Other)?;
             let spec = target_std::install_spec(addr.clone(), &factors, &self.go_version);
@@ -1369,12 +1401,26 @@ impl ProviderInner {
         }
 
         // Everything below is variant-parameterized. Resolve the addr's variant —
-        // `v` (user targets) or the `v`+`vp` pin (internal / dependency targets) —
-        // into the concrete `factors` this target builds with, plus the `vref` to
-        // thread verbatim onto every sub-target and dependency address.
-        let (factors, vref) = variant::resolve(addr, &req.states, req.executor.as_ref())
-            .await
-            .map_err(GetError::Other)?;
+        // a bare `@v` (binary/entry target) resolves by module-bounded ancestry;
+        // `@v,vp` (library / dependency target) resolves `(name, vp)` against the
+        // module universe. Returns the concrete `factors` this target builds with,
+        // plus the `vref` to thread onto every sub-target and dependency address.
+        //
+        // `module_root` bounds ancestry resolution at the go.mod dir (not repo
+        // root); it is unused for the `vp` (library) branch.
+        let module_root = match &*kind {
+            GoPackageKind::FirstParty { module_root, .. }
+            | GoPackageKind::ThirdParty { module_root, .. } => module_root
+                .strip_prefix(&self.workspace_root)
+                .unwrap_or(module_root)
+                .to_string_lossy()
+                .into_owned(),
+            GoPackageKind::Stdlib { .. } => String::new(),
+        };
+        let (factors, vref) =
+            variant::resolve(addr, &req.states, &module_root, req.executor.as_ref())
+                .await
+                .map_err(GetError::Other)?;
 
         // _golist — generate spec without executing go list (before stdlib check so
         // stdlib packages can also expose a _golist target for cached dep resolution)
@@ -3102,6 +3148,21 @@ mod tests {
     }
 
     impl ProviderExecutor for GoListTestExecutor {
+        // The test fixtures are single-module workspaces (go.mod at root), so the
+        // module universe = the root `host` variant. Serve it for `states_under`
+        // of the root prefix; deeper prefixes have no declarations.
+        fn states_under<'a>(
+            &'a self,
+            prefix: &'a hmodel::htpkg::PkgBuf,
+        ) -> BoxFuture<'a, anyhow::Result<Vec<hplugin::provider::State>>> {
+            let states = if prefix.as_str().is_empty() {
+                vec![host_variant_state()]
+            } else {
+                vec![]
+            };
+            Box::pin(async move { Ok(states) })
+        }
+
         fn result<'a>(&'a self, addr: &'a Addr) -> BoxFuture<'a, anyhow::Result<Arc<EResult>>> {
             Box::pin(async move {
                 if addr.name != "_golist" {
@@ -4530,12 +4591,90 @@ golang.org/x/oauth2 v0.0.0-20200107190931-bf48bf16ab8d h1:pE8b58s1HRDMi8RDc79m0H
             request_id: "test".to_string(),
             package: PkgBuf::from(package),
             states: vec![host_variant_state()],
+            executor: test_executor(&p.inner.workspace_root),
         };
         p.list(req, &ctoken)
             .await
             .unwrap()
             .map(|r| r.unwrap().addr.name.clone())
             .collect()
+    }
+
+    /// The completeness fix: a library target must list a variant declared at a
+    /// **sibling** package (reachable only via the module universe / `states_under`),
+    /// not just the package's own ancestry. Entry targets stay ancestry-scoped.
+    #[tokio::test]
+    async fn list_library_enumerates_sibling_variant_from_universe() {
+        let sandbox = copy_fixture("simple_lib"); // a library package at the module root
+        let p = Provider::new(sandbox.path().to_path_buf()).unwrap();
+
+        // `release` declared ONLY at sibling package `other` — not in the root
+        // lib's ancestry. `states_under` (the module universe) surfaces it.
+        struct SiblingUniverse;
+        impl ProviderExecutor for SiblingUniverse {
+            fn result<'a>(
+                &'a self,
+                _addr: &'a Addr,
+            ) -> BoxFuture<'a, anyhow::Result<Arc<EResult>>> {
+                unimplemented!("list must not resolve results")
+            }
+            fn query<'a>(
+                &'a self,
+                _m: &'a hmodel::htmatcher::Matcher,
+                _s: &'a [String],
+            ) -> BoxFuture<'a, anyhow::Result<Vec<Addr>>> {
+                unimplemented!("list must not query")
+            }
+            fn states_under<'a>(
+                &'a self,
+                prefix: &'a PkgBuf,
+            ) -> BoxFuture<'a, anyhow::Result<Vec<State>>> {
+                let release = Value::Map(HashMap::from([
+                    ("goos".to_string(), Value::String("linux".into())),
+                    ("goarch".to_string(), Value::String("amd64".into())),
+                ]));
+                let states = if prefix.as_str().is_empty() {
+                    vec![State {
+                        package: PkgBuf::from("other"),
+                        provider: "go".to_string(),
+                        state: HashMap::from([(
+                            "variants".to_string(),
+                            Value::Map(HashMap::from([("release".to_string(), release)])),
+                        )]),
+                    }]
+                } else {
+                    vec![]
+                };
+                Box::pin(async move { Ok(states) })
+            }
+        }
+
+        let req = ListRequest {
+            request_id: "test".to_string(),
+            package: PkgBuf::from(""),
+            states: vec![], // no ancestry variants for this package
+            executor: Arc::new(SiblingUniverse),
+        };
+        let addrs: Vec<Addr> = p
+            .list(req, &StdCancellationToken::new())
+            .await
+            .unwrap()
+            .map(|r| r.unwrap().addr)
+            .collect();
+
+        // build_lib (library) lists the sibling's variant, pinned via `vp`.
+        assert!(
+            addrs.iter().any(|a| a.name == "build_lib"
+                && a.args.get("v").map(String::as_str) == Some("release")
+                && a.args.get("vp").map(String::as_str) == Some("other")),
+            "sibling-declared variant must be listed on build_lib: {addrs:?}"
+        );
+        // build (entry) is ancestry-scoped — nothing declared in ancestry, so it
+        // is not listed.
+        assert!(
+            !addrs.iter().any(|a| a.name == "build"),
+            "entry target must not list a variant absent from ancestry: {addrs:?}"
+        );
     }
 
     #[tokio::test]
@@ -5407,6 +5546,7 @@ golang.org/x/oauth2 v0.0.0-20200107190931-bf48bf16ab8d h1:pE8b58s1HRDMi8RDc79m0H
                 with_recursive(state_with_test_skip("", true)),
                 host_variant_state(),
             ],
+            executor: test_executor(sandbox.path()),
         };
         let names: Vec<String> = p
             .list(req, &ctoken)

--- a/crates/plugin-go/src/plugingo/provider.rs
+++ b/crates/plugin-go/src/plugingo/provider.rs
@@ -444,7 +444,6 @@ impl ProviderTrait for Provider {
             ("goexperiment", ParamType::list(ParamType::String)),
             ("gcflags", ParamType::list(ParamType::String)),
             ("ldflags", ParamType::list(ParamType::String)),
-            ("cgo_enabled", ParamType::Bool),
         ]);
         Some(StateSchema {
             fields: vec![
@@ -454,8 +453,8 @@ impl ProviderTrait for Provider {
                     "Named Go build variants for this package (and its descendants, via \
                      closest-ancestor lookup). Maps a variant name to a static factor set: \
                      `goos`/`goarch` (required), plus optional `tags` (build tags), \
-                     `goexperiment` (GOEXPERIMENT), `gcflags` (extra `go tool compile` flags), \
-                     `ldflags` (extra `go tool link` flags) and `cgo_enabled` (default False). \
+                     `goexperiment` (GOEXPERIMENT), `gcflags` (extra `go tool compile` flags) \
+                     and `ldflags` (extra `go tool link` flags). \
                      A user-facing target selects one with `@v=NAME`, resolving the closest \
                      ancestor package that defines that name; variants do NOT compound across \
                      the tree (each definition is self-contained).",

--- a/crates/plugin-go/src/plugingo/provider.rs
+++ b/crates/plugin-go/src/plugingo/provider.rs
@@ -724,10 +724,17 @@ impl ProviderInner {
                         ));
                     }
                     if lint_enabled {
-                        push_names(
-                            &mut addrs,
-                            &["lint-check", "lint", "format-check", "format"],
-                        );
+                        push_names(&mut addrs, &["lint-check", "lint"]);
+                        // Formatting is syntactic, so `format`/`format-check` are
+                        // variant-free (see `VARIANT_FREE_TARGET_NAMES`): one bare
+                        // addr per package, never multiplied across variants.
+                        for name in VARIANT_FREE_TARGET_NAMES {
+                            addrs.push(Addr::new(
+                                req.package.clone(),
+                                (*name).to_string(),
+                                Default::default(),
+                            ));
+                        }
                     }
                     if !skip_tests {
                         push_names(
@@ -850,11 +857,11 @@ fn is_test_target_name(name: &str) -> bool {
 /// other target is a **library / intermediate** (carries `vp`, resolved against
 /// the module universe). Used by `list` to choose the enumeration scope
 /// (ancestry vs universe) per target name.
+///
+/// `format`/`format-check` are deliberately absent: formatting is syntactic, so
+/// they are variant-independent (see [`VARIANT_FREE_TARGET_NAMES`]).
 fn is_entry_target_name(name: &str) -> bool {
-    matches!(
-        name,
-        "build" | "test" | "xtest" | "lint-check" | "lint" | "format-check" | "format"
-    )
+    matches!(name, "build" | "test" | "xtest" | "lint-check" | "lint")
 }
 
 /// **Runnable** test target names — the ones that execute the built test binary
@@ -921,9 +928,24 @@ const GOLIST_TARGET_NAMES: &[&str] = &[
     "lint-check",
     "lint",
     "_lint-analyze",
-    "format-check",
-    "format",
 ];
+
+/// Target names this provider owns that are **variant-free**: they carry no `@v`
+/// / `@vp` and are handled before variant resolution.
+///
+/// Formatting is purely syntactic — gofmt/gofumpt/goimports never look at
+/// `GOOS`/`GOARCH`/build tags — so a per-variant `format` would be three kinds of
+/// wrong: it would silently skip files excluded by the variant's build
+/// constraints (`foo_windows.go` never formatted unless a windows variant is
+/// declared), run N near-identical jobs for N variants, and have several variants
+/// claim the same `codegen = in_place` source paths. So they source their file
+/// list straight off disk (every `*.go` in the package dir) instead of from the
+/// variant-scoped `_golist`.
+///
+/// Linting is *not* in here on purpose: `_lint-analyze` type-checks against
+/// variant-scoped dependency facts, so its results legitimately differ per
+/// variant.
+const VARIANT_FREE_TARGET_NAMES: &[&str] = &["format", "format-check"];
 
 /// Workspace-relative package of heph's own go/analysis unitchecker binary
 /// (`heph-govet`), built as an ordinary `build` (package main) target like any
@@ -954,6 +976,7 @@ fn is_firstparty_pkg(pkg: &str) -> bool {
 fn is_known_go_target_name(name: &str) -> bool {
     SPECIAL_TARGET_NAMES.contains(&name)
         || GOLIST_TARGET_NAMES.contains(&name)
+        || VARIANT_FREE_TARGET_NAMES.contains(&name)
         || TEST_TARGET_NAMES.contains(&name)
 }
 
@@ -1527,6 +1550,16 @@ impl ProviderInner {
         // root); it is unused for the `vp` (library) branch.
         let module_root = module_root_rel(&kind, &self.workspace_root);
 
+        // format / format-check — variant-free (see `VARIANT_FREE_TARGET_NAMES`),
+        // so handle them before variant resolution and source the file list from
+        // disk rather than the variant-scoped `_golist`.
+        if VARIANT_FREE_TARGET_NAMES.contains(&addr.name.as_str()) {
+            return match self.get_format(addr, &kind).map_err(GetError::Other)? {
+                Some(resp) => Ok(resp),
+                None => Err(GetError::NotFound),
+            };
+        }
+
         // Magic host-default `build`: a *truly bare* `//pkg:build` (no addr args at
         // all) is served as a `group` target forwarding to `build@v=<variant>` for
         // the first ancestry variant matching this machine's goos/goarch. It gives
@@ -1807,40 +1840,6 @@ impl ProviderInner {
                     &pkg.go_files,
                     Some(&config_addr),
                 );
-                Ok(GetResponse { target_spec: spec })
-            }
-            // Formatting: `format-check` is the gate (fails on unformatted files),
-            // `format` rewrites the sources in place (codegen). Both run the
-            // heph-govet `-format` mode; neither needs facts or dep archives.
-            "format-check" | "format" => {
-                if pkg.go_files.is_empty() {
-                    return Err(GetError::NotFound);
-                }
-                // Format only where the module opts in with a golangci config
-                // (the same gate as lint); the config also carries formatter
-                // settings (gofumpt/goimports).
-                let config_addr = match self.golangci_config_addr(&module_root) {
-                    Some(a) => a,
-                    None => return Err(GetError::NotFound),
-                };
-                let pkg_addrs = self
-                    .read_golist_package_addrs(Arc::clone(&req.executor), &golist_addr)
-                    .await
-                    .map_err(GetError::Other)?;
-                let govet_addr = self.govet_tool_addr().map_err(GetError::Other)?;
-                let config_addr = Some(config_addr);
-                let params = crate::plugingo::driver_format::FormatParams {
-                    addr: addr.clone(),
-                    govet_addr: &govet_addr,
-                    src_addrs: &pkg_addrs.go_files,
-                    go_files: &pkg.go_files,
-                    config_addr: config_addr.as_ref(),
-                };
-                let spec = if addr.name == "format" {
-                    crate::plugingo::driver_format::build_format_spec(params)
-                } else {
-                    crate::plugingo::driver_format::build_format_check_spec(params)
-                };
                 Ok(GetResponse { target_spec: spec })
             }
             // Analyze unit: runs heph-govet, produces `lint.facts` (consumed by
@@ -2696,6 +2695,117 @@ impl ProviderInner {
         Addr::new(package.clone(), name.to_string(), vref.to_args())
     }
 
+    /// Spec for the variant-free `format` / `format-check` targets. `Ok(None)`
+    /// means "no such target here" (the caller maps it to `NotFound`).
+    ///
+    /// Formatting is syntactic, so this deliberately does **not** go through
+    /// `_golist`: `go list` reports only the `GoFiles` the current
+    /// `GOOS`/`GOARCH`/`-tags` select, which would leave every
+    /// constraint-excluded file (`foo_windows.go` on a linux-only workspace) and
+    /// every `_test.go` file permanently unformatted. Reading the package
+    /// directory instead formats exactly what a developer sees in it.
+    fn get_format(&self, addr: &Addr, kind: &GoPackageKind) -> anyhow::Result<Option<GetResponse>> {
+        // `format` is listed for first-party packages only — stdlib/thirdparty
+        // sources are vendored, not ours to rewrite.
+        let GoPackageKind::FirstParty { module_root, .. } = kind else {
+            return Ok(None);
+        };
+
+        // No variant to select. Reject args rather than ignore them, so a stale
+        // `format@v=NAME` is an actionable error instead of silently doing
+        // something else.
+        if let Some(bad) = addr.args.keys().next() {
+            anyhow::bail!(
+                "unknown addr arg `{bad}` on go target `:{}` — formatting is \
+                 syntactic and therefore variant-free; use a bare `:{}`",
+                addr.name,
+                addr.name,
+            );
+        }
+
+        // Format only where the module opts in with a golangci config (the same
+        // gate as lint); the config also carries formatter settings
+        // (gofumpt/goimports).
+        let Some(config_addr) = self.golangci_config_addr(module_root) else {
+            return Ok(None);
+        };
+
+        let go_files = self.package_go_files_on_disk(addr.package.as_str())?;
+        if go_files.is_empty() {
+            return Ok(None);
+        }
+        let src_addrs: Vec<String> = go_files
+            .iter()
+            .map(|f| {
+                let rel = if addr.package.as_str().is_empty() {
+                    f.clone()
+                } else {
+                    format!("{}/{}", addr.package.as_str(), f)
+                };
+                pluginfs::file_addr(&rel).format()
+            })
+            .collect();
+
+        let govet_addr = self.govet_tool_addr()?;
+        let params = crate::plugingo::driver_format::FormatParams {
+            addr: addr.clone(),
+            govet_addr: &govet_addr,
+            src_addrs: &src_addrs,
+            go_files: &go_files,
+            config_addr: Some(&config_addr),
+        };
+        let target_spec = if addr.name == "format" {
+            crate::plugingo::driver_format::build_format_spec(params)
+        } else {
+            crate::plugingo::driver_format::build_format_check_spec(params)
+        };
+        Ok(Some(GetResponse { target_spec }))
+    }
+
+    /// Every `.go` file directly in `pkg`'s directory, sorted, as basenames.
+    ///
+    /// Build constraints are deliberately not applied — see [`Self::get_format`].
+    /// Codegen-stamped files are skipped: they are owned by their generator (an
+    /// `fs:file` over one resolves to nothing anyway), and declaring one as a
+    /// `codegen = in_place` output of `format` would collide with the generator's
+    /// own output. Files reached through a `.heph*` cache dir are skipped for the
+    /// same reason they are in the fs provider — they are engine artifacts, not
+    /// source.
+    fn package_go_files_on_disk(&self, pkg: &str) -> anyhow::Result<Vec<String>> {
+        let dir = if pkg.is_empty() {
+            self.workspace_root.clone()
+        } else {
+            self.workspace_root.join(pkg)
+        };
+        let entries = match std::fs::read_dir(&dir) {
+            Ok(e) => e,
+            Err(e) if e.kind() == std::io::ErrorKind::NotFound => return Ok(Vec::new()),
+            Err(e) => return Err(anyhow::Error::new(e).context(format!("read go pkg dir {dir:?}"))),
+        };
+        let mut files: Vec<String> = Vec::new();
+        for entry in entries {
+            let entry = entry.with_context(|| format!("read go pkg dir entry in {dir:?}"))?;
+            let path = entry.path();
+            let Some(name) = path.file_name().and_then(|n| n.to_str()) else {
+                continue;
+            };
+            if !name.ends_with(".go") {
+                continue;
+            }
+            if !path.is_file() {
+                continue;
+            }
+            if pluginfs::has_codegen_xattr(&path) || pluginfs::resolves_into_heph_dir(&path) {
+                continue;
+            }
+            files.push(name.to_string());
+        }
+        // `read_dir` order is filesystem-defined; sort so the spec (and therefore
+        // the target's input hash) is reproducible.
+        files.sort();
+        Ok(files)
+    }
+
     /// The addr of the module's golangci-lint config, if the module root (the
     /// `go.mod` directory) holds one. Lint/format targets exist ONLY for modules
     /// that have such a config — the presence of a `.golangci.yml`/`.golangci.yaml`
@@ -3520,6 +3630,12 @@ mod tests {
         )
     }
 
+    /// Addr with no variant args — for the variant-free targets
+    /// (`format`/`format-check`, `download`, `_go_mod`).
+    fn make_bare_addr(package: &str, name: &str) -> Addr {
+        Addr::new(PkgBuf::from(package), name.to_string(), Default::default())
+    }
+
     /// A root `provider_state(provider="go", variants={"host": {goos, goarch}})`
     /// defining the default `host` variant every test target resolves against.
     fn host_variant_state() -> State {
@@ -3630,14 +3746,13 @@ mod tests {
         enable_golangci(sandbox.path());
         // Default `govet` — i.e. the dev build's (nonexistent) release target.
         let p = Provider::new(sandbox.path().to_path_buf()).expect("provider");
-        for name in [
-            "_lint-analyze",
-            "lint-check",
-            "lint",
-            "format-check",
-            "format",
-        ] {
+        for name in ["_lint-analyze", "lint-check", "lint"] {
             provider_get(&p, make_addr("cmd", name))
+                .await
+                .unwrap_or_else(|e| panic!("{name} spec must resolve on a dev build: {e:?}"));
+        }
+        for name in ["format-check", "format"] {
+            provider_get(&p, make_bare_addr("cmd", name))
                 .await
                 .unwrap_or_else(|e| panic!("{name} spec must resolve on a dev build: {e:?}"));
         }
@@ -4178,7 +4293,13 @@ golang.org/x/oauth2 v0.0.0-20200107190931-bf48bf16ab8d h1:pE8b58s1HRDMi8RDc79m0H
         );
 
         for name in ["_lint-analyze", "format-check", "format"] {
-            let resp = provider_get(&p, make_addr("cmd", name)).await.unwrap();
+            // Formatting is variant-free; lint is not.
+            let addr = if name.starts_with("format") {
+                make_bare_addr("cmd", name)
+            } else {
+                make_addr("cmd", name)
+            };
+            let resp = provider_get(&p, addr).await.unwrap();
             let deps = match resp.target_spec.config.get("deps").unwrap() {
                 Value::Map(m) => m,
                 other => panic!("{name}: expected deps map, got {other:?}"),
@@ -4276,7 +4397,7 @@ golang.org/x/oauth2 v0.0.0-20200107190931-bf48bf16ab8d h1:pE8b58s1HRDMi8RDc79m0H
         enable_golangci(sandbox.path());
         let p = provider_with_govet(sandbox.path().to_path_buf(), GOVET_SOURCE_ADDR);
 
-        let check = provider_get(&p, make_addr("cmd", "format-check"))
+        let check = provider_get(&p, make_bare_addr("cmd", "format-check"))
             .await
             .unwrap();
         assert_eq!(check.target_spec.driver, "go_format_check");
@@ -4285,7 +4406,9 @@ golang.org/x/oauth2 v0.0.0-20200107190931-bf48bf16ab8d h1:pE8b58s1HRDMi8RDc79m0H
             "check gate declares no outputs"
         );
 
-        let fix = provider_get(&p, make_addr("cmd", "format")).await.unwrap();
+        let fix = provider_get(&p, make_bare_addr("cmd", "format"))
+            .await
+            .unwrap();
         assert_eq!(fix.target_spec.driver, "go_format");
         // Stages the heph-govet tool + the package's own sources.
         let deps = match fix.target_spec.config.get("deps").unwrap() {
@@ -4300,6 +4423,140 @@ golang.org/x/oauth2 v0.0.0-20200107190931-bf48bf16ab8d h1:pE8b58s1HRDMi8RDc79m0H
         assert!(
             fix.target_spec.config.get("out").is_some(),
             "fix declares in_place outputs"
+        );
+    }
+
+    /// Formatting is syntactic: it must cover every `.go` file in the package,
+    /// including the ones the current variant's build constraints exclude.
+    /// Sourcing the list from `_golist` (i.e. `go list`'s `GoFiles`) left
+    /// `foo_windows.go` unformatted forever on a workspace with no windows
+    /// variant — and `_test.go` files unformatted everywhere.
+    #[tokio::test]
+    async fn test_format_covers_constraint_excluded_and_test_files() {
+        require_go!();
+        let sandbox = copy_fixture("with_dep");
+        enable_golangci(sandbox.path());
+        // Neither of these is in `go list`'s GoFiles for the host variant: the
+        // first is excluded by its filename build constraint (no test host is
+        // both windows and plan9), the second is a test file.
+        let pkg_dir = sandbox.path().join("cmd");
+        std::fs::write(
+            pkg_dir.join("only_windows.go"),
+            "//go:build windows && plan9\n\npackage main\n",
+        )
+        .unwrap();
+        std::fs::write(pkg_dir.join("main_test.go"), "package main\n").unwrap();
+        let p = provider_with_govet(sandbox.path().to_path_buf(), GOVET_SOURCE_ADDR);
+
+        let fix = provider_get(&p, make_bare_addr("cmd", "format"))
+            .await
+            .unwrap();
+        let out = match fix.target_spec.config.get("out").expect("out") {
+            Value::Map(m) => match m.iter().find(|(k, _)| *k == "src").map(|(_, v)| v) {
+                Some(Value::List(l)) => l
+                    .iter()
+                    .map(|v| match v {
+                        Value::String(s) => s.clone(),
+                        other => panic!("out entry not a string: {other:?}"),
+                    })
+                    .collect::<Vec<_>>(),
+                other => panic!("src group missing: {other:?}"),
+            },
+            other => panic!("out not a map: {other:?}"),
+        };
+        for expected in ["only_windows.go", "main_test.go", "main.go"] {
+            assert!(
+                out.iter().any(|f| f == expected),
+                "{expected} must be formatted: {out:?}"
+            );
+        }
+    }
+
+    /// `format`/`format-check` carry no variant, so `list` emits exactly one bare
+    /// addr each no matter how many variants a module declares — while `lint`
+    /// (whose analysis genuinely depends on the variant) is still emitted per
+    /// variant.
+    #[tokio::test]
+    async fn list_emits_format_once_and_variant_free() {
+        require_go!();
+        let sandbox = copy_fixture("with_dep");
+        enable_golangci(sandbox.path());
+        let p = provider_with_govet(sandbox.path().to_path_buf(), GOVET_SOURCE_ADDR);
+
+        // Two variants in ancestry: `host` (so runnable targets list) and a
+        // second, cross-compiled one.
+        let cross = Value::Map(HashMap::from([
+            ("goos".to_string(), Value::String("linux".into())),
+            ("goarch".to_string(), Value::String("arm64".into())),
+        ]));
+        let host = Value::Map(HashMap::from([
+            ("goos".to_string(), Value::String(current_goos())),
+            ("goarch".to_string(), Value::String(current_goarch())),
+        ]));
+        let states = vec![State {
+            package: PkgBuf::from(""),
+            provider: "go".to_string(),
+            state: HashMap::from([(
+                "variants".to_string(),
+                Value::Map(HashMap::from([
+                    ("host".to_string(), host),
+                    ("cross".to_string(), cross),
+                ])),
+            )]),
+        }];
+        let req = ListRequest {
+            request_id: "test".to_string(),
+            package: PkgBuf::from("cmd"),
+            states,
+            executor: test_executor(&p.inner.workspace_root),
+        };
+        let addrs: Vec<Addr> = p
+            .list(req, &StdCancellationToken::new())
+            .await
+            .unwrap()
+            .map(|r| r.unwrap().addr)
+            .collect();
+
+        for name in ["format", "format-check"] {
+            let listed: Vec<&Addr> = addrs.iter().filter(|a| a.name == name).collect();
+            assert_eq!(
+                listed.len(),
+                1,
+                "{name} must be listed once, not per variant: {listed:?}"
+            );
+            assert!(
+                listed[0].args.is_empty(),
+                "{name} must carry no variant args: {:?}",
+                listed[0]
+            );
+        }
+        // Lint is the contrast: its analysis is variant-scoped, so it stays
+        // multiplied across the declared variants.
+        assert_eq!(
+            addrs.iter().filter(|a| a.name == "lint-check").count(),
+            2,
+            "lint-check must still be listed per variant: {addrs:?}"
+        );
+    }
+
+    /// A stale `format@v=NAME` (e.g. carried over from when formatting was
+    /// variant-parameterized) must fail loudly, not silently format something
+    /// else.
+    #[tokio::test]
+    async fn test_format_rejects_a_variant_arg() {
+        require_go!();
+        let sandbox = copy_fixture("with_dep");
+        enable_golangci(sandbox.path());
+        let p = provider_with_govet(sandbox.path().to_path_buf(), GOVET_SOURCE_ADDR);
+
+        let msg = match provider_get(&p, make_addr("cmd", "format")).await {
+            Err(GetError::Other(e)) => format!("{e:#}"),
+            Err(other) => panic!("expected a typed error, got {other:?}"),
+            Ok(_) => panic!("a variant arg on format must be rejected"),
+        };
+        assert!(
+            msg.contains("variant-free") && msg.contains("`v`"),
+            "error must explain formatting is variant-free: {msg}"
         );
     }
 
@@ -4320,11 +4577,14 @@ golang.org/x/oauth2 v0.0.0-20200107190931-bf48bf16ab8d h1:pE8b58s1HRDMi8RDc79m0H
             "format-check",
             "format",
         ] {
+            // Formatting is variant-free; lint is not.
+            let addr = if name.starts_with("format") {
+                make_bare_addr("cmd", name)
+            } else {
+                make_addr("cmd", name)
+            };
             assert!(
-                matches!(
-                    provider_get(&p, make_addr("cmd", name)).await,
-                    Err(GetError::NotFound)
-                ),
+                matches!(provider_get(&p, addr).await, Err(GetError::NotFound)),
                 "{name} must be NotFound without a golangci config"
             );
         }

--- a/crates/plugin-go/src/plugingo/provider.rs
+++ b/crates/plugin-go/src/plugingo/provider.rs
@@ -724,11 +724,18 @@ impl ProviderInner {
                         ));
                     }
                     if lint_enabled {
-                        push_names(&mut addrs, &["lint-check", "lint"]);
-                        // Formatting is syntactic, so `format`/`format-check` are
-                        // variant-free (see `VARIANT_FREE_TARGET_NAMES`): one bare
-                        // addr per package, never multiplied across variants.
-                        for name in VARIANT_FREE_TARGET_NAMES {
+                        // One bare addr per package for both families, never
+                        // multiplied across variants: formatting is syntactic and
+                        // so variant-free outright (`VARIANT_FREE_TARGET_NAMES`),
+                        // while the lint gate/fixer aggregate every ancestry
+                        // variant's analysis (`VARIANT_AGGREGATE_TARGET_NAMES`).
+                        // The per-variant `_lint-analyze` stays unlisted (as
+                        // before): it is internal, and the aggregators pull it in
+                        // as a dep.
+                        for name in VARIANT_AGGREGATE_TARGET_NAMES
+                            .iter()
+                            .chain(VARIANT_FREE_TARGET_NAMES)
+                        {
                             addrs.push(Addr::new(
                                 req.package.clone(),
                                 (*name).to_string(),
@@ -859,9 +866,11 @@ fn is_test_target_name(name: &str) -> bool {
 /// (ancestry vs universe) per target name.
 ///
 /// `format`/`format-check` are deliberately absent: formatting is syntactic, so
-/// they are variant-independent (see [`VARIANT_FREE_TARGET_NAMES`]).
+/// they are variant-independent (see [`VARIANT_FREE_TARGET_NAMES`]). So are
+/// `lint-check`/`lint`, which aggregate over every ancestry variant instead of
+/// being selected with one (see [`VARIANT_AGGREGATE_TARGET_NAMES`]).
 fn is_entry_target_name(name: &str) -> bool {
-    matches!(name, "build" | "test" | "xtest" | "lint-check" | "lint")
+    matches!(name, "build" | "test" | "xtest")
 }
 
 /// **Runnable** test target names — the ones that execute the built test binary
@@ -921,14 +930,7 @@ const SPECIAL_TARGET_NAMES: &[&str] = &["_golist", "_go_mod", "download"];
 
 /// Non-test first-party/thirdparty target names this provider owns and resolves
 /// through `_golist` (see the `match addr.name` arms in `handle_get`).
-const GOLIST_TARGET_NAMES: &[&str] = &[
-    "build_lib",
-    "build",
-    "embed",
-    "lint-check",
-    "lint",
-    "_lint-analyze",
-];
+const GOLIST_TARGET_NAMES: &[&str] = &["build_lib", "build", "embed", "_lint-analyze"];
 
 /// Target names this provider owns that are **variant-free**: they carry no `@v`
 /// / `@vp` and are handled before variant resolution.
@@ -942,10 +944,29 @@ const GOLIST_TARGET_NAMES: &[&str] = &[
 /// list straight off disk (every `*.go` in the package dir) instead of from the
 /// variant-scoped `_golist`.
 ///
-/// Linting is *not* in here on purpose: `_lint-analyze` type-checks against
-/// variant-scoped dependency facts, so its results legitimately differ per
-/// variant.
+/// The lint targets are *not* in here: they carry no variant either, but they
+/// reach the per-variant analysis units underneath, so they need their own
+/// handling (see [`VARIANT_AGGREGATE_TARGET_NAMES`]).
 const VARIANT_FREE_TARGET_NAMES: &[&str] = &["format", "format-check"];
+
+/// Target names that carry no `@v`/`@vp` themselves but **fan out over every
+/// declared variant** underneath — one bare addr per package aggregating N
+/// per-variant analysis units.
+///
+/// Lint *rules* are variant-independent, but the object they analyze is not:
+/// `_lint-analyze` type-checks the package, and a typed package only exists per
+/// `(GOOS, GOARCH, tags)` — `foo_linux.go` and `foo_windows.go` redeclare each
+/// other's symbols, and their imports differ. Facts are variant-scoped for the
+/// same reason. So the analysis unit stays per-variant while the user-facing
+/// gate (`lint-check`) and fixer (`lint`) aggregate the module-bounded ancestry
+/// variants.
+///
+/// That fixes two things a variant-selected `lint` got wrong: a file excluded by
+/// the selected variant's build constraints was silently never linted
+/// (`foo_windows.go` on a host-variant run), and N per-variant fixers each
+/// declared the same `codegen = in_place` source paths — N targets racing to
+/// rewrite one file. One aggregating fixer claims each path once.
+const VARIANT_AGGREGATE_TARGET_NAMES: &[&str] = &["lint-check", "lint"];
 
 /// Workspace-relative package of heph's own go/analysis unitchecker binary
 /// (`heph-govet`), built as an ordinary `build` (package main) target like any
@@ -977,6 +998,7 @@ fn is_known_go_target_name(name: &str) -> bool {
     SPECIAL_TARGET_NAMES.contains(&name)
         || GOLIST_TARGET_NAMES.contains(&name)
         || VARIANT_FREE_TARGET_NAMES.contains(&name)
+        || VARIANT_AGGREGATE_TARGET_NAMES.contains(&name)
         || TEST_TARGET_NAMES.contains(&name)
 }
 
@@ -1560,6 +1582,16 @@ impl ProviderInner {
             };
         }
 
+        // lint-check / lint — one bare addr per package aggregating the
+        // per-variant `_lint-analyze` units (see `VARIANT_AGGREGATE_TARGET_NAMES`).
+        // They carry no variant of their own, so they also resolve before variant
+        // resolution; they enumerate the ancestry variants themselves.
+        if VARIANT_AGGREGATE_TARGET_NAMES.contains(&addr.name.as_str()) {
+            return Arc::clone(&self)
+                .get_lint_aggregate(&req, &kind, &module_root)
+                .await;
+        }
+
         // Magic host-default `build`: a *truly bare* `//pkg:build` (no addr args at
         // all) is served as a `group` target forwarding to `build@v=<variant>` for
         // the first ancestry variant matching this machine's goos/goarch. It gives
@@ -1793,53 +1825,6 @@ impl ProviderInner {
                         )
                     }
                 };
-                Ok(GetResponse { target_spec: spec })
-            }
-            // User-facing check gate: depends on `_lint-analyze`'s report and fails on
-            // findings. `_lint-analyze` always exits 0 so facts cache regardless; the gate
-            // is the thing that fails.
-            "lint-check" => {
-                if pkg.go_files.is_empty() {
-                    return Err(GetError::NotFound);
-                }
-                // Lint only where the module opts in with a golangci config;
-                // attach it as a hash-only dep so a config change re-keys the gate.
-                let config_addr = match self.golangci_config_addr(&module_root) {
-                    Some(a) => a,
-                    None => return Err(GetError::NotFound),
-                };
-                let analyze_addr = self.make_addr_with_name(&addr.package, "_lint-analyze", &vref);
-                let spec = crate::plugingo::driver_lint::build_lint_gate_spec(
-                    addr.clone(),
-                    &analyze_addr,
-                    Some(&config_addr),
-                );
-                Ok(GetResponse { target_spec: spec })
-            }
-            // The plain `lint` target FIXES: it consumes `_lint-analyze`'s report (suggested
-            // fixes) + the package sources, applies the edits, and rewrites the
-            // sources in place (codegen). Runs no analysis itself — reuses `_lint-analyze`'s
-            // cache. Use `lint-check` to only report.
-            "lint" => {
-                if pkg.go_files.is_empty() {
-                    return Err(GetError::NotFound);
-                }
-                let config_addr = match self.golangci_config_addr(&module_root) {
-                    Some(a) => a,
-                    None => return Err(GetError::NotFound),
-                };
-                let analyze_addr = self.make_addr_with_name(&addr.package, "_lint-analyze", &vref);
-                let pkg_addrs = self
-                    .read_golist_package_addrs(Arc::clone(&req.executor), &golist_addr)
-                    .await
-                    .map_err(GetError::Other)?;
-                let spec = crate::plugingo::driver_lint::build_lint_fix_spec(
-                    addr.clone(),
-                    &analyze_addr,
-                    &pkg_addrs.go_files,
-                    &pkg.go_files,
-                    Some(&config_addr),
-                );
                 Ok(GetResponse { target_spec: spec })
             }
             // Analyze unit: runs heph-govet, produces `lint.facts` (consumed by
@@ -2806,6 +2791,146 @@ impl ProviderInner {
         Ok(files)
     }
 
+    /// Spec for the user-facing `lint-check` (gate) and `lint` (fixer) targets:
+    /// one bare addr per package that aggregates the per-variant `_lint-analyze`
+    /// units of every module-bounded ancestry variant.
+    ///
+    /// Why aggregate rather than let the user select a variant (see
+    /// [`VARIANT_AGGREGATE_TARGET_NAMES`]): lint rules don't depend on the
+    /// variant, only the typed package they run against does. Selecting one
+    /// variant therefore reported on an arbitrary subset of the package's files
+    /// — `foo_windows.go` was silently unlinted on a host-variant run — and gave
+    /// every variant its own fixer, each declaring the same source files as
+    /// `codegen = in_place` outputs.
+    ///
+    /// A variant whose build constraints leave the package with no Go files is
+    /// skipped: it has no `_lint-analyze` target, so wiring one would be a dep
+    /// that resolves to `NotFound`. All variants skipped (or none declared) →
+    /// `NotFound`, matching what the per-variant targets did.
+    async fn get_lint_aggregate(
+        self: Arc<Self>,
+        req: &GetRequest,
+        kind: &GoPackageKind,
+        module_root: &str,
+    ) -> Result<GetResponse, GetError> {
+        let addr = &req.addr;
+
+        // Linting is first-party only: std/thirdparty sources are vendored, and
+        // their modules carry no golangci config to opt in with.
+        let GoPackageKind::FirstParty {
+            module_root: module_root_path,
+            ..
+        } = kind
+        else {
+            return Err(GetError::NotFound);
+        };
+
+        // No variant to select any more. Reject a stale `@v=`/`@vp=` rather than
+        // ignore it, so a pinned addr surfaces the migration instead of quietly
+        // linting a different (now wider) set of files.
+        if let Some(bad) = addr.args.keys().next() {
+            return Err(GetError::Other(anyhow::anyhow!(
+                "unknown addr arg `{bad}` on go target `:{}` — lint rules are \
+                 variant-independent, so `:{}` now aggregates every declared \
+                 variant's analysis; use a bare `:{}` (the per-variant unit is \
+                 `:_lint-analyze@v=NAME,vp=PKG`)",
+                addr.name,
+                addr.name,
+                addr.name,
+            )));
+        }
+
+        // Lint only where the module opts in with a golangci config; attach it as
+        // a hash-only dep so a config change re-keys the gate/fixer directly.
+        let Some(config_addr) = self.golangci_config_addr(module_root_path) else {
+            return Err(GetError::NotFound);
+        };
+
+        // The ancestry variants — the same set `list` used to multiply these
+        // targets across, now folded into one target's deps.
+        let vrefs: Vec<VariantRef> =
+            variant::ancestry_variants_with_factors(&req.states, module_root)
+                .into_iter()
+                .map(|(v, _)| v)
+                .collect();
+
+        // One `_golist` read per variant, fanned out: they are independent and
+        // engine-cached (the `_lint-analyze` targets read the very same ones).
+        let per_variant = futures::future::try_join_all(vrefs.iter().map(|vref| {
+            let this = Arc::clone(&self);
+            let executor = Arc::clone(&req.executor);
+            let golist_addr = self.make_addr_with_name(&addr.package, "_golist", vref);
+            async move {
+                match this.read_golist_package(executor, &golist_addr).await {
+                    // No buildable Go files under this variant's constraints →
+                    // no analysis unit to aggregate.
+                    Ok(pkg) if pkg.go_files.is_empty() => anyhow::Ok(None),
+                    Ok(pkg) => anyhow::Ok(Some((vref.clone(), pkg, golist_addr))),
+                    Err(e) if downcast_chain_ref::<NoGoFilesError>(&e).is_some() => {
+                        anyhow::Ok(None)
+                    }
+                    Err(e) => Err(e),
+                }
+            }
+        }))
+        .await
+        .map_err(GetError::Other)?;
+
+        let analyzed: Vec<(VariantRef, Arc<GoPackage>, Addr)> =
+            per_variant.into_iter().flatten().collect();
+        if analyzed.is_empty() {
+            return Err(GetError::NotFound);
+        }
+
+        let analyze_addrs: Vec<Addr> = analyzed
+            .iter()
+            .map(|(vref, _, _)| self.make_addr_with_name(&addr.package, "_lint-analyze", vref))
+            .collect();
+
+        if addr.name == "lint-check" {
+            let spec = crate::plugingo::driver_lint::build_lint_gate_spec(
+                addr.clone(),
+                &analyze_addrs,
+                Some(&config_addr),
+            );
+            return Ok(GetResponse { target_spec: spec });
+        }
+
+        // The fixer additionally stages the sources it rewrites. Union them
+        // across variants: a file the selected variant's constraints excluded is
+        // still linted (and so still fixable) under another one, and it must be a
+        // declared output or the engine has nowhere to write the fix back.
+        let addrs_per_variant =
+            futures::future::try_join_all(analyzed.iter().map(|(_, _, golist_addr)| {
+                self.read_golist_package_addrs(Arc::clone(&req.executor), golist_addr)
+            }))
+            .await
+            .map_err(GetError::Other)?;
+
+        // Keyed by basename (a Go package's files are flat, so basenames are
+        // unique in it) → source addr. `resolve_package_addrs` maps files 1:1 in
+        // order, so `go_files[i]` is the addr of `pkg.go_files[i]`. `BTreeMap`
+        // keeps the two emitted lists aligned, deduped and in a stable order, so
+        // the spec — and the target's input hash — is reproducible.
+        let mut by_file: BTreeMap<String, String> = BTreeMap::new();
+        for ((_, pkg, _), pkg_addrs) in analyzed.iter().zip(addrs_per_variant.iter()) {
+            for (file, src) in pkg.go_files.iter().zip(pkg_addrs.go_files.iter()) {
+                by_file.entry(file.clone()).or_insert_with(|| src.clone());
+            }
+        }
+        let go_files: Vec<String> = by_file.keys().cloned().collect();
+        let src_addrs: Vec<String> = by_file.into_values().collect();
+
+        let spec = crate::plugingo::driver_lint::build_lint_fix_spec(
+            addr.clone(),
+            &analyze_addrs,
+            &src_addrs,
+            &go_files,
+            Some(&config_addr),
+        );
+        Ok(GetResponse { target_spec: spec })
+    }
+
     /// The addr of the module's golangci-lint config, if the module root (the
     /// `go.mod` directory) holds one. Lint/format targets exist ONLY for modules
     /// that have such a config — the presence of a `.golangci.yml`/`.golangci.yaml`
@@ -3444,6 +3569,11 @@ mod tests {
         workspace_root: PathBuf,
         /// Source map applied when generating `package_addrs.bin`.
         source_map: HashMap<String, String>,
+        /// The variant declarations this workspace has. Served from
+        /// `states_under`, and used to turn an addr's `v` into the `GOOS`/`GOARCH`
+        /// the mocked `go list` runs under — so a `_golist` really does see a
+        /// different file set per variant, as it does in production.
+        states: Vec<State>,
     }
 
     struct BinaryArtifact {
@@ -3475,14 +3605,14 @@ mod tests {
 
     impl ProviderExecutor for GoListTestExecutor {
         // The test fixtures are single-module workspaces (go.mod at root), so the
-        // module universe = the root `host` variant. Serve it for `states_under`
-        // of the root prefix; deeper prefixes have no declarations.
+        // module universe = the variants declared at the root. Serve them for
+        // `states_under` of the root prefix; deeper prefixes have no declarations.
         fn states_under<'a>(
             &'a self,
             prefix: &'a hmodel::htpkg::PkgBuf,
         ) -> BoxFuture<'a, anyhow::Result<Vec<hplugin::provider::State>>> {
             let states = if prefix.as_str().is_empty() {
-                vec![host_variant_state()]
+                self.states.clone()
             } else {
                 vec![]
             };
@@ -3498,13 +3628,24 @@ mod tests {
                     );
                 }
 
-                // This mock runs a real host `go list`, so use host factors
-                // regardless of the addr's variant coordinate.
-                let factors = Factors {
-                    goos: current_goos(),
-                    goarch: current_goarch(),
-                    ..Default::default()
-                };
+                // Resolve the addr's variant against the declared states so the
+                // mocked `go list` runs with that variant's `GOOS`/`GOARCH` —
+                // build constraints must select a different file set per variant
+                // here just as they do in production. Falls back to host factors
+                // for an addr with no `v` (or a name this workspace never
+                // declared).
+                let factors = addr
+                    .args
+                    .get("v")
+                    .and_then(|name| variant::resolve_ancestry(name, &self.states, "").ok())
+                    .map_or_else(
+                        || Factors {
+                            goos: current_goos(),
+                            goarch: current_goarch(),
+                            ..Default::default()
+                        },
+                        |(f, _)| f,
+                    );
                 let kind = decode_package(&addr.package, &self.workspace_root)
                     .ok_or_else(|| anyhow::anyhow!("unknown package: {}", addr.package))?;
 
@@ -3593,6 +3734,7 @@ mod tests {
         Arc::new(GoListTestExecutor {
             workspace_root: workspace_root.to_path_buf(),
             source_map: HashMap::new(),
+            states: vec![host_variant_state()],
         })
     }
 
@@ -3746,12 +3888,12 @@ mod tests {
         enable_golangci(sandbox.path());
         // Default `govet` — i.e. the dev build's (nonexistent) release target.
         let p = Provider::new(sandbox.path().to_path_buf()).expect("provider");
-        for name in ["_lint-analyze", "lint-check", "lint"] {
-            provider_get(&p, make_addr("cmd", name))
-                .await
-                .unwrap_or_else(|e| panic!("{name} spec must resolve on a dev build: {e:?}"));
-        }
-        for name in ["format-check", "format"] {
+        // `_lint-analyze` is the per-variant unit; the gate/fixer and the
+        // formatters are bare.
+        provider_get(&p, make_addr("cmd", "_lint-analyze"))
+            .await
+            .unwrap_or_else(|e| panic!("_lint-analyze spec must resolve on a dev build: {e:?}"));
+        for name in ["lint-check", "lint", "format-check", "format"] {
             provider_get(&p, make_bare_addr("cmd", name))
                 .await
                 .unwrap_or_else(|e| panic!("{name} spec must resolve on a dev build: {e:?}"));
@@ -4050,6 +4192,7 @@ golang.org/x/oauth2 v0.0.0-20200107190931-bf48bf16ab8d h1:pE8b58s1HRDMi8RDc79m0H
             executor: Arc::new(GoListTestExecutor {
                 workspace_root: sandbox.path().to_path_buf(),
                 source_map: HashMap::new(),
+                states: vec![host_variant_state()],
             }),
         };
         let resp = p.get(req, &ctoken).await.unwrap();
@@ -4094,6 +4237,7 @@ golang.org/x/oauth2 v0.0.0-20200107190931-bf48bf16ab8d h1:pE8b58s1HRDMi8RDc79m0H
         let inner: Arc<dyn ProviderExecutor> = Arc::new(GoListTestExecutor {
             workspace_root: sandbox.path().to_path_buf(),
             source_map: HashMap::new(),
+            states: vec![host_variant_state()],
         });
         let counter = Arc::new(std::sync::atomic::AtomicUsize::new(0));
         let executor: Arc<dyn ProviderExecutor> = Arc::new(CountingExecutor {
@@ -4327,7 +4471,7 @@ golang.org/x/oauth2 v0.0.0-20200107190931-bf48bf16ab8d h1:pE8b58s1HRDMi8RDc79m0H
         let sandbox = copy_fixture("with_dep");
         enable_golangci(sandbox.path());
         let p = Provider::new(sandbox.path().to_path_buf()).unwrap();
-        let resp = provider_get(&p, make_addr("cmd", "lint-check"))
+        let resp = provider_get(&p, make_bare_addr("cmd", "lint-check"))
             .await
             .unwrap();
         assert_eq!(resp.target_spec.driver, "go_lint_gate");
@@ -4358,7 +4502,9 @@ golang.org/x/oauth2 v0.0.0-20200107190931-bf48bf16ab8d h1:pE8b58s1HRDMi8RDc79m0H
         let sandbox = copy_fixture("with_dep");
         enable_golangci(sandbox.path());
         let p = Provider::new(sandbox.path().to_path_buf()).unwrap();
-        let resp = provider_get(&p, make_addr("cmd", "lint")).await.unwrap();
+        let resp = provider_get(&p, make_bare_addr("cmd", "lint"))
+            .await
+            .unwrap();
         assert_eq!(resp.target_spec.driver, "go_lint_fix");
 
         let deps = match resp.target_spec.config.get("deps").unwrap() {
@@ -4472,12 +4618,203 @@ golang.org/x/oauth2 v0.0.0-20200107190931-bf48bf16ab8d h1:pE8b58s1HRDMi8RDc79m0H
         }
     }
 
-    /// `format`/`format-check` carry no variant, so `list` emits exactly one bare
-    /// addr each no matter how many variants a module declares — while `lint`
-    /// (whose analysis genuinely depends on the variant) is still emitted per
-    /// variant.
+    /// A state declaring `host` plus a second, cross-compiled variant — the
+    /// two-variant ancestry the aggregation tests need.
+    fn two_variant_state() -> State {
+        let cross = Value::Map(HashMap::from([
+            ("goos".to_string(), Value::String("windows".into())),
+            ("goarch".to_string(), Value::String("amd64".into())),
+        ]));
+        let host = Value::Map(HashMap::from([
+            ("goos".to_string(), Value::String(current_goos())),
+            ("goarch".to_string(), Value::String(current_goarch())),
+        ]));
+        State {
+            package: PkgBuf::from(""),
+            provider: "go".to_string(),
+            state: HashMap::from([(
+                "variants".to_string(),
+                Value::Map(HashMap::from([
+                    ("host".to_string(), host),
+                    ("win".to_string(), cross),
+                ])),
+            )]),
+        }
+    }
+
+    /// `provider_get` with a custom variant declaration — threaded into both the
+    /// request's ancestry states and the executor, so the mocked `_golist` runs
+    /// under each variant's own factors.
+    async fn provider_get_with_states(
+        p: &Provider,
+        addr: Addr,
+        states: Vec<State>,
+    ) -> Result<GetResponse, GetError> {
+        let ctoken = StdCancellationToken::new();
+        let workspace = p.inner.workspace_root.clone();
+        p.get(
+            GetRequest {
+                request_id: "test".to_string(),
+                addr,
+                states: states.clone(),
+                executor: Arc::new(GoListTestExecutor {
+                    workspace_root: workspace,
+                    source_map: HashMap::new(),
+                    states,
+                }),
+            },
+            &ctoken,
+        )
+        .await
+    }
+
+    /// The string entries of a spec's dep group.
+    fn dep_group(spec: &hplugin::provider::TargetSpec, group: &str) -> Vec<String> {
+        let deps = match spec.config.get("deps").expect("deps") {
+            Value::Map(m) => m,
+            other => panic!("deps not a map: {other:?}"),
+        };
+        match deps.get(group) {
+            Some(Value::List(l)) => l
+                .iter()
+                .map(|v| match v {
+                    Value::String(s) => s.clone(),
+                    other => panic!("dep entry not a string: {other:?}"),
+                })
+                .collect(),
+            other => panic!("dep group `{group}` missing: {other:?}"),
+        }
+    }
+
+    /// The gate aggregates: one `_lint-analyze` report dep per declared variant,
+    /// off a single bare addr. Selecting one variant instead would report on
+    /// whichever subset of the package's files that variant's build constraints
+    /// happen to admit.
     #[tokio::test]
-    async fn list_emits_format_once_and_variant_free() {
+    async fn test_lint_check_aggregates_every_variants_report() {
+        require_go!();
+        let sandbox = copy_fixture("with_dep");
+        enable_golangci(sandbox.path());
+        let p = provider_with_govet(sandbox.path().to_path_buf(), GOVET_SOURCE_ADDR);
+
+        let resp = provider_get_with_states(
+            &p,
+            make_bare_addr("cmd", "lint-check"),
+            vec![two_variant_state()],
+        )
+        .await
+        .unwrap();
+        assert_eq!(resp.target_spec.driver, "go_lint_gate");
+
+        let reports = dep_group(&resp.target_spec, "report");
+        assert_eq!(
+            reports.len(),
+            2,
+            "one analyze report per declared variant: {reports:?}"
+        );
+        for v in ["v=host", "v=win"] {
+            assert!(
+                reports.iter().any(|r| r.contains(":_lint-analyze")
+                    && r.contains(v)
+                    && r.ends_with("|report")),
+                "gate must consume {v}'s analyze report: {reports:?}"
+            );
+        }
+    }
+
+    /// The fixer unions its sources across variants: a file only one variant's
+    /// build constraints admit is still analyzed under that variant, so its fix
+    /// must have somewhere to land. Under the old per-variant fixer it was both
+    /// unfixable from the other variant AND claimed as a `codegen = in_place`
+    /// output by two targets at once.
+    #[tokio::test]
+    async fn test_lint_fix_unions_sources_across_variants() {
+        require_go!();
+        let sandbox = copy_fixture("with_dep");
+        enable_golangci(sandbox.path());
+        // One file per variant, each invisible to the other's `go list`. Note the
+        // filenames: `_windows.go` is itself a build constraint, so the
+        // non-windows file must not be named `not_windows.go`.
+        let pkg_dir = sandbox.path().join("cmd");
+        std::fs::write(
+            pkg_dir.join("only_windows.go"),
+            "//go:build windows\n\npackage main\n",
+        )
+        .unwrap();
+        std::fs::write(
+            pkg_dir.join("elsewhere.go"),
+            "//go:build !windows\n\npackage main\n",
+        )
+        .unwrap();
+        let p = provider_with_govet(sandbox.path().to_path_buf(), GOVET_SOURCE_ADDR);
+
+        let resp =
+            provider_get_with_states(&p, make_bare_addr("cmd", "lint"), vec![two_variant_state()])
+                .await
+                .unwrap();
+        assert_eq!(resp.target_spec.driver, "go_lint_fix");
+
+        let out = match resp.target_spec.config.get("out").expect("out") {
+            Value::Map(m) => match m.iter().find(|(k, _)| *k == "src").map(|(_, v)| v) {
+                Some(Value::List(l)) => l
+                    .iter()
+                    .map(|v| match v {
+                        Value::String(s) => s.clone(),
+                        other => panic!("out entry not a string: {other:?}"),
+                    })
+                    .collect::<Vec<_>>(),
+                other => panic!("src group missing: {other:?}"),
+            },
+            other => panic!("out not a map: {other:?}"),
+        };
+        for expected in ["only_windows.go", "elsewhere.go", "main.go"] {
+            assert!(
+                out.iter().any(|f| f == expected),
+                "{expected} must be a fixable output: {out:?}"
+            );
+        }
+        // Each path claimed exactly once — the whole point of one fixer instead
+        // of one per variant.
+        let mut sorted = out.clone();
+        sorted.sort();
+        sorted.dedup();
+        assert_eq!(
+            sorted.len(),
+            out.len(),
+            "duplicate in_place claims: {out:?}"
+        );
+        // Sources and outputs stay index-aligned and deduped the same way.
+        assert_eq!(dep_group(&resp.target_spec, "").len(), out.len());
+    }
+
+    /// A stale `lint@v=NAME` (from when the gate/fixer were variant-selected)
+    /// must fail loudly rather than silently linting a now-wider set of files.
+    #[tokio::test]
+    async fn test_lint_rejects_a_variant_arg() {
+        require_go!();
+        let sandbox = copy_fixture("with_dep");
+        enable_golangci(sandbox.path());
+        let p = provider_with_govet(sandbox.path().to_path_buf(), GOVET_SOURCE_ADDR);
+
+        for name in ["lint", "lint-check"] {
+            let msg = match provider_get(&p, make_addr("cmd", name)).await {
+                Err(GetError::Other(e)) => format!("{e:#}"),
+                Err(other) => panic!("expected a typed error for {name}, got {other:?}"),
+                Ok(_) => panic!("a variant arg on {name} must be rejected"),
+            };
+            assert!(
+                msg.contains("variant-independent") && msg.contains("_lint-analyze"),
+                "error must explain the aggregation and name the per-variant unit: {msg}"
+            );
+        }
+    }
+
+    /// None of the user-facing lint/format targets carry a variant, so `list`
+    /// emits exactly one bare addr each no matter how many variants a module
+    /// declares. `format` is variant-free outright; `lint-check`/`lint` aggregate
+    /// the per-variant `_lint-analyze` units, which stay internal (unlisted).
+    #[tokio::test]
+    async fn list_emits_lint_and_format_once_and_variant_free() {
         require_go!();
         let sandbox = copy_fixture("with_dep");
         enable_golangci(sandbox.path());
@@ -4517,7 +4854,7 @@ golang.org/x/oauth2 v0.0.0-20200107190931-bf48bf16ab8d h1:pE8b58s1HRDMi8RDc79m0H
             .map(|r| r.unwrap().addr)
             .collect();
 
-        for name in ["format", "format-check"] {
+        for name in ["format", "format-check", "lint", "lint-check"] {
             let listed: Vec<&Addr> = addrs.iter().filter(|a| a.name == name).collect();
             assert_eq!(
                 listed.len(),
@@ -4530,12 +4867,22 @@ golang.org/x/oauth2 v0.0.0-20200107190931-bf48bf16ab8d h1:pE8b58s1HRDMi8RDc79m0H
                 listed[0]
             );
         }
-        // Lint is the contrast: its analysis is variant-scoped, so it stays
-        // multiplied across the declared variants.
+        // The variant-scoped analysis unit stays internal: the aggregators pull
+        // it in as a dep, so listing it too would run every variant's analysis
+        // twice over in a `//...` sweep.
+        assert!(
+            !addrs.iter().any(|a| a.name == "_lint-analyze"),
+            "_lint-analyze must stay unlisted: {addrs:?}"
+        );
+        // The contrast: `build` genuinely is variant-selected, so it stays
+        // multiplied across the two declared variants (plus the bare host-default).
         assert_eq!(
-            addrs.iter().filter(|a| a.name == "lint-check").count(),
+            addrs
+                .iter()
+                .filter(|a| a.name == "build" && !a.args.is_empty())
+                .count(),
             2,
-            "lint-check must still be listed per variant: {addrs:?}"
+            "build must still be listed per variant: {addrs:?}"
         );
     }
 
@@ -4577,11 +4924,12 @@ golang.org/x/oauth2 v0.0.0-20200107190931-bf48bf16ab8d h1:pE8b58s1HRDMi8RDc79m0H
             "format-check",
             "format",
         ] {
-            // Formatting is variant-free; lint is not.
-            let addr = if name.starts_with("format") {
-                make_bare_addr("cmd", name)
-            } else {
+            // Only the internal `_lint-analyze` unit carries a variant; the
+            // user-facing gate/fixer and the formatters are bare.
+            let addr = if name == "_lint-analyze" {
                 make_addr("cmd", name)
+            } else {
+                make_bare_addr("cmd", name)
             };
             assert!(
                 matches!(provider_get(&p, addr).await, Err(GetError::NotFound)),
@@ -4615,7 +4963,7 @@ golang.org/x/oauth2 v0.0.0-20200107190931-bf48bf16ab8d h1:pE8b58s1HRDMi8RDc79m0H
         )
         .unwrap();
         let p = provider_with_govet(sandbox.path().to_path_buf(), GOVET_SOURCE_ADDR);
-        provider_get(&p, make_addr("cmd", "lint-check"))
+        provider_get(&p, make_bare_addr("cmd", "lint-check"))
             .await
             .expect("lint-check resolves with a .golangci.yaml");
         let names = provider_list(&p, "cmd").await;
@@ -6447,6 +6795,7 @@ golang.org/x/oauth2 v0.0.0-20200107190931-bf48bf16ab8d h1:pE8b58s1HRDMi8RDc79m0H
             executor: Arc::new(GoListTestExecutor {
                 workspace_root: sandbox.path().to_path_buf(),
                 source_map: HashMap::new(),
+                states: vec![host_variant_state()],
             }),
         };
         let resp = p.get(req, &StdCancellationToken::new()).await.unwrap();
@@ -6494,6 +6843,7 @@ golang.org/x/oauth2 v0.0.0-20200107190931-bf48bf16ab8d h1:pE8b58s1HRDMi8RDc79m0H
             executor: Arc::new(GoListTestExecutor {
                 workspace_root: sandbox.path().to_path_buf(),
                 source_map: HashMap::new(),
+                states: vec![host_variant_state()],
             }),
         };
         let resp = p.get(req, &StdCancellationToken::new()).await.unwrap();
@@ -6680,6 +7030,7 @@ golang.org/x/oauth2 v0.0.0-20200107190931-bf48bf16ab8d h1:pE8b58s1HRDMi8RDc79m0H
             executor: Arc::new(GoListTestExecutor {
                 workspace_root: sandbox.path().to_path_buf(),
                 source_map: HashMap::new(),
+                states: vec![host_variant_state()],
             }),
         };
         let resp = p.get(req, &StdCancellationToken::new()).await.unwrap();

--- a/crates/plugin-go/src/plugingo/provider.rs
+++ b/crates/plugin-go/src/plugingo/provider.rs
@@ -414,16 +414,19 @@ impl ProviderTrait for Provider {
             signature: FnSignature {
                 positional: vec![
                     Param::required("pkg", ParamType::String),
-                    Param::required("v", ParamType::String),
+                    Param::optional("variant", ParamType::String, Value::String(String::new())),
                 ],
                 named: vec![],
                 variadic: None,
                 returns: ParamType::String,
             },
-            doc: "Build the address of a Go package's user-facing `build` target for \
-                  a given variant name, as used in `deps` — returns \
-                  `//<pkg>:build@v=<variant>`. The provider resolves the variant \
-                  (and pins the defining package) when the target is built."
+            doc: "Build the address of a Go package's user-facing `build` target, as \
+                  used in `deps`. With a variant name, returns \
+                  `//<pkg>:build@v=<variant>`. Omit `variant` (or pass \"\") to get \
+                  the magic host-default target `//<pkg>:build` — a `group` that \
+                  forwards to the first variant matching this machine's os/arch. The \
+                  provider resolves the variant (and pins the defining package) when \
+                  built."
                 .to_string(),
             func: Arc::new(BuildAddrFn),
         }]
@@ -542,18 +545,40 @@ impl BuildAddrFn {
             other => anyhow::bail!("heph.go.build_addr: `{name}` must be a string, got {other:?}"),
         }
     }
+
+    /// Optional string arg: `None` when absent, error when present but non-string.
+    fn opt_arg_str<'a>(
+        args: &'a FnArgs,
+        idx: usize,
+        name: &str,
+    ) -> anyhow::Result<Option<&'a str>> {
+        match args.named.get(name).or_else(|| args.positional.get(idx)) {
+            None => Ok(None),
+            Some(Value::String(s)) => Ok(Some(s.as_str())),
+            Some(other) => {
+                anyhow::bail!("heph.go.build_addr: `{name}` must be a string, got {other:?}")
+            }
+        }
+    }
 }
 
 #[async_trait]
 impl ProviderFn for BuildAddrFn {
     async fn call(&self, _ctx: &FnCallContext<'_>, args: FnArgs) -> anyhow::Result<Value> {
         let pkg = Self::arg_str(&args, 0, "pkg")?;
-        let v = Self::arg_str(&args, 1, "v")?;
+        let v = Self::opt_arg_str(&args, 1, "variant")?.unwrap_or("");
 
-        // A user-facing `build` target carries only `v`; the provider resolves the
-        // closest variant definition (and fills in `vp`) when the target is built.
-        let args = BTreeMap::from([("v".to_string(), v.to_string())]);
-        let addr = Addr::new(PkgBuf::from(pkg), "build".to_string(), args);
+        // With a variant name, a user-facing `build` target carries only `v` (the
+        // provider resolves the closest variant and fills in `vp` when built).
+        // Without one, return the magic host-default `//<pkg>:build` — a bare,
+        // variant-less addr the provider serves as a `group` forwarding to the
+        // first variant matching this machine's os/arch.
+        let addr_args = if v.is_empty() {
+            BTreeMap::new()
+        } else {
+            BTreeMap::from([("v".to_string(), v.to_string())])
+        };
+        let addr = Addr::new(PkgBuf::from(pkg), "build".to_string(), addr_args);
         Ok(Value::String(addr.format()))
     }
 }
@@ -614,7 +639,19 @@ impl ProviderInner {
                     .into_owned(),
                 GoPackageKind::Stdlib { .. } => String::new(),
             };
-            let ancestry = variant::ancestry_variants(&req.states, &module_root);
+            let ancestry_pairs = variant::ancestry_variants_with_factors(&req.states, &module_root);
+            let ancestry: Vec<VariantRef> = ancestry_pairs.iter().map(|(v, _)| v.clone()).collect();
+            // Runnable `test`/`xtest` targets execute the built binary, so they
+            // only make sense for the host platform — enumerate them for the
+            // ancestry variants whose `goos`/`goarch` match this machine. The
+            // corresponding `build_test`/`build_xtest` (cross-compilable) still
+            // list for every variant, below.
+            let (host_goos, host_goarch) = (current_goos(), current_goarch());
+            let ancestry_host: Vec<VariantRef> = ancestry_pairs
+                .iter()
+                .filter(|(_, f)| f.goos == host_goos && f.goarch == host_goarch)
+                .map(|(v, _)| v.clone())
+                .collect();
             // First-party libs enumerate the module universe; stdlib/thirdparty
             // (rarely listed directly, and always consumed with a `vp` pin) fall
             // back to ancestry.
@@ -628,7 +665,9 @@ impl ProviderInner {
                 ancestry.clone()
             };
             let vrefs_for = |name: &str| -> &[VariantRef] {
-                if is_entry_target_name(name) {
+                if is_run_test_target_name(name) {
+                    &ancestry_host
+                } else if is_entry_target_name(name) {
                     &ancestry
                 } else {
                     &universe
@@ -672,6 +711,16 @@ impl ProviderInner {
                     let lint_enabled = self.golangci_config_addr(module_root).is_some();
                     let skip_tests = pick_test_skip(&req.states, req.package.as_str());
                     push_names(&mut addrs, &["_golist", "build_lib", "build", "embed"]);
+                    // Magic host-default `build` (bare, no `@v`): a `group`
+                    // forwarding to the first host-matching variant. Listed only
+                    // when such a variant exists in ancestry.
+                    if !ancestry_host.is_empty() {
+                        addrs.push(Addr::new(
+                            req.package.clone(),
+                            "build".to_string(),
+                            Default::default(),
+                        ));
+                    }
                     if lint_enabled {
                         push_names(
                             &mut addrs,
@@ -804,6 +853,29 @@ fn is_entry_target_name(name: &str) -> bool {
         name,
         "build" | "test" | "xtest" | "lint-check" | "lint" | "format-check" | "format"
     )
+}
+
+/// **Runnable** test target names — the ones that execute the built test binary
+/// (as opposed to `build_test`/`build_xtest`, which only cross-compile it). Only
+/// these are gated to the host `goos`/`goarch` in `list`, since a test binary
+/// built for another platform can't run here.
+fn is_run_test_target_name(name: &str) -> bool {
+    matches!(name, "test" | "xtest")
+}
+
+/// Spec for the magic host-default `build` (bare `//pkg:build`): a `group` target
+/// that re-exports the outputs of the concrete `build@v=<variant>` it forwards to.
+fn magic_build_group_spec(addr: Addr, target: &Addr) -> hplugin::provider::TargetSpec {
+    let config = HashMap::from([(
+        "deps".to_string(),
+        Value::List(vec![Value::String(target.format())]),
+    )]);
+    hplugin::provider::TargetSpec {
+        addr,
+        driver: hbuiltins::plugingroup::DRIVER_NAME.to_string(),
+        config,
+        ..Default::default()
+    }
 }
 
 /// Targets handled by `handle_get` *before* the `_golist` resolve (no go list
@@ -1429,6 +1501,35 @@ impl ProviderInner {
                 .into_owned(),
             GoPackageKind::Stdlib { .. } => String::new(),
         };
+
+        // Magic host-default `build`: a bare `//pkg:build` (no `@v`) is served as a
+        // `group` target forwarding to `build@v=<variant>` for the first ancestry
+        // variant matching this machine's goos/goarch. It gives `//pkg:build` an
+        // ergonomic host default without an implicit variant on the real per-variant
+        // build. Intercept before `variant::resolve`, which requires an explicit `v`.
+        // First-party only — `build` (and thus its host-default) exists solely for
+        // first-party packages, matching what `list` emits.
+        if addr.name == "build"
+            && !addr.args.contains_key("v")
+            && matches!(&*kind, GoPackageKind::FirstParty { .. })
+        {
+            let (host_goos, host_goarch) = (current_goos(), current_goarch());
+            let chosen = variant::ancestry_variants_with_factors(&req.states, &module_root)
+                .into_iter()
+                .find(|(_, f)| f.goos == host_goos && f.goarch == host_goarch);
+            let Some((vref, _)) = chosen else {
+                return Err(GetError::NotFound);
+            };
+            let target = Addr::new(
+                addr.package.clone(),
+                "build".to_string(),
+                BTreeMap::from([("v".to_string(), vref.name.clone())]),
+            );
+            return Ok(GetResponse {
+                target_spec: magic_build_group_spec(addr.clone(), &target),
+            });
+        }
+
         let (factors, vref) =
             variant::resolve(addr, &req.states, &module_root, req.executor.as_ref())
                 .await
@@ -3088,7 +3189,7 @@ mod tests {
     async fn test_build_addr_named_args() {
         let mut named = HashMap::new();
         named.insert("pkg".to_string(), Value::String("mylib".into()));
-        named.insert("v".to_string(), Value::String("release".into()));
+        named.insert("variant".to_string(), Value::String("release".into()));
         let args = FnArgs {
             positional: vec![],
             named,
@@ -3097,14 +3198,27 @@ mod tests {
         assert_eq!(v, Value::String("//mylib:build@v=release".into()));
     }
 
+    // Omitting `variant` returns the magic host-default `build` addr (bare, no
+    // `@v`) — the provider serves it as a `group` to the host-matching variant.
     #[tokio::test]
-    async fn test_build_addr_missing_variant_errors() {
+    async fn test_build_addr_without_variant_returns_magic_addr() {
         let args = FnArgs {
             positional: vec![Value::String("mylib".into())],
             named: HashMap::new(),
         };
-        let err = BuildAddrFn.call(&build_addr_ctx(), args).await.unwrap_err();
-        assert!(err.to_string().contains("missing `v`"), "{err}");
+        let v = BuildAddrFn.call(&build_addr_ctx(), args).await.unwrap();
+        assert_eq!(v, Value::String("//mylib:build".into()));
+    }
+
+    // An explicit empty variant is treated the same as omitting it.
+    #[tokio::test]
+    async fn test_build_addr_empty_variant_returns_magic_addr() {
+        let args = FnArgs {
+            positional: vec![Value::String("mylib".into()), Value::String("".into())],
+            named: HashMap::new(),
+        };
+        let v = BuildAddrFn.call(&build_addr_ctx(), args).await.unwrap();
+        assert_eq!(v, Value::String("//mylib:build".into()));
     }
 
     fn go_available() -> bool {
@@ -5575,6 +5689,171 @@ golang.org/x/oauth2 v0.0.0-20200107190931-bf48bf16ab8d h1:pE8b58s1HRDMi8RDc79m0H
         // Non-test targets still emitted.
         assert!(names.iter().any(|n| n == "build_lib"));
         assert!(names.iter().any(|n| n == "_golist"));
+    }
+
+    /// Runnable `test`/`xtest` targets execute the built binary, so `list` emits
+    /// them only for ancestry variants matching the host `goos`/`goarch`. The
+    /// cross-compilable `build_test`/`build_xtest` list for *every* variant.
+    #[tokio::test]
+    async fn list_runnable_test_targets_only_for_host_variant() {
+        let sandbox = copy_fixture("with_test");
+        let p = Provider::new(sandbox.path().to_path_buf()).unwrap();
+
+        // Module root declares two variants: `host` (this machine) and `cross`
+        // (host goos, a non-host goarch).
+        let host = Value::Map(HashMap::from([
+            ("goos".to_string(), Value::String(current_goos())),
+            ("goarch".to_string(), Value::String(current_goarch())),
+        ]));
+        let cross = Value::Map(HashMap::from([
+            ("goos".to_string(), Value::String(current_goos())),
+            ("goarch".to_string(), Value::String("otherarch".into())),
+        ]));
+        let two = State {
+            package: PkgBuf::from(""),
+            provider: "go".to_string(),
+            state: HashMap::from([(
+                "variants".to_string(),
+                Value::Map(HashMap::from([
+                    ("host".to_string(), host),
+                    ("cross".to_string(), cross),
+                ])),
+            )]),
+        };
+
+        struct TwoVariantUniverse(State);
+        impl ProviderExecutor for TwoVariantUniverse {
+            fn result<'a>(
+                &'a self,
+                _addr: &'a Addr,
+            ) -> BoxFuture<'a, anyhow::Result<Arc<EResult>>> {
+                unimplemented!("list must not resolve results")
+            }
+            fn query<'a>(
+                &'a self,
+                _m: &'a hmodel::htmatcher::Matcher,
+                _s: &'a [String],
+            ) -> BoxFuture<'a, anyhow::Result<Vec<Addr>>> {
+                unimplemented!("list must not query")
+            }
+            fn states_under<'a>(
+                &'a self,
+                prefix: &'a PkgBuf,
+            ) -> BoxFuture<'a, anyhow::Result<Vec<State>>> {
+                let states = if prefix.as_str().is_empty() {
+                    vec![self.0.clone()]
+                } else {
+                    vec![]
+                };
+                Box::pin(async move { Ok(states) })
+            }
+        }
+
+        let req = ListRequest {
+            request_id: "test".to_string(),
+            package: PkgBuf::from("pkg"),
+            states: vec![two.clone()],
+            executor: Arc::new(TwoVariantUniverse(two)),
+        };
+        let addrs: Vec<Addr> = p
+            .list(req, &StdCancellationToken::new())
+            .await
+            .unwrap()
+            .map(|r| r.unwrap().addr)
+            .collect();
+
+        let variants_of = |name: &str| -> Vec<String> {
+            let mut v: Vec<String> = addrs
+                .iter()
+                .filter(|a| a.name == name)
+                .filter_map(|a| a.args.get("v").cloned())
+                .collect();
+            v.sort();
+            v
+        };
+
+        assert_eq!(
+            variants_of("test"),
+            vec!["host".to_string()],
+            "runnable test must list only the host variant: {addrs:?}"
+        );
+        assert_eq!(
+            variants_of("xtest"),
+            vec!["host".to_string()],
+            "runnable xtest must list only the host variant: {addrs:?}"
+        );
+        assert_eq!(
+            variants_of("build_test"),
+            vec!["cross".to_string(), "host".to_string()],
+            "build_test must list every variant: {addrs:?}"
+        );
+        assert_eq!(
+            variants_of("build_xtest"),
+            vec!["cross".to_string(), "host".to_string()],
+            "build_xtest must list every variant: {addrs:?}"
+        );
+        // The magic host-default `build` (bare, no `@v`) is listed once alongside
+        // the per-variant `build@v=…`.
+        assert!(
+            addrs
+                .iter()
+                .any(|a| a.name == "build" && !a.args.contains_key("v")),
+            "magic bare build must be listed when a host variant exists: {addrs:?}"
+        );
+    }
+
+    /// The magic host-default `build`: a bare `//pkg:build` resolves to a `group`
+    /// target forwarding to `build@v=<host-matching variant>`.
+    #[tokio::test]
+    async fn magic_build_returns_group_forwarding_to_host_variant() {
+        let sandbox = copy_fixture("with_test");
+        let p = Provider::new(sandbox.path().to_path_buf()).unwrap();
+        let addr = Addr::new(PkgBuf::from("pkg"), "build".to_string(), Default::default());
+        let resp = provider_get(&p, addr).await.expect("magic build resolves");
+        let spec = resp.target_spec;
+        assert_eq!(spec.driver, "group");
+        let deps = match spec.config.get("deps") {
+            Some(Value::List(v)) => v,
+            other => panic!("group deps must be a list, got: {other:?}"),
+        };
+        assert_eq!(
+            deps,
+            &vec![Value::String("//pkg:build@v=host".into())],
+            "magic build must forward to the host variant"
+        );
+    }
+
+    /// No ancestry variant matches the host os/arch → the magic bare `build` does
+    /// not resolve (there is nothing to forward to).
+    #[tokio::test]
+    async fn magic_build_not_found_without_host_variant() {
+        let sandbox = copy_fixture("with_test");
+        let p = Provider::new(sandbox.path().to_path_buf()).unwrap();
+        let cross = State {
+            package: PkgBuf::from(""),
+            provider: "go".to_string(),
+            state: HashMap::from([(
+                "variants".to_string(),
+                Value::Map(HashMap::from([(
+                    "cross".to_string(),
+                    Value::Map(HashMap::from([
+                        ("goos".to_string(), Value::String(current_goos())),
+                        ("goarch".to_string(), Value::String("otherarch".into())),
+                    ])),
+                )])),
+            )]),
+        };
+        let req = GetRequest {
+            request_id: "test".to_string(),
+            addr: Addr::new(PkgBuf::from("pkg"), "build".to_string(), Default::default()),
+            states: vec![cross],
+            executor: test_executor(sandbox.path()),
+        };
+        let res = p.get(req, &StdCancellationToken::new()).await;
+        assert!(
+            matches!(res, Err(GetError::NotFound)),
+            "magic build must NotFound when no host variant exists"
+        );
     }
 
     #[tokio::test]

--- a/crates/plugin-go/src/plugingo/provider.rs
+++ b/crates/plugin-go/src/plugingo/provider.rs
@@ -1520,6 +1520,26 @@ impl ProviderInner {
             let Some((vref, _)) = chosen else {
                 return Err(GetError::NotFound);
             };
+            // The magic target must resolve exactly where the real `build` does —
+            // a `main` package. A non-main / library / directory-only package (no
+            // buildable Go files) has no `build`, so decline here on the *magic*
+            // addr rather than emit a `group` whose `build@v=…` dep can't resolve.
+            // Declining on the self addr lets the codegen/query/`validate` walks
+            // skip it (they match a self-addr `TargetNotFound`); a cross-addr dep
+            // NotFound would surface instead. Checked via the chosen variant's
+            // `_golist` (engine-cached; the real `build@v=…` reads the same one).
+            let golist_addr = self.make_addr_with_name(&addr.package, "_golist", &vref);
+            match self
+                .read_golist_package(Arc::clone(&req.executor), &golist_addr)
+                .await
+            {
+                Ok(pkg) if pkg.name.as_deref() == Some("main") => {}
+                Ok(_) => return Err(GetError::NotFound),
+                Err(e) if downcast_chain_ref::<NoGoFilesError>(&e).is_some() => {
+                    return Err(GetError::NotFound);
+                }
+                Err(e) => return Err(GetError::Other(e)),
+            }
             let target = Addr::new(
                 addr.package.clone(),
                 "build".to_string(),
@@ -5802,13 +5822,14 @@ golang.org/x/oauth2 v0.0.0-20200107190931-bf48bf16ab8d h1:pE8b58s1HRDMi8RDc79m0H
         );
     }
 
-    /// The magic host-default `build`: a bare `//pkg:build` resolves to a `group`
-    /// target forwarding to `build@v=<host-matching variant>`.
+    /// The magic host-default `build`: a bare `//pkg:build` on a `main` package
+    /// resolves to a `group` target forwarding to `build@v=<host-matching variant>`.
     #[tokio::test]
     async fn magic_build_returns_group_forwarding_to_host_variant() {
-        let sandbox = copy_fixture("with_test");
+        require_go!();
+        let sandbox = copy_fixture("with_dep"); // `cmd` is `package main`
         let p = Provider::new(sandbox.path().to_path_buf()).unwrap();
-        let addr = Addr::new(PkgBuf::from("pkg"), "build".to_string(), Default::default());
+        let addr = Addr::new(PkgBuf::from("cmd"), "build".to_string(), Default::default());
         let resp = provider_get(&p, addr).await.expect("magic build resolves");
         let spec = resp.target_spec;
         assert_eq!(spec.driver, "group");
@@ -5818,16 +5839,16 @@ golang.org/x/oauth2 v0.0.0-20200107190931-bf48bf16ab8d h1:pE8b58s1HRDMi8RDc79m0H
         };
         assert_eq!(
             deps,
-            &vec![Value::String("//pkg:build@v=host".into())],
+            &vec![Value::String("//cmd:build@v=host".into())],
             "magic build must forward to the host variant"
         );
     }
 
     /// No ancestry variant matches the host os/arch → the magic bare `build` does
-    /// not resolve (there is nothing to forward to).
+    /// not resolve (there is nothing to forward to). Checked before `go list`.
     #[tokio::test]
     async fn magic_build_not_found_without_host_variant() {
-        let sandbox = copy_fixture("with_test");
+        let sandbox = copy_fixture("with_dep");
         let p = Provider::new(sandbox.path().to_path_buf()).unwrap();
         let cross = State {
             package: PkgBuf::from(""),
@@ -5845,7 +5866,7 @@ golang.org/x/oauth2 v0.0.0-20200107190931-bf48bf16ab8d h1:pE8b58s1HRDMi8RDc79m0H
         };
         let req = GetRequest {
             request_id: "test".to_string(),
-            addr: Addr::new(PkgBuf::from("pkg"), "build".to_string(), Default::default()),
+            addr: Addr::new(PkgBuf::from("cmd"), "build".to_string(), Default::default()),
             states: vec![cross],
             executor: test_executor(sandbox.path()),
         };
@@ -5853,6 +5874,25 @@ golang.org/x/oauth2 v0.0.0-20200107190931-bf48bf16ab8d h1:pE8b58s1HRDMi8RDc79m0H
         assert!(
             matches!(res, Err(GetError::NotFound)),
             "magic build must NotFound when no host variant exists"
+        );
+    }
+
+    /// Regression: the magic bare `build` on a NON-main package (a library or a
+    /// directory that only holds go sub-packages) must resolve to a self-addr
+    /// `NotFound` — exactly like the real `build@v=…` — so the codegen/query
+    /// walks skip it, rather than emitting a `group` whose `build@v=…` dep can't
+    /// resolve (which surfaced as a cross-addr `target not found` in
+    /// `heph tool gen-gitignore`).
+    #[tokio::test]
+    async fn magic_build_not_found_for_non_main_package() {
+        require_go!();
+        let sandbox = copy_fixture("with_dep"); // `lib` is a library (package lib)
+        let p = Provider::new(sandbox.path().to_path_buf()).unwrap();
+        let addr = Addr::new(PkgBuf::from("lib"), "build".to_string(), Default::default());
+        let res = provider_get(&p, addr).await;
+        assert!(
+            matches!(res, Err(GetError::NotFound)),
+            "magic build on a non-main package must NotFound"
         );
     }
 

--- a/crates/plugin-go/src/plugingo/provider.rs
+++ b/crates/plugin-go/src/plugingo/provider.rs
@@ -1,9 +1,9 @@
 use crate::plugingo::addr_util::{
     GoPackageKind, decode_package, encode_firstparty, encode_stdlib, encode_thirdparty,
-    encode_thirdparty_download, factors_to_args,
+    encode_thirdparty_download,
 };
 use crate::plugingo::errors::NoGoFilesError;
-use crate::plugingo::factors::{Factors, current_goarch, current_goos};
+use crate::plugingo::factors::{Factors, VariantRef, current_goarch, current_goos};
 use crate::plugingo::govet;
 use crate::plugingo::pkg_analysis::{
     GoPackage, PackageAddrs, decode_go_package, decode_package_addrs, find_module_for_import,
@@ -17,6 +17,7 @@ use crate::plugingo::target_std;
 use crate::plugingo::target_test;
 use crate::plugingo::thirdparty;
 use crate::plugingo::toolchain;
+use crate::plugingo::variant;
 use anyhow::Context;
 use async_recursion::async_recursion;
 use async_trait::async_trait;
@@ -157,7 +158,7 @@ pub(crate) struct GoModData {
 struct LibsKey {
     imports: Vec<String>,
     extra: Vec<String>,
-    factors: Factors,
+    vref: VariantRef,
     module_root: PathBuf,
     transitive: bool,
 }
@@ -165,7 +166,7 @@ struct LibsKey {
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]
 struct ImportClosureKey {
     import_path: String,
-    factors: Factors,
+    vref: VariantRef,
     module_root: PathBuf,
 }
 
@@ -413,19 +414,16 @@ impl ProviderTrait for Provider {
             signature: FnSignature {
                 positional: vec![
                     Param::required("pkg", ParamType::String),
-                    Param::required("goos", ParamType::String),
-                    Param::required("goarch", ParamType::String),
+                    Param::required("v", ParamType::String),
                 ],
-                named: vec![Param::optional(
-                    "tags",
-                    ParamType::list(ParamType::String),
-                    Value::List(vec![]),
-                )],
+                named: vec![],
                 variadic: None,
                 returns: ParamType::String,
             },
-            doc: "Build the address of a Go package's `_golist` target for a given \
-                  GOOS/GOARCH (and optional build tags), as used in `deps`."
+            doc: "Build the address of a Go package's user-facing `build` target for \
+                  a given variant name, as used in `deps` — returns \
+                  `//<pkg>:build@v=<variant>`. The provider resolves the variant \
+                  (and pins the defining package) when the target is built."
                 .to_string(),
             func: Arc::new(BuildAddrFn),
         }]
@@ -439,8 +437,29 @@ impl ProviderTrait for Provider {
             doc: doc.to_string(),
             required: false,
         };
+        let variant_struct = ParamType::strukt(vec![
+            ("goos", ParamType::String),
+            ("goarch", ParamType::String),
+            ("tags", ParamType::list(ParamType::String)),
+            ("goexperiment", ParamType::list(ParamType::String)),
+            ("gcflags", ParamType::list(ParamType::String)),
+            ("ldflags", ParamType::list(ParamType::String)),
+            ("cgo_enabled", ParamType::Bool),
+        ]);
         Some(StateSchema {
             fields: vec![
+                field(
+                    "variants",
+                    ParamType::map(variant_struct),
+                    "Named Go build variants for this package (and its descendants, via \
+                     closest-ancestor lookup). Maps a variant name to a static factor set: \
+                     `goos`/`goarch` (required), plus optional `tags` (build tags), \
+                     `goexperiment` (GOEXPERIMENT), `gcflags` (extra `go tool compile` flags), \
+                     `ldflags` (extra `go tool link` flags) and `cgo_enabled` (default False). \
+                     A user-facing target selects one with `@v=NAME`, resolving the closest \
+                     ancestor package that defines that name; variants do NOT compound across \
+                     the tree (each definition is self-contained).",
+                ),
                 field(
                     "go_codegen_root",
                     ParamType::Bool,
@@ -504,13 +523,12 @@ impl ProviderTrait for Provider {
     }
 }
 
-/// `heph.go.build_addr(pkg, goos, goarch, tags=[])` — format the heph
-/// address of a Go target without resolving anything. Takes a heph package (the addr's
-/// package, e.g. `"mylib"`, `"@heph/go/std/fmt"`, or a thirdparty `@heph/go/thirdparty/…@v`
-/// path) and the platform factors, and returns the canonical addr
-/// string `//<pkg>:build@goos=…,goarch=…[,tags=…]`. Pure string transform — same
-/// factor encoding the provider uses internally ([`factors_to_args`]), so the result
-/// matches the addr the provider serves for that package.
+/// `heph.go.build_addr(pkg, v)` — format the heph address of a Go package's
+/// user-facing `build` target for variant `v`, without resolving anything. Takes
+/// a heph package (the addr's package, e.g. `"mylib"`, `"@heph/go/std/fmt"`, or a
+/// thirdparty `@heph/go/thirdparty/…@v` path) and a variant name, and returns the
+/// canonical addr string `//<pkg>:build@v=<variant>`. Pure string transform — the
+/// provider resolves the variant (and pins its defining package) at get time.
 struct BuildAddrFn;
 
 impl BuildAddrFn {
@@ -531,25 +549,12 @@ impl BuildAddrFn {
 impl ProviderFn for BuildAddrFn {
     async fn call(&self, _ctx: &FnCallContext<'_>, args: FnArgs) -> anyhow::Result<Value> {
         let pkg = Self::arg_str(&args, 0, "pkg")?;
-        let goos = Self::arg_str(&args, 1, "goos")?;
-        let goarch = Self::arg_str(&args, 2, "goarch")?;
+        let v = Self::arg_str(&args, 1, "v")?;
 
-        let mut build_tags = match args.named.get("tags") {
-            Some(v) => parse_strings(v).context("heph.go.build_addr: parsing `tags`")?,
-            None => Vec::new(),
-        };
-        build_tags.sort();
-
-        let factors = Factors {
-            goos: goos.to_string(),
-            goarch: goarch.to_string(),
-            build_tags,
-        };
-        let addr = Addr::new(
-            PkgBuf::from(pkg),
-            "build".to_string(),
-            factors_to_args(&factors),
-        );
+        // A user-facing `build` target carries only `v`; the provider resolves the
+        // closest variant definition (and fills in `vp`) when the target is built.
+        let args = BTreeMap::from([("v".to_string(), v.to_string())]);
+        let addr = Addr::new(PkgBuf::from(pkg), "build".to_string(), args);
         Ok(Value::String(addr.format()))
     }
 }
@@ -568,18 +573,16 @@ impl ProviderInner {
     ) -> BoxFuture<'a, anyhow::Result<Box<dyn Iterator<Item = anyhow::Result<ListResponse>> + Send>>>
     {
         Box::pin(async move {
-            let factors = Factors {
-                goos: current_goos(),
-                goarch: current_goarch(),
-                build_tags: vec![],
+            let empty = || {
+                Ok(Box::new(std::iter::empty())
+                    as Box<
+                        dyn Iterator<Item = anyhow::Result<ListResponse>> + Send,
+                    >)
             };
 
             let kind = match decode_package(&req.package, &self.workspace_root) {
                 Some(k) => k,
-                None => {
-                    return Ok(Box::new(std::iter::empty())
-                        as Box<dyn Iterator<Item = anyhow::Result<ListResponse>> + Send>);
-                }
+                None => return empty(),
             };
 
             // A first-party package inside a skipped subtree lists nothing —
@@ -589,71 +592,54 @@ impl ProviderInner {
                     .skip
                     .prunes_package(&self.workspace_root, Path::new(req.package.as_str()))
             {
-                return Ok(Box::new(std::iter::empty())
-                    as Box<dyn Iterator<Item = anyhow::Result<ListResponse>> + Send>);
+                return empty();
             }
 
+            // Every build/list target is variant-parameterized: list one copy per
+            // variant applicable to this package (each pinned to its defining
+            // package via `vp`). A package with no variants declared in scope lists
+            // no build targets — there is no implicit default variant.
+            let variants = variant::applicable(&req.states);
+
+            let mut addrs: Vec<Addr> = Vec::new();
             match &*kind {
                 GoPackageKind::Stdlib { .. } => {
-                    let addrs = vec![
-                        Addr::new(
-                            req.package.clone(),
-                            "_golist".to_string(),
-                            factors_to_args(&factors),
-                        ),
-                        Addr::new(
-                            req.package,
-                            "build_lib".to_string(),
-                            factors_to_args(&factors),
-                        ),
-                    ];
-                    let responses: Vec<anyhow::Result<ListResponse>> = addrs
-                        .into_iter()
-                        .map(|addr| Ok(ListResponse { addr }))
-                        .collect();
-                    Ok(Box::new(responses.into_iter())
-                        as Box<
-                            dyn Iterator<Item = anyhow::Result<ListResponse>> + Send,
-                        >)
+                    for vref in &variants {
+                        for name in ["_golist", "build_lib"] {
+                            addrs.push(Addr::new(
+                                req.package.clone(),
+                                name.to_string(),
+                                vref.to_args(),
+                            ));
+                        }
+                    }
                 }
                 GoPackageKind::ThirdParty { subpath, .. } => {
-                    let mut addrs = vec![
-                        Addr::new(
-                            req.package.clone(),
-                            "_golist".to_string(),
-                            factors_to_args(&factors),
-                        ),
-                        Addr::new(
-                            req.package.clone(),
-                            "build_lib".to_string(),
-                            factors_to_args(&factors),
-                        ),
-                    ];
-                    // The `download` target lives at the module root only and
-                    // is factor-independent (one per module@version).
+                    for vref in &variants {
+                        for name in ["_golist", "build_lib"] {
+                            addrs.push(Addr::new(
+                                req.package.clone(),
+                                name.to_string(),
+                                vref.to_args(),
+                            ));
+                        }
+                    }
+                    // The `download` target lives at the module root only and is
+                    // variant-independent (one per module@version).
                     if subpath.is_empty() {
                         addrs.push(Addr::new(
-                            req.package,
+                            req.package.clone(),
                             "download".to_string(),
                             Default::default(),
                         ));
                     }
-                    let responses: Vec<anyhow::Result<ListResponse>> = addrs
-                        .into_iter()
-                        .map(|addr| Ok(ListResponse { addr }))
-                        .collect();
-                    Ok(Box::new(responses.into_iter())
-                        as Box<
-                            dyn Iterator<Item = anyhow::Result<ListResponse>> + Send,
-                        >)
                 }
                 GoPackageKind::FirstParty { module_root, .. } => {
                     // Emit the full candidate set unconditionally for any dir
-                    // under a go.mod (decode_package guarantees that). Each
-                    // variant is filtered at `get` time by inspecting the
-                    // `_golist` result — no filesystem scan needed.
+                    // under a go.mod (decode_package guarantees that). Each target
+                    // is filtered at `get` time by inspecting the `_golist` result.
                     //
-                    // Lint/format variants are the exception: they exist only for
+                    // Lint/format targets are the exception: they exist only for
                     // modules that opt in with a golangci config at the go.mod
                     // root, so gate them here (matching the `get`-time gate) to
                     // avoid advertising targets that would resolve to NotFound.
@@ -672,25 +658,26 @@ impl ProviderInner {
                             "xtest",
                         ]);
                     }
-                    let responses: Vec<anyhow::Result<ListResponse>> = names
-                        .iter()
-                        .map(|name| {
-                            Ok(ListResponse {
-                                addr: Addr::new(
-                                    req.package.clone(),
-                                    (*name).to_string(),
-                                    factors_to_args(&factors),
-                                ),
-                            })
-                        })
-                        .collect();
-
-                    Ok(Box::new(responses.into_iter())
-                        as Box<
-                            dyn Iterator<Item = anyhow::Result<ListResponse>> + Send,
-                        >)
+                    for vref in &variants {
+                        for name in &names {
+                            addrs.push(Addr::new(
+                                req.package.clone(),
+                                (*name).to_string(),
+                                vref.to_args(),
+                            ));
+                        }
+                    }
                 }
             }
+
+            let responses: Vec<anyhow::Result<ListResponse>> = addrs
+                .into_iter()
+                .map(|addr| Ok(ListResponse { addr }))
+                .collect();
+            Ok(Box::new(responses.into_iter())
+                as Box<
+                    dyn Iterator<Item = anyhow::Result<ListResponse>> + Send,
+                >)
         })
     }
 
@@ -1247,7 +1234,6 @@ fn pkg_static_embed_glob_addr(pkg_str: &str) -> String {
 impl ProviderInner {
     async fn handle_get(self: Arc<Self>, req: GetRequest) -> Result<GetResponse, GetError> {
         let addr = &req.addr;
-        let factors = Factors::from_addr(addr);
 
         // Hermetic Go toolchain: `//@heph/go/toolchain/<version>:go` downloads
         // the pinned SDK for the host platform. This replaces the former
@@ -1289,17 +1275,25 @@ impl ProviderInner {
                      (\"//@heph/go/govet/<tag>:heph-govet\")"
                 )));
             }
-            let sha256 =
-                govet::expected_sha256(&self.sdk_checksums, tag, &factors.goos, &factors.goarch);
+            // The govet tool is host-native (never cross-compiled), so its asset
+            // is keyed by the host platform — read the host factors directly, not a
+            // build variant.
+            let (goos, goarch) = (current_goos(), current_goarch());
+            let sha256 = govet::expected_sha256(&self.sdk_checksums, tag, &goos, &goarch);
             let spec = govet::build_spec(addr.clone(), tag, &sha256);
             return Ok(GetResponse { target_spec: spec });
         }
 
         // Standard library install: `@heph/go/std:install` builds all of std from
-        // source once (per factor); per-package `build_lib` extracts archives from
+        // source once (per variant); per-package `build_lib` extracts archives from
         // its output. Lives at the bare `@heph/go/std` package, which does not
-        // decode as a Stdlib import path, so handle it before `decode_package`.
+        // decode as a Stdlib import path, so handle it before `decode_package`. It
+        // is variant-parameterized (std is compiled with the variant's factors), so
+        // resolve the variant here.
         if addr.package.as_str() == target_std::STD_PKG && addr.name == "install" {
+            let (factors, _vref) = variant::resolve(addr, &req.states, req.executor.as_ref())
+                .await
+                .map_err(GetError::Other)?;
             let spec = target_std::install_spec(addr.clone(), &factors, &self.go_version);
             return Ok(GetResponse { target_spec: spec });
         }
@@ -1332,20 +1326,8 @@ impl ProviderInner {
             return Err(GetError::NotFound);
         }
 
-        // _golist — generate spec without executing go list (before stdlib check so
-        // stdlib packages can also expose a _golist target for cached dep resolution)
-        if addr.name == "_golist" {
-            return self
-                .get_golist_spec(addr.clone(), &kind, &factors, &req.states)
-                .map_err(GetError::Other);
-        }
-
-        // Stdlib — no go list needed for other targets
-        if let GoPackageKind::Stdlib { import_path } = &*kind {
-            return self.get_stdlib(addr.clone(), import_path, &factors);
-        }
-
-        // _go_mod — copy go.mod/go.sum; no go list needed
+        // _go_mod — copy go.mod/go.sum; variant-independent, so handle it before
+        // variant resolution (its addr carries no `v`).
         if addr.name == "_go_mod" {
             let module_root = self.workspace_root.join(addr.package.as_str());
             let mod_files: Vec<String> = ["go.mod", "go.sum"]
@@ -1360,9 +1342,11 @@ impl ProviderInner {
             return Ok(GetResponse { target_spec: spec });
         }
 
-        // download — module-root only, factor-independent. Runs `go mod download`
-        // and exposes the module source tree as artifacts so downstream build_lib
-        // / embed targets get fully sandboxed sources instead of host GOMODCACHE.
+        // download — module-root only, variant-independent (module bytes don't
+        // depend on the build variant). Runs `go mod download` and exposes the
+        // module source tree as artifacts so downstream build_lib / embed targets
+        // get fully sandboxed sources instead of host GOMODCACHE. Handle before
+        // variant resolution (its addr carries no `v`).
         if addr.name == "download" {
             if let GoPackageKind::ThirdParty {
                 module,
@@ -1383,6 +1367,27 @@ impl ProviderInner {
                 return Ok(GetResponse { target_spec: spec });
             }
             return Err(GetError::NotFound);
+        }
+
+        // Everything below is variant-parameterized. Resolve the addr's variant —
+        // `v` (user targets) or the `v`+`vp` pin (internal / dependency targets) —
+        // into the concrete `factors` this target builds with, plus the `vref` to
+        // thread verbatim onto every sub-target and dependency address.
+        let (factors, vref) = variant::resolve(addr, &req.states, req.executor.as_ref())
+            .await
+            .map_err(GetError::Other)?;
+
+        // _golist — generate spec without executing go list (before stdlib check so
+        // stdlib packages can also expose a _golist target for cached dep resolution)
+        if addr.name == "_golist" {
+            return self
+                .get_golist_spec(addr.clone(), &kind, &factors, &req.states)
+                .map_err(GetError::Other);
+        }
+
+        // Stdlib — no go list needed for other targets
+        if let GoPackageKind::Stdlib { import_path } = &*kind {
+            return self.get_stdlib(addr.clone(), import_path, &factors, &vref);
         }
 
         // provider_state(provider="go", test=False) opts the package (and all
@@ -1411,7 +1416,7 @@ impl ProviderInner {
         // `NoGoFilesError` (raised by `read_golist_package` when `go list -e`
         // reports the package has no buildable Go files) maps uniformly to
         // `NotFound` for every variant — no per-arm duck-typed check needed.
-        let golist_addr = self.make_addr_with_name(&addr.package, "_golist", &factors);
+        let golist_addr = self.make_addr_with_name(&addr.package, "_golist", &vref);
         let pkg = match self
             .read_golist_package(Arc::clone(&req.executor), &golist_addr)
             .await
@@ -1448,13 +1453,7 @@ impl ProviderInner {
                     return Err(GetError::NotFound);
                 }
                 let transitive = Arc::clone(&self)
-                    .collect_direct_libs(
-                        Arc::clone(&req.executor),
-                        &pkg,
-                        &[],
-                        &factors,
-                        &module_root,
-                    )
+                    .collect_direct_libs(Arc::clone(&req.executor), &pkg, &[], &vref, &module_root)
                     .await
                     .map_err(GetError::Other)?;
 
@@ -1528,8 +1527,7 @@ impl ProviderInner {
                     Some(a) => a,
                     None => return Err(GetError::NotFound),
                 };
-                let analyze_addr =
-                    self.make_addr_with_name(&addr.package, "_lint-analyze", &factors);
+                let analyze_addr = self.make_addr_with_name(&addr.package, "_lint-analyze", &vref);
                 let spec = crate::plugingo::driver_lint::build_lint_gate_spec(
                     addr.clone(),
                     &analyze_addr,
@@ -1549,8 +1547,7 @@ impl ProviderInner {
                     Some(a) => a,
                     None => return Err(GetError::NotFound),
                 };
-                let analyze_addr =
-                    self.make_addr_with_name(&addr.package, "_lint-analyze", &factors);
+                let analyze_addr = self.make_addr_with_name(&addr.package, "_lint-analyze", &vref);
                 let pkg_addrs = self
                     .read_golist_package_addrs(Arc::clone(&req.executor), &golist_addr)
                     .await
@@ -1608,13 +1605,7 @@ impl ProviderInner {
                     return Err(GetError::NotFound);
                 }
                 let transitive = Arc::clone(&self)
-                    .collect_direct_libs(
-                        Arc::clone(&req.executor),
-                        &pkg,
-                        &[],
-                        &factors,
-                        &module_root,
-                    )
+                    .collect_direct_libs(Arc::clone(&req.executor), &pkg, &[], &vref, &module_root)
                     .await
                     .map_err(GetError::Other)?;
 
@@ -1689,13 +1680,13 @@ impl ProviderInner {
                     return Err(GetError::NotFound);
                 }
 
-                let own_lib_addr = self.build_lib_addr(addr, &factors);
+                let own_lib_addr = self.build_lib_addr(addr, &vref);
                 let mut transitive = Arc::clone(&self)
                     .collect_transitive_libs(
                         Arc::clone(&req.executor),
                         &pkg,
                         &[],
-                        &factors,
+                        &vref,
                         &module_root,
                     )
                     .await
@@ -1770,7 +1761,7 @@ impl ProviderInner {
                         Arc::clone(&req.executor),
                         &pkg,
                         &test_extra,
-                        &factors,
+                        &vref,
                         &module_root,
                     )
                     .await
@@ -1868,7 +1859,7 @@ impl ProviderInner {
                         Arc::clone(&req.executor),
                         &xtest_imports_pkg,
                         &[],
-                        &factors,
+                        &vref,
                         &module_root,
                     )
                     .await
@@ -1882,9 +1873,8 @@ impl ProviderInner {
                         if ip != import_path {
                             return Some((ip, a));
                         }
-                        p_lib_name.map(|name| {
-                            (ip, self.make_addr_with_name(&addr.package, name, &factors))
-                        })
+                        p_lib_name
+                            .map(|name| (ip, self.make_addr_with_name(&addr.package, name, &vref)))
                     })
                     .collect();
 
@@ -1934,21 +1924,18 @@ impl ProviderInner {
                         Arc::clone(&req.executor),
                         &testmain_pkg,
                         &[],
-                        &factors,
+                        &vref,
                         &module_root,
                     )
                     .await
                     .map_err(GetError::Other)?;
                 // testmain imports `_test "P"` → importcfg needs P→test_lib.
                 let test_lib_addr =
-                    self.make_addr_with_name(&addr.package, "build_test_lib", &factors);
+                    self.make_addr_with_name(&addr.package, "build_test_lib", &vref);
                 transitive.libs.push((import_path.clone(), test_lib_addr));
 
-                let testmain_src_addr = Addr::new(
-                    addr.package.clone(),
-                    "testmain".to_string(),
-                    factors_to_args(&factors),
-                );
+                let testmain_src_addr =
+                    Addr::new(addr.package.clone(), "testmain".to_string(), vref.to_args());
                 let spec = target_test::build_testmain_lib_spec(
                     addr.clone(),
                     &factors,
@@ -1971,14 +1958,14 @@ impl ProviderInner {
                         Arc::clone(&req.executor),
                         &testmain_pkg,
                         &[],
-                        &factors,
+                        &vref,
                         &module_root,
                     )
                     .await
                     .map_err(GetError::Other)?;
                 // testmain imports `_xtest "P_test"` → importcfg needs P_test→xtest_lib.
                 let xtest_lib_addr =
-                    self.make_addr_with_name(&addr.package, "build_xtest_lib", &factors);
+                    self.make_addr_with_name(&addr.package, "build_xtest_lib", &vref);
                 transitive
                     .libs
                     .push((format!("{}_test", import_path), xtest_lib_addr));
@@ -1986,7 +1973,7 @@ impl ProviderInner {
                 let testmain_src_addr = Addr::new(
                     addr.package.clone(),
                     "xtestmain".to_string(),
-                    factors_to_args(&factors),
+                    vref.to_args(),
                 );
                 let spec = target_test::build_testmain_lib_spec(
                     addr.clone(),
@@ -2021,7 +2008,7 @@ impl ProviderInner {
                         Arc::clone(&req.executor),
                         &pkg,
                         &test_extra,
-                        &factors,
+                        &vref,
                         &module_root,
                     )
                     .await
@@ -2039,11 +2026,11 @@ impl ProviderInner {
                     }
                 }
                 let test_lib_addr =
-                    self.make_addr_with_name(&addr.package, "build_test_lib", &factors);
+                    self.make_addr_with_name(&addr.package, "build_test_lib", &vref);
                 all_libs.push((import_path.clone(), test_lib_addr));
 
                 let testmain_lib_addr =
-                    self.make_addr_with_name(&addr.package, "build_testmain_lib", &factors);
+                    self.make_addr_with_name(&addr.package, "build_testmain_lib", &vref);
                 let spec = target_test::build_test_spec(
                     addr.clone(),
                     &factors,
@@ -2108,7 +2095,7 @@ impl ProviderInner {
                         Arc::clone(&req.executor),
                         &xtest_root,
                         &[],
-                        &factors,
+                        &vref,
                         &module_root,
                     )
                     .await
@@ -2121,7 +2108,7 @@ impl ProviderInner {
                 // packages P has no lib at all — skip the slot entirely so we
                 // don't request a non-existent target.
                 if let Some(p_lib_name) = pick_xtest_p_lib_name(&pkg) {
-                    let p_addr = self.make_addr_with_name(&addr.package, p_lib_name, &factors);
+                    let p_addr = self.make_addr_with_name(&addr.package, p_lib_name, &vref);
                     all_libs.push((import_path.clone(), p_addr));
                     seen.insert(import_path.clone());
                 } else {
@@ -2138,11 +2125,11 @@ impl ProviderInner {
                     }
                 }
                 let xtest_lib_addr =
-                    self.make_addr_with_name(&addr.package, "build_xtest_lib", &factors);
+                    self.make_addr_with_name(&addr.package, "build_xtest_lib", &vref);
                 all_libs.push((p_test, xtest_lib_addr));
 
                 let testmain_lib_addr =
-                    self.make_addr_with_name(&addr.package, "build_xtestmain_lib", &factors);
+                    self.make_addr_with_name(&addr.package, "build_xtestmain_lib", &vref);
                 let spec = target_test::build_test_spec(
                     addr.clone(),
                     &factors,
@@ -2157,8 +2144,7 @@ impl ProviderInner {
                 if pkg.test_go_files.is_empty() {
                     return Err(GetError::NotFound);
                 }
-                let build_test_addr =
-                    self.make_addr_with_name(&addr.package, "build_test", &factors);
+                let build_test_addr = self.make_addr_with_name(&addr.package, "build_test", &vref);
                 let data_query_addr = go_test_data_query_addr(addr.package.as_str());
                 let test_env =
                     pick_test_env(&req.states, addr.package.as_str()).map_err(GetError::Other)?;
@@ -2176,7 +2162,7 @@ impl ProviderInner {
                     return Err(GetError::NotFound);
                 }
                 let build_xtest_addr =
-                    self.make_addr_with_name(&addr.package, "build_xtest", &factors);
+                    self.make_addr_with_name(&addr.package, "build_xtest", &vref);
                 let data_query_addr = go_test_data_query_addr(addr.package.as_str());
                 let test_env =
                     pick_test_env(&req.states, addr.package.as_str()).map_err(GetError::Other)?;
@@ -2282,10 +2268,11 @@ impl ProviderInner {
         addr: Addr,
         import_path: &str,
         factors: &Factors,
+        vref: &VariantRef,
     ) -> Result<GetResponse, GetError> {
         match addr.name.as_str() {
             "build_lib" => {
-                let spec = target_std::build_spec(addr, import_path, factors);
+                let spec = target_std::build_spec(addr, import_path, factors, vref);
                 Ok(GetResponse { target_spec: spec })
             }
             _ => Err(GetError::NotFound),
@@ -2405,8 +2392,8 @@ impl ProviderInner {
             .map_err(unwrap_arc_err)
     }
 
-    fn build_lib_addr(&self, addr: &Addr, factors: &Factors) -> Addr {
-        self.make_addr_with_name(&addr.package, "build_lib", factors)
+    fn build_lib_addr(&self, addr: &Addr, vref: &VariantRef) -> Addr {
+        self.make_addr_with_name(&addr.package, "build_lib", vref)
     }
 
     /// Addr of the `heph-govet` binary the lint and format targets exec: the
@@ -2438,14 +2425,17 @@ impl ProviderInner {
         if !addr.args.is_empty() {
             return Ok(addr);
         }
+        // The govet tool is a host-native binary, not variant-parameterized: its
+        // `http_fetch` URL templates over plain `goos`/`goarch` args (like the Go
+        // toolchain download), so it keeps that vocabulary rather than `v`/`vp`.
+        let host_args = BTreeMap::from([
+            ("goos".to_string(), current_goos()),
+            ("goarch".to_string(), current_goarch()),
+        ]);
         Ok(Addr::new(
             addr.package.clone(),
             addr.name.clone(),
-            factors_to_args(&Factors {
-                goos: current_goos(),
-                goarch: current_goarch(),
-                build_tags: vec![],
-            }),
+            host_args,
         ))
     }
 
@@ -2453,9 +2443,9 @@ impl ProviderInner {
         &self,
         package: &hmodel::htpkg::PkgBuf,
         name: &str,
-        factors: &Factors,
+        vref: &VariantRef,
     ) -> Addr {
-        Addr::new(package.clone(), name.to_string(), factors_to_args(factors))
+        Addr::new(package.clone(), name.to_string(), vref.to_args())
     }
 
     /// The addr of the module's golangci-lint config, if the module root (the
@@ -2480,7 +2470,7 @@ impl ProviderInner {
     fn libs_key(
         root_pkg: &GoPackage,
         extra_imports: &[String],
-        factors: &Factors,
+        vref: &VariantRef,
         module_root: &Path,
         transitive: bool,
     ) -> LibsKey {
@@ -2493,7 +2483,7 @@ impl ProviderInner {
         LibsKey {
             imports,
             extra,
-            factors: factors.clone(),
+            vref: vref.clone(),
             module_root: module_root.to_path_buf(),
             transitive,
         }
@@ -2514,18 +2504,11 @@ impl ProviderInner {
         executor: Arc<dyn ProviderExecutor>,
         root_pkg: &GoPackage,
         extra_imports: &[String],
-        factors: &Factors,
+        vref: &VariantRef,
         module_root: &Path,
     ) -> anyhow::Result<TransitiveDeps> {
-        self.collect_libs(
-            executor,
-            root_pkg,
-            extra_imports,
-            factors,
-            module_root,
-            true,
-        )
-        .await
+        self.collect_libs(executor, root_pkg, extra_imports, vref, module_root, true)
+            .await
     }
 
     /// Resolve direct imports only (no recursion) — correct for compile steps.
@@ -2534,18 +2517,11 @@ impl ProviderInner {
         executor: Arc<dyn ProviderExecutor>,
         root_pkg: &GoPackage,
         extra_imports: &[String],
-        factors: &Factors,
+        vref: &VariantRef,
         module_root: &Path,
     ) -> anyhow::Result<TransitiveDeps> {
-        self.collect_libs(
-            executor,
-            root_pkg,
-            extra_imports,
-            factors,
-            module_root,
-            false,
-        )
-        .await
+        self.collect_libs(executor, root_pkg, extra_imports, vref, module_root, false)
+            .await
     }
 
     async fn collect_libs(
@@ -2553,23 +2529,23 @@ impl ProviderInner {
         executor: Arc<dyn ProviderExecutor>,
         root_pkg: &GoPackage,
         extra_imports: &[String],
-        factors: &Factors,
+        vref: &VariantRef,
         module_root: &Path,
         transitive: bool,
     ) -> anyhow::Result<TransitiveDeps> {
-        let key = Self::libs_key(root_pkg, extra_imports, factors, module_root, transitive);
+        let key = Self::libs_key(root_pkg, extra_imports, vref, module_root, transitive);
         let extra = extra_imports.to_vec();
         let module_root = module_root.to_path_buf();
         let arc = self
             .libs_cache
             .once(
                 key,
-                enclose!((self => me, executor, factors, root_pkg.imports => root_imports) move || async move {
+                enclose!((self => me, executor, vref, root_pkg.imports => root_imports) move || async move {
                     me.collect_libs_inner(
                         executor,
                         &root_imports,
                         &extra,
-                        &factors,
+                        &vref,
                         &module_root,
                         transitive,
                     )
@@ -2649,24 +2625,24 @@ impl ProviderInner {
         self: Arc<Self>,
         executor: Arc<dyn ProviderExecutor>,
         import_path: String,
-        factors: Factors,
+        vref: VariantRef,
         go_mod: Arc<GoModData>,
         module_root: PathBuf,
     ) -> anyhow::Result<Arc<ImportClosure>> {
         let key = ImportClosureKey {
             import_path: import_path.clone(),
-            factors: factors.clone(),
+            vref: vref.clone(),
             module_root: module_root.clone(),
         };
         self.import_closure_cache
             .once(
                 key,
-                enclose!((self => me, executor, import_path, factors, go_mod, module_root) move || async move {
+                enclose!((self => me, executor, import_path, vref, go_mod, module_root) move || async move {
                     let (resolved_path, dep_addr_opt, sub_imports) = me
                         .resolve_import(
                             Arc::clone(&executor),
                             &import_path,
-                            &factors,
+                            &vref,
                             &go_mod.requires,
                             &go_mod.module_path,
                             &module_root,
@@ -2681,7 +2657,7 @@ impl ProviderInner {
                                 Arc::clone(&me).import_closure(
                                     Arc::clone(&executor),
                                     sub,
-                                    factors.clone(),
+                                    vref.clone(),
                                     Arc::clone(&go_mod),
                                     module_root.clone(),
                                 )
@@ -2707,7 +2683,7 @@ impl ProviderInner {
         executor: Arc<dyn ProviderExecutor>,
         root_imports: &[String],
         extra_imports: &[String],
-        factors: &Factors,
+        vref: &VariantRef,
         module_root: &Path,
         transitive: bool,
     ) -> anyhow::Result<TransitiveDeps> {
@@ -2734,7 +2710,7 @@ impl ProviderInner {
                 Arc::clone(&self).import_closure(
                     Arc::clone(&executor),
                     ip,
-                    factors.clone(),
+                    vref.clone(),
                     Arc::clone(&go_mod),
                     module_root_buf.clone(),
                 )
@@ -2773,7 +2749,7 @@ impl ProviderInner {
             self.resolve_import(
                 Arc::clone(&executor),
                 ip,
-                factors,
+                vref,
                 go_mod_requires,
                 workspace_module_path,
                 module_root,
@@ -2794,7 +2770,7 @@ impl ProviderInner {
         &self,
         executor: Arc<dyn ProviderExecutor>,
         import_path: &str,
-        factors: &Factors,
+        vref: &VariantRef,
         go_mod_requires: &[(String, String)],
         workspace_module_path: &str,
         module_root: &Path,
@@ -2803,11 +2779,11 @@ impl ProviderInner {
             && (import_path == workspace_module_path
                 || import_path.starts_with(&format!("{}/", workspace_module_path)));
         if !is_workspace_module && is_stdlib_import_path(import_path) {
-            let addr = encode_stdlib(import_path, factors);
+            let addr = encode_stdlib(import_path, vref);
             let golist_addr = Addr::new(
                 hmodel::htpkg::PkgBuf::from(format!("@heph/go/std/{}", import_path)),
                 "_golist".to_string(),
-                factors_to_args(factors),
+                vref.to_args(),
             );
             // Propagate golist errors instead of swallowing them: a missing or
             // partial closure here turns into a broken link step downstream
@@ -2823,7 +2799,7 @@ impl ProviderInner {
 
         let dep_addr = match self.resolve_import_to_addr(
             import_path,
-            factors,
+            vref,
             module_root,
             workspace_module_path,
             go_mod_requires,
@@ -2861,7 +2837,7 @@ impl ProviderInner {
     fn resolve_import_to_addr(
         &self,
         import_path: &str,
-        factors: &Factors,
+        vref: &VariantRef,
         module_root: &Path,
         workspace_module_path: &str,
         go_mod_requires: &[(String, String)],
@@ -2886,7 +2862,7 @@ impl ProviderInner {
             } else {
                 self.workspace_root.join(module_rel).join(rel_suffix)
             };
-            return Some(encode_firstparty(&src_dir, &self.workspace_root, factors));
+            return Some(encode_firstparty(&src_dir, &self.workspace_root, vref));
         }
 
         // Third-party: look up in go.mod requires
@@ -2902,7 +2878,7 @@ impl ProviderInner {
                 .to_string_lossy()
                 .to_string();
             return Some(encode_thirdparty(
-                &mod_path, &version, &subpath, &base_pkg, factors,
+                &mod_path, &version, &subpath, &base_pkg, vref,
             ));
         }
 
@@ -3043,86 +3019,35 @@ mod tests {
         let args = FnArgs {
             positional: vec![
                 Value::String("mylib".into()),
-                Value::String("linux".into()),
-                Value::String("amd64".into()),
+                Value::String("release".into()),
             ],
             named: HashMap::new(),
         };
         let v = BuildAddrFn.call(&build_addr_ctx(), args).await.unwrap();
-        assert_eq!(
-            v,
-            Value::String("//mylib:build@goarch=amd64,goos=linux".into())
-        );
-    }
-
-    #[tokio::test]
-    async fn test_build_addr_tags() {
-        let mut named = HashMap::new();
-        // Unsorted on input — must come out sorted (bar,foo) in the addr.
-        named.insert(
-            "tags".to_string(),
-            Value::List(vec![
-                Value::String("foo".into()),
-                Value::String("bar".into()),
-            ]),
-        );
-        let args = FnArgs {
-            positional: vec![
-                Value::String("@heph/go/std/fmt".into()),
-                Value::String("darwin".into()),
-                Value::String("arm64".into()),
-            ],
-            named,
-        };
-        let v = BuildAddrFn.call(&build_addr_ctx(), args).await.unwrap();
-        assert_eq!(
-            v,
-            Value::String(
-                "//@heph/go/std/fmt:build@goarch=arm64,goos=darwin,tags=\"bar,foo\"".into()
-            )
-        );
+        assert_eq!(v, Value::String("//mylib:build@v=release".into()));
     }
 
     #[tokio::test]
     async fn test_build_addr_named_args() {
         let mut named = HashMap::new();
         named.insert("pkg".to_string(), Value::String("mylib".into()));
-        named.insert("goos".to_string(), Value::String("linux".into()));
-        named.insert("goarch".to_string(), Value::String("amd64".into()));
+        named.insert("v".to_string(), Value::String("release".into()));
         let args = FnArgs {
             positional: vec![],
             named,
         };
         let v = BuildAddrFn.call(&build_addr_ctx(), args).await.unwrap();
-        assert_eq!(
-            v,
-            Value::String("//mylib:build@goarch=amd64,goos=linux".into())
-        );
+        assert_eq!(v, Value::String("//mylib:build@v=release".into()));
     }
 
     #[tokio::test]
-    async fn test_build_addr_missing_goarch_errors() {
+    async fn test_build_addr_missing_variant_errors() {
         let args = FnArgs {
-            positional: vec![Value::String("mylib".into()), Value::String("linux".into())],
+            positional: vec![Value::String("mylib".into())],
             named: HashMap::new(),
         };
         let err = BuildAddrFn.call(&build_addr_ctx(), args).await.unwrap_err();
-        assert!(err.to_string().contains("missing `goarch`"), "{err}");
-    }
-
-    fn run_str(spec: &hplugin::provider::TargetSpec) -> String {
-        match spec.config.get("run").unwrap() {
-            Value::String(s) => s.clone(),
-            Value::List(v) => v
-                .iter()
-                .map(|x| match x {
-                    Value::String(s) => s.as_str(),
-                    _ => panic!("run entry not a string"),
-                })
-                .collect::<Vec<_>>()
-                .join("\n"),
-            _ => panic!("run not string or list"),
-        }
+        assert!(err.to_string().contains("missing `v`"), "{err}");
     }
 
     fn go_available() -> bool {
@@ -3187,7 +3112,13 @@ mod tests {
                     );
                 }
 
-                let factors = Factors::from_addr(addr);
+                // This mock runs a real host `go list`, so use host factors
+                // regardless of the addr's variant coordinate.
+                let factors = Factors {
+                    goos: current_goos(),
+                    goarch: current_goarch(),
+                    ..Default::default()
+                };
                 let kind = decode_package(&addr.package, &self.workspace_root)
                     .ok_or_else(|| anyhow::anyhow!("unknown package: {}", addr.package))?;
 
@@ -3303,8 +3234,31 @@ mod tests {
         Ok(())
     }
 
+    /// Build a fully-resolved internal addr carrying the default test variant
+    /// (`host`, defined at the root by [`host_variant_state`]).
     fn make_addr(package: &str, name: &str) -> Addr {
-        Addr::new(PkgBuf::from(package), name.to_string(), Default::default())
+        Addr::new(
+            PkgBuf::from(package),
+            name.to_string(),
+            VariantRef::new("host", "").to_args(),
+        )
+    }
+
+    /// A root `provider_state(provider="go", variants={"host": {goos, goarch}})`
+    /// defining the default `host` variant every test target resolves against.
+    fn host_variant_state() -> State {
+        let variant = Value::Map(HashMap::from([
+            ("goos".to_string(), Value::String(current_goos())),
+            ("goarch".to_string(), Value::String(current_goarch())),
+        ]));
+        State {
+            package: PkgBuf::from(""),
+            provider: "go".to_string(),
+            state: HashMap::from([(
+                "variants".to_string(),
+                Value::Map(HashMap::from([("host".to_string(), variant)])),
+            )]),
+        }
     }
 
     /// Write a minimal `.golangci.yml` at a fixture's module root so its lint and
@@ -3607,7 +3561,7 @@ mod tests {
         GetRequest {
             request_id: "test".to_string(),
             addr,
-            states: vec![],
+            states: vec![host_variant_state()],
             executor: test_executor(workspace_root),
         }
     }
@@ -3701,7 +3655,7 @@ golang.org/x/oauth2 v0.0.0-20200107190931-bf48bf16ab8d h1:pE8b58s1HRDMi8RDc79m0H
         let req = GetRequest {
             request_id: "test".to_string(),
             addr: make_addr("", "_golist"),
-            states: vec![],
+            states: vec![host_variant_state()],
             executor: Arc::new(GoListTestExecutor {
                 workspace_root: sandbox.path().to_path_buf(),
                 source_map: HashMap::new(),
@@ -3823,7 +3777,7 @@ golang.org/x/oauth2 v0.0.0-20200107190931-bf48bf16ab8d h1:pE8b58s1HRDMi8RDc79m0H
         let req = GetRequest {
             request_id: "test".to_string(),
             addr: make_addr("", "codegen_gen"),
-            states: vec![],
+            states: vec![host_variant_state()],
             executor,
         };
 
@@ -4404,17 +4358,36 @@ golang.org/x/oauth2 v0.0.0-20200107190931-bf48bf16ab8d h1:pE8b58s1HRDMi8RDc79m0H
     // ---- factors ----
 
     #[tokio::test]
-    async fn test_factors_linux_amd64_in_compile_config() {
+    async fn test_variant_factors_flow_to_compile_config() {
         require_go!();
         let sandbox = copy_fixture("simple_lib");
         let p = Provider::new(sandbox.path().to_path_buf()).unwrap();
-        let addr = {
-            let mut args = std::collections::BTreeMap::new();
-            args.insert("goos".to_string(), "linux".to_string());
-            args.insert("goarch".to_string(), "amd64".to_string());
-            Addr::new(PkgBuf::from(""), "build_lib".to_string(), args)
+        // A root variant pinning linux/amd64; resolving `build_lib@v=x` must thread
+        // those factors into the go_compile config.
+        let variant = Value::Map(HashMap::from([
+            ("goos".to_string(), Value::String("linux".into())),
+            ("goarch".to_string(), Value::String("amd64".into())),
+        ]));
+        let state = State {
+            package: PkgBuf::from(""),
+            provider: "go".to_string(),
+            state: HashMap::from([(
+                "variants".to_string(),
+                Value::Map(HashMap::from([("x".to_string(), variant)])),
+            )]),
         };
-        let resp = provider_get(&p, addr).await.unwrap();
+        let addr = Addr::new(
+            PkgBuf::from(""),
+            "build_lib".to_string(),
+            VariantRef::new("x", "").to_args(),
+        );
+        let req = GetRequest {
+            request_id: "test".to_string(),
+            addr,
+            states: vec![state],
+            executor: test_executor(sandbox.path()),
+        };
+        let resp = p.get(req, &StdCancellationToken::new()).await.unwrap();
         let cfg = &resp.target_spec.config;
         assert!(matches!(cfg.get("goos"), Some(Value::String(s)) if s == "linux"));
         assert!(matches!(cfg.get("goarch"), Some(Value::String(s)) if s == "amd64"));
@@ -4557,7 +4530,7 @@ golang.org/x/oauth2 v0.0.0-20200107190931-bf48bf16ab8d h1:pE8b58s1HRDMi8RDc79m0H
         let req = ListRequest {
             request_id: "test".to_string(),
             package: PkgBuf::from(package),
-            states: vec![],
+            states: vec![host_variant_state()],
         };
         p.list(req, &ctoken)
             .await
@@ -5431,7 +5404,10 @@ golang.org/x/oauth2 v0.0.0-20200107190931-bf48bf16ab8d h1:pE8b58s1HRDMi8RDc79m0H
         let req = ListRequest {
             request_id: "test".to_string(),
             package: PkgBuf::from("pkg"),
-            states: vec![with_recursive(state_with_test_skip("", true))],
+            states: vec![
+                with_recursive(state_with_test_skip("", true)),
+                host_variant_state(),
+            ],
         };
         let names: Vec<String> = p
             .list(req, &ctoken)
@@ -5460,7 +5436,10 @@ golang.org/x/oauth2 v0.0.0-20200107190931-bf48bf16ab8d h1:pE8b58s1HRDMi8RDc79m0H
             let req = GetRequest {
                 request_id: "test".to_string(),
                 addr: make_addr("pkg", name),
-                states: vec![with_recursive(state_with_test_skip("", true))],
+                states: vec![
+                    with_recursive(state_with_test_skip("", true)),
+                    host_variant_state(),
+                ],
                 executor: test_executor(sandbox.path()),
             };
             let res = p.get(req, &ctoken).await;
@@ -5483,6 +5462,7 @@ golang.org/x/oauth2 v0.0.0-20200107190931-bf48bf16ab8d h1:pE8b58s1HRDMi8RDc79m0H
             states: vec![
                 with_recursive(state_with_test_skip("", true)),
                 state_with_test_skip("pkg", false),
+                host_variant_state(),
             ],
             executor: test_executor(sandbox.path()),
         };
@@ -5515,7 +5495,7 @@ golang.org/x/oauth2 v0.0.0-20200107190931-bf48bf16ab8d h1:pE8b58s1HRDMi8RDc79m0H
         let req = GetRequest {
             request_id: "test".to_string(),
             addr: make_addr("", "_golist"),
-            states: vec![],
+            states: vec![host_variant_state()],
             executor: Arc::new(GoListTestExecutor {
                 workspace_root: sandbox.path().to_path_buf(),
                 source_map: HashMap::new(),
@@ -5562,7 +5542,7 @@ golang.org/x/oauth2 v0.0.0-20200107190931-bf48bf16ab8d h1:pE8b58s1HRDMi8RDc79m0H
         let req = GetRequest {
             request_id: "test".to_string(),
             addr: make_addr("", "_golist"),
-            states: vec![state],
+            states: vec![state, host_variant_state()],
             executor: Arc::new(GoListTestExecutor {
                 workspace_root: sandbox.path().to_path_buf(),
                 source_map: HashMap::new(),
@@ -5748,7 +5728,7 @@ golang.org/x/oauth2 v0.0.0-20200107190931-bf48bf16ab8d h1:pE8b58s1HRDMi8RDc79m0H
         let req = GetRequest {
             request_id: "test".to_string(),
             addr: make_addr("", "_golist"),
-            states: vec![state],
+            states: vec![state, host_variant_state()],
             executor: Arc::new(GoListTestExecutor {
                 workspace_root: sandbox.path().to_path_buf(),
                 source_map: HashMap::new(),

--- a/crates/plugin-go/src/plugingo/provider.rs
+++ b/crates/plugin-go/src/plugingo/provider.rs
@@ -1130,8 +1130,9 @@ fn pkg_prefix_pattern(pkg: &str) -> String {
 ///
 /// Excludes the `go` provider: these labels are carried by buildfile-emitted
 /// codegen targets, never by go targets. Skipping the go provider avoids
-/// resolving (and cascade-building) the go provider's own targets, whose spec
-/// resolution pulls in the whole golist/std graph.
+/// resolving (and cascade-building) the go provider's own variant-parameterized
+/// targets — which are multiplied per variant and whose spec resolution pulls in
+/// the whole per-variant golist/std graph.
 fn go_test_data_query_addr(pkg: &str) -> Addr {
     let expr = format!("{} && label(go_test_data)", pkg_pattern(pkg));
     hplugin_query::pluginquery::query_addr(&expr, "", &["go"])
@@ -1177,9 +1178,9 @@ fn compute_pkg_src_addrs(pkg_str: &str, states: &[State]) -> anyhow::Result<Vec<
     // tier, `label` at the spec tier (`get_spec`), and `tree_output` only at the
     // def tier (`get_def`, the most expensive). Order terms by that cost so the
     // engine's left-to-right `&&` bails at the cheapest possible tier.
-    // Exclude the `go` provider: `go_src` labels only buildfile codegen targets,
-    // never go targets — skipping go avoids spec-resolving (and cascade-building)
-    // the go provider's own targets just to reject them on the label.
+    // Exclude the `go` provider: `go_src` labels only its buildfile codegen
+    // targets, never go targets — skipping go avoids resolving (and cascade-
+    // building) the go provider's per-variant targets.
     let go_src_expr = format!("{scope} && label(go_src) && tree_output({pkg_str})");
     let go_src_query_addr = hplugin_query::pluginquery::query_addr(&go_src_expr, "", &["go"]);
     addrs.push(go_src_query_addr.format());

--- a/crates/plugin-go/src/plugingo/target_bin.rs
+++ b/crates/plugin-go/src/plugingo/target_bin.rs
@@ -58,12 +58,17 @@ pub fn build_spec(
         .unwrap_or(import_path)
         .to_string();
 
+    // Link flags = the variant's ldflags first, then any per-package `link`
+    // provider_state flags (so a package can append/override).
+    let mut link_flags = factors.ldflags.clone();
+    link_flags.extend(link.flags.iter().cloned());
+
     let mut run = go_run_prelude(go_version);
     run.extend(generate_link_script(
         import_path,
         &binary_name,
         transitive_libs,
-        &link.flags,
+        &link_flags,
     ));
 
     let mut deps: BTreeMap<String, Value> = transitive_libs
@@ -124,13 +129,14 @@ pub fn build_spec(
             Value::List(vec![Value::String(binary_name)]),
         )])),
     );
-    config.insert(
-        "runtime_env".to_string(),
-        Value::Map(HashMap::from([
-            ("GOOS".to_string(), Value::String(factors.goos.clone())),
-            ("GOARCH".to_string(), Value::String(factors.goarch.clone())),
-        ])),
-    );
+    let mut runtime_env = HashMap::from([
+        ("GOOS".to_string(), Value::String(factors.goos.clone())),
+        ("GOARCH".to_string(), Value::String(factors.goarch.clone())),
+    ]);
+    if let Some(exp) = factors.goexperiment_env() {
+        runtime_env.insert("GOEXPERIMENT".to_string(), Value::String(exp));
+    }
+    config.insert("runtime_env".to_string(), Value::Map(runtime_env));
     // CGO/toolchain pins live in `env` (hashed) so stale archives don't survive
     // cache lookups (pluginexec/mod.rs:70 excludes runtime_env from the def hash).
     config.insert("env".to_string(), go_build_env());
@@ -197,6 +203,7 @@ mod tests {
             goos: "linux".into(),
             goarch: "amd64".into(),
             build_tags: vec![],
+            ..Default::default()
         }
     }
 

--- a/crates/plugin-go/src/plugingo/target_golist.rs
+++ b/crates/plugin-go/src/plugingo/target_golist.rs
@@ -118,6 +118,22 @@ fn build_spec_inner(
             ),
         );
     }
+    if !factors.goexperiment.is_empty() {
+        config.insert(
+            "goexperiment".to_string(),
+            Value::List(
+                factors
+                    .goexperiment
+                    .iter()
+                    .map(|t| Value::String(t.clone()))
+                    .collect(),
+            ),
+        );
+    }
+    config.insert(
+        "cgo_enabled".to_string(),
+        Value::String(factors.cgo_enabled_env().to_string()),
+    );
     if !deps.is_empty() {
         config.insert("deps".to_string(), Value::Map(deps));
     }
@@ -164,6 +180,7 @@ mod tests {
             goos: "linux".into(),
             goarch: "amd64".into(),
             build_tags: vec![],
+            ..Default::default()
         }
     }
 
@@ -426,6 +443,7 @@ mod tests {
             goos: "linux".into(),
             goarch: "amd64".into(),
             build_tags: vec!["integration".to_string()],
+            ..Default::default()
         };
         let spec = build_spec_stdlib(test_addr(), "fmt", &factors, V).unwrap();
         assert!(

--- a/crates/plugin-go/src/plugingo/target_golist.rs
+++ b/crates/plugin-go/src/plugingo/target_golist.rs
@@ -130,10 +130,6 @@ fn build_spec_inner(
             ),
         );
     }
-    config.insert(
-        "cgo_enabled".to_string(),
-        Value::String(factors.cgo_enabled_env().to_string()),
-    );
     if !deps.is_empty() {
         config.insert("deps".to_string(), Value::Map(deps));
     }

--- a/crates/plugin-go/src/plugingo/target_lib.rs
+++ b/crates/plugin-go/src/plugingo/target_lib.rs
@@ -86,6 +86,7 @@ mod tests {
             goos: "linux".into(),
             goarch: "amd64".into(),
             build_tags: vec![],
+            ..Default::default()
         }
     }
     fn lib_spec(

--- a/crates/plugin-go/src/plugingo/target_std.rs
+++ b/crates/plugin-go/src/plugingo/target_std.rs
@@ -1,8 +1,7 @@
 use crate::plugingo::addr_util::{
-    factors_to_args, go_host_pass_env_config, go_run_prelude, go_sdk_dep, go_sdk_read_only_config,
-    to_run_value,
+    go_host_pass_env_config, go_run_prelude, go_sdk_dep, go_sdk_read_only_config, to_run_value,
 };
-use crate::plugingo::factors::Factors;
+use crate::plugingo::factors::{Factors, VariantRef};
 use hcore::htvalue::Value;
 use hmodel::htaddr::Addr;
 use hmodel::htpkg::PkgBuf;
@@ -29,13 +28,9 @@ pub fn archive_filename(import_path: &str) -> String {
     format!("{}.a", sanitized)
 }
 
-/// Address of the `@heph/go/std:install` target for the given factors.
-pub fn install_addr(factors: &Factors) -> Addr {
-    Addr::new(
-        PkgBuf::from(STD_PKG),
-        "install".to_string(),
-        factors_to_args(factors),
-    )
+/// Address of the `@heph/go/std:install` target for the given variant.
+pub fn install_addr(vref: &VariantRef) -> Addr {
+    Addr::new(PkgBuf::from(STD_PKG), "install".to_string(), vref.to_args())
 }
 
 /// Sandbox-relative dir the std archives land in after `go install std`, e.g.
@@ -139,7 +134,12 @@ pub fn install_spec(addr: Addr, factors: &Factors, go_version: &str) -> TargetSp
 /// Build the `@heph/go/std/<import>:build_lib` target: extract a single
 /// precompiled archive from the `install` output. Mirrors `v1`'s `stdLibBuild` —
 /// pure `mv`, no Go invocation, so it carries no SDK dep.
-pub fn build_spec(addr: Addr, import_path: &str, factors: &Factors) -> TargetSpec {
+pub fn build_spec(
+    addr: Addr,
+    import_path: &str,
+    factors: &Factors,
+    vref: &VariantRef,
+) -> TargetSpec {
     let out_file = archive_filename(import_path);
     let subdir = pkg_subdir(factors);
 
@@ -153,7 +153,7 @@ pub fn build_spec(addr: Addr, import_path: &str, factors: &Factors) -> TargetSpe
         "install".to_string(),
         Value::List(vec![Value::String(format!(
             "{}|pkg",
-            install_addr(factors).format()
+            install_addr(vref).format()
         ))]),
     );
 
@@ -213,12 +213,17 @@ mod tests {
             goos: "linux".into(),
             goarch: "amd64".into(),
             build_tags: vec![],
+            ..Default::default()
         }
+    }
+
+    fn test_vref() -> VariantRef {
+        VariantRef::new("dev", "")
     }
 
     #[test]
     fn test_install_builds_std_from_source() {
-        let spec = install_spec(install_addr(&test_factors()), &test_factors(), V);
+        let spec = install_spec(install_addr(&test_vref()), &test_factors(), V);
         let run = run_str(&spec);
         assert!(
             run.contains("install --trimpath std"),
@@ -230,7 +235,7 @@ mod tests {
 
     #[test]
     fn test_install_reads_no_host_go() {
-        let spec = install_spec(install_addr(&test_factors()), &test_factors(), V);
+        let spec = install_spec(install_addr(&test_vref()), &test_factors(), V);
         let run = run_str(&spec);
         // GOROOT must come from the staged hermetic SDK, never the host.
         assert!(
@@ -253,7 +258,7 @@ mod tests {
 
     #[test]
     fn test_install_out_has_pkg_dir_and_list() {
-        let spec = install_spec(install_addr(&test_factors()), &test_factors(), V);
+        let spec = install_spec(install_addr(&test_vref()), &test_factors(), V);
         let out = match spec.config.get("out").unwrap() {
             Value::Map(m) => m,
             _ => panic!("out must be map"),
@@ -271,8 +276,9 @@ mod tests {
             goos: "darwin".into(),
             goarch: "arm64".into(),
             build_tags: vec![],
+            ..Default::default()
         };
-        let spec = install_spec(install_addr(&factors), &factors, V);
+        let spec = install_spec(install_addr(&test_vref()), &factors, V);
         let env = match spec.config.get("env").unwrap() {
             Value::Map(m) => m,
             _ => panic!("env must be map"),
@@ -284,7 +290,7 @@ mod tests {
 
     #[test]
     fn test_build_lib_extracts_from_install() {
-        let spec = build_spec(build_lib_addr(), "fmt", &test_factors());
+        let spec = build_spec(build_lib_addr(), "fmt", &test_factors(), &test_vref());
         let run = run_str(&spec);
         assert!(
             run.contains("@heph/go/std/goroot/pkg/linux_amd64/fmt.a"),
@@ -295,7 +301,7 @@ mod tests {
 
     #[test]
     fn test_build_lib_deps_on_install() {
-        let spec = build_spec(build_lib_addr(), "fmt", &test_factors());
+        let spec = build_spec(build_lib_addr(), "fmt", &test_factors(), &test_vref());
         let deps = match spec.config.get("deps").unwrap() {
             Value::Map(m) => m,
             _ => panic!("deps must be map"),
@@ -313,7 +319,7 @@ mod tests {
     #[test]
     fn test_build_lib_carries_no_sdk_dep() {
         // build_lib is a pure mv; pulling the whole SDK in would be wasteful.
-        let spec = build_spec(build_lib_addr(), "fmt", &test_factors());
+        let spec = build_spec(build_lib_addr(), "fmt", &test_factors(), &test_vref());
         let deps = match spec.config.get("deps").unwrap() {
             Value::Map(m) => m,
             _ => panic!("deps must be map"),
@@ -323,7 +329,7 @@ mod tests {
 
     #[test]
     fn test_build_lib_out_group() {
-        let spec = build_spec(build_lib_addr(), "fmt", &test_factors());
+        let spec = build_spec(build_lib_addr(), "fmt", &test_factors(), &test_vref());
         let out = spec.config.get("out").unwrap();
         assert!(matches!(out, Value::Map(m) if m.contains_key("a")));
     }

--- a/crates/plugin-go/src/plugingo/target_test.rs
+++ b/crates/plugin-go/src/plugingo/target_test.rs
@@ -178,9 +178,15 @@ pub fn build_test_spec(
 ) -> TargetSpec {
     let mut script = go_run_prelude(go_version);
     script.extend(write_importcfg_script(all_libs, None));
-    script.push(
-        "\"$GO\" tool link -importcfg \"$importcfg\" -buildmode=pie -o test_binary \"$SRC_TESTMAIN\"".to_string(),
-    );
+    // Variant ldflags inserted verbatim before `-o`.
+    let ldflags = if factors.ldflags.is_empty() {
+        String::new()
+    } else {
+        format!(" {}", factors.ldflags.join(" "))
+    };
+    script.push(format!(
+        "\"$GO\" tool link -importcfg \"$importcfg\" -buildmode=pie{ldflags} -o test_binary \"$SRC_TESTMAIN\""
+    ));
 
     let mut deps: BTreeMap<String, Value> = BTreeMap::new();
     deps.insert(
@@ -211,13 +217,14 @@ pub fn build_test_spec(
             Value::List(vec![Value::String("test_binary".to_string())]),
         )])),
     );
-    config.insert(
-        "runtime_env".to_string(),
-        Value::Map(HashMap::from([
-            ("GOOS".to_string(), Value::String(factors.goos.clone())),
-            ("GOARCH".to_string(), Value::String(factors.goarch.clone())),
-        ])),
-    );
+    let mut runtime_env = HashMap::from([
+        ("GOOS".to_string(), Value::String(factors.goos.clone())),
+        ("GOARCH".to_string(), Value::String(factors.goarch.clone())),
+    ]);
+    if let Some(exp) = factors.goexperiment_env() {
+        runtime_env.insert("GOEXPERIMENT".to_string(), Value::String(exp));
+    }
+    config.insert("runtime_env".to_string(), Value::Map(runtime_env));
     // CGO/toolchain pins live in `env` (hashed) so stale archives don't survive
     // cache lookups (pluginexec/mod.rs:70 excludes runtime_env from the def hash).
     config.insert("env".to_string(), go_build_env());
@@ -360,6 +367,7 @@ mod tests {
             goos: "linux".into(),
             goarch: "amd64".into(),
             build_tags: vec![],
+            ..Default::default()
         }
     }
 

--- a/crates/plugin-go/src/plugingo/thirdparty.rs
+++ b/crates/plugin-go/src/plugingo/thirdparty.rs
@@ -209,6 +209,7 @@ mod tests {
             goos: "linux".into(),
             goarch: "amd64".into(),
             build_tags: vec![],
+            ..Default::default()
         }
     }
 

--- a/crates/plugin-go/src/plugingo/variant.rs
+++ b/crates/plugin-go/src/plugingo/variant.rs
@@ -1,17 +1,30 @@
-//! Go build *variants*: named, static bundles of toolchain factors declared via
+//! Go build *variants*: named bundles of toolchain factors declared via
 //! `provider_state(provider="go", variants={...})`.
 //!
-//! A user-facing target selects a variant by name with a single `@v=NAME` addr
-//! arg; the provider resolves the closest ancestor package that defines that
-//! name ([`resolve_user`]) and threads the resulting `{v, vp}` coordinate (a
-//! [`VariantRef`]) — plus, verbatim, down the whole dependency graph — onto every
-//! internal / dependency address. An internal address therefore always carries
-//! both `v` and `vp`, and re-resolves to the *same* [`Factors`] no matter which
-//! subtree it lives in ([`resolve_internal`]).
+//! # Scoping — module, not repo
 //!
-//! Variants do **not** compound across the tree: each definition is static and
-//! self-contained. The closest-ancestor lookup only chooses *which* definition
-//! applies — it never merges a shallower one into a deeper one.
+//! Variants belong to a Go **module** (the `go.mod` directory). The *universe* of
+//! a module is every variant declared anywhere in that module's package subtree.
+//! Two resolution modes:
+//!
+//! - **Binary / entry targets** (`@v=NAME`, no `vp`): resolve by **ancestry**,
+//!   walking the target package up to (and including) its module root — the
+//!   closest declaration wins. Repo-level declarations *above* the module root do
+//!   not apply. See [`resolve_ancestry`].
+//! - **Library / dependency targets** (`@v=NAME,vp=PKG`): resolve `(name, vp)`
+//!   against the module **universe**. `vp` pins the declaring package, so the same
+//!   name declared at different levels stays unambiguous. See [`resolve_in_universe`].
+//!
+//! A binary threads the `{name, vp}` it resolved (`vp` = the winning declaring
+//! package) onto every dependency address, so libs re-resolve to the *same*
+//! factors no matter which subtree they live in — the universe is module-wide, so
+//! a variant declared at a sibling package is still found.
+//!
+//! # Inheritance
+//!
+//! A variant may carry `inherit = "OTHER"` to start from another variant in the
+//! **same `variants` map** and override selected fields (list fields replace, not
+//! append). `goos`/`goarch` may be omitted when inherited. Cycles are rejected.
 
 use crate::plugingo::factors::{Factors, VariantRef};
 use anyhow::{Context, bail};
@@ -19,13 +32,13 @@ use hcore::htvalue::{Value, parse_strings};
 use hmodel::htaddr::Addr;
 use hmodel::htpkg::PkgBuf;
 use hplugin::provider::{ProviderExecutor, State};
+use std::collections::BTreeMap;
 
 /// The go provider name, used to filter states fetched via the executor (which
 /// returns states for all providers).
 const GO_PROVIDER: &str = "go";
 
-/// Keys accepted inside a single variant definition struct. `goos`/`goarch` are
-/// required; the rest are optional.
+/// Keys accepted inside a single variant definition struct.
 const VARIANT_KEYS: &[&str] = &[
     "goos",
     "goarch",
@@ -33,11 +46,33 @@ const VARIANT_KEYS: &[&str] = &[
     "goexperiment",
     "gcflags",
     "ldflags",
+    "inherit",
 ];
 
-/// Parse one variant definition (`Value::Map`) into concrete [`Factors`].
-/// Rejects unknown keys and missing required fields (fail-fast).
-fn parse_variant_def(name: &str, v: &Value) -> anyhow::Result<Factors> {
+/// A variant definition before inheritance is applied: every factor is optional
+/// (an omitted field inherits from `inherit`, if any), plus the optional parent
+/// reference.
+#[derive(Debug, Clone, Default)]
+struct RawVariant {
+    goos: Option<String>,
+    goarch: Option<String>,
+    tags: Option<Vec<String>>,
+    goexperiment: Option<Vec<String>>,
+    gcflags: Option<Vec<String>>,
+    ldflags: Option<Vec<String>>,
+    inherit: Option<String>,
+}
+
+/// Whether `pkg` lies within the module rooted at `module_root` (i.e. is the root
+/// itself or a descendant). `module_root == ""` (a root `go.mod`) contains
+/// everything.
+fn under_module_root(pkg: &str, module_root: &str) -> bool {
+    module_root.is_empty() || pkg == module_root || pkg.starts_with(&format!("{module_root}/"))
+}
+
+/// Parse one raw variant definition (`Value::Map`). Rejects unknown keys; wrong
+/// value types fail-fast.
+fn parse_raw(name: &str, v: &Value) -> anyhow::Result<RawVariant> {
     let Value::Map(m) = v else {
         bail!("go variant `{name}` must be a struct, got: {v:?}");
     };
@@ -49,84 +84,196 @@ fn parse_variant_def(name: &str, v: &Value) -> anyhow::Result<Factors> {
             );
         }
     }
-    let req_str = |k: &str| -> anyhow::Result<String> {
+    let opt_str = |k: &str| -> anyhow::Result<Option<String>> {
         match m.get(k) {
-            Some(Value::String(s)) => Ok(s.clone()),
+            Some(Value::String(s)) => Ok(Some(s.clone())),
             Some(other) => bail!("go variant `{name}`: `{k}` must be a string, got: {other:?}"),
-            None => bail!("go variant `{name}`: `{k}` is required"),
+            None => Ok(None),
         }
     };
-    let goos = req_str("goos")?;
-    let goarch = req_str("goarch")?;
-    let list = |k: &str| -> anyhow::Result<Vec<String>> {
+    let opt_list = |k: &str| -> anyhow::Result<Option<Vec<String>>> {
         match m.get(k) {
             Some(val) => {
-                parse_strings(val).with_context(|| format!("go variant `{name}`: parsing `{k}`"))
+                Ok(Some(parse_strings(val).with_context(|| {
+                    format!("go variant `{name}`: parsing `{k}`")
+                })?))
             }
-            None => Ok(Vec::new()),
+            None => Ok(None),
         }
     };
-    let mut build_tags = list("tags")?;
-    build_tags.sort();
-    let mut goexperiment = list("goexperiment")?;
-    goexperiment.sort();
-    let gcflags = list("gcflags")?;
-    let ldflags = list("ldflags")?;
-    Ok(Factors {
-        goos,
-        goarch,
-        build_tags,
-        goexperiment,
-        gcflags,
-        ldflags,
+    Ok(RawVariant {
+        goos: opt_str("goos")?,
+        goarch: opt_str("goarch")?,
+        tags: opt_list("tags")?,
+        goexperiment: opt_list("goexperiment")?,
+        gcflags: opt_list("gcflags")?,
+        ldflags: opt_list("ldflags")?,
+        inherit: opt_str("inherit")?,
     })
 }
 
-/// Look up variant `name` in a single state's `variants` map.
-fn variant_in_state(state: &State, name: &str) -> anyhow::Result<Option<Factors>> {
+/// Parse a state's `variants` provider_state map into raw (pre-inheritance) defs.
+/// Returns an empty map if the state declares no variants.
+fn raw_variants(state: &State) -> anyhow::Result<BTreeMap<String, RawVariant>> {
     let Some(variants_val) = state.state.get("variants") else {
-        return Ok(None);
+        return Ok(BTreeMap::new());
     };
     let Value::Map(variants) = variants_val else {
         bail!("go provider_state `variants` must be a map, got: {variants_val:?}");
     };
-    match variants.get(name) {
-        Some(def) => Ok(Some(parse_variant_def(name, def)?)),
-        None => Ok(None),
-    }
+    variants
+        .iter()
+        .map(|(k, v)| Ok((k.clone(), parse_raw(k, v)?)))
+        .collect()
 }
 
-/// All variant names defined across `states`, sorted and deduped. Used to
-/// enumerate targets in `list` and to build helpful "available: [...]" errors.
+/// Resolve `name` within a single raw map, applying inheritance. `inherit`
+/// references another variant in the *same* map. `visiting` carries the active
+/// chain for cycle detection.
+fn resolve_in_map(
+    name: &str,
+    raw: &BTreeMap<String, RawVariant>,
+    visiting: &mut Vec<String>,
+) -> anyhow::Result<Factors> {
+    if visiting.iter().any(|n| n == name) {
+        visiting.push(name.to_string());
+        bail!("go variant inheritance cycle: {}", visiting.join(" -> "));
+    }
+    let def = raw
+        .get(name)
+        .ok_or_else(|| anyhow::anyhow!("go variant `{name}` is not defined"))?;
+
+    let mut f = match &def.inherit {
+        Some(parent) => {
+            visiting.push(name.to_string());
+            let base = resolve_in_map(parent, raw, visiting).with_context(|| {
+                format!("resolving go variant `{name}`'s `inherit = \"{parent}\"`")
+            })?;
+            visiting.pop();
+            base
+        }
+        None => Factors::default(),
+    };
+
+    // Declared fields overlay the (possibly inherited) base — list fields replace.
+    if let Some(v) = &def.goos {
+        f.goos = v.clone();
+    }
+    if let Some(v) = &def.goarch {
+        f.goarch = v.clone();
+    }
+    if let Some(v) = &def.tags {
+        f.build_tags = v.clone();
+        f.build_tags.sort();
+    }
+    if let Some(v) = &def.goexperiment {
+        f.goexperiment = v.clone();
+        f.goexperiment.sort();
+    }
+    if let Some(v) = &def.gcflags {
+        f.gcflags = v.clone();
+    }
+    if let Some(v) = &def.ldflags {
+        f.ldflags = v.clone();
+    }
+
+    if f.goos.is_empty() || f.goarch.is_empty() {
+        bail!(
+            "go variant `{name}`: `goos` and `goarch` are required \
+             (declare them, or inherit from a variant that does)"
+        );
+    }
+    Ok(f)
+}
+
+/// Look up `name` in a single state's variants (with inheritance), or `None` if
+/// the state doesn't declare it.
+fn variant_in_state(state: &State, name: &str) -> anyhow::Result<Option<Factors>> {
+    let raw = raw_variants(state)?;
+    if !raw.contains_key(name) {
+        return Ok(None);
+    }
+    Ok(Some(resolve_in_map(name, &raw, &mut Vec::new())?))
+}
+
+/// Every variant name declared across `states` (deduped, sorted) — for `list`
+/// enumeration and "available: [...]" errors.
 pub fn defined_variant_names(states: &[State]) -> Vec<String> {
     let mut names = std::collections::BTreeSet::new();
     for s in states {
-        if let Some(Value::Map(variants)) = s.state.get("variants") {
-            for k in variants.keys() {
-                names.insert(k.clone());
-            }
+        if let Ok(raw) = raw_variants(s) {
+            names.extend(raw.into_keys());
         }
     }
     names.into_iter().collect()
 }
 
-/// The [`VariantRef`]s applicable to a package (for `list` enumeration): one per
-/// distinct variant name defined in `states`, each pinned to its closest-ancestor
-/// defining package. `states` are the package's own ancestry.
-pub fn applicable(states: &[State]) -> Vec<VariantRef> {
-    defined_variant_names(states)
+/// The `(name, defining-pkg)` pairs applicable to a **binary/entry** target: one
+/// per variant name declared in the module-bounded ancestry, pinned to its
+/// closest declaring package. `states` is the target package's ancestry.
+pub fn ancestry_variants(states: &[State], module_root: &str) -> Vec<VariantRef> {
+    let mut names = std::collections::BTreeSet::new();
+    for s in states {
+        if under_module_root(s.package.as_str(), module_root)
+            && let Ok(raw) = raw_variants(s)
+        {
+            names.extend(raw.into_keys());
+        }
+    }
+    names
         .into_iter()
-        .filter_map(|name| resolve_user(&name, states).ok().map(|(_, vref)| vref))
+        .filter_map(|name| {
+            resolve_ancestry(&name, states, module_root)
+                .ok()
+                .map(|(_, v)| v)
+        })
         .collect()
 }
 
-/// Resolve a user-facing target's variant: pick the closest (deepest) ancestor
-/// package among `states` that defines variant `name`. `states` are the target
-/// package's own ancestry (already go-filtered by the engine), so the closest
-/// definition is the one with the longest package path.
-pub fn resolve_user(name: &str, states: &[State]) -> anyhow::Result<(Factors, VariantRef)> {
+/// The full module **universe** as `(VariantRef, Factors)` pairs — every variant
+/// declared anywhere in the module, keyed by `(name, declaring-pkg)`. `states`
+/// are all provider states in the module subtree ([`ProviderExecutor::states_under`]).
+/// A variant that fails to resolve (bad inheritance, missing goos) is a hard
+/// error — a broken declaration must surface, not be silently dropped.
+pub fn build_universe(states: &[State]) -> anyhow::Result<Vec<(VariantRef, Factors)>> {
+    let mut out = Vec::new();
+    for s in states {
+        if s.provider != GO_PROVIDER {
+            continue;
+        }
+        let raw = raw_variants(s)?;
+        for name in raw.keys() {
+            let f = resolve_in_map(name, &raw, &mut Vec::new())
+                .with_context(|| format!("in package `{}`", s.package.as_str()))?;
+            out.push((VariantRef::new(name.clone(), s.package.as_str()), f));
+        }
+    }
+    Ok(out)
+}
+
+/// The `VariantRef`s of a module **universe** — every `(name, declaring-pkg)`
+/// declared across `states` (a module subtree, from `states_under`). For `list`
+/// of library targets, so a variant declared at a sibling package is enumerated.
+pub fn universe_variants(states: &[State]) -> anyhow::Result<Vec<VariantRef>> {
+    Ok(build_universe(states)?
+        .into_iter()
+        .map(|(vref, _)| vref)
+        .collect())
+}
+
+/// Resolve a **binary/entry** target's variant: the closest (deepest) ancestor
+/// package that declares `name`, bounded at `module_root` (declarations above the
+/// module root are ignored). `states` is the target package's ancestry.
+pub fn resolve_ancestry(
+    name: &str,
+    states: &[State],
+    module_root: &str,
+) -> anyhow::Result<(Factors, VariantRef)> {
     let mut best: Option<(&State, Factors)> = None;
     for s in states {
+        if !under_module_root(s.package.as_str(), module_root) {
+            continue;
+        }
         if let Some(f) = variant_in_state(s, name)? {
             let deeper = match &best {
                 Some((bs, _)) => s.package.as_str().len() > bs.package.as_str().len(),
@@ -140,80 +287,79 @@ pub fn resolve_user(name: &str, states: &[State]) -> anyhow::Result<(Factors, Va
     match best {
         Some((s, f)) => Ok((f, VariantRef::new(name, s.package.as_str()))),
         None => bail!(
-            "no go variant `{name}` is defined for this package or any ancestor \
-             (available: [{}]); declare it with \
+            "no go variant `{name}` is declared for this package or any ancestor \
+             within its module (available: [{}]); declare it with \
              provider_state(provider=\"go\", variants={{\"{name}\": {{...}}}})",
             defined_variant_names(states).join(", ")
         ),
     }
 }
 
-/// Resolve an internal / dependency target's variant. The addr pins the defining
-/// package via `vp`, so the lookup is exact-package. Prefer the states the engine
-/// already provided (a hit whenever `vp` is an ancestor of the target — the
-/// common case, e.g. a root-defined variant); only when `vp` is in a disjoint
-/// subtree do we fetch its states through the executor.
-pub async fn resolve_internal(
+/// Resolve a **library** target's variant against a module universe: the exact
+/// `(name, vp)` entry. `universe` comes from [`build_universe`].
+pub fn resolve_in_universe(
     vref: &VariantRef,
-    states: &[State],
-    executor: &dyn ProviderExecutor,
+    universe: &[(VariantRef, Factors)],
 ) -> anyhow::Result<Factors> {
-    for s in states {
-        if s.package.as_str() == vref.pkg
-            && let Some(f) = variant_in_state(s, &vref.name)?
-        {
-            return Ok(f);
-        }
-    }
-    // `vp` is not in the target's own ancestry — fetch its states directly. This
-    // registers no dep edge (config lookup, not a build dependency).
-    let vp_states = executor
-        .states(&PkgBuf::from(vref.pkg.as_str()))
-        .await
-        .with_context(|| format!("fetching states for go variant package `{}`", vref.pkg))?;
-    for s in &vp_states {
-        if s.provider == GO_PROVIDER
-            && s.package.as_str() == vref.pkg
-            && let Some(f) = variant_in_state(s, &vref.name)?
-        {
-            return Ok(f);
-        }
-    }
-    bail!(
-        "go variant `{}` is not defined at package `{}` (pinned via the `vp` addr arg)",
-        vref.name,
-        vref.pkg
-    )
+    universe
+        .iter()
+        .find(|(v, _)| v.name == vref.name && v.pkg == vref.pkg)
+        .map(|(_, f)| f.clone())
+        .ok_or_else(|| {
+            anyhow::anyhow!(
+                "go variant `{}` is not declared at package `{}` (pinned via the `vp` addr arg)",
+                vref.name,
+                vref.pkg
+            )
+        })
 }
 
-/// Resolve the variant for any variant-parameterized target address, returning
-/// the concrete [`Factors`] plus the [`VariantRef`] to thread onto its sub-target
-/// and dependency addresses.
+/// Resolve the variant for any variant-parameterized target address.
 ///
-/// - internal / dep address (`v` + `vp`): exact-package lookup via
-///   [`resolve_internal`].
-/// - user address (`v` only): closest-ancestor lookup via [`resolve_user`].
+/// - **library / dependency** address (`v` + `vp`): exact `(name, vp)` lookup in
+///   the module universe (fetched via `executor.states_under(module_root)`).
+/// - **binary / entry** address (`v` only): closest-ancestor lookup, module-bounded.
 /// - no `v`: hard error — there is no implicit default variant.
+///
+/// `module_root` is the target's `go.mod` package (workspace-relative).
 pub async fn resolve(
     addr: &Addr,
-    states: &[State],
+    req_states: &[State],
+    module_root: &str,
     executor: &dyn ProviderExecutor,
 ) -> anyhow::Result<(Factors, VariantRef)> {
     let Some(name) = addr.args.get("v") else {
         bail!(
-            "go target `:{}` requires a variant: specify `@v=NAME` \
-             (available: [{}])",
+            "go target `:{}` requires a variant: specify `@v=NAME` (available: [{}])",
             addr.name,
-            defined_variant_names(states).join(", ")
+            defined_variant_names(req_states).join(", ")
         );
     };
     match addr.args.get("vp") {
         Some(vp) => {
             let vref = VariantRef::new(name.clone(), vp.clone());
-            let f = resolve_internal(&vref, states, executor).await?;
+            // Fast path: a `vp` already in the target's ancestry (`req_states` —
+            // common for a module-root-declared variant) needs no fetch.
+            if let Some(f) = req_states
+                .iter()
+                .filter(|s| s.package.as_str() == vp)
+                .find_map(|s| variant_in_state(s, name).transpose())
+                .transpose()?
+            {
+                return Ok((f, vref));
+            }
+            // Otherwise fetch `vp`'s own declaration directly. `states_under(vp)`
+            // includes `vp`'s package (siblings of the target are reachable this
+            // way, which ancestry-only `req_states` cannot supply).
+            let vp_states = executor
+                .states_under(&PkgBuf::from(vp.as_str()))
+                .await
+                .with_context(|| format!("fetching variant declaration at `{vp}`"))?;
+            let universe = build_universe(&vp_states)?;
+            let f = resolve_in_universe(&vref, &universe)?;
             Ok((f, vref))
         }
-        None => resolve_user(name, states),
+        None => resolve_ancestry(name, req_states, module_root),
     }
 }
 
@@ -245,59 +391,60 @@ mod tests {
         }
     }
 
+    fn s(x: &str) -> Value {
+        Value::String(x.into())
+    }
+
+    fn list(xs: &[&str]) -> Value {
+        Value::List(xs.iter().map(|x| Value::String((*x).into())).collect())
+    }
+
     fn linux_amd64() -> Value {
-        variant_val(&[
-            ("goos", Value::String("linux".into())),
-            ("goarch", Value::String("amd64".into())),
-        ])
+        variant_val(&[("goos", s("linux")), ("goarch", s("amd64"))])
     }
 
     #[test]
     fn parse_requires_goos_goarch() {
-        let err = parse_variant_def(
-            "v",
-            &variant_val(&[("goos", Value::String("linux".into()))]),
-        )
-        .unwrap_err();
-        assert!(err.to_string().contains("`goarch` is required"), "{err}");
+        let raw = go_state("", &[("v", variant_val(&[("goos", s("linux"))]))]);
+        let err = variant_in_state(&raw, "v").unwrap_err();
+        assert!(err.to_string().contains("required"), "{err}");
     }
 
     #[test]
     fn parse_rejects_unknown_key() {
-        let def = variant_val(&[
-            ("goos", Value::String("linux".into())),
-            ("goarch", Value::String("amd64".into())),
-            ("bogus", Value::Bool(true)),
-        ]);
-        let err = parse_variant_def("v", &def).unwrap_err();
+        let st = go_state(
+            "",
+            &[(
+                "v",
+                variant_val(&[
+                    ("goos", s("linux")),
+                    ("goarch", s("amd64")),
+                    ("bogus", s("x")),
+                ]),
+            )],
+        );
+        let err = variant_in_state(&st, "v").unwrap_err();
         assert!(err.to_string().contains("unknown key `bogus`"), "{err}");
     }
 
     #[test]
     fn parse_full_variant() {
-        let def = variant_val(&[
-            ("goos", Value::String("linux".into())),
-            ("goarch", Value::String("arm64".into())),
-            (
-                "tags",
-                Value::List(vec![Value::String("b".into()), Value::String("a".into())]),
-            ),
-            (
-                "goexperiment",
-                Value::List(vec![Value::String("arenas".into())]),
-            ),
-            (
-                "gcflags",
-                Value::List(vec![Value::String("-l".into()), Value::String("-N".into())]),
-            ),
-            (
-                "ldflags",
-                Value::List(vec![Value::String("-s".into()), Value::String("-w".into())]),
-            ),
-        ]);
-        let f = parse_variant_def("release", &def).unwrap();
-        assert_eq!(f.goos, "linux");
-        assert_eq!(f.goarch, "arm64");
+        let st = go_state(
+            "",
+            &[(
+                "release",
+                variant_val(&[
+                    ("goos", s("linux")),
+                    ("goarch", s("arm64")),
+                    ("tags", list(&["b", "a"])),
+                    ("goexperiment", list(&["arenas"])),
+                    ("gcflags", list(&["-l", "-N"])),
+                    ("ldflags", list(&["-s", "-w"])),
+                ]),
+            )],
+        );
+        let f = variant_in_state(&st, "release").unwrap().unwrap();
+        assert_eq!((f.goos.as_str(), f.goarch.as_str()), ("linux", "arm64"));
         assert_eq!(f.build_tags, vec!["a", "b"]); // sorted
         assert_eq!(f.goexperiment, vec!["arenas"]);
         assert_eq!(f.gcflags, vec!["-l", "-N"]); // order preserved
@@ -305,105 +452,148 @@ mod tests {
     }
 
     #[test]
-    fn resolve_user_picks_closest_ancestor() {
+    fn inherit_overlays_declared_fields() {
+        let st = go_state(
+            "",
+            &[
+                (
+                    "base",
+                    variant_val(&[
+                        ("goos", s("linux")),
+                        ("goarch", s("amd64")),
+                        ("tags", list(&["base"])),
+                        ("ldflags", list(&["-s"])),
+                    ]),
+                ),
+                (
+                    "release",
+                    // inherits base's goos/goarch/ldflags, overrides tags (replace).
+                    variant_val(&[("inherit", s("base")), ("tags", list(&["prod"]))]),
+                ),
+            ],
+        );
+        let f = variant_in_state(&st, "release").unwrap().unwrap();
+        assert_eq!((f.goos.as_str(), f.goarch.as_str()), ("linux", "amd64"));
+        assert_eq!(f.ldflags, vec!["-s"]); // inherited
+        assert_eq!(f.build_tags, vec!["prod"]); // replaced, not appended
+    }
+
+    #[test]
+    fn inherit_cycle_errors() {
+        let st = go_state(
+            "",
+            &[
+                ("a", variant_val(&[("inherit", s("b"))])),
+                ("b", variant_val(&[("inherit", s("a"))])),
+            ],
+        );
+        let err = variant_in_state(&st, "a").unwrap_err();
+        assert!(format!("{err:#}").contains("inheritance cycle"), "{err:#}");
+    }
+
+    #[test]
+    fn resolve_ancestry_picks_closest_within_module() {
+        // Repo root declares release=linux; the module root `app` overrides it
+        // darwin. A binary in `app` must get the module's, and the repo-root one
+        // (above the module) must be ignored.
         let states = vec![
             go_state("", &[("release", linux_amd64())]),
             go_state(
                 "app",
                 &[(
                     "release",
-                    variant_val(&[
-                        ("goos", Value::String("darwin".into())),
-                        ("goarch", Value::String("arm64".into())),
-                    ]),
+                    variant_val(&[("goos", s("darwin")), ("goarch", s("arm64"))]),
                 )],
             ),
         ];
-        let (f, vref) = resolve_user("release", &states).unwrap();
+        let (f, vref) = resolve_ancestry("release", &states, "app").unwrap();
         assert_eq!((f.goos.as_str(), f.goarch.as_str()), ("darwin", "arm64"));
-        assert_eq!(vref.pkg, "app"); // deepest definition wins
-        assert_eq!(vref.name, "release");
+        assert_eq!(vref.pkg, "app");
     }
 
     #[test]
-    fn resolve_user_unknown_variant_errors() {
+    fn resolve_ancestry_ignores_declarations_above_module_root() {
+        // release is only at the repo root, which is ABOVE the module root `app`.
         let states = vec![go_state("", &[("release", linux_amd64())])];
-        let err = resolve_user("prod", &states).unwrap_err();
-        assert!(err.to_string().contains("no go variant `prod`"), "{err}");
-        assert!(
-            err.to_string().contains("release"),
-            "lists available: {err}"
-        );
+        let err = resolve_ancestry("release", &states, "app").unwrap_err();
+        assert!(err.to_string().contains("no go variant `release`"), "{err}");
     }
 
-    /// Mock executor exercising the `states(pkg)` callback only. `result`/`query`
-    /// panic — `resolve_internal` must never reach them. `states(pkg)` returns the
-    /// registered states for that exact package (mirroring the engine, which
-    /// returns states for `pkg`'s whole ancestry, all providers).
-    struct StatesExec {
-        by_pkg: HashMap<String, Vec<State>>,
+    #[test]
+    fn universe_disambiguates_same_name_by_vp() {
+        // `release` at two packages with different factors — the universe keeps
+        // both, keyed by declaring package.
+        let module_states = vec![
+            go_state("app", &[("release", linux_amd64())]),
+            go_state(
+                "app/cmd",
+                &[(
+                    "release",
+                    variant_val(&[("goos", s("darwin")), ("goarch", s("arm64"))]),
+                )],
+            ),
+        ];
+        let universe = build_universe(&module_states).unwrap();
+        let at_app = resolve_in_universe(&VariantRef::new("release", "app"), &universe).unwrap();
+        let at_cmd =
+            resolve_in_universe(&VariantRef::new("release", "app/cmd"), &universe).unwrap();
+        assert_eq!(at_app.goos, "linux");
+        assert_eq!(at_cmd.goos, "darwin");
     }
 
-    impl ProviderExecutor for StatesExec {
+    /// Mock executor exercising `states_under` only; `result`/`query` must never
+    /// be reached during variant resolution.
+    struct UniverseExec {
+        under: HashMap<String, Vec<State>>,
+    }
+
+    impl ProviderExecutor for UniverseExec {
         fn result<'a>(
             &'a self,
             _addr: &'a Addr,
         ) -> futures::future::BoxFuture<'a, anyhow::Result<std::sync::Arc<hplugin::eresult::EResult>>>
         {
-            unimplemented!("resolve_internal must not resolve a result")
+            unimplemented!("variant resolution must not resolve a result")
         }
-
         fn query<'a>(
             &'a self,
             _m: &'a hmodel::htmatcher::Matcher,
             _skip: &'a [String],
         ) -> futures::future::BoxFuture<'a, anyhow::Result<Vec<Addr>>> {
-            unimplemented!("resolve_internal must not query")
+            unimplemented!("variant resolution must not query")
         }
-
-        fn states<'a>(
+        fn states_under<'a>(
             &'a self,
-            pkg: &'a PkgBuf,
+            prefix: &'a PkgBuf,
         ) -> futures::future::BoxFuture<'a, anyhow::Result<Vec<State>>> {
-            let out = self.by_pkg.get(pkg.as_str()).cloned().unwrap_or_default();
+            let out = self.under.get(prefix.as_str()).cloned().unwrap_or_default();
             Box::pin(async move { Ok(out) })
         }
     }
 
-    // The load-bearing case for cross-subtree deps: `release` is defined ONLY at
-    // `//cmd`. Building `//cmd:build@v=release` threads `vp=cmd` onto its dep
-    // `//lib:build_lib@v=release,vp=cmd`. When THAT dep resolves, the engine only
-    // hands it `//lib`'s ancestry — which does NOT contain `//cmd`'s variant (cmd
-    // is a sibling). `resolve_internal` must fall back to `executor.states(cmd)`.
+    // The load-bearing case: `release` is declared ONLY at sibling `//app/cmd`.
+    // A library `//app/lib`'s dep addr is pinned `vp=app/cmd`. Its own ancestry
+    // (module root `app`) does NOT contain it, so resolution must fetch the module
+    // universe via `states_under(app)` and find the sibling's declaration.
     #[tokio::test]
-    async fn resolve_internal_fetches_sibling_vp_via_executor() {
-        let lib_ancestry: Vec<State> = vec![]; // //lib sees no variant of its own
-        let exec = StatesExec {
-            by_pkg: HashMap::from([(
-                "cmd".to_string(),
-                vec![go_state("cmd", &[("release", linux_amd64())])],
+    async fn resolve_library_finds_sibling_variant_via_universe() {
+        let lib_ancestry: Vec<State> = vec![]; // //app/lib sees no variant of its own
+        let exec = UniverseExec {
+            // `states_under(vp)` — vp is the sibling `app/cmd`.
+            under: HashMap::from([(
+                "app/cmd".to_string(),
+                vec![go_state("app/cmd", &[("release", linux_amd64())])],
             )]),
         };
-        let vref = VariantRef::new("release", "cmd");
-        let f = resolve_internal(&vref, &lib_ancestry, &exec)
+        let addr = Addr::new(
+            PkgBuf::from("app/lib"),
+            "build_lib".to_string(),
+            VariantRef::new("release", "app/cmd").to_args(),
+        );
+        let (f, vref) = resolve(&addr, &lib_ancestry, "app", &exec)
             .await
-            .expect("sibling variant must resolve via executor.states");
+            .expect("sibling variant resolves via the module universe");
         assert_eq!((f.goos.as_str(), f.goarch.as_str()), ("linux", "amd64"));
-    }
-
-    // When `vp` IS in the target's own ancestry (the common root-defined case),
-    // the provided states satisfy the lookup and the executor is never touched
-    // (its `states` returns nothing here, and `result`/`query` would panic).
-    #[tokio::test]
-    async fn resolve_internal_uses_provided_states_without_executor() {
-        let states = vec![go_state("", &[("release", linux_amd64())])];
-        let exec = StatesExec {
-            by_pkg: HashMap::new(),
-        };
-        let vref = VariantRef::new("release", "");
-        let f = resolve_internal(&vref, &states, &exec)
-            .await
-            .expect("root variant resolves from provided states");
-        assert_eq!(f.goos, "linux");
+        assert_eq!(vref.pkg, "app/cmd");
     }
 }

--- a/crates/plugin-go/src/plugingo/variant.rs
+++ b/crates/plugin-go/src/plugingo/variant.rs
@@ -335,4 +335,75 @@ mod tests {
             "lists available: {err}"
         );
     }
+
+    /// Mock executor exercising the `states(pkg)` callback only. `result`/`query`
+    /// panic — `resolve_internal` must never reach them. `states(pkg)` returns the
+    /// registered states for that exact package (mirroring the engine, which
+    /// returns states for `pkg`'s whole ancestry, all providers).
+    struct StatesExec {
+        by_pkg: HashMap<String, Vec<State>>,
+    }
+
+    impl ProviderExecutor for StatesExec {
+        fn result<'a>(
+            &'a self,
+            _addr: &'a Addr,
+        ) -> futures::future::BoxFuture<'a, anyhow::Result<std::sync::Arc<hplugin::eresult::EResult>>>
+        {
+            unimplemented!("resolve_internal must not resolve a result")
+        }
+
+        fn query<'a>(
+            &'a self,
+            _m: &'a hmodel::htmatcher::Matcher,
+            _skip: &'a [String],
+        ) -> futures::future::BoxFuture<'a, anyhow::Result<Vec<Addr>>> {
+            unimplemented!("resolve_internal must not query")
+        }
+
+        fn states<'a>(
+            &'a self,
+            pkg: &'a PkgBuf,
+        ) -> futures::future::BoxFuture<'a, anyhow::Result<Vec<State>>> {
+            let out = self.by_pkg.get(pkg.as_str()).cloned().unwrap_or_default();
+            Box::pin(async move { Ok(out) })
+        }
+    }
+
+    // The load-bearing case for cross-subtree deps: `release` is defined ONLY at
+    // `//cmd`. Building `//cmd:build@v=release` threads `vp=cmd` onto its dep
+    // `//lib:build_lib@v=release,vp=cmd`. When THAT dep resolves, the engine only
+    // hands it `//lib`'s ancestry — which does NOT contain `//cmd`'s variant (cmd
+    // is a sibling). `resolve_internal` must fall back to `executor.states(cmd)`.
+    #[tokio::test]
+    async fn resolve_internal_fetches_sibling_vp_via_executor() {
+        let lib_ancestry: Vec<State> = vec![]; // //lib sees no variant of its own
+        let exec = StatesExec {
+            by_pkg: HashMap::from([(
+                "cmd".to_string(),
+                vec![go_state("cmd", &[("release", linux_amd64())])],
+            )]),
+        };
+        let vref = VariantRef::new("release", "cmd");
+        let f = resolve_internal(&vref, &lib_ancestry, &exec)
+            .await
+            .expect("sibling variant must resolve via executor.states");
+        assert_eq!((f.goos.as_str(), f.goarch.as_str()), ("linux", "amd64"));
+    }
+
+    // When `vp` IS in the target's own ancestry (the common root-defined case),
+    // the provided states satisfy the lookup and the executor is never touched
+    // (its `states` returns nothing here, and `result`/`query` would panic).
+    #[tokio::test]
+    async fn resolve_internal_uses_provided_states_without_executor() {
+        let states = vec![go_state("", &[("release", linux_amd64())])];
+        let exec = StatesExec {
+            by_pkg: HashMap::new(),
+        };
+        let vref = VariantRef::new("release", "");
+        let f = resolve_internal(&vref, &states, &exec)
+            .await
+            .expect("root variant resolves from provided states");
+        assert_eq!(f.goos, "linux");
+    }
 }

--- a/crates/plugin-go/src/plugingo/variant.rs
+++ b/crates/plugin-go/src/plugingo/variant.rs
@@ -208,10 +208,16 @@ pub fn defined_variant_names(states: &[State]) -> Vec<String> {
     names.into_iter().collect()
 }
 
-/// The `(name, defining-pkg)` pairs applicable to a **binary/entry** target: one
+/// The `(VariantRef, Factors)` pairs applicable to a **binary/entry** target: one
 /// per variant name declared in the module-bounded ancestry, pinned to its
-/// closest declaring package. `states` is the target package's ancestry.
-pub fn ancestry_variants(states: &[State], module_root: &str) -> Vec<VariantRef> {
+/// closest declaring package, with its resolved factors. `states` is the target
+/// package's ancestry. Callers map away the `Factors` when they only need the
+/// refs; those that must inspect factors (e.g. filter `test` targets to the host
+/// `goos`/`goarch`) keep them.
+pub fn ancestry_variants_with_factors(
+    states: &[State],
+    module_root: &str,
+) -> Vec<(VariantRef, Factors)> {
     let mut names = std::collections::BTreeSet::new();
     for s in states {
         if under_module_root(s.package.as_str(), module_root)
@@ -225,7 +231,7 @@ pub fn ancestry_variants(states: &[State], module_root: &str) -> Vec<VariantRef>
         .filter_map(|name| {
             resolve_ancestry(&name, states, module_root)
                 .ok()
-                .map(|(_, v)| v)
+                .map(|(f, v)| (v, f))
         })
         .collect()
 }

--- a/crates/plugin-go/src/plugingo/variant.rs
+++ b/crates/plugin-go/src/plugingo/variant.rs
@@ -342,7 +342,13 @@ pub async fn resolve(
         );
     };
     match addr.args.get("vp") {
-        Some(vp) => {
+        // Only honor `vp` when it lies within the target's OWN go module. The
+        // variant universe is bounded to the module: a `vp` threaded from a
+        // consumer in a *different* module (a cross-module dependency) must not
+        // drag that foreign module's variant declaration in. Re-resolve the name
+        // by ancestry within this module instead — the dep provides its own
+        // same-named variant, or it is genuinely undeclared here.
+        Some(vp) if under_module_root(vp, module_root) => {
             let vref = VariantRef::new(name.clone(), vp.clone());
             // Fast path: a `vp` already in the target's ancestry (`req_states` —
             // common for a module-root-declared variant) needs no fetch.
@@ -365,7 +371,8 @@ pub async fn resolve(
             let f = resolve_in_universe(&vref, &universe)?;
             Ok((f, vref))
         }
-        None => resolve_ancestry(name, req_states, module_root),
+        // No `vp`, or a `vp` outside this module: resolve by module-bounded ancestry.
+        _ => resolve_ancestry(name, req_states, module_root),
     }
 }
 
@@ -601,5 +608,33 @@ mod tests {
             .expect("sibling variant resolves via the module universe");
         assert_eq!((f.goos.as_str(), f.goarch.as_str()), ("linux", "amd64"));
         assert_eq!(vref.pkg, "app/cmd");
+    }
+
+    // A `vp` from a consumer in a DIFFERENT go module (a cross-module dependency)
+    // must NOT be honored: the universe is bounded to the target's own module.
+    // Here `dev/app/graphql`'s dep addr carries `vp=mgmt/go` (a foreign module);
+    // resolution ignores it and resolves `release` by ancestry within `dev/app`,
+    // rebasing `vp` to the target's own module. `states_under` is never consulted.
+    #[tokio::test]
+    async fn foreign_vp_outside_module_resolves_by_ancestry() {
+        let ancestry = vec![go_state("dev/app", &[("release", linux_amd64())])];
+        // Empty universe: if resolution wrongly consulted `states_under(mgmt/go)`
+        // it would find nothing and fail, proving the ancestry path is taken.
+        let exec = UniverseExec {
+            under: HashMap::new(),
+        };
+        let addr = Addr::new(
+            PkgBuf::from("dev/app/graphql"),
+            "build_lib".to_string(),
+            VariantRef::new("release", "mgmt/go").to_args(),
+        );
+        let (f, vref) = resolve(&addr, &ancestry, "dev/app", &exec)
+            .await
+            .expect("foreign vp falls back to module-bounded ancestry");
+        assert_eq!((f.goos.as_str(), f.goarch.as_str()), ("linux", "amd64"));
+        assert_eq!(
+            vref.pkg, "dev/app",
+            "vp rebased to the target's own module, not the foreign `mgmt/go`"
+        );
     }
 }

--- a/crates/plugin-go/src/plugingo/variant.rs
+++ b/crates/plugin-go/src/plugingo/variant.rs
@@ -33,7 +33,6 @@ const VARIANT_KEYS: &[&str] = &[
     "goexperiment",
     "gcflags",
     "ldflags",
-    "cgo_enabled",
 ];
 
 /// Parse one variant definition (`Value::Map`) into concrete [`Factors`].
@@ -73,11 +72,6 @@ fn parse_variant_def(name: &str, v: &Value) -> anyhow::Result<Factors> {
     goexperiment.sort();
     let gcflags = list("gcflags")?;
     let ldflags = list("ldflags")?;
-    let cgo_enabled = match m.get("cgo_enabled") {
-        Some(Value::Bool(b)) => *b,
-        Some(other) => bail!("go variant `{name}`: `cgo_enabled` must be a bool, got: {other:?}"),
-        None => false,
-    };
     Ok(Factors {
         goos,
         goarch,
@@ -85,7 +79,6 @@ fn parse_variant_def(name: &str, v: &Value) -> anyhow::Result<Factors> {
         goexperiment,
         gcflags,
         ldflags,
-        cgo_enabled,
     })
 }
 
@@ -301,7 +294,6 @@ mod tests {
                 "ldflags",
                 Value::List(vec![Value::String("-s".into()), Value::String("-w".into())]),
             ),
-            ("cgo_enabled", Value::Bool(true)),
         ]);
         let f = parse_variant_def("release", &def).unwrap();
         assert_eq!(f.goos, "linux");
@@ -310,7 +302,6 @@ mod tests {
         assert_eq!(f.goexperiment, vec!["arenas"]);
         assert_eq!(f.gcflags, vec!["-l", "-N"]); // order preserved
         assert_eq!(f.ldflags, vec!["-s", "-w"]);
-        assert!(f.cgo_enabled);
     }
 
     #[test]

--- a/crates/plugin-go/src/plugingo/variant.rs
+++ b/crates/plugin-go/src/plugingo/variant.rs
@@ -1,0 +1,347 @@
+//! Go build *variants*: named, static bundles of toolchain factors declared via
+//! `provider_state(provider="go", variants={...})`.
+//!
+//! A user-facing target selects a variant by name with a single `@v=NAME` addr
+//! arg; the provider resolves the closest ancestor package that defines that
+//! name ([`resolve_user`]) and threads the resulting `{v, vp}` coordinate (a
+//! [`VariantRef`]) — plus, verbatim, down the whole dependency graph — onto every
+//! internal / dependency address. An internal address therefore always carries
+//! both `v` and `vp`, and re-resolves to the *same* [`Factors`] no matter which
+//! subtree it lives in ([`resolve_internal`]).
+//!
+//! Variants do **not** compound across the tree: each definition is static and
+//! self-contained. The closest-ancestor lookup only chooses *which* definition
+//! applies — it never merges a shallower one into a deeper one.
+
+use crate::plugingo::factors::{Factors, VariantRef};
+use anyhow::{Context, bail};
+use hcore::htvalue::{Value, parse_strings};
+use hmodel::htaddr::Addr;
+use hmodel::htpkg::PkgBuf;
+use hplugin::provider::{ProviderExecutor, State};
+
+/// The go provider name, used to filter states fetched via the executor (which
+/// returns states for all providers).
+const GO_PROVIDER: &str = "go";
+
+/// Keys accepted inside a single variant definition struct. `goos`/`goarch` are
+/// required; the rest are optional.
+const VARIANT_KEYS: &[&str] = &[
+    "goos",
+    "goarch",
+    "tags",
+    "goexperiment",
+    "gcflags",
+    "ldflags",
+    "cgo_enabled",
+];
+
+/// Parse one variant definition (`Value::Map`) into concrete [`Factors`].
+/// Rejects unknown keys and missing required fields (fail-fast).
+fn parse_variant_def(name: &str, v: &Value) -> anyhow::Result<Factors> {
+    let Value::Map(m) = v else {
+        bail!("go variant `{name}` must be a struct, got: {v:?}");
+    };
+    for key in m.keys() {
+        if !VARIANT_KEYS.contains(&key.as_str()) {
+            bail!(
+                "unknown key `{key}` in go variant `{name}` (allowed: {})",
+                VARIANT_KEYS.join(", ")
+            );
+        }
+    }
+    let req_str = |k: &str| -> anyhow::Result<String> {
+        match m.get(k) {
+            Some(Value::String(s)) => Ok(s.clone()),
+            Some(other) => bail!("go variant `{name}`: `{k}` must be a string, got: {other:?}"),
+            None => bail!("go variant `{name}`: `{k}` is required"),
+        }
+    };
+    let goos = req_str("goos")?;
+    let goarch = req_str("goarch")?;
+    let list = |k: &str| -> anyhow::Result<Vec<String>> {
+        match m.get(k) {
+            Some(val) => {
+                parse_strings(val).with_context(|| format!("go variant `{name}`: parsing `{k}`"))
+            }
+            None => Ok(Vec::new()),
+        }
+    };
+    let mut build_tags = list("tags")?;
+    build_tags.sort();
+    let mut goexperiment = list("goexperiment")?;
+    goexperiment.sort();
+    let gcflags = list("gcflags")?;
+    let ldflags = list("ldflags")?;
+    let cgo_enabled = match m.get("cgo_enabled") {
+        Some(Value::Bool(b)) => *b,
+        Some(other) => bail!("go variant `{name}`: `cgo_enabled` must be a bool, got: {other:?}"),
+        None => false,
+    };
+    Ok(Factors {
+        goos,
+        goarch,
+        build_tags,
+        goexperiment,
+        gcflags,
+        ldflags,
+        cgo_enabled,
+    })
+}
+
+/// Look up variant `name` in a single state's `variants` map.
+fn variant_in_state(state: &State, name: &str) -> anyhow::Result<Option<Factors>> {
+    let Some(variants_val) = state.state.get("variants") else {
+        return Ok(None);
+    };
+    let Value::Map(variants) = variants_val else {
+        bail!("go provider_state `variants` must be a map, got: {variants_val:?}");
+    };
+    match variants.get(name) {
+        Some(def) => Ok(Some(parse_variant_def(name, def)?)),
+        None => Ok(None),
+    }
+}
+
+/// All variant names defined across `states`, sorted and deduped. Used to
+/// enumerate targets in `list` and to build helpful "available: [...]" errors.
+pub fn defined_variant_names(states: &[State]) -> Vec<String> {
+    let mut names = std::collections::BTreeSet::new();
+    for s in states {
+        if let Some(Value::Map(variants)) = s.state.get("variants") {
+            for k in variants.keys() {
+                names.insert(k.clone());
+            }
+        }
+    }
+    names.into_iter().collect()
+}
+
+/// The [`VariantRef`]s applicable to a package (for `list` enumeration): one per
+/// distinct variant name defined in `states`, each pinned to its closest-ancestor
+/// defining package. `states` are the package's own ancestry.
+pub fn applicable(states: &[State]) -> Vec<VariantRef> {
+    defined_variant_names(states)
+        .into_iter()
+        .filter_map(|name| resolve_user(&name, states).ok().map(|(_, vref)| vref))
+        .collect()
+}
+
+/// Resolve a user-facing target's variant: pick the closest (deepest) ancestor
+/// package among `states` that defines variant `name`. `states` are the target
+/// package's own ancestry (already go-filtered by the engine), so the closest
+/// definition is the one with the longest package path.
+pub fn resolve_user(name: &str, states: &[State]) -> anyhow::Result<(Factors, VariantRef)> {
+    let mut best: Option<(&State, Factors)> = None;
+    for s in states {
+        if let Some(f) = variant_in_state(s, name)? {
+            let deeper = match &best {
+                Some((bs, _)) => s.package.as_str().len() > bs.package.as_str().len(),
+                None => true,
+            };
+            if deeper {
+                best = Some((s, f));
+            }
+        }
+    }
+    match best {
+        Some((s, f)) => Ok((f, VariantRef::new(name, s.package.as_str()))),
+        None => bail!(
+            "no go variant `{name}` is defined for this package or any ancestor \
+             (available: [{}]); declare it with \
+             provider_state(provider=\"go\", variants={{\"{name}\": {{...}}}})",
+            defined_variant_names(states).join(", ")
+        ),
+    }
+}
+
+/// Resolve an internal / dependency target's variant. The addr pins the defining
+/// package via `vp`, so the lookup is exact-package. Prefer the states the engine
+/// already provided (a hit whenever `vp` is an ancestor of the target — the
+/// common case, e.g. a root-defined variant); only when `vp` is in a disjoint
+/// subtree do we fetch its states through the executor.
+pub async fn resolve_internal(
+    vref: &VariantRef,
+    states: &[State],
+    executor: &dyn ProviderExecutor,
+) -> anyhow::Result<Factors> {
+    for s in states {
+        if s.package.as_str() == vref.pkg
+            && let Some(f) = variant_in_state(s, &vref.name)?
+        {
+            return Ok(f);
+        }
+    }
+    // `vp` is not in the target's own ancestry — fetch its states directly. This
+    // registers no dep edge (config lookup, not a build dependency).
+    let vp_states = executor
+        .states(&PkgBuf::from(vref.pkg.as_str()))
+        .await
+        .with_context(|| format!("fetching states for go variant package `{}`", vref.pkg))?;
+    for s in &vp_states {
+        if s.provider == GO_PROVIDER
+            && s.package.as_str() == vref.pkg
+            && let Some(f) = variant_in_state(s, &vref.name)?
+        {
+            return Ok(f);
+        }
+    }
+    bail!(
+        "go variant `{}` is not defined at package `{}` (pinned via the `vp` addr arg)",
+        vref.name,
+        vref.pkg
+    )
+}
+
+/// Resolve the variant for any variant-parameterized target address, returning
+/// the concrete [`Factors`] plus the [`VariantRef`] to thread onto its sub-target
+/// and dependency addresses.
+///
+/// - internal / dep address (`v` + `vp`): exact-package lookup via
+///   [`resolve_internal`].
+/// - user address (`v` only): closest-ancestor lookup via [`resolve_user`].
+/// - no `v`: hard error — there is no implicit default variant.
+pub async fn resolve(
+    addr: &Addr,
+    states: &[State],
+    executor: &dyn ProviderExecutor,
+) -> anyhow::Result<(Factors, VariantRef)> {
+    let Some(name) = addr.args.get("v") else {
+        bail!(
+            "go target `:{}` requires a variant: specify `@v=NAME` \
+             (available: [{}])",
+            addr.name,
+            defined_variant_names(states).join(", ")
+        );
+    };
+    match addr.args.get("vp") {
+        Some(vp) => {
+            let vref = VariantRef::new(name.clone(), vp.clone());
+            let f = resolve_internal(&vref, states, executor).await?;
+            Ok((f, vref))
+        }
+        None => resolve_user(name, states),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use hcore::htvalue::Value;
+    use hmodel::htpkg::PkgBuf;
+    use std::collections::HashMap;
+
+    fn variant_val(fields: &[(&str, Value)]) -> Value {
+        Value::Map(
+            fields
+                .iter()
+                .map(|(k, v)| (k.to_string(), v.clone()))
+                .collect(),
+        )
+    }
+
+    fn go_state(pkg: &str, variants: &[(&str, Value)]) -> State {
+        let variants_map: HashMap<String, Value> = variants
+            .iter()
+            .map(|(k, v)| (k.to_string(), v.clone()))
+            .collect();
+        State {
+            package: PkgBuf::from(pkg),
+            provider: GO_PROVIDER.to_string(),
+            state: HashMap::from([("variants".to_string(), Value::Map(variants_map))]),
+        }
+    }
+
+    fn linux_amd64() -> Value {
+        variant_val(&[
+            ("goos", Value::String("linux".into())),
+            ("goarch", Value::String("amd64".into())),
+        ])
+    }
+
+    #[test]
+    fn parse_requires_goos_goarch() {
+        let err = parse_variant_def(
+            "v",
+            &variant_val(&[("goos", Value::String("linux".into()))]),
+        )
+        .unwrap_err();
+        assert!(err.to_string().contains("`goarch` is required"), "{err}");
+    }
+
+    #[test]
+    fn parse_rejects_unknown_key() {
+        let def = variant_val(&[
+            ("goos", Value::String("linux".into())),
+            ("goarch", Value::String("amd64".into())),
+            ("bogus", Value::Bool(true)),
+        ]);
+        let err = parse_variant_def("v", &def).unwrap_err();
+        assert!(err.to_string().contains("unknown key `bogus`"), "{err}");
+    }
+
+    #[test]
+    fn parse_full_variant() {
+        let def = variant_val(&[
+            ("goos", Value::String("linux".into())),
+            ("goarch", Value::String("arm64".into())),
+            (
+                "tags",
+                Value::List(vec![Value::String("b".into()), Value::String("a".into())]),
+            ),
+            (
+                "goexperiment",
+                Value::List(vec![Value::String("arenas".into())]),
+            ),
+            (
+                "gcflags",
+                Value::List(vec![Value::String("-l".into()), Value::String("-N".into())]),
+            ),
+            (
+                "ldflags",
+                Value::List(vec![Value::String("-s".into()), Value::String("-w".into())]),
+            ),
+            ("cgo_enabled", Value::Bool(true)),
+        ]);
+        let f = parse_variant_def("release", &def).unwrap();
+        assert_eq!(f.goos, "linux");
+        assert_eq!(f.goarch, "arm64");
+        assert_eq!(f.build_tags, vec!["a", "b"]); // sorted
+        assert_eq!(f.goexperiment, vec!["arenas"]);
+        assert_eq!(f.gcflags, vec!["-l", "-N"]); // order preserved
+        assert_eq!(f.ldflags, vec!["-s", "-w"]);
+        assert!(f.cgo_enabled);
+    }
+
+    #[test]
+    fn resolve_user_picks_closest_ancestor() {
+        let states = vec![
+            go_state("", &[("release", linux_amd64())]),
+            go_state(
+                "app",
+                &[(
+                    "release",
+                    variant_val(&[
+                        ("goos", Value::String("darwin".into())),
+                        ("goarch", Value::String("arm64".into())),
+                    ]),
+                )],
+            ),
+        ];
+        let (f, vref) = resolve_user("release", &states).unwrap();
+        assert_eq!((f.goos.as_str(), f.goarch.as_str()), ("darwin", "arm64"));
+        assert_eq!(vref.pkg, "app"); // deepest definition wins
+        assert_eq!(vref.name, "release");
+    }
+
+    #[test]
+    fn resolve_user_unknown_variant_errors() {
+        let states = vec![go_state("", &[("release", linux_amd64())])];
+        let err = resolve_user("prod", &states).unwrap_err();
+        assert!(err.to_string().contains("no go variant `prod`"), "{err}");
+        assert!(
+            err.to_string().contains("release"),
+            "lists available: {err}"
+        );
+    }
+}

--- a/crates/plugin-go/src/plugingo/variant.rs
+++ b/crates/plugin-go/src/plugingo/variant.rs
@@ -328,11 +328,18 @@ pub fn resolve_in_universe(
 /// - no `v`: hard error — there is no implicit default variant.
 ///
 /// `module_root` is the target's `go.mod` package (workspace-relative).
+/// `vp_same_module` says whether the addr's `vp` (if any) names a package in the
+/// target's *own* go module — a real nearest-`go.mod` check the caller performs
+/// (a plain path-prefix test is insufficient: a `vp` can prefix-match while
+/// living inside a *nested* submodule). Only an in-module `vp` is honored; a
+/// foreign one (a cross-module dependency's pin) is ignored so its module's
+/// variant declaration can't leak in.
 pub async fn resolve(
     addr: &Addr,
     req_states: &[State],
     module_root: &str,
     executor: &dyn ProviderExecutor,
+    vp_same_module: bool,
 ) -> anyhow::Result<(Factors, VariantRef)> {
     let Some(name) = addr.args.get("v") else {
         bail!(
@@ -348,7 +355,7 @@ pub async fn resolve(
         // drag that foreign module's variant declaration in. Re-resolve the name
         // by ancestry within this module instead — the dep provides its own
         // same-named variant, or it is genuinely undeclared here.
-        Some(vp) if under_module_root(vp, module_root) => {
+        Some(vp) if vp_same_module => {
             let vref = VariantRef::new(name.clone(), vp.clone());
             // Fast path: a `vp` already in the target's ancestry (`req_states` —
             // common for a module-root-declared variant) needs no fetch.
@@ -603,7 +610,7 @@ mod tests {
             "build_lib".to_string(),
             VariantRef::new("release", "app/cmd").to_args(),
         );
-        let (f, vref) = resolve(&addr, &lib_ancestry, "app", &exec)
+        let (f, vref) = resolve(&addr, &lib_ancestry, "app", &exec, true)
             .await
             .expect("sibling variant resolves via the module universe");
         assert_eq!((f.goos.as_str(), f.goarch.as_str()), ("linux", "amd64"));
@@ -612,9 +619,10 @@ mod tests {
 
     // A `vp` from a consumer in a DIFFERENT go module (a cross-module dependency)
     // must NOT be honored: the universe is bounded to the target's own module.
-    // Here `dev/app/graphql`'s dep addr carries `vp=mgmt/go` (a foreign module);
-    // resolution ignores it and resolves `release` by ancestry within `dev/app`,
-    // rebasing `vp` to the target's own module. `states_under` is never consulted.
+    // Here `dev/app/graphql`'s dep addr carries `vp=mgmt/go` (a foreign module),
+    // so the caller passes `vp_same_module = false`; resolution ignores the `vp`
+    // and resolves `release` by ancestry within `dev/app`, rebasing `vp` to the
+    // target's own module. `states_under` is never consulted.
     #[tokio::test]
     async fn foreign_vp_outside_module_resolves_by_ancestry() {
         let ancestry = vec![go_state("dev/app", &[("release", linux_amd64())])];
@@ -628,7 +636,7 @@ mod tests {
             "build_lib".to_string(),
             VariantRef::new("release", "mgmt/go").to_args(),
         );
-        let (f, vref) = resolve(&addr, &ancestry, "dev/app", &exec)
+        let (f, vref) = resolve(&addr, &ancestry, "dev/app", &exec, false)
             .await
             .expect("foreign vp falls back to module-bounded ancestry");
         assert_eq!((f.goos.as_str(), f.goarch.as_str()), ("linux", "amd64"));

--- a/crates/plugin-sdk/src/guest.rs
+++ b/crates/plugin-sdk/src/guest.rs
@@ -7,8 +7,9 @@ use futures::future::BoxFuture;
 use hcore::hartifactcontent::{Content, WalkEntry};
 use hmodel::htaddr::Addr;
 use hmodel::htmatcher::Matcher;
+use hmodel::htpkg::PkgBuf;
 use hplugin::eresult::{ArtifactMeta, EResult};
-use hplugin::provider::ProviderExecutor;
+use hplugin::provider::{ProviderExecutor, State};
 use hplugin_stabby::abi::{
     DynArtifact, DynExecutor, DynRead, StableAddr, StableArtifactContentDyn, StableExecutorDyn,
     StableReadDyn,
@@ -108,6 +109,23 @@ impl ProviderExecutor for GuestExecutor {
                 let mut out = Vec::with_capacity(r.addrs.len());
                 for a in r.addrs.iter() {
                     out.push(hmodel::htaddr::parse_addr(a)?);
+                }
+                Ok(out)
+            } else {
+                anyhow::bail!("{}", r.message)
+            }
+        })
+    }
+
+    fn states<'a>(&'a self, pkg: &'a PkgBuf) -> BoxFuture<'a, Result<Vec<State>>> {
+        Box::pin(async move {
+            let r = self.exec.states(pkg.as_str().into()).await;
+            if r.ok {
+                let mut out = Vec::with_capacity(r.states.len());
+                for b in r.states.iter() {
+                    let pb = plugin_abi::pb::State::decode(&b[..])
+                        .context("decoding pb::State from host states callback")?;
+                    out.push(plugin_abi::convert::state_from_pb(pb));
                 }
                 Ok(out)
             } else {

--- a/crates/plugin-sdk/src/guest.rs
+++ b/crates/plugin-sdk/src/guest.rs
@@ -117,14 +117,14 @@ impl ProviderExecutor for GuestExecutor {
         })
     }
 
-    fn states<'a>(&'a self, pkg: &'a PkgBuf) -> BoxFuture<'a, Result<Vec<State>>> {
+    fn states_under<'a>(&'a self, prefix: &'a PkgBuf) -> BoxFuture<'a, Result<Vec<State>>> {
         Box::pin(async move {
-            let r = self.exec.states(pkg.as_str().into()).await;
+            let r = self.exec.states_under(prefix.as_str().into()).await;
             if r.ok {
                 let mut out = Vec::with_capacity(r.states.len());
                 for b in r.states.iter() {
                     let pb = plugin_abi::pb::State::decode(&b[..])
-                        .context("decoding pb::State from host states callback")?;
+                        .context("decoding pb::State from host states_under callback")?;
                     out.push(plugin_abi::convert::state_from_pb(pb));
                 }
                 Ok(out)

--- a/crates/plugin-sdk/src/serve.rs
+++ b/crates/plugin-sdk/src/serve.rs
@@ -307,13 +307,19 @@ fn unimplemented(method: u32) -> SVec<u8> {
 // Server-streaming: the provider's iterator is pulled lazily across the seam (one
 // item per `StableItemStream::next`), never materialized into one blob.
 
-async fn provider_list_stream(provider: Arc<dyn Provider>, req: SVec<u8>) -> DynItemStream {
+async fn provider_list_stream(
+    provider: Arc<dyn Provider>,
+    req: SVec<u8>,
+    exec: DynExecutor,
+) -> DynItemStream {
     let req = pb::ListRequest::decode(&req[..]).unwrap_or_default();
     let tok = StdCancellationToken::new();
+    let executor: Arc<dyn ProviderExecutor> = Arc::new(GuestExecutor::new(exec));
     let lreq = ListRequest {
         request_id: req.request_id,
         package: PkgBuf::from(req.package),
         states: req.states.into_iter().map(convert::state_from_pb).collect(),
+        executor,
     };
     match provider.list(lreq, &tok).await {
         Ok(iter) => make_item_stream(frame_iter(iter, |lr| {
@@ -542,10 +548,25 @@ impl StableProvider for StableProviderImpl {
         let provider = Arc::clone(&self.provider);
         dynify(stabby::boxed::Box::new(async move {
             match pb::ProviderMethod::try_from(method as i32) {
-                Ok(pb::ProviderMethod::List) => provider_list_stream(provider, req).await,
+                // `List` rides `invoke_exec_server_stream` (it needs an executor).
                 Ok(pb::ProviderMethod::ListPackages) => {
                     provider_list_packages_stream(provider, req).await
                 }
+                _ => unimplemented_item_stream(method),
+            }
+        }))
+    }
+
+    extern "C" fn invoke_exec_server_stream<'a>(
+        &'a self,
+        method: u32,
+        req: SVec<u8>,
+        exec: DynExecutor,
+    ) -> DynFuture<'a, DynItemStream> {
+        let provider = Arc::clone(&self.provider);
+        dynify(stabby::boxed::Box::new(async move {
+            match pb::ProviderMethod::try_from(method as i32) {
+                Ok(pb::ProviderMethod::List) => provider_list_stream(provider, req, exec).await,
                 _ => unimplemented_item_stream(method),
             }
         }))
@@ -1481,6 +1502,7 @@ mod tests {
                 request_id: String::new(),
                 package: PkgBuf::from("p"),
                 states: vec![],
+                executor: Arc::new(hplugin::provider::NoopExecutor),
             },
             &tok,
         ))

--- a/crates/plugin-stabby/src/abi.rs
+++ b/crates/plugin-stabby/src/abi.rs
@@ -94,6 +94,17 @@ pub struct QueryOutcome {
     pub addrs: SVec<SString>,
 }
 
+/// Outcome of a `states` call. `State` has no canonical string form, so each
+/// state crosses as prost-encoded `pb::State` bytes — mirroring how `query`'s
+/// matcher crosses as `SVec<u8>`.
+#[stabby::stabby]
+pub struct StatesOutcome {
+    pub ok: bool,
+    pub message: SString,
+    /// Each entry is a prost-encoded `pb::State`.
+    pub states: SVec<SVec<u8>>,
+}
+
 /// The host callback surface, called by the plugin while serving `get`/`parse`.
 /// Mirrors `hplugin::provider::ProviderExecutor`. Implemented host-side over the
 /// real engine executor ([`crate::host`]); consumed guest-side wrapped back into
@@ -114,6 +125,9 @@ pub trait StableExecutor {
         matcher_pb: SVec<u8>,
         extra_skip: SVec<SString>,
     ) -> DynFuture<'a, QueryOutcome>;
+    /// Fetch provider states for `pkg` and its ancestry (config lookup; no dep
+    /// edge). `pkg` is the package path string.
+    extern "C" fn states<'a>(&'a self, pkg: SString) -> DynFuture<'a, StatesOutcome>;
 }
 
 /// An owned, ABI-stable handle to a host executor — what the host passes into the

--- a/crates/plugin-stabby/src/abi.rs
+++ b/crates/plugin-stabby/src/abi.rs
@@ -94,9 +94,9 @@ pub struct QueryOutcome {
     pub addrs: SVec<SString>,
 }
 
-/// Outcome of a `states` call. `State` has no canonical string form, so each
-/// state crosses as prost-encoded `pb::State` bytes — mirroring how `query`'s
-/// matcher crosses as `SVec<u8>`.
+/// Outcome of a `states_under` call. `State` has no canonical string form, so
+/// each state crosses as prost-encoded `pb::State` bytes — mirroring how
+/// `query`'s matcher crosses as `SVec<u8>`.
 #[stabby::stabby]
 pub struct StatesOutcome {
     pub ok: bool,
@@ -125,9 +125,9 @@ pub trait StableExecutor {
         matcher_pb: SVec<u8>,
         extra_skip: SVec<SString>,
     ) -> DynFuture<'a, QueryOutcome>;
-    /// Fetch provider states for `pkg` and its ancestry (config lookup; no dep
-    /// edge). `pkg` is the package path string.
-    extern "C" fn states<'a>(&'a self, pkg: SString) -> DynFuture<'a, StatesOutcome>;
+    /// Fetch provider states for every package at or under `prefix` — the
+    /// downward subtree (config lookup; no dep edge). `prefix` is a package path.
+    extern "C" fn states_under<'a>(&'a self, prefix: SString) -> DynFuture<'a, StatesOutcome>;
 }
 
 /// An owned, ABI-stable handle to a host executor — what the host passes into the
@@ -223,6 +223,16 @@ pub trait StableProvider {
         req: SVec<u8>,
         exec: DynExecutor,
     ) -> DynFuture<'a, SVec<u8>>;
+    /// Server-streaming **with** a native [`DynExecutor`] — for `list`, whose
+    /// enumeration may call back (e.g. the go plugin gathering a module's variant
+    /// universe via `states_under`). Combines the `invoke_server_stream` and
+    /// `invoke_exec` cardinalities.
+    extern "C" fn invoke_exec_server_stream<'a>(
+        &'a self,
+        method: u32,
+        req: SVec<u8>,
+        exec: DynExecutor,
+    ) -> DynFuture<'a, DynItemStream>;
     extern "C" fn invoke_registry(&self, method: u32, req: SVec<u8>, reg: DynFunctionRegistry);
 }
 

--- a/crates/plugin-stabby/src/host.rs
+++ b/crates/plugin-stabby/src/host.rs
@@ -346,10 +346,10 @@ impl StableExecutor for HostExecutor {
         }))
     }
 
-    extern "C" fn states<'a>(&'a self, pkg: SString) -> DynFuture<'a, StatesOutcome> {
+    extern "C" fn states_under<'a>(&'a self, prefix: SString) -> DynFuture<'a, StatesOutcome> {
         dynify(stabby::boxed::Box::new(async move {
-            let pkg = PkgBuf::from(pkg.to_string());
-            match self.inner.states(&pkg).await {
+            let prefix = PkgBuf::from(prefix.to_string());
+            match self.inner.states_under(&prefix).await {
                 Ok(states) => StatesOutcome {
                     ok: true,
                     message: SString::new(),

--- a/crates/plugin-stabby/src/host.rs
+++ b/crates/plugin-stabby/src/host.rs
@@ -4,7 +4,7 @@
 use crate::abi::{
     DynArtifact, DynExecutor, DynFunctionRegistry, DynLogSink, DynRead, DynSupervisor,
     NoteDepOutcome, QueryOutcome, ResultOutcome, StableAddr, StableArtifactContent, StableExecutor,
-    StableFunctionRegistry, StableLogSink, StableRead, StableSupervisor,
+    StableFunctionRegistry, StableLogSink, StableRead, StableSupervisor, StatesOutcome,
 };
 use crate::vtable::dynify;
 use hcore::hartifactcontent::Content;
@@ -341,6 +341,27 @@ impl StableExecutor for HostExecutor {
                     ok: false,
                     message: e.to_string().into(),
                     addrs: SVec::new(),
+                },
+            }
+        }))
+    }
+
+    extern "C" fn states<'a>(&'a self, pkg: SString) -> DynFuture<'a, StatesOutcome> {
+        dynify(stabby::boxed::Box::new(async move {
+            let pkg = PkgBuf::from(pkg.to_string());
+            match self.inner.states(&pkg).await {
+                Ok(states) => StatesOutcome {
+                    ok: true,
+                    message: SString::new(),
+                    states: states
+                        .iter()
+                        .map(|s| SVec::from(convert::state_to_pb(s).encode_to_vec().as_slice()))
+                        .collect(),
+                },
+                Err(e) => StatesOutcome {
+                    ok: false,
+                    message: e.to_string().into(),
+                    states: SVec::new(),
                 },
             }
         }))

--- a/crates/plugin-stabby/src/load_stable.rs
+++ b/crates/plugin-stabby/src/load_stable.rs
@@ -333,11 +333,13 @@ impl Provider for StableRemoteProvider {
                 states: req.states.iter().map(convert::state_to_pb).collect(),
             }
             .encode_to_vec();
-            // Server-streaming: pull items lazily across the seam — the whole list
-            // is never materialized on either side.
+            // Server-streaming **with** the executor, so the plugin's `list` can
+            // call back (e.g. the go module variant universe via `states_under`).
+            // Items still stream lazily across the seam.
+            let exec: DynExecutor = HostExecutor::wrap(Arc::clone(&req.executor));
             let stream = self
                 .inner
-                .invoke_server_stream(pb::ProviderMethod::List as u32, sv(&pb_req))
+                .invoke_exec_server_stream(pb::ProviderMethod::List as u32, sv(&pb_req), exec)
                 .await;
             Ok(Box::new(ItemStreamIter {
                 stream,

--- a/crates/plugin/src/provider.rs
+++ b/crates/plugin/src/provider.rs
@@ -120,6 +120,25 @@ pub trait ProviderExecutor: Send + Sync {
     fn note_dep<'a>(&'a self, addr: &'a Addr) -> BoxFuture<'a, anyhow::Result<()>> {
         Box::pin(async move { self.result(addr).await.map(|_| ()) })
     }
+
+    /// Fetch the provider states declared for `pkg` and its package ancestry
+    /// (every `provider_state` up the tree, all providers), backed by the
+    /// engine's memoized `probe_segments` — repeated calls for the same package
+    /// are near-free.
+    ///
+    /// Unlike `result`/`query`, this registers **no** `DepDag` edge: states are
+    /// build *configuration*, not a build dependency, so reading them must not
+    /// couple the caller into a cycle. Used by a provider that must resolve
+    /// config declared in a package outside the target's own ancestry — e.g. the
+    /// go plugin resolving a variant pinned by a `vp` addr arg to a sibling
+    /// subtree, whose defining `provider_state` is absent from `GetRequest.states`
+    /// (which the engine gathers only along the target package's ancestry).
+    ///
+    /// Default returns empty — real executors (engine, cdylib guest) override it;
+    /// test mocks that never resolve a foreign-subtree variant can keep the default.
+    fn states<'a>(&'a self, _pkg: &'a PkgBuf) -> BoxFuture<'a, anyhow::Result<Vec<State>>> {
+        Box::pin(async move { Ok(Vec::new()) })
+    }
 }
 
 /// The [`ProviderExecutor`] callback surface, addressed by request scope id

--- a/crates/plugin/src/provider.rs
+++ b/crates/plugin/src/provider.rs
@@ -22,6 +22,12 @@ pub struct ListRequest {
     pub request_id: String,
     pub package: PkgBuf,
     pub states: Vec<State>,
+    /// Engine callback surface, so `list` can gather config beyond the package's
+    /// ancestry `states` — e.g. the go plugin fetching a module's variant universe
+    /// via [`ProviderExecutor::states_under`] to enumerate library variants.
+    /// Providers that don't need it ignore it; non-engine call sites (LSP, tests)
+    /// pass [`NoopExecutor`].
+    pub executor: Arc<dyn ProviderExecutor>,
 }
 pub struct ListResponse {
     pub addr: Addr,
@@ -121,23 +127,45 @@ pub trait ProviderExecutor: Send + Sync {
         Box::pin(async move { self.result(addr).await.map(|_| ()) })
     }
 
-    /// Fetch the provider states declared for `pkg` and its package ancestry
-    /// (every `provider_state` up the tree, all providers), backed by the
-    /// engine's memoized `probe_segments` — repeated calls for the same package
-    /// are near-free.
+    /// Fetch the provider states declared for every package **at or under**
+    /// `prefix` (each package's own `provider_state`s, all providers) — the
+    /// downward subtree, not the upward ancestry that `GetRequest.states`
+    /// carries.
     ///
     /// Unlike `result`/`query`, this registers **no** `DepDag` edge: states are
     /// build *configuration*, not a build dependency, so reading them must not
-    /// couple the caller into a cycle. Used by a provider that must resolve
-    /// config declared in a package outside the target's own ancestry — e.g. the
-    /// go plugin resolving a variant pinned by a `vp` addr arg to a sibling
-    /// subtree, whose defining `provider_state` is absent from `GetRequest.states`
-    /// (which the engine gathers only along the target package's ancestry).
+    /// couple the caller into a cycle. Used by a provider that needs config
+    /// declared across a whole subtree — e.g. the go plugin gathering a Go
+    /// module's variant *universe* (every `variants` declaration under the
+    /// `go.mod` root, siblings included) to resolve/enumerate library variants,
+    /// which `GetRequest.states` (ancestry-only) cannot supply.
     ///
     /// Default returns empty — real executors (engine, cdylib guest) override it;
-    /// test mocks that never resolve a foreign-subtree variant can keep the default.
-    fn states<'a>(&'a self, _pkg: &'a PkgBuf) -> BoxFuture<'a, anyhow::Result<Vec<State>>> {
+    /// test mocks that never gather a subtree can keep the default.
+    fn states_under<'a>(
+        &'a self,
+        _prefix: &'a PkgBuf,
+    ) -> BoxFuture<'a, anyhow::Result<Vec<State>>> {
         Box::pin(async move { Ok(Vec::new()) })
+    }
+}
+
+/// A [`ProviderExecutor`] that resolves nothing — for call sites that build a
+/// [`ListRequest`] outside the engine (LSP, tests) where no real callback surface
+/// exists. `result`/`query` error if reached; `note_dep`/`states_under` are no-ops.
+#[derive(Debug, Default)]
+pub struct NoopExecutor;
+
+impl ProviderExecutor for NoopExecutor {
+    fn result<'a>(&'a self, addr: &'a Addr) -> BoxFuture<'a, anyhow::Result<Arc<EResult>>> {
+        Box::pin(async move { anyhow::bail!("NoopExecutor: cannot resolve {}", addr.format()) })
+    }
+    fn query<'a>(
+        &'a self,
+        _m: &'a Matcher,
+        _extra_skip: &'a [String],
+    ) -> BoxFuture<'a, anyhow::Result<Vec<Addr>>> {
+        Box::pin(async move { anyhow::bail!("NoopExecutor: cannot query") })
     }
 }
 

--- a/crates/plugingo-e2e/Cargo.toml
+++ b/crates/plugingo-e2e/Cargo.toml
@@ -12,6 +12,9 @@ heph = { path = "../.." }
 # go is no longer a heph built-in; the e2e harness constructs it directly.
 plugin-go = { path = "../plugin-go" }
 htestkit = { package = "testkit", path = "../testkit" }
+hcore = { package = "core", path = "../core" }
+hmodel = { package = "model", path = "../model" }
+hplugin = { package = "plugin", path = "../plugin" }
 tokio = { version = "1", features = ["rt", "rt-multi-thread", "macros"] }
 anyhow = "1"
 tempfile = "3"

--- a/crates/plugingo-e2e/testdata/codegencycle/BUILD
+++ b/crates/plugingo-e2e/testdata/codegencycle/BUILD
@@ -37,7 +37,7 @@ target(
     name = "a-dist",
     driver = "sh",
     run = "mv ${SRC} ${OUT}",
-    deps = ["//cmd/a:build"],
+    deps = ["//cmd/a:build@v=host"],
     out = "dist/a",
     labels = ["build"],
 )
@@ -46,7 +46,7 @@ target(
     name = "b-dist",
     driver = "sh",
     run = "mv ${SRC} ${OUT}",
-    deps = ["//cmd/b:build"],
+    deps = ["//cmd/b:build@v=host"],
     out = "dist/b",
     labels = ["build"],
 )

--- a/crates/plugingo-e2e/testdata/embed_gen_tool/app/BUILD
+++ b/crates/plugingo-e2e/testdata/embed_gen_tool/app/BUILD
@@ -9,7 +9,7 @@ target(
         "$TOOL_GEN > $OUT",
     ],
     out = "openapi/openapi_gen.yaml",
-    tools = {"gen": ["//tool:build"]},
+    tools = {"gen": ["//tool:build@v=host"]},
     labels = ["go_embed_src"],
     codegen = "copy",
 )

--- a/crates/plugingo-e2e/testdata/variant_sibling/cmd/BUILD
+++ b/crates/plugingo-e2e/testdata/variant_sibling/cmd/BUILD
@@ -1,0 +1,8 @@
+# The `release` variant is declared ONLY here at //cmd. Building
+# //cmd:build@v=release threads vp=cmd onto the //lib dependency, whose own
+# ancestry does not contain `release` (cmd is a sibling) — so it must resolve
+# through the module universe (states_under).
+provider_state(
+    provider = "go",
+    variants = {"release": {"goos": "linux", "goarch": "amd64"}},
+)

--- a/crates/plugingo-e2e/testdata/variant_sibling/cmd/main.go
+++ b/crates/plugingo-e2e/testdata/variant_sibling/cmd/main.go
@@ -1,0 +1,11 @@
+package main
+
+import (
+	"fmt"
+
+	"example.com/variant_sibling/lib"
+)
+
+func main() {
+	fmt.Println(lib.Greet("world"))
+}

--- a/crates/plugingo-e2e/testdata/variant_sibling/go.mod
+++ b/crates/plugingo-e2e/testdata/variant_sibling/go.mod
@@ -1,0 +1,3 @@
+module example.com/variant_sibling
+
+go 1.21

--- a/crates/plugingo-e2e/testdata/variant_sibling/lib/lib.go
+++ b/crates/plugingo-e2e/testdata/variant_sibling/lib/lib.go
@@ -1,0 +1,7 @@
+package lib
+
+import "fmt"
+
+func Greet(name string) string {
+	return fmt.Sprintf("hello, %s", name)
+}

--- a/crates/plugingo-e2e/tests/build.rs
+++ b/crates/plugingo-e2e/tests/build.rs
@@ -8,7 +8,7 @@ async fn test_simple_lib_build_lib() -> anyhow::Result<()> {
     require_go!();
     let dir = fixture("simple_lib")?;
     let ws = make_workspace(dir)?;
-    let result = ws.run("//:build_lib").await?;
+    let result = ws.run("//:build_lib@v=host").await?;
     assert!(
         !artifact_paths(&result).is_empty(),
         "build_lib should produce at least one artifact"
@@ -26,7 +26,7 @@ async fn test_embed_build_lib_compiles_with_embedcfg() -> anyhow::Result<()> {
     require_go!();
     let dir = fixture("with_embed")?;
     let ws = make_workspace(dir)?;
-    let result = ws.run("//:build_lib").await?;
+    let result = ws.run("//:build_lib@v=host").await?;
     assert!(
         !artifact_paths(&result).is_empty(),
         "embedding build_lib should compile and produce an archive"
@@ -43,7 +43,7 @@ async fn test_embed_subdir_build_lib_compiles_with_embedcfg() -> anyhow::Result<
     require_go!();
     let dir = fixture("with_embed_subdir")?;
     let ws = make_workspace(dir)?;
-    let result = ws.run("//:build_lib").await?;
+    let result = ws.run("//:build_lib@v=host").await?;
     assert!(
         !artifact_paths(&result).is_empty(),
         "subdir-embedding build_lib should compile and produce an archive"
@@ -58,7 +58,7 @@ async fn test_embed_nested_pkg_build_lib_compiles_with_embedcfg() -> anyhow::Res
     require_go!();
     let dir = fixture("with_embed_nested")?;
     let ws = make_workspace(dir)?;
-    let result = ws.run("//app:build_lib").await?;
+    let result = ws.run("//app:build_lib@v=host").await?;
     assert!(
         !artifact_paths(&result).is_empty(),
         "nested-package subdir-embedding build_lib should compile"
@@ -75,7 +75,7 @@ async fn test_embed_buildtagged_file_compiles_with_embedcfg() -> anyhow::Result<
     require_go!();
     let dir = fixture("with_embed_buildtag")?;
     let ws = make_workspace(dir)?;
-    let result = ws.run("//app:build_lib@goarch=amd64,goos=linux").await?;
+    let result = ws.run("//app:build_lib@v=linux_amd64").await?;
     assert!(
         !artifact_paths(&result).is_empty(),
         "build-tagged embedding build_lib should compile for goos=linux"
@@ -92,7 +92,7 @@ async fn test_embed_group_go_embed_src_compiles() -> anyhow::Result<()> {
     require_go!();
     let dir = fixture("with_embed_group")?;
     let ws = make_workspace(dir)?;
-    let result = ws.run("//:build_lib").await?;
+    let result = ws.run("//:build_lib@v=host").await?;
     assert!(
         !artifact_paths(&result).is_empty(),
         "go_embed_src group embedding build_lib should compile"
@@ -110,7 +110,7 @@ async fn test_embed_generated_go_embed_src_compiles() -> anyhow::Result<()> {
     require_go!();
     let dir = fixture("with_embed_gen")?;
     let ws = make_workspace(dir)?;
-    let result = ws.run("//:build_lib").await?;
+    let result = ws.run("//:build_lib@v=host").await?;
     assert!(
         !artifact_paths(&result).is_empty(),
         "generated go_embed_src embedding build_lib should compile"
@@ -126,9 +126,7 @@ async fn test_embed_buildtagged_build_test_lib_compiles() -> anyhow::Result<()> 
     require_go!();
     let dir = fixture("with_embed_buildtag")?;
     let ws = make_workspace(dir)?;
-    let result = ws
-        .run("//app:build_test_lib@goarch=amd64,goos=linux")
-        .await?;
+    let result = ws.run("//app:build_test_lib@v=linux_amd64").await?;
     assert!(
         !artifact_paths(&result).is_empty(),
         "build-tagged build_test_lib should compile for goos=linux"
@@ -141,7 +139,7 @@ async fn test_with_dep_cmd_build() -> anyhow::Result<()> {
     require_go!();
     let dir = fixture("with_dep")?;
     let ws = make_workspace(dir)?;
-    let result = ws.run("//cmd:build").await?;
+    let result = ws.run("//cmd:build@v=host").await?;
     assert!(
         !artifact_paths(&result).is_empty(),
         "cmd build should produce at least one artifact"
@@ -161,7 +159,7 @@ async fn test_thirdparty_asm_build_lib_compiles() -> anyhow::Result<()> {
     require_go!();
     let dir = fixture("thirdparty_asm")?;
     let ws = make_workspace(dir)?;
-    let lib = "//@heph/go/thirdparty/github.com/klauspost/cpuid/v2@v2.2.5:build_lib";
+    let lib = "//@heph/go/thirdparty/github.com/klauspost/cpuid/v2@v2.2.5:build_lib@v=host";
     match ws.run(lib).await {
         Ok(result) => {
             assert!(
@@ -195,7 +193,7 @@ async fn test_with_dep_cmd_build_host_toolchain() -> anyhow::Result<()> {
     require_go!();
     let dir = fixture("with_dep")?;
     let ws = make_workspace_host(dir)?;
-    let result = ws.run("//cmd:build").await?;
+    let result = ws.run("//cmd:build@v=host").await?;
     assert!(
         !artifact_paths(&result).is_empty(),
         "host-toolchain cmd build should produce at least one artifact"
@@ -212,7 +210,7 @@ async fn test_embed_mixed_go_src_and_go_embed_src_compiles() -> anyhow::Result<(
     require_go!();
     let dir = fixture("with_embed_mixed")?;
     let ws = make_workspace(dir)?;
-    let result = ws.run("//:build_lib").await?;
+    let result = ws.run("//:build_lib@v=host").await?;
     assert!(
         !artifact_paths(&result).is_empty(),
         "mixed go_src + go_embed_src embedding build_lib should compile"
@@ -225,7 +223,7 @@ async fn test_embed_mixed_build_testmain_lib() -> anyhow::Result<()> {
     require_go!();
     let dir = fixture("with_embed_mixed")?;
     let ws = make_workspace(dir)?;
-    let result = ws.run("//:build_testmain_lib").await?;
+    let result = ws.run("//:build_testmain_lib@v=host").await?;
     assert!(
         !artifact_paths(&result).is_empty(),
         "testmain_lib should compile"
@@ -248,7 +246,7 @@ async fn test_embed_generated_by_in_tree_tool_resolves_deterministically() -> an
     for attempt in 0..2 {
         let ws = make_workspace_host(fixture("embed_gen_tool")?)?;
         let result = ws
-            .run("//app:build_lib")
+            .run("//app:build_lib@v=host")
             .await
             .with_context(|| format!("attempt {attempt}"))?;
         assert!(
@@ -273,7 +271,7 @@ async fn test_embed_generated_by_in_tree_tool_resolves_deterministically() -> an
 async fn test_embed_generated_in_subpackage_of_the_embedder() -> anyhow::Result<()> {
     require_go!();
     let ws = make_workspace_host(fixture("embed_gen_subpkg")?)?;
-    let result = ws.run("//app:build_lib").await?;
+    let result = ws.run("//app:build_lib@v=host").await?;
     assert!(
         !artifact_paths(&result).is_empty(),
         "build_lib embedding a sub-package's generated asset must compile"

--- a/crates/plugingo-e2e/tests/build.rs
+++ b/crates/plugingo-e2e/tests/build.rs
@@ -1,7 +1,10 @@
 mod common;
 
 use anyhow::Context as _;
-use common::{artifact_paths, fixture, make_workspace, make_workspace_host, require_go};
+use common::{
+    artifact_paths, fixture, make_workspace, make_workspace_hermetic, make_workspace_host,
+    require_go,
+};
 
 #[tokio::test]
 async fn test_simple_lib_build_lib() -> anyhow::Result<()> {
@@ -134,11 +137,15 @@ async fn test_embed_buildtagged_build_test_lib_compiles() -> anyhow::Result<()> 
     Ok(())
 }
 
+/// The deliberate **hermetic** toolchain build: this is the one build test that
+/// stages the pinned Go SDK and compiles std from source (its host-`go`
+/// counterpart is `test_with_dep_cmd_build_host_toolchain`). Every other build
+/// test uses the host toolchain (`make_workspace`) to keep disk/time down.
 #[tokio::test]
 async fn test_with_dep_cmd_build() -> anyhow::Result<()> {
     require_go!();
     let dir = fixture("with_dep")?;
-    let ws = make_workspace(dir)?;
+    let ws = make_workspace_hermetic(dir)?;
     let result = ws.run("//cmd:build@v=host").await?;
     assert!(
         !artifact_paths(&result).is_empty(),

--- a/crates/plugingo-e2e/tests/build.rs
+++ b/crates/plugingo-e2e/tests/build.rs
@@ -147,6 +147,26 @@ async fn test_with_dep_cmd_build() -> anyhow::Result<()> {
     Ok(())
 }
 
+/// End-to-end proof of the cross-subtree variant universe: the `release` variant
+/// is declared ONLY at `//cmd` (via its BUILD `provider_state`). Building
+/// `//cmd:build@v=release` threads `vp=cmd` onto the `//lib` dependency, whose own
+/// ancestry does not contain `release` (cmd is a sibling of lib). Resolving it
+/// therefore exercises the real engine `states_under` path — the module universe
+/// — not the ancestry fast path. A green build means the whole cross-subtree
+/// resolution works through the actual engine, not just a mocked executor.
+#[tokio::test]
+async fn test_variant_declared_at_sibling_resolves_via_universe() -> anyhow::Result<()> {
+    require_go!();
+    let dir = fixture("variant_sibling")?;
+    let ws = make_workspace(dir)?;
+    let result = ws.run("//cmd:build@v=release").await?;
+    assert!(
+        !artifact_paths(&result).is_empty(),
+        "a variant declared at a sibling package must resolve for the lib dep and build"
+    );
+    Ok(())
+}
+
 /// End-to-end proof of the `go_compile` **assembly** pipeline (symabis →
 /// compile → per-`.s` asm → `pack r`). First-party packages never carry `.s`
 /// files in this provider, so asm is only reachable through a thirdparty module:

--- a/crates/plugingo-e2e/tests/codegen.rs
+++ b/crates/plugingo-e2e/tests/codegen.rs
@@ -28,7 +28,7 @@ async fn test_codegen_build_lib_compiles_with_generated_source() -> anyhow::Resu
     let ws = make_workspace(dir)?;
     // build_lib depends on _golist (for source_map) which depends on the query for go_src
     // labels, which finds //:gen. The engine must run //:gen first, then build_lib.
-    let result = ws.run("//:build_lib").await?;
+    let result = ws.run("//:build_lib@v=host").await?;
     let paths = artifact_paths(&result);
     assert!(
         !paths.is_empty(),
@@ -43,7 +43,7 @@ async fn test_codegen_build_produces_binary() -> anyhow::Result<()> {
     let dir = fixture("codegen")?;
     let ws = make_workspace(dir)?;
     let _ = fs::remove_file(ws.dir.path().join("gen.go"));
-    let result = ws.run("//:build").await?;
+    let result = ws.run("//:build@v=host").await?;
     let paths = artifact_paths(&result);
     assert!(
         !paths.is_empty(),
@@ -60,7 +60,7 @@ async fn test_codegen_build_binary_outputs_hello() -> anyhow::Result<()> {
     require_go!();
     let dir = fixture("codegen")?;
     let ws = make_workspace(dir)?;
-    let result = ws.run("//:build").await?;
+    let result = ws.run("//:build@v=host").await?;
 
     let tmp = tempfile::tempdir().context("create tempdir for binary")?;
     let mut binary_path: Option<std::path::PathBuf> = None;
@@ -112,7 +112,7 @@ async fn test_codegen_root_build_multi_package() -> anyhow::Result<()> {
     let dir = fixture("codegenroot")?;
     let ws = make_workspace(dir)?;
     let result = ws
-        .run("//:build")
+        .run("//:build@v=host")
         .await
         .context("build //:build under a go_codegen_root")?;
     assert!(
@@ -135,7 +135,7 @@ async fn test_codegen_root_build_with_generated_pkg_skipped() -> anyhow::Result<
     let dir = fixture("codegenroot")?;
     let ws = make_workspace_fs_skip(dir, &["genpb/**"])?;
     let result = ws
-        .run("//:build")
+        .run("//:build@v=host")
         .await
         .context("build //:build with the generated sub-package under fs.skip")?;
     assert!(
@@ -193,7 +193,7 @@ async fn test_codegencycle_single_target_builds() -> anyhow::Result<()> {
     let dir = fixture("codegencycle")?;
     let ws = make_workspace(dir)?;
     let result = ws
-        .run("//shared:build_lib")
+        .run("//shared:build_lib@v=host")
         .await
         .context("build //shared:build_lib directly")?;
     assert!(
@@ -249,7 +249,7 @@ async fn test_build_lib_still_builds_go_first() -> anyhow::Result<()> {
     // Guard off: the failed go over-claim of `//:gen` must not leave a stale DAG
     // edge that false-cycles this legit build.
     let ws = make_workspace_go_first(dir, false)?;
-    let result = ws.run("//:build_lib").await?;
+    let result = ws.run("//:build_lib@v=host").await?;
     assert!(
         !artifact_paths(&result).is_empty(),
         "build_lib must produce the .a archive even with go registered first"

--- a/crates/plugingo-e2e/tests/common/mod.rs
+++ b/crates/plugingo-e2e/tests/common/mod.rs
@@ -192,14 +192,29 @@ impl hplugin::provider::Provider for VariantInjector {
     }
 }
 
+/// Default workspace: builds with the **host** `go` (gotool = "host"). This is
+/// what almost every e2e test should use — it reuses the host toolchain's
+/// prebuilt std, so it stages no hermetic SDK and builds no std from source,
+/// which is dramatically less disk and time. (Staging a full hermetic SDK + std
+/// tree per isolated test workspace is what exhausted the CI runner disk.) Only
+/// the few tests that specifically exercise the hermetic toolchain use
+/// [`make_workspace_hermetic`]. Requires `go` on PATH (guard with `require_go!`).
 pub fn make_workspace(dir: TempDir) -> anyhow::Result<Workspace> {
-    make_workspace_ordered(dir, false, true, &[], HERMETIC_GO)
+    make_workspace_ordered(dir, false, true, &[], HOST_GO)
 }
 
-/// Build the workspace using the **host** `go` (gotool = "host") instead of a
-/// hermetic SDK. Requires `go` on PATH (guard call sites with `require_go!`).
+/// Alias for [`make_workspace`] kept for call sites that spell the host toolchain
+/// explicitly.
 pub fn make_workspace_host(dir: TempDir) -> anyhow::Result<Workspace> {
-    make_workspace_ordered(dir, false, true, &[], HOST_GO)
+    make_workspace(dir)
+}
+
+/// Build the workspace against the pinned **hermetic** Go SDK ([`HERMETIC_GO`]) —
+/// downloaded and staged, with std compiled from source. Expensive (disk + time),
+/// so reserve it for the *select few* tests that must prove the hermetic
+/// toolchain path itself; everything else uses [`make_workspace`] (host `go`).
+pub fn make_workspace_hermetic(dir: TempDir) -> anyhow::Result<Workspace> {
+    make_workspace_ordered(dir, false, true, &[], HERMETIC_GO)
 }
 
 /// A published heph release whose `heph-govet_<goos>_<goarch>` assets the lint
@@ -216,7 +231,7 @@ pub fn govet_addr() -> String {
 /// `fs: { skip: [...] }`. Used to reproduce a codegen target whose generated Go
 /// package lives under a skipped subtree (e.g. a generated `gen/**` tree).
 pub fn make_workspace_fs_skip(dir: TempDir, skip: &[&str]) -> anyhow::Result<Workspace> {
-    make_workspace_ordered(dir, false, true, skip, HERMETIC_GO)
+    make_workspace_ordered(dir, false, true, skip, HOST_GO)
 }
 
 /// Same as [`make_workspace`] but registers the **go provider before** the
@@ -231,7 +246,7 @@ pub fn make_workspace_go_first(
     dir: TempDir,
     foreign_name_guard: bool,
 ) -> anyhow::Result<Workspace> {
-    make_workspace_ordered(dir, true, foreign_name_guard, &[], HERMETIC_GO)
+    make_workspace_ordered(dir, true, foreign_name_guard, &[], HOST_GO)
 }
 
 fn make_workspace_ordered(

--- a/crates/plugingo-e2e/tests/common/mod.rs
+++ b/crates/plugingo-e2e/tests/common/mod.rs
@@ -97,6 +97,101 @@ fn sdk_checksums_for(gotool: &str) -> std::collections::HashMap<String, String> 
         .collect()
 }
 
+/// A minimal provider that injects the Go build *variants* every e2e workspace
+/// needs, without editing each fixture's BUILD file. Its `probe` returns, for the
+/// root package, a `provider="go"` state declaring two variants:
+///   - `host`: the build host's own GOOS/GOARCH (the default the suite uses),
+///   - `linux_amd64`: pinned linux/amd64 (for the build-tag cross-compile tests).
+/// Every other endpoint is empty — targets/packages come from the real providers.
+struct VariantInjector;
+
+impl VariantInjector {
+    fn variants_state() -> hplugin::provider::State {
+        use hcore::htvalue::Value;
+        let variant = |goos: &str, goarch: &str| {
+            Value::Map(std::collections::HashMap::from([
+                ("goos".to_string(), Value::String(goos.to_string())),
+                ("goarch".to_string(), Value::String(goarch.to_string())),
+            ]))
+        };
+        let variants = Value::Map(std::collections::HashMap::from([
+            (
+                "host".to_string(),
+                variant(hcore::htplatform::os(), hcore::htplatform::arch()),
+            ),
+            ("linux_amd64".to_string(), variant("linux", "amd64")),
+        ]));
+        hplugin::provider::State {
+            package: hmodel::htpkg::PkgBuf::from(""),
+            provider: "go".to_string(),
+            state: std::collections::HashMap::from([("variants".to_string(), variants)]),
+        }
+    }
+}
+
+impl hplugin::provider::Provider for VariantInjector {
+    fn config(
+        &self,
+        _req: hplugin::provider::ConfigRequest,
+    ) -> anyhow::Result<hplugin::provider::ConfigResponse> {
+        Ok(hplugin::provider::ConfigResponse {
+            name: "go-variant-injector".to_string(),
+        })
+    }
+
+    fn list<'a>(
+        &'a self,
+        _req: hplugin::provider::ListRequest,
+        _ctoken: &'a (dyn hcore::hasync::Cancellable + Send + Sync),
+    ) -> futures::future::BoxFuture<
+        'a,
+        anyhow::Result<
+            Box<dyn Iterator<Item = anyhow::Result<hplugin::provider::ListResponse>> + Send>,
+        >,
+    > {
+        Box::pin(async move { Ok(Box::new(std::iter::empty()) as Box<_>) })
+    }
+
+    fn list_packages<'a>(
+        &'a self,
+        _req: hplugin::provider::ListPackagesRequest,
+        _ctoken: &'a (dyn hcore::hasync::Cancellable + Send + Sync),
+    ) -> futures::future::BoxFuture<
+        'a,
+        anyhow::Result<
+            Box<dyn Iterator<Item = anyhow::Result<hplugin::provider::ListPackageResponse>> + Send>,
+        >,
+    > {
+        Box::pin(async move { Ok(Box::new(std::iter::empty()) as Box<_>) })
+    }
+
+    fn get<'a>(
+        &'a self,
+        _req: hplugin::provider::GetRequest,
+        _ctoken: &'a (dyn hcore::hasync::Cancellable + Send + Sync),
+    ) -> futures::future::BoxFuture<
+        'a,
+        Result<hplugin::provider::GetResponse, hplugin::provider::GetError>,
+    > {
+        Box::pin(async move { Err(hplugin::provider::GetError::NotFound) })
+    }
+
+    fn probe<'a>(
+        &'a self,
+        req: hplugin::provider::ProbeRequest,
+        _ctoken: &'a (dyn hcore::hasync::Cancellable + Send + Sync),
+    ) -> futures::future::BoxFuture<'a, anyhow::Result<hplugin::provider::ProbeResponse>> {
+        Box::pin(async move {
+            let states = if req.package.as_str().is_empty() {
+                vec![Self::variants_state()]
+            } else {
+                vec![]
+            };
+            Ok(hplugin::provider::ProbeResponse { states })
+        })
+    }
+}
+
 pub fn make_workspace(dir: TempDir) -> anyhow::Result<Workspace> {
     make_workspace_ordered(dir, false, true, &[], HERMETIC_GO)
 }
@@ -150,6 +245,10 @@ fn make_workspace_ordered(
     let go_bin = go_bin_path();
     // `fs` is auto-registered by `Engine::new`.
     let mut b = WorkspaceBuilder::from_dir(dir).with_fs_skip(fs_skip.iter().copied());
+
+    // Inject the Go build variants (`host`, `linux_amd64`) every fixture builds
+    // against, so targets resolve `@v=…` without each BUILD declaring them.
+    b = b.with_provider(|_| Box::new(VariantInjector));
 
     if go_first {
         let gotool = gotool.clone();

--- a/crates/plugingo-e2e/tests/lint.rs
+++ b/crates/plugingo-e2e/tests/lint.rs
@@ -16,7 +16,7 @@ async fn test_lint_execs_the_downloaded_govet() -> anyhow::Result<()> {
     let ws = common::make_workspace_host(common::fixture("with_dep")?)?;
 
     // `_lint-analyze` is the analyze unit: it runs heph-govet and writes facts + report.
-    let result = ws.run("//lib:_lint-analyze").await?;
+    let result = ws.run("//lib:_lint-analyze@v=host").await?;
 
     let paths = common::artifact_paths(&result);
     assert!(
@@ -39,7 +39,7 @@ async fn test_format_check_execs_the_downloaded_govet() -> anyhow::Result<()> {
 
     // The fixture is gofmt-clean, so the check gate passes — the point is that it
     // gets far enough to actually run the tool.
-    ws.run("//lib:format-check").await?;
+    ws.run("//lib:format-check@v=host").await?;
     Ok(())
 }
 
@@ -52,7 +52,7 @@ async fn test_lint_consumes_a_deps_empty_facts() -> anyhow::Result<()> {
     let ws = common::make_workspace_host(common::fixture("with_dep")?)?;
 
     // cmd imports lib, so lib's facts are wired into cmd's analysis.
-    let result = ws.run("//cmd:_lint-analyze").await?;
+    let result = ws.run("//cmd:_lint-analyze@v=host").await?;
 
     let paths = common::artifact_paths(&result);
     assert!(
@@ -71,7 +71,7 @@ async fn test_lint_package_importing_unsafe() -> anyhow::Result<()> {
     require_go!();
     let ws = common::make_workspace_host(common::fixture("lint_unsafe")?)?;
 
-    let result = ws.run("//mem:_lint-analyze").await?;
+    let result = ws.run("//mem:_lint-analyze@v=host").await?;
 
     let paths = common::artifact_paths(&result);
     assert!(

--- a/crates/plugingo-e2e/tests/lint.rs
+++ b/crates/plugingo-e2e/tests/lint.rs
@@ -38,8 +38,9 @@ async fn test_format_check_execs_the_downloaded_govet() -> anyhow::Result<()> {
     let ws = common::make_workspace_host(common::fixture("with_dep")?)?;
 
     // The fixture is gofmt-clean, so the check gate passes — the point is that it
-    // gets far enough to actually run the tool.
-    ws.run("//lib:format-check@v=host").await?;
+    // gets far enough to actually run the tool. Bare addr: formatting is syntactic,
+    // so `format`/`format-check` carry no variant.
+    ws.run("//lib:format-check").await?;
     Ok(())
 }
 


### PR DESCRIPTION
## What

Replaces the per-target `goos`/`goarch`/`tags` address args in the Go plugin with named **build variants** declared in provider state, scoped to a Go **module**.

```python
provider_state(provider="go", variants={
    "base":    {"goos": "linux", "goarch": "amd64", "cgo": False},   # cgo is hardcoded off; example only
    "release": {"inherit": "base", "goexperiment": ["arenas"],
                "gcflags": ["-l"], "ldflags": ["-s", "-w"], "tags": ["prod"]},
})
```

### Variant model (module-scoped)

- A Go **module** (the `go.mod` dir) has a variant **universe**: every `variants` declaration in the module subtree, keyed `(name, declaring-pkg)`. The same name may be declared at different levels — `vp` disambiguates.
- **Binary / entry targets** (`@v=NAME`) resolve by **ancestry**, walking the target package up to its **module root** (declarations above the module root don't apply — module, not repo).
- **Library / dependency targets** (`@v=NAME,vp=PKG`) resolve `(name, vp)` against the module universe; `vp` threads down the whole dep graph so a lib re-resolves to the same factors even when the variant was declared at a **sibling** package.
- **Inheritance**: `inherit = "OTHER"` starts from another variant in the same `variants` map and overlays declared fields (lists replace); `goos`/`goarch` may be inherited; cycles are rejected.
- **No implicit default**: a target with no `@v` is a hard error. Factors: GOOS, GOARCH, build tags, `GOEXPERIMENT`, gcflags, ldflags — each wired into the commands and every `Go*Def::hash` (cache key). `CGO_ENABLED` is hardcoded `0`.

### Engine / ABI

- `ProviderExecutor::states(pkg)` → **`states_under(prefix)`**: the engine walks the subtree, probes each package, unions their states (no `DepDag` edge; memoized per request+prefix). The go plugin fetches a module's variant universe with it.
- **`list` enumerates the full universe** for library targets (so a sibling-declared variant is *listed*, complete), ancestry for entry targets. `list` had no callback channel, so `ListRequest` gains an `executor` and a new stream+executor ABI cardinality **`StableProvider::invoke_exec_server_stream`** carries it across the stabby seam (append-only cold surface). Non-engine list callers pass `NoopExecutor`.
- These changes bump **`ABI_SEMVER` 0.4.0 → 0.5.0** (`states_under` is a new `#[stabby::stabby]` vtable method → hard break; every cdylib plugin must rebuild).

### Notable fixes found via e2e

- The go plugin's own `go_src`/`go_embed_src`/`go_test_data` **label queries now exclude the `go` provider** — those labels only mark buildfile codegen targets, so resolving the universe-multiplied `build_lib` specs was pure waste that cascaded a full golist/std graph per variant. (Also removes the pre-existing single-variant waste and the `go_src` self-cycle the foreign-name guard was containing.)
- A foreign target name spec-resolved through a go-first registration now **declines before variant resolution** instead of erroring "requires a variant".

## Other

- `heph.go.build_addr(pkg, goos, goarch, tags)` → `heph.go.build_addr(pkg, v)`.
- govet / toolchain host tools keep their own `goos`/`goarch` (`os`/`arch`) vocabulary — host-native, not variant-parameterized.

## Design notes (raised for review)

1. **No implicit default** — every invocation needs `@v=`; a workspace with no variants declared builds nothing. An implicit `host` variant would remove that friction if wanted.
2. **Universe-`list` cost** — a user's explicit `//...` / `label(X)` query over go packages spec-resolves the universe-multiplied `build_lib` addrs, cascading a golist graph per declared variant (usually few: release/debug). The exclude-`go` fix removes this for the plugin's own queries (so plain builds are clean); user whole-graph queries still pay it.
3. **Breaking ABI + addr syntax** (hard cut, no shim).

## Tests

- Full plugin-go unit suite (variant parse/inheritance + cycle, module-root bounding, universe disambiguation by `vp`, sibling resolution via `states_under`, list completeness); stabby list round-trip exercises the new ABI cardinality.
- `plugingo-e2e` build suite: 16/16 (hermetic + host toolchains, `linux_amd64` cross-compile, and a real-engine cross-subtree sibling fixture where `release` is declared only at `//cmd`). Codegen suite passes (aside from a flaky SDK-download timeout on the local box). A `VariantInjector` harness provider supplies variants without per-fixture edits.

🤖 Generated with [Claude Code](https://claude.com/claude-code)