### PR TITLE
fix(driver): reject two targets producing the same sandbox file

### DIFF
--- a/crates/core/src/hartifactcontent/mod.rs
+++ b/crates/core/src/hartifactcontent/mod.rs
@@ -40,6 +40,17 @@ pub trait Content: Send + Sync {
     fn reader(&self) -> anyhow::Result<Box<dyn io::Read>>;
     fn walk(&self) -> anyhow::Result<Box<dyn Iterator<Item = anyhow::Result<WalkEntry>> + '_>>;
     fn hashout(&self) -> anyhow::Result<String>;
+    /// Relative paths of the file and symlink entries in this content —
+    /// directory entries excluded. Intended for callers that only need the set
+    /// of materialized paths (e.g. output-collision detection), not the bytes.
+    ///
+    /// The default enumerates via [`Content::walk`], which for stream-only
+    /// backings reads (and discards) file data to advance. Seekable, indexable
+    /// backings (tar-backed cache artifacts) override this with a header-only
+    /// scan that seeks past data — keeping the format detail behind the trait.
+    fn entry_paths(&self) -> anyhow::Result<Vec<PathBuf>> {
+        self.walk()?.map(|r| r.map(|e| e.path)).collect()
+    }
     /// Returns a seekable handle to the underlying bytes when the backing
     /// store supports random access (sqlite blobs, on-disk files). Backends
     /// without efficient seek (pipes, streams) return `Ok(None)` and the

--- a/crates/core/src/hartifactcontent/tar_index.rs
+++ b/crates/core/src/hartifactcontent/tar_index.rs
@@ -74,6 +74,18 @@ impl TarIndex {
         }
         Ok(Self { entries })
     }
+
+    /// Relative paths of the file and symlink entries, directory entries
+    /// excluded — the header-only enumeration backing
+    /// [`Content::entry_paths`](crate::hartifactcontent::Content::entry_paths)
+    /// for tar-backed content.
+    pub fn entry_paths(&self) -> Vec<PathBuf> {
+        self.entries
+            .iter()
+            .filter(|(_, e)| !matches!(e.kind, IndexEntryKind::Dir))
+            .map(|(path, _)| path.clone())
+            .collect()
+    }
 }
 
 #[cfg(test)]
@@ -126,6 +138,41 @@ mod tests {
         let mut out = vec![0u8; b.size as usize];
         cur.read_exact(&mut out).expect("read");
         assert_eq!(out, b"world!");
+    }
+
+    #[test]
+    fn entry_paths_excludes_directories() {
+        // Pack an explicit directory entry plus a file under it. entry_paths
+        // must return the file (and any symlink) but not the directory.
+        let mut buf = Vec::new();
+        {
+            let mut b = tar::Builder::new(&mut buf);
+            let mut dh = tar::Header::new_gnu();
+            dh.set_entry_type(tar::EntryType::Directory);
+            dh.set_size(0);
+            dh.set_mode(0o755);
+            b.append_data(&mut dh, "d/", std::io::empty())
+                .expect("append dir");
+            let mut fh = tar::Header::new_gnu();
+            fh.set_entry_type(tar::EntryType::Regular);
+            fh.set_size(3);
+            fh.set_mode(0o644);
+            b.append_data(&mut fh, "d/f.txt", &b"abc"[..])
+                .expect("append file");
+            b.finish().expect("finish");
+        }
+        let idx = TarIndex::build(Cursor::new(buf)).expect("build");
+        let paths = idx.entry_paths();
+        assert!(
+            paths.contains(&PathBuf::from("d/f.txt")),
+            "file must be listed: {paths:?}"
+        );
+        assert!(
+            !paths
+                .iter()
+                .any(|p| p == std::path::Path::new("d/") || p == std::path::Path::new("d")),
+            "directory entry must be excluded: {paths:?}"
+        );
     }
 
     #[cfg(unix)]

--- a/crates/driver-bridge/src/driver_managed_fuse.rs
+++ b/crates/driver-bridge/src/driver_managed_fuse.rs
@@ -3,8 +3,8 @@ use hcore::hartifactcontent;
 use hcore::hartifactcontent::tar_index::TarIndex;
 use hcore::hasync::Cancellable;
 use hdriver_support::driver_managed::{
-    ManagedDriver, ManagedRunInput, ShellFallback, collect_outputs, invoke_inner, list_path_for,
-    resolve_unpack_root, write_source_map,
+    ManagedDriver, ManagedRunInput, ShellFallback, collect_outputs, detect_output_collisions,
+    invoke_inner, list_path_for, resolve_unpack_root, write_source_map,
 };
 use hplugin::driver::{RunInput, RunRequest, RunResponse, SandboxGuard};
 use hsandboxfuse as sandboxfuse;
