### PR TITLE
perf(engine): run blocking cache/eval work on a dedicated thread pool

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -828,6 +828,7 @@ name = "core"
 version = "0.1.0"
 dependencies = [
  "anyhow",
+ "crossbeam-channel",
  "enclose",
  "futures",
  "libc",

--- a/crates/core/Cargo.toml
+++ b/crates/core/Cargo.toml
@@ -8,6 +8,7 @@ workspace = true
 
 [dependencies]
 anyhow = "1.0.102"
+crossbeam-channel = "0.5"
 serde = { version = "1", features = ["derive"] }
 tar = "0.4"
 futures = "0.3.32"

--- a/crates/core/src/blocking.rs
+++ b/crates/core/src/blocking.rs
@@ -1,0 +1,198 @@
+//! Fixed pool of long-lived OS threads for synchronous blocking work that must
+//! not run on a tokio runtime worker.
+//!
+//! Every other way of running blocking work is unusable here for a different
+//! reason:
+//!
+//! - **Inline on the worker** — what `hproc::process_supervisor::block_or_inline`
+//!   does on Linux. The runtime is never told, so it neither hands the worker's
+//!   queue off nor spawns a replacement: that thread simply stops polling. With
+//!   `worker_threads = ncpu` (2–4 on a CI runner) a handful of concurrent cache
+//!   writes park *every* worker, and then the reactor and the timer wheel stop
+//!   running too — in-flight HTTP transfers make no progress, their deadlines
+//!   never fire, the TUI freezes. Nothing is deadlocked and the build looks hung.
+//!   This is the failure this module exists to remove.
+//! - **`tokio::task::block_in_place`** — correct in principle (the runtime hands
+//!   off), but measured a concurrency regression on this workload (0.94 → 0.74,
+//!   see `PERFORMANCE.md`), because every call burns a worker handoff and pulls a
+//!   fresh thread out of the blocking pool.
+//! - **`tokio::task::spawn_blocking`** — its `JoinHandle` wake-up rides tokio's
+//!   cross-thread waker, observed to drop wake-ups on macOS under heavy load (see
+//!   `RCA_MACOS_WAKER.md`), which strands the awaiting task.
+//!
+//! So: a fixed set of named threads, a `crossbeam_channel` queue, and a
+//! `oneshot` for the result. The threads are created once and live for the
+//! process, so a job costs a channel send rather than a thread spawn.
+//!
+//! **Dropped-wake-up backstop.** The result still crosses threads, so [`run`]
+//! does not simply `await` the `oneshot` — it re-polls on a timer
+//! ([`WAKE_BACKSTOP`]). A lost wake-up then costs latency instead of stranding
+//! the caller forever. This is the same defence the macOS child watcher uses for
+//! its own dropped kernel events (`kqueue_macos.rs`), and it is cheap: the timer
+//! only fires for jobs that outlive it.
+//!
+//! Jobs must be `'static`: a caller's future can be dropped (cancellation) while
+//! its job is still running, so the job cannot borrow from the caller's frame.
+//! Clone or `Arc` what it needs.
+
+use crossbeam_channel::{Sender, unbounded};
+use std::any::Any;
+use std::panic::{AssertUnwindSafe, catch_unwind};
+use std::sync::OnceLock;
+use std::thread;
+use std::time::Duration;
+
+/// One unit of blocking work. Erased to `()` because the result travels back
+/// over a `oneshot` the closure already owns.
+type Job = Box<dyn FnOnce() + Send + 'static>;
+
+/// A panicking job's payload, forwarded so it resurfaces on the caller's task
+/// rather than silently killing a pool thread.
+type Panic = Box<dyn Any + Send + 'static>;
+
+/// How often [`run`] re-polls a pending result.
+///
+/// Purely a backstop against a dropped cross-thread wake-up: on a healthy wake-up
+/// the result arrives immediately and the timer is never reached. Short enough
+/// that a lost wake-up is a hiccup, long enough that a pool of thousands of
+/// queued jobs isn't paying for a busy poll.
+const WAKE_BACKSTOP: Duration = Duration::from_millis(250);
+
+/// Pool size.
+///
+/// The work is a mix of filesystem I/O (tar/copy into the cache, `stat`, rmdir)
+/// and CPU (gzip, borsh, starlark evaluation), so it wants more threads than
+/// cores — an I/O-bound job should not hold a slot a CPU-bound one could use —
+/// but not so many that thousands of concurrent targets thrash the disk. Callers
+/// that need a *tighter* bound impose their own (e.g. the remote cache's
+/// `CODEC_SLOTS` caps concurrent gzip at the core count); this is the ceiling
+/// underneath them.
+fn pool_size() -> usize {
+    let cores = std::thread::available_parallelism()
+        .map(|p| p.get())
+        .unwrap_or(8);
+    (cores * 2).max(4)
+}
+
+static POOL: OnceLock<Sender<Job>> = OnceLock::new();
+
+fn sender() -> &'static Sender<Job> {
+    POOL.get_or_init(|| {
+        let (tx, rx) = unbounded::<Job>();
+        for i in 0..pool_size() {
+            let rx = rx.clone();
+            thread::Builder::new()
+                .name(format!("heph-blocking-{i}"))
+                .spawn(move || {
+                    // Ends only when every sender is dropped, which for a
+                    // process-lifetime static means at exit.
+                    for job in rx.iter() {
+                        job();
+                    }
+                })
+                // Same stance as the sandbox cleaner: a process that cannot spawn
+                // its worker threads at startup has nothing to fall back to.
+                .expect("spawn heph blocking-io thread");
+        }
+        tx
+    })
+}
+
+/// Fail a [`run`] the same way a panicking job does, for the two states that
+/// cannot happen unless the pool itself is broken (its queue closed, or a thread
+/// dropping a job without answering — `catch_unwind` means even a panic answers).
+/// Raised as a panic rather than folded into the return type so [`run`] stays a
+/// drop-in for the synchronous call it replaced.
+fn pool_broken(what: &'static str) -> ! {
+    std::panic::resume_unwind(Box::new(format!("heph blocking pool {what}")))
+}
+
+/// Run `f` on the blocking pool and await its result.
+///
+/// Panics are transparent: a panicking job resurfaces on the caller's task
+/// instead of taking down a pool thread and stranding every later job.
+pub async fn run<F, R>(f: F) -> R
+where
+    F: FnOnce() -> R + Send + 'static,
+    R: Send + 'static,
+{
+    let (tx, mut rx) = tokio::sync::oneshot::channel::<Result<R, Panic>>();
+    let job: Job = Box::new(move || {
+        let out = catch_unwind(AssertUnwindSafe(f));
+        // The receiver is gone when the caller's future was dropped — the job
+        // still had to run to completion, but nobody wants the answer.
+        drop(tx.send(out));
+    });
+    if sender().send(job).is_err() {
+        pool_broken("queue closed");
+    }
+
+    // Re-poll rather than awaiting once: see the dropped-wake-up backstop note
+    // in the module docs.
+    loop {
+        match tokio::time::timeout(WAKE_BACKSTOP, &mut rx).await {
+            Ok(Ok(Ok(value))) => return value,
+            Ok(Ok(Err(panic))) => std::panic::resume_unwind(panic),
+            Ok(Err(_closed)) => pool_broken("dropped a job unanswered"),
+            Err(_elapsed) => continue,
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::sync::Arc;
+    use std::sync::atomic::{AtomicUsize, Ordering};
+
+    #[tokio::test]
+    async fn runs_off_the_calling_thread_and_returns_the_value() {
+        let here = thread::current().id();
+        let (value, ran_on) = run(move || (41 + 1, thread::current().id())).await;
+        assert_eq!(value, 42);
+        assert_ne!(ran_on, here, "job must not run on the caller's thread");
+    }
+
+    /// The whole point: a job that blocks its thread outright must not stop the
+    /// runtime from making progress. If the work ran inline on the worker (what
+    /// `block_or_inline` does on Linux) a single-worker runtime would never poll
+    /// the timer, and this test would hang.
+    #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
+    async fn blocking_work_does_not_stall_the_runtime() {
+        let ticks = Arc::new(AtomicUsize::new(0));
+        let ticker = tokio::spawn({
+            let ticks = Arc::clone(&ticks);
+            async move {
+                for _ in 0..10 {
+                    tokio::time::sleep(Duration::from_millis(5)).await;
+                    ticks.fetch_add(1, Ordering::SeqCst);
+                }
+            }
+        });
+
+        run(|| thread::sleep(Duration::from_millis(120))).await;
+        assert!(
+            ticks.load(Ordering::SeqCst) > 0,
+            "the runtime must keep polling while a pool job blocks",
+        );
+        ticker.await.expect("ticker");
+    }
+
+    /// A panicking job must not kill its pool thread — that would silently strand
+    /// every job scheduled onto it for the rest of the process.
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn panic_surfaces_on_the_caller_and_the_pool_survives() {
+        let panicked = tokio::spawn(run(|| panic!("boom"))).await;
+        assert!(panicked.is_err(), "panic must propagate to the caller");
+        assert_eq!(run(|| 7).await, 7, "the pool must still serve jobs");
+    }
+
+    /// Many jobs at once all complete, exercising the queue past the pool size.
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn queues_beyond_the_pool_size() {
+        let n = pool_size() * 4;
+        let jobs = (0..n).map(|i| run(move || i * 2));
+        let out = futures::future::join_all(jobs).await;
+        assert_eq!(out, (0..n).map(|i| i * 2).collect::<Vec<_>>());
+    }
+}

--- a/crates/core/src/lib.rs
+++ b/crates/core/src/lib.rs
@@ -25,6 +25,7 @@
     )
 )]
 
