### PR TITLE
fix(remote-cache): rebuild when an advertised blob can't be served

### DIFF
--- a/crates/engine/src/engine/remote_cache.rs
+++ b/crates/engine/src/engine/remote_cache.rs
@@ -72,7 +72,7 @@ use std::sync::{Arc, LazyLock};
 use std::time::{Duration, Instant};
 use tokio::io::{AsyncRead, AsyncWrite, AsyncWriteExt};
 use tokio::sync::{OnceCell, Semaphore};
-use tracing::warn;
+use tracing::{debug, warn};
 
 /// Max blobs of a *single* revision transferred concurrently, on both the pull
 /// and the push side.
@@ -449,6 +449,28 @@ impl RemoteCacheSet {
             config_hash,
             read_order: OnceCell::new(),
         }))
+    }
+
+    /// Test-only: a set of exactly one readable+writable cache over `backend`, so
+    /// a test can drive the read path against a stub object store.
+    #[cfg(test)]
+    pub(crate) fn with_backend(backend: Arc<dyn RemoteCacheBackend>, home: PathBuf) -> Arc<Self> {
+        Arc::new(Self {
+            caches: vec![ConfiguredCache {
+                def: RemoteCacheDef {
+                    name: "stub".to_string(),
+                    uri: "memory:///stub".to_string(),
+                    read: true,
+                    write: true,
+                    concurrency: 4,
+                },
+                backend,
+                health: CacheHealth::default(),
+            }],
+            home,
+            config_hash: String::new(),
+            read_order: OnceCell::new(),
+        })
     }
 
     /// An empty set — used by tests and the no-config path.