@@ -65,6 +65,12 @@ impl ManagedDriverFuse {
             let unpack_root = resolve_unpack_root(&input, &sandbox_dir, &ws_dir);
             groups.entry(unpack_root).or_default().push(input);
         }
+
+        // Reject two distinct targets producing the same sandbox file before we
+        // register any slot — overlapping layer paths would otherwise silently
+        // shadow by registration order.
+        detect_output_collisions(&groups)
+            .with_context(|| format!("output-collision check for {}", req.target.addr.format()))?;
 
         let mut slot_guards: Vec<sandboxfuse::SlotGuard> = Vec::new();
         let mut inputs: Vec<ManagedRunInput> = Vec::new();

--- a/crates/driver-support/src/driver_managed.rs
+++ b/crates/driver-support/src/driver_managed.rs
@@ -1,7 +1,6 @@
 use anyhow::Context;
 use async_trait::async_trait;
 use hcore::hartifactcontent;
-use hcore::hartifactcontent::tar_index::{IndexEntryKind, TarIndex};
 use hcore::hasync::{self, Cancellable};
 use hplugin::driver::inputartifact;
 use hplugin::driver::outputartifact::Content::TarPath;
@@ -381,17 +380,15 @@ pub fn list_path_for(input: &RunInput, list_dir: &Path) -> Option<PathBuf> {
 /// claimed by the *same* `source_addr` more than once — a diamond dependency, or
 /// a target depended on twice — resolves to a single owner and is allowed.
 ///
-/// Only file and symlink paths are compared — directory entries are skipped, so
-/// shared parent directories never trip the check (two targets may populate
+/// Only file and symlink paths are compared — directory entries are excluded,
+/// so shared parent directories never trip the check (two targets may populate
 /// disjoint files under a common dir). `filters` are honored so a
 /// partially-consumed input only claims the paths it exposes.
 ///
-/// Enumerates each input header-only: it builds a [`TarIndex`] over the
-/// seekable reader, which seeks past file data instead of reading it, so the
-/// check stays cheap and — crucially — does not read the input bytes the FUSE
-/// path is designed never to touch. Only content with no seekable reader falls
-/// back to a full [`Content::walk`], and those inputs get unpacked (their bytes
-/// read) regardless.
+/// Path enumeration goes through [`Content::entry_paths`], which the tar-backed
+/// cache artifact implements as a header-only scan (seeking past file data), so
+/// the check stays cheap and does not read the input bytes the FUSE path is
+/// designed never to touch — the format detail stays behind the trait.
 ///
 /// Runs on the execution (cache-miss) path before any input is materialized, so
 /// a collision fails fast with both producers named rather than silently
@@ -403,7 +400,7 @@ pub fn detect_output_collisions(groups: &BTreeMap<PathBuf, Vec<RunInput>>) -> an
     for (unpack_root, inputs) in groups {
         for input in inputs {
             let producer = input.source_addr.format();
-            let paths = input_claim_paths(input).with_context(|| {
+            let paths = input.artifact.content.entry_paths().with_context(|| {
                 format!(
                     "enumerate paths for output-collision check \
                      (origin_id={}, source_addr={producer})",
@@ -434,36 +431,6 @@ pub fn detect_output_collisions(groups: &BTreeMap<PathBuf, Vec<RunInput>>) -> an
         }
     }
     Ok(())
-}
-
-/// Relative file/symlink paths an input contributes, for collision checking.
-/// Prefers the seekable header-only [`TarIndex`] (seeks past data); falls back
-/// to a full [`Content::walk`] only when the content has no seekable reader.
-/// Directory entries are excluded — collisions are at file granularity.
-fn input_claim_paths(input: &RunInput) -> anyhow::Result<Vec<PathBuf>> {
-    if let Some(reader) = input
-        .artifact
-        .content
-        .seekable_reader()
-        .context("open seekable reader")?
-    {
-        let index = TarIndex::build(reader).context("build tar index")?;
-        return Ok(index
-            .entries
-            .into_iter()
-            .filter(|(_, e)| !matches!(e.kind, IndexEntryKind::Dir))
-            .map(|(path, _)| path)
-            .collect());
-    }
-    // Non-seekable: full walk (reads data). walk() already yields only
-    // file/symlink entries, no directories.
-    input
-        .artifact
-        .content
-        .walk()
-        .context("walk content")?
-        .map(|e| e.map(|e| e.path))
-        .collect()
 }
 
 // ---------------------------------------------------------------------
@@ -607,7 +574,7 @@ fn pack_to_artifact_tar(
 mod source_map_tests {
     use super::*;
     use hcore::hartifactcontent::tar::{TarPacker, TarWalker};
-    use hcore::hartifactcontent::{Content, ReadSeek, WalkEntry};
+    use hcore::hartifactcontent::{Content, WalkEntry};
     use hmodel::htaddr::parse_addr;
     use hplugin::driver::inputartifact::{InputArtifact, Type};
     use std::io::{Cursor, Read};
@@ -623,11 +590,6 @@ mod source_map_tests {
         }
         fn hashout(&self) -> anyhow::Result<String> {
             Ok(String::new())
-        }
-        // Real artifacts are seekable, so the collision check enumerates paths
-        // via the header-only `TarIndex` path; mirror that here.
-        fn seekable_reader(&self) -> anyhow::Result<Option<Box<dyn ReadSeek + Send>>> {
-            Ok(Some(Box::new(Cursor::new(self.0.clone()))))
         }
     }
 
@@ -868,66 +830,5 @@ mod source_map_tests {
             make_input("dep|b|0", "//pkg:_b", &[("pkg/x.txt", "2")]),
         ]);
         detect_output_collisions(&groups).expect("filtered-out path must not collide");
-    }
-
-    /// Pack a single explicit directory entry plus a file under it.
-    fn pack_dir_and_file(dir: &str, file: &str, body: &str) -> Vec<u8> {
-        let mut buf = Vec::new();
-        {
-            let mut b = tar::Builder::new(&mut buf);
-            let mut dh = tar::Header::new_gnu();
-            dh.set_entry_type(tar::EntryType::Directory);
-            dh.set_size(0);
-            dh.set_mode(0o755);
-            b.append_data(&mut dh, dir, std::io::empty())
-                .expect("append dir");
-            let mut fh = tar::Header::new_gnu();
-            fh.set_entry_type(tar::EntryType::Regular);
-            fh.set_size(body.len() as u64);
-            fh.set_mode(0o644);
-            b.append_data(&mut fh, file, body.as_bytes())
-                .expect("append file");
-            b.finish().expect("finish");
-        }
-        buf
-    }
-
-    fn make_raw_input(origin_id: &str, source_addr: &str, tar: Vec<u8>) -> ManagedRunInput {
-        ManagedRunInput {
-            input: RunInput {
-                artifact: InputArtifact {
-                    r#type: Type::Dep,
-                    origin_id: origin_id.to_string(),
-                    content: Arc::new(TarBytes(tar)),
-                },
-                origin_id: origin_id.to_string(),
-                source_addr: parse_addr(source_addr).expect("parse addr"),
-                filters: vec![],
-                annotations: BTreeMap::new(),
-            },
-            list_path: Some(PathBuf::from("/dev/null")),
-            unpack_root: PathBuf::from("/ws"),
-        }
-    }
-
-    // Two targets whose archives both carry an *explicit* directory entry for
-    // the same shared dir must not collide on that directory — only the file
-    // paths under it matter. (The header-only TarIndex path indexes dir
-    // entries; the check must skip them, matching walk() semantics.)
-    #[test]
-    fn shared_explicit_dir_entry_does_not_collide() {
-        let groups = group(vec![
-            make_raw_input(
-                "dep|a|0",
-                "//pkg:_a",
-                pack_dir_and_file("shared/", "shared/a.txt", "a"),
-            ),
-            make_raw_input(
-                "dep|b|0",
-                "//pkg:_b",
-                pack_dir_and_file("shared/", "shared/b.txt", "b"),
-            ),
-        ]);
-        detect_output_collisions(&groups).expect("shared dir entry must not collide");
     }
 }

--- a/crates/driver-support/src/driver_managed.rs
+++ b/crates/driver-support/src/driver_managed.rs
@@ -10,7 +10,7 @@ use hplugin::driver::{
     ParseResponse, RunInput, RunRequest, outputartifact,
 };
 use hplugin::provider::TargetSpec;
-use std::collections::BTreeMap;
+use std::collections::{BTreeMap, HashMap};
 use std::fs::File;
 use std::io::Write;
 use std::path::{Path, PathBuf};
@@ -374,6 +374,65 @@ pub fn list_path_for(input: &RunInput, list_dir: &Path) -> Option<PathBuf> {
     }
 }
 
+/// Reject two *different* producer targets writing the same file into one
+/// sandbox. Keyed on producer identity (`source_addr`), per the sandbox
+/// isolation model: a materialized path has exactly one owning target. A path
+/// claimed by the *same* `source_addr` more than once — a diamond dependency, or
+/// a target depended on twice — resolves to a single owner and is allowed.
+///
+/// Only file and symlink paths are compared: the content walk yields no
+/// directory entries, so shared parent directories never trip the check (two
+/// targets may populate disjoint files under a common dir). `filters` are
+/// honored so a partially-consumed input only claims the paths it exposes.
+///
+/// Runs on the execution (cache-miss) path before any input is materialized, so
+/// a collision fails fast with both producers named rather than silently
+/// last-write-wins in the sandbox (regular deps `File::create`-truncate; FUSE
+/// layers shadow by registration order — neither surfaces the conflict).
+pub fn detect_output_collisions(groups: &BTreeMap<PathBuf, Vec<RunInput>>) -> anyhow::Result<()> {
+    // Absolute sandbox path -> the source_addr of the target that claimed it.
+    let mut owners: HashMap<PathBuf, String> = HashMap::new();
+    for (unpack_root, inputs) in groups {
+        for input in inputs {
+            let producer = input.source_addr.format();
+            for entry in input.artifact.content.walk().with_context(|| {
+                format!(
+                    "walk content for output-collision check \
+                     (origin_id={}, source_addr={producer})",
+                    input.origin_id,
+                )
+            })? {
+                let entry = entry.with_context(|| {
+                    format!("read entry for output-collision check (source_addr={producer})")
+                })?;
+                if !input.filters.is_empty()
+                    && !input
+                        .filters
+                        .iter()
+                        .any(|f| Path::new(f) == entry.path.as_path())
+                {
+                    continue;
+                }
+                let abs = unpack_root.join(&entry.path);
+                match owners.get(&abs) {
+                    Some(existing) if *existing != producer => anyhow::bail!(
+                        "output collision: {} is produced by two different targets \
+                         ({existing} and {producer}); a sandbox file may be provided by \
+                         only one target",
+                        abs.display(),
+                    ),
+                    // Same producer (diamond / depended twice) — one owner, allowed.
+                    Some(_) => {}
+                    None => {
+                        owners.insert(abs, producer.clone());
+                    }
+                }
+            }
+        }
+    }
+    Ok(())
+}
+
 // ---------------------------------------------------------------------
 // Output collection helpers
 // ---------------------------------------------------------------------
@@ -694,5 +753,82 @@ mod source_map_tests {
             msg.contains("out") && msg.contains("data"),
             "must name path+group: {msg}"
         );
+    }
+
+    fn group(inputs: Vec<ManagedRunInput>) -> BTreeMap<PathBuf, Vec<RunInput>> {
+        let mut m: BTreeMap<PathBuf, Vec<RunInput>> = BTreeMap::new();
+        for mi in inputs {
+            m.entry(mi.unpack_root.clone()).or_default().push(mi.input);
+        }
+        m
+    }
+
+    // Two *different* targets writing the same sandbox path must fail, naming
+    // both producers — not silently last-write-wins.
+    #[test]
+    fn collision_between_two_targets_errors() {
+        let groups = group(vec![
+            make_input("dep|a|0", "//pkg:_a", &[("pkg/x.txt", "1")]),
+            make_input("dep|b|0", "//pkg:_b", &[("pkg/x.txt", "2")]),
+        ]);
+        let err = detect_output_collisions(&groups).expect_err("expected collision");
+        let msg = format!("{err:#}");
+        assert!(msg.contains("two different targets"), "got: {msg}");
+        assert!(
+            msg.contains("//pkg:_a") && msg.contains("//pkg:_b"),
+            "must name both producers: {msg}"
+        );
+        assert!(msg.contains("pkg/x.txt"), "must name the path: {msg}");
+    }
+
+    // The same target contributing a path twice (diamond dep / depended twice)
+    // is one owner — allowed.
+    #[test]
+    fn same_target_twice_is_allowed() {
+        let groups = group(vec![
+            make_input("dep|a|0", "//pkg:_a", &[("pkg/x.txt", "1")]),
+            make_input("dep|a|1", "//pkg:_a", &[("pkg/x.txt", "1")]),
+        ]);
+        detect_output_collisions(&groups).expect("same producer must not collide");
+    }
+
+    // Different targets under a shared directory but at disjoint files: no
+    // collision (only file paths are compared, not the parent dir).
+    #[test]
+    fn disjoint_files_under_shared_dir_ok() {
+        let groups = group(vec![
+            make_input("dep|a|0", "//pkg:_a", &[("pkg/a.txt", "1")]),
+            make_input("dep|b|0", "//pkg:_b", &[("pkg/b.txt", "2")]),
+        ]);
+        detect_output_collisions(&groups).expect("disjoint files must not collide");
+    }
+
+    // The same relative path in two *different* unpack roots is two distinct
+    // sandbox paths — not a collision.
+    #[test]
+    fn same_rel_path_different_unpack_root_ok() {
+        let mut a = make_input("dep|a|0", "//pkg:_a", &[("pkg/x.txt", "1")]);
+        let mut b = make_input("dep|b|0", "//pkg:_b", &[("pkg/x.txt", "2")]);
+        a.unpack_root = PathBuf::from("/sandbox/exec_toolsA");
+        b.unpack_root = PathBuf::from("/sandbox/exec_toolsB");
+        let groups = group(vec![a, b]);
+        detect_output_collisions(&groups).expect("distinct roots must not collide");
+    }
+
+    // A filtered input only claims the paths it actually exposes: a path it
+    // filters out cannot collide with another target's file at that path.
+    #[test]
+    fn filtered_out_path_does_not_collide() {
+        let mut a = make_input(
+            "dep|a|0",
+            "//pkg:_a",
+            &[("pkg/x.txt", "1"), ("pkg/y.txt", "1")],
+        );
+        a.input.filters = vec!["pkg/y.txt".to_string()];
+        let groups = group(vec![
+            a,
+            make_input("dep|b|0", "//pkg:_b", &[("pkg/x.txt", "2")]),
+        ]);
+        detect_output_collisions(&groups).expect("filtered-out path must not collide");
     }
 }

