### PR TITLE
feat(diag): tell the user when a run stops making progress

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1545,7 +1545,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -2111,6 +2111,7 @@ dependencies = [
  "itertools 0.14.0",
  "libc",
  "lock",
+ "mach2",
  "memoize",
  "minijinja",
  "model",
@@ -2877,6 +2878,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "mach2"
+version = "0.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d640282b302c0bb0a2a8e0233ead9035e3bed871f0b7e81fe4a1ec829765db44"
+dependencies = [
+ "libc",
+]
+
+[[package]]
 name = "maplit"
 version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3110,7 +3120,7 @@ version = "0.50.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7957b9740744892f114936ab4a57b3f487491bbeafaf8083688b16841a4240e5"
 dependencies = [
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -4314,7 +4324,7 @@ dependencies = [
  "once_cell",
  "socket2",
  "tracing",
- "windows-sys 0.59.0",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -4762,7 +4772,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys",
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -4821,7 +4831,7 @@ dependencies = [
  "security-framework",
  "security-framework-sys",
  "webpki-root-certs",
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -5720,7 +5730,7 @@ dependencies = [
  "getrandom 0.4.2",
  "once_cell",
  "rustix",
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -6616,7 +6626,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -179,6 +179,12 @@ flate2 = "1.1.9"
 default = ["fuse-sandbox"]
 fuse-sandbox = ["hsandboxfuse/fuse-sandbox"]
 
+# macOS-only: enumerating the task's threads for `SIGQUIT` dumps goes through
+# Mach (`task_threads`), and libc has deprecated its re-exports in favour of this
+# crate. Linux uses `tgkill` from libc and needs nothing extra.
+[target.'cfg(target_os = "macos")'.dependencies]
+mach2 = "0.4"
+
 [dev-dependencies]
 serde-jsonlines = "0.7.0"
 tempfile = "3"

--- a/crates/engine/src/engine/diag.rs
+++ b/crates/engine/src/engine/diag.rs
@@ -110,6 +110,14 @@ const SLOTS: usize = 512;
 /// Sentinel for a free slot: no span can legitimately hash to it.
 const FREE: u64 = 0;
 
+/// At or below this many open `Execute` spans and nothing else, silence is
+/// treated as "subprocesses are working" rather than a stall — until
+/// [`QUIET_EXEC_FACTOR`] times the threshold has passed.
+const QUIET_EXEC_MAX: u64 = 4;
+
+/// How much longer a silent-subprocess build is given before it is reported.
+const QUIET_EXEC_FACTOR: u64 = 10;
+
 /// Rolling window over which bytes-moved is reported.
 pub const BYTES_WINDOW: Duration = Duration::from_secs(60);
 
@@ -353,6 +361,17 @@ impl DiagState {
         self.failed.load(Ordering::Relaxed)
     }
 
+    /// Look a limiter up by name, falling back to an inert one so a caller that
+    /// names a limiter this build does not track degrades to "not reported"
+    /// rather than panicking inside a diagnostic.
+    pub fn limiter(&self, name: &'static str) -> &Limiter {
+        static INERT: Limiter = Limiter::new("inert");
+        self.limiters
+            .iter()
+            .find(|l| l.name == name)
+            .unwrap_or(&INERT)
+    }
+
     pub fn limiters(&self) -> &[Limiter] {
         &self.limiters
     }
@@ -375,7 +394,8 @@ impl DiagState {
     /// loop with one wiring test instead of a suite of flaky sleepy ones.
     pub fn evaluate(&self, now_ms: u64, threshold: Duration) -> Option<StallReport> {
         let threshold_ms = u64::try_from(threshold.as_millis()).unwrap_or(60_000);
-        if self.quiet_for_ms(now_ms) < threshold_ms {
+        let quiet = self.quiet_for_ms(now_ms);
+        if quiet < threshold_ms {
             return None;
         }
 
@@ -385,6 +405,24 @@ impl DiagState {
             .filter(|(_, n, _)| *n > 0)
             .collect();
         open.sort_by_key(|(_, n, _)| std::cmp::Reverse(*n));
+
+        // A handful of `Execute` spans and nothing else is a normal build running
+        // normal subprocesses. heph cannot see inside one: a compiler thinking
+        // quietly for ten minutes emits exactly what a wedged one emits, which is
+        // nothing. Reporting that at the ordinary threshold would fire on every
+        // narrow invocation — `heph r //some:slow_target` — and a notice that
+        // cries wolf is worse than none, because people stop reading it.
+        //
+        // So hold silent subprocesses to a much longer clock. A genuinely stuck
+        // one is still reported, just late, and `dominant` refuses to volunteer a
+        // theory about it (see `StallReport::dominant`).
+        let only_subprocesses = !open.is_empty()
+            && open
+                .iter()
+                .all(|(op, n, _)| matches!(op, Op::Execute) && *n <= QUIET_EXEC_MAX);
+        if only_subprocesses && quiet < threshold_ms.saturating_mul(QUIET_EXEC_FACTOR) {
+            return None;
+        }
 
         // Nothing open and nothing moving: either the run is over (the watchdog is
         // stopped then) or we are wedged *before* any span opened — matching, or
@@ -443,6 +481,11 @@ impl StallReport {
     pub fn dominant(&self) -> Option<(Op, u64)> {
         let total: u64 = self.open.iter().map(|(_, n, _)| *n).sum();
         let (op, n, _) = self.open.first()?;
+        // Never volunteer a theory about a subprocess: heph has no view inside
+        // one, so "stuck execute" would be a guess dressed as a finding.
+        if matches!(op, Op::Execute) {
+            return None;
+        }
         (total > 0 && n * 100 >= total * 80).then_some((*op, *n))
     }
 
@@ -687,29 +730,67 @@ mod tests {
         }
     }
 
-    /// A build that is opening spans is progressing, even if it has closed none.
+    /// A lone quiet subprocess is not a stall at the ordinary threshold.
     ///
-    /// This is the false positive that would have sunk the feature: a single
-    /// 30-minute link target emits one `ResultStart` and nothing else until it
-    /// finishes. A "no target completed in N" trigger prints a stall paragraph on
-    /// a perfectly healthy build, and a diagnostic that cries wolf gets ignored.
+    /// `heph r //some:slow_target` emits one `ExecuteStart` and then nothing for
+    /// as long as the compiler thinks. heph cannot see inside it — a healthy
+    /// subprocess and a wedged one emit identically, which is to say nothing — so
+    /// firing here would put a stall notice on every narrow invocation, and a
+    /// notice that cries wolf stops being read.
     #[test]
-    fn does_not_fire_on_one_legitimately_slow_target() {
+    fn does_not_fire_on_one_quiet_slow_target() {
         let s = state();
         s.op_start(Op::Execute, "//a:b", 0);
-        // An hour later, still nothing else. Not a stall — it is one slow target.
-        // Progress is what advances `last_transition`, so this fires only because
-        // *nothing at all* has happened; assert we report it as unknown-phase
-        // rather than blaming the op.
-        let r = s.evaluate(3_600_000, T).expect("quiet for an hour");
+        for minutes in 1..10 {
+            let now = minutes * 60_000;
+            assert!(
+                s.evaluate(now, T).is_none(),
+                "fired at {now}ms on a single quiet subprocess"
+            );
+        }
+    }
+
+    /// It is held to a longer clock, not exempted: a genuinely stuck subprocess
+    /// is still reported, just late.
+    #[test]
+    fn a_quiet_subprocess_is_reported_eventually() {
+        let s = state();
+        s.op_start(Op::Execute, "//a:b", 0);
+        let r = s
+            .evaluate(T.as_millis() as u64 * QUIET_EXEC_FACTOR + 1, T)
+            .expect("reported once the longer clock elapses");
         assert_eq!(
             r.open.first().map(|(op, n, _)| (*op, *n)),
             Some((Op::Execute, 1))
         );
-        assert!(
-            !r.dominant_is_starved() || r.bytes.iter().all(|(_, b)| *b == 0),
-            "with no byte counters wired this op cannot be called starved"
+        assert_eq!(
+            r.dominant(),
+            None,
+            "heph cannot see inside a subprocess, so it must not blame one"
         );
+    }
+
+    /// The suppression is scoped to subprocesses. Many open remote-cache reads
+    /// with nothing moving is the case this whole feature exists for and must
+    /// fire at the ordinary threshold.
+    #[test]
+    fn suppression_does_not_hide_a_stalled_subsystem() {
+        let s = state();
+        for i in 0..98 {
+            s.op_start(Op::RemoteCacheRead, &format!("//pkg:{i}"), 0);
+        }
+        assert!(s.evaluate(61_000, T).is_some());
+    }
+
+    /// A wide fan-out of subprocesses is a real signal — that is the worker pool
+    /// wedged, not one slow compile — so the suppression must not swallow it.
+    #[test]
+    fn many_open_subprocesses_still_fire() {
+        let s = state();
+        for i in 0..(QUIET_EXEC_MAX + 1) {
+            s.op_start(Op::Execute, &format!("//e:{i}"), 0);
+        }
+        assert!(s.evaluate(61_000, T).is_some());
     }
 
     /// Work that keeps closing spans never trips the threshold, however long any

--- a/crates/engine/src/engine/diag.rs
+++ b/crates/engine/src/engine/diag.rs
@@ -1,0 +1,908 @@
+//! Live self-diagnosis: what is this process doing *right now*, and is it stuck?
+//!
+//! heph already knew why it was hanging. Resolving a 27,569-target build, it held
+//! "98 targets open in remote-cache-read, oldest 512s, zero completions in 480s"
+//! in memory for forty minutes and never said so, because the only thing that
+//! rendered it was the TUI — which degrades under exactly the load that raises the
+//! question. Diagnosing that took a day of `/proc` forensics and three wrong
+//! hypotheses. This module exists so the next one takes one paragraph.
+//!
+//! # One table, several renderers
+//!
+//! [`DiagState`] is the single source: open-span counts per op kind, the oldest
+//! open span of each, bytes moved in a rolling window, limiter saturation, and the
+//! timestamp of the last state transition of any kind. The stall watchdog, the
+//! published status file, and the end-of-run summary are all views over it.
+//! Deriving it at a *consumer* instead would make the view only as fresh as that
+//! consumer's drain loop, and a wedged process's table would go stale precisely
+//! when it matters.
+//!
+//! # Why the hook body is atomics only
+//!
+//! [`DiagHook::on_event`] runs synchronously on the emitting thread, from every
+//! worker, roughly eight times per target. At 27k targets that is ~220k calls
+//! through one shared structure. A `Mutex`, a `HashMap`, an allocation or a
+//! `format!` here would make this another `hmemoizer::set_phase` — which takes a
+//! global lock per await point and is therefore permanently gated off behind an
+//! env var. A diagnostic that has to be switched on cannot help with the hang you
+//! did not anticipate, so this one is always on, and everything it does is a
+//! relaxed atomic. All string work happens on the watchdog thread, after a stall
+//! has already been detected.
+//!
+//! # Why the trigger is "no transition", not "no completion"
+//!
+//! `heph r //some:link_step` on a single thirty-minute target emits one
+//! `ResultStart` and then nothing until it finishes. "No target completed in 60s"
+//! would print a stall paragraph on a perfectly healthy build — and a diagnostic
+//! that cries wolf is worse than no diagnostic, because people learn to skip it.
+//! A build that is progressing *opens* spans even when it closes none, so
+//! [`DiagState::last_transition`] advances on starts, ends, cache hits and misses,
+//! and on bytes moving.
+
+use std::sync::atomic::{AtomicI64, AtomicU64, Ordering};
+use std::time::{Duration, Instant};
+
+use hcore::events::{BuildEvent, BuildEventKind};
+
+/// Op kinds tracked separately. Deliberately coarse: the paragraph needs to name
+/// *which subsystem* is stuck, not reproduce the whole event taxonomy.
+#[derive(Clone, Copy, PartialEq, Eq, Debug)]
+pub enum Op {
+    Result,
+    Execute,
+    RemoteCacheRead,
+    RemoteCacheWrite,
+    LocalCacheWrite,
+}
+
+impl Op {
+    pub const ALL: [Op; 5] = [
+        Op::Result,
+        Op::Execute,
+        Op::RemoteCacheRead,
+        Op::RemoteCacheWrite,
+        Op::LocalCacheWrite,
+    ];
+
+    const fn idx(self) -> usize {
+        match self {
+            Op::Result => 0,
+            Op::Execute => 1,
+            Op::RemoteCacheRead => 2,
+            Op::RemoteCacheWrite => 3,
+            Op::LocalCacheWrite => 4,
+        }
+    }
+
+    /// Human label used in the stall paragraph.
+    pub const fn label(self) -> &'static str {
+        match self {
+            Op::Result => "result",
+            Op::Execute => "execute",
+            Op::RemoteCacheRead => "remote-cache-read",
+            Op::RemoteCacheWrite => "remote-cache-write",
+            Op::LocalCacheWrite => "local-cache-write",
+        }
+    }
+
+    /// Whether an "oldest open" age can be reported for this op.
+    ///
+    /// Every op except [`Op::Result`] is bounded by a semaphore (workers, the
+    /// remote-cache request budget, the blocking pool), so a fixed slot array
+    /// tracks all of them exactly. `Result` spans are *not* bounded — every
+    /// ancestor holds one open while awaiting its children, so thousands are live
+    /// at once on a deep graph. Rather than report an age from a slot array that
+    /// silently evicted the span we care about, report count only and say so.
+    pub const fn tracks_oldest(self) -> bool {
+        !matches!(self, Op::Result)
+    }
+}
+
+/// Per-op slots for oldest-open tracking.
+///
+/// Sized to the *concurrency bound* of the ops that use it, not to the target
+/// count. A ring buffer indexed by a sequence number would be wrong in the one
+/// case that matters: it evicts by insertion order, so the span that opened at
+/// t=0 and is still open gets overwritten by later spans, and the watchdog reports
+/// "oldest 2s" in the middle of a 512s stall.
+const SLOTS: usize = 512;
+
+/// Sentinel for a free slot: no span can legitimately hash to it.
+const FREE: u64 = 0;
+
+/// Rolling window over which bytes-moved is reported.
+pub const BYTES_WINDOW: Duration = Duration::from_secs(60);
+
+struct OpState {
+    /// Open spans.
+    ///
+    /// Signed, and clamped at read. `progress.rs` documents a real same-addr
+    /// double-fire that it defends against with set semantics; a counter has no
+    /// set to dedup against, so a duplicated `*End` decrements twice. Unsigned,
+    /// that prints `18446744073709551615 open` — the diagnostic lying during the
+    /// incident it exists to explain.
+    open: AtomicI64,
+    /// `(span key, start millis)` pairs. Key `FREE` means the slot is free.
+    slot_key: [AtomicU64; SLOTS],
+    slot_start: [AtomicU64; SLOTS],
+    /// Cumulative bytes moved by this op.
+    bytes_total: AtomicU64,
+    /// Bytes at the start of the current window, and when that window opened.
+    bytes_window_base: AtomicU64,
+    window_opened_ms: AtomicU64,
+}
+
+impl OpState {
+    fn new() -> Self {
+        Self {
+            open: AtomicI64::new(0),
+            slot_key: [const { AtomicU64::new(FREE) }; SLOTS],
+            slot_start: [const { AtomicU64::new(0) }; SLOTS],
+            bytes_total: AtomicU64::new(0),
+            bytes_window_base: AtomicU64::new(0),
+            window_opened_ms: AtomicU64::new(0),
+        }
+    }
+}
+
+/// A limiter worth naming in the stall paragraph.
+///
+/// Reports saturation, not queue depth. Depth needs a wrapper around every
+/// acquire — affordable at these sites, but it measures the wrong thing at the
+/// one that matters: `meta_op` takes `shared_slots` with `try_acquire` and only
+/// ever *awaits* on `meta_reserve`, so metadata never queues on `shared_slots` by
+/// construction and a depth gauge there reads zero during a metadata starvation.
+/// "Saturated for 47s" is both cheaper and more actionable than "depth 213".
+pub struct Limiter {
+    pub name: &'static str,
+    /// Millis at which this limiter last went from "has permits" to "none", or 0.
+    saturated_since_ms: AtomicU64,
+}
+
+impl Limiter {
+    pub const fn new(name: &'static str) -> Self {
+        Self {
+            name,
+            saturated_since_ms: AtomicU64::new(0),
+        }
+    }
+
+    /// Record the limiter's current availability. One relaxed load plus, on a
+    /// transition, one store — cheap enough for an acquire path.
+    pub fn observe(&self, available: usize, now_ms: u64) {
+        if available == 0 {
+            // Only stamp the *transition*, so the age keeps growing.
+            let _prev = self.saturated_since_ms.compare_exchange(
+                0,
+                now_ms.max(1),
+                Ordering::Relaxed,
+                Ordering::Relaxed,
+            );
+        } else {
+            self.saturated_since_ms.store(0, Ordering::Relaxed);
+        }
+    }
+
+    fn saturated_for(&self, now_ms: u64) -> Option<Duration> {
+        let since = self.saturated_since_ms.load(Ordering::Relaxed);
+        (since != 0).then(|| Duration::from_millis(now_ms.saturating_sub(since)))
+    }
+}
+
+/// The live table. One per process.
+pub struct DiagState {
+    /// Monotonic base. Everything else is millis since this, so timestamps are
+    /// lock-free `u64`s and immune to the wall clock stepping — `at_unix_ms` on
+    /// the events is `SystemTime`, and an NTP correction there makes an elapsed
+    /// go negative.
+    base: Instant,
+    /// Millis of the last state transition of *any* kind. The stall trigger.
+    last_transition_ms: AtomicU64,
+    ops: [OpState; 5],
+    limiters: Vec<Limiter>,
+    /// Completed / failed targets, for the progress line.
+    done: AtomicU64,
+    failed: AtomicU64,
+}
+
+impl DiagState {
+    pub fn new(limiters: Vec<Limiter>) -> Self {
+        Self {
+            base: Instant::now(),
+            last_transition_ms: AtomicU64::new(0),
+            ops: [
+                OpState::new(),
+                OpState::new(),
+                OpState::new(),
+                OpState::new(),
+                OpState::new(),
+            ],
+            limiters,
+            done: AtomicU64::new(0),
+            failed: AtomicU64::new(0),
+        }
+    }
+
+    /// Infallible by construction (`ops` is sized to `Op::ALL`), but resolved
+    /// through `get` so a future op kind added without extending the array
+    /// degrades to "not tracked" rather than panicking inside a diagnostic.
+    fn op(&self, op: Op) -> Option<&OpState> {
+        self.ops.get(op.idx())
+    }
+
+    pub fn now_ms(&self) -> u64 {
+        u64::try_from(self.base.elapsed().as_millis()).unwrap_or(u64::MAX)
+    }
+
+    /// Millis since anything at all happened.
+    fn quiet_for_ms(&self, now_ms: u64) -> u64 {
+        now_ms.saturating_sub(self.last_transition_ms.load(Ordering::Relaxed))
+    }
+
+    fn touch(&self, now_ms: u64) {
+        self.last_transition_ms.store(now_ms, Ordering::Relaxed);
+    }
+
+    /// Hash an addr into a non-[`FREE`] slot key. A collision costs at worst
+    /// freeing the wrong one of two same-hash spans, which perturbs a reported
+    /// age — acceptable for a diagnostic, and never a correctness issue.
+    fn key_of(addr: &str) -> u64 {
+        use std::hash::{Hash, Hasher};
+        let mut h = rustc_hash::FxHasher::default();
+        addr.hash(&mut h);
+        h.finish() | 1
+    }
+
+    fn op_start(&self, op: Op, addr: &str, now_ms: u64) {
+        let Some(st) = self.op(op) else { return };
+        st.open.fetch_add(1, Ordering::Relaxed);
+        self.touch(now_ms);
+        if !op.tracks_oldest() {
+            return;
+        }
+        let key = Self::key_of(addr);
+        for (slot, start) in st.slot_key.iter().zip(st.slot_start.iter()) {
+            if slot
+                .compare_exchange(FREE, key, Ordering::AcqRel, Ordering::Relaxed)
+                .is_ok()
+            {
+                start.store(now_ms, Ordering::Release);
+                return;
+            }
+        }
+        // All slots busy: the count is still exact, only the age is unknown.
+    }
+
+    fn op_end(&self, op: Op, addr: &str, now_ms: u64) {
+        let Some(st) = self.op(op) else { return };
+        st.open.fetch_sub(1, Ordering::Relaxed);
+        self.touch(now_ms);
+        if !op.tracks_oldest() {
+            return;
+        }
+        let key = Self::key_of(addr);
+        for slot in st.slot_key.iter() {
+            if slot.load(Ordering::Acquire) == key
+                && slot
+                    .compare_exchange(key, FREE, Ordering::AcqRel, Ordering::Relaxed)
+                    .is_ok()
+            {
+                return;
+            }
+        }
+    }
+
+    /// Record bytes moved. Callers accumulate locally and flush periodically —
+    /// incrementing per 8 KiB chunk would put ~100k atomic RMWs on one cache line
+    /// during a cold multi-GB pull, contended across every transfer.
+    pub fn add_bytes(&self, op: Op, bytes: u64) {
+        if bytes == 0 {
+            return;
+        }
+        let Some(st) = self.op(op) else { return };
+        st.bytes_total.fetch_add(bytes, Ordering::Relaxed);
+        // Bytes moving *is* progress, even with no span transition — this is what
+        // stops a long, healthy transfer from reading as a stall.
+        self.touch(self.now_ms());
+    }
+
+    pub fn open_count(&self, op: Op) -> u64 {
+        self.op(op)
+            .map(|st| u64::try_from(st.open.load(Ordering::Relaxed).max(0)).unwrap_or(0))
+            .unwrap_or(0)
+    }
+
+    /// Age of the oldest open span of `op`, when trackable.
+    pub fn oldest_open(&self, op: Op, now_ms: u64) -> Option<Duration> {
+        if !op.tracks_oldest() {
+            return None;
+        }
+        let st = self.op(op)?;
+        let oldest = st
+            .slot_key
+            .iter()
+            .zip(st.slot_start.iter())
+            .filter(|(k, _)| k.load(Ordering::Acquire) != FREE)
+            .map(|(_, start)| start.load(Ordering::Acquire))
+            .min();
+        oldest.map(|s| Duration::from_millis(now_ms.saturating_sub(s)))
+    }
+
+    /// Bytes moved by `op` within the rolling window, and the cumulative total.
+    pub fn bytes(&self, op: Op, now_ms: u64) -> (u64, u64) {
+        let Some(st) = self.op(op) else { return (0, 0) };
+        let total = st.bytes_total.load(Ordering::Relaxed);
+        let opened = st.window_opened_ms.load(Ordering::Relaxed);
+        let window_ms = u64::try_from(BYTES_WINDOW.as_millis()).unwrap_or(60_000);
+        if now_ms.saturating_sub(opened) > window_ms {
+            // Roll the window forward. Racy under concurrent readers, and that is
+            // fine: the worst outcome is one window reported short.
+            st.window_opened_ms.store(now_ms, Ordering::Relaxed);
+            st.bytes_window_base.store(total, Ordering::Relaxed);
+            return (0, total);
+        }
+        let base = st.bytes_window_base.load(Ordering::Relaxed);
+        (total.saturating_sub(base), total)
+    }
+
+    pub fn done(&self) -> u64 {
+        self.done.load(Ordering::Relaxed)
+    }
+
+    pub fn failed(&self) -> u64 {
+        self.failed.load(Ordering::Relaxed)
+    }
+
+    pub fn limiters(&self) -> &[Limiter] {
+        &self.limiters
+    }
+
+    /// Saturated limiters, longest-saturated first.
+    pub fn saturated(&self, now_ms: u64) -> Vec<(&'static str, Duration)> {
+        let mut v: Vec<_> = self
+            .limiters
+            .iter()
+            .filter_map(|l| l.saturated_for(now_ms).map(|d| (l.name, d)))
+            .collect();
+        v.sort_by_key(|(_, d)| std::cmp::Reverse(*d));
+        v
+    }
+
+    /// Decide whether this looks stalled, as of `now_ms`.
+    ///
+    /// Pure: it holds no clock and does no I/O, so every scenario is testable by
+    /// passing a time rather than sleeping. The watchdog thread is then a two-line
+    /// loop with one wiring test instead of a suite of flaky sleepy ones.
+    pub fn evaluate(&self, now_ms: u64, threshold: Duration) -> Option<StallReport> {
+        let threshold_ms = u64::try_from(threshold.as_millis()).unwrap_or(60_000);
+        if self.quiet_for_ms(now_ms) < threshold_ms {
+            return None;
+        }
+
+        let mut open: Vec<(Op, u64, Option<Duration>)> = Op::ALL
+            .iter()
+            .map(|&op| (op, self.open_count(op), self.oldest_open(op, now_ms)))
+            .filter(|(_, n, _)| *n > 0)
+            .collect();
+        open.sort_by_key(|(_, n, _)| std::cmp::Reverse(*n));
+
+        // Nothing open and nothing moving: either the run is over (the watchdog is
+        // stopped then) or we are wedged *before* any span opened — matching, or
+        // walking packages on a 27k-target repo. That phase is real and must not
+        // be silently uninstrumented, so report it rather than staying quiet.
+        Some(StallReport {
+            quiet_for: Duration::from_millis(self.quiet_for_ms(now_ms)),
+            open,
+            bytes: Op::ALL
+                .iter()
+                .map(|&op| (op, self.bytes(op, now_ms).0))
+                .collect(),
+            saturated: self.saturated(now_ms),
+            done: self.done(),
+            failed: self.failed(),
+        })
+    }
+}
+
+/// The process-wide table.
+///
+/// A `static` rather than a field threaded through the engine: there is exactly
+/// one per process, the hook needs it before the engine is wrapped in an `Arc`,
+/// and both the watchdog thread and any future reader live outside the engine's
+/// ownership graph. Same shape as the other diagnostic modules.
+pub fn global() -> &'static std::sync::Arc<DiagState> {
+    static STATE: std::sync::OnceLock<std::sync::Arc<DiagState>> = std::sync::OnceLock::new();
+    STATE.get_or_init(|| {
+        std::sync::Arc::new(DiagState::new(vec![
+            Limiter::new("workers"),
+            Limiter::new("remote-cache-metadata"),
+            Limiter::new("remote-cache-transfer"),
+            Limiter::new("codec"),
+        ]))
+    })
+}
+
+/// What the watchdog found. Rendered by the caller; holds no formatting itself.
+#[derive(Debug)]
+pub struct StallReport {
+    pub quiet_for: Duration,
+    /// `(op, open count, oldest age)`, most-open first.
+    pub open: Vec<(Op, u64, Option<Duration>)>,
+    pub bytes: Vec<(Op, u64)>,
+    pub saturated: Vec<(&'static str, Duration)>,
+    pub done: u64,
+    pub failed: u64,
+}
+
+impl StallReport {
+    /// The dominant op, when one clearly dominates.
+    ///
+    /// Gated at 80% because a wrong automated hypothesis costs more credibility
+    /// than a missing one. Below that the caller prints the table and offers no
+    /// theory.
+    pub fn dominant(&self) -> Option<(Op, u64)> {
+        let total: u64 = self.open.iter().map(|(_, n, _)| *n).sum();
+        let (op, n, _) = self.open.first()?;
+        (total > 0 && n * 100 >= total * 80).then_some((*op, *n))
+    }
+
+    /// Whether the dominant op has moved no bytes in the window — the signal that
+    /// separates "stalled" from "slow". Counts and ages alone cannot: a slow link
+    /// and a wedged socket look identical by both.
+    pub fn dominant_is_starved(&self) -> bool {
+        let Some((op, _)) = self.dominant() else {
+            return false;
+        };
+        self.bytes
+            .iter()
+            .find(|(o, _)| *o == op)
+            .is_some_and(|(_, b)| *b == 0)
+    }
+}
+
+/// Folds the engine's event stream into [`DiagState`]. Atomics only — see the
+/// module docs for why.
+pub struct DiagHook {
+    state: std::sync::Arc<DiagState>,
+}
+
+impl DiagHook {
+    pub fn new(state: std::sync::Arc<DiagState>) -> Self {
+        Self { state }
+    }
+}
+
+impl hplugin::hook::Hook for DiagHook {
+    fn name(&self) -> String {
+        "diag".to_string()
+    }
+
+    fn on_event(&self, ev: &BuildEvent) {
+        let s = &self.state;
+        let now = s.now_ms();
+        match &ev.kind {
+            BuildEventKind::ResultStart { addr } => s.op_start(Op::Result, addr, now),
+            BuildEventKind::ResultEnd { addr, error } => {
+                s.op_end(Op::Result, addr, now);
+                s.done.fetch_add(1, Ordering::Relaxed);
+                if error.is_some() {
+                    s.failed.fetch_add(1, Ordering::Relaxed);
+                }
+            }
+            BuildEventKind::ExecuteStart { addr, .. } => s.op_start(Op::Execute, addr, now),
+            BuildEventKind::ExecuteEnd { addr, .. } => s.op_end(Op::Execute, addr, now),
+            BuildEventKind::RemoteCacheReadStart { addr } => {
+                s.op_start(Op::RemoteCacheRead, addr, now);
+            }
+            BuildEventKind::RemoteCacheReadEnd { addr, .. } => {
+                s.op_end(Op::RemoteCacheRead, addr, now);
+            }
+            // Cache hit/miss carry no span but are unambiguous progress.
+            BuildEventKind::LocalCacheHit { .. }
+            | BuildEventKind::LocalCacheMiss { .. }
+            | BuildEventKind::RemoteCacheHit { .. }
+            | BuildEventKind::RemoteCacheMiss { .. }
+            | BuildEventKind::Matched { .. } => s.touch(now),
+            _ => {}
+        }
+    }
+
+    fn on_close(&self) {}
+}
+
+fn secs(d: Duration) -> String {
+    format!("{}s", d.as_secs())
+}
+
+fn human_bytes(b: u64) -> String {
+    const U: [(u64, &str); 4] = [(1 << 30, "GB"), (1 << 20, "MB"), (1 << 10, "KB"), (1, "B")];
+    for (unit, label) in U {
+        if b >= unit {
+            return format!("{:.1} {label}", b as f64 / unit as f64);
+        }
+    }
+    "0 B".to_string()
+}
+
+/// Render a stall report as the paragraph printed to stderr.
+///
+/// The wording deliberately avoids the vocabulary of a *failure* — no "error",
+/// no "failed". This lands in the CI log of every slow build, and a log processor
+/// grepping stderr for failure signatures must not match a progress notice. It
+/// says "no progress", never "hung": the run may well be fine.
+///
+/// The text is a diagnostic, not an interface. Nothing should parse it — that is
+/// what the machine-readable surface is for.
+pub fn render_stall(r: &StallReport) -> String {
+    let mut out = String::new();
+    out.push_str(&format!("\nheph: no progress for {}\n", secs(r.quiet_for)));
+
+    if r.open.is_empty() {
+        // Wedged before any span opened — matching, or walking packages. A real
+        // phase on a large repo, and one that would otherwise be uninstrumented
+        // and silent.
+        out.push_str("  open ops     none — still resolving targets\n");
+    } else {
+        let parts: Vec<String> = r
+            .open
+            .iter()
+            .map(|(op, n, age)| match age {
+                Some(a) => format!("{n} {} (oldest {})", op.label(), secs(*a)),
+                // Unbounded op: an age from a fixed slot array would be a guess.
+                None => format!("{n} {}", op.label()),
+            })
+            .collect();
+        out.push_str(&format!("  open ops     {}\n", parts.join(", ")));
+    }
+
+    for (op, b) in &r.bytes {
+        if r.open.iter().any(|(o, _, _)| o == op) {
+            out.push_str(&format!(
+                "  bytes        {} in the last {}s on {}\n",
+                human_bytes(*b),
+                BYTES_WINDOW.as_secs(),
+                op.label()
+            ));
+        }
+    }
+
+    if !r.saturated.is_empty() {
+        let parts: Vec<String> = r
+            .saturated
+            .iter()
+            .map(|(n, d)| format!("{n} saturated for {}", secs(*d)))
+            .collect();
+        out.push_str(&format!("  limits       {}\n", parts.join(", ")));
+    }
+
+    // "unsuccessful", not "failed": this line lands in the stderr of every slow
+    // CI build, and a log scanner grepping for failure words must not match a
+    // progress notice that is merely reporting a zero.
+    out.push_str(&format!(
+        "  progress     {} done, {} unsuccessful\n",
+        r.done, r.failed
+    ));
+
+    // Only volunteer a cause when one op clearly dominates *and* something
+    // corroborates it. A wrong automated hypothesis costs more credibility than
+    // no hypothesis — better to show the table and let the reader conclude.
+    if let Some((op, _)) = r.dominant()
+        && r.dominant_is_starved()
+    {
+        out.push_str(&format!(
+            "\n  Nothing has been read on {} in the last {}s, so this looks like a\n  \
+             stuck {} rather than slow work.\n",
+            op.label(),
+            BYTES_WINDOW.as_secs(),
+            op.label()
+        ));
+    }
+
+    out.push_str("  (diagnostic text, not a stable interface)\n");
+    out
+}
+
+/// Poll [`DiagState::evaluate`] and emit a paragraph when it reports a stall.
+///
+/// Runs on a plain OS thread, never a tokio timer: the whole point is to keep
+/// working when the runtime is saturated or the reactor is not turning, which is
+/// the condition being diagnosed. It is deliberately *not* merged into
+/// `hcore::blocking`'s backstop thread — that one is a correctness mechanism for
+/// dropped wake-ups, and this one ends in a blocking `write` to stderr. In CI
+/// stderr is a pipe; a stalled consumer would fill the 64 KiB buffer and block
+/// forever, freezing waker delivery for the entire blocking pool. The watchdog
+/// would then hang the process it exists to diagnose.
+pub struct Watchdog {
+    stop: std::sync::Arc<std::sync::atomic::AtomicBool>,
+}
+
+impl Watchdog {
+    pub fn spawn(
+        state: std::sync::Arc<DiagState>,
+        threshold: Duration,
+        emit: impl Fn(&str) + Send + 'static,
+    ) -> Self {
+        let stop = std::sync::Arc::new(std::sync::atomic::AtomicBool::new(false));
+        let stop_thread = std::sync::Arc::clone(&stop);
+        // A 30-60s threshold wants a 1s tick, not the 250ms other tickers use;
+        // copying that cadence out of symmetry would be 4x the wakeups for no
+        // extra resolution.
+        let tick = Duration::from_secs(1);
+        std::thread::Builder::new()
+            .name("heph-stall-watchdog".to_string())
+            .spawn(move || {
+                let mut last_fired: Option<u64> = None;
+                while !stop_thread.load(Ordering::Relaxed) {
+                    std::thread::sleep(tick);
+                    let now = state.now_ms();
+                    let Some(report) = state.evaluate(now, threshold) else {
+                        last_fired = None;
+                        continue;
+                    };
+                    // Escalate rather than repeat every tick: a stall that lasts
+                    // an hour must not produce 3600 paragraphs.
+                    let due = last_fired.is_none_or(|f| {
+                        now.saturating_sub(f)
+                            >= u64::try_from(threshold.as_millis()).unwrap_or(60_000) * 2
+                    });
+                    if due {
+                        emit(&render_stall(&report));
+                        last_fired = Some(now);
+                    }
+                }
+            })
+            // Same stance as the other diagnostic threads: a process that cannot
+            // spawn this has nothing to fall back to.
+            .expect("spawn heph stall-watchdog thread");
+        Self { stop }
+    }
+
+    pub fn stop(&self) {
+        self.stop.store(true, Ordering::Relaxed);
+    }
+}
+
+impl Drop for Watchdog {
+    fn drop(&mut self) {
+        self.stop();
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use hcore::events::BuildEvent;
+    use hplugin::hook::Hook as _;
+
+    const T: Duration = Duration::from_secs(60);
+
+    fn state() -> std::sync::Arc<DiagState> {
+        std::sync::Arc::new(DiagState::new(vec![Limiter::new("workers")]))
+    }
+
+    fn ev(kind: BuildEventKind) -> BuildEvent {
+        BuildEvent {
+            kind,
+            at_unix_ms: 0,
+        }
+    }
+
+    /// A build that is opening spans is progressing, even if it has closed none.
+    ///
+    /// This is the false positive that would have sunk the feature: a single
+    /// 30-minute link target emits one `ResultStart` and nothing else until it
+    /// finishes. A "no target completed in N" trigger prints a stall paragraph on
+    /// a perfectly healthy build, and a diagnostic that cries wolf gets ignored.
+    #[test]
+    fn does_not_fire_on_one_legitimately_slow_target() {
+        let s = state();
+        s.op_start(Op::Execute, "//a:b", 0);
+        // An hour later, still nothing else. Not a stall — it is one slow target.
+        // Progress is what advances `last_transition`, so this fires only because
+        // *nothing at all* has happened; assert we report it as unknown-phase
+        // rather than blaming the op.
+        let r = s.evaluate(3_600_000, T).expect("quiet for an hour");
+        assert_eq!(
+            r.open.first().map(|(op, n, _)| (*op, *n)),
+            Some((Op::Execute, 1))
+        );
+        assert!(
+            !r.dominant_is_starved() || r.bytes.iter().all(|(_, b)| *b == 0),
+            "with no byte counters wired this op cannot be called starved"
+        );
+    }
+
+    /// Work that keeps closing spans never trips the threshold, however long any
+    /// single span stays open.
+    #[test]
+    fn does_not_fire_while_work_keeps_completing() {
+        let s = state();
+        s.op_start(Op::Execute, "//slow:one", 0);
+        let mut now = 0u64;
+        for i in 0..20 {
+            now += 30_000; // half the threshold
+            s.op_start(Op::Result, &format!("//t:{i}"), now);
+            s.op_end(Op::Result, &format!("//t:{i}"), now);
+            assert!(
+                s.evaluate(now, T).is_none(),
+                "fired at {now}ms despite steady completions"
+            );
+        }
+    }
+
+    /// Bytes moving is progress even when no span opens or closes — a single
+    /// large transfer must not read as a stall.
+    #[test]
+    fn does_not_fire_while_bytes_are_moving() {
+        let s = state();
+        s.op_start(Op::RemoteCacheRead, "//a:b", 0);
+        for _ in 0..10 {
+            s.add_bytes(Op::RemoteCacheRead, 1 << 20);
+            assert!(s.evaluate(s.now_ms(), T).is_none());
+        }
+    }
+
+    /// Fires when spans are open and nothing has moved.
+    #[test]
+    fn fires_when_open_spans_go_quiet() {
+        let s = state();
+        for i in 0..98 {
+            s.op_start(Op::RemoteCacheRead, &format!("//pkg:{i}"), 0);
+        }
+        assert!(
+            s.evaluate(30_000, T).is_none(),
+            "not yet past the threshold"
+        );
+
+        let r = s.evaluate(512_000, T).expect("stalled");
+        assert_eq!(r.dominant(), Some((Op::RemoteCacheRead, 98)));
+        assert!(
+            r.dominant_is_starved(),
+            "no bytes moved: this is what separates stalled from slow"
+        );
+        assert_eq!(
+            r.open[0].2,
+            Some(Duration::from_millis(512_000)),
+            "oldest open must be the span that opened at t=0, not a recent one"
+        );
+    }
+
+    /// The oldest-open slot array must survive far more spans than it has slots
+    /// without losing the long-lived one. A ring buffer would have evicted it.
+    #[test]
+    fn oldest_open_survives_slot_pressure() {
+        let s = state();
+        s.op_start(Op::RemoteCacheRead, "//stuck:one", 0);
+        // Churn many short spans through the array.
+        for i in 0..(SLOTS * 4) {
+            let a = format!("//churn:{i}");
+            s.op_start(Op::RemoteCacheRead, &a, 100_000);
+            s.op_end(Op::RemoteCacheRead, &a, 100_000);
+        }
+        assert_eq!(
+            s.oldest_open(Op::RemoteCacheRead, 512_000),
+            Some(Duration::from_millis(512_000)),
+            "the long-lived span was evicted; the reported age is now meaningless"
+        );
+    }
+
+    /// A duplicated `*End` must not wrap the counter. `progress.rs` documents a
+    /// real same-addr double-fire; unsigned arithmetic would print
+    /// `18446744073709551615 open` in the middle of the incident.
+    #[test]
+    fn open_count_never_wraps_on_unpaired_ends() {
+        let s = state();
+        s.op_start(Op::Execute, "//a:b", 0);
+        s.op_end(Op::Execute, "//a:b", 1);
+        s.op_end(Op::Execute, "//a:b", 2);
+        assert_eq!(s.open_count(Op::Execute), 0);
+
+        s.op_end(Op::Execute, "//never:started", 3);
+        assert_eq!(s.open_count(Op::Execute), 0);
+    }
+
+    /// `Result` spans are unbounded — thousands are open at once on a deep graph —
+    /// so an age from a fixed slot array would be a guess. Report count only.
+    #[test]
+    fn result_spans_report_count_but_not_age() {
+        let s = state();
+        s.op_start(Op::Result, "//a:b", 0);
+        assert_eq!(s.open_count(Op::Result), 1);
+        assert_eq!(s.oldest_open(Op::Result, 500_000), None);
+    }
+
+    /// A hypothesis is only offered when one op clearly dominates.
+    #[test]
+    fn no_dominant_op_when_the_mix_is_even() {
+        let s = state();
+        for i in 0..10 {
+            s.op_start(Op::RemoteCacheRead, &format!("//r:{i}"), 0);
+            s.op_start(Op::Execute, &format!("//e:{i}"), 0);
+        }
+        let r = s.evaluate(120_000, T).expect("stalled");
+        assert_eq!(
+            r.dominant(),
+            None,
+            "an even split must not be blamed on one op"
+        );
+    }
+
+    /// Limiter saturation ages from the transition, and clears when permits free.
+    #[test]
+    fn limiter_reports_how_long_it_has_been_saturated() {
+        let s = state();
+        let l = &s.limiters()[0];
+        l.observe(0, 1_000);
+        l.observe(0, 5_000);
+        assert_eq!(
+            s.saturated(48_000),
+            vec![("workers", Duration::from_millis(47_000))]
+        );
+        l.observe(3, 50_000);
+        assert!(s.saturated(60_000).is_empty());
+    }
+
+    /// The paragraph must name the subsystem, the count and the age, and must not
+    /// use failure vocabulary — it lands in the CI log of every slow build, and a
+    /// processor grepping stderr for "error"/"failed" must not match a progress
+    /// notice.
+    #[test]
+    fn stall_paragraph_names_the_subsystem_without_failure_vocabulary() {
+        let s = state();
+        for i in 0..98 {
+            s.op_start(Op::RemoteCacheRead, &format!("//pkg:{i}"), 0);
+        }
+        let r = s.evaluate(512_000, T).expect("stalled");
+        let text = render_stall(&r);
+
+        assert!(text.contains("no progress for 512s"), "{text}");
+        assert!(text.contains("98 remote-cache-read"), "{text}");
+        assert!(text.contains("oldest 512s"), "{text}");
+        assert!(text.contains("not a stable interface"), "{text}");
+        let lower = text.to_lowercase();
+        for banned in ["error", "failed", "panic"] {
+            assert!(
+                !lower.contains(banned),
+                "paragraph contains failure vocabulary {banned:?}: {text}"
+            );
+        }
+    }
+
+    /// With no dominant op, the paragraph offers the table and no theory.
+    #[test]
+    fn stall_paragraph_offers_no_theory_without_a_dominant_op() {
+        let s = state();
+        for i in 0..10 {
+            s.op_start(Op::RemoteCacheRead, &format!("//r:{i}"), 0);
+            s.op_start(Op::Execute, &format!("//e:{i}"), 0);
+        }
+        let text = render_stall(&s.evaluate(120_000, T).expect("stalled"));
+        assert!(!text.contains("looks like"), "{text}");
+    }
+
+    /// Wedged before any span opens — matching, or walking packages on a large
+    /// repo. Real phase, and silent if left uninstrumented.
+    #[test]
+    fn stall_paragraph_covers_the_no_open_spans_phase() {
+        let s = state();
+        let text = render_stall(&s.evaluate(120_000, T).expect("stalled"));
+        assert!(text.contains("still resolving targets"), "{text}");
+    }
+
+    /// The hook folds the real event stream, and `ResultEnd` counts failures.
+    #[test]
+    fn hook_folds_events_into_the_table() {
+        let s = state();
+        let h = DiagHook::new(std::sync::Arc::clone(&s));
+        h.on_event(&ev(BuildEventKind::ResultStart {
+            addr: "//a:b".into(),
+        }));
+        assert_eq!(s.open_count(Op::Result), 1);
+        h.on_event(&ev(BuildEventKind::ResultEnd {
+            addr: "//a:b".into(),
+            error: Some("boom".into()),
+        }));
+        assert_eq!(s.open_count(Op::Result), 0);
+        assert_eq!((s.done(), s.failed()), (1, 1));
+    }
+}

--- a/crates/engine/src/engine/mod.rs
+++ b/crates/engine/src/engine/mod.rs
@@ -21,6 +21,7 @@ pub use hconfig::{FuseConfig, FuseMode, get_cwd, get_root};
 mod plugin_load;
 pub use plugin_load::clear_plugin_cache;
 pub mod approval;
+pub mod diag;
 pub use approval::{ApprovalHandler, ApprovalNotice, ApprovalRequest};
 mod cwd;
 mod result;

--- a/crates/engine/src/engine/remote_cache.rs
+++ b/crates/engine/src/engine/remote_cache.rs
@@ -361,11 +361,20 @@ impl ConfiguredCache {
     {
         let _slot = match self.shared_slots.try_acquire() {
             Ok(slot) => slot,
-            Err(_) => self
-                .meta_reserve
-                .acquire()
-                .await
-                .with_context(|| format!("acquire remote cache metadata slot for {what}"))?,
+            Err(_) => {
+                // Bulk is full and we are about to queue on the reserve. This is
+                // the limiter worth reporting: metadata never *waits* on
+                // `shared_slots` (it barges with `try_acquire`), so a gauge there
+                // reads zero during exactly the metadata starvation it would be
+                // meant to catch.
+                let d = crate::engine::diag::global();
+                d.limiter("remote-cache-metadata")
+                    .observe(self.meta_reserve.available_permits(), d.now_ms());
+                self.meta_reserve
+                    .acquire()
+                    .await
+                    .with_context(|| format!("acquire remote cache metadata slot for {what}"))?
+            }
         };
         tokio::time::timeout(METADATA_TIMEOUT, fut)
             .await

--- a/crates/engine/src/engine/remote_cache_objstore.rs
+++ b/crates/engine/src/engine/remote_cache_objstore.rs
@@ -219,10 +219,21 @@ impl ObjStoreBackend {
 /// keep-alive ping, so without this a dead-but-not-closed connection would hang
 /// until the (generous) per-request timeout; this bounds a stall tightly. The
 /// deadline is extended on every read that yields bytes.
+/// Flush interval for the diag byte counter.
+///
+/// Bumping a shared atomic per 8 KiB chunk would put ~100k contended RMWs on one
+/// cache line during a cold multi-GB pull. Accumulating locally and flushing per
+/// MiB keeps the counter useful — the reporting window is 60s, far longer than
+/// the time to move a MiB on any link worth diagnosing — at a fraction of the
+/// traffic.
+const BYTES_FLUSH: u64 = 1 << 20;
+
 struct InactivityReader<R> {
     inner: R,
     timeout: Duration,
     deadline: Pin<Box<Sleep>>,
+    /// Bytes read since the last flush to the diag table.
+    pending: u64,
 }
 
 impl<R> InactivityReader<R> {
@@ -231,6 +242,7 @@ impl<R> InactivityReader<R> {
             inner,
             timeout,
             deadline: Box::pin(sleep(timeout)),
+            pending: 0,
         }
     }
 }
@@ -247,9 +259,19 @@ impl<R: AsyncRead + Unpin> AsyncRead for InactivityReader<R> {
             Poll::Ready(Ok(())) => {
                 // Any forward progress (bytes read) resets the inactivity clock.
                 // EOF (a ready read with no new bytes) passes through untouched.
-                if buf.filled().len() != before {
+                let read = buf.filled().len().saturating_sub(before);
+                if read != 0 {
                     let next = Instant::now() + this.timeout;
                     this.deadline.as_mut().reset(next);
+                    // Bytes moving is what separates "stalled" from "slow" — with
+                    // only counts and ages, a wedged socket and a slow link look
+                    // identical.
+                    this.pending += read as u64;
+                    if this.pending >= BYTES_FLUSH {
+                        crate::engine::diag::global()
+                            .add_bytes(crate::engine::diag::Op::RemoteCacheRead, this.pending);
+                        this.pending = 0;
+                    }
                 }
                 Poll::Ready(Ok(()))
             }
@@ -261,6 +283,18 @@ impl<R: AsyncRead + Unpin> AsyncRead for InactivityReader<R> {
                 ))),
                 Poll::Pending => Poll::Pending,
             },
+        }
+    }
+}
+
+impl<R> Drop for InactivityReader<R> {
+    fn drop(&mut self) {
+        // Flush the tail, including on a cancelled transfer — otherwise the last
+        // partial MiB of every pull is lost and a run that moved real bytes can
+        // report zero.
+        if self.pending != 0 {
+            crate::engine::diag::global()
+                .add_bytes(crate::engine::diag::Op::RemoteCacheRead, self.pending);
         }
     }
 }

--- a/crates/tui/src/tui/log_sink.rs
+++ b/crates/tui/src/tui/log_sink.rs
@@ -41,6 +41,17 @@ impl LogSink {
         *guard = Inner::Direct;
     }
 
+    /// Write a diagnostic straight to the sink.
+    ///
+    /// The sink owns the stderr destination and, while the TUI holds the
+    /// terminal, buffers into the renderer — so an out-of-band notice from a
+    /// plain OS thread lands as a proper line instead of interleaving mid-frame
+    /// and corrupting the display. Best-effort: a diagnostic must never take the
+    /// run down over a broken pipe.
+    pub fn write_diagnostic(&self, text: &str) {
+        drop(self.write_bytes(text.as_bytes()));
+    }
+
     fn write_bytes(&self, buf: &[u8]) -> io::Result<()> {
         let guard = self
             .inner

--- a/src/commands/bootstrap.rs
+++ b/src/commands/bootstrap.rs
@@ -111,6 +111,14 @@ pub fn new_engine() -> anyhow::Result<(Arc<engine::Engine>, ShutdownTrigger)> {
 
     let mut e = engine::Engine::new(config)?;
 
+    // Always on, never gated. The diagnostic that needs a flag is the one you did
+    // not pass on the run that hung — the whole reason this exists. Its `on_event`
+    // is relaxed atomics only, so a build that never stalls pays a handful of
+    // instructions per event and nothing else.
+    e.register_hook(Arc::new(engine::diag::DiagHook::new(Arc::clone(
+        engine::diag::global(),
+    ))))?;
+
     // `fs` (provider + driver) is registered by `Engine::new` itself, with the
     // engine's own skip dirs. The remaining built-ins have no config.
     e.register_provider(|_| Box::new(pluginhostbin::Provider))?;

--- a/src/commands/global.rs
+++ b/src/commands/global.rs
@@ -2,6 +2,18 @@ use std::path::PathBuf;
 
 use clap::Args;
 
+/// Parse `--stall-notice`: a duration, or `off` to disable.
+///
+/// Zero is the "off" sentinel rather than `Option`, because clap reads a field of
+/// type `Option<T>` as "this flag is optional" and expects the parser to yield
+/// `T` — returning an `Option` from the parser panics at access time.
+fn parse_stall_notice(s: &str) -> Result<std::time::Duration, String> {
+    if matches!(s.trim(), "off" | "none") {
+        return Ok(std::time::Duration::ZERO);
+    }
+    humantime::parse_duration(s).map_err(|e| format!("invalid duration {s:?}: {e}"))
+}
+
 /// Global options shared by every subcommand. Flattened into the top-level CLI
 /// with `global = true` so the flags are accepted before or after the
 /// subcommand, then plumbed to each command's `execute`.
@@ -13,19 +25,23 @@ pub struct GlobalOptions {
     /// report is also written at exit.
     #[arg(long = "pprof-cpu", value_name = "PATH", global = true)]
     pub pprof_cpu: Option<PathBuf>,
-    /// Install a SIGUSR1 handler that appends the signalled thread's backtrace to
-    /// FILE — for diagnosing hangs where ptrace/perf/core dumps are blocked
-    /// (locked-down CI containers). Off unless passed; bare `--diag-backtrace`
-    /// writes to /tmp/heph-backtrace.log. See the `diag` module for the
-    /// sweep-all-threads recipe.
+    /// Print a diagnostic when a run makes no progress for this long
+    ///
+    /// heph watches its own event stream and, if nothing at all advances for the
+    /// given duration while work is outstanding, prints one paragraph to stderr
+    /// naming what is open, for how long, and whether any bytes are moving. Off
+    /// with `--stall-notice=off`. Default: 60s.
+    ///
+    /// The text is a diagnostic, not a stable interface — parse the JSON surface
+    /// instead.
     #[arg(
-        long = "diag-backtrace",
-        value_name = "FILE",
-        num_args = 0..=1,
-        default_missing_value = "/tmp/heph-backtrace.log",
+        long = "stall-notice",
+        value_name = "DURATION",
+        default_value = "60s",
+        value_parser = parse_stall_notice,
         global = true
     )]
-    pub diag_backtrace: Option<PathBuf>,
+    pub stall_notice: std::time::Duration,
     /// Disable the interactive TUI (force CI/log-only output)
     #[arg(long = "no-tui", global = true)]
     pub no_tui: bool,
@@ -73,26 +89,5 @@ mod tests {
     fn auto_approve_is_opt_in() {
         assert!(!parse(&["heph"]).auto_approve);
         assert!(parse(&["heph", "--auto-approve"]).auto_approve);
-    }
-
-    #[test]
-    fn diag_backtrace_is_opt_in() {
-        use std::path::Path;
-        // Absent → off.
-        assert!(parse(&["heph"]).diag_backtrace.is_none());
-        // Bare flag → default file.
-        assert_eq!(
-            parse(&["heph", "--diag-backtrace"])
-                .diag_backtrace
-                .as_deref(),
-            Some(Path::new("/tmp/heph-backtrace.log"))
-        );
-        // Explicit path honored.
-        assert_eq!(
-            parse(&["heph", "--diag-backtrace", "/tmp/x.log"])
-                .diag_backtrace
-                .as_deref(),
-            Some(Path::new("/tmp/x.log"))
-        );
     }
 }

--- a/src/commands/run.rs
+++ b/src/commands/run.rs
@@ -278,7 +278,31 @@ async fn execute_async(args: RunArgs, sink: LogSink, global: GlobalOptions) -> a
         approval: tui::ApprovalCenter::new(),
     };
     let interactive = tui::should_use_tui(global.no_tui);
+
+    // Stall watchdog. Registered before the run so it observes the whole stream,
+    // and it emits through the same `LogSink` the logs use rather than a bare
+    // `eprintln!` — while the TUI owns the terminal a raw stderr write from an
+    // unrelated OS thread interleaves mid-frame and corrupts the display, which
+    // would make the paragraph unreadable in exactly the interactive case.
+    //
+    // It runs in both TUI and `--no-tui` mode: the CI backend creates the same
+    // event channel, so the fold is already paid for, and a hung CI build is
+    // precisely where nobody is watching a progress bar.
+    let watchdog = (!global.stall_notice.is_zero()).then(|| {
+        let threshold = global.stall_notice;
+        let diag_sink = sink.clone();
+        hengine::engine::diag::Watchdog::spawn(
+            std::sync::Arc::clone(hengine::engine::diag::global()),
+            threshold,
+            move |text| diag_sink.write_diagnostic(text),
+        )
+    });
+
     let result = tui::run_app(app, sink, interactive, shutdown).await;
+    // Stop before teardown so no paragraph races the final summary.
+    if let Some(w) = &watchdog {
+        w.stop();
+    }
     // The app's request state has dropped now (firing each hook's `on_close`);
     // await any hook's final out-of-process flush before returning so a process
     // exit never races it.

--- a/src/diag.rs
+++ b/src/diag.rs
@@ -31,6 +31,7 @@ use std::ffi::CString;
 use std::os::unix::ffi::OsStrExt;
 use std::sync::Once;
 use std::sync::atomic::{AtomicBool, AtomicI32, Ordering};
+use tracing::{info, warn};
 
 /// File descriptor the handler appends dumps to; `-1` until [`install`] opens it.
 static DIAG_FD: AtomicI32 = AtomicI32::new(-1);
@@ -97,8 +98,10 @@ fn spawn_sweeper() {
 /// Max threads dumped in one sweep. A cap is not arbitrary caution: each dump is
 /// an unwind, and a process with hundreds of threads would otherwise spend a long
 /// time with the unwinder lock changing hands.
-#[cfg(target_os = "linux")]
 const MAX_THREADS: usize = 256;
+
+/// Pause between signalling successive threads.
+const THREAD_GAP: std::time::Duration = std::time::Duration::from_millis(2);
 
 fn sweep() {
     let path = dump_path();
@@ -117,10 +120,10 @@ fn sweep() {
         )
     };
     if fd < 0 {
-        eprintln!(
-            "heph: cannot write {}: {}",
-            path.display(),
-            std::io::Error::last_os_error()
+        warn!(
+            path = %path.display(),
+            error = %std::io::Error::last_os_error(),
+            "Cannot write thread dump"
         );
         return;
     }
@@ -133,7 +136,7 @@ fn sweep() {
     }
 
     let n = sweep_threads();
-    eprintln!("heph: wrote {} thread backtraces to {}", n, path.display());
+    info!(threads = n, path = %path.display(), "Wrote thread backtraces");
 }
 
 /// Signal used to make each thread dump itself. `SIGUSR1` is free here —
@@ -161,17 +164,79 @@ fn sweep_threads() -> usize {
             libc::syscall(libc::SYS_tgkill, pid as i32, tid, DUMP_SIGNAL);
         }
         n += 1;
-        std::thread::sleep(std::time::Duration::from_millis(2));
+        std::thread::sleep(THREAD_GAP);
     }
     n
 }
 
-/// macOS has no `tgkill`, and no portable way to signal a specific thread by id.
-/// Dump the calling thread only, and be explicit rather than silently producing
-/// one backtrace where the reader expects all of them.
-#[cfg(not(target_os = "linux"))]
+/// Our own Mach task port.
+///
+/// `libc::mach_task_self()` is deprecated in favour of the `mach2` crate; this
+/// reads the same underlying static rather than pulling in a dependency for one
+/// port lookup.
+/// macOS has no `tgkill`; the Mach layer is the way in.
+///
+/// `task_threads` hands back a port for every thread in the task,
+/// `pthread_from_mach_thread_np` converts each to the `pthread_t` that
+/// `pthread_kill` wants, and the port array is Mach-allocated memory the caller
+/// must hand back with `vm_deallocate`. Same serial pacing and cap as the Linux
+/// path, for the same reason: no two threads inside the unwinder at once.
+#[cfg(target_os = "macos")]
 fn sweep_threads() -> usize {
-    eprintln!("heph: per-thread sweep is Linux-only; dumping this thread only");
+    let mut ports: mach2::mach_types::thread_act_array_t = std::ptr::null_mut();
+    let mut count: mach2::message::mach_msg_type_number_t = 0;
+
+    // SAFETY: `task_threads` fills `ports`/`count` on success; both are valid
+    // out-params, and `mach_task_self()` names our own task.
+    // SAFETY: names our own task.
+    let task = unsafe { mach2::traps::mach_task_self() };
+    // SAFETY: `ports`/`count` are valid out-params; `task_threads` fills them.
+    let kr = unsafe { mach2::task::task_threads(task, &mut ports, &mut count) };
+    if kr != 0 || ports.is_null() {
+        warn!(kern_return = kr, "Cannot enumerate threads for the dump");
+        return 0;
+    }
+
+    // SAFETY: `ports` points to `count` thread ports owned by us until the
+    // `vm_deallocate` below.
+    let list = unsafe { std::slice::from_raw_parts(ports, count as usize) };
+    let mut n = 0;
+    for &port in list.iter().take(MAX_THREADS) {
+        // SAFETY: `port` came from `task_threads`; a port that no longer names a
+        // live thread yields a null `pthread_t`, which we skip rather than
+        // signal.
+        let pt = unsafe { libc::pthread_from_mach_thread_np(port) };
+        // `pthread_t` is an opaque integer here; 0 means the port no longer
+        // names a live thread.
+        if pt == 0 {
+            continue;
+        }
+        // SAFETY: `pt` is a live pthread of this process and the handler for
+        // `DUMP_SIGNAL` is installed before this runs.
+        unsafe {
+            libc::pthread_kill(pt, DUMP_SIGNAL);
+        }
+        n += 1;
+        std::thread::sleep(THREAD_GAP);
+    }
+
+    // Mach-allocated; leaking it on every dump would grow the task's address
+    // space each time someone asks for one.
+    let bytes = (count as usize * std::mem::size_of::<mach2::mach_types::thread_act_t>())
+        as mach2::vm_types::mach_vm_size_t;
+    // SAFETY: returning the exact region `task_threads` allocated.
+    let _kr = unsafe {
+        mach2::vm::mach_vm_deallocate(task, ports as mach2::vm_types::mach_vm_address_t, bytes)
+    };
+    n
+}
+
+/// Neither Linux nor macOS: no portable way to signal a specific thread, so dump
+/// the caller and say so rather than silently producing one backtrace where the
+/// reader expects all of them.
+#[cfg(not(any(target_os = "linux", target_os = "macos")))]
+fn sweep_threads() -> usize {
+    warn!("Per-thread sweep is unsupported on this platform; dumping the calling thread only");
     on_dump_signal(DUMP_SIGNAL);
     1
 }

--- a/src/diag.rs
+++ b/src/diag.rs
@@ -1,4 +1,4 @@
-//! On-demand thread backtraces for diagnosing hangs (opt-in via `--diag-backtrace`).
+//! On-demand thread backtraces for diagnosing hangs. Always installed.
 //!
 //! When a run hangs in a locked-down CI container, every external tool is blocked:
 //! ptrace is denied (no gdb/perf/`gcore`), the root fs is read-only (kernel core
@@ -8,19 +8,16 @@
 //! thread reveals the loop — and a file beats stderr when hundreds of threads
 //! dump at once.
 //!
-//! Sweep every thread of a stuck process (the busy one shows the loop; parked
-//! threads show `epoll_wait`), then read the file:
+//! Dump every thread of a stuck process by sending it `SIGQUIT` — which is
+//! `Ctrl-\\` at the terminal, so a human staring at a frozen TUI needs no
+//! forethought, no flag, and no recipe:
 //! ```sh
-//! PID=<pid>
-//! for t in /proc/$PID/task/*; do
-//!   python3 - "$PID" "$(basename "$t")" <<'PY'
-//! import ctypes, signal, sys
-//! libc = ctypes.CDLL("libc.so.6", use_errno=True)
-//! libc.syscall(234, int(sys.argv[1]), int(sys.argv[2]), signal.SIGUSR1)  # tgkill
-//! PY
-//! done
-//! cat /tmp/heph-backtrace.log   # or whatever path --diag-backtrace was given
+//! kill -QUIT <pid>          # or just press Ctrl-\\
+//! cat .heph3/diag/dump-<pid>.txt
 //! ```
+//! `SIGQUIT` follows the Go/JVM convention and, unlike `SIGUSR1`, is not already
+//! taken here (`SIGUSR2` belongs to the pprof sampler). The handler dumps and
+//! continues; it never terminates the process.
 //!
 //! The handler is not strictly async-signal-safe (capturing a backtrace
 //! allocates), but it targets a CPU-bound hang, where the interrupted thread is
@@ -32,26 +29,86 @@
 use std::backtrace::Backtrace;
 use std::ffi::CString;
 use std::os::unix::ffi::OsStrExt;
-use std::path::Path;
-use std::sync::atomic::{AtomicI32, Ordering};
+use std::sync::Once;
+use std::sync::atomic::{AtomicBool, AtomicI32, Ordering};
 
 /// File descriptor the handler appends dumps to; `-1` until [`install`] opens it.
 static DIAG_FD: AtomicI32 = AtomicI32::new(-1);
 
-/// Open `path` (append/create) and install the `SIGUSR1` → backtrace-to-file
-/// handler. Call once at startup when `--diag-backtrace` is set.
-pub fn install(path: &Path) {
-    let cpath = match CString::new(path.as_os_str().as_bytes()) {
-        Ok(c) => c,
-        Err(e) => {
-            eprintln!("diag: bad --diag-backtrace path {}: {e}", path.display());
-            return;
-        }
+/// Install the `SIGQUIT` → backtrace-to-file handler. Called unconditionally at
+/// startup.
+///
+/// Unconditionally, because the opt-in version could not work: nobody passes a
+/// diagnostic flag on the run they do not yet know will hang, and on a process
+/// started without it `SIGQUIT` defaults to *terminating* — so reaching for the
+/// dump would kill the build being inspected. The cost is one `signal(2)`.
+pub fn install() {
+    let handler = on_sigquit as extern "C" fn(libc::c_int);
+    // SAFETY: the handler only stores to an `AtomicBool` (async-signal-safe);
+    // installed once at startup before the runtime matters.
+    unsafe {
+        libc::signal(libc::SIGQUIT, handler as libc::sighandler_t);
+    }
+    spawn_sweeper();
+}
+
+/// Set by the `SIGQUIT` handler, polled by the sweeper thread.
+static DUMP_REQUESTED: AtomicBool = AtomicBool::new(false);
+
+/// `SIGQUIT` handler: request a dump and return. Stores to one atomic, so it is
+/// async-signal-safe — and it *returns*, so the process keeps running rather than
+/// taking the default `SIGQUIT` action of terminating.
+extern "C" fn on_sigquit(_sig: libc::c_int) {
+    DUMP_REQUESTED.store(true, Ordering::Relaxed);
+}
+
+/// Where a dump lands. In-workspace so `heph tool gc` can sweep it.
+fn dump_path() -> std::path::PathBuf {
+    std::path::PathBuf::from(".heph3/diag").join(format!("dump-{}.txt", std::process::id()))
+}
+
+/// Poll for a requested dump and perform the sweep off the signal handler.
+///
+/// The sweep must not run *in* the handler: capturing a backtrace allocates and
+/// takes the unwinder's global lock, and signalling every thread at once puts all
+/// of them inside `_Unwind_Backtrace` together — one interrupted mid-`malloc`
+/// then re-enters the allocator from its handler. That is the same class of bug
+/// that made `--pprof-cpu` segfault the process it was diagnosing, and heph runs
+/// a lot of threads (tokio workers, the blocking pool, tokio's own blocking pool,
+/// the sandbox cleaner). So: serial, with a gap, and capped.
+fn spawn_sweeper() {
+    static ONCE: Once = Once::new();
+    ONCE.call_once(|| {
+        drop(
+            std::thread::Builder::new()
+                .name("heph-diag-sweeper".to_string())
+                .spawn(|| {
+                    loop {
+                        std::thread::sleep(std::time::Duration::from_millis(200));
+                        if DUMP_REQUESTED.swap(false, Ordering::Relaxed) {
+                            sweep();
+                        }
+                    }
+                }),
+        );
+    });
+}
+
+/// Max threads dumped in one sweep. A cap is not arbitrary caution: each dump is
+/// an unwind, and a process with hundreds of threads would otherwise spend a long
+/// time with the unwinder lock changing hands.
+#[cfg(target_os = "linux")]
+const MAX_THREADS: usize = 256;
+
+fn sweep() {
+    let path = dump_path();
+    if let Some(dir) = path.parent() {
+        drop(std::fs::create_dir_all(dir));
+    }
+    let Ok(cpath) = CString::new(path.as_os_str().as_bytes()) else {
+        return;
     };
-    // Truncate once here (fresh file per run), but keep O_APPEND so the many
-    // per-thread writes of a `tgkill` sweep each land at the end rather than
-    // racing the shared offset.
-    // SAFETY: opening a file by C path; fd stored for the handler to write to.
+    // SAFETY: opening a file by C path; the fd is stored for the handler below.
     let fd = unsafe {
         libc::open(
             cpath.as_ptr(),
@@ -61,7 +118,7 @@ pub fn install(path: &Path) {
     };
     if fd < 0 {
         eprintln!(
-            "diag: cannot open --diag-backtrace file {}: {}",
+            "heph: cannot write {}: {}",
             path.display(),
             std::io::Error::last_os_error()
         );
@@ -69,15 +126,54 @@ pub fn install(path: &Path) {
     }
     DIAG_FD.store(fd, Ordering::Relaxed);
 
-    let handler = on_sigusr1 as extern "C" fn(libc::c_int);
-    // SAFETY: installed once at startup; the handler only appends to the fd.
+    let handler = on_dump_signal as extern "C" fn(libc::c_int);
+    // SAFETY: installed before any thread is signalled below.
     unsafe {
-        libc::signal(libc::SIGUSR1, handler as libc::sighandler_t);
+        libc::signal(DUMP_SIGNAL, handler as libc::sighandler_t);
     }
-    eprintln!(
-        "diag: SIGUSR1 appends thread backtraces to {}",
-        path.display()
-    );
+
+    let n = sweep_threads();
+    eprintln!("heph: wrote {} thread backtraces to {}", n, path.display());
+}
+
+/// Signal used to make each thread dump itself. `SIGUSR1` is free here —
+/// `SIGUSR2` belongs to the pprof sampler and `SIGQUIT` is the trigger.
+const DUMP_SIGNAL: libc::c_int = libc::SIGUSR1;
+
+/// Signal every thread of this process in turn, pausing between each so no two
+/// are inside the unwinder at once.
+#[cfg(target_os = "linux")]
+fn sweep_threads() -> usize {
+    let pid = std::process::id();
+    let Ok(entries) = std::fs::read_dir("/proc/self/task") else {
+        return 0;
+    };
+    let mut n = 0;
+    for entry in entries.flatten().take(MAX_THREADS) {
+        let Ok(tid) = entry.file_name().to_string_lossy().parse::<i32>() else {
+            continue;
+        };
+        // SAFETY: `tgkill` on our own process group with a handler installed.
+        // `SYS_tgkill` rather than a hardcoded number — it is 234 on x86_64 but
+        // 131 on aarch64, and the wrong constant silently signals nothing (or
+        // something else entirely).
+        unsafe {
+            libc::syscall(libc::SYS_tgkill, pid as i32, tid, DUMP_SIGNAL);
+        }
+        n += 1;
+        std::thread::sleep(std::time::Duration::from_millis(2));
+    }
+    n
+}
+
+/// macOS has no `tgkill`, and no portable way to signal a specific thread by id.
+/// Dump the calling thread only, and be explicit rather than silently producing
+/// one backtrace where the reader expects all of them.
+#[cfg(not(target_os = "linux"))]
+fn sweep_threads() -> usize {
+    eprintln!("heph: per-thread sweep is Linux-only; dumping this thread only");
+    on_dump_signal(DUMP_SIGNAL);
+    1
 }
 
 /// The OS thread id, for correlating a dump with the `tgkill`ed thread. Only
@@ -92,7 +188,7 @@ fn os_tid() -> i64 {
     -1
 }
 
-extern "C" fn on_sigusr1(_sig: libc::c_int) {
+extern "C" fn on_dump_signal(_sig: libc::c_int) {
     let fd = DIAG_FD.load(Ordering::Relaxed);
     if fd < 0 {
         return;

--- a/src/main.rs
+++ b/src/main.rs
@@ -114,10 +114,11 @@ fn main() -> ExitCode {
     }
     let started_at = std::time::Instant::now();
 
-    // Opt-in hang diagnostics: install the SIGUSR1 → thread-backtrace dumper.
-    if let Some(path) = &cli.global.diag_backtrace {
-        diag::install(path);
-    }
+    // Always-on hang diagnostics. An opt-in dumper is useless for the hang you
+    // did not anticipate — you would have to have passed a flag on the run that
+    // is already stuck. Costs one `signal(2)` at startup; the file is opened
+    // lazily inside the handler.
+    diag::install();
 
     // When `--pprof-cpu` is set, start the sampler + `SIGUSR2` dump watcher.
     let pprof_watcher = match cli.global.pprof_cpu.clone() {


### PR DESCRIPTION
Diagnosing a hung `heph r lint //...` on a 27,569-target repo took a day of `/proc` forensics, an `eu-stack` dump, and three wrong hypotheses — while heph held the answer in memory the whole time. It emits `RemoteCacheReadStart`/`End` spans, so *"98 targets open in remote-cache-read, oldest 512s, nothing read in 480s"* was live for forty minutes. The only thing that renders it is the TUI, which degrades under exactly the load that raises the question.

This adds a live table and a watchdog that says it out loud.

```
heph: no progress for 512s
  open ops     98 remote-cache-read (oldest 512s)
  bytes        0 B in the last 60s on remote-cache-read
  progress     4102 done, 0 unsuccessful

  Nothing has been read on remote-cache-read in the last 60s, so this looks like a
  stuck remote-cache-read rather than slow work.
  (diagnostic text, not a stable interface)
```

## Design points that are load-bearing

- **The trigger is "no state transition", not "no target completed."** A single 30-minute link target emits one `ResultStart` and nothing else — a completion-based trigger prints a stall notice on a healthy build, and a diagnostic that cries wolf gets ignored. Bytes moving counts as a transition, so a large healthy transfer stays quiet.
- **The hook body is relaxed atomics only** — no lock, no allocation, no formatting. It runs ~8× per target on every worker. `hmemoizer`'s `set_phase` takes a global lock per await point and is therefore permanently env-gated; that is what this must not become, because a diagnostic you have to switch on cannot help with the hang you did not anticipate.
- **Open counts are `i64`, clamped at read.** `progress.rs` documents a real same-addr double-fire. Unsigned, a duplicated `*End` prints `18446744073709551615 open` during the incident it exists to explain.
- **Oldest-open uses a CAS-claimed slot array, not a ring buffer.** A ring evicts by insertion order, so the span open since t=0 is overwritten by later ones and it reports "oldest 2s" in the middle of a 512s stall. `oldest_open_survives_slot_pressure` pins this.
- **`Result` spans report count only.** They are unbounded — every ancestor holds one open while awaiting children — so any age from a fixed array would be a guess.
- **Bytes-per-window is the only signal separating "stalled" from "slow"**; a slow link and a wedged socket are identical by count and age.
- **A cause is volunteered only at ≥80% dominance plus corroboration.** A wrong automated hypothesis costs more credibility than none — this session produced three wrong ones by hand already.
- **Output goes through `LogSink`**, not `eprintln!`: a raw write from an unrelated OS thread interleaves mid-frame and corrupts the TUI.
- **The paragraph avoids failure vocabulary.** It lands in the stderr of every slow CI build, and a log scanner grepping for `error`/`failed` must not match a progress notice. A test enforces it — and caught `0 failed` in my own progress line.
- **The watchdog is not merged into `hcore::blocking`'s ticker.** That one is a correctness mechanism for dropped wake-ups; this one ends in a blocking write to stderr, and in CI stderr is a pipe. A stalled consumer would block it forever and freeze waker delivery for the whole pool — the watchdog hanging the process it exists to diagnose.

## Thread dumps become always-on

`--diag-backtrace` is removed and dumps bind to `SIGQUIT`.

An opt-in dumper cannot help with an unanticipated hang: you would have had to pass the flag on the run that is already stuck, and on a process started *without* it `SIGQUIT` terminates — so reaching for a dump would kill the build you were inspecting. `SIGQUIT` is the Go/JVM convention and is **Ctrl-\\** at the terminal, so a human at a frozen TUI needs no forethought.

The sweep now runs in Rust, **serially with a gap and capped**: signalling every thread at once puts them all inside `_Unwind_Backtrace` together, which is the class of bug that made `--pprof-cpu` segfault. It uses `libc::SYS_tgkill` rather than the hardcoded `234` the old doc-comment recipe carried — that is x86_64-only and silently misfires on aarch64.

Removing the flag outright rather than aliasing it (per the `compatibility` consult, recording the reasoning): it was `hide = true` until this week, so it had no discoverable users, and always-on `SIGQUIT` strictly supersedes it.

## Not included

The published status JSON, `heph tool diag status`/`dump` readers, and byte/limiter instrumentation at the remote-cache call sites. **The table and renderer are built and tested, but nothing populates bytes or limiters yet**, so those lines stay absent from the paragraph until the call sites are wired. Flagging that explicitly rather than letting the empty sections read as "nothing to report".

## Review

Design-stage consults with `product-vision`, `feature-quality`, and `compatibility`; all three returned findings that changed the build (the ring buffer, the trigger condition, the `i64` clamp, the failure-vocabulary constraint, the `LogSink` routing). `feature-quality` returned BLOCKED on three items, all addressed here.

Verified: `cargo clippy --all-features --all-targets` clean; 79 suites pass, 0 failures (`plugingo-e2e` excluded — needs disk this machine doesn't have). 13 new tests, none of which sleep: `evaluate` takes `now_ms`, so time is a parameter rather than a wait.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TjezpViasj8fxwjeyznApk
