### PR TITLE
fix: unstick wide builds — memoizer wake storm, metadata slot cap, and a segfaulting profiler

### DIFF
--- a/crates/core/src/hmemoizer/cell.rs
+++ b/crates/core/src/hmemoizer/cell.rs
@@ -1,0 +1,695 @@
+//! A single-flight cell: one shared future, many awaiters, **completion-only
+//! broadcast**.
+//!
+//! This replaces `futures::future::Shared` inside [`Memoizer`](super::Memoizer).
+//! `Shared` is otherwise exactly the right shape — it re-elects a driver on every
+//! poll, polls the inner future with a cell-owned waker, and keeps that future
+//! alive in the cell rather than on any awaiter's stack — and all three of those
+//! properties are preserved here deliberately. See "What is kept, and why" below
+//! before changing any of them.
+//!
+//! The one thing `Shared` gets wrong for this workload is *who it wakes*. Its
+//! `Notifier::wake_by_ref` drains the waker slab and `take()`s **every** slot on
+//! **every** inner wake, so each awaiter is forced to re-poll merely to
+//! re-register. In heph that is quadratic: a base library with W reverse-deps has
+//! W awaiters on its `mem_result` cell, and every one of that library's own D
+//! dependencies completing wakes all W, each of which re-descends ~27 levels of
+//! nested cells to get back to where it was. Six saturated worker threads and a
+//! build that makes no progress, which is the bug this module exists to remove.
+//!
+//! Here an inner wake goes to the **driver alone** — the awaiter that last polled
+//! the inner future, identified by its slab key in [`Cell::driver`]. Everyone else
+//! is woken exactly once, when the value is ready.
+//!
+//! ## What is kept, and why
+//!
+//! - **Election is per-poll, never "first awaiter wins".** Drivership is held only
+//!   for the duration of one poll — it is literally the `slot` mutex — so an
+//!   awaiter that is dropped between polls leaves a cell any other awaiter can
+//!   pick up. A cell whose driver is assigned once and owned thereafter would
+//!   strand every awaiter the moment that task dies, and dying is routine here:
+//!   `try_join_all` with fail-fast drops every sibling on the first error, and
+//!   Ctrl-C drops them wholesale.
+//! - **The inner future is polled with a cell-owned waker**, never the driver's
+//!   `cx.waker()`. Sub-futures stash the waker they are handed — a semaphore
+//!   acquire parks it in its wait list — so handing out the driver's waker means
+//!   a later wake lands on a task that no longer exists, and nothing ever polls
+//!   the cell again.
+//! - **The future lives in the cell.** It survives every awaiter coming and going.
+//!
+//! ## What is fixed beyond the wake set
+//!
+//! - **Abdication wakes everyone.** When the driver is dropped it clears
+//!   [`Cell::driver`] and wakes all remaining awaiters, so one of them re-elects
+//!   itself. Waking just one is not enough: that one may itself be mid-drop, and
+//!   the wake is then lost with nobody left to re-poll.
+//! - **Completion drops the future immediately.** The value moves into
+//!   [`Cell::done`] and the boxed future is dropped while the lock is still held.
+//!   `result_addr_impl` is `#[async_recursion]` and its state machine is large
+//!   (the `large_futures` lint is on for this reason); retaining one per cell for
+//!   the life of a request would cost more memory than the wake fix saves.
+//! - **A completed cell is read with no lock at all** — `done` is a `OnceLock`, so
+//!   the warm-hit path is an acquire load and a clone. That path dominates a
+//!   cached build.
+
+use futures::future::BoxFuture;
+use futures::task::{ArcWake, waker_ref};
+use std::future::Future;
+use std::pin::Pin;
+use std::sync::atomic::{AtomicUsize, Ordering};
+use std::sync::{Arc, Mutex, MutexGuard, Once, OnceLock};
+use std::task::{Context, Poll, Waker};
+use std::thread;
+use std::time::{Duration, Instant};
+
+/// [`Cell::driver`] when no awaiter is currently on the hook for re-polling.
+const NO_DRIVER: usize = usize::MAX;
+
+/// Waker set, keyed by a stable index each awaiter holds for its lifetime.
+///
+/// A `Vec` with a free list rather than a `HashMap`: this allocates one slot per
+/// awaiter instead of a hash entry, and the engine holds on the order of a
+/// million cells. `crates/core/src/hasync/cancellable_std.rs` teaches the right
+/// *lessons* here — never a single `Option<Waker>`, always remove on drop — but
+/// its `HashMap<u64, Waker>` is the wrong container at this scale.
+#[derive(Default)]
+struct Wakers {
+    slots: Vec<Option<Waker>>,
+    free: Vec<usize>,
+}
+
+impl Wakers {
+    /// Record `waker` under `key`, allocating a key on first registration.
+    ///
+    /// Re-registration **updates in place**. Pushing a new slot per poll would
+    /// grow the set without bound across the many re-polls a busy cell sees.
+    fn register(&mut self, key: &mut Option<usize>, waker: &Waker) {
+        match *key {
+            Some(k) => {
+                if let Some(slot) = self.slots.get_mut(k) {
+                    // `will_wake` spares a clone on the overwhelmingly common
+                    // re-poll-by-the-same-task path.
+                    match slot {
+                        Some(existing) if existing.will_wake(waker) => {}
+                        _ => *slot = Some(waker.clone()),
+                    }
+                }
+            }
+            None => {
+                // A key popped off the free list always indexes an existing
+                // slot; `get_mut` keeps that an invariant rather than a panic.
+                let reused = self
+                    .free
+                    .pop()
+                    .filter(|k| self.slots.get(*k).is_some())
+                    .inspect(|k| {
+                        if let Some(slot) = self.slots.get_mut(*k) {
+                            *slot = Some(waker.clone());
+                        }
+                    });
+                *key = Some(reused.unwrap_or_else(|| {
+                    self.slots.push(Some(waker.clone()));
+                    self.slots.len() - 1
+                }));
+            }
+        }
+    }
+
+    /// Take the waker at `key`, if one is registered. The awaiter re-registers on
+    /// its next poll — same contract as the slab `Shared` uses.
+    fn take(&mut self, key: usize) -> Option<Waker> {
+        self.slots.get_mut(key).and_then(Option::take)
+    }
+
+    /// Drop `key`'s slot and return it to the free list. Called once, from the
+    /// awaiter's `Drop`, so a long-lived popular cell doesn't accumulate wakers
+    /// for awaiters that have gone away.
+    fn remove(&mut self, key: usize) {
+        if let Some(slot) = self.slots.get_mut(key) {
+            *slot = None;
+            self.free.push(key);
+        }
+    }
+
+    fn take_all(&mut self) -> Vec<Waker> {
+        self.slots.iter_mut().filter_map(Option::take).collect()
+    }
+}
+
+/// The shared state behind one memoized key.
+pub(crate) struct Cell<V> {
+    /// The value, once computed. A `OnceLock` so the warm-hit path never takes a
+    /// lock — this is the path a fully-cached build spends its time on.
+    done: OnceLock<V>,
+    /// The in-flight future. `None` once it has completed (dropped eagerly) or
+    /// been taken. The mutex **is** the drivership election: whoever wins
+    /// `try_lock` drives this poll, and only for this poll.
+    slot: Mutex<Option<BoxFuture<'static, V>>>,
+    wakers: Mutex<Wakers>,
+    /// Slab key of the awaiter that last polled the inner future, or
+    /// [`NO_DRIVER`]. An inner wake is routed here and nowhere else.
+    driver: AtomicUsize,
+}
+
+impl<V> Cell<V> {
+    pub(crate) fn new(fut: BoxFuture<'static, V>) -> Arc<Self> {
+        Arc::new(Self {
+            done: OnceLock::new(),
+            slot: Mutex::new(Some(fut)),
+            wakers: Mutex::new(Wakers::default()),
+            driver: AtomicUsize::new(NO_DRIVER),
+        })
+    }
+
+    /// The completed value, if there is one. No locking.
+    pub(crate) fn peek(&self) -> Option<&V> {
+        self.done.get()
+    }
+
+    /// The lock guarding the waker set.
+    ///
+    /// Poisoning is ignored: every critical section only moves `Waker`s and
+    /// indices around, so a panicking waker leaves the set structurally intact,
+    /// and refusing to hand it back would strand every awaiter. Same stance as
+    /// `hasync::cancellable_std`.
+    fn wakers(&self) -> MutexGuard<'_, Wakers> {
+        self.wakers.lock().unwrap_or_else(|e| e.into_inner())
+    }
+
+    /// Wake every registered awaiter and clear the set.
+    fn wake_all(&self) {
+        let all = self.wakers().take_all();
+        for waker in all {
+            waker.wake();
+        }
+    }
+}
+
+/// The inner future is polled with this, so a wake from deep inside it lands on
+/// the cell rather than on whichever task happened to be driving.
+impl<V: Send + Sync + 'static> ArcWake for Cell<V> {
+    fn wake_by_ref(cell: &Arc<Self>) {
+        let driver = cell.driver.load(Ordering::Acquire);
+        let waker = {
+            let mut wakers = cell.wakers();
+            if driver == NO_DRIVER {
+                // Nobody is on the hook — the driver abdicated between our load
+                // and here. Wake everyone so one of them re-elects itself;
+                // waking a single awaiter risks picking one that is mid-drop.
+                let all = wakers.take_all();
+                drop(wakers);
+                for waker in all {
+                    waker.wake();
+                }
+                return;
+            }
+            wakers.take(driver)
+        };
+        // This is the whole point of the module: an inner wake reaches exactly
+        // one task, not all W of them.
+        if let Some(waker) = waker {
+            waker.wake();
+        }
+    }
+}
+
+/// One awaiter's handle on a [`Cell`]. Cloning the `Arc` is how a second caller
+/// joins the same single-flight computation.
+pub(crate) struct Await<V> {
+    cell: Arc<Cell<V>>,
+    /// Our slot in the cell's waker set, allocated on first `Pending` poll.
+    key: Option<usize>,
+}
+
+impl<V> Await<V> {
+    pub(crate) fn new(cell: Arc<Cell<V>>) -> Self {
+        Self { cell, key: None }
+    }
+}
+
+impl<V: Clone + Send + Sync + 'static> Future for Await<V> {
+    type Output = V;
+
+    fn poll(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<V> {
+        let this = self.get_mut();
+        let cell = &this.cell;
+
+        // Warm hit: an acquire load, no lock, no waker traffic.
+        if let Some(v) = cell.peek() {
+            return Poll::Ready(v.clone());
+        }
+
+        // Register before attempting to drive, and re-check completion while
+        // holding the waker lock. Without that re-check a value landing between
+        // our `peek` above and our registration would wake a set we are not yet
+        // in, and we would park forever. This is the same store-then-lock,
+        // re-check-under-the-lock ordering `hasync::cancellable_std` documents.
+        {
+            let mut wakers = cell.wakers();
+            if let Some(v) = cell.peek() {
+                return Poll::Ready(v.clone());
+            }
+            wakers.register(&mut this.key, cx.waker());
+        }
+
+        // Elect ourselves by taking the future. Failure means another task is
+        // mid-poll; we are registered, so its completion (or its abdication)
+        // will reach us.
+        let Ok(mut slot) = cell.slot.try_lock() else {
+            return Poll::Pending;
+        };
+
+        // It may have completed while we were registering.
+        if let Some(v) = cell.peek() {
+            return Poll::Ready(v.clone());
+        }
+        let Some(fut) = slot.as_mut() else {
+            // No future and no value: only reachable if a driver unwound out of
+            // the poll below. Stay parked rather than spin; `Memoizer::once`
+            // converts panics to values before they get here.
+            return Poll::Pending;
+        };
+
+        // Safe to unwrap-free: `register` above always leaves `key` set.
+        if let Some(key) = this.key {
+            cell.driver.store(key, Ordering::Release);
+        }
+
+        let waker = waker_ref(cell);
+        let mut cx = Context::from_waker(&waker);
+        match fut.as_mut().poll(&mut cx) {
+            Poll::Ready(v) => {
+                // Publish, then drop the future while still holding the lock, so
+                // no awaiter can observe a completed cell that is still carrying
+                // its (large) state machine.
+                let stored = cell.done.get_or_init(|| v.clone());
+                let out = stored.clone();
+                *slot = None;
+                drop(slot);
+                cell.driver.store(NO_DRIVER, Ordering::Release);
+                cell.wake_all();
+                Poll::Ready(out)
+            }
+            // We stay recorded as driver: the inner future kept our cell-owned
+            // waker, and its next wake routes back here.
+            Poll::Pending => Poll::Pending,
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::sync::atomic::{AtomicBool, AtomicUsize};
+
+    /// A waker that only counts, so a test can assert *how many* wakes a given
+    /// awaiter received rather than merely that it eventually resolved.
+    struct Counting(AtomicUsize);
+
+    impl std::task::Wake for Counting {
+        fn wake(self: Arc<Self>) {
+            self.wake_by_ref();
+        }
+        fn wake_by_ref(self: &Arc<Self>) {
+            self.0.fetch_add(1, Ordering::SeqCst);
+        }
+    }
+
+    fn counting() -> (Arc<Counting>, Waker) {
+        let arc = Arc::new(Counting(AtomicUsize::new(0)));
+        let waker = Waker::from(Arc::clone(&arc));
+        (arc, waker)
+    }
+
+    fn count(c: &Arc<Counting>) -> usize {
+        c.0.load(Ordering::SeqCst)
+    }
+
+    /// Inner future that stashes whichever waker it is polled with and stays
+    /// `Pending` until `ready` is set — standing in for the semaphore acquire
+    /// the real stacks were parked on.
+    struct Stash {
+        stashed: Arc<Mutex<Option<Waker>>>,
+        ready: Arc<AtomicBool>,
+        value: u32,
+    }
+
+    impl Future for Stash {
+        type Output = u32;
+        fn poll(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<u32> {
+            if self.ready.load(Ordering::SeqCst) {
+                return Poll::Ready(self.value);
+            }
+            *self.stashed.lock().unwrap_or_else(|e| e.into_inner()) = Some(cx.waker().clone());
+            Poll::Pending
+        }
+    }
+
+    fn stash_cell(value: u32) -> (Arc<Cell<u32>>, Arc<Mutex<Option<Waker>>>, Arc<AtomicBool>) {
+        let stashed = Arc::new(Mutex::new(None));
+        let ready = Arc::new(AtomicBool::new(false));
+        let fut = Stash {
+            stashed: Arc::clone(&stashed),
+            ready: Arc::clone(&ready),
+            value,
+        };
+        (Cell::new(Box::pin(fut)), stashed, ready)
+    }
+
+    fn poll_with(waiter: &mut Await<u32>, waker: &Waker) -> Poll<u32> {
+        Pin::new(waiter).poll(&mut Context::from_waker(waker))
+    }
+
+    /// **The reason this module exists.** A wake from inside the shared future
+    /// must reach the driver and nobody else.
+    ///
+    /// `futures::Shared` drains and `take()`s *every* registered slot on *every*
+    /// inner wake, so each of W awaiters is forced to re-poll — and in the engine
+    /// each of those re-polls re-descends ~27 levels of nested cells. That is the
+    /// quadratic blow-up that pegged six workers with the build making no
+    /// progress. This test is red under that behavior: the parked awaiters would
+    /// show a non-zero count.
+    #[test]
+    fn inner_wake_reaches_only_the_driver() {
+        let (cell, stashed, ready) = stash_cell(7);
+
+        // Poll the parked awaiters first, the driver last — election is per-poll,
+        // so the last one to poll the inner future is the one on the hook.
+        let mut parked: Vec<(Await<u32>, Arc<Counting>, Waker)> = (0..8)
+            .map(|_| {
+                let (c, w) = counting();
+                (Await::new(Arc::clone(&cell)), c, w)
+            })
+            .collect();
+        for (waiter, _, waker) in &mut parked {
+            assert!(poll_with(waiter, waker).is_pending());
+        }
+        let (dc, dw) = counting();
+        let mut driver = Await::new(Arc::clone(&cell));
+        assert!(poll_with(&mut driver, &dw).is_pending());
+
+        let inner = stashed
+            .lock()
+            .unwrap_or_else(|e| e.into_inner())
+            .clone()
+            .expect("inner future must have stashed the cell's waker");
+
+        // Progress inside the shared future, over and over.
+        for _ in 0..100 {
+            inner.wake_by_ref();
+        }
+
+        for (i, (_, c, _)) in parked.iter().enumerate() {
+            assert_eq!(
+                count(c),
+                0,
+                "parked awaiter {i} was woken by inner progress; this is the wake storm"
+            );
+        }
+        assert_eq!(
+            count(&dc),
+            1,
+            "the driver is woken once and re-registers on its next poll"
+        );
+
+        // Completion is the one event that must reach everybody.
+        ready.store(true, Ordering::SeqCst);
+        assert!(poll_with(&mut driver, &dw).is_ready());
+        for (i, (_, c, _)) in parked.iter().enumerate() {
+            assert_eq!(count(c), 1, "parked awaiter {i} must be woken on completion");
+        }
+    }
+
+    /// A dropped driver must hand the cell back, not strand it.
+    ///
+    /// This is the routine path, not an exotic one: `try_join_all` with fail-fast
+    /// drops every sibling on the first error, and Ctrl-C drops them wholesale.
+    /// A design where drivership is assigned once and owned would leave the
+    /// remaining awaiters — and any *later* arrival at the same key — parked
+    /// forever.
+    #[test]
+    fn dropped_driver_hands_the_cell_to_the_others() {
+        let (cell, stashed, ready) = stash_cell(11);
+
+        let (bc, bw) = counting();
+        let mut b = Await::new(Arc::clone(&cell));
+        assert!(poll_with(&mut b, &bw).is_pending());
+
+        let (dc, dw) = counting();
+        let mut driver = Await::new(Arc::clone(&cell));
+        assert!(poll_with(&mut driver, &dw).is_pending());
+        assert_ne!(cell.driver.load(Ordering::SeqCst), NO_DRIVER);
+
+        drop(driver);
+        assert_eq!(
+            cell.driver.load(Ordering::SeqCst),
+            NO_DRIVER,
+            "abdication must clear the driver slot"
+        );
+        assert_eq!(
+            count(&bc),
+            1,
+            "the remaining awaiter must be woken so it can re-elect itself"
+        );
+        assert_eq!(count(&dc), 0);
+
+        // B re-polls, takes over the *same* future, and completes it.
+        ready.store(true, Ordering::SeqCst);
+        assert_eq!(poll_with(&mut b, &bw), Poll::Ready(11));
+        drop(stashed);
+    }
+
+    /// A late arrival at a cell whose driver already went away must still be able
+    /// to drive it.
+    #[test]
+    fn a_new_awaiter_can_drive_an_abandoned_cell() {
+        let (cell, _stashed, ready) = stash_cell(3);
+
+        let (_dc, dw) = counting();
+        let mut driver = Await::new(Arc::clone(&cell));
+        assert!(poll_with(&mut driver, &dw).is_pending());
+        drop(driver);
+
+        ready.store(true, Ordering::SeqCst);
+        let (_lc, lw) = counting();
+        let mut latecomer = Await::new(Arc::clone(&cell));
+        assert_eq!(poll_with(&mut latecomer, &lw), Poll::Ready(3));
+    }
+
+    /// Completion must drop the shared future immediately.
+    ///
+    /// `result_addr_impl` is `#[async_recursion]` and its state machine is large
+    /// — the `large_futures` lint is on precisely because of this. Holding one
+    /// per completed cell for the life of a request would cost far more memory
+    /// than the wake fix saves.
+    #[test]
+    fn completion_drops_the_inner_future() {
+        struct Flag(Arc<AtomicBool>);
+        impl Drop for Flag {
+            fn drop(&mut self) {
+                self.0.store(true, Ordering::SeqCst);
+            }
+        }
+
+        let dropped = Arc::new(AtomicBool::new(false));
+        let flag = Flag(Arc::clone(&dropped));
+        let cell = Cell::new(Box::pin(async move {
+            let _held = flag;
+            5u32
+        }));
+
+        let (_c, w) = counting();
+        let mut waiter = Await::new(Arc::clone(&cell));
+        assert_eq!(poll_with(&mut waiter, &w), Poll::Ready(5));
+
+        assert!(
+            dropped.load(Ordering::SeqCst),
+            "the shared future must be dropped at completion, not retained beside the value"
+        );
+        // Still resolvable afterwards, from the stored value.
+        assert_eq!(cell.peek().copied(), Some(5));
+    }
+
+    /// Re-polling the same awaiter updates its slot instead of adding one.
+    /// A busy cell is re-polled constantly; growing the set per poll would leak
+    /// for the life of the request.
+    #[test]
+    fn re_registration_does_not_grow_the_waker_set() {
+        let (cell, _stashed, _ready) = stash_cell(1);
+        let (_c, w) = counting();
+        let mut waiter = Await::new(Arc::clone(&cell));
+        for _ in 0..1000 {
+            assert!(poll_with(&mut waiter, &w).is_pending());
+        }
+        assert_eq!(cell.wakers().slots.len(), 1);
+    }
+
+    /// A dropped awaiter releases its slot, so a long-lived popular cell doesn't
+    /// accumulate wakers for tasks that are gone.
+    #[test]
+    fn dropped_awaiter_is_unregistered_and_its_slot_reused() {
+        let (cell, _stashed, _ready) = stash_cell(1);
+        let (_c, w) = counting();
+
+        let mut first = Await::new(Arc::clone(&cell));
+        assert!(poll_with(&mut first, &w).is_pending());
+        assert_eq!(cell.wakers().slots.iter().flatten().count(), 1);
+        drop(first);
+        assert_eq!(cell.wakers().slots.iter().flatten().count(), 0);
+
+        let mut second = Await::new(Arc::clone(&cell));
+        assert!(poll_with(&mut second, &w).is_pending());
+        assert_eq!(
+            cell.wakers().slots.len(),
+            1,
+            "the freed slot must be reused rather than appended to"
+        );
+    }
+
+    /// An awaiter that arrives while the value is being published must observe
+    /// it rather than park on a waker set that has already been drained.
+    ///
+    /// This is the classic lost-wakeup, and it is why registration re-checks
+    /// completion while holding the waker lock.
+    #[test]
+    fn awaiter_racing_completion_never_parks_forever() {
+        for _ in 0..2_000 {
+            let ready = Arc::new(AtomicBool::new(true));
+            let stashed = Arc::new(Mutex::new(None));
+            let cell = Cell::new(Box::pin(Stash {
+                stashed,
+                ready,
+                value: 42,
+            }));
+
+            let completer = Arc::clone(&cell);
+            let handle = std::thread::spawn(move || {
+                let (_c, w) = counting();
+                let mut a = Await::new(completer);
+                poll_with(&mut a, &w)
+            });
+
+            let (_c, w) = counting();
+            let mut b = Await::new(Arc::clone(&cell));
+            let mine = poll_with(&mut b, &w);
+            let theirs = handle.join().expect("completer thread");
+
+            // Whoever lost the election is either Ready (value already stored) or
+            // Pending-with-a-registered-waker; the latter must have been woken by
+            // the winner, so a re-poll resolves it.
+            for outcome in [mine, theirs] {
+                if outcome.is_pending() {
+                    assert_eq!(poll_with(&mut b, &w), Poll::Ready(42));
+                }
+            }
+        }
+    }
+}
+
+/// How often a waiter of [`timeout_without_reactor`] is re-woken so it can
+/// observe its own deadline.
+const STALL_TICK: Duration = Duration::from_millis(250);
+
+/// Waiters to re-wake on the next tick, drained each time.
+static STALL_PENDING: Mutex<Vec<Waker>> = Mutex::new(Vec::new());
+static STALL_THREAD: Once = Once::new();
+
+fn stall_pending() -> MutexGuard<'static, Vec<Waker>> {
+    STALL_PENDING.lock().unwrap_or_else(|e| e.into_inner())
+}
+
+/// Re-wake `waker` within [`STALL_TICK`], starting the ticker on first use — so a
+/// process that never enables the stall check never pays for the thread.
+fn stall_backstop(waker: Waker) {
+    STALL_THREAD.call_once(|| {
+        thread::Builder::new()
+            .name("heph-memoizer-stall".to_string())
+            .spawn(|| {
+                loop {
+                    thread::sleep(STALL_TICK);
+                    for waker in std::mem::take(&mut *stall_pending()) {
+                        waker.wake();
+                    }
+                }
+            })
+            // Same stance as `hcore::blocking`: a process that cannot spawn its
+            // diagnostic thread has nothing to fall back to.
+            .expect("spawn heph memoizer stall thread");
+    });
+    stall_pending().push(waker);
+}
+
+/// `tokio::time::timeout`, without touching the reactor.
+///
+/// The memoizer is statically linked into cdylib plugins, and a plugin's
+/// `provider_get` / `list` / `probe` / `parse` are awaited **inline by host
+/// workers** — only `driver_run_stream` hops to the plugin's own runtime. So the
+/// plugin's tokio holds no runtime context there, a timer call panics with "there
+/// is no reactor running", and that panic aborts the process at the `extern "C"`
+/// seam. This function is reached only when `HEPH_MEMOIZER_STALL_SECS` is set,
+/// i.e. exactly when someone is already debugging a hang — the tool would abort
+/// on the workload it exists for. Same class of bug as PR #180/#182.
+///
+/// So: a plain `Instant` deadline checked on each poll, plus a plain-thread
+/// ticker to guarantee those polls happen even when the inner future never wakes
+/// (which is the stalled case, and the whole point). Nothing here is a timer.
+/// `Err(())` means the deadline passed.
+pub(crate) fn timeout_without_reactor<F: Future + Unpin>(
+    limit: Duration,
+    inner: F,
+) -> TimeoutWithoutReactor<F> {
+    TimeoutWithoutReactor {
+        inner,
+        deadline: Instant::now() + limit,
+    }
+}
+
+pub(crate) struct TimeoutWithoutReactor<F> {
+    inner: F,
+    deadline: Instant,
+}
+
+impl<F: Future + Unpin> Future for TimeoutWithoutReactor<F> {
+    type Output = Result<F::Output, ()>;
+
+    fn poll(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Self::Output> {
+        let this = self.get_mut();
+        if let Poll::Ready(v) = Pin::new(&mut this.inner).poll(cx) {
+            return Poll::Ready(Ok(v));
+        }
+        if Instant::now() >= this.deadline {
+            return Poll::Ready(Err(()));
+        }
+        stall_backstop(cx.waker().clone());
+        Poll::Pending
+    }
+}
+
+impl<V> Drop for Await<V> {
+    fn drop(&mut self) {
+        let Some(key) = self.key else {
+            return;
+        };
+        let was_driver = self
+            .cell
+            .driver
+            .compare_exchange(key, NO_DRIVER, Ordering::AcqRel, Ordering::Acquire)
+            .is_ok();
+
+        let mut wakers = self.cell.wakers();
+        wakers.remove(key);
+
+        // We were the one the inner future would have woken, and we are going
+        // away. Hand the cell back to the others — otherwise the next inner wake
+        // has nobody to reach and every remaining awaiter parks forever. This is
+        // the cancellation path: fail-fast sibling drops and Ctrl-C both land
+        // here.
+        if was_driver && self.cell.done.get().is_none() {
+            let all = wakers.take_all();
+            drop(wakers);
+            for waker in all {
+                waker.wake();
+            }
+        }
+    }
+}

--- a/crates/core/src/hmemoizer/cell.rs
+++ b/crates/core/src/hmemoizer/cell.rs
@@ -416,7 +416,11 @@ mod tests {
         ready.store(true, Ordering::SeqCst);
         assert!(poll_with(&mut driver, &dw).is_ready());
         for (i, (_, c, _)) in parked.iter().enumerate() {
-            assert_eq!(count(c), 1, "parked awaiter {i} must be woken on completion");
+            assert_eq!(
+                count(c),
+                1,
+                "parked awaiter {i} must be woken on completion"
+            );
         }
     }
 

--- a/crates/core/src/hmemoizer/mod.rs
+++ b/crates/core/src/hmemoizer/mod.rs
@@ -684,9 +684,7 @@ where
         // deadlocking the runtime, and most runs don't have cycles. Opt back in
         // with `HEPH_DEBUG_MEMOIZER_CYCLE=1`.
         if !cycle_detection_enabled() {
-            return self
-                .process(key, || guard_panics(f()))
-                .await;
+            return self.process(key, || guard_panics(f())).await;
         }
 
         let key_hash = compute_key_hash(&key);

--- a/crates/core/src/hmemoizer/mod.rs
+++ b/crates/core/src/hmemoizer/mod.rs
@@ -1,5 +1,6 @@
+mod cell;
+
 use futures::FutureExt;
-use futures::future::{BoxFuture, Shared};
 use rustc_hash::FxHashMap;
 use std::collections::HashMap;
 use std::fmt;
@@ -415,7 +416,7 @@ pub fn downcast_chain_ref<T: std::error::Error + Send + Sync + 'static>(
 }
 
 pub struct Memoizer<K, V> {
-    cache: Mutex<FxHashMap<K, Shared<BoxFuture<'static, V>>>>,
+    cache: Mutex<FxHashMap<K, Arc<cell::Cell<V>>>>,
     /// Tag used in stall warnings to identify which memoizer is stuck.
     tag: &'static str,
 }
@@ -474,7 +475,7 @@ where
     /// full `result`) without disturbing the cache or deduping with in-flight work.
     pub fn peek(&self, key: &K) -> Option<V> {
         let cache = self.cache.lock().expect("memoizer lock poisoned");
-        cache.get(key).and_then(|shared| shared.peek().cloned())
+        cache.get(key).and_then(|cell| cell.peek().cloned())
     }
 
     pub async fn process<F, Fut>(&self, key: K, f: F) -> V
@@ -482,55 +483,82 @@ where
         F: FnOnce() -> Fut,
         Fut: Future<Output = V> + Send + 'static,
     {
-        // Phase 1: fast path — check without creating the future.
-        // Block ensures MutexGuard is dropped before any await.
-        let existing = {
-            let cache = self.cache.lock().expect("memoizer lock poisoned");
-            cache.get(&key).cloned()
-        };
-
-        if let Some(shared) = existing {
-            // Post-completion fast path: a Shared future that has already
-            // resolved exposes its output via `peek`. Cloning that directly
-            // skips the full `Shared::poll` path (waker registration, inner
-            // Mutex acquire) and the `take_or_clone_output` profile hotspot.
-            if let Some(v) = shared.peek() {
-                return v.clone();
-            }
-            return await_with_stall_check(shared, &key, self.tag).await;
-        }
-
-        // Phase 2: create candidate, then re-lock to insert.
-        // Another caller may have inserted between phase 1 and phase 2;
-        // entry().or_insert_with() handles that race correctly.
-        let candidate = f().boxed().shared();
-        let shared = {
+        // One lock acquisition, and no handle clone on the warm hit: the
+        // completed value is read through the guard we already hold. Cloning the
+        // cell's `Arc` only to `peek` and drop it costs two atomic RMWs on the
+        // hottest path the engine has — `spec`, `def`, `meta` and `result` all
+        // land here for every target of every build.
+        let cell = {
             let mut cache = self.cache.lock().expect("memoizer lock poisoned");
-            cache
-                .entry(key.clone())
-                .or_insert_with(|| candidate)
-                .clone()
+            match cache.entry(key.clone()) {
+                std::collections::hash_map::Entry::Occupied(e) => {
+                    if let Some(v) = e.get().peek() {
+                        return v.clone();
+                    }
+                    Arc::clone(e.get())
+                }
+                std::collections::hash_map::Entry::Vacant(e) => {
+                    // `f()` only builds the async block's state machine — async
+                    // blocks are lazy, so no user code runs and nothing can
+                    // await — which makes it safe to construct under the lock.
+                    // Constructing it *outside* meant every loser of an insert
+                    // race boxed a large future just to discard it, and on a
+                    // cell with hundreds of concurrent callers that is hundreds
+                    // of wasted allocations.
+                    let cell = cell::Cell::new(f().boxed());
+                    e.insert(Arc::clone(&cell));
+                    cell
+                }
+            }
         };
 
-        await_with_stall_check(shared, &key, self.tag).await
+        await_with_stall_check(cell::Await::new(cell), &key, self.tag).await
     }
 }
 
-async fn await_with_stall_check<V, K>(
-    shared: Shared<BoxFuture<'static, V>>,
-    key: &K,
-    tag: &'static str,
-) -> V
+/// Run a memoized computation, turning a panic into an `Err` for every awaiter.
+///
+/// Without this a panicking cell strands the graph rather than failing it. The
+/// cell can only ever publish a value, so an unwinding poll leaves it with no
+/// value and no future, and every task parked on it waits forever — one
+/// panicking target silently hanging every one of its reverse-deps. (`Shared`
+/// has the same defect: its poison path never drains the waker slab. It was
+/// partly masked before, because any inner progress woke everyone; with
+/// completion-only wakes there is no masking left.)
+///
+/// It also removes an abort vector. `provider_get` / `provider_list` /
+/// `driver_parse` are awaited directly by host workers with nothing between them
+/// and the `extern "C"` seam, where an unwind aborts the process — and
+/// `unwrap_used` / `panic` are `warn`, not `deny`, so panics inside plugin
+/// providers are reachable. `hcore::blocking` already takes this shape.
+async fn guard_panics<T, Fut>(fut: Fut) -> Result<T, Arc<anyhow::Error>>
 where
-    V: Clone,
+    Fut: Future<Output = anyhow::Result<T>>,
+{
+    match std::panic::AssertUnwindSafe(fut).catch_unwind().await {
+        Ok(r) => r.map_err(Arc::new),
+        Err(panic) => {
+            let msg = panic
+                .downcast_ref::<&str>()
+                .map(|s| (*s).to_string())
+                .or_else(|| panic.downcast_ref::<String>().cloned())
+                .unwrap_or_else(|| "<non-string panic payload>".to_string());
+            Err(Arc::new(anyhow::anyhow!("memoized task panicked: {msg}")))
+        }
+    }
+}
+
+async fn await_with_stall_check<V, K>(waiter: cell::Await<V>, key: &K, tag: &'static str) -> V
+where
+    V: Clone + Send + Sync + 'static,
     K: fmt::Debug,
 {
     let Some(threshold) = stall_threshold() else {
-        return shared.await;
+        return waiter.await;
     };
-    match tokio::time::timeout(threshold, shared).await {
+    match cell::timeout_without_reactor(threshold, waiter).await {
         Ok(v) => v,
-        Err(_) => {
+        Err(()) => {
             // Debug-only: opt-in via HEPH_MEMOIZER_STALL_SECS. Panic surfaces a
             // suspected deadlock with as much state as we can dump:
             //   * the offending cell.
@@ -657,7 +685,7 @@ where
         // with `HEPH_DEBUG_MEMOIZER_CYCLE=1`.
         if !cycle_detection_enabled() {
             return self
-                .process(key, || async move { f().await.map_err(Arc::new) })
+                .process(key, || guard_panics(f()))
                 .await;
         }
 
@@ -743,10 +771,25 @@ where
         let frame = push_frame(tag, key_hash, Arc::clone(&debug_key), me);
         let key_for_evict = key.clone();
 
+        // The scope goes around the *cell's* future, not around the await.
+        //
+        // `IN_FLIGHT` is a task-local, so a cell polled by a driver other than
+        // its creator would otherwise see that driver's chain. Under the old
+        // wake-everyone behavior the creator kept retaking the poll, so a wrong
+        // chain was transient; with the driver stable, whichever chain first won
+        // the election would be captured for good — and `check_recursion` would
+        // then report `SelfRecursion` for a graph that has no cycle, which makes
+        // `EngineProviderExecutor::query` skip a perfectly good addr. Scoping at
+        // creation makes `IN_FLIGHT` mean "the lineage that created this cell",
+        // which is exactly what self-recursion detection needs; cross-lineage
+        // cycles remain the wait-for graph's job.
+        let creator_frame = frame.clone();
         let result = IN_FLIGHT
             .scope(
                 frame,
-                self.process(key, || async move { f().await.map_err(Arc::new) }),
+                self.process(key, move || {
+                    IN_FLIGHT.scope(creator_frame, guard_panics(f()))
+                }),
             )
             .await;
 
@@ -832,6 +875,48 @@ mod tests {
     use std::sync::Arc;
     use std::sync::atomic::{AtomicUsize, Ordering};
     use tokio::time::{Duration, sleep};
+
+    /// A panicking memoized computation must fail every awaiter, not hang them.
+    ///
+    /// Before `guard_panics`, an unwinding cell left no value and no future, and
+    /// every task parked on it waited forever — one panicking target silently
+    /// hanging all of its reverse-deps. The `tokio::time::timeout` here is the
+    /// assertion: without the fix these awaits never return.
+    #[tokio::test]
+    async fn panic_in_a_memoized_task_fails_every_waiter() {
+        let memo: Arc<Memoizer<String, Result<Arc<i32>, Arc<anyhow::Error>>>> =
+            Arc::new(Memoizer::new());
+        let key = "boom".to_string();
+
+        // The first caller panics; three more join the same in-flight cell.
+        let waiters: Vec<_> = (0..4)
+            .map(|i| {
+                let (memo, key) = (Arc::clone(&memo), key.clone());
+                tokio::spawn(async move {
+                    memo.once(key, move || async move {
+                        if i == 0 {
+                            sleep(Duration::from_millis(20)).await;
+                            panic!("cell exploded");
+                        }
+                        Ok(Arc::new(1))
+                    })
+                    .await
+                })
+            })
+            .collect();
+
+        for w in waiters {
+            let outcome = tokio::time::timeout(Duration::from_secs(5), w)
+                .await
+                .expect("a panicking cell must not strand its waiters")
+                .expect("waiter task itself must not panic");
+            let err = outcome.expect_err("a panicking cell must surface as an error");
+            assert!(
+                err.to_string().contains("cell exploded"),
+                "the panic payload must survive into the error: {err}"
+            );
+        }
+    }
 
     #[tokio::test]
     async fn test_memoizer() {

--- a/crates/engine/src/engine/remote_cache.rs
+++ b/crates/engine/src/engine/remote_cache.rs
@@ -233,21 +233,29 @@ impl RemoteCacheDef {
 /// the breaker below and a perfectly healthy cache drops out of the run — the
 /// build then rebuilds everything from scratch and looks hung.
 ///
-/// So the budget is split: metadata draws from its own reserve and can never
-/// queue behind a blob stream.
+/// So metadata gets a reserve of its own that a blob stream can never occupy.
+///
+/// This is a **floor, not a ceiling**. An earlier version partitioned the budget
+/// outright — metadata could use only these slots even while every bulk slot sat
+/// idle. That inverts on a metadata-heavy run: resolving a fully-cached graph is
+/// almost entirely manifest reads and presence checks (a target whose manifest is
+/// local but whose blobs are not still has to ask the remote), so a build would
+/// serialize thousands of targets through 32 slots while 224 went unused. See
+/// [`ConfiguredCache::meta_op`] for how the floor is preserved without the cap.
 const META_SLOT_RESERVE: usize = 32;
 
-/// Split a cache's request budget into `(metadata, blob)` slot counts.
+/// Split a cache's request budget into `(metadata reserve, shared pool)` slot
+/// counts.
 ///
-/// Metadata takes [`META_SLOT_RESERVE`], or half the budget when that is
-/// smaller, so a deliberately tiny `concurrency` still leaves room for both
-/// classes. The two halves sum to the budget, so the store's own request cap
-/// (`LimitStore`) is never the binding constraint and therefore never a place
-/// where the two classes contend again.
+/// The reserve is [`META_SLOT_RESERVE`], or half the budget when that is smaller,
+/// so a deliberately tiny `concurrency` still leaves room for both classes. The
+/// two sum to the budget, so the store's own request cap (`LimitStore`) is never
+/// the binding constraint and therefore never a place where the two classes
+/// contend again.
 fn split_request_budget(concurrency: usize) -> (usize, usize) {
     let total = concurrency.max(2);
-    let meta = META_SLOT_RESERVE.min(total / 2).max(1);
-    (meta, (total - meta).max(1))
+    let reserve = META_SLOT_RESERVE.min(total / 2).max(1);
+    (reserve, (total - reserve).max(1))
 }
 
 /// After this many consecutive failures a cache is circuit-broken: skipped
@@ -294,26 +302,28 @@ struct CacheHealth {
 }
 
 /// A configured cache: its definition, the constructed backend, its health, and
-/// the two halves of its request budget (see [`META_SLOT_RESERVE`]).
+/// its request budget (see [`META_SLOT_RESERVE`]).
 struct ConfiguredCache {
     def: RemoteCacheDef,
     backend: Arc<dyn RemoteCacheBackend>,
     health: CacheHealth,
-    /// Concurrent metadata requests (manifest reads, presence checks).
-    meta_slots: Semaphore,
-    /// Concurrent bulk blob transfers, in either direction.
-    blob_slots: Semaphore,
+    /// Metadata-only permits. Nothing bulk may take one, so a manifest read can
+    /// always find a slot that no blob stream is sitting on.
+    meta_reserve: Semaphore,
+    /// The rest of the budget. Blob transfers draw only from here; metadata
+    /// borrows from here first, so idle bulk capacity is usable.
+    shared_slots: Semaphore,
 }
 
 impl ConfiguredCache {
     fn new(def: RemoteCacheDef, backend: Arc<dyn RemoteCacheBackend>) -> Self {
-        let (meta, blob) = split_request_budget(def.concurrency);
+        let (reserve, shared) = split_request_budget(def.concurrency);
         Self {
             def,
             backend,
             health: CacheHealth::default(),
-            meta_slots: Semaphore::new(meta),
-            blob_slots: Semaphore::new(blob),
+            meta_reserve: Semaphore::new(reserve),
+            shared_slots: Semaphore::new(shared),
         }
     }
 
@@ -324,9 +334,22 @@ impl ConfiguredCache {
     /// The slot is taken **before** the clock starts. The timeout is a liveness
     /// bound on the request; charging it for time spent queued turns ordinary
     /// backpressure into a fake failure, and three of those trip the breaker and
-    /// cost the whole run its cache. Queue time is bounded instead by the reserve
-    /// being metadata-only — nothing ahead of us in it is a long blob stream
-    /// (see [`META_SLOT_RESERVE`]).
+    /// cost the whole run its cache. Queue time is bounded instead by *where* we
+    /// queue, below.
+    ///
+    /// Slot order — the shared pool first, the reserve only as a fallback:
+    ///
+    /// - `try_acquire` on the shared pool, never `acquire`. A success means bulk
+    ///   capacity was idle and we borrow it, which is what lets a metadata-heavy
+    ///   run use the whole budget instead of [`META_SLOT_RESERVE`] of it. It is a
+    ///   non-blocking barge, so we never *wait* behind a blob stream.
+    /// - On failure — bulk is saturated — fall back to the metadata reserve and
+    ///   wait there. Nothing bulk can hold one of those, so anything ahead of us
+    ///   is another short metadata request. That is the [`META_SLOT_RESERVE`]
+    ///   guarantee, and it is the reason the fallback order is not the other way
+    ///   round: draining the reserve first would leave later metadata queued on
+    ///   the shared pool, behind exactly the multi-GiB transfers this reserve
+    ///   exists to avoid.
     ///
     /// The timeout also has to be *ours*: object_store's own budget
     /// (`retry_config`) is sized for resuming multi-GiB blobs, so left to it a
@@ -336,11 +359,14 @@ impl ConfiguredCache {
     where
         F: Future<Output = anyhow::Result<T>>,
     {
-        let _slot = self
-            .meta_slots
-            .acquire()
-            .await
-            .with_context(|| format!("acquire remote cache metadata slot for {what}"))?;
+        let _slot = match self.shared_slots.try_acquire() {
+            Ok(slot) => slot,
+            Err(_) => self
+                .meta_reserve
+                .acquire()
+                .await
+                .with_context(|| format!("acquire remote cache metadata slot for {what}"))?,
+        };
         tokio::time::timeout(METADATA_TIMEOUT, fut)
             .await
             .with_context(|| format!("{what} timed out after {METADATA_TIMEOUT:?}"))?
@@ -836,7 +862,7 @@ impl RemoteCacheSet {
                         // Uploads are bulk too, and background: they must never
                         // hold a slot a critical-path metadata read needs.
                         let _slot =
-                            cache.blob_slots.acquire().await.with_context(|| {
+                            cache.shared_slots.acquire().await.with_context(|| {
                                 format!("acquire remote cache blob slot for {key}")
                             })?;
                         stream_file_to_backend(cache.backend.as_ref(), &key, path).await
@@ -1026,7 +1052,7 @@ impl RemoteCacheSet {
         // presence checks that decide every other target's hit
         // (see `META_SLOT_RESERVE`).
         let _slot = cache
-            .blob_slots
+            .shared_slots
             .acquire()
             .await
             .with_context(|| format!("acquire remote cache blob slot for {name}"))?;
@@ -2154,7 +2180,7 @@ mod tests {
     #[tokio::test(start_paused = true)]
     async fn saturated_blob_transfers_do_not_starve_a_manifest_read() {
         const CONCURRENCY: usize = 8;
-        let (meta_slots, blob_slots) = split_request_budget(CONCURRENCY);
+        let (meta_reserve, shared_slots) = split_request_budget(CONCURRENCY);
 
         let addr = addr();
         let manifest = RemoteManifest {
@@ -2194,7 +2220,7 @@ mod tests {
             manifest,
         });
         let tmp = tempfile::tempdir().expect("tempdir");
-        for i in 0..blob_slots + 4 {
+        for i in 0..shared_slots + 4 {
             let (set, rev, addr, tmp) = (
                 Arc::clone(&set),
                 Arc::clone(&rev),
@@ -2212,13 +2238,13 @@ mod tests {
         // Wait for the bulk half to actually fill before reading the manifest —
         // otherwise the test could pass without ever reproducing contention.
         for _ in 0..10_000 {
-            if budget.available_permits() <= meta_slots {
+            if budget.available_permits() <= meta_reserve {
                 break;
             }
             tokio::task::yield_now().await;
         }
         assert!(
-            budget.available_permits() <= meta_slots,
+            budget.available_permits() <= meta_reserve,
             "blob transfers never saturated their half of the budget"
         );
 
@@ -2228,6 +2254,120 @@ mod tests {
             .expect("a manifest read must not be starved by in-flight blob transfers")
             .is_some();
         assert!(found, "manifest read must resolve to a hit");
+    }
+
+    /// Backend that parks every read on `gate` and records how many were in
+    /// flight at once, so a test can observe the real metadata concurrency
+    /// rather than infer it from timing.
+    struct ConcurrencyProbeBackend {
+        gate: Arc<Semaphore>,
+        in_flight: Arc<std::sync::atomic::AtomicUsize>,
+        peak: Arc<std::sync::atomic::AtomicUsize>,
+        manifest: Vec<u8>,
+    }
+
+    #[async_trait]
+    impl RemoteCacheBackend for ConcurrencyProbeBackend {
+        async fn open_read(
+            &self,
+            _key: &str,
+        ) -> anyhow::Result<Option<Pin<Box<dyn AsyncRead + Send>>>> {
+            let now = self.in_flight.fetch_add(1, Ordering::SeqCst) + 1;
+            self.peak.fetch_max(now, Ordering::SeqCst);
+            let _open = self.gate.acquire().await.context("gate closed")?;
+            self.in_flight.fetch_sub(1, Ordering::SeqCst);
+            Ok(Some(Box::pin(std::io::Cursor::new(self.manifest.clone()))))
+        }
+        async fn open_write(&self, _key: &str) -> anyhow::Result<Pin<Box<dyn AsyncWrite + Send>>> {
+            anyhow::bail!("unused")
+        }
+        async fn exists(&self, _key: &str) -> anyhow::Result<bool> {
+            Ok(true)
+        }
+        async fn list_names(&self, _prefix: &str) -> anyhow::Result<Vec<String>> {
+            Ok(Vec::new())
+        }
+    }
+
+    /// Metadata must be able to use idle bulk capacity, not just its reserve.
+    ///
+    /// The regression this guards: the reserve was implemented as a partition, so
+    /// metadata could never exceed [`META_SLOT_RESERVE`] slots even with every
+    /// bulk slot idle. Resolving a fully-cached graph is almost entirely metadata
+    /// — a target whose manifest is local but whose blobs are not still has to ask
+    /// the remote — so a wide build serialized thousands of targets through 32
+    /// slots while the other 224 went unused, and the run looked hung.
+    ///
+    /// With no blob transfer in flight, `CONCURRENCY` concurrent manifest reads
+    /// must all be in flight together. Under the old split the peak would pin to
+    /// the reserve.
+    #[tokio::test]
+    async fn metadata_uses_idle_bulk_capacity() {
+        const CONCURRENCY: usize = 8;
+        let (meta_reserve, _shared) = split_request_budget(CONCURRENCY);
+
+        let addr = addr();
+        let manifest = RemoteManifest {
+            version: REMOTE_MANIFEST_VERSION.to_string(),
+            target: addr.format(),
+            hashin: "h".to_string(),
+            artifacts: Vec::new(),
+        };
+
+        // No permits: every read parks inside the backend until released, so all
+        // of them pile up and the peak is observable.
+        let gate = Arc::new(Semaphore::new(0));
+        let peak = Arc::new(std::sync::atomic::AtomicUsize::new(0));
+        let backend = Arc::new(ConcurrencyProbeBackend {
+            gate: Arc::clone(&gate),
+            in_flight: Arc::new(std::sync::atomic::AtomicUsize::new(0)),
+            peak: Arc::clone(&peak),
+            manifest: borsh::to_vec(&manifest).expect("serialize"),
+        });
+
+        let dir = tempfile::tempdir().expect("tempdir");
+        let mut cache_def = def("probe", "memory:///probe", true, true);
+        cache_def.concurrency = CONCURRENCY;
+        let set = Arc::new(RemoteCacheSet {
+            caches: vec![ConfiguredCache::new(cache_def, backend)],
+            home: dir.path().to_path_buf(),
+            config_hash: String::new(),
+            read_order: OnceCell::new(),
+        });
+
+        let reads: Vec<_> = (0..CONCURRENCY)
+            .map(|i| {
+                let (set, addr) = (Arc::clone(&set), addr.clone());
+                tokio::spawn(async move {
+                    drop(set.fetch_manifest(&never(), &addr, &format!("h{i}")).await);
+                })
+            })
+            .collect();
+
+        for _ in 0..10_000 {
+            if peak.load(Ordering::SeqCst) >= CONCURRENCY {
+                break;
+            }
+            tokio::task::yield_now().await;
+        }
+        let observed = peak.load(Ordering::SeqCst);
+
+        // Release before asserting so a failure doesn't leave the reads parked.
+        gate.add_permits(CONCURRENCY);
+        for r in reads {
+            drop(r.await);
+        }
+
+        assert!(
+            observed > meta_reserve,
+            "metadata peaked at {observed} concurrent reads, capped by the {meta_reserve}-slot \
+             reserve — idle bulk capacity is not being borrowed"
+        );
+        assert_eq!(
+            observed, CONCURRENCY,
+            "metadata should reach the cache's full request budget when no blob transfer is \
+             holding slots"
+        );
     }
 
     /// Backend that records how many times `exists` was called and sleeps a

--- a/src/commands/global.rs
+++ b/src/commands/global.rs
@@ -7,7 +7,10 @@ use clap::Args;
 /// subcommand, then plumbed to each command's `execute`.
 #[derive(Args, Clone, Debug, Default)]
 pub struct GlobalOptions {
-    /// Write CPU pprof on exit
+    /// Sample CPU and write a pprof profile to PATH. `kill -USR2 <pid>`
+    /// snapshots the profile so far without stopping the run — this is the point
+    /// of the flag, since a hung build never reaches exit. A filtered final
+    /// report is also written at exit.
     #[arg(long = "pprof-cpu", value_name = "PATH", global = true)]
     pub pprof_cpu: Option<PathBuf>,
     /// Install a SIGUSR1 handler that appends the signalled thread's backtrace to
@@ -20,8 +23,7 @@ pub struct GlobalOptions {
         value_name = "FILE",
         num_args = 0..=1,
         default_missing_value = "/tmp/heph-backtrace.log",
-        global = true,
-        hide = true
+        global = true
     )]
     pub diag_backtrace: Option<PathBuf>,
     /// Disable the interactive TUI (force CI/log-only output)

--- a/src/pprof_dump.rs
+++ b/src/pprof_dump.rs
@@ -8,6 +8,7 @@
 //! process in place (to a writable tmpfs path). The filtered final report is
 //! still written at shutdown.
 
+use anyhow::Context;
 use std::path::{Path, PathBuf};
 use std::sync::atomic::{AtomicBool, Ordering};
 use std::thread::JoinHandle;
@@ -18,6 +19,57 @@ use tracing::{info, warn};
 static DUMP_REQUESTED: AtomicBool = AtomicBool::new(false);
 /// Set by [`Watcher::shutdown`]: write the final report and stop the watcher.
 static SHUTDOWN: AtomicBool = AtomicBool::new(false);
+
+/// Sampling frequency, Hz.
+///
+/// Every sample is a signal delivered to a running thread, and each one is a
+/// chance to interrupt somewhere the unwinder cannot walk (see
+/// [`UNWIND_BLOCKLIST`]). 1000 Hz across every thread of a wide build multiplied
+/// that exposure for resolution this diagnostic never needed: it exists to show
+/// *which loop* is burning a pegged worker, and a hang that has lasted minutes
+/// is not a signal 199 Hz can miss.
+const SAMPLE_HZ: libc::c_int = 199;
+
+/// Libraries the sampler must not unwind out of.
+///
+/// `pprof` unwinds from inside its `SIGPROF` handler via the `backtrace` crate,
+/// i.e. `_Unwind_Backtrace`, which takes a global lock and is not
+/// async-signal-safe. Interrupt a thread that is already inside `libc`, the
+/// dynamic loader, or the unwinder itself, and walking that frame faults — which
+/// is how `--pprof-cpu` segfaulted the process it was meant to diagnose, within
+/// seconds of startup on a wide run.
+///
+/// `pprof` resolves these names against the loaded shared objects and checks the
+/// interrupted PC *before* attempting any unwind, so a sample landing in one of
+/// them is dropped whole rather than walked. That costs only samples attributable
+/// to libc frames, which carry no information about heph's own hot loops.
+///
+/// Only the **leaf** PC is checked: the per-frame variant of this test is
+/// `#[cfg(feature = "frame-pointer")]` in pprof, and this build uses the
+/// `backtrace`/`_Unwind_Backtrace` tracer instead. So a sample that *starts* in
+/// heph code and walks up into libc is still unwound in full. This removes the
+/// dominant crash class, not the class — see the module TODO for the durable fix.
+///
+/// Matched as substrings against shared-object paths, and `str::contains` is
+/// **case-sensitive**: macOS ships `/usr/lib/libSystem.B.dylib`, which lowercase
+/// `libsystem` does not match. Both spellings are listed for that reason, and
+/// [`tests::blocklist_covers_the_c_library_but_not_the_main_binary`] fails if any
+/// platform's C library stops being covered.
+const UNWIND_BLOCKLIST: &[&str] = &[
+    "libc",
+    "libgcc",
+    "libunwind",
+    "pthread",
+    "ld-linux",
+    "ld.so",
+    "vdso",
+    // macOS. Both cases: `libSystem.B.dylib` and `libsystem_c.dylib` both exist.
+    "libsystem",
+    "libSystem",
+    "libdyld",
+    // GCD frames are their own unwind hazard on Darwin.
+    "libdispatch",
+];
 
 /// Handle to the running pprof watcher thread.
 pub struct Watcher {
@@ -37,8 +89,24 @@ impl Watcher {
 /// Start CPU sampling plus the `SIGUSR2`-driven dump watcher, writing profiles to
 /// `path`. Call [`Watcher::shutdown`] at exit for the final report.
 pub fn start(path: PathBuf) -> anyhow::Result<Watcher> {
+    // Fail here, where `main` already surfaces the error, rather than at dump
+    // time where an unwritable path is a `warn!` the user may never see — by
+    // which point they have re-run a multi-minute hang to get nothing. Probed by
+    // creating and removing, so no empty file is left to be mistaken for a
+    // profile.
+    std::fs::write(&path, b"")
+        .and_then(|()| std::fs::remove_file(&path))
+        .with_context(|| format!("prepare CPU profile path {}", path.display()))?;
+
+    // These outlive any single `Watcher`, so a second `start` in one process
+    // (tests; a future re-arm) would otherwise inherit a set `SHUTDOWN` and get a
+    // watcher that exits on its first tick, silently ignoring every `SIGUSR2`.
+    SHUTDOWN.store(false, Ordering::Relaxed);
+    DUMP_REQUESTED.store(false, Ordering::Relaxed);
+
     let guard = pprof::ProfilerGuardBuilder::default()
-        .frequency(1000)
+        .frequency(SAMPLE_HZ)
+        .blocklist(UNWIND_BLOCKLIST)
         .build()
         .map_err(|e| anyhow::anyhow!("start CPU profiler: {e}"))?;
     install_signal();
@@ -47,10 +115,19 @@ pub fn start(path: PathBuf) -> anyhow::Result<Watcher> {
     })
 }
 
+/// Ask the watcher to write a snapshot of the profile accumulated so far.
+///
+/// The `SIGUSR2` handler is one caller; the other is the test, which drives this
+/// path directly rather than raising a signal at its own process — a signal is an
+/// untestable side channel, and the handler's whole body is this one store.
+fn request_dump() {
+    DUMP_REQUESTED.store(true, Ordering::Relaxed);
+}
+
 /// `SIGUSR2` handler: request a dump. Only stores to an atomic, so it is
 /// async-signal-safe.
 extern "C" fn on_sigusr2(_sig: libc::c_int) {
-    DUMP_REQUESTED.store(true, Ordering::Relaxed);
+    request_dump();
 }
 
 fn install_signal() {
@@ -116,10 +193,25 @@ fn dump(guard: &pprof::ProfilerGuard<'_>, path: &Path, filter_runtime: bool) {
         warn!(error = %e, "Failed to encode pprof profile");
         return;
     }
-    match std::fs::write(path, &content) {
+    match write_atomic(path, &content) {
         Ok(()) => info!(path = %path.display(), "CPU profile written"),
         Err(e) => warn!(path = %path.display(), error = %e, "Failed to write pprof file"),
     }
+}
+
+/// Write `content` to `path` via a sibling temp file plus a rename.
+///
+/// The whole premise of the on-demand dump is that someone reads the file while
+/// the process is still stuck, so a plain `fs::write` — truncate, then fill —
+/// hands them an empty or half-written profile whenever they read during the
+/// write. The temp file is a sibling so the rename stays within one filesystem
+/// and is therefore atomic.
+fn write_atomic(path: &Path, content: &[u8]) -> std::io::Result<()> {
+    let mut tmp = path.as_os_str().to_owned();
+    tmp.push(".partial");
+    let tmp = PathBuf::from(tmp);
+    std::fs::write(&tmp, content)?;
+    std::fs::rename(&tmp, path)
 }
 
 /// Retain only frames that aren't pure tokio/std scheduler machinery, so the
@@ -139,4 +231,226 @@ fn filter_runtime_frames(frames: &mut pprof::Frames) {
                 && !name.starts_with("__pthread")
         })
     });
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use pprof::Symbol;
+    use pprof::protos::Message;
+    use std::time::Instant;
+
+    /// Keep `threads` threads busy for `at_least` **inside libc** — allocator
+    /// churn, syscalls, and thread create/join.
+    ///
+    /// A pure integer loop is the wrong workload: every sample's leaf PC lands in
+    /// this binary's own text with a shallow stack, which is precisely the case
+    /// that never crashed. The unwinder faults when it interrupts a thread that
+    /// is already inside `malloc`, the dynamic loader, or a syscall stub, so the
+    /// workload has to live there for the sampler to be tested at all.
+    fn burn(threads: usize, at_least: Duration) {
+        let handles: Vec<_> = (0..threads)
+            .map(|_| {
+                std::thread::spawn(move || {
+                    let start = Instant::now();
+                    while start.elapsed() < at_least {
+                        // Allocator churn across size classes: malloc/free, and
+                        // large sizes push glibc into mmap/munmap.
+                        let mut kept: Vec<Vec<u8>> = Vec::new();
+                        for i in 0..64usize {
+                            let byte = u8::try_from(i % 256).unwrap_or(0);
+                            kept.push(vec![byte; 1 << (6 + (i % 12))]);
+                        }
+                        kept.retain(|v| v.len() % 3 == 0);
+                        // Syscalls, and string formatting on top of the allocator.
+                        for _ in 0..16 {
+                            drop(std::fs::metadata(std::env::current_exe().unwrap_or_default()));
+                        }
+                        // Nested thread create/join: pthread + loader paths, and
+                        // it deepens the stack the sampler has to walk.
+                        let inner = std::thread::spawn(|| format!("{:?}", Instant::now()));
+                        drop(inner.join());
+                    }
+                })
+            })
+            .collect();
+        for h in handles {
+            drop(h.join());
+        }
+    }
+
+    /// Resolve the shared object owning `sym`, as the dynamic loader sees it —
+    /// the same name `pprof` matches [`UNWIND_BLOCKLIST`] against.
+    fn owning_object(sym: *const std::ffi::c_void) -> Option<String> {
+        // SAFETY: `Dl_info` is a plain C struct of pointers and integers, for
+        // which all-zero is a valid initial state; `dladdr` fills it.
+        let mut info: libc::Dl_info = unsafe { std::mem::zeroed() };
+        // SAFETY: `sym` is a code address and `info` is a live, correctly-typed
+        // out-param. `dladdr` only writes through it.
+        let found = unsafe { libc::dladdr(sym, &mut info) };
+        if found == 0 || info.dli_fname.is_null() {
+            return None;
+        }
+        // SAFETY: `dladdr` succeeded and `dli_fname` is non-null, so it points at
+        // a NUL-terminated string owned by the loader and valid for this read.
+        let name = unsafe { std::ffi::CStr::from_ptr(info.dli_fname) };
+        Some(name.to_string_lossy().into_owned())
+    }
+
+    fn blocklisted(path: &str) -> bool {
+        UNWIND_BLOCKLIST.iter().any(|b| path.contains(b))
+    }
+
+    /// The blocklist has to name the C library this process actually loaded, and
+    /// must not name the main binary.
+    ///
+    /// Both halves are silent failures otherwise, which is what makes this the
+    /// load-bearing test. `pprof` resolves these substrings against loaded shared
+    /// objects **once**, at `start()`, and stores address ranges: match nothing
+    /// and `blocklist_segments` is empty, so the fix is a no-op and the sampler
+    /// goes back to faulting. Match the main binary and every heph frame is
+    /// dropped, so `--pprof-cpu` writes empty profiles forever — crashing
+    /// nothing, telling no one. `str::contains` is case-sensitive, which is how
+    /// `libSystem.B.dylib` slips past a lowercase entry.
+    ///
+    /// A static build resolves `malloc` to the executable itself and fails here.
+    /// That is correct: the blocklist genuinely cannot work in that build, and
+    /// `src/diag.rs` already records that the sampler segfaults on static
+    /// binaries.
+    #[test]
+    fn blocklist_covers_the_c_library_but_not_the_main_binary() {
+        let libc_obj = owning_object(libc::malloc as *const std::ffi::c_void)
+            .expect("dladdr must resolve malloc");
+        assert!(
+            blocklisted(&libc_obj),
+            "UNWIND_BLOCKLIST does not cover the loaded C library ({libc_obj}); \
+             the blocklist resolves to no address ranges and the fix is a no-op"
+        );
+
+        let own_obj = owning_object(blocklisted as *const std::ffi::c_void)
+            .expect("dladdr must resolve a local function");
+        assert!(
+            !blocklisted(&own_obj),
+            "UNWIND_BLOCKLIST matches the main binary ({own_obj}); \
+             every heph sample would be dropped"
+        );
+    }
+
+    fn sym(name: &str) -> Symbol {
+        Symbol {
+            name: Some(name.as_bytes().to_vec()),
+            addr: None,
+            lineno: None,
+            filename: None,
+        }
+    }
+
+    fn frames(groups: Vec<Vec<Symbol>>) -> pprof::Frames {
+        pprof::Frames {
+            frames: groups,
+            thread_name: "test".to_string(),
+            thread_id: 0,
+            sample_timestamp: std::time::SystemTime::UNIX_EPOCH,
+        }
+    }
+
+    /// The exit-time report drops pure-runtime frames and keeps heph's own.
+    ///
+    /// This is the filter behind the profile `--pprof-cpu` produces when nobody
+    /// sends a signal — i.e. the flag's default output.
+    #[test]
+    fn filter_runtime_frames_drops_runtime_and_keeps_app_frames() {
+        let mut f = frames(vec![
+            vec![sym("tokio::runtime::park::park")],
+            vec![sym("heph::engine::result::result_addr")],
+            vec![sym("std::thread::spawn")],
+        ]);
+        filter_runtime_frames(&mut f);
+        let kept: Vec<String> = f.frames.iter().map(|g| g[0].name()).collect();
+        assert_eq!(kept, vec!["heph::engine::result::result_addr".to_string()]);
+    }
+
+    /// The rules are matched against `Symbol::name()`, which demangles first — so
+    /// they must fire on the mangled symbols a real profile actually carries.
+    #[test]
+    fn filter_runtime_frames_matches_mangled_symbols() {
+        let mut f = frames(vec![vec![sym("_ZN5tokio7runtime4park4park17h0123456789abcdefE")]]);
+        filter_runtime_frames(&mut f);
+        assert!(
+            f.frames.is_empty(),
+            "mangled runtime symbol survived the filter: demangling is not being applied"
+        );
+    }
+
+    /// An inline group is dropped if *any* symbol in it is runtime, so a heph
+    /// frame with an inlined tokio call disappears from the exit-time report.
+    /// Freezing the behavior because it is a real, non-obvious consequence of
+    /// `all()` — not because it is obviously the right choice.
+    #[test]
+    fn filter_runtime_frames_drops_a_whole_inline_group() {
+        let mut f = frames(vec![vec![
+            sym("heph::engine::execute::run"),
+            sym("tokio::task::spawn_blocking"),
+        ]]);
+        filter_runtime_frames(&mut f);
+        assert!(f.frames.is_empty());
+    }
+
+    /// Profiling a busy multi-threaded process must produce a decodable profile
+    /// with samples in it.
+    ///
+    /// Regression: `--pprof-cpu` segfaulted the process it was meant to diagnose,
+    /// within seconds of startup on a wide run, because the `SIGPROF` handler
+    /// unwound through libc frames. A crash takes this whole test binary down —
+    /// that is the first half of the assertion, and it cannot be written any
+    /// other way.
+    ///
+    /// The non-empty sample set is the second half, and it guards the fix rather
+    /// than the bug: an over-broad [`UNWIND_BLOCKLIST`] (one matching the main
+    /// binary) would drop every sample and leave `--pprof-cpu` writing empty
+    /// profiles forever, crashing nothing and telling no one.
+    #[test]
+    fn sampling_a_busy_process_yields_a_profile_without_crashing() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let path = dir.path().join("cpu.pb");
+
+        let watcher = start(path.clone()).expect("start profiler");
+        burn(4, Duration::from_millis(500));
+        request_dump();
+
+        // The watcher wakes on a 200ms tick, then encodes and renames into place.
+        // Poll for the file rather than sleeping a fixed amount.
+        let deadline = Instant::now() + Duration::from_secs(20);
+        let mut snapshot = None;
+        while Instant::now() < deadline {
+            if let Ok(content) = std::fs::read(&path) {
+                snapshot = Some(content);
+                break;
+            }
+            std::thread::sleep(Duration::from_millis(50));
+        }
+
+        // Before any assertion: an `assert!` that escapes here would leave the
+        // watcher thread looping forever, holding the `ProfilerGuard` and keeping
+        // SIGPROF firing for the rest of this test binary's life, with the
+        // `TempDir` deleted out from under its next write.
+        let snapshot = snapshot;
+        watcher.shutdown();
+        let final_report = std::fs::read(&path);
+
+        let snapshot = snapshot.unwrap_or_else(|| panic!("no profile at {}", path.display()));
+        let profile = pprof::protos::Profile::decode(snapshot.as_slice())
+            .expect("on-demand dump must be a decodable pprof profile — never a partial write");
+        assert!(
+            !profile.sample.is_empty(),
+            "profiler collected no samples: UNWIND_BLOCKLIST is dropping everything"
+        );
+
+        // `shutdown` writes the filtered exit-time report — the profile the flag
+        // produces when nobody sends a signal — and swallows a watcher panic into
+        // a `warn!`, so this is the only thing that can catch it failing.
+        let final_report = final_report.expect("exit-time report must be written on shutdown");
+        pprof::protos::Profile::decode(final_report.as_slice())
+            .expect("exit-time report must be a decodable pprof profile");
+    }
 }

--- a/src/pprof_dump.rs
+++ b/src/pprof_dump.rs
@@ -55,23 +55,32 @@ const SAMPLE_HZ: libc::c_int = 199;
 /// `libsystem` does not match. Both spellings are listed for that reason, and
 /// [`tests::blocklist_covers_the_c_library_but_not_the_main_binary`] fails if any
 /// platform's C library stops being covered.
+///
+/// Entries are anchored (`libc.so`, not `libc`) because the match is a bare
+/// substring and over-blocking is the quieter failure of the two: an unanchored
+/// `libc` also swallows `libc++abi`, `libcharset`, `libcorecrypto` — and
+/// `libcrypto`/`libcurl` the day a dependency links them. Those samples would
+/// then vanish from every profile with nothing to indicate it, which for a
+/// profiler pointed at a network stall drops exactly the frames worth having.
 const UNWIND_BLOCKLIST: &[&str] = &[
-    "libc",
-    "libgcc",
+    // Linux/glibc.
+    "libc.so",
+    "libgcc_s",
     "libunwind",
-    "pthread",
+    "libpthread",
     "ld-linux",
-    "ld.so",
     "vdso",
     // macOS. Both cases: `libSystem.B.dylib` and `libsystem_c.dylib` both exist.
     "libsystem",
     "libSystem",
+    "libc.dylib",
     "libdyld",
     // GCD frames are their own unwind hazard on Darwin.
     "libdispatch",
 ];
 
 /// Handle to the running pprof watcher thread.
+#[derive(Debug)]
 pub struct Watcher {
     handle: JoinHandle<()>,
 }
@@ -107,8 +116,10 @@ pub fn start(path: PathBuf) -> anyhow::Result<Watcher> {
     let guard = pprof::ProfilerGuardBuilder::default()
         .frequency(SAMPLE_HZ)
         .blocklist(UNWIND_BLOCKLIST)
+        // `pprof::Error` wraps `nix`/`io` errors, so keep it as a source rather
+        // than stringifying it away.
         .build()
-        .map_err(|e| anyhow::anyhow!("start CPU profiler: {e}"))?;
+        .context("start CPU profiler")?;
     install_signal();
     Ok(Watcher {
         handle: spawn_watcher(guard, path),
@@ -275,7 +286,7 @@ mod tests {
             })
             .collect();
         for h in handles {
-            drop(h.join());
+            h.join().expect("burn thread must not panic");
         }
     }
 
@@ -409,6 +420,12 @@ mod tests {
     /// than the bug: an over-broad [`UNWIND_BLOCKLIST`] (one matching the main
     /// binary) would drop every sample and leave `--pprof-cpu` writing empty
     /// profiles forever, crashing nothing and telling no one.
+    ///
+    /// **Only one test in this binary may call [`start`].** pprof's `PROFILER` is
+    /// a process singleton: a concurrent second `start` fails with
+    /// `Error::Running`, and a sequential one would silently profile under the
+    /// previous run's state. The deterministic properties are asserted by the
+    /// sampler-free tests below precisely so this stays the only one.
     #[test]
     fn sampling_a_busy_process_yields_a_profile_without_crashing() {
         let dir = tempfile::tempdir().expect("tempdir");

--- a/src/pprof_dump.rs
+++ b/src/pprof_dump.rs
@@ -275,7 +275,9 @@ mod tests {
                         kept.retain(|v| v.len() % 3 == 0);
                         // Syscalls, and string formatting on top of the allocator.
                         for _ in 0..16 {
-                            drop(std::fs::metadata(std::env::current_exe().unwrap_or_default()));
+                            drop(std::fs::metadata(
+                                std::env::current_exe().unwrap_or_default(),
+                            ));
                         }
                         // Nested thread create/join: pthread + loader paths, and
                         // it deepens the stack the sampler has to walk.
@@ -385,7 +387,9 @@ mod tests {
     /// they must fire on the mangled symbols a real profile actually carries.
     #[test]
     fn filter_runtime_frames_matches_mangled_symbols() {
-        let mut f = frames(vec![vec![sym("_ZN5tokio7runtime4park4park17h0123456789abcdefE")]]);
+        let mut f = frames(vec![vec![sym(
+            "_ZN5tokio7runtime4park4park17h0123456789abcdefE",
+        )]]);
         filter_runtime_frames(&mut f);
         assert!(
             f.frames.is_empty(),


### PR DESCRIPTION
`heph r lint //...` on a large monorepo hung: ~100 targets sat in the remote-cache-read step for 500+ seconds, six tokio workers pegged at 100% for 12+ minutes, the TUI dropping frames, 9.5–14.5 GB RSS.

Reaching for the profiler made it worse — `--pprof-cpu` segfaulted the process within seconds. So the first two commits fix the diagnostic, and the last two fix what it (eventually) showed.

The evidence that drove this is an `eu-stack` dump of the live stuck process. All six pegged threads were in one synchronous poll cascade of 266–408 frames. Of 2350 frames in the dump: 257 `Shared::poll`, 257 `await_with_stall_check`, 258 `result_addr_impl`, 124 `inner_meta`, 124 `try_join_all`. One thread held **54 nested `Shared::poll` levels** — a single poll descending ~27 dependency-graph levels. Four of six bottomed out on `Semaphore::acquire` inside `fetch_manifest`; one was in `Mutex::lock_contended` inside that semaphore's own wait list.

## Commits

### `fix(diag)` — stop `--pprof-cpu` segfaulting the run

`pprof-rs` is depended on without its `frame-pointer` feature, so it unwinds via `_Unwind_Backtrace` from inside its `SIGPROF` handler — a global lock, not async-signal-safe. Interrupt a thread already in libc/`ld.so`/the unwinder and it faults; at 1000 Hz across every thread of a wide build, seconds.

Adds pprof's own `blocklist` mitigation, drops the rate to 199 Hz (`setitimer(ITIMER_PROF)` counts *process* CPU, so the signal rate is freq × busy-cores — 1000 Hz bought lock contention and dropped samples, not resolution), and fixes several adjacent defects: the dump wrote non-atomically to the live path a user reads while the process is stuck; `start()` was silently one-shot; an unwritable path was only discovered at dump time as a `warn!`; `--pprof-cpu`'s help said "on exit" when the mid-run `SIGUSR2` snapshot is the whole point; `--diag-backtrace` was `hide = true`, invisible to anyone who hadn't read the source.

**This mitigates rather than closes the crash.** Only the *leaf* PC is blocklisted — the per-frame check is `frame-pointer`-gated and off in this build — so a sample starting in heph code and unwinding up into libc still faults. The durable fix is `frame-pointer` + `-Cforce-frame-pointers` or `framehop-unwinder`, both of which change the shipped release profile and are left as a follow-up.

### `perf(remote-cache)` — let metadata borrow idle bulk slots

`META_SLOT_RESERVE` was meant as a floor (metadata must never queue behind a multi-GiB blob stream, #178) but was implemented as a partition: 32 metadata slots, 224 bulk, and metadata could never exceed 32 even with every bulk slot idle.

That inverts on a metadata-heavy run — which is what resolving a fully-cached graph *is*. A target whose manifest is local but whose blobs are not still has to ask the remote whether it can serve them, and under lazy pull that's the normal state. So thousands of targets serialize through 32 permits while 224 go unused.

`meta_op` now `try_acquire`s the shared pool (a non-blocking barge, so metadata never *waits* behind a blob) and falls back to waiting on the metadata-only reserve. The fallback order is load-bearing: draining the reserve first would leave later metadata queued behind exactly the transfers the reserve exists to avoid — #178's bug again.

### `perf(memoizer)` — wake awaiters on completion, not on every inner poll

`futures::Shared::Notifier::wake_by_ref` drains its waker slab and `take()`s **every** slot on **every** inner wake, so each awaiter must re-poll merely to re-register. Quadratic here: a base library with W reverse-deps has W awaiters on its `mem_result` cell, and each of *its* D dependencies completing wakes all W, each re-descending ~27 levels. W=500, D=20 is ~270k nested polls, nearly all waste.

Replaced with a cell that routes an inner wake to the **driver alone** and wakes everyone else exactly once, at completion. `Shared`'s state machine is otherwise right and is kept deliberately — per-poll re-election, a cell-owned waker for the inner future, and the future living in the cell. Each is load-bearing and documented as such; in particular, owned (rather than per-poll) drivership would strand every awaiter whenever a driver is dropped, which `try_join_all` fail-fast and Ctrl-C both do routinely.

Fixed alongside, each its own silent failure: a panicking cell used to hang every awaiter forever; `await_with_stall_check` called `tokio::time::timeout`, which aborts the process from inside a cdylib provider (so `HEPH_MEMOIZER_STALL_SECS` failed on exactly the workload it exists for — same class as #180/#182); `IN_FLIGHT` is now scoped at cell creation, since a stable driver would otherwise permanently capture the wrong chain and report `SelfRecursion` on an acyclic graph.

## Verification

- `cargo clippy --all-features --all-targets` — clean.
- 79 test suites pass, 0 failures. `plugingo-e2e` excluded: it fails with `os error 28` on a disk at 100%, the known parallel-Go-std-build issue, unrelated to this branch.
- **Both regression tests were verified red against the old behavior**, not merely green against the new:
  - `metadata peaked at 4 concurrent reads, capped by the 4-slot reserve`
  - `parked awaiter 0 was woken by inner progress; this is the wake storm`

## What this does not fix

**The 9.5–14.5 GB RSS is untouched and still unexplained.** Measured per-cell cost is ~145 bytes, so ~800k memoizer cells is 150–300 MB — two orders of magnitude short. Three leads, none investigated:

1. Abandoned cells forming an `Arc` cycle through `RequestStateData`, so the request never drops and `ctoken.cancel()` never fires. Fail-fast creates these on every failing build.
2. `mem_expanded_inputs` retention — `Input` carries an owned `origin_id` and an annotation map, never evicted for the life of a request.
3. `stacker` has no segment cache: every descent past the 512 KiB red zone is a fresh 8 MiB `mmap`/`munmap`. This one should shrink with the memoizer fix, so it doubles as a cheap check on that hypothesis.

Also not included, and not claimed: **no loom model** of the cell (the 2000-round race test is weaker), and **no criterion baseline** — the workspace has no benchmarks, so the justification is the stack dump plus the falsified wake-count test, not a measured before/after.

## Review notes

The review board was consulted at design and review. `feature-quality` and `code-quality` both returned BLOCKED on the memoizer design; the blockers (driver hand-off on drop, cell-owned inner waker, latched progress signal, panic drains waiters, future dropped at completion) are all addressed. Two findings were deliberately not actioned: `Watcher::shutdown` still warns rather than propagating a watcher panic (a diagnostic should degrade, not abort the run at exit), and the pprof test stays in-process rather than moving to a subprocess test in `tests/`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TjezpViasj8fxwjeyznApk
