### PR TITLE
feat(fs): exempt fs-provider overlaps from collision checks

### DIFF
--- a/crates/builtins/src/pluginfs/mod.rs
+++ b/crates/builtins/src/pluginfs/mod.rs
@@ -98,6 +98,12 @@ pub fn is_glob_addr(addr: &Addr) -> bool {
     addr.package.as_str() == PKG && addr.name == "glob"
 }
 
+/// Returns `true` if `addr` is any fs-provider target (e.g. `file`/`glob`), i.e.
+/// it lives in the fs provider's package.
+pub fn is_fs_addr(addr: &Addr) -> bool {
+    addr.package.as_str() == PKG
+}
+
 // ─── Provider ────────────────────────────────────────────────────────────────
 
 #[derive(Default)]

--- a/crates/driver-support/src/driver_managed.rs
+++ b/crates/driver-support/src/driver_managed.rs
@@ -2,6 +2,7 @@ use anyhow::Context;
 use async_trait::async_trait;
 use hcore::hartifactcontent;
 use hcore::hasync::{self, Cancellable};
+use hmodel::htaddr::Addr;
 use hplugin::driver::inputartifact;
 use hplugin::driver::outputartifact::Content::TarPath;
 use hplugin::driver::targetdef::path::{self, Content};
@@ -392,16 +393,17 @@ pub fn list_path_for(input: &RunInput, list_dir: &Path) -> Option<PathBuf> {
 /// last-write-wins in the sandbox (regular deps `File::create`-truncate; FUSE
 /// layers shadow by registration order — neither surfaces the conflict).
 pub fn detect_output_collisions(groups: &BTreeMap<PathBuf, Vec<RunInput>>) -> anyhow::Result<()> {
-    // Absolute sandbox path -> the source_addr of the target that claimed it.
-    let mut owners: HashMap<PathBuf, String> = HashMap::new();
+    // Absolute sandbox path -> the target that claimed it.
+    let mut owners: HashMap<PathBuf, Addr> = HashMap::new();
     for (unpack_root, inputs) in groups {
         for input in inputs {
-            let producer = input.source_addr.format();
+            let producer = &input.source_addr;
             let paths = input.artifact.content.entry_paths().with_context(|| {
                 format!(
                     "enumerate paths for output-collision check \
-                     (origin_id={}, source_addr={producer})",
+                     (origin_id={}, source_addr={})",
                     input.origin_id,
+                    producer.format(),
                 )
             })?;
             for rel in paths {
@@ -412,12 +414,26 @@ pub fn detect_output_collisions(groups: &BTreeMap<PathBuf, Vec<RunInput>>) -> an
                 }
                 let abs = unpack_root.join(&rel);
                 match owners.get(&abs) {
-                    Some(existing) if *existing != producer => anyhow::bail!(
-                        "output collision: {} is produced by two different targets \
-                         ({existing} and {producer}); a sandbox file may be provided by \
-                         only one target",
-                        abs.display(),
-                    ),
+                    Some(existing) if existing != producer => {
+                        // Two fs-provider inputs (e.g. a `glob` and a specific
+                        // `file`) claiming the same path expose the *same*
+                        // workspace source bytes — the fs provider only surfaces
+                        // existing files, it never materializes — so this overlap
+                        // is benign (last-writer-wins is safe when the bytes
+                        // match). Allow it, keeping the first owner. Mirrors the
+                        // `validate` codegen-overlap exemption. Any collision
+                        // involving a non-fs producer is still a hard error.
+                        if is_fs_source(existing) && is_fs_source(producer) {
+                            continue;
+                        }
+                        anyhow::bail!(
+                            "output collision: {} is produced by two different targets \
+                             ({} and {}); a sandbox file may be provided by only one target",
+                            abs.display(),
+                            existing.format(),
+                            producer.format(),
+                        )
+                    }
                     // Same producer (diamond / depended twice) — one owner, allowed.
                     Some(_) => {}
                     None => {
@@ -428,6 +444,17 @@ pub fn detect_output_collisions(groups: &BTreeMap<PathBuf, Vec<RunInput>>) -> an
         }
     }
     Ok(())
+}
+
+/// The fs provider's package. Its `file`/`glob` targets only expose existing
+/// workspace source (never materialize), so two of them claiming the same
+/// sandbox path provide identical bytes — a benign overlap. Kept as a literal to
+/// avoid a `driver-support` → `builtins` dependency (would cycle); mirrors
+/// `hbuiltins::pluginfs::is_fs_addr`.
+const FS_PROVIDER_PKG: &str = "@heph/fs";
+
+fn is_fs_source(addr: &Addr) -> bool {
+    addr.package.as_str() == FS_PROVIDER_PKG
 }
 
 // ---------------------------------------------------------------------
@@ -776,6 +803,44 @@ mod source_map_tests {
             "must name both producers: {msg}"
         );
         assert!(msg.contains("pkg/x.txt"), "must name the path: {msg}");
+    }
+
+    // Two fs-provider inputs (a glob and a specific file) claiming the same path
+    // expose the same workspace source, so the overlap is allowed.
+    #[test]
+    fn two_fs_provider_inputs_same_path_allowed() {
+        let groups = group(vec![
+            make_input(
+                "dep|glob|0",
+                "//@heph/fs:glob@p=mgmt/tsconfig*.json",
+                &[("mgmt/tsconfig.lib.json", "{}")],
+            ),
+            make_input(
+                "dep|file|0",
+                "//@heph/fs:file@f=mgmt/tsconfig.lib.json",
+                &[("mgmt/tsconfig.lib.json", "{}")],
+            ),
+        ]);
+        detect_output_collisions(&groups).expect("two fs deps overlapping must be allowed");
+    }
+
+    // The exemption is fs-only: an fs input colliding with a real (non-fs)
+    // producer is still a hard error.
+    #[test]
+    fn fs_vs_non_fs_collision_still_errors() {
+        let groups = group(vec![
+            make_input(
+                "dep|glob|0",
+                "//@heph/fs:glob@p=mgmt/*.json",
+                &[("mgmt/x.json", "1")],
+            ),
+            make_input("dep|gen|0", "//mgmt:gen", &[("mgmt/x.json", "2")]),
+        ]);
+        let err = detect_output_collisions(&groups).expect_err("fs vs non-fs must collide");
+        assert!(
+            format!("{err:#}").contains("two different targets"),
+            "{err:#}"
+        );
     }
 
     // The same target contributing a path twice (diamond dep / depended twice)

--- a/crates/engine/src/engine/validate.rs
+++ b/crates/engine/src/engine/validate.rs
@@ -22,6 +22,7 @@ use crate::engine::driver::targetdef::path::CodegenMode;
 use crate::engine::error::TargetNotFoundError;
 use crate::engine::gitignore::content_to_pattern;
 use crate::engine::request_state::RequestState;
+use hbuiltins::pluginfs;
 use hcore::hmemoizer::downcast_chain_ref;
 use hmodel::htaddr::Addr;
 use hmodel::htmatcher::Matcher;
@@ -63,6 +64,15 @@ fn paths_overlap(a: &str, b: &str) -> bool {
     let a = a.trim_end_matches('/');
     let b = b.trim_end_matches('/');
     a == b || is_ancestor(a, b) || is_ancestor(b, a)
+}
+
+/// An overlap between two outputs that is *not* a codegen clobber, so it must not
+/// be flagged. Two fs-provider inputs (e.g. a broad `glob` and a specific `file`,
+/// or two globs) may legitimately cover the same path — the fs provider only
+/// exposes existing source, it never materializes or overwrites — so their
+/// overlap is a normal dependency pattern, allowed by exception.
+fn overlap_exempt(a: &Addr, b: &Addr) -> bool {
+    pluginfs::is_fs_addr(a) && pluginfs::is_fs_addr(b)
 }
 
 impl Engine {
@@ -156,7 +166,7 @@ impl Engine {
                 if !paths_overlap(&a.path, &b.path) {
                     break;
                 }
-                if a.addr != b.addr {
+                if a.addr != b.addr && !overlap_exempt(&a.addr, &b.addr) {
                     overlaps.push(CodegenOverlap {
                         a: a.clone(),
                         b: b.clone(),
@@ -248,6 +258,24 @@ mod tests {
             "{overlaps:?}"
         );
         Ok(())
+    }
+
+    #[test]
+    fn fs_provider_overlaps_are_exempt() {
+        let file = pluginfs::file_addr("a/gen.go");
+        let glob = pluginfs::glob_addr("a/*.go", &[]);
+        let other = hmodel::htaddr::parse_addr("//a:t").expect("valid addr");
+        // Two fs-provider inputs overlapping is allowed.
+        assert!(overlap_exempt(&file, &glob), "two fs deps must be exempt");
+        // An fs input overlapping a real (non-fs) codegen output is NOT exempt.
+        assert!(
+            !overlap_exempt(&file, &other),
+            "fs vs non-fs must still be flagged"
+        );
+        assert!(
+            !overlap_exempt(&other, &other),
+            "two non-fs outputs must still be flagged"
+        );
     }
 
     #[tokio::test]


### PR DESCRIPTION
## What

Split out of #161 (unrelated to the go build-variant work in that PR).

Two `@heph/fs` inputs may legitimately cover the same path — a broad `glob(mgmt/tsconfig*.json)` and a specific `file(mgmt/tsconfig.lib.json)`, or two overlapping globs. The fs provider only exposes files that already exist in the workspace; it never materializes or overwrites. So both inputs carry the *same* source bytes and last-writer-wins is a no-op.

Both collision checks rejected this:

- `validate`'s `codegen_copy_overlaps` flagged it as a codegen clobber.
- the sandbox's `detect_output_collisions` failed the run before materializing inputs.

## How

Exempt the pair only when **both** producers are fs targets:

- `hbuiltins::pluginfs::is_fs_addr` — new predicate for "any target in the fs provider's package".
- `engine/validate.rs` — `overlap_exempt(a, b)` gates the cross-target overlap push.
- `driver-support/driver_managed.rs` — `is_fs_source` gates the bail. `owners` is now keyed by `Addr` rather than a formatted string, so the check is a typed package comparison instead of string work; formatting moved to the error/context sites. A local `@heph/fs` literal is used because `driver-support` → `builtins` would cycle.

A collision involving any non-fs producer is still a hard error — that one really can clobber.

## Tests

- `validate::fs_provider_overlaps_are_exempt` — fs+fs exempt; fs+non-fs and non-fs+non-fs still flagged.
- `driver_managed::two_fs_provider_inputs_same_path_allowed` — a glob and a file over the same path pass.
- `driver_managed::fs_vs_non_fs_collision_still_errors` — the exemption does not leak.
- Existing collision tests (two plain targets, same target twice, disjoint files) unchanged and passing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EC6SmCeSGqUB3pYaUw7F1D