### PR TITLE
feat(inspect): add `states` to show provider_state across the tree

### DIFF
--- a/crates/engine/src/engine/mod.rs
+++ b/crates/engine/src/engine/mod.rs
@@ -41,6 +41,8 @@ mod local_cache_sqlite;
 mod local_cache_tmp;
 mod packages;
 mod remote_cache;
+mod states;
+pub use states::{PackageStates, StatesOptions};
 mod remote_cache_latency;
 mod remote_cache_objstore;
 pub use hplugin::provider;

--- a/crates/engine/src/engine/states.rs
+++ b/crates/engine/src/engine/states.rs
@@ -1,0 +1,331 @@
+use crate::engine::Engine;
+use crate::engine::provider::State;
+use crate::engine::request_state::RequestState;
+use enclose::enclose;
+use futures::StreamExt;
+use futures::stream::FuturesOrdered;
+use hmodel::htaddr::Addr;
+use hmodel::htmatcher::{MatchResult, Matcher};
+use hmodel::htpkg::PkgBuf;
+use std::collections::BTreeMap;
+use std::sync::Arc;
+
+/// What [`Engine::states`] should collect.
+#[derive(Debug, Clone, Default)]
+pub struct StatesOptions {
+    /// Also report the states a package inherits from its ancestors — the full
+    /// chain a provider is handed. When false, only the declarations the package
+    /// makes itself are kept.
+    pub inherited: bool,
+    /// Keep only the states addressed to this provider.
+    pub provider: Option<String>,
+}
+
+/// The `provider_state(...)` declarations visible to one package.
+#[derive(Debug, Clone)]
+pub struct PackageStates {
+    /// The package the states were resolved for.
+    pub package: PkgBuf,
+    /// Ordered shallow->deep: the root package's declarations first, `package`'s
+    /// own last. Each `State::package` records where it was declared. Ordering
+    /// is the declaration order a provider sees; precedence between two states
+    /// carrying the same key is a provider-defined policy, not an engine one.
+    pub states: Vec<State>,
+}
+
+/// Whether `pkg` is selected by `m`. States are declared per package and carry
+/// no target name, so a matcher arm that needs one (`Label`, `TreeOutputTo`)
+/// can only shrug — those are treated as selecting the package, keeping the
+/// scan inclusive rather than silently dropping declarations.
+fn matches_package(m: &Matcher, pkg: &PkgBuf) -> bool {
+    let probe = Addr::new(pkg.clone(), String::new(), BTreeMap::new());
+    m.matches_addr(&probe) != MatchResult::MatchNo
+}
+
+impl Engine {
+    /// Resolve the `provider_state(...)` declarations for every package matching `m`.
+    ///
+    /// An exact `Matcher::Package` is probed directly rather than discovered via
+    /// `list_packages`: a package that declares state for its subtree need not
+    /// itself hold any target, and asking "what applies at `//foo`" must answer
+    /// even then. Broader matchers walk the discovered package set.
+    ///
+    /// Packages are returned in lexical order, each with its states — including
+    /// packages that have none, so callers can distinguish "no state here" from
+    /// "package not matched".
+    pub async fn states(
+        self: Arc<Self>,
+        rs: Arc<RequestState>,
+        m: &Matcher,
+        opts: &StatesOptions,
+    ) -> anyhow::Result<Vec<PackageStates>> {
+        let pkgs = match m {
+            Matcher::Package(p) => vec![p.clone()],
+            _ => {
+                let mut pkgs: Vec<PkgBuf> = Vec::new();
+                for p in self.packages(m, &rs).await? {
+                    let pkg = PkgBuf::from(p?.as_str());
+                    if matches_package(m, &pkg) {
+                        pkgs.push(pkg);
+                    }
+                }
+                pkgs.sort_by(|a, b| a.as_str().cmp(b.as_str()));
+                pkgs
+            }
+        };
+
+        // `probe_segments` memoizes per (provider, package) within the request,
+        // so overlapping ancestor chains are probed once no matter how many
+        // packages ask. Keep the fan-out ordered so output is deterministic.
+        let mut probes: FuturesOrdered<_> = pkgs
+            .into_iter()
+            .map(|pkg| {
+                enclose!((self => engine, rs) async move {
+                    let states = engine.probe_segments(&rs, &pkg).await?;
+                    anyhow::Ok((pkg, states))
+                })
+            })
+            .collect();
+
+        let mut out = Vec::new();
+        while let Some(res) = probes.next().await {
+            let (pkg, states) = res?;
+            let mut states: Vec<State> = states
+                .iter()
+                .filter(|s| opts.inherited || s.package == pkg)
+                .filter(|s| opts.provider.as_ref().is_none_or(|p| &s.provider == p))
+                .cloned()
+                .collect();
+            // `probe_segments` walks the chain deepest-first; flip to root-first
+            // so output reads down the tree. Ancestors form a chain, so the
+            // declaring package's length totally orders them, and the stable
+            // sort keeps per-package provider order intact.
+            states.sort_by_key(|s| s.package.as_str().len());
+            out.push(PackageStates {
+                package: pkg,
+                states,
+            });
+        }
+
+        Ok(out)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::engine::Config;
+    use crate::engine::provider::{
+        ConfigRequest, ConfigResponse, GetError, GetRequest, GetResponse, ListPackageResponse,
+        ListPackagesRequest, ListRequest, ListResponse, ProbeRequest, ProbeResponse,
+    };
+    use futures::future::BoxFuture;
+    use hcore::hasync::Cancellable;
+    use hcore::htvalue::Value;
+
+    fn pkg(s: &str) -> PkgBuf {
+        PkgBuf::from(s)
+    }
+
+    /// Lists `a`, `a/b`, `other`; every package declares one state naming itself,
+    /// under the provider name it was registered with.
+    struct StatingProvider(&'static str);
+
+    impl crate::engine::provider::Provider for StatingProvider {
+        fn config(&self, _req: ConfigRequest) -> anyhow::Result<ConfigResponse> {
+            Ok(ConfigResponse {
+                name: self.0.to_string(),
+            })
+        }
+        fn list<'a>(
+            &'a self,
+            _req: ListRequest,
+            _ctoken: &'a (dyn Cancellable + Send + Sync),
+        ) -> BoxFuture<
+            'a,
+            anyhow::Result<Box<dyn Iterator<Item = anyhow::Result<ListResponse>> + Send>>,
+        > {
+            Box::pin(async {
+                Ok(Box::new(std::iter::empty())
+                    as Box<
+                        dyn Iterator<Item = anyhow::Result<ListResponse>> + Send,
+                    >)
+            })
+        }
+        fn list_packages<'a>(
+            &'a self,
+            _req: ListPackagesRequest,
+            _ctoken: &'a (dyn Cancellable + Send + Sync),
+        ) -> BoxFuture<
+            'a,
+            anyhow::Result<Box<dyn Iterator<Item = anyhow::Result<ListPackageResponse>> + Send>>,
+        > {
+            Box::pin(async {
+                let items: Vec<anyhow::Result<ListPackageResponse>> = ["a", "a/b", "other"]
+                    .into_iter()
+                    .map(|p| {
+                        Ok(ListPackageResponse {
+                            pkg: PkgBuf::from(p),
+                        })
+                    })
+                    .collect();
+                Ok(Box::new(items.into_iter())
+                    as Box<
+                        dyn Iterator<Item = anyhow::Result<ListPackageResponse>> + Send,
+                    >)
+            })
+        }
+        fn get<'a>(
+            &'a self,
+            _req: GetRequest,
+            _ctoken: &'a (dyn Cancellable + Send + Sync),
+        ) -> BoxFuture<'a, Result<GetResponse, GetError>> {
+            Box::pin(async { Err(GetError::NotFound) })
+        }
+        fn probe<'a>(
+            &'a self,
+            req: ProbeRequest,
+            _ctoken: &'a (dyn Cancellable + Send + Sync),
+        ) -> BoxFuture<'a, anyhow::Result<ProbeResponse>> {
+            let pkg = req.package.clone();
+            let name = self.0.to_string();
+            Box::pin(async move {
+                Ok(ProbeResponse {
+                    states: vec![State {
+                        package: pkg.clone(),
+                        provider: name,
+                        state: [("at".to_string(), Value::String(pkg.to_string()))]
+                            .into_iter()
+                            .collect(),
+                    }],
+                })
+            })
+        }
+    }
+
+    fn make_engine(names: &[&'static str]) -> anyhow::Result<Arc<Engine>> {
+        let root = tempfile::tempdir()?;
+        let mut engine = Engine::new(Config {
+            root: root.path().to_path_buf(),
+            home_dir: std::path::PathBuf::new(),
+            parallelism: None,
+            ..Default::default()
+        })?;
+        for name in names {
+            engine.register_provider(move |_| Box::new(StatingProvider(name)))?;
+        }
+        Ok(Arc::new(engine))
+    }
+
+    fn declared_in(ps: &PackageStates) -> Vec<&str> {
+        ps.states.iter().map(|s| s.package.as_str()).collect()
+    }
+
+    #[tokio::test]
+    async fn declared_only_keeps_the_packages_own_states() -> anyhow::Result<()> {
+        let engine = make_engine(&["p1"])?;
+        let rs = engine.new_state();
+
+        let out = engine
+            .states(rs, &Matcher::Package(pkg("a/b")), &StatesOptions::default())
+            .await?;
+
+        assert_eq!(out.len(), 1);
+        assert_eq!(declared_in(&out[0]), vec!["a/b"]);
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn inherited_returns_the_ancestor_chain_root_first() -> anyhow::Result<()> {
+        let engine = make_engine(&["p1"])?;
+        let rs = engine.new_state();
+
+        let out = engine
+            .states(
+                rs,
+                &Matcher::Package(pkg("a/b")),
+                &StatesOptions {
+                    inherited: true,
+                    provider: None,
+                },
+            )
+            .await?;
+
+        assert_eq!(out.len(), 1);
+        // Root first, the queried package last — the order a reader walks down
+        // the tree, the reverse of the deepest-first probe walk.
+        assert_eq!(declared_in(&out[0]), vec!["", "a", "a/b"]);
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn provider_filter_drops_other_providers_states() -> anyhow::Result<()> {
+        let engine = make_engine(&["p1", "p2"])?;
+        let rs = engine.new_state();
+
+        let out = engine
+            .states(
+                rs,
+                &Matcher::Package(pkg("a")),
+                &StatesOptions {
+                    inherited: true,
+                    provider: Some("p2".to_string()),
+                },
+            )
+            .await?;
+
+        let providers: Vec<&str> = out[0].states.iter().map(|s| s.provider.as_str()).collect();
+        assert_eq!(providers, vec!["p2", "p2"]);
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn prefix_matcher_scans_the_discovered_packages() -> anyhow::Result<()> {
+        let engine = make_engine(&["p1"])?;
+        let rs = engine.new_state();
+
+        let out = engine
+            .states(
+                rs,
+                &Matcher::PackagePrefix(pkg("a")),
+                &StatesOptions::default(),
+            )
+            .await?;
+
+        // `other` is outside the prefix; `@heph/fs` (the always-on built-in
+        // provider's package) is too. Lexical order.
+        let pkgs: Vec<&str> = out.iter().map(|p| p.package.as_str()).collect();
+        assert_eq!(pkgs, vec!["a", "a/b"]);
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn exact_matcher_answers_for_a_package_no_provider_lists() -> anyhow::Result<()> {
+        let engine = make_engine(&["p1"])?;
+        let rs = engine.new_state();
+
+        // `zz` is never listed by `list_packages`, but a state declared at the
+        // root still applies to it — the query must say so.
+        let out = engine
+            .states(
+                rs,
+                &Matcher::Package(pkg("zz")),
+                &StatesOptions {
+                    inherited: true,
+                    provider: None,
+                },
+            )
+            .await?;
+
+        assert_eq!(declared_in(&out[0]), vec!["", "zz"]);
+        Ok(())
+    }
+
+    #[test]
+    fn label_matcher_shrug_keeps_the_package() {
+        // A label says nothing about a package, and states have no target name
+        // to test it against — stay inclusive.
+        assert!(matches_package(&Matcher::Label("l".to_string()), &pkg("a")));
+        assert!(!matches_package(&Matcher::Package(pkg("b")), &pkg("a")));
+    }
+}

--- a/src/commands/inspect/mod.rs
+++ b/src/commands/inspect/mod.rs
@@ -9,6 +9,7 @@ mod packages;
 mod path;
 mod revdeps;
 mod spec;
+mod states;
 
 use clap::{Args, Subcommand};
 
@@ -127,6 +128,31 @@ pub enum InspectCommands {
     ///
     /// `heph inspect path //cmd/server:bin //lib:core --no-transitive`
     Path(path::Args),
+    /// Show the `provider_state(...)` declared across the package tree
+    ///
+    /// A `provider_state(provider="X", …)` call in a BUILD file configures
+    /// provider `X` for that package and — depending on the provider — its
+    /// descendants. This prints where those declarations live and what they
+    /// carry: a `//pkg` header per package, then one line per state as
+    /// `<provider>  <field>=<json> …`. Packages declaring nothing are omitted,
+    /// so empty output means "no state here".
+    ///
+    /// Pass --inherited to see the whole chain a provider is handed for a
+    /// package — its own declarations plus every ancestor's — each line
+    /// prefixed with the package that declared it, root first. Which of two
+    /// declarations wins is the provider's own policy; this only reports what
+    /// applies.
+    ///
+    /// Examples:
+    ///
+    /// `heph inspect states` — every declaration in the workspace
+    ///
+    /// `heph inspect states //cmd/...`
+    ///
+    /// `heph inspect states //cmd/server --inherited` — what applies there
+    ///
+    /// `heph inspect states -p go --json`
+    States(states::Args),
     /// List provider-exposed functions (`heph.<provider>.<fn>`)
     ///
     /// Prints every function registered by a provider for use in BUILD files,
@@ -158,6 +184,7 @@ impl InspectCommands {
             InspectCommands::Deps(args) => deps::execute(args, sink, global),
             InspectCommands::Revdeps(args) => revdeps::execute(args, sink, global),
             InspectCommands::Path(args) => path::execute(args, sink, global),
+            InspectCommands::States(args) => states::execute(args, sink, global),
             InspectCommands::Functions(args) => functions::execute(args, sink, global),
         }
     }

--- a/src/commands/inspect/states.rs
+++ b/src/commands/inspect/states.rs
@@ -17,8 +17,6 @@ pub struct Args {
     pub matcher: Option<String>,
 
     /// Also show the states a package inherits from its ancestors
-    // No short form on purpose: `-i` is `--interactive` on the sibling `deps`
-    // command, and quietly meaning something else here would bite.
     #[arg(long)]
     pub inherited: bool,
 

--- a/src/commands/inspect/states.rs
+++ b/src/commands/inspect/states.rs
@@ -1,0 +1,352 @@
+use std::sync::Arc;
+
+use anyhow::Context;
+use async_trait::async_trait;
+
+use crate::commands::GlobalOptions;
+use crate::commands::bootstrap;
+use crate::engine::{Engine, PackageStates, StatesOptions};
+use crate::htmatcher::Matcher;
+use crate::htpkg::{self, PkgBuf};
+use crate::htvalue::Value;
+use crate::tui::{self, App, AppContext, BufferedStdout, LogSink};
+
+#[derive(clap::Args, Clone)]
+pub struct Args {
+    /// Package matcher (defaults to all packages)
+    pub matcher: Option<String>,
+
+    /// Also show the states a package inherits from its ancestors
+    // No short form on purpose: `-i` is `--interactive` on the sibling `deps`
+    // command, and quietly meaning something else here would bite.
+    #[arg(long)]
+    pub inherited: bool,
+
+    /// Only show states addressed to this provider
+    #[arg(short, long)]
+    pub provider: Option<String>,
+
+    /// Emit JSON instead of the text listing
+    #[arg(long)]
+    pub json: bool,
+}
+
+struct StatesApp {
+    engine: Arc<Engine>,
+    matcher: Matcher,
+    opts: StatesOptions,
+    json: bool,
+    fail_fast: bool,
+}
+
+#[async_trait]
+impl App for StatesApp {
+    type Output = ();
+    type TuiView = crate::tui::TuiProgressView;
+    type CiView = crate::tui::CiProgressView;
+
+    fn tui_view(&self) -> Self::TuiView {
+        crate::tui::TuiProgressView::new(format!("States {:?}", self.matcher))
+    }
+
+    fn ci_view(&self) -> Self::CiView {
+        crate::tui::CiProgressView::new(format!("States {:?}", self.matcher))
+    }
+
+    async fn run(self, ctx: AppContext) -> anyhow::Result<()> {
+        let rs = self
+            .engine
+            .new_state_with_events(self.fail_fast, ctx.event_sender());
+
+        // Probing runs BUILD evaluation, which records rich failures in `rs`;
+        // `finalize` prefers those over the returned error.
+        let out = BufferedStdout::new(&ctx);
+        let res: anyhow::Result<()> = async {
+            let found = Arc::clone(&self.engine)
+                .states(rs.clone(), &self.matcher, &self.opts)
+                .await?;
+            // A package with nothing to say is noise in a workspace-wide scan,
+            // and "absent" already reads as "no state here" for a single one.
+            let found: Vec<&PackageStates> =
+                found.iter().filter(|p| !p.states.is_empty()).collect();
+
+            if self.json {
+                out.println(render_json(&found)?);
+            } else {
+                for line in render_text(&found, self.opts.inherited) {
+                    out.println(line);
+                }
+            }
+            Ok(())
+        }
+        .await;
+        out.close().await;
+
+        crate::commands::errors::finalize!(ctx, rs, res)
+    }
+}
+
+/// Render a state value as JSON. BUILD files spell booleans `True`, but every
+/// consumer of this output (a human grepping, an agent parsing) is better served
+/// by one unambiguous encoding than by a Starlark round-trip.
+fn value_to_json(v: &Value) -> serde_json::Value {
+    match v {
+        Value::String(s) => serde_json::Value::String(s.clone()),
+        Value::Bool(b) => serde_json::Value::Bool(*b),
+        Value::Int(i) => serde_json::Value::from(*i),
+        Value::Uint(u) => serde_json::Value::from(*u),
+        // A non-finite float has no JSON encoding; `serde_json::Number` rejects
+        // it, so fall back to null rather than dropping the field entirely.
+        Value::Float(f) => serde_json::Number::from_f64(*f)
+            .map(serde_json::Value::Number)
+            .unwrap_or(serde_json::Value::Null),
+        Value::Null() => serde_json::Value::Null,
+        Value::List(l) => serde_json::Value::Array(l.iter().map(value_to_json).collect()),
+        // Sorted so repeat invocations diff cleanly — `state` is a HashMap.
+        Value::Map(m) => {
+            let mut obj = serde_json::Map::with_capacity(m.len());
+            let mut keys: Vec<&String> = m.keys().collect();
+            keys.sort();
+            for k in keys {
+                obj.insert(k.clone(), value_to_json(&m[k]));
+            }
+            serde_json::Value::Object(obj)
+        }
+    }
+}
+
+fn state_fields(state: &std::collections::HashMap<String, Value>) -> String {
+    let mut keys: Vec<&String> = state.keys().collect();
+    keys.sort();
+    keys.into_iter()
+        .map(|k| format!("{k}={}", value_to_json(&state[k])))
+        .collect::<Vec<_>>()
+        .join(" ")
+}
+
+fn fmt_pkg(pkg: &PkgBuf) -> String {
+    format!("//{}", pkg.as_str())
+}
+
+/// One block per package: a `//pkg` header, then one line per state. With
+/// `inherited`, each line is prefixed with the package that declared it — that
+/// column is the whole point of the mode, so it stays even when it repeats the
+/// header.
+fn render_text(found: &[&PackageStates], inherited: bool) -> Vec<String> {
+    let mut lines = Vec::new();
+    for (i, ps) in found.iter().enumerate() {
+        if i > 0 {
+            lines.push(String::new());
+        }
+        lines.push(fmt_pkg(&ps.package));
+
+        let origin_width = if inherited {
+            ps.states
+                .iter()
+                .map(|s| fmt_pkg(&s.package).len())
+                .max()
+                .unwrap_or(0)
+        } else {
+            0
+        };
+        let provider_width = ps
+            .states
+            .iter()
+            .map(|s| s.provider.len())
+            .max()
+            .unwrap_or(0);
+
+        for state in &ps.states {
+            let mut line = String::from("  ");
+            if inherited {
+                line.push_str(&format!(
+                    "{:<origin_width$}  ",
+                    fmt_pkg(&state.package),
+                    origin_width = origin_width
+                ));
+            }
+            line.push_str(&format!(
+                "{:<provider_width$}",
+                state.provider,
+                provider_width = provider_width
+            ));
+            let fields = state_fields(&state.state);
+            if !fields.is_empty() {
+                line.push_str("  ");
+                line.push_str(&fields);
+            }
+            lines.push(line);
+        }
+    }
+    lines
+}
+
+fn render_json(found: &[&PackageStates]) -> anyhow::Result<String> {
+    let out: Vec<serde_json::Value> = found
+        .iter()
+        .map(|ps| {
+            let states: Vec<serde_json::Value> = ps
+                .states
+                .iter()
+                .map(|s| {
+                    serde_json::json!({
+                        "declared_in": fmt_pkg(&s.package),
+                        "provider": s.provider,
+                        "state": value_to_json(&Value::Map(s.state.clone())),
+                    })
+                })
+                .collect();
+            serde_json::json!({ "package": fmt_pkg(&ps.package), "states": states })
+        })
+        .collect();
+    serde_json::to_string_pretty(&out).context("serialize states")
+}
+
+pub fn execute(args: &Args, sink: LogSink, global: &GlobalOptions) -> anyhow::Result<()> {
+    bootstrap::block_on(execute_async(args.clone(), sink, global.clone()))?
+}
+
+async fn execute_async(args: Args, sink: LogSink, global: GlobalOptions) -> anyhow::Result<()> {
+    let matcher = match &args.matcher {
+        Some(s) => htpkg::parse(s.as_str(), &crate::engine::get_cwp()?)?,
+        None => Matcher::PackagePrefix(PkgBuf::from("")),
+    };
+    let (engine, shutdown) = bootstrap::new_engine()?;
+    let app = StatesApp {
+        engine,
+        matcher,
+        opts: StatesOptions {
+            inherited: args.inherited,
+            provider: args.provider.clone(),
+        },
+        json: args.json,
+        fail_fast: global.fail_fast,
+    };
+    let interactive = tui::should_use_tui(global.no_tui);
+    tui::run_app(app, sink, interactive, shutdown).await
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::engine::provider::State;
+    use std::collections::HashMap;
+
+    fn state(pkg: &str, provider: &str, fields: &[(&str, Value)]) -> State {
+        State {
+            package: PkgBuf::from(pkg),
+            provider: provider.to_string(),
+            state: fields
+                .iter()
+                .map(|(k, v)| ((*k).to_string(), v.clone()))
+                .collect(),
+        }
+    }
+
+    #[test]
+    fn fields_are_sorted_and_json_encoded() {
+        let s: HashMap<String, Value> = [
+            ("root".to_string(), Value::String("src".to_string())),
+            ("strict".to_string(), Value::Bool(true)),
+            (
+                "flags".to_string(),
+                Value::List(vec![Value::String("-race".to_string())]),
+            ),
+        ]
+        .into_iter()
+        .collect();
+
+        assert_eq!(
+            state_fields(&s),
+            r#"flags=["-race"] root="src" strict=true"#
+        );
+    }
+
+    #[test]
+    fn nested_map_keys_are_sorted_for_stable_diffs() {
+        let inner: HashMap<String, Value> = [
+            ("b".to_string(), Value::Int(2)),
+            ("a".to_string(), Value::Int(1)),
+        ]
+        .into_iter()
+        .collect();
+        let s: HashMap<String, Value> = [("test".to_string(), Value::Map(inner))]
+            .into_iter()
+            .collect();
+
+        assert_eq!(state_fields(&s), r#"test={"a":1,"b":2}"#);
+    }
+
+    #[test]
+    fn text_omits_the_origin_column_without_inherited() {
+        let ps = PackageStates {
+            package: PkgBuf::from("a/b"),
+            states: vec![state("a/b", "go", &[("strict", Value::Bool(true))])],
+        };
+
+        assert_eq!(
+            render_text(&[&ps], false),
+            vec!["//a/b".to_string(), "  go  strict=true".to_string()]
+        );
+    }
+
+    #[test]
+    fn text_shows_where_each_inherited_state_was_declared() {
+        let ps = PackageStates {
+            package: PkgBuf::from("a/b"),
+            states: vec![
+                state("", "go", &[("root", Value::String("src".to_string()))]),
+                state("a/b", "exec", &[("strict", Value::Bool(true))]),
+            ],
+        };
+
+        // Origin and provider columns are padded to the widest entry so the
+        // fields line up down the block.
+        assert_eq!(
+            render_text(&[&ps], true),
+            vec![
+                "//a/b".to_string(),
+                r#"  //     go    root="src""#.to_string(),
+                "  //a/b  exec  strict=true".to_string(),
+            ]
+        );
+    }
+
+    #[test]
+    fn packages_are_separated_by_a_blank_line() {
+        let a = PackageStates {
+            package: PkgBuf::from("a"),
+            states: vec![state("a", "go", &[])],
+        };
+        let b = PackageStates {
+            package: PkgBuf::from("b"),
+            states: vec![state("b", "go", &[])],
+        };
+
+        assert_eq!(
+            render_text(&[&a, &b], false),
+            vec![
+                "//a".to_string(),
+                "  go".to_string(),
+                String::new(),
+                "//b".to_string(),
+                "  go".to_string(),
+            ]
+        );
+    }
+
+    #[test]
+    fn json_carries_the_declaring_package_per_state() -> anyhow::Result<()> {
+        let ps = PackageStates {
+            package: PkgBuf::from("a/b"),
+            states: vec![state("a", "go", &[("strict", Value::Bool(true))])],
+        };
+
+        let parsed: serde_json::Value = serde_json::from_str(&render_json(&[&ps])?)?;
+        assert_eq!(parsed[0]["package"], "//a/b");
+        assert_eq!(parsed[0]["states"][0]["declared_in"], "//a");
+        assert_eq!(parsed[0]["states"][0]["provider"], "go");
+        assert_eq!(parsed[0]["states"][0]["state"]["strict"], true);
+        Ok(())
+    }
+}


### PR DESCRIPTION
## What

`heph inspect states [MATCHER]` — see where `provider_state(...)` is declared in the package tree, and what reaches a given package.

```
$ heph inspect states
//
  go  go_codegen_root=true recursive=true

//cmd
  go  link={"flags":["-s","-w"]}

//cmd/server
  go  test={"env":{"CGO_ENABLED":"0"}}
```

```
$ heph inspect states //cmd/server --inherited
//cmd/server
  //            go  go_codegen_root=true recursive=true
  //cmd         go  link={"flags":["-s","-w"]}
  //cmd/server  go  test={"env":{"CGO_ENABLED":"0"}}
```

Flags: `--inherited` (whole ancestor chain, tagged with the declaring package, root first), `-p/--provider` (narrow to one provider), `--json`.

Packages that declare nothing are omitted, so empty output reads as "no state here". Field values are rendered as JSON in both modes — one unambiguous encoding for a human grepping and an agent parsing, rather than a Starlark round-trip (`true`, not `True`). Map keys are sorted so repeat runs diff cleanly.

`--inherited` reports what a provider *is handed*; which of two declarations wins on a shared key is provider policy (plugin-go, for example, applies `recursive` and closest-wins rules of its own), and the command says so in `--help` rather than pretending to resolve it.

## Why no TUI

`deps -i` exists because a dependency graph is deep, branching, and larger than a screen — navigation earns its keep. States are the opposite: a handful of declarations, flat, one line each, already ordered by the tree. Interactivity would add a UI over something that needs none, and it would put the data behind a terminal the agent case can't use. Plain stdout plus `--json` covers both audiences.

## How

`Engine::states` (new, `crates/engine/src/engine/states.rs`) wraps the existing `probe_segments` — the same call every provider dispatch already makes to collect the ancestor chain — so the CLI reports what a provider actually receives instead of a re-derived approximation. Per-request memoization means overlapping ancestor chains are probed once no matter how many packages ask.

An exact `Matcher::Package` is probed directly rather than discovered through `list_packages`: a package can declare state for its subtree without holding a target of its own, and "what applies at `//foo`" must still answer there.

## Tests

- Engine: declared-only vs inherited, root-first ordering, provider filter, prefix scan, and the exact-matcher-on-an-unlisted-package case.
- CLI: field sorting/JSON encoding, nested-map key ordering, both text layouts (with and without the origin column), block separation, JSON shape.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HSSM28ujXE27b9J5QJSkeH