+pub mod blocking;
 pub mod debug_hash;
 pub mod defer;
 pub mod events;

--- a/crates/engine/src/engine/execute.rs
+++ b/crates/engine/src/engine/execute.rs
@@ -200,15 +200,14 @@ impl Engine {
     }
 }
 
-/// Run a synchronous `std::fs` operation on the current tokio worker
-/// thread via `block_in_place` (on multi-thread runtime) or directly (on
-/// current-thread, e.g. tests). `tokio::fs::*` routes through
-/// `spawn_blocking` and has been observed to lose wake-ups on macOS
-/// under heavy load; doing the fs op on the worker is the path that
-/// surely makes progress.
+/// Run a synchronous `std::fs` operation on the dedicated blocking pool.
+///
+/// Not `tokio::fs::*` (which routes through `spawn_blocking`, observed to lose
+/// wake-ups on macOS under heavy load) and not inline on the worker (which parks
+/// it without telling the runtime). See `hcore::blocking`.
 async fn sync_fs_op_on_thread<F>(f: F) -> std::io::Result<()>
 where
     F: FnOnce() -> std::io::Result<()> + Send + 'static,
 {
-    hproc::process_supervisor::block_or_inline(f)
+    hcore::blocking::run(f).await
 }

--- a/crates/engine/src/engine/gc.rs
+++ b/crates/engine/src/engine/gc.rs
@@ -253,9 +253,9 @@ impl Engine {
         // TTL and rows whose path no longer exists. Best-effort — a prune failure
         // never fails the artifact GC.
         let walker = self.walker.clone();
-        match hproc::process_supervisor::block_or_inline(move || {
-            walker.prune(hwalk::cached_walker::DEFAULT_TTL, true)
-        }) {
+        match hcore::blocking::run(move || walker.prune(hwalk::cached_walker::DEFAULT_TTL, true))
+            .await
+        {
             Ok(n) => stats.fswalk_rows_removed = n,
             Err(e) => tracing::warn!(error = %format!("{e:#}"), "fswalk prune failed"),
         }
@@ -263,8 +263,7 @@ impl Engine {
         // Clear staged read-only inputs — a pure cache, re-materialized on
         // demand — respecting each entry's advisory lock.
         let engine = Arc::clone(&self);
-        let (stage_removed, stage_bytes) =
-            hproc::process_supervisor::block_or_inline(move || engine.gc_stage());
+        let (stage_removed, stage_bytes) = hcore::blocking::run(move || engine.gc_stage()).await;
         stats.stage_entries_removed = stage_removed;
         stats.bytes_removed = stats.bytes_removed.saturating_add(stage_bytes);
 

--- a/crates/engine/src/engine/local_cache.rs
+++ b/crates/engine/src/engine/local_cache.rs
@@ -229,119 +229,120 @@ impl Engine {
         artifact: &outputartifact::OutputArtifact,
     ) -> anyhow::Result<(CacheArtifact, ManifestArtifact)> {
         let hashin = hashin.to_string();
-        // `block_or_inline` runs on the current worker via `block_in_place`
-        // (multi-thread) or inline (current-thread). Avoids `spawn_blocking`
-        // whose JoinHandle wake-up uses tokio's cross-thread waker, which
-        // is observed to drop wakeups on macOS under heavy load — see
-        // `RCA_MACOS_WAKER.md`.
-        hproc::process_supervisor::block_or_inline(
-            enclose!((cache => local_cache, addr, artifact) move || {
-                let open_writer =
-                    |name: &str| -> anyhow::Result<Box<dyn io::Write>> {
-                        local_cache.writer(&addr, &hashin, name)
-                    };
-                let type_prefix = match artifact.r#type {
-                    outputartifact::Type::Output => "out",
-                    outputartifact::Type::Log => "log",
-                    outputartifact::Type::SupportFile => "support",
+        // Writing a revision tars and copies every output — the heaviest
+        // synchronous work in a build, once per target. It runs on the dedicated
+        // blocking pool: not inline (that parks a runtime worker with the runtime
+        // unaware, and enough concurrent writes stop the reactor entirely) and not
+        // `spawn_blocking` (whose JoinHandle wake-up rides tokio's cross-thread
+        // waker, observed to drop wakeups on macOS under load — see
+        // `RCA_MACOS_WAKER.md`). See `hcore::blocking`.
+        hcore::blocking::run(enclose!((cache => local_cache, addr, artifact) move || {
+            let open_writer =
+                |name: &str| -> anyhow::Result<Box<dyn io::Write>> {
+                    local_cache.writer(&addr, &hashin, name)
                 };
+            let type_prefix = match artifact.r#type {
+                outputartifact::Type::Output => "out",
+                outputartifact::Type::Log => "log",
+                outputartifact::Type::SupportFile => "support",
+            };
 
-                let (size, content_type, name) = match &artifact.content {
-                    outputartifact::Content::Raw(raw) => {
-                        let name = format!("{}_{}.tar", type_prefix, artifact.name);
-                        let mut cw = CountingWriter::new(
-                            open_writer(&name).with_context(|| {
-                                format!("open cache writer for {addr} {name}")
-                            })?,
-                        );
-                        let mut p = hartifactcontent::tar::TarPacker::new();
-                        p.create_raw(raw.data.clone(), raw.path.clone(), raw.x);
-                        p.pack(&mut cw)
-                            .with_context(|| format!("pack raw artifact into {addr} {name}"))?;
-                        (cw.bytes_written(), hartifactcontent::Type::Tar, name)
-                    }
-                    outputartifact::Content::File(file) => {
-                        let name = format!("{}_{}.tar", type_prefix, artifact.name);
-                        let mut cw = CountingWriter::new(
-                            open_writer(&name).with_context(|| {
-                                format!("open cache writer for {addr} {name}")
-                            })?,
-                        );
-                        let mut p = hartifactcontent::tar::TarPacker::new();
-                        p.create_file(file.source_path.clone(), file.out_path.clone());
-                        p.pack(&mut cw).with_context(|| {
-                            format!(
-                                "pack file artifact {} into {addr} {name}",
-                                file.source_path
-                            )
-                        })?;
-                        (cw.bytes_written(), hartifactcontent::Type::Tar, name)
-                    }
-                    outputartifact::Content::TarPath(path) => {
-                        let name = format!("{}_{}", type_prefix, artifact.name);
-                        let mut f = File::open(path)
-                            .with_context(|| format!("open tar artifact {path}"))?;
-                        let size = f
-                            .metadata()
-                            .with_context(|| format!("stat tar artifact {path}"))?
-                            .size();
-                        let mut w = open_writer(&name)
-                            .with_context(|| format!("open cache writer for {addr} {name}"))?;
-                        io::copy(&mut f, &mut w).with_context(|| {
-                            format!("copy tar artifact {path} into {addr} {name}")
-                        })?;
-                        (size, hartifactcontent::Type::Tar, name)
-                    }
-                    outputartifact::Content::CpioPath(path) => {
-                        let name = format!("{}_{}", type_prefix, artifact.name);
-                        let mut f = File::open(path)
-                            .with_context(|| format!("open cpio artifact {path}"))?;
-                        let size = f
-                            .metadata()
-                            .with_context(|| format!("stat cpio artifact {path}"))?
-                            .size();
-                        let mut w = open_writer(&name)
-                            .with_context(|| format!("open cache writer for {addr} {name}"))?;
-                        io::copy(&mut f, &mut w).with_context(|| {
-                            format!("copy cpio artifact {path} into {addr} {name}")
-                        })?;
-                        (size, hartifactcontent::Type::Cpio, name)
-                    }
-                };
+            let (size, content_type, name) = match &artifact.content {
+                outputartifact::Content::Raw(raw) => {
+                    let name = format!("{}_{}.tar", type_prefix, artifact.name);
+                    let mut cw = CountingWriter::new(
+                        open_writer(&name).with_context(|| {
+                            format!("open cache writer for {addr} {name}")
+                        })?,
+                    );
+                    let mut p = hartifactcontent::tar::TarPacker::new();
+                    p.create_raw(raw.data.clone(), raw.path.clone(), raw.x);
+                    p.pack(&mut cw)
+                        .with_context(|| format!("pack raw artifact into {addr} {name}"))?;
+                    (cw.bytes_written(), hartifactcontent::Type::Tar, name)
+                }
+                outputartifact::Content::File(file) => {
+                    let name = format!("{}_{}.tar", type_prefix, artifact.name);
+                    let mut cw = CountingWriter::new(
+                        open_writer(&name).with_context(|| {
+                            format!("open cache writer for {addr} {name}")
+                        })?,
+                    );
+                    let mut p = hartifactcontent::tar::TarPacker::new();
+                    p.create_file(file.source_path.clone(), file.out_path.clone());
+                    p.pack(&mut cw).with_context(|| {
+                        format!(
+                            "pack file artifact {} into {addr} {name}",
+                            file.source_path
+                        )
+                    })?;
+                    (cw.bytes_written(), hartifactcontent::Type::Tar, name)
+                }
+                outputartifact::Content::TarPath(path) => {
+                    let name = format!("{}_{}", type_prefix, artifact.name);
+                    let mut f = File::open(path)
+                        .with_context(|| format!("open tar artifact {path}"))?;
+                    let size = f
+                        .metadata()
+                        .with_context(|| format!("stat tar artifact {path}"))?
+                        .size();
+                    let mut w = open_writer(&name)
+                        .with_context(|| format!("open cache writer for {addr} {name}"))?;
+                    io::copy(&mut f, &mut w).with_context(|| {
+                        format!("copy tar artifact {path} into {addr} {name}")
+                    })?;
+                    (size, hartifactcontent::Type::Tar, name)
+                }
+                outputartifact::Content::CpioPath(path) => {
+                    let name = format!("{}_{}", type_prefix, artifact.name);
+                    let mut f = File::open(path)
+                        .with_context(|| format!("open cpio artifact {path}"))?;
+                    let size = f
+                        .metadata()
+                        .with_context(|| format!("stat cpio artifact {path}"))?
+                        .size();
+                    let mut w = open_writer(&name)
+                        .with_context(|| format!("open cache writer for {addr} {name}"))?;
+                    io::copy(&mut f, &mut w).with_context(|| {
+                        format!("copy cpio artifact {path} into {addr} {name}")
+                    })?;
+                    (size, hartifactcontent::Type::Cpio, name)
+                }
+            };
 
-                let artifact_type = match artifact.r#type {
-                    outputartifact::Type::Output => ManifestArtifactType::Output,
-                    outputartifact::Type::Log => ManifestArtifactType::Log,
-                    outputartifact::Type::SupportFile => ManifestArtifactType::SupportFile,
-                };
+            let artifact_type = match artifact.r#type {
+                outputartifact::Type::Output => ManifestArtifactType::Output,
+                outputartifact::Type::Log => ManifestArtifactType::Log,
+                outputartifact::Type::SupportFile => ManifestArtifactType::SupportFile,
+            };
 
-                anyhow::Ok((
-                    CacheArtifact {
-                        addr: addr.clone(),
-                        hashin: hashin.clone(),
-                        name: name.clone(),
-                        cache: local_cache.clone(),
-                        hashout: artifact.hashout.clone(),
-                        content_type,
-                        group: artifact.group.clone(),
-                        r#type: artifact_type.clone(),
-                        size,
+            anyhow::Ok((
+                CacheArtifact {
+                    addr: addr.clone(),
+                    hashin: hashin.clone(),
+                    name: name.clone(),
+                    cache: local_cache.clone(),
+                    hashout: artifact.hashout.clone(),
+                    content_type,
+                    group: artifact.group.clone(),
+                    r#type: artifact_type.clone(),
+                    size,
+                },
+                ManifestArtifact {
+                    hashout: artifact.hashout.clone(),
+                    group: artifact.group.clone(),
+                    name: name.clone(),
+                    size,
+                    r#type: artifact_type,
+                    content_type: match content_type {
+                        hartifactcontent::Type::Tar => ManifestArtifactContentType::Tar,
+                        hartifactcontent::Type::Cpio => ManifestArtifactContentType::Cpio,
                     },
-                    ManifestArtifact {
-                        hashout: artifact.hashout.clone(),
-                        group: artifact.group.clone(),
-                        name: name.clone(),
-                        size,
-                        r#type: artifact_type,
-                        content_type: match content_type {
-                            hartifactcontent::Type::Tar => ManifestArtifactContentType::Tar,
-                            hartifactcontent::Type::Cpio => ManifestArtifactContentType::Cpio,
-                        },
-                        encoding: ManifestArtifactEncoding::None,
-                    },
-                ))
-            }),
-        )
+                    encoding: ManifestArtifactEncoding::None,
+                },
+            ))
+        }))
+        .await
     }
 
     /// Persist `artifacts` for `addr` under the input hash `hashin`.
@@ -413,7 +414,18 @@ impl Engine {
         addr: &Addr,
         hashin: &str,
     ) -> anyhow::Result<Option<Manifest>> {
-        let sized = match self.local_cache.reader(addr, hashin, MANIFEST_V1) {
+        Self::read_manifest_from(&self.local_cache, addr, hashin)
+    }
+
+    /// [`read_manifest`](Self::read_manifest) against a cache handle rather than
+    /// `&self`, so it can be moved onto the blocking pool (which needs a `'static`
+    /// job — see [`read_manifest_blocking`](Self::read_manifest_blocking)).
+    pub(crate) fn read_manifest_from(
+        cache: &Arc<dyn LocalCache>,
+        addr: &Addr,
+        hashin: &str,
+    ) -> anyhow::Result<Option<Manifest>> {
+        let sized = match cache.reader(addr, hashin, MANIFEST_V1) {
             Ok(s) => s,
             Err(e) if e.is::<NotFoundError>() => return Ok(None),
             Err(e) => return Err(e).with_context(|| format!("read manifest for {addr} {hashin}")),
@@ -510,14 +522,23 @@ impl Engine {
     /// result hot path. The backend `reader` + `borsh::from_slice` is the expensive
     /// half of a cache lookup, so its result is stashed and reused across the
     /// presence-probe and the per-caller output read (see `LockedResolution::manifest`).
-    /// See `cache_artifact_locally` for why this is `block_or_inline`, not `spawn_blocking`.
+    ///
+    /// On the dedicated blocking pool (see `hcore::blocking`, and
+    /// `cache_artifact_locally` for why neither inline nor `spawn_blocking` works):
+    /// this runs once per target on the hot path, and a backend read plus a borsh
+    /// parse is more than a runtime worker should disappear into.
     pub(crate) async fn read_manifest_blocking(
         &self,
         _ctoken: &dyn Cancellable,
         addr: &Addr,
         hashin: &str,
     ) -> anyhow::Result<Option<Manifest>> {
-        hproc::process_supervisor::block_or_inline(move || self.read_manifest(addr, hashin))
+        // Cloned rather than borrowed: a pool job outlives a dropped caller future
+        // (cancellation), so it cannot borrow the caller's frame. An `Addr` plus a
+        // hash is a handful of small strings — cheap next to the read itself.
+        let (local_cache, addr, hashin) =
+            (self.local_cache.clone(), addr.clone(), hashin.to_string());
+        hcore::blocking::run(move || Self::read_manifest_from(&local_cache, &addr, &hashin)).await
     }
 
     /// The blobs a caller asking for `outputs` will actually read: its Output
@@ -558,6 +579,12 @@ impl Engine {
         outputs: &[String],
     ) -> anyhow::Result<Vec<String>> {
         let local_cache = &self.local_cache;
+        // Deliberately still inline, unlike the write path: this is a walk of an
+        // already-parsed manifest plus one `exists` stat per needed artifact — no
+        // bytes read, no compression. Moving it to the blocking pool would mean a
+        // `'static` job, so `manifest` and `outputs` would have to be cloned or
+        // re-plumbed as `Arc`s through the whole read path, to take work off the
+        // worker that barely occupies it.
         hproc::process_supervisor::block_or_inline(move || {
             let mut missing = Vec::new();
             for artifact in Self::needed_artifacts(manifest, outputs) {
@@ -588,6 +615,8 @@ impl Engine {
         outputs: &[String],
     ) -> anyhow::Result<Option<(Vec<CacheArtifact>, Vec<ArtifactMeta>)>> {
         let local_cache = &self.local_cache;
+        // Inline for the same reason as `missing_local_blobs`: stats and struct
+        // building over a manifest already in memory.
         hproc::process_supervisor::block_or_inline(move || {
             let mut results: Vec<CacheArtifact> = Vec::with_capacity(manifest.artifacts.len());
             let mut result_meta: Vec<ArtifactMeta> = Vec::with_capacity(manifest.artifacts.len());

--- a/crates/engine/src/engine/local_cache_sqlite.rs
+++ b/crates/engine/src/engine/local_cache_sqlite.rs
@@ -33,12 +33,13 @@ impl PipeSemaphore {
 
     /// Blocks the calling thread until a permit is available.
     ///
-    /// **Contract:** callers must be on a thread that may block — either a
-    /// dedicated OS thread (e.g. the sqlite writer thread, rayon pool) or a
-    /// tokio worker that has handed off its core via
-    /// `hproc::process_supervisor::block_or_inline` /
+    /// **Contract:** callers must be on a thread that may block — a dedicated OS
+    /// thread (the sqlite writer thread, the `hcore::blocking` pool, a rayon
+    /// worker) or a tokio worker that has handed off its core via
     /// `tokio::task::block_in_place`. Calling this directly from a tokio task
-    /// parks the worker and can starve the runtime.
+    /// parks the worker and can starve the runtime; so does
+    /// `hproc::process_supervisor::block_or_inline`, which on Linux *is* inline on
+    /// the worker — the cache write path goes through `hcore::blocking` instead.
     fn acquire(self: &Arc<Self>) -> PipePermit {
         let mut count = self.count.lock().expect("pipe semaphore mutex poisoned");
         while *count == 0 {

--- a/crates/engine/src/engine/remote_cache.rs
+++ b/crates/engine/src/engine/remote_cache.rs
@@ -131,7 +131,7 @@ static CODEC_SLOTS: LazyLock<Semaphore> = LazyLock::new(|| {
 });
 
 /// Run the synchronous codec step (gzip/gunzip plus local-cache reads/writes) on
-/// the blocking pool, bounded by [`CODEC_SLOTS`].
+/// the dedicated blocking pool, bounded by [`CODEC_SLOTS`].
 ///
 /// It must **not** run on a runtime worker. Compressing or decompressing a
 /// revision takes hundreds of milliseconds to seconds of straight CPU; with
@@ -140,6 +140,10 @@ static CODEC_SLOTS: LazyLock<Semaphore> = LazyLock::new(|| {
 /// transfers, their inactivity deadlines, the TUI. The build looks hung even
 /// though no lock is actually deadlocked. (The previous `block_or_inline` did
 /// exactly that: inline on Linux, `block_in_place` on macOS.)
+///
+/// `hcore::blocking` rather than `spawn_blocking`: the latter's `JoinHandle`
+/// wake-up rides tokio's cross-thread waker, observed to drop wake-ups on macOS
+/// under load (`RCA_MACOS_WAKER.md`) — the same load this path generates.
 ///
 /// The closure is `Send`, but the values it builds are not required to be — the
 /// non-`Send` local-cache reader/writer is created and dropped entirely inside
@@ -153,9 +157,9 @@ where
         .acquire()
         .await
         .with_context(|| format!("acquire remote cache codec slot for {what}"))?;
-    tokio::task::spawn_blocking(f)
+    hcore::blocking::run(f)
         .await
-        .with_context(|| format!("join remote cache {what} task"))?
+        .with_context(|| format!("remote cache {what}"))
 }
 
 /// A streaming object store. The set layers cache semantics (manifest affinity,
@@ -1538,7 +1542,7 @@ impl Engine {
         let hashin_owned = hashin.to_string();
         // Same reasoning as `cache_artifact_locally`: the local-cache writer is
         // synchronous (and not `Send`), so it must not run on a runtime worker.
-        hproc::process_supervisor::block_or_inline(move || {
+        hcore::blocking::run(move || {
             use std::io::Write;
             let mut w = local_cache
                 .writer(&addr_owned, &hashin_owned, MANIFEST_V1)
@@ -1546,6 +1550,7 @@ impl Engine {
             w.write_all(&bytes).context("write remote manifest")?;
             anyhow::Ok(())
         })
+        .await
         .with_context(|| format!("mirror remote manifest for {addr} {hashin}"))?;
 
         Ok(Some((local_manifest, rev)))

--- a/crates/engine/src/engine/result.rs
+++ b/crates/engine/src/engine/result.rs
@@ -2093,11 +2093,12 @@ impl Engine {
         // Blob copy is synchronous IO — run it off the async poll like every
         // other cache write (see `cache_artifact_locally`).
         let primary = opts.hashin.clone();
-        let dup = hproc::process_supervisor::block_or_inline(enclose!(
+        let dup = hcore::blocking::run(enclose!(
             (self => engine, addr, fixpoint, primary) move || {
                 engine.duplicate_cache_revision(&addr, &primary, &fixpoint)
             }
-        ));
+        ))
+        .await;
         if let Err(e) = dup {
             // Best-effort: the primary cache entry is already written, so a
             // failure here just means the next run re-executes instead of

--- a/crates/plugin-buildfile/src/pluginbuildfile/provider.rs
+++ b/crates/plugin-buildfile/src/pluginbuildfile/provider.rs
@@ -338,13 +338,14 @@ impl EProvider for Provider {
                 .once(
                     (),
                     enclose!((self.root => root, self.build_file_patterns => patterns, self.skip => skip, self.walker => walker) move || async move {
-                        let packages = hproc::process_supervisor::block_or_inline(move || {
+                        let packages = hcore::blocking::run(move || {
                             // Recursion reads dirs through the shared walker, so an
                             // unchanged tree is served from the cross-run fswalk cache.
                             let mut packages = std::collections::HashSet::new();
                             find_packages_sync(&walker, &root, &root, &patterns, &skip, &mut packages)?;
                             Ok::<_, anyhow::Error>(packages.into_iter().collect::<Vec<String>>())
-                        })?;
+                        })
+                        .await?;
                         Ok(Arc::new(packages))
                     }),
                 )

--- a/crates/plugin-buildfile/src/pluginbuildfile/run_file.rs
+++ b/crates/plugin-buildfile/src/pluginbuildfile/run_file.rs
@@ -1036,13 +1036,18 @@ impl Provider {
             .once(
                 key.clone(),
                 enclose!((key) move || async move {
-                    hproc::process_supervisor::block_or_inline(move || -> anyhow::Result<Arc<RunResult>> {
+                    // Starlark evaluation of a whole package: the single heaviest
+                    // synchronous unit in a build, and one per package. On a runtime
+                    // worker it stops that worker polling anything at all — see
+                    // `hcore::blocking`.
+                    hcore::blocking::run(move || -> anyhow::Result<Arc<RunResult>> {
                         let loader =
                             BuildFileLoader::new(root, patterns, file_cache, dir_cache, registry, globals, walker, skip);
                         loader
                             .load_pkg(&key)
                             .with_context(|| format!("pkg: `{}`", key))
                     })
+                    .await
                 }),
             )
             .await

--- a/crates/plugin-go/src/plugingo/provider.rs
+++ b/crates/plugin-go/src/plugingo/provider.rs
@@ -726,13 +726,14 @@ impl ProviderInner {
                     >);
             }
 
-            let packages = hproc::process_supervisor::block_or_inline(
+            let packages = hcore::blocking::run(
                 enclose!((self.workspace_root => workspace_root, self.skip => skip, self.walker => walker) move || {
                     let mut packages = Vec::new();
                     collect_go_packages(&walker, &search_dir, &workspace_root, false, &skip, &mut packages);
                     packages
                 }),
-            );
+            )
+            .await;
 
             Ok(Box::new(packages.into_iter())
                 as Box<
@@ -2320,7 +2321,7 @@ impl ProviderInner {
             .once(
                 golist_addr.clone(),
                 enclose!((result) move || async move {
-                    let pkg = hproc::process_supervisor::block_or_inline(move || -> anyhow::Result<_> {
+                    let pkg = hcore::blocking::run(move || -> anyhow::Result<_> {
                         for artifact in &result.artifacts {
                             for entry_result in artifact.walk()? {
                                 let entry = entry_result?;
@@ -2337,7 +2338,8 @@ impl ProviderInner {
                             }
                         }
                         anyhow::bail!("_golist produced no package.bin")
-                    })?;
+                    })
+                    .await?;
                     // `go list -e` reports no-buildable-files cases as a JSON
                     // entry with the Error field populated and empty GoFiles.
                     // Surface that as a typed sentinel so consumers can map it
@@ -2377,7 +2379,7 @@ impl ProviderInner {
             .once(
                 golist_addr.clone(),
                 enclose!((result) move || async move {
-                    let addrs = hproc::process_supervisor::block_or_inline(move || -> anyhow::Result<_> {
+                    let addrs = hcore::blocking::run(move || -> anyhow::Result<_> {
                         for artifact in &result.artifacts {
                             for entry_result in artifact.walk()? {
                                 let entry = entry_result?;
@@ -2394,7 +2396,8 @@ impl ProviderInner {
                             }
                         }
                         anyhow::bail!("_golist produced no package_addrs.bin")
-                    })?;
+                    })
+                    .await?;
                     Ok(Arc::new(addrs))
                 }),
             )
@@ -2585,6 +2588,8 @@ impl ProviderInner {
             return Ok(Arc::clone(hit));
         }
         let data = if go_mod_path.exists() {
+            // Stays inline: one small `read_to_string`, from a sync fn, memoized
+            // per module. Not worth an async hop onto the blocking pool.
             let content = hproc::process_supervisor::block_or_inline(
                 enclose!((go_mod_path) move || std::fs::read_to_string(&go_mod_path)),
             )

--- a/src/commands/bootstrap.rs
+++ b/src/commands/bootstrap.rs
@@ -17,8 +17,12 @@ use crate::{
 /// execute permits, since every `block_in_place` site parks a runtime worker and
 /// spawns a replacement from the blocking pool. Default `512` is enough today but
 /// silently degrades to inline execution if saturated; the explicit `8 × N + 64`
-/// gives clear headroom for nested `block_or_inline` chains (execute → cache →
-/// plugingo) without ever hitting the cliff.
+/// gives clear headroom without ever hitting the cliff.
+///
+/// The heavy synchronous work — cache writes, gzip, starlark evaluation, the Go
+/// package walks — does *not* draw on this pool: it runs on `hcore::blocking`'s own
+/// dedicated threads, which is what keeps these `n` workers free to poll the
+/// reactor and the timer wheel.
 pub fn build_runtime() -> std::io::Result<Runtime> {
     let n = available_parallelism().map(|p| p.get()).unwrap_or(8);
     Builder::new_multi_thread()


### PR DESCRIPTION
Follow-up to #178, which fixed the remote cache starving itself. This fixes the other half of "the build looks hung": the runtime stops polling because its workers are all parked in synchronous work.

## The bug

`hproc::process_supervisor::block_or_inline` is `block_in_place` on macOS but **inline** on Linux:

```rust
#[cfg(not(target_os = "macos"))]
pub fn block_or_inline<F, R>(f: F) -> R where F: FnOnce() -> R { f() }
```

The closure runs straight on the runtime worker with the runtime unaware, so it neither hands that worker's queue off nor spawns a replacement. That thread simply stops polling.

With `worker_threads = ncpu` (2–4 on a CI runner) a handful of concurrent cache writes park *every* worker — and then the reactor and the timer wheel stop running too. In-flight HTTP transfers make no progress, their deadlines never fire, the TUI freezes. Nothing is deadlocked and the build looks hung.

`run_codec` already documented this exact failure and moved the remote codec off `block_or_inline`. Every other heavy call site was left on it — including `cache_artifact_locally`, which tars and copies every output of every target, and buildfile `run_pkg`, which evaluates a whole package of starlark.

## Why a dedicated pool

All three alternatives are ruled out on this codebase:

| | why not |
|---|---|
| inline (`block_or_inline` on Linux) | the bug above |
| `tokio::task::block_in_place` | measured concurrency regression 0.94 → 0.74 (`PERFORMANCE.md`) |
| `tokio::task::spawn_blocking` | `JoinHandle` wake-up rides tokio's cross-thread waker, observed to drop wake-ups on macOS under load (`RCA_MACOS_WAKER.md`) |

So `hcore::blocking`: a fixed set of named OS threads fed by a `crossbeam_channel` queue, result returned over a `oneshot`. Threads are created once and live for the process, so a job costs a channel send, not a thread spawn. Same shape as `sandbox_cleaner`, which already uses a dedicated thread for exactly these reasons.

**Dropped-wake-up backstop.** The result still crosses threads, so `run` does not simply `await` the oneshot — it re-polls on a 250ms timer. A lost wake-up then costs latency instead of stranding the caller forever. This is the same defence the macOS child watcher already applies to dropped kernel events (`kqueue_macos.rs`, 1s `kevent` backstop), and it is cheap: the timer is only reached by jobs that outlive it.

Jobs are `'static` because a caller's future can be dropped (cancellation) while its job is still running, so a job must not borrow the caller's frame.

## Moved onto the pool

Heaviest first:

- `cache_artifact_locally` — tars and copies every output, once per target
- buildfile `run_pkg` — starlark evaluation of a package, once per package
- `run_codec` — gzip/gunzip (off `spawn_blocking`, onto the pool)
- `read_manifest_blocking` — backend read + borsh parse, once per target
- plugingo `_golist` package/addr decode, and the Go package walk
- buildfile package discovery; GC's fswalk prune and stage sweep; the fixpoint revision copy; `execute`'s sync fs ops

## Left inline, deliberately

- `missing_local_blobs` / `artifacts_from_manifest` — a walk of an already-parsed manifest plus one `exists` stat per artifact. No bytes read, no compression. A `'static` job would mean cloning the manifest or threading `Arc`s through the whole read path, to take work off the worker that barely occupies it.
- `load_go_mod`'s two `read_to_string`s — one small file, called from a sync fn, memoized per module.

`local_cache_sqlite`'s `PipeSemaphore::acquire` contract doc and `build_runtime`'s sizing comment are updated to match reality.

## Tests

`hcore::blocking` has four:

- `blocking_work_does_not_stall_the_runtime` — the actual regression test. On a `worker_threads = 1` runtime, a ticker task must keep advancing while a pool job blocks its thread for 120ms. Run inline (what `block_or_inline` does on Linux) the timer would never be polled and this hangs.
- `panic_surfaces_on_the_caller_and_the_pool_survives` — a panicking job must not kill its thread and silently strand every job after it.
- `runs_off_the_calling_thread_and_returns_the_value`, `queues_beyond_the_pool_size`.

Suites on the rebased tree: `core` 65, `engine` 282, `plugin-go` 371, `plugin-buildfile` 129, `e2e`, `tui` 81 — all green. `lint` clean. `plugingo-e2e` build suite 15/15.

**`plugingo-e2e` codegen fails 4/10 on my machine — but master fails 5/10, and every failure is `No space left on device (os error 28)`.** Ten parallel fixtures each building the full Go std tree exhausted the disk; unrelated to this change. CI has the room.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HDQfPJMkbY4hJCLw6n6WGw