### PR TITLE
fix(codegen): write xattrs on existing symlinks

### DIFF
--- a/utils/tar/tar.go
+++ b/utils/tar/tar.go
@@ -251,13 +251,12 @@ func Untar(in io.Reader, to string, o UntarOptions) (err error) {
 
 			recordFile(hdr.Name)
 
-			if xfs.PathExists(dest) {
-				return nil
-			}
-
-			err := os.Symlink(hdr.Linkname, dest)
-			if err != nil {
-				return fmt.Errorf("untar: %v: %w", hdr.Name, err)
+			// The symlink may already be there, still (re)write the xattrs, they may be missing
+			if !xfs.PathExists(dest) {
+				err := os.Symlink(hdr.Linkname, dest)
+				if err != nil {
+					return fmt.Errorf("untar: %v: %w", hdr.Name, err)
+				}
 			}
 
 			if err := writeXattrs(dest, o.Xattrs); err != nil {


### PR DESCRIPTION
The symlink branch of `Untar` returned early when the destination already existed, so codegen xattrs (`user.heph.codegen`, `user.heph.v0`) were never stamped on trees that had already been linked. Now the symlink is only created when missing, but `writeXattrs` always runs.

Regular files were already fine: `untarFile` early-returns on a size+mtime match, but `writeXattrs` runs after it either way.

Not changed: the `o.Dedup` hit path still returns before anything else, but codegen (`lcache/codegen_link.go`) passes no `Dedup`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DV9ckTaCzbVzc752bPmSVk