### PR TITLE
ci: move sccache to R2, stop cache-key clobbering

### DIFF
--- a/.github/actions/setup-nix/action.yml
+++ b/.github/actions/setup-nix/action.yml
@@ -102,6 +102,7 @@ runs:
     # tarball compiled the whole workspace at a 0% hit rate, then dropped its
     # own results because actions/cache does not re-save an existing key.
     - name: Configure sccache backend
+      if: inputs.cargo-target != ''
       shell: bash
       env:
         R2_SECRET: ${{ inputs.r2-secret }}

--- a/.github/actions/setup-nix/action.yml
+++ b/.github/actions/setup-nix/action.yml
@@ -114,7 +114,7 @@ runs:
           exit 0
         fi
         {
-          echo "SCCACHE_BUCKET=heph-sccache"
+          echo "SCCACHE_BUCKET=heph-sscache"
           echo "SCCACHE_REGION=auto"
           echo "SCCACHE_ENDPOINT=https://b9d7099532d2613531d6f54b60211d0c.r2.cloudflarestorage.com"
           # Bump to invalidate every cached object at once.

--- a/.github/actions/setup-nix/action.yml
+++ b/.github/actions/setup-nix/action.yml
@@ -3,19 +3,30 @@ description: >-
   Install Nix, restore the persisted Nix store, repair/re-substitute any
   invalid paths, install devenv, and warm the devenv shell with self-healing
   retries so a partial or poisoned cache restore recovers instead of failing
-  the job. Optionally restores the cargo registry + sccache caches.
+  the job. Optionally restores the cargo registry cache and points sccache at
+  the shared R2 bucket.
 
 inputs:
   cargo-target:
     description: >-
-      Rust target triple used to key the cargo registry + sccache caches. Leave
-      empty to skip those caches (e.g. the codegen job, which does not compile).
+      Rust target triple used to key the cargo registry cache. Leave empty to
+      skip it (e.g. the codegen job, which does not compile).
     required: false
     default: ""
   cache-suffix:
     description: >-
-      Extra suffix appended to the cargo/sccache cache keys so jobs that compile
-      different artifact sets (e.g. test vs build) do not clobber each other.
+      Extra suffix appended to the cargo registry cache key so jobs that pull
+      different crate sets (e.g. test vs build vs lint) do not clobber each
+      other. actions/cache skips the save when the exact key already exists, so
+      two jobs sharing a key means whichever saves first freezes the entry and
+      the other never contributes.
+    required: false
+    default: ""
+  r2-secret:
+    description: >-
+      Cloudflare R2 secret access key (`secrets.CF_SSCACHE`) for the shared
+      sccache bucket. Empty — as on fork PRs, where secrets are not exposed —
+      falls back to an ephemeral local-disk sccache.
     required: false
     default: ""
 
@@ -45,6 +56,11 @@ runs:
       with:
         primary-key: nix-${{ runner.os }}-${{ hashFiles('devenv.lock', 'devenv.nix', 'devenv.yaml') }}
         restore-prefixes-first-match: nix-${{ runner.os }}-
+        # PRs are restore-only. Every PR ref used to save its own ~1.5 GB copy
+        # per OS; with the repo's 10 GB Actions cache quota that LRU-evicted
+        # master's copies before the next PR could read them, so jobs kept
+        # starting cold. Only master writes the store now; PRs read it.
+        save: ${{ github.ref == 'refs/heads/master' }}
         gc-max-store-size-linux: 5368709120
         gc-max-store-size-macos: 5368709120
 
@@ -77,8 +93,38 @@ runs:
         # Surface the real error if the store is still broken after retries.
         devenv shell true
 
+    # sccache stores objects in Cloudflare R2 rather than an actions/cache
+    # tarball. Object storage is shared across every branch, PR and runner, is
+    # not subject to the repo's Actions cache quota, and needs no cache key at
+    # all: sccache's own hash of (source, args, compiler) already separates
+    # lint's check units from the release builds. The tarball scheme could not —
+    # jobs sharing a key clobbered each other, and a job that restored a foreign
+    # tarball compiled the whole workspace at a 0% hit rate, then dropped its
+    # own results because actions/cache does not re-save an existing key.
+    - name: Configure sccache backend
+      shell: bash
+      env:
+        R2_SECRET: ${{ inputs.r2-secret }}
+      run: |
+        if [ -z "$R2_SECRET" ]; then
+          # Fork PRs are not given secrets. Fall back to a local-disk cache so
+          # rustc still has a working wrapper (cold, and discarded with the job).
+          echo "SCCACHE_DIR=$GITHUB_WORKSPACE/.sccache" >> "$GITHUB_ENV"
+          echo "::notice title=sccache::no R2 credentials — using local disk (cold cache)"
+          exit 0
+        fi
+        {
+          echo "SCCACHE_BUCKET=heph-sccache"
+          echo "SCCACHE_REGION=auto"
+          echo "SCCACHE_ENDPOINT=https://b9d7099532d2613531d6f54b60211d0c.r2.cloudflarestorage.com"
+          # Bump to invalidate every cached object at once.
+          echo "SCCACHE_S3_KEY_PREFIX=v1"
+          echo "AWS_ACCESS_KEY_ID=47bb1ffef0f93339c11fa28d7540fc3c"
+          echo "AWS_SECRET_ACCESS_KEY=$R2_SECRET"
+        } >> "$GITHUB_ENV"
+
     # Cargo registry/git only — crate downloads + index. Compiled artifacts are
-    # handled by sccache (below), so target/ is intentionally not cached here.
+    # handled by sccache (above), so target/ is intentionally not cached here.
     - name: Cargo registry cache
       if: inputs.cargo-target != ''
       uses: actions/cache@v5
@@ -90,12 +136,3 @@ runs:
         key: cargo-${{ inputs.cargo-target }}${{ inputs.cache-suffix }}-${{ hashFiles('**/Cargo.lock') }}
         restore-keys: |
           cargo-${{ inputs.cargo-target }}${{ inputs.cache-suffix }}-
-
-    - name: sccache cache
-      if: inputs.cargo-target != ''
-      uses: actions/cache@v5
-      with:
-        path: ${{ github.workspace }}/.sccache
-        key: sccache-${{ inputs.cargo-target }}${{ inputs.cache-suffix }}-${{ hashFiles('**/Cargo.lock') }}
-        restore-keys: |
-          sccache-${{ inputs.cargo-target }}${{ inputs.cache-suffix }}-

--- a/.github/workflows/heph.yml
+++ b/.github/workflows/heph.yml
@@ -14,11 +14,11 @@ concurrency:
   cancel-in-progress: ${{ github.ref != 'refs/heads/master' }}
 
 # sccache config shared by every compiling job. RUSTC_WRAPPER=sccache is set by
-# the devenv shell; here we pin the cache dir to a workspace path so actions/cache
-# can persist it, and disable incremental compilation (sccache cannot cache
-# incremental units, and fresh runners have no warm incremental dir to reuse).
+# the devenv shell; the storage backend (R2, or local disk on fork PRs) is wired
+# up by the setup-nix action. Incremental compilation is off because sccache
+# cannot cache incremental units, and fresh runners have no warm incremental dir
+# to reuse. SCCACHE_CACHE_SIZE bounds only the local-disk fallback.
 env:
-  SCCACHE_DIR: ${{ github.workspace }}/.sccache
   SCCACHE_CACHE_SIZE: "2G"
   CARGO_INCREMENTAL: "0"
 
@@ -223,6 +223,7 @@ jobs:
         uses: ./.github/actions/setup-nix
         with:
           cargo-target: ${{ matrix.target }}
+          r2-secret: ${{ secrets.CF_SSCACHE }}
 
       - name: Build
         id: build
@@ -420,6 +421,11 @@ jobs:
         uses: ./.github/actions/setup-nix
         with:
           cargo-target: x86_64-unknown-linux-gnu
+          # Distinct from the linux/amd64 build job, which uses the same target
+          # triple: sharing a cargo cache key means whichever job saves first
+          # freezes the entry and the other's crate downloads never persist.
+          cache-suffix: "-lint"
+          r2-secret: ${{ secrets.CF_SSCACHE }}
 
       - name: Lint
         shell: devenv shell bash -- -e {0}
@@ -462,6 +468,7 @@ jobs:
         with:
           cargo-target: ${{ matrix.target }}
           cache-suffix: "-test"
+          r2-secret: ${{ secrets.CF_SSCACHE }}
 
       # No macFUSE on the runner: the macOS binaries weak-link libfuse, so they
       # launch with the dylib absent. `support_check` finds no macfuse.fs and


### PR DESCRIPTION
## Problem

Three of six compiling jobs in [run 30169138492](https://github.com/hephbuild/heph/actions/runs/30169138492) had a **0% sccache hit rate**:

| Job | sccache restore | Hits |
|---|---|---|
| Lint (x86_64-linux) | exact key | 865 / 99.77% |
| Build linux/arm64 | exact key | 837 / 97.33% |
| Test linux/amd64 | exact key (`-test`) | 97 / 100% |
| Build linux/amd64 | exact key | **0 / 0.00%** |
| Build darwin/arm64 | **not found** | **0 / 0.00%** |
| Test darwin/arm64 | **not found** | 1 / 0.11% |

Two independent causes.

### 1. Lint and Build linux/amd64 shared a cache key

Both passed `cargo-target: x86_64-unknown-linux-gnu` with no `cache-suffix`, so both used `sccache-x86_64-unknown-linux-gnu-<lockhash>`. Lint caches clippy check units; build caches release units (thin-LTO, opt-level=3) — completely disjoint.

`actions/cache` skips the save when the exact key already exists. So the first job to ever save that key froze the entry; from then on the other job restored a foreign tarball, recompiled the workspace (873 compilations, 0 hits), grew its local dir to 1 GiB and **discarded all of it**. Permanently, for that lock hash.

### 2. Repo cache quota blown, darwin evicted

```
25 entries, 11.77 GB used — GitHub limit is 10 GB/repo
```

~6.6 GB saved per commit: nix store 3.0 GB, sccache 3.1 GB (6 jobs × 490–750 MB), cargo registry 0.5 GB. Master run + one PR run = 13 GB, so LRU wiped master's caches before any PR could read them. Both darwin jobs found nothing under their exact key *or* the restore-key prefix. PR caches also save to `refs/pull/N/merge`, invisible to every other PR — so each PR paid full cold cost *and* evicted master's copy for everyone else.

## Fix

**sccache → Cloudflare R2** (`heph-sccache`, creds via `secrets.CF_SSCACHE`). Object storage is shared across every branch, PR and runner, is not subject to the Actions quota, and needs no cache key at all — sccache's own hash of (source, args, compiler) already separates check units from release units, which is exactly what a shared tarball key could not do. Also drops ~15s/job of tar upload/download.

Fork PRs get no secrets; the setup step detects the empty value and falls back to a local-disk cache so `RUSTC_WRAPPER` is never left pointing at an unconfigured server.

**Nix store cache is restore-only off master.** Every PR ref was saving its own ~1.5 GB copy per OS. Only master writes now; PRs read it.

**Lint gets `cache-suffix: "-lint"`** for the cargo registry cache, which had the same first-saver-wins collision with the linux/amd64 build.

Steady-state quota use: **11.8 GB → ~3.6 GB** (3.0 GB nix on master only + ~0.6 GB cargo registry).

## Note

The orphaned `sccache-*` entries still hold ~3.1 GB of quota. Worth purging with `gh cache delete` once this merges.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01R6pTVcn4HSNNbQSj6xz3Xs