### PR TITLE
fix(remote-cache): pull manifests, not outputs, to decide a hit

### DIFF
--- a/crates/e2e/tests/remote_cache.rs
+++ b/crates/e2e/tests/remote_cache.rs
@@ -135,6 +135,106 @@ async fn remote_cache_cold_warm_hot() {
     );
 }
 
+/// Total bytes of every file under `dir`.
+fn dir_bytes(dir: &Path) -> u64 {
+    let mut bytes = 0;
+    let Ok(entries) = std::fs::read_dir(dir) else {
+        return 0;
+    };
+    for entry in entries.flatten() {
+        let path = entry.path();
+        if path.is_dir() {
+            bytes += dir_bytes(&path);
+        } else if let Ok(meta) = entry.metadata() {
+            bytes += meta.len();
+        }
+    }
+    bytes
+}
+
+/// A remote hit must not drag down output blobs nobody reads.
+///
+/// `top` depends on `dep`, and `dep`'s output is several MiB. On a run where
+/// `top` is itself a cache hit, `dep` is resolved only to feed `top`'s `hashin`
+/// — its `hashout` comes from the manifest — so none of its output bytes are
+/// needed. The local cache must therefore stay tiny: only manifests (and the
+/// blob `top` itself hands back) come down.
+///
+/// Then asking for `dep`'s output directly pulls that blob, on demand, and it
+/// comes back byte-identical — proving the deferral is a deferral, not a loss.
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn remote_pull_is_lazy_per_output() {
+    let root = tempfile::tempdir().expect("root tempdir");
+    let remote = tempfile::tempdir().expect("remote tempdir");
+    let remote_uri = format!("file://{}", remote.path().display());
+
+    // `dep`'s output is large AND random: large so downloading it is impossible to
+    // miss in the local-cache byte count, random so serving it later proves it came
+    // from the cache rather than a re-execution.
+    std::fs::create_dir_all(root.path().join("pkg")).expect("mkdir pkg");
+    std::fs::write(
+        root.path().join("pkg").join("BUILD"),
+        r#"
+dep = target(
+    name = "dep",
+    driver = "bash",
+    run = "head -c 3000000 /dev/urandom | base64 > $OUT",
+    out = "dep.txt",
+)
+
+target(
+    name = "top",
+    driver = "bash",
+    run = "echo $RANDOM$RANDOM$RANDOM$(wc -c < $SRC_DEP) > $OUT",
+    deps = {"dep": dep},
+    out = "top.txt",
+)
+"#,
+    )
+    .expect("write BUILD");
+
+    // ---- COLD: build both, push both to the remote. ----
+    let cold = build_engine(root.path(), &remote_uri);
+    let top_cold = run_drain(&cold, "//pkg:top").await;
+    let dep_cold = run_drain(&cold, "//pkg:dep").await;
+    let dep_bytes = dep_cold.len() as u64;
+    assert!(
+        dep_bytes > 3_000_000,
+        "dep output should be multi-MiB, got {dep_bytes} bytes"
+    );
+    drop(cold);
+
+    let local_cache = root.path().join(".heph3").join("cache");
+    std::fs::remove_dir_all(&local_cache).expect("rm local cache");
+
+    // ---- WARM: `top` is a remote hit; `dep` is only needed for its hashout. ----
+    let warm = build_engine(root.path(), &remote_uri);
+    let top_warm = run_drain(&warm, "//pkg:top").await;
+    assert_eq!(
+        top_warm, top_cold,
+        "warm run must serve the remote-cached output, not re-execute"
+    );
+
+    let after_top = dir_bytes(&local_cache);
+    assert!(
+        after_top < dep_bytes / 2,
+        "resolving //pkg:top pulled {after_top} bytes into the local cache — \
+         //pkg:dep's {dep_bytes}-byte output was downloaded despite only its \
+         hashout being needed"
+    );
+
+    // ---- Asking for dep's output pulls exactly that blob, on demand. ----
+    let dep_warm = run_drain(&warm, "//pkg:dep").await;
+    assert_eq!(
+        dep_warm, dep_cold,
+        "the deferred blob must still be pullable, byte-identical"
+    );
+    assert!(
+        dir_bytes(&local_cache) > dep_bytes / 2,
+        "asking for dep's output must actually download it"
+    );
+}
+
 /// Companion check: with **no** remote configured, deleting the local cache and
 /// re-running *does* re-execute (different output). This guards against the
 /// cold→warh→hot test passing for the wrong reason (e.g. a stray reproducible

--- a/crates/engine/src/engine/gc.rs
+++ b/crates/engine/src/engine/gc.rs
@@ -78,10 +78,19 @@ impl Engine {
         let mut bytes = 0u64;
         if let Some(manifest) = self.read_manifest(addr, hashin)? {
             for a in &manifest.artifacts {
+                // A manifest can name blobs that were never downloaded (a
+                // revision mirrored from a remote materializes lazily), so only
+                // count bytes actually reclaimed.
+                let present = self
+                    .local_cache
+                    .exists(addr, hashin, &a.name)
+                    .with_context(|| format!("probe cached artifact {} for {addr}", a.name))?;
                 self.local_cache
                     .delete(addr, hashin, &a.name)
                     .with_context(|| format!("delete cached artifact {} for {addr}", a.name))?;
-                bytes = bytes.saturating_add(a.size);
+                if present {
+                    bytes = bytes.saturating_add(a.size);
+                }
             }
         }
         self.local_cache

--- a/crates/engine/src/engine/local_cache.rs
+++ b/crates/engine/src/engine/local_cache.rs
@@ -137,6 +137,15 @@ pub trait LocalCache: Send + Sync {
 #[error("not found")]
 pub struct NotFoundError;
 
+/// Name of a revision's manifest blob.
+///
+/// The manifest records a revision's *identity* — its target, `hashin`, and every
+/// artifact's `hashout`/size/type — not which of its blobs are resident. A
+/// revision written by [`cache_locally`](Engine::cache_locally) does have all of
+/// them (blobs first, manifest last); one mirrored from a remote
+/// ([`probe_remote_revision`](Engine::probe_remote_revision)) starts with none of
+/// them, and materializes per caller. Read paths therefore check residency
+/// explicitly — see [`missing_local_blobs`](Engine::missing_local_blobs).
 pub(crate) const MANIFEST_V1: &str = "manifest-v1.borsh";
 
 #[derive(Clone)]
@@ -511,6 +520,60 @@ impl Engine {
         hproc::process_supervisor::block_or_inline(move || self.read_manifest(addr, hashin))
     }
 
+    /// The blobs a caller asking for `outputs` will actually read: its Output
+    /// groups plus every SupportFile (which travels with the target wherever it is
+    /// referenced), and never a Log — logs are written to the cache but no read
+    /// path surfaces them.
+    ///
+    /// The single definition of "needed", shared by the read path
+    /// ([`artifacts_from_manifest`](Self::artifacts_from_manifest)), the residency
+    /// check ([`missing_local_blobs`](Self::missing_local_blobs)) and the remote
+    /// presence check — so a lazy pull can never be decided against a different
+    /// set than the one that will be read.
+    pub(crate) fn needed_artifacts<'a>(
+        manifest: &'a Manifest,
+        outputs: &'a [String],
+    ) -> impl Iterator<Item = &'a ManifestArtifact> {
+        manifest.artifacts.iter().filter(|a| match a.r#type {
+            ManifestArtifactType::Output => outputs.contains(&a.group),
+            ManifestArtifactType::SupportFile => true,
+            ManifestArtifactType::Log => false,
+        })
+    }
+
+    /// Names of the blobs a caller asking for `outputs` needs that are not in the
+    /// local cache yet — exactly what has to be pulled from a remote before
+    /// [`artifacts_from_manifest`](Self::artifacts_from_manifest) can serve the
+    /// read.
+    ///
+    /// A non-empty result is the normal state of a revision whose manifest came
+    /// from a remote: the manifest records the revision's identity and hashouts,
+    /// not which of its blobs happen to be resident.
+    pub(crate) async fn missing_local_blobs(
+        &self,
+        _ctoken: &dyn Cancellable,
+        addr: &Addr,
+        hashin: &str,
+        manifest: &Manifest,
+        outputs: &[String],
+    ) -> anyhow::Result<Vec<String>> {
+        let local_cache = &self.local_cache;
+        hproc::process_supervisor::block_or_inline(move || {
+            let mut missing = Vec::new();
+            for artifact in Self::needed_artifacts(manifest, outputs) {
+                if !local_cache
+                    .exists(addr, hashin, &artifact.name)
+                    .with_context(|| {
+                        format!("probe local blob {} for {addr} {hashin}", artifact.name)
+                    })?
+                {
+                    missing.push(artifact.name.clone());
+                }
+            }
+            anyhow::Ok(missing)
+        })
+    }
+
     /// Build this caller's artifact set from an already-parsed `manifest`, gating
     /// Output groups to `outputs` (SupportFiles always travel). Returns `None`
     /// when a required blob is missing — treat as a miss. Splitting this from
@@ -676,13 +739,28 @@ mod tests {
             "engine B local cache must start cold"
         );
 