--- a/crates/driver-support/src/driver_managed.rs
+++ b/crates/driver-support/src/driver_managed.rs
@@ -1,6 +1,7 @@
 use anyhow::Context;
 use async_trait::async_trait;
 use hcore::hartifactcontent;
+use hcore::hartifactcontent::tar_index::{IndexEntryKind, TarIndex};
 use hcore::hasync::{self, Cancellable};
 use hplugin::driver::inputartifact;
 use hplugin::driver::outputartifact::Content::TarPath;
@@ -380,10 +381,17 @@ pub fn list_path_for(input: &RunInput, list_dir: &Path) -> Option<PathBuf> {
 /// claimed by the *same* `source_addr` more than once — a diamond dependency, or
 /// a target depended on twice — resolves to a single owner and is allowed.
 ///
-/// Only file and symlink paths are compared: the content walk yields no
-/// directory entries, so shared parent directories never trip the check (two
-/// targets may populate disjoint files under a common dir). `filters` are
-/// honored so a partially-consumed input only claims the paths it exposes.
+/// Only file and symlink paths are compared — directory entries are skipped, so
+/// shared parent directories never trip the check (two targets may populate
+/// disjoint files under a common dir). `filters` are honored so a
+/// partially-consumed input only claims the paths it exposes.
+///
+/// Enumerates each input header-only: it builds a [`TarIndex`] over the
+/// seekable reader, which seeks past file data instead of reading it, so the
+/// check stays cheap and — crucially — does not read the input bytes the FUSE
+/// path is designed never to touch. Only content with no seekable reader falls
+/// back to a full [`Content::walk`], and those inputs get unpacked (their bytes
+/// read) regardless.
 ///
 /// Runs on the execution (cache-miss) path before any input is materialized, so
 /// a collision fails fast with both producers named rather than silently
@@ -395,25 +403,20 @@ pub fn detect_output_collisions(groups: &BTreeMap<PathBuf, Vec<RunInput>>) -> an
     for (unpack_root, inputs) in groups {
         for input in inputs {
             let producer = input.source_addr.format();
-            for entry in input.artifact.content.walk().with_context(|| {
+            let paths = input_claim_paths(input).with_context(|| {
                 format!(
-                    "walk content for output-collision check \
+                    "enumerate paths for output-collision check \
                      (origin_id={}, source_addr={producer})",
                     input.origin_id,
                 )
-            })? {
-                let entry = entry.with_context(|| {
-                    format!("read entry for output-collision check (source_addr={producer})")
-                })?;
+            })?;
+            for rel in paths {
                 if !input.filters.is_empty()
-                    && !input
-                        .filters
-                        .iter()
-                        .any(|f| Path::new(f) == entry.path.as_path())
+                    && !input.filters.iter().any(|f| Path::new(f) == rel.as_path())
                 {
                     continue;
                 }
-                let abs = unpack_root.join(&entry.path);
+                let abs = unpack_root.join(&rel);
                 match owners.get(&abs) {
                     Some(existing) if *existing != producer => anyhow::bail!(
                         "output collision: {} is produced by two different targets \
@@ -431,6 +434,36 @@ pub fn detect_output_collisions(groups: &BTreeMap<PathBuf, Vec<RunInput>>) -> an
         }
     }
     Ok(())
+}
+
+/// Relative file/symlink paths an input contributes, for collision checking.
+/// Prefers the seekable header-only [`TarIndex`] (seeks past data); falls back
+/// to a full [`Content::walk`] only when the content has no seekable reader.
+/// Directory entries are excluded — collisions are at file granularity.
+fn input_claim_paths(input: &RunInput) -> anyhow::Result<Vec<PathBuf>> {
+    if let Some(reader) = input
+        .artifact
+        .content
+        .seekable_reader()
+        .context("open seekable reader")?
+    {
+        let index = TarIndex::build(reader).context("build tar index")?;
+        return Ok(index
+            .entries
+            .into_iter()
+            .filter(|(_, e)| !matches!(e.kind, IndexEntryKind::Dir))
+            .map(|(path, _)| path)
+            .collect());
+    }
+    // Non-seekable: full walk (reads data). walk() already yields only
+    // file/symlink entries, no directories.
+    input
+        .artifact
+        .content
+        .walk()
+        .context("walk content")?
+        .map(|e| e.map(|e| e.path))
+        .collect()
 }
 
 // ---------------------------------------------------------------------
@@ -574,7 +607,7 @@ fn pack_to_artifact_tar(
 mod source_map_tests {
     use super::*;
     use hcore::hartifactcontent::tar::{TarPacker, TarWalker};
-    use hcore::hartifactcontent::{Content, WalkEntry};
+    use hcore::hartifactcontent::{Content, ReadSeek, WalkEntry};
     use hmodel::htaddr::parse_addr;
     use hplugin::driver::inputartifact::{InputArtifact, Type};
     use std::io::{Cursor, Read};
@@ -590,6 +623,11 @@ mod source_map_tests {
         }
         fn hashout(&self) -> anyhow::Result<String> {
             Ok(String::new())
+        }
+        // Real artifacts are seekable, so the collision check enumerates paths
+        // via the header-only `TarIndex` path; mirror that here.
+        fn seekable_reader(&self) -> anyhow::Result<Option<Box<dyn ReadSeek + Send>>> {
+            Ok(Some(Box::new(Cursor::new(self.0.clone()))))
         }
     }
 
@@ -830,5 +868,66 @@ mod source_map_tests {
             make_input("dep|b|0", "//pkg:_b", &[("pkg/x.txt", "2")]),
         ]);
         detect_output_collisions(&groups).expect("filtered-out path must not collide");
+    }
+
+    /// Pack a single explicit directory entry plus a file under it.
+    fn pack_dir_and_file(dir: &str, file: &str, body: &str) -> Vec<u8> {
+        let mut buf = Vec::new();
+        {
+            let mut b = tar::Builder::new(&mut buf);
+            let mut dh = tar::Header::new_gnu();
+            dh.set_entry_type(tar::EntryType::Directory);
+            dh.set_size(0);
+            dh.set_mode(0o755);
+            b.append_data(&mut dh, dir, std::io::empty())
+                .expect("append dir");
+            let mut fh = tar::Header::new_gnu();
+            fh.set_entry_type(tar::EntryType::Regular);
+            fh.set_size(body.len() as u64);
+            fh.set_mode(0o644);
+            b.append_data(&mut fh, file, body.as_bytes())
+                .expect("append file");
+            b.finish().expect("finish");
+        }
+        buf
+    }
+
+    fn make_raw_input(origin_id: &str, source_addr: &str, tar: Vec<u8>) -> ManagedRunInput {
+        ManagedRunInput {
+            input: RunInput {
+                artifact: InputArtifact {
+                    r#type: Type::Dep,
+                    origin_id: origin_id.to_string(),
+                    content: Arc::new(TarBytes(tar)),
+                },
+                origin_id: origin_id.to_string(),
+                source_addr: parse_addr(source_addr).expect("parse addr"),
+                filters: vec![],
+                annotations: BTreeMap::new(),
+            },
+            list_path: Some(PathBuf::from("/dev/null")),
+            unpack_root: PathBuf::from("/ws"),
+        }
+    }
+
+    // Two targets whose archives both carry an *explicit* directory entry for
+    // the same shared dir must not collide on that directory — only the file
+    // paths under it matter. (The header-only TarIndex path indexes dir
+    // entries; the check must skip them, matching walk() semantics.)
+    #[test]
+    fn shared_explicit_dir_entry_does_not_collide() {
+        let groups = group(vec![
+            make_raw_input(
+                "dep|a|0",
+                "//pkg:_a",
+                pack_dir_and_file("shared/", "shared/a.txt", "a"),
+            ),
+            make_raw_input(
+                "dep|b|0",
+                "//pkg:_b",
+                pack_dir_and_file("shared/", "shared/b.txt", "b"),
+            ),
+        ]);
+        detect_output_collisions(&groups).expect("shared dir entry must not collide");
     }
 }

--- a/crates/driver-support/src/driver_managed.rs
+++ b/crates/driver-support/src/driver_managed.rs
@@ -313,24 +313,21 @@ pub(crate) fn build_source_map(
         }
         let source_addr_str = managed_input.input.source_addr.format();
         let filters = &managed_input.input.filters;
-        // Walk artifact directly instead of reading list_path: after group
-        // expansion, multiple inputs share parent origin_id → list_path_for
-        // gives them one shared file (opened append). Reading that shared
-        // list per-input would let the last-iterated input's source_addr
-        // overwrite earlier ones for paths only the earlier inputs produced.
+        // Enumerate the artifact's own paths directly instead of reading
+        // list_path: after group expansion, multiple inputs share parent
+        // origin_id → list_path_for gives them one shared file (opened append).
+        // Reading that shared list per-input would let the last-iterated input's
+        // source_addr overwrite earlier ones for paths only the earlier inputs
+        // produced. `entry_paths` is header-only for tar-backed content, so this
+        // maps paths without reading the file bytes.
         let content = managed_input.input.artifact.content.as_ref();
-        for entry in content
-            .walk()
-            .with_context(|| format!("walk content for source_map (source={source_addr_str})"))?
-        {
-            let entry = entry
-                .with_context(|| format!("read entry for source_map (source={source_addr_str})"))?;
-            if !filters.is_empty() && !filters.iter().any(|f| Path::new(f) == entry.path.as_path())
-            {
+        for rel in content.entry_paths().with_context(|| {
+            format!("enumerate content for source_map (source={source_addr_str})")
+        })? {
+            if !filters.is_empty() && !filters.iter().any(|f| Path::new(f) == rel.as_path()) {
                 continue;
             }
-            let rel = entry.path.to_string_lossy().into_owned();
-            source_map.insert(rel, source_addr_str.clone());
+            source_map.insert(rel.to_string_lossy().into_owned(), source_addr_str.clone());
         }
     }
     Ok(source_map)

--- a/crates/driver-support/src/driver_managed_os.rs
+++ b/crates/driver-support/src/driver_managed_os.rs
@@ -1,6 +1,6 @@
 use crate::driver_managed::{
-    ManagedDriver, ManagedRunInput, ShellFallback, collect_outputs, invoke_inner, list_path_for,
-    resolve_unpack_root, write_source_map,
+    ManagedDriver, ManagedRunInput, ShellFallback, collect_outputs, detect_output_collisions,
+    invoke_inner, list_path_for, resolve_unpack_root, write_source_map,
 };
 use anyhow::Context;
 use hcore::hartifactcontent;
@@ -62,6 +62,12 @@ impl ManagedDriverOs {
             let unpack_root = resolve_unpack_root(&input, &sandbox_dir, &ws_dir);
             groups.entry(unpack_root).or_default().push(input);
         }
+
+        // Reject two distinct targets producing the same sandbox file before we
+        // materialize anything — the copy path would otherwise silently
+        // last-write-wins.
+        detect_output_collisions(&groups)
+            .with_context(|| format!("output-collision check for {}", req.target.addr.format()))?;
 
         let mut inputs: Vec<ManagedRunInput> = Vec::new();
         for (unpack_root, group) in groups {

--- a/crates/engine/src/engine/local_cache.rs
+++ b/crates/engine/src/engine/local_cache.rs
@@ -179,6 +179,21 @@ impl hartifactcontent::Content for CacheArtifact {
         Ok(self.hashout.clone())
     }
 
+    fn entry_paths(&self) -> anyhow::Result<Vec<std::path::PathBuf>> {
+        match &self.content_type {
+            // Header-only: index the tar over the seekable reader (seeks past
+            // file data) instead of walking and reading every byte.
+            hartifactcontent::Type::Tar => {
+                let reader = self.seekable_reader()?.ok_or_else(|| {
+                    anyhow::anyhow!("tar cache artifact {} has no seekable reader", self.name)
+                })?;
+                Ok(hcore::hartifactcontent::tar_index::TarIndex::build(reader)?.entry_paths())
+            }
+            // No index for cpio yet — fall back to the walk-based default.
+            hartifactcontent::Type::Cpio => self.walk()?.map(|r| r.map(|e| e.path)).collect(),
+        }
+    }
+
     fn seekable_reader(
         &self,
     ) -> anyhow::Result<Option<Box<dyn hartifactcontent::ReadSeek + Send>>> {

--- a/crates/plugin-go/src/plugingo/provider.rs
+++ b/crates/plugin-go/src/plugingo/provider.rs
@@ -1121,7 +1121,14 @@ fn compute_pkg_src_addrs(pkg_str: &str, states: &[State]) -> anyhow::Result<Vec<
     } else {
         format!("{}/**/*", pkg_str)
     };
-    let non_go_glob_addr = pluginfs::glob_addr(&non_go_glob, &["**/*.go"]);
+    // Exclude `.go` (their own lane) and the module files `go.mod`/`go.sum`:
+    // the latter are delivered into `_golist` by the modfiles (`_go_mod`) lane
+    // as `fs:file` deps. Without excluding them here the non-go glob and the
+    // modfiles dep both produce `go.mod`/`go.sum` in the sandbox — two
+    // different targets writing the same file, which the sandbox runner now
+    // rejects as an output collision.
+    let non_go_glob_addr =
+        pluginfs::glob_addr(&non_go_glob, &["**/*.go", "**/go.mod", "**/go.sum"]);
     let mut addrs = vec![non_go_glob_addr.format()];
 
     let codegen_root = pick_codegen_root(states);
@@ -5641,6 +5648,27 @@ golang.org/x/oauth2 v0.0.0-20200107190931-bf48bf16ab8d h1:pE8b58s1HRDMi8RDc79m0H
         assert!(
             !addrs.iter().any(|s| s.contains("go_embed_src")),
             "golist srcfiles must NOT reference the go_embed_src lane: {addrs:?}"
+        );
+    }
+
+    // Regression: the root non-go glob (`**/*` minus `.go`) also captured
+    // `go.mod`/`go.sum`, which the modfiles (`_go_mod`) lane already delivers
+    // into `_golist` as `fs:file` deps. Both producing the same sandbox file is
+    // an output collision, so the glob must exclude the module files.
+    #[test]
+    fn compute_pkg_src_addrs_glob_excludes_module_files() {
+        let addrs = compute_pkg_src_addrs("", &[]).unwrap();
+        let glob = addrs
+            .iter()
+            .find(|s| s.contains(":glob@"))
+            .expect("non-go glob present in golist srcfiles");
+        assert!(
+            glob.contains("**/go.mod"),
+            "glob must exclude go.mod: {glob}"
+        );
+        assert!(
+            glob.contains("**/go.sum"),
+            "glob must exclude go.sum: {glob}"
         );
     }
 

--- a/crates/plugin-go/src/plugingo/toolchain.rs
+++ b/crates/plugin-go/src/plugingo/toolchain.rs
@@ -257,18 +257,20 @@ pub(crate) fn resolve_target_go(inputs: &[ManagedRunInput]) -> anyhow::Result<st
         .find(|m| m.input.origin_id.starts_with(&prefix))
         .context("go toolchain: target `gosdk` dep not staged")?;
 
+    // Only paths are needed to locate the `go` binary — `entry_paths` is
+    // header-only for tar-backed content, so we don't read the whole SDK tree
+    // (~thousands of files) just to match a filename.
     let mut candidates: Vec<std::path::PathBuf> = Vec::new();
-    for entry in gosdk
+    for rel in gosdk
         .input
         .artifact
         .content
         .as_ref()
-        .walk()
-        .context("walk target toolchain output")?
+        .entry_paths()
+        .context("enumerate target toolchain output")?
     {
-        let entry = entry.context("read target toolchain entry")?;
-        if entry.path.file_name().and_then(|n| n.to_str()) == Some("go") {
-            candidates.push(gosdk.unpack_root.join(&entry.path));
+        if rel.file_name().and_then(|n| n.to_str()) == Some("go") {
+            candidates.push(gosdk.unpack_root.join(&rel));
         }
     }
 


### PR DESCRIPTION
## Problem

Materializing a target's inputs into the sandbox had **no cross-input collision guard**. When two *different* dependency targets each produce the same relative path, both are materialized into the same sandbox location:

- **Regular deps (OS copy / FUSE-fallback):** `unpack` calls `File::create` → **silent truncate, last-write-wins**.
- **FUSE slot:** overlapping layer paths are **shadowed by registration order**.

Neither surfaces the conflict, so the materialized file is nondeterministic → violates the isolation/reproducibility guarantee. (Symlinks already errored on divergent targets; regular files did not. The read-only staging path had *content*-based dedup but no producer-identity check.)

## Fix

New `detect_output_collisions` in `driver_managed.rs`, run on the execution (cache-miss) path in **both** the OS and FUSE managed runners, before any input is materialized:

- Walks each input's declared path set (honoring `filters`) and rejects a path claimed by **two different `source_addr`s**, failing fast with both producers named.
- **Keyed on producer identity:** a path claimed by the *same* target more than once — a diamond dependency, or a target depended on twice — resolves to one owner and is **allowed**.
- Only **file/symlink** paths compared (the content walk yields no directory entries), so two targets may still populate **disjoint files under a shared parent dir**.
- **Support (tool) inputs** are grouped and checked the same way.

Enforced at the runner layer (above staging), so it works regardless of the physical materialization mechanism; no changes to `unpack`/`stage` internals. Extra cost is a header-only walk on the cache-miss path, dwarfed by the unpack/copy it precedes.

### Behavior change
Two *different* targets supplying a byte-identical file into one sandbox now **error** (previously the staging path let identical bytes coexist). This is intentional per the producer-identity rule.

## Tests
`driver_managed.rs`: collision names both producers + path; same-target-twice allowed; disjoint files under a shared dir OK; same rel path in different unpack roots OK; filtered-out path does not collide.

🤖 Generated with [Claude Code](https://claude.com/claude-code)