### PR TITLE
fix(gitignore): drop trailing slash from DirPath patterns

### DIFF
--- a/crates/engine/src/engine/gitignore.rs
+++ b/crates/engine/src/engine/gitignore.rs
@@ -227,12 +227,19 @@ pub fn merge_section(
 /// paths are already workspace-root-relative (package-rooted), so a leading
 /// `/` anchors them precisely.
 ///
+/// A `DirPath` is emitted *without* a trailing slash. In gitignore syntax a
+/// trailing `/` restricts the pattern to directories, and a `codegen = copy`
+/// directory output is materialized as a **symlink** into the cache — which git
+/// treats as a file, not a directory — so `/gen/` would fail to ignore it and the
+/// link would show up untracked. `/gen` matches both spellings.
+///
 /// Reused by `validate` as the canonical, normalized output-path key for
-/// detecting overlapping `codegen = copy` outputs across targets.
+/// detecting overlapping `codegen = copy` outputs across targets; its overlap
+/// tests trim trailing slashes anyway, so they are unaffected.
 pub(crate) fn content_to_pattern(content: &Content) -> String {
     match content {
         Content::FilePath(p) => format!("/{}", p.trim_start_matches('/')),
-        Content::DirPath(p) => format!("/{}/", p.trim_start_matches('/').trim_end_matches('/')),
+        Content::DirPath(p) => format!("/{}", p.trim_start_matches('/').trim_end_matches('/')),
         Content::Glob(g) => format!("/{}", g.trim_start_matches('/')),
     }
 }
@@ -310,9 +317,11 @@ mod tests {
             content_to_pattern(&Content::FilePath("foo/bar.go".into())),
             "/foo/bar.go"
         );
+        // No trailing slash: a gitignore `dir/` pattern only matches real
+        // directories, and a codegen dir output is materialized as a symlink.
         assert_eq!(
             content_to_pattern(&Content::DirPath("foo/gen".into())),
-            "/foo/gen/"
+            "/foo/gen"
         );
         assert_eq!(
             content_to_pattern(&Content::Glob("foo/gen/**/*.go".into())),

--- a/crates/engine/src/engine/validate.rs
+++ b/crates/engine/src/engine/validate.rs
@@ -5,9 +5,10 @@
 //! each other when materialized, so they must be rejected.
 //!
 //! Outputs are normalized to root-anchored paths via
-//! [`crate::engine::gitignore::content_to_pattern`] (directories carry a trailing
-//! `/`). Two outputs overlap when they are the *same* path, or when one is a
-//! directory that *contains* the other (e.g. `/gen/` vs `/gen/a.go`). Glob
+//! [`crate::engine::gitignore::content_to_pattern`]. Two outputs overlap when
+//! they are the *same* path, or when one is a directory that *contains* the other
+//! (e.g. `/gen` vs `/gen/a.go`); overlap tests trim any trailing slash first, so
+//! this holds regardless of how directories are spelled. Glob
 //! patterns are compared as their literal strings, so a glob lying inside a
 //! declared directory is caught, but glob-vs-concrete-file fuzzy matching is not
 //! resolved.
@@ -267,7 +268,7 @@ mod tests {
         assert!(
             has_pair(
                 &overlaps,
-                "/a/gen/",
+                "/a/gen",
                 "//a:dir",
                 "/a/gen/sub/x.go",
                 "//a:file"


### PR DESCRIPTION
## What

Split out of #161 (unrelated to the go build-variant work in that PR).

A `codegen = "copy"` output declared as a **directory** (`DirPath`) was written into the managed `.gitignore` section as `/gen/`. In gitignore syntax a trailing `/` restricts the pattern to real directories — but such an output is materialized as a **symlink** into the cache, which git treats as a file. So `/gen/` did not match it and the link showed up as untracked.

`/gen` matches both spellings (directory and symlink), so the trailing slash is dropped.

## Blast radius

`content_to_pattern` doubles as `validate`'s canonical normalized key for `codegen = copy` overlap detection. That is unaffected: `paths_overlap` and `is_ancestor` already `trim_end_matches('/')` before comparing, so a directory key compares identically with or without the slash. Only the expected key strings in validate's tests and the module doc's description of the convention change.

## Tests

- `content_to_pattern_anchors_paths` asserts the `DirPath` pattern has no trailing slash, with the reason inline.
- `directory_output_overlaps_file_inside_it` still detects `/a/gen` vs `/a/gen/sub/x.go` as one collision — the overlap semantics are unchanged, only the key spelling.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EC6SmCeSGqUB3pYaUw7F1D