@@ -1292,9 +1314,11 @@ impl Engine {
     /// single-flighted per blob by the caller, so two output groups needing the
     /// same support file transfer it once.
     ///
-    /// A blob the remote no longer serves is an error, not a miss: presence was
-    /// already checked when the hit was accepted, so losing it here means the
-    /// revision was evicted mid-build.
+    /// `Ok(false)` when the remote could not serve one of them — the object was
+    /// evicted between the presence check and the read, or its transfer failed.
+    /// That is **not** an error: the caller falls back to executing the target,
+    /// exactly as it would have on a plain cache miss. Only genuinely fatal
+    /// failures (local temp/codec I/O) and cancellation propagate as `Err`.
     pub(crate) async fn pull_remote_blobs(
         &self,
         ctoken: &dyn Cancellable,
@@ -1302,9 +1326,9 @@ impl Engine {
         hashin: &str,
         rev: &RemoteRevision,
         names: &[String],
-    ) -> anyhow::Result<()> {
+    ) -> anyhow::Result<bool> {
         if names.is_empty() {
-            return Ok(());
+            return Ok(true);
         }
         let tmp_dir = self.remote_tmp_dir();
         std::fs::create_dir_all(&tmp_dir)
@@ -1317,15 +1341,16 @@ impl Engine {
             .iter()
             .map(|name| self.pull_remote_blob(ctoken, addr, hashin, rev, name, &tmp_dir))
             .collect();
-        stream::iter(pulls)
+        let served: Vec<bool> = stream::iter(pulls)
             .buffered(REVISION_BLOB_CONCURRENCY)
-            .try_collect::<Vec<()>>()
+            .try_collect()
             .await?;
-        Ok(())
+        Ok(served.into_iter().all(|ok| ok))
     }
 
-    /// Stream one blob into a temp file, then decode it into the local cache.
-    /// The temp file is dropped on both paths.
+    /// Stream one blob into a temp file, then decode it into the local cache. The
+    /// temp file is dropped on both paths. `Ok(false)` if the remote could not
+    /// serve it — see [`Self::pull_remote_blobs`].
     async fn pull_remote_blob(
         &self,
         ctoken: &dyn Cancellable,
@@ -1334,7 +1359,7 @@ impl Engine {
         rev: &RemoteRevision,
         name: &str,
         tmp_dir: &Path,
-    ) -> anyhow::Result<()> {
+    ) -> anyhow::Result<bool> {
         let encoding = rev.artifact(name)?.encoding.clone();
         let Some(temp) = self
             .remote_caches
@@ -1344,10 +1369,15 @@ impl Engine {
             if ctoken.is_cancelled() {
                 return Err(crate::engine::error::CancelledError.into());
             }
-            anyhow::bail!(
-                "remote cache no longer serves blob {name} of {addr} {hashin}: the revision was \
-                 evicted after its manifest was read — re-run to rebuild it",
+            // Evicted between the presence check and the read, or the transfer
+            // failed (already noted on the cache). Degrade to a miss.
+            debug!(
+                %addr,
+                hashin,
+                blob = name,
+                "remote cache could not serve blob; rebuilding target",
             );
+            return Ok(false);
         };
 
         let local_cache = self.local_cache.clone();
@@ -1370,7 +1400,7 @@ impl Engine {
         .await;
 
         drop(std::fs::remove_file(&temp));
-        res
+        res.map(|()| true)
     }
 }
 

--- a/crates/engine/src/engine/request_state.rs
+++ b/crates/engine/src/engine/request_state.rs
@@ -184,7 +184,7 @@ pub struct RequestStateData {
     /// its support files, so without this they would download and write the same
     /// blob concurrently — duplicate transfer, and two writers racing on one cache
     /// key.
-    pub(crate) mem_remote_blob: Memoizer<(Addr, String, String), Result<(), ArcErr>>,
+    pub(crate) mem_remote_blob: Memoizer<(Addr, String, String), Result<bool, ArcErr>>,
     pub mem_meta: Memoizer<Addr, Result<ResultMeta, ArcErr>>,
     pub mem_spec: Memoizer<Addr, Result<Arc<EngineTargetSpec>, ArcErr>>,
     pub mem_def: Memoizer<Addr, Result<Arc<ExtendedTargetDef>, ArcErr>>,

--- a/crates/engine/src/engine/result.rs
+++ b/crates/engine/src/engine/result.rs
@@ -578,7 +578,7 @@ async fn pull_one_remote_blob(
     addr: Addr,
     hashin: String,
     name: String,
-) -> anyhow::Result<()> {
+) -> anyhow::Result<bool> {
     let ctoken = rs.ctoken().clone_arc();
     engine
         .pull_remote_blobs(ctoken.as_ref(), &addr, &hashin, &rev, &[name])
@@ -1172,25 +1172,37 @@ impl Engine {
                         // reads, and only those it doesn't already have locally.
                         // `locked.remote` is `Some` exactly when the revision has
                         // remote-only blobs, so a fully-local hit does no I/O here.
-                        if let Some(rev) = &locked.remote {
-                            self.materialize_from_remote(
-                                &rs,
+                        //
+                        // An unservable blob answers `false` instead of failing —
+                        // the entry was confirmed, then the bytes went away. Both
+                        // that and a local blob that vanished fall through to
+                        // `unavailable` below.
+                        let served = match &locked.remote {
+                            Some(rev) => {
+                                self.materialize_from_remote(
+                                    &rs,
+                                    &def.target.addr,
+                                    opts.hashin.as_str(),
+                                    manifest,
+                                    &outputs,
+                                    rev,
+                                )
+                                .await?
+                            }
+                            None => true,
+                        };
+                        if served {
+                            self.artifacts_from_manifest(
+                                rs.ctoken(),
                                 &def.target.addr,
                                 opts.hashin.as_str(),
                                 manifest,
                                 &outputs,
-                                rev,
                             )
-                            .await?;
+                            .await?
+                        } else {
+                            None
                         }
-                        self.artifacts_from_manifest(
-                            rs.ctoken(),
-                            &def.target.addr,
-                            opts.hashin.as_str(),
-                            manifest,
-                            &outputs,
-                        )
-                        .await?
                     }
                     None => {
                         self.clone()
@@ -1203,19 +1215,40 @@ impl Engine {
                             .await?
                     }
                 };
-                let (cache_arts, meta) = res.with_context(|| {
-                    format!(
-                        "result lock confirmed a cache entry for {} but it vanished before read",
-                        def.target.addr
-                    )
-                })?;
-                (
-                    cache_arts
-                        .into_iter()
-                        .map(ResultArtifact::from_cache)
-                        .collect(),
-                    meta,
-                )
+                match res {
+                    Some((cache_arts, meta)) => (
+                        cache_arts
+                            .into_iter()
+                            .map(ResultArtifact::from_cache)
+                            .collect(),
+                        meta,
+                    ),
+                    // The entry was confirmed but its bytes are unavailable: a
+                    // remote object expired between the presence check and the
+                    // read, a transfer failed, or a local blob went missing. Build
+                    // the target instead of failing the run — the same outcome a
+                    // plain cache miss would have had, just decided later. Debug,
+                    // not warn: a shared cache reclaiming an old revision mid-build
+                    // is ordinary, and the rebuild is the correct response.
+                    //
+                    // This executes under the riding *read* lock rather than the
+                    // write lock the miss path holds. In-process the execute
+                    // memoizer still collapses concurrent callers to one run; a
+                    // second *process* racing the same rebuild is possible but
+                    // needs both an eviction and a concurrent build of the same
+                    // target, and the blobs it writes are content-addressed by
+                    // `hashin` and land atomically, so the cache stays consistent.
+                    None => {
+                        tracing::debug!(
+                            addr = %def.target.addr,
+                            hashin = opts.hashin.as_str(),
+                            "cache entry confirmed but its artifacts are unavailable; rebuilding",
+                        );
+                        self.clone()
+                            .execute_and_cache_inner(rs.clone(), opts)
+                            .await?
+                    }
+                }
             }
         };
 
@@ -1249,6 +1282,9 @@ impl Engine {
     /// so two output groups needing the same support file download it once. The
     /// `RemoteCacheRead` span is emitted only when something actually transfers, so
     /// a `↓` op in the timeline always means real bytes.
+    ///
+    /// `false` when the remote could not serve a blob it had advertised — the
+    /// caller rebuilds the target rather than failing.
     async fn materialize_from_remote(
         self: &Arc<Self>,
         rs: &Arc<RequestState>,
@@ -1257,12 +1293,12 @@ impl Engine {
         manifest: &Manifest,
         outputs: &[String],
         rev: &Arc<RemoteRevision>,
-    ) -> anyhow::Result<()> {
+    ) -> anyhow::Result<bool> {
         let missing = self
             .missing_local_blobs(rs.ctoken(), addr, hashin, manifest, outputs)
             .await?;
         if missing.is_empty() {
-            return Ok(());
+            return Ok(true);
         }
 
         let addr_s = addr.format();
@@ -1292,12 +1328,12 @@ impl Engine {
                 }
                 // Bounded: one in-flight pull holds a temp file plus a live
                 // response stream, and a caller may have asked for many groups.
-                futures::stream::iter(pulls)
+                let served: Vec<bool> = futures::stream::iter(pulls)
                     .buffered(crate::engine::remote_cache::REVISION_BLOB_CONCURRENCY)
-                    .try_collect::<Vec<()>>()
+                    .try_collect()
                     .await
                     .map_err(unwrap_arc_err)?;
-                anyhow::Ok(())
+                anyhow::Ok(served.into_iter().all(|ok| ok))
             },
         )
         .await
@@ -3438,6 +3474,141 @@ mod tests {
                 |e| matches!(&e.kind, BuildEventKind::ExecuteStart { addr, .. } if addr == "//pkg:t")
             ),
             "remote-on target must use the remote hit, not execute: {events:?}"
+        );
+        Ok(())
+    }
+
+    /// Bash target that actually writes an output, so a cache hit has a blob to
+    /// materialize — a no-output target has nothing to pull and would never reach
+    /// the lazy path.
+    fn out_target(addr: &str) -> pluginstatictarget::Target {
+        pluginstatictarget::Target {
+            addr: addr.to_string(),
+            driver: "bash".to_string(),
+            run: Some("echo hi > $OUT".to_string()),
+            out: HashMap::from([(String::new(), vec!["out.txt".to_string()])]),
+            codegen: None,
+            deps: HashMap::new(),
+            labels: vec![],
+            ..Default::default()
+        }
+    }
+
+    /// [`engine_with_remote`] wired to the bash driver, for targets that need a
+    /// shell to produce an output.
+    fn engine_with_remote_bash(
+        targets: Vec<pluginstatictarget::Target>,
+        remote_uri: &str,
+    ) -> anyhow::Result<(Arc<Engine>, tempfile::TempDir)> {
+        let root = tempdir()?;
+        let mut engine = Engine::new(Config {
+            root: root.path().to_path_buf(),
+            home_dir: std::path::PathBuf::new(),
+            parallelism: None,
+            remote_caches: vec![crate::engine::RemoteCacheDef {
+                name: "shared".to_string(),
+                uri: remote_uri.to_string(),
+                read: true,
+                write: true,
+                concurrency: 10,
+            }],
+            ..Default::default()
+        })?;
+        engine
+            .register_managed_driver(|_| Box::new(hplugin_exec::pluginexec::Driver::new_bash()))?;
+        let provider = pluginstatictarget::Provider::new(targets)?;
+        engine.register_provider(move |_| Box::new(provider))?;
+        Ok((Arc::new(engine), root))
+    }
+
+    /// Object store that still advertises every object but can only serve
+    /// manifests — a revision whose blobs were reclaimed after their manifest was
+    /// written, or a backend erroring on blob reads only.
+    struct EvictedBlobBackend {
+        /// Directory of a `file://` remote seeded by a real engine, so the
+        /// manifest it serves is the genuine one for the target's `hashin`.
+        root: std::path::PathBuf,
+    }
+
+    #[async_trait::async_trait]
+    impl crate::engine::remote_cache::RemoteCacheBackend for EvictedBlobBackend {
+        async fn open_read(
+            &self,
+            key: &str,
+        ) -> anyhow::Result<Option<Pin<Box<dyn tokio::io::AsyncRead + Send>>>> {
+            if !key.ends_with(crate::engine::local_cache::MANIFEST_V1) {
+                // The blob is gone, even though `exists` still claims otherwise.
+                return Ok(None);
+            }
+            match std::fs::read(self.root.join(key)) {
+                Ok(bytes) => Ok(Some(Box::pin(std::io::Cursor::new(bytes)))),
+                Err(e) if e.kind() == std::io::ErrorKind::NotFound => Ok(None),
+                Err(e) => Err(e.into()),
+            }
+        }
+        async fn open_write(
+            &self,
+            _key: &str,
+        ) -> anyhow::Result<Pin<Box<dyn tokio::io::AsyncWrite + Send>>> {
+            anyhow::bail!("read-only stub backend")
+        }
+        /// Still advertised: this is what makes the pull, not the probe, discover
+        /// that the bytes are gone.
+        async fn exists(&self, _key: &str) -> anyhow::Result<bool> {
+            Ok(true)
+        }
+    }
+
+    /// A revision the remote advertised but cannot actually serve must rebuild the
+    /// target, not fail the run.
+    ///
+    /// The hit is decided from the manifest plus a presence check, so the bytes can
+    /// still disappear before the read: an object expired in that window, or the
+    /// blob GET failed. That leaves the engine holding a confirmed "already built"
+    /// entry with nothing behind it — which must degrade to executing the target,
+    /// exactly as a plain cache miss would have.
+    #[tokio::test]
+    async fn unservable_remote_blob_rebuilds_instead_of_failing() -> anyhow::Result<()> {
+        let remote = tempdir()?;
+        let remote_uri = format!("file://{}", remote.path().display());
+        let addr = hmodel::htaddr::parse_addr("//pkg:t")?;
+
+        // Seed the remote for real, so the stub serves a genuine manifest.
+        let (seeder, _seeder_home) =
+            engine_with_remote_bash(vec![out_target("//pkg:t")], &remote_uri)?;
+        let seed_rs = seeder.new_state();
+        seeder
+            .clone()
+            .result_addr(
+                seed_rs.clone(),
+                &addr,
+                OutputMatcher::All,
+                &ResultOptions::default(),
+            )
+            .await?;
+        drain_bg(&seed_rs).await;
+
+        // Cold engine whose remote serves the manifest, claims the blobs exist,
+        // and then cannot produce them.
+        let (engine, _home) = engine_with_remote_bash(vec![out_target("//pkg:t")], &remote_uri)?;
+        let mut engine = engine;
+        let home = engine.home.clone();
+        Arc::get_mut(&mut engine)
+            .expect("engine must not be shared yet")
+            .remote_caches = crate::engine::RemoteCacheSet::with_backend(
+            Arc::new(EvictedBlobBackend {
+                root: remote.path().to_path_buf(),
+            }),
+            home,
+        );
+
+        let (res, events) = resolve_collecting_events(&engine, &addr).await;
+        res.expect("an unservable remote revision must rebuild, not fail the run");
+        assert!(
+            events.iter().any(
+                |e| matches!(&e.kind, BuildEventKind::ExecuteStart { addr, .. } if addr == "//pkg:t")
+            ),
+            "the target must be rebuilt when its advertised blobs cannot be served: {events:?}"
         );
         Ok(())
     }


### PR DESCRIPTION
Follow-up to #169, fixing a failure hit in a real build:

```
remote cache no longer serves blob out_.tar of //mgmt/go/@heph/go/thirdparty/google.golang.org/api@v0.274.0:download fd965dd4bc179d67: the revision was evicted after its manifest was read — re-run to rebuild it
```

#169 decides a hit from the manifest plus a presence check, so the bytes can still go away before the read — the object expired in that window, or its GET failed (`fetch_blob` reports a transient backend error as "cannot serve" too). That left the engine holding a confirmed "already built" entry with nothing behind it, and it failed the run.

A shared cache reclaiming an old revision mid-build is ordinary, and the right response is the one a plain cache miss would have taken. So:

- `pull_remote_blobs` answers `Ok(false)` instead of erroring, and logs at debug.
- The read path treats that as "artifacts unavailable" and **executes the target**.
- Genuinely fatal failures (local temp/codec I/O) and cancellation still propagate as errors.

The same fallback now covers a local blob that went missing, replacing the old `"result lock confirmed a cache entry … but it vanished before read"` error with a rebuild.

### Lock caveat

The rebuild runs under the riding **read** lock, not the write lock the miss path holds. In-process the execute memoizer still collapses concurrent callers to a single run. A second *process* racing the same rebuild is possible — it needs both an eviction and a concurrent build of the same target — and the blobs it writes are content-addressed by `hashin` and land atomically (FS renames into place, SQLite writes in one transaction), so the cache stays consistent either way.

### Test

`unservable_remote_blob_rebuilds_instead_of_failing`: a stub object store that serves the real manifest, keeps claiming its blobs exist, then cannot produce them. The target must resolve by rebuilding. Reverting the fallback reproduces the reported error verbatim — same `out_.tar` blob name.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WtpPZqzMvv5SqDvV2Tb1A5