-        // Pulling from the remote populates B's local cache and returns the manifest.
-        let manifest = engine_b
-            .download_from_remote(&ctoken, &addr, "HASHIN1")
+        // Probing the remote mirrors the manifest — and only the manifest.
+        let needed = vec!["out".to_string()];
+        let (manifest, rev) = engine_b
+            .probe_remote_revision(&ctoken, &addr, "HASHIN1", &needed)
             .await
-            .expect("download")
+            .expect("probe")
             .expect("remote hit");
         assert_eq!(manifest.artifacts.len(), 1);
+        let blob_name = manifest.artifacts[0].name.clone();
+        assert!(
+            !engine_b
+                .local_cache
+                .exists(&addr, "HASHIN1", &blob_name)
+                .expect("exists"),
+            "probing the remote must not download any output blob"
+        );
+
+        // Pulling that one blob is what puts bytes in B's local cache.
+        engine_b
+            .pull_remote_blobs(&ctoken, &addr, "HASHIN1", &rev, &[blob_name])
+            .await
+            .expect("pull");
 
         // The blob is now served from B's *local* cache, byte-identical.
         let (arts, _) = engine_b
@@ -741,13 +819,13 @@ mod tests {
             tokio::time::sleep(std::time::Duration::from_millis(5)).await;
         }
 
-        // The revision is now on the remote: a cold engine pulls it.
+        // The revision is now on the remote: a cold engine locates it.
         let (engine2, _e2) = engine_with_remote(&remote_uri);
         assert!(
             engine2
-                .download_from_remote(&ctoken, &addr, "HASHBG")
+                .probe_remote_revision(&ctoken, &addr, "HASHBG", &["out".to_string()])
                 .await
-                .expect("download")
+                .expect("probe")
                 .is_some(),
             "background upload must land on the remote"
         );
@@ -763,11 +841,80 @@ mod tests {
         let addr = test_addr();
         assert!(
             engine
-                .download_from_remote(&ctoken, &addr, "NOPE")
+                .probe_remote_revision(&ctoken, &addr, "NOPE", &["out".to_string()])
                 .await
-                .expect("download")
+                .expect("probe")
                 .is_none()
         );
+    }
+
+    /// A revision whose manifest is on the remote but whose blob has been expired
+    /// (an independent object-store lifecycle rule can do exactly that) must read
+    /// as a **miss**, so the target executes. Accepting the hit on the manifest
+    /// alone would strand the build: the pull would fail after the engine already
+    /// decided "already built".
+    #[tokio::test]
+    async fn remote_probe_rejects_a_revision_whose_blob_is_gone() {
+        let remote = tempfile::tempdir().expect("remote dir");
+        let remote_uri = format!("file://{}", remote.path().display());
+        let ctoken = StdCancellationToken::new();
+        let addr = test_addr();
+
+        let (engine_a, _a) = engine_with_remote(&remote_uri);
+        engine_a
+            .cache_locally(
+                &ctoken,
+                &addr,
+                "HASHEVICT",
+                vec![raw_artifact("a", b"payload")],
+                false,
+            )
+            .await
+            .expect("cache_locally");
+        engine_a.upload_to_remote(&addr, "HASHEVICT").await;
+
+        // Expire every blob object, leaving the manifest behind.
+        let needed = vec!["out".to_string()];
+        let (manifest, _) = engine_a
+            .probe_remote_revision(&ctoken, &addr, "HASHEVICT", &needed)
+            .await
+            .expect("probe")
+            .expect("remote hit while intact");
+        let blob_names: Vec<String> = manifest.artifacts.iter().map(|a| a.name.clone()).collect();
+        let removed = evict_objects(remote.path(), &blob_names);
+        assert!(removed > 0, "test must actually evict a blob");
+
+        let (engine_b, _b) = engine_with_remote(&remote_uri);
+        assert!(
+            engine_b
+                .probe_remote_revision(&ctoken, &addr, "HASHEVICT", &needed)
+                .await
+                .expect("probe")
+                .is_none(),
+            "a revision the remote can no longer serve must read as a miss"
+        );
+    }
+
+    /// Delete every file under `dir` (recursively) whose file name is in `names`.
+    /// Mimics an object-store lifecycle rule expiring blobs while leaving the
+    /// revision's manifest object in place. Returns how many were removed.
+    fn evict_objects(dir: &std::path::Path, names: &[String]) -> usize {
+        let mut removed = 0;
+        let Ok(entries) = std::fs::read_dir(dir) else {
+            return 0;
+        };
+        for entry in entries.flatten() {
+            let path = entry.path();
+            if path.is_dir() {
+                removed += evict_objects(&path, names);
+            } else if let Some(file_name) = path.file_name().and_then(|n| n.to_str())
+                && names.iter().any(|n| n == file_name)
+            {
+                std::fs::remove_file(&path).expect("evict blob");
+                removed += 1;
+            }
+        }
+        removed
     }
 
     fn test_addr() -> Addr {

--- a/crates/engine/src/engine/local_cache_fs.rs
+++ b/crates/engine/src/engine/local_cache_fs.rs
@@ -4,6 +4,7 @@ use crate::engine::local_cache::{
 use anyhow::{Context, Result};
 use hcore::hartifactcontent;
 use hmodel::htaddr::Addr;
+use std::io::Write as _;
 use std::path::{Path, PathBuf};
 use std::{fs, io};
 
@@ -37,6 +38,54 @@ impl LocalCacheFS {
     }
 }
 
+/// Staging writer behind [`LocalCacheFS::writer`]: bytes land in a temp file that
+/// is renamed over the final path when the writer is dropped, so the blob appears
+/// atomically. A write error (or a failed final flush) drops the temp instead,
+/// leaving whatever was already at the destination untouched rather than
+/// replacing it with a truncated blob.
+struct AtomicFileWriter {
+    file: Option<fs::File>,
+    temp: PathBuf,
+    dest: PathBuf,
+    failed: bool,
+}
+
+impl io::Write for AtomicFileWriter {
+    fn write(&mut self, buf: &[u8]) -> io::Result<usize> {
+        let Some(file) = self.file.as_mut() else {
+            return Err(io::Error::other("cache writer already finalized"));
+        };
+        let res = file.write(buf);
+        if res.is_err() {
+            self.failed = true;
+        }
+        res
+    }
+
+    fn flush(&mut self) -> io::Result<()> {
+        let Some(file) = self.file.as_mut() else {
+            return Ok(());
+        };
+        let res = file.flush();
+        if res.is_err() {
+            self.failed = true;
+        }
+        res
+    }
+}
+
+impl Drop for AtomicFileWriter {
+    fn drop(&mut self) {
+        let flushed = match self.file.take() {
+            Some(mut file) => file.flush().is_ok(),
+            None => false,
+        };
+        if self.failed || !flushed || fs::rename(&self.temp, &self.dest).is_err() {
+            drop(fs::remove_file(&self.temp));
+        }
+    }
+}
+
 impl LocalCache for LocalCacheFS {
     fn reader(&self, addr: &Addr, hashin: &str, name: &str) -> Result<SizedReader> {
         let path = self.get_path(addr, hashin, name);
@@ -59,15 +108,35 @@ impl LocalCache for LocalCacheFS {
         })
     }
 
+    /// Write to a sibling temp file and rename it into place once the writer is
+    /// dropped.
+    ///
+    /// The rename makes a blob appear atomically: a concurrent reader either sees
+    /// the previous complete file or the new one, never a truncated write in
+    /// progress. That matters because a blob can be (re)written while another
+    /// request holds only a *read* lock on the revision — a lazy remote pull
+    /// materializes into an entry other callers are already reading. Both writers
+    /// store the same content-addressed bytes, so whichever rename lands last is
+    /// equally correct.
     fn writer(&self, addr: &Addr, hashin: &str, name: &str) -> Result<Box<dyn io::Write>> {
         let path = self.get_path(addr, hashin, name);
         if let Some(parent) = path.parent() {
             fs::create_dir_all(parent)
                 .with_context(|| format!("Failed to create parent directories for: {:?}", path))?;
         }
-        let file = fs::File::create(&path)
-            .with_context(|| format!("Failed to create writer for cache path: {:?}", path))?;
-        Ok(Box::new(file))
+        let temp = path.with_file_name(format!(
+            ".{}.{}.tmp",
+            name,
+            uuid::Uuid::new_v4().as_simple()
+        ));
+        let file = fs::File::create(&temp)
+            .with_context(|| format!("Failed to create writer for cache path: {:?}", temp))?;
+        Ok(Box::new(AtomicFileWriter {
+            file: Some(file),
+            temp,
+            dest: path,
+            failed: false,
+        }))
     }
 
     fn exists(&self, addr: &Addr, hashin: &str, name: &str) -> Result<bool> {

--- a/crates/engine/src/engine/remote_cache.rs
+++ b/crates/engine/src/engine/remote_cache.rs
@@ -3,12 +3,21 @@
 //!
 //! Semantics (see [`RemoteCacheSet`]):
 //! - **write** — push to every writable cache in parallel; within each cache the
-//!   manifest is written *last*, so a reader that sees a manifest is guaranteed
-//!   every blob it names is already present (same invariant the local cache
-//!   relies on).
+//!   manifest is written *last*, so a manifest that appears was complete at
+//!   upload time. Blobs are independent objects, though, and a bucket lifecycle
+//!   rule can expire them out from under a surviving manifest — hence the
+//!   presence check in [`RemoteCacheSet::blobs_exist`].
 //! - **read** — try caches one-by-one in ascending-latency order. The first
-//!   cache whose manifest is present serves the *whole* revision: every blob is
-//!   pulled from that same cache, never spliced across caches.
+//!   cache whose manifest is present serves the revision: every blob comes from
+//!   that same cache, never spliced across caches.
+//!
+//! **Reads are lazy.** A remote hit is decided from the *manifest alone* — it
+//! carries every artifact's `hashout`, which is all a dependent needs to compute
+//! its own `hashin`. Output blobs transfer only when a caller actually reads
+//! them, and only the groups it asked for (see [`Engine::pull_remote_blobs`]).
+//! A target resolved purely to feed a dependent's hash — the common case in a
+//! fully-cached build — therefore moves a few hundred manifest bytes, not its
+//! outputs.
 //!
 //! **Separate manifest.** The remote uses its own [`RemoteManifest`], distinct
 //! from the local [`Manifest`], so the two layers can store artifacts
@@ -74,7 +83,7 @@ use tracing::warn;
 /// buffer (10 MiB). A target with thousands of artifacts, multiplied by the
 /// engine's own target-level parallelism, would otherwise run the process out of
 /// file descriptors or memory. Requests past this bound simply queue.
-const REVISION_BLOB_CONCURRENCY: usize = 32;
+pub(crate) const REVISION_BLOB_CONCURRENCY: usize = 32;
 
 /// Max background upload *tasks* in flight process-wide.
 ///
@@ -374,13 +383,35 @@ fn compression_for(size: u64) -> ManifestArtifactEncoding {
     }
 }
 
-/// A revision fetched from one remote cache: the remote manifest plus the local
-/// temp files each blob was streamed into (still in their on-remote encoding —
-/// the engine decodes them per [`RemoteManifestArtifact::encoding`]).
-pub(crate) struct FetchedRevision {
+/// A revision *located* on one remote cache — the decision half of a remote hit.
+///
+/// Holds no blob bytes. The manifest names the revision's artifacts, records
+/// each one's `hashout` (enough to answer "already built" and to feed a
+/// dependent's `hashin`) and its on-remote [`encoding`](RemoteManifestArtifact::encoding),
+/// so individual blobs can be pulled later, on demand, from the same cache the
+/// manifest came from (manifest affinity).
+pub(crate) struct RemoteRevision {
+    /// The cache that served the manifest. Every blob of this revision is pulled
+    /// from it, so a revision is never spliced across caches.
+    cache_idx: usize,
     pub manifest: RemoteManifest,
-    /// `(artifact name, temp file holding its on-remote bytes)`.
-    pub blobs: Vec<(String, PathBuf)>,
+}
+
+impl RemoteRevision {
+    /// The artifact entry for `name`, or an error if the manifest never named it
+    /// — a caller asking for a blob outside the revision is a bug, not a miss.
+    fn artifact(&self, name: &str) -> anyhow::Result<&RemoteManifestArtifact> {
+        self.manifest
+            .artifacts
+            .iter()
+            .find(|a| a.name == name)
+            .with_context(|| {
+                format!(
+                    "remote manifest for {} does not name blob {name}",
+                    self.manifest.target
+                )
+            })
+    }
 }
 
 /// The ordered set of remote caches. Empty when no `caches:` are configured, in
@@ -645,17 +676,21 @@ impl RemoteCacheSet {
         join_all(per_cache).await;
     }
 
-    /// Find the first readable cache (latency order) holding the manifest for
-    /// `(addr, hashin)`, then stream every blob it names from that same cache
-    /// into temp files under `dest_dir`. Returns `None` on a miss, or if any
-    /// named blob is absent (an incomplete revision is treated as a miss).
-    pub(crate) async fn fetch_revision(
+    /// Locate `(addr, hashin)` on the first readable cache (latency order) that
+    /// holds its manifest — **manifest only, no blob transfer**.
+    ///
+    /// This is the whole remote hit/miss decision: the manifest carries every
+    /// artifact's `hashout`, so "already built" is answerable, and a dependent's
+    /// `hashin` computable, without moving a single output byte. Blobs follow
+    /// later, per caller, via [`Self::fetch_blob`].
+    ///
+    /// `None` on a miss (no readable cache has it) or on an unparseable manifest.
+    pub(crate) async fn fetch_manifest(
         &self,
         ctoken: &dyn Cancellable,
         addr: &Addr,
         hashin: &str,
-        dest_dir: &Path,
-    ) -> anyhow::Result<Option<FetchedRevision>> {
+    ) -> anyhow::Result<Option<RemoteRevision>> {
         if !self.has_readable() {
             return Ok(None);
         }
@@ -700,91 +735,126 @@ impl RemoteCacheSet {
                 return Ok(None);
             }
         };
+        Ok(Some(RemoteRevision {
+            cache_idx,
+            manifest,
+        }))
+    }
 
-        let cache = self
-            .caches
-            .get(cache_idx)
-            .context("remote cache index out of range")?;
-        // Fetch the revision's blobs concurrently — a multi-output target no
-        // longer downloads them one at a time. The shared `LimitStore` still caps
-        // total in-flight ops per cache, so this only parallelizes within that
-        // ceiling. Each future yields `Some((name, temp))` on success or `None`
-        // on a miss (blob absent, or a best-effort backend/stream error already
-        // noted on the cache); a fatal local temp-IO failure is `Err`.
+    /// Whether `rev`'s cache still holds every one of `names` — presence only, no
+    /// bytes transferred.
+    ///
+    /// This is what keeps a lazy pull fail-*soft*. The hit is decided from the
+    /// manifest, but the blobs it names are separate objects that a bucket
+    /// lifecycle rule can expire independently, so "manifest present" alone does
+    /// not prove the revision is still servable. Checking presence up front, at
+    /// decision time, turns an evicted revision back into an ordinary cache miss
+    /// (the target executes) instead of a failure discovered later, mid-read,
+    /// after the engine already committed to "already built".
+    ///
+    /// Any error (or cancellation) answers `false`: unproven presence must never
+    /// be reported as a hit.
+    pub(crate) async fn blobs_exist(
+        &self,
+        ctoken: &dyn Cancellable,
+        rev: &RemoteRevision,
+        addr: &Addr,
+        hashin: &str,
+        names: &[String],
+    ) -> bool {
+        let Some(cache) = self.caches.get(rev.cache_idx) else {
+            return false;
+        };
         // Collected eagerly — see the note in `put_revision`.
-        let fetches: Vec<_> = manifest
-            .artifacts
+        let checks: Vec<_> = names
             .iter()
-            .map(|artifact| {
-                let key = Self::key(addr, hashin, &artifact.name);
+            .map(|name| {
+                let key = Self::key(addr, hashin, name);
                 async move {
-                    let reader = match cache.backend.open_read(&key).await {
-                        Ok(Some(reader)) => reader,
-                        // Manifest names a blob the cache no longer has → incomplete.
-                        Ok(None) => return Ok(None),
-                        Err(e) => {
-                            cache.note_err("blob download", &e);
-                            return Ok(None);
-                        }
-                    };
-                    let temp = dest_dir.join(format!("{}.gz", uuid::Uuid::new_v4()));
-                    // Temp-file I/O is local and genuinely fatal — propagate.
-                    let mut file = tokio::fs::File::create(&temp).await.with_context(|| {
-                        format!("create temp for remote blob {}", artifact.name)
-                    })?;
-                    let mut reader = reader;
-                    // Race the transfer against cancellation. Without this a
-                    // Ctrl-C during a large pull is ignored until the copy ends —
-                    // and the copy is exactly where a wedged connection sits, so
-                    // the run the user just cancelled keeps hanging. A cancelled
-                    // blob makes the revision incomplete, which the caller already
-                    // treats as a miss.
-                    let copied = tokio::select! {
-                        biased;
-                        () = ctoken.cancelled() => {
-                            drop(file);
-                            drop(std::fs::remove_file(&temp));
-                            return Ok(None);
-                        }
-                        r = tokio::io::copy(&mut reader, &mut file) => r,
-                    };
-                    if let Err(e) = copied {
-                        // Mid-stream network error from the cache → best-effort miss.
-                        cache.note_err(
-                            "blob download",
-                            &anyhow::Error::new(e)
-                                .context(format!("stream remote blob {}", artifact.name)),
-                        );
-                        drop(file);
-                        drop(std::fs::remove_file(&temp));
-                        return Ok(None);
+                    if ctoken.is_cancelled() {
+                        return false;
                     }
-                    file.shutdown()
-                        .await
-                        .with_context(|| format!("flush temp for remote blob {}", artifact.name))?;
-                    Ok::<_, anyhow::Error>(Some((artifact.name.clone(), temp)))
+                    match cache.backend.exists(&key).await {
+                        Ok(present) => present,
+                        Err(e) => {
+                            cache.note_err("blob presence check", &e);
+                            false
+                        }
+                    }
                 }
             })
             .collect();
-        // Bounded fan-out — see `REVISION_BLOB_CONCURRENCY`. `buffered` (not
-        // `buffer_unordered`) yields in input order, so the results line up with
-        // `manifest.artifacts` (the local-decode step zips them by position).
-        let slots: Vec<Option<(String, PathBuf)>> = stream::iter(fetches)
+        stream::iter(checks)
             .buffered(REVISION_BLOB_CONCURRENCY)
-            .try_collect()
-            .await?;
+            .all(|present| async move { present })
+            .await
+    }
 
-        // A single missing blob makes the whole revision incomplete: drop every
-        // temp we did download and treat it as a miss so the build executes.
-        if slots.iter().any(Option::is_none) {
-            let downloaded: Vec<(String, PathBuf)> = slots.into_iter().flatten().collect();
-            cleanup_temps(&downloaded);
+    /// Stream one blob of `rev` from the cache that served its manifest into a
+    /// temp file under `dest_dir`, still in its on-remote encoding (the engine
+    /// decodes it into the local cache — see [`Engine::pull_remote_blobs`]).
+    ///
+    /// `Ok(None)` when the cache no longer has the object, the transfer failed
+    /// (already noted on the cache), or the request was cancelled — all of which
+    /// mean "this cache cannot serve the blob". Local temp-file I/O failures are
+    /// genuinely fatal and propagate.
+    pub(crate) async fn fetch_blob(
+        &self,
+        ctoken: &dyn Cancellable,
+        rev: &RemoteRevision,
+        addr: &Addr,
+        hashin: &str,
+        name: &str,
+        dest_dir: &Path,
+    ) -> anyhow::Result<Option<PathBuf>> {
+        let cache = self
+            .caches
+            .get(rev.cache_idx)
+            .context("remote cache index out of range")?;
+        let key = Self::key(addr, hashin, name);
+        let reader = match cache.backend.open_read(&key).await {
+            Ok(Some(reader)) => reader,
+            // Manifest names a blob the cache no longer has → incomplete.
+            Ok(None) => return Ok(None),
+            Err(e) => {
+                cache.note_err("blob download", &e);
+                return Ok(None);
+            }
+        };
+        let temp = dest_dir.join(format!("{}.blob", uuid::Uuid::new_v4()));
+        // Temp-file I/O is local and genuinely fatal — propagate.
+        let mut file = tokio::fs::File::create(&temp)
+            .await
+            .with_context(|| format!("create temp for remote blob {name}"))?;
+        let mut reader = reader;
+        // Race the transfer against cancellation. Without this a Ctrl-C during a
+        // large pull is ignored until the copy ends — and the copy is exactly
+        // where a wedged connection sits, so the run the user just cancelled
+        // keeps hanging.
+        let copied = tokio::select! {
+            biased;
+            () = ctoken.cancelled() => {
+                drop(file);
+                drop(std::fs::remove_file(&temp));
+                return Ok(None);
+            }
+            r = tokio::io::copy(&mut reader, &mut file) => r,
+        };
+        if let Err(e) = copied {
+            // Mid-stream network error from the cache → best-effort miss.
+            cache.note_err(
+                "blob download",
+                &anyhow::Error::new(e).context(format!("stream remote blob {name}")),
+            );
+            drop(file);
+            drop(std::fs::remove_file(&temp));
             return Ok(None);
         }
-        let blobs: Vec<(String, PathBuf)> = slots.into_iter().flatten().collect();
-
+        file.shutdown()
+            .await
+            .with_context(|| format!("flush temp for remote blob {name}"))?;
         cache.note_ok();
-        Ok(Some(FetchedRevision { manifest, blobs }))
+        Ok(Some(temp))
     }
 }
 
@@ -801,14 +871,6 @@ async fn read_small_inner(cache: &ConfiguredCache, key: &str) -> anyhow::Result<
             Ok(Some(buf))
         }
         None => Ok(None),
-    }
-}
-
-/// Best-effort removal of temp files collected during a fetch that ended up a
-/// miss, so a remote failure mid-download doesn't leak.
-fn cleanup_temps(temps: &[(String, PathBuf)]) {
-    for (_, path) in temps {
-        drop(std::fs::remove_file(path));
     }
 }
 
@@ -1152,97 +1214,187 @@ impl Engine {
         Ok(())
     }
 
-    /// On a local cache miss, pull a complete revision from the remote caches
-    /// into the local cache. Returns the manifest on success (the entry is now
-    /// fully present locally), or `None` to fall through to execution.
+    /// Locate a revision on the remote and, if every blob a caller could ask for
+    /// is still there, mirror its manifest into the local cache — **without
+    /// downloading a single output blob**.
     ///
-    /// Must be called under the per-addr **write** lock: it writes blobs into
-    /// the local cache, and the write lock excludes GC and other writers. The
-    /// whole revision comes from a single cache (manifest affinity); blobs land
-    /// first and the manifest is written *last*.
-    pub(crate) async fn download_from_remote(
+    /// This is the remote half of the hit/miss decision. `output_groups` are the
+    /// groups the target's callers may ask for; the blobs backing them (plus
+    /// support files, never logs — see [`Engine::needed_artifacts`]) are
+    /// presence-checked before the hit is accepted, so a revision whose blobs the
+    /// remote has expired degrades to a miss (execute) instead of failing later,
+    /// mid-read. Returns the mirrored local manifest plus the located
+    /// [`RemoteRevision`], which callers keep to pull their own outputs on demand
+    /// via [`Self::pull_remote_blobs`].
+    ///
+    /// Must be called under the per-addr **write** lock: it writes the manifest
+    /// into the local cache, and the write lock excludes GC and other writers.
+    ///
+    /// The mirrored manifest deliberately names blobs that are not local yet — it
+    /// records the revision's identity and hashouts, not its residency. Every
+    /// read path materializes what it needs first (see
+    /// [`Engine::missing_local_blobs`]).
+    pub(crate) async fn probe_remote_revision(
         &self,
         ctoken: &dyn Cancellable,
         addr: &Addr,
         hashin: &str,
-    ) -> anyhow::Result<Option<Manifest>> {
-        if !self.remote_caches.has_readable() {
-            return Ok(None);
-        }
-
-        let tmp_dir = self.remote_tmp_dir();
-        std::fs::create_dir_all(&tmp_dir)
-            .with_context(|| format!("create remote temp dir {}", tmp_dir.display()))?;
-
-        let Some(fetched) = self
+        output_groups: &[String],
+    ) -> anyhow::Result<Option<(Manifest, RemoteRevision)>> {
+        let Some(rev) = self
             .remote_caches
-            .fetch_revision(ctoken, addr, hashin, &tmp_dir)
+            .fetch_manifest(ctoken, addr, hashin)
             .await?
         else {
             return Ok(None);
         };
 
-        // Decode each temp file into the local cache per its on-remote encoding
-        // (synchronous, on the blocking pool; the non-`Send` local writer stays
-        // on that thread). Then build the *local* manifest — which always
-        // describes decoded bytes (`encoding = None`) — and write it last,
-        // mirroring `cache_locally`.
+        let local_manifest = local_manifest_from_remote(&rev.manifest, hashin);
+        // Resolve groups to blob names through the same "needed" rule the read
+        // path uses, so presence is checked against exactly what will be read.
+        let needed: Vec<String> = Self::needed_artifacts(&local_manifest, output_groups)
+            .map(|a| a.name.clone())
+            .collect();
+        if !self
+            .remote_caches
+            .blobs_exist(ctoken, &rev, addr, hashin, &needed)
+            .await
+        {
+            return Ok(None);
+        }
+
+        let bytes = borsh::to_vec(&local_manifest).context("serialize local manifest")?;
         let local_cache = self.local_cache.clone();
         let addr_owned = addr.clone();
         let hashin_owned = hashin.to_string();
-        let temp_paths: Vec<PathBuf> = fetched.blobs.iter().map(|(_, p)| p.clone()).collect();
-        let RemoteManifest {
-            target, artifacts, ..
-        } = fetched.manifest;
-        let blobs = fetched.blobs;
-        let res = run_codec("download decode", move || -> anyhow::Result<Manifest> {
+        // Same reasoning as `cache_artifact_locally`: the local-cache writer is
+        // synchronous (and not `Send`), so it must not run on a runtime worker.
+        hproc::process_supervisor::block_or_inline(move || {
             use std::io::Write;
-            for (artifact, (name, path)) in artifacts.iter().zip(blobs.iter()) {
-                let mut w = local_cache
-                    .writer(&addr_owned, &hashin_owned, name)
-                    .with_context(|| format!("open local writer for downloaded blob {name}"))?;
-                match artifact.encoding {
-                    ManifestArtifactEncoding::Gzip => gunzip_from_file(path, &mut w)
-                        .with_context(|| format!("decompress downloaded blob {name}"))?,
-                    _ => copy_file_to(path, &mut w)
-                        .with_context(|| format!("write downloaded blob {name}"))?,
-                }
-            }
-
-            let local_manifest = Manifest {
-                version: "1.0.0".to_string(),
-                target,
-                created_at_nanos: Utc::now().timestamp_nanos_opt().unwrap_or(0),
-                hashin: hashin_owned.clone(),
-                artifacts: artifacts
-                    .iter()
-                    .map(|a| ManifestArtifact {
-                        hashout: a.hashout.clone(),
-                        group: a.group.clone(),
-                        name: a.name.clone(),
-                        size: a.size,
-                        r#type: a.r#type.clone(),
-                        content_type: a.content_type.clone(),
-                        // Local cache stores decoded bytes.
-                        encoding: ManifestArtifactEncoding::None,
-                    })
-                    .collect(),
-            };
-            let bytes = borsh::to_vec(&local_manifest).context("serialize local manifest")?;
-            let mut mw = local_cache
+            let mut w = local_cache
                 .writer(&addr_owned, &hashin_owned, MANIFEST_V1)
-                .context("open local writer for downloaded manifest")?;
-            mw.write_all(&bytes).context("write downloaded manifest")?;
-            Ok(local_manifest)
+                .context("open local writer for remote manifest")?;
+            w.write_all(&bytes).context("write remote manifest")?;
+            anyhow::Ok(())
+        })
+        .with_context(|| format!("mirror remote manifest for {addr} {hashin}"))?;
+
+        Ok(Some((local_manifest, rev)))
+    }
+
+    /// Pull exactly `names` from `rev` into the local cache, decoding each blob
+    /// per its on-remote encoding. Nothing else transfers — this is where a lazy
+    /// read materializes, so it must stay scoped to the blobs the caller asked
+    /// for.
+    ///
+    /// Runs under the per-addr riding **read** lock (which excludes GC's
+    /// `try_write`, so the revision cannot be reclaimed underneath). Pulls are
+    /// single-flighted per blob by the caller, so two output groups needing the
+    /// same support file transfer it once.
+    ///
+    /// A blob the remote no longer serves is an error, not a miss: presence was
+    /// already checked when the hit was accepted, so losing it here means the
+    /// revision was evicted mid-build.
+    pub(crate) async fn pull_remote_blobs(
+        &self,
+        ctoken: &dyn Cancellable,
+        addr: &Addr,
+        hashin: &str,
+        rev: &RemoteRevision,
+        names: &[String],
+    ) -> anyhow::Result<()> {
+        if names.is_empty() {
+            return Ok(());
+        }
+        let tmp_dir = self.remote_tmp_dir();
+        std::fs::create_dir_all(&tmp_dir)
+            .with_context(|| format!("create remote temp dir {}", tmp_dir.display()))?;
+
+        // Bounded fan-out — see `REVISION_BLOB_CONCURRENCY`. A target whose caller
+        // asks for many output groups must not open every stream at once.
+        // Collected eagerly — see the note in `put_revision`.
+        let pulls: Vec<_> = names
+            .iter()
+            .map(|name| self.pull_remote_blob(ctoken, addr, hashin, rev, name, &tmp_dir))
+            .collect();
+        stream::iter(pulls)
+            .buffered(REVISION_BLOB_CONCURRENCY)
+            .try_collect::<Vec<()>>()
+            .await?;
+        Ok(())
+    }
+
+    /// Stream one blob into a temp file, then decode it into the local cache.
+    /// The temp file is dropped on both paths.
+    async fn pull_remote_blob(
+        &self,
+        ctoken: &dyn Cancellable,
+        addr: &Addr,
+        hashin: &str,
+        rev: &RemoteRevision,
+        name: &str,
+        tmp_dir: &Path,
+    ) -> anyhow::Result<()> {
+        let encoding = rev.artifact(name)?.encoding.clone();
+        let Some(temp) = self
+            .remote_caches
+            .fetch_blob(ctoken, rev, addr, hashin, name, tmp_dir)
+            .await?
+        else {
+            if ctoken.is_cancelled() {
+                return Err(crate::engine::error::CancelledError.into());
+            }
+            anyhow::bail!(
+                "remote cache no longer serves blob {name} of {addr} {hashin}: the revision was \
+                 evicted after its manifest was read — re-run to rebuild it",
+            );
+        };
+
+        let local_cache = self.local_cache.clone();
+        let addr_owned = addr.clone();
+        let hashin_owned = hashin.to_string();
+        let name_owned = name.to_string();
+        let temp_for_codec = temp.clone();
+        let res = run_codec("download decode", move || -> anyhow::Result<()> {
+            let mut w = local_cache
+                .writer(&addr_owned, &hashin_owned, &name_owned)
+                .with_context(|| format!("open local writer for downloaded blob {name_owned}"))?;
+            match encoding {
+                ManifestArtifactEncoding::Gzip => gunzip_from_file(&temp_for_codec, &mut w)
+                    .with_context(|| format!("decompress downloaded blob {name_owned}"))?,
+                _ => copy_file_to(&temp_for_codec, &mut w)
+                    .with_context(|| format!("write downloaded blob {name_owned}"))?,
+            }
+            Ok(())
         })
         .await;
 
-        // Always drop the temp files, success or failure.
-        for path in &temp_paths {
-            drop(std::fs::remove_file(path));
-        }
+        drop(std::fs::remove_file(&temp));
+        res
+    }
+}
 
-        Ok(Some(res?))
+/// The local view of a remote manifest: same artifacts, but `encoding = None`
+/// because the local cache always stores decoded bytes.
+fn local_manifest_from_remote(remote: &RemoteManifest, hashin: &str) -> Manifest {
+    Manifest {
+        version: "1.0.0".to_string(),
+        target: remote.target.clone(),
+        created_at_nanos: Utc::now().timestamp_nanos_opt().unwrap_or(0),
+        hashin: hashin.to_string(),
+        artifacts: remote
+            .artifacts
+            .iter()
+            .map(|a| ManifestArtifact {
+                hashout: a.hashout.clone(),
+                group: a.group.clone(),
+                name: a.name.clone(),
+                size: a.size,
+                r#type: a.r#type.clone(),
+                content_type: a.content_type.clone(),
+                encoding: ManifestArtifactEncoding::None,
+            })
+            .collect(),
     }
 }
 
@@ -1423,7 +1575,7 @@ mod tests {
                 "should not break before the threshold"
             );
             let res = set
-                .fetch_revision(&never(), &addr, "h", dir.path())
+                .fetch_manifest(&never(), &addr, "h")
                 .await
                 .expect("fetch must be best-effort (Ok), never a hard error");
             assert!(res.is_none(), "a failing remote read is a miss");
@@ -1673,12 +1825,12 @@ mod tests {
         }
     }
 
-    /// A revision's blobs download in parallel, but never more than
+    /// Blobs download in parallel, but never more than
     /// [`REVISION_BLOB_CONCURRENCY`] at a time: sequential pulls made a wide
     /// fan-out crawl, while an unbounded one would hold an open temp file and a
     /// live response stream per artifact.
     #[tokio::test]
-    async fn fetch_revision_fans_out_within_the_blob_bound() {
+    async fn blob_pulls_fan_out_within_the_blob_bound() {
         let dir = tempfile::tempdir().expect("tempdir");
         let addr = addr();
         let artifacts: Vec<RemoteManifestArtifact> =
@@ -1706,13 +1858,24 @@ mod tests {
         });
         let set = set_with(backend.clone(), dir.path().to_path_buf());
 
-        let fetched = set
-            .fetch_revision(&never(), &addr, "h", dir.path())
+        let rev = set
+            .fetch_manifest(&never(), &addr, "h")
             .await
-            .expect("fetch")
+            .expect("fetch manifest")
             .expect("hit");
+        // Collected eagerly — see the note in `put_revision`.
+        let ctoken = never();
+        let fetches: Vec<_> = artifacts
+            .iter()
+            .map(|a| set.fetch_blob(&ctoken, &rev, &addr, "h", &a.name, dir.path()))
+            .collect();
+        let temps: Vec<Option<PathBuf>> = stream::iter(fetches)
+            .buffered(REVISION_BLOB_CONCURRENCY)
+            .try_collect()
+            .await
+            .expect("fetch blobs");
         assert_eq!(
-            fetched.blobs.len(),
+            temps.iter().filter(|t| t.is_some()).count(),
             FANOUT_ARTIFACTS,
             "every blob must be fetched"
         );
@@ -1769,7 +1932,7 @@ mod tests {
     /// target's per-addr write lock — so an uninterruptible copy means Ctrl-C
     /// leaves the build hanging on the very transfer the user gave up on.
     #[tokio::test]
-    async fn fetch_revision_aborts_on_cancellation() {
+    async fn blob_fetch_aborts_on_cancellation() {
         /// Serves a manifest, then never delivers a single blob byte.
         struct StalledBlobBackend {
             manifest_key: String,
@@ -1825,7 +1988,12 @@ mod tests {
         let set = set_with(backend, dir.path().to_path_buf());
 
         let ctoken = never();
-        let fetch = set.fetch_revision(&ctoken, &addr, "h", dir.path());
+        let rev = set
+            .fetch_manifest(&ctoken, &addr, "h")
+            .await
+            .expect("fetch manifest")
+            .expect("hit");
+        let fetch = set.fetch_blob(&ctoken, &rev, &addr, "h", "blob-0", dir.path());
         // Cancel once the copy is underway; without the wiring this never
         // resolves and the test times out.
         let cancel = async {
@@ -1843,7 +2011,7 @@ mod tests {
         let leftovers: Vec<_> = std::fs::read_dir(dir.path())
             .expect("read temp dir")
             .filter_map(Result::ok)
-            .filter(|e| e.path().extension().is_some_and(|x| x == "gz"))
+            .filter(|e| e.path().extension().is_some_and(|x| x == "blob"))
             .collect();
         assert!(
             leftovers.is_empty(),
@@ -1887,7 +2055,7 @@ mod tests {
         let set = RemoteCacheSet::empty();
         assert!(set.is_empty());
         assert!(
-            set.fetch_revision(&never(), &addr(), "h", Path::new("/tmp"))
+            set.fetch_manifest(&never(), &addr(), "h")
                 .await
                 .expect("fetch")
                 .is_none()
@@ -1962,26 +2130,37 @@ mod tests {
         // decodes per its recorded encoding.
         let fetch_dir = dir.path().join("fetched");
         std::fs::create_dir_all(&fetch_dir).expect("mkdir");
-        let fetched = set
-            .fetch_revision(&never(), &addr, "h1", &fetch_dir)
+        let rev = set
+            .fetch_manifest(&never(), &addr, "h1")
             .await
             .expect("fetch")
             .expect("present");
-        assert_eq!(fetched.manifest.artifacts.len(), 2);
+        assert_eq!(rev.manifest.artifacts.len(), 2);
         assert_eq!(
-            fetched.manifest.artifacts[0].encoding,
+            rev.manifest.artifacts[0].encoding,
             ManifestArtifactEncoding::Gzip
         );
         assert_eq!(
-            fetched.manifest.artifacts[1].encoding,
+            rev.manifest.artifacts[1].encoding,
             ManifestArtifactEncoding::None
         );
 
+        let gz_temp = set
+            .fetch_blob(&never(), &rev, &addr, "h1", "gz.tar", &fetch_dir)
+            .await
+            .expect("fetch gz")
+            .expect("gz present");
+        let plain_temp = set
+            .fetch_blob(&never(), &rev, &addr, "h1", "plain.tar", &fetch_dir)
+            .await
+            .expect("fetch plain")
+            .expect("plain present");
+
         let mut restored_gz = Vec::new();
-        gunzip_from_file(&fetched.blobs[0].1, &mut restored_gz).expect("gunzip");
+        gunzip_from_file(&gz_temp, &mut restored_gz).expect("gunzip");
         assert_eq!(restored_gz, raw_gz);
 
-        let restored_plain = std::fs::read(&fetched.blobs[1].1).expect("read plain");
+        let restored_plain = std::fs::read(&plain_temp).expect("read plain");
         assert_eq!(
             restored_plain, raw_plain,
             "None-encoded artifact is stored verbatim"
@@ -2084,7 +2263,7 @@ mod tests {
         set.put_revision(&addr, "h1", b"m", &[("o.tar".to_string(), blob_tmp)])
             .await;
         assert!(
-            set.fetch_revision(&never(), &addr, "h1", dir.path())
+            set.fetch_manifest(&never(), &addr, "h1")
                 .await
                 .expect("fetch")
                 .is_none()

--- a/crates/engine/src/engine/request_state.rs
+++ b/crates/engine/src/engine/request_state.rs
@@ -179,6 +179,12 @@ pub struct RequestStateData {
     /// addr can never both hold the non-reentrant per-addr lock — the
     /// self-deadlock this prevents.
     pub(crate) mem_locked_result: Memoizer<Addr, Result<Arc<LockedResolution>, ArcErr>>,
+    /// Single-flights the lazy pull of one remote blob, keyed by
+    /// `(addr, hashin, blob name)`. Two `outputs` cells of the same addr both need
+    /// its support files, so without this they would download and write the same
+    /// blob concurrently — duplicate transfer, and two writers racing on one cache
+    /// key.
+    pub(crate) mem_remote_blob: Memoizer<(Addr, String, String), Result<(), ArcErr>>,
     pub mem_meta: Memoizer<Addr, Result<ResultMeta, ArcErr>>,
     pub mem_spec: Memoizer<Addr, Result<Arc<EngineTargetSpec>, ArcErr>>,
     pub mem_def: Memoizer<Addr, Result<Arc<ExtendedTargetDef>, ArcErr>>,
@@ -548,6 +554,7 @@ impl Engine {
             dep_dag: Mutex::new(DepDag::new()),
             mem_execute_cache: Memoizer::with_tag("execute_cache"),
             mem_locked_result: Memoizer::with_tag("locked_result"),
+            mem_remote_blob: Memoizer::with_tag("remote_blob"),
             mem_result: Memoizer::with_tag("result"),
             mem_meta: Memoizer::with_tag("meta"),
             mem_spec: Memoizer::with_tag("spec"),

--- a/crates/engine/src/engine/result.rs
+++ b/crates/engine/src/engine/result.rs
@@ -13,6 +13,7 @@ use crate::engine::request_state::RequestState;
 use crate::engine::spec::EngineTargetSpec;
 use async_recursion::async_recursion;
 use enclose::enclose;
+use hcore::hasync::Cancellable;
 use hcore::hmemoizer::{downcast_chain_ref, unwrap_arc_err};
 use hmodel::htaddr::Addr;
 use hmodel::htmatcher::MatchResult;
@@ -22,9 +23,10 @@ use crate::engine::driver::sandbox::Sandbox;
 use crate::engine::grow_stack::{GrowStack, grow_stack};
 use crate::engine::link::LinkedTargetDef;
 use crate::engine::local_cache::{CacheArtifact, Manifest, ManifestArtifactType};
+use crate::engine::remote_cache::RemoteRevision;
 use crate::engine::result_lock::ResultReadGuard;
 use anyhow::Context;
-use futures::TryStreamExt;
+use futures::{StreamExt, TryStreamExt};
 use hcore::defer;
 use hcore::hartifactcontent::{Content, ReadSeek, WalkEntry, WalkEntryKind};
 use hmodel::htmatcher::Matcher;
@@ -555,6 +557,39 @@ pub(crate) struct LockedResolution {
     /// backend. `Some` exactly when `executed` is `None` (a pre-existing hit);
     /// `None` on the execute / force / shell paths (no pre-existing manifest).
     manifest: Option<Arc<Manifest>>,
+    /// The remote revision backing this hit, when some of the blobs it names are
+    /// still remote-only. Carries the remote manifest (per-blob encodings) and the
+    /// cache that served it, so each caller pulls just its own output groups on
+    /// demand in [`execute_and_cache`](Engine::execute_and_cache).
+    ///
+    /// `None` whenever the revision is fully resident locally — the pure local-hit
+    /// fast path, which touches the network not at all.
+    remote: Option<Arc<RemoteRevision>>,
+}
+
+/// Pull one blob of `rev` into the local cache. A free function taking every
+/// capture by value so the memoizer cell it feeds
+/// ([`RequestStateData::mem_remote_blob`](crate::engine::request_state::RequestStateData))
+/// gets a plain `'static` future.
+async fn pull_one_remote_blob(
+    engine: Arc<Engine>,
+    rs: Arc<RequestState>,
+    rev: Arc<RemoteRevision>,
+    addr: Addr,
+    hashin: String,
+    name: String,
+) -> anyhow::Result<()> {
+    let ctoken = rs.ctoken().clone_arc();
+    engine
+        .pull_remote_blobs(ctoken.as_ref(), &addr, &hashin, &rev, &[name])
+        .await
+}
+
+/// A confirmed pre-existing cache entry: the revision's manifest plus, when some
+/// of its blobs are not local yet, the remote revision they can be pulled from.
+struct CacheHit {
+    manifest: Arc<Manifest>,
+    remote: Option<Arc<RemoteRevision>>,
 }
 
 /// The full freshly-produced artifact set of an executing [`LockedResolution`]
@@ -1133,6 +1168,21 @@ impl Engine {
             None => {
                 let res = match &locked.manifest {
                     Some(manifest) => {
+                        // Lazy materialization: pull just the blobs THIS caller
+                        // reads, and only those it doesn't already have locally.
+                        // `locked.remote` is `Some` exactly when the revision has
+                        // remote-only blobs, so a fully-local hit does no I/O here.
+                        if let Some(rev) = &locked.remote {
+                            self.materialize_from_remote(
+                                &rs,
+                                &def.target.addr,
+                                opts.hashin.as_str(),
+                                manifest,
+                                &outputs,
+                                rev,
+                            )
+                            .await?;
+                        }
                         self.artifacts_from_manifest(
                             rs.ctoken(),
                             &def.target.addr,
@@ -1184,6 +1234,73 @@ impl Engine {
         }
 
         Ok(build_eresult(cached, meta, &outputs, locked.guard.clone()))
+    }
+
+    /// Download the blobs this caller needs and doesn't have, and nothing else.
+    ///
+    /// See [`pull_one_remote_blob`] for the per-blob body.
+    ///
+    /// The lazy half of a remote hit: the decision was made from the manifest
+    /// alone, so the bytes arrive here — scoped to `outputs` (plus support files),
+    /// which is why resolving a target purely for its `hashout` transfers none of
+    /// its outputs. Runs under the riding read lock.
+    ///
+    /// Each blob is single-flighted per `(addr, hashin, name)` through the request,
+    /// so two output groups needing the same support file download it once. The
+    /// `RemoteCacheRead` span is emitted only when something actually transfers, so
+    /// a `↓` op in the timeline always means real bytes.
+    async fn materialize_from_remote(
+        self: &Arc<Self>,
+        rs: &Arc<RequestState>,
+        addr: &Addr,
+        hashin: &str,
+        manifest: &Manifest,
+        outputs: &[String],
+        rev: &Arc<RemoteRevision>,
+    ) -> anyhow::Result<()> {
+        let missing = self
+            .missing_local_blobs(rs.ctoken(), addr, hashin, manifest, outputs)
+            .await?;
+        if missing.is_empty() {
+            return Ok(());
+        }
+
+        let addr_s = addr.format();
+        let hashin = hashin.to_string();
+        crate::engine::event::emit_scope(
+            rs,
+            crate::engine::event::BuildEventKind::RemoteCacheReadStart {
+                addr: addr_s.clone(),
+            },
+            move |error| crate::engine::event::BuildEventKind::RemoteCacheReadEnd {
+                addr: addr_s,
+                error,
+            },
+            async {
+                let mut pulls = Vec::with_capacity(missing.len());
+                for name in &missing {
+                    let key = (addr.clone(), hashin.clone(), name.clone());
+                    let engine = Arc::clone(self);
+                    let rs_owned = Arc::clone(rs);
+                    let rev = Arc::clone(rev);
+                    let addr = addr.clone();
+                    let hashin = hashin.clone();
+                    let name = name.clone();
+                    pulls.push(rs.data.mem_remote_blob.once(key, move || {
+                        pull_one_remote_blob(engine, rs_owned, rev, addr, hashin, name)
+                    }));
+                }
+                // Bounded: one in-flight pull holds a temp file plus a live
+                // response stream, and a caller may have asked for many groups.
+                futures::stream::iter(pulls)
+                    .buffered(crate::engine::remote_cache::REVISION_BLOB_CONCURRENCY)
+                    .try_collect::<Vec<()>>()
+                    .await
+                    .map_err(unwrap_arc_err)?;
+                anyhow::Ok(())
+            },
+        )
+        .await
     }
 
     /// Single-flight the per-addr result-lock + cache-fetch/execute, keyed by
@@ -1250,32 +1367,26 @@ impl Engine {
     /// non-cacheable force/shell branch). Runs once per addr per request via
     /// [`resolve_locked`].
     ///
-    /// Cache presence is decided at the **manifest** level, not per output:
-    /// `cache_locally` writes the manifest last and GC deletes whole revisions
-    /// under this very lock, so a present manifest guarantees every output blob
-    /// for this `hashin` is already on disk. Probing with an empty output set
-    /// therefore answers "has this addr been built?" without forcing any output
-    /// blob to be fetched — each caller pulls only its own outputs afterwards in
-    /// [`execute_and_cache`], keeping partial/remote pulls lazy.
+    /// Cache presence is decided at the **manifest** level, never by downloading
+    /// outputs, and the split must stay intact:
     ///
-    /// **Remote-cache contract (TODO(remote-cache)) — keep this split intact:**
-    /// - *Presence (here):* must stay manifest-only. When remote lands, this
-    ///   becomes a manifest-exists check that consults **local OR remote** and
-    ///   downloads NO output blobs — a remote manifest still means "already
-    ///   built, do not execute". Note the empty-output probe below is not a true
-    ///   manifest-only check: it still `exists`-checks SupportFile blobs, so once
-    ///   support files can live remote-only it must be replaced by an explicit
-    ///   `manifest_exists(addr, hashin)` (local-or-remote, no blob I/O).
-    /// - *Materialization (per caller, in [`execute_and_cache`]):* this is where
-    ///   lazy download belongs. The local read there becomes local→remote: use
-    ///   the blob if local, else download just the requested output group(s);
-    ///   only a genuine local+remote miss returns `None` (→ execute). Each caller
-    ///   pulls only the groups it asked for — never the full output set.
-    /// - *Hazard:* that per-caller download writes blobs into the local cache
-    ///   while holding only the riding **read** lock. It is content-addressed by
-    ///   `hashin` (idempotent), but a concurrent GC `try_write` could race a
-    ///   half-written blob — the download path will need atomic
-    ///   rename-into-place or a per-blob write guard.
+    /// - *Presence (here):* a manifest — local, or fetched from a remote — plus a
+    ///   guarantee that the blobs it names are obtainable. A manifest carries
+    ///   every artifact's `hashout`, which is all a dependent needs to compute its
+    ///   own `hashin`, so this answers "has this addr been built?" while moving no
+    ///   output bytes. See [`probe_cache_manifest`](Self::probe_cache_manifest)
+    ///   for how a partially-resident revision is classified.
+    /// - *Materialization (per caller, in [`execute_and_cache`]):* where bytes
+    ///   actually move. Each caller pulls only the output groups it asked for
+    ///   (plus support files), so a target resolved just to feed a dependent's
+    ///   hash — the common case in a fully-cached build — transfers nothing but
+    ///   its manifest.
+    /// - *Hazard:* that per-caller pull writes blobs into the local cache while
+    ///   holding only the riding **read** lock. The read excludes GC (whose
+    ///   `try_write` fails while it is alive) and the blobs are content-addressed
+    ///   by `hashin`, so a concurrent writer can only write identical bytes; the
+    ///   FS backend renames into place and the SQLite backend writes in one
+    ///   transaction, so no reader ever observes a half-written blob.
     async fn resolve_locked_inner(
         self: Arc<Self>,
         rs: Arc<RequestState>,
@@ -1312,16 +1423,17 @@ impl Engine {
                 guard: None,
                 executed: Some(Arc::new(ExecutedArtifacts { cached, meta })),
                 manifest: None,
+                remote: None,
             }));
         }
 
         // 1. Optimistically take a plain shared read lock and probe the cache at
-        //    the manifest level (empty output set — see the doc comment). The read
-        //    rides with every caller's artifacts, protecting the entry while in use.
+        //    the manifest level (see the doc comment). The read rides with every
+        //    caller's artifacts, protecting the entry while in use.
         let read = self
             .acquire_with_notice(&rs, addr, self.result_lock().read(addr, ctoken))
             .await?;
-        if let Some(manifest) = self.probe_cache_manifest(&rs, def, opts).await? {
+        if let Some(hit) = self.probe_cache_manifest(&rs, def, opts).await? {
             // A. Hit — share this read; each caller reads its own outputs under
             // it and runs its own codegen write-back / fixpoint in
             // `execute_and_cache` (is_top-gated, under this riding read). The
@@ -1329,7 +1441,8 @@ impl Engine {
             return Ok(Arc::new(LockedResolution {
                 guard: Some(Arc::new(read)),
                 executed: None,
-                manifest: Some(manifest),
+                manifest: Some(hit.manifest),
+                remote: hit.remote,
             }));
         }
 
@@ -1347,14 +1460,16 @@ impl Engine {
         // write lock excludes all others, so one re-check suffices. On the rare
         // race-win we share without executing; otherwise we execute + cache the
         // full set, which `build_eresult` filters per caller.
-        let (executed, manifest) = match self.probe_cache_manifest(&rs, def, opts).await? {
-            Some(manifest) => (None, Some(manifest)),
+        let (executed, manifest, remote) = match self.probe_cache_manifest(&rs, def, opts).await? {
+            Some(hit) => (None, Some(hit.manifest), hit.remote),
             None => {
-                // Local miss under the write lock: try to pull a complete
-                // revision from the remote caches into the local cache before
-                // executing. Safe to write local blobs here — the write lock
-                // excludes GC and other writers. A remote hit means "already
-                // built": skip execution and share the now-local entry.
+                // Local miss under the write lock: ask the remote caches whether
+                // this revision exists. Manifest only — no output blob is
+                // downloaded here, and none may be: a dependent that just needs
+                // this target's `hashout` must not pay for its outputs. The
+                // manifest is mirrored into the local cache (safe under the write
+                // lock, which excludes GC and other writers) and each caller pulls
+                // the groups it reads in `execute_and_cache`.
                 //
                 // Bracket the pull with one `RemoteCacheRead` span per target
                 // (only when a readable cache exists) so a slow download shows as
@@ -1367,8 +1482,12 @@ impl Engine {
                 // store path — which would `exec` a missing path (status 127).
                 let remote_attempted =
                     def.target.cache.remote_enabled && self.remote_caches.has_readable();
-                let downloaded = if remote_attempted {
+                let located = if remote_attempted {
                     let addr_s = addr.format();
+                    // Every blob a caller of this addr could read must still be on
+                    // the remote for the hit to stand — checked by presence, not by
+                    // transfer (see `RemoteCacheSet::blobs_exist`).
+                    let needed: Vec<String> = def.target.output_names();
                     crate::engine::event::emit_scope(
                         &rs,
                         crate::engine::event::BuildEventKind::RemoteCacheReadStart {
@@ -1378,22 +1497,22 @@ impl Engine {
                             addr: addr_s,
                             error,
                         },
-                        self.download_from_remote(ctoken, addr, opts.hashin.as_str()),
+                        self.probe_remote_revision(ctoken, addr, opts.hashin.as_str(), &needed),
                     )
                     .await?
                 } else {
                     None
                 };
-                match downloaded {
-                    Some(manifest) => {
-                        // A remote pull that landed a revision is a cache hit —
+                match located {
+                    Some((manifest, rev)) => {
+                        // A revision located on the remote is a cache hit —
                         // "already built elsewhere", execution skipped. Emit it so
                         // the cached count (TUI, GHA, telemetry) reflects remote
                         // hits, not just local ones.
                         rs.emit(crate::engine::event::BuildEventKind::RemoteCacheHit {
                             addr: addr.format(),
                         });
-                        (None, Some(Arc::new(manifest)))
+                        (None, Some(Arc::new(manifest)), Some(Arc::new(rev)))
                     }
                     None => {
                         // Only a real remote lookup that came back empty is a
@@ -1408,7 +1527,11 @@ impl Engine {
                             .clone()
                             .execute_and_cache_inner(rs.clone(), opts)
                             .await?;
-                        (Some(Arc::new(ExecutedArtifacts { cached, meta })), None)
+                        (
+                            Some(Arc::new(ExecutedArtifacts { cached, meta })),
+                            None,
+                            None,
+                        )
                     }
                 }
             }
@@ -1428,6 +1551,7 @@ impl Engine {
             guard: Some(Arc::new(read)),
             executed,
             manifest,
+            remote,
         }))
     }
 
@@ -1947,39 +2071,78 @@ impl Engine {
         Ok(())
     }
 
-    /// Presence-probe the local cache at the manifest level (empty output set —
-    /// see the [`resolve_locked_inner`](Self::resolve_locked_inner) doc), emitting
-    /// the hit/miss event. On a hit, returns the parsed manifest so the per-caller
-    /// output read in [`execute_and_cache`](Self::execute_and_cache) reuses it
-    /// instead of re-reading + re-deserializing the manifest from the cache backend.
+    /// Probe the **local** manifest for `(addr, hashin)` and decide whether it is
+    /// a usable hit, emitting the hit/miss event. Returns the parsed manifest so
+    /// the per-caller output read in
+    /// [`execute_and_cache`](Self::execute_and_cache) reuses it instead of
+    /// re-reading + re-deserializing it from the cache backend.
     ///
-    /// Confirming SupportFile blobs exist (via `artifacts_from_manifest` with no
-    /// requested outputs) preserves the exact hit/miss semantics of the former
-    /// empty-output `artifacts_from_local_cache` probe — a present manifest whose
-    /// support blob has been GC'd is still a miss.
+    /// A local manifest is not proof of residency: a revision whose manifest was
+    /// mirrored from a remote (see
+    /// [`probe_remote_revision`](Self::probe_remote_revision)) names blobs that
+    /// were never downloaded, because nothing has needed them yet. So the probe
+    /// classifies:
+    ///
+    /// - **fully resident** → local hit, no remote I/O at all.
+    /// - **some needed blob absent, remote can still serve the revision** → hit
+    ///   backed by that [`RemoteRevision`]; each caller pulls only its own
+    ///   outputs.
+    /// - **some needed blob absent and unobtainable** (no readable remote, remote
+    ///   opted out for this target, or the remote no longer has the revision) →
+    ///   **miss**, so the target executes. Deciding this here, before the engine
+    ///   commits to "already built", is what keeps an evicted or half-written
+    ///   revision fail-soft instead of erroring later, mid-read.
+    ///
+    /// Residency is judged against *every* output group (any caller may ask for
+    /// any of them) plus support files — never logs, which no read path surfaces.
     async fn probe_cache_manifest(
         &self,
         rs: &Arc<RequestState>,
         def: &LinkedTargetDef,
         opts: &ExecuteOptions<'_>,
-    ) -> anyhow::Result<Option<Arc<Manifest>>> {
+    ) -> anyhow::Result<Option<CacheHit>> {
         let addr = &def.target.addr;
         let hashin = opts.hashin.as_str();
-        // TODO(remote-cache): when remote lands, this becomes a manifest-exists
-        // check consulting local OR remote and downloading NO output blobs.
         let hit = match self
             .read_manifest_blocking(rs.ctoken(), addr, hashin)
             .await?
         {
-            Some(manifest)
-                if self
-                    .artifacts_from_manifest(rs.ctoken(), addr, hashin, &manifest, &[])
-                    .await?
-                    .is_some() =>
-            {
-                Some(Arc::new(manifest))
+            Some(manifest) => {
+                let all_groups = def.target.output_names();
+                let missing = self
+                    .missing_local_blobs(rs.ctoken(), addr, hashin, &manifest, &all_groups)
+                    .await?;
+                if missing.is_empty() {
+                    Some(CacheHit {
+                        manifest: Arc::new(manifest),
+                        remote: None,
+                    })
+                } else if !def.target.cache.remote_enabled || !self.remote_caches.has_readable() {
+                    None
+                } else {
+                    // The manifest is local but (some of) the bytes are not. Only a
+                    // remote that still holds every missing blob makes this a hit —
+                    // presence is checked here, not discovered during the read.
+                    match self
+                        .remote_caches
+                        .fetch_manifest(rs.ctoken(), addr, hashin)
+                        .await?
+                    {
+                        Some(rev) => {
+                            let servable = self
+                                .remote_caches
+                                .blobs_exist(rs.ctoken(), &rev, addr, hashin, &missing)
+                                .await;
+                            servable.then(|| CacheHit {
+                                manifest: Arc::new(manifest),
+                                remote: Some(Arc::new(rev)),
+                            })
+                        }
+                        None => None,
+                    }
+                }
             }
-            _ => None,
+            None => None,
         };
         rs.emit(if hit.is_some() {
             crate::engine::event::BuildEventKind::LocalCacheHit {


### PR DESCRIPTION
## The bug

A remote cache hit downloaded the **whole revision** — every blob of every output group — before the engine knew which outputs anyone wanted. `fetch_revision` fanned out over `manifest.artifacts` unconditionally.

The worst case is the common one: dependencies are resolved for hashing with `OutputMatcher::None` (`meta.rs`), so in a fully-cached build every dep pulled its entire output set just to hand back one `hashout` string that was already sitting in the manifest.

## The fix

Split the decision from the transfer.

| | before | after |
|---|---|---|
| decide hit/miss | download all blobs | `fetch_manifest` — manifest object only |
| prove it's servable | implied by manifest | `blobs_exist` — presence check, no bytes |
| transfer | eager, all groups | `pull_remote_blobs` — this caller's groups, on read |

- **`fetch_manifest`** locates a revision from its manifest alone. That manifest carries every artifact's `hashout`, which is all "already built" and a dependent's `hashin` need.
- **`blobs_exist`** presence-checks the blobs the target's callers could read. Manifests are written last, but blobs are independent objects a lifecycle rule can expire on their own — so this is what keeps an evicted revision an ordinary cache **miss** (execute) rather than a failure discovered later, mid-read, after the engine committed to "already built".
- **`pull_remote_blobs`** downloads one caller's output groups plus support files (never logs), single-flighted per `(addr, hashin, blob)` so two output groups sharing a support file fetch it once, and bounded by `REVISION_BLOB_CONCURRENCY`.

A remote hit now mirrors the manifest into the local cache **without** its blobs. That weakens an invariant the read path used to assume, so residency is checked explicitly (`missing_local_blobs`) instead. Side benefit: a locally-incomplete revision now fails soft — before, a present manifest with a missing blob was a hit that then errored with `"vanished before read"`; now it re-executes or completes from the remote.

Two supporting fixes the lazy path needs:

- `LocalCacheFS::writer` renames into place instead of truncating, so a blob materialized under the riding **read** lock can't be observed half-written by a concurrent reader of the same revision. (The SQLite backend already writes in one transaction.)
- GC counts only bytes it actually reclaimed — a mirrored manifest can name blobs that were never downloaded.

## Cost

One extra small request per remote-hit target (the presence check), against a revision's full output set previously. Fully-local hits are unchanged and touch the network not at all.

## Tests

- `remote_pull_is_lazy_per_output` (e2e): `top` depends on a multi-MiB `dep`. On a run where `top` is a cache hit, the local cache must stay far below `dep`'s output size — then asking for `dep` directly pulls it, byte-identical.
- `remote_probe_rejects_a_revision_whose_blob_is_gone`: manifest present, blob expired ⇒ miss, not a stranded build.
- Round-trip test now asserts the probe leaves the blob absent locally until pulled.
- Existing fan-out / cancellation / encoding tests retargeted onto the split API.

> [!NOTE]
> `cargo test --all` could not complete locally: this host ran out of disk (~870 MiB free, with 26 GiB of leaked test tempdirs under `/var/folders/.../T`). The 15 failures in that run were all `No space left on device` in `plugingo-e2e`. `engine` + `e2e` suites pass; leaving the full run to CI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WtpPZqzMvv5SqDvV2Tb1A5