### PR TITLE
ci: run the test suite on linux/arm64

### DIFF
--- a/.github/actions/setup-nix/action.yml
+++ b/.github/actions/setup-nix/action.yml
@@ -54,8 +54,12 @@ runs:
     - name: Cache Nix store
       uses: nix-community/cache-nix-action@v7
       with:
-        primary-key: nix-${{ runner.os }}-${{ hashFiles('devenv.lock', 'devenv.nix', 'devenv.yaml') }}
-        restore-prefixes-first-match: nix-${{ runner.os }}-
+        # Keyed on arch as well as OS: the store holds realized derivations for
+        # the runner's own system, so an arm64 runner restoring an x86_64 store
+        # registers paths it cannot execute — which surfaces as the "path is not
+        # valid" eval failure the repair step below exists to fight.
+        primary-key: nix-${{ runner.os }}-${{ runner.arch }}-${{ hashFiles('devenv.lock', 'devenv.nix', 'devenv.yaml') }}
+        restore-prefixes-first-match: nix-${{ runner.os }}-${{ runner.arch }}-
         # PRs are restore-only. Every PR ref used to save its own ~1.5 GB copy
         # per OS; with the repo's 10 GB Actions cache quota that LRU-evicted
         # master's copies before the next PR could read them, so jobs kept

--- a/.github/workflows/heph.yml
+++ b/.github/workflows/heph.yml
@@ -258,6 +258,15 @@ jobs:
           # syslibroot and fails to find `-lfuse`, so the (native arm64) macOS
           # runner uses plain `cargo build` — no cross needed there.
           #
+          # Both Linux targets go through zigbuild even though amd64 runs on a
+          # native runner (and arm64 could now, since the test job uses
+          # ubuntu-24.04-arm). This is about the glibc floor, not the host arch:
+          # zigbuild pins it independent of the runner image — the shipped
+          # binaries need at most GLIBC_2.30 — where a native build on
+          # ubuntu-24.04 would link 2.39 and stop running on RHEL 9 (2.34),
+          # Debian 12 (2.36), Ubuntu 22.04 (2.35) and Amazon Linux 2023 (2.34).
+          # Do not "simplify" this to a native cargo build.
+          #
           # The heph bin and the two plugin cdylibs build in ONE invocation. They
           # share nearly the whole workspace dep graph, and under the release
           # profile (thin-LTO + opt-level=3) each artifact's final codegen/LTO pass

--- a/.github/workflows/heph.yml
+++ b/.github/workflows/heph.yml
@@ -451,6 +451,16 @@ jobs:
             runs-on: ubuntu-latest
             target: x86_64-unknown-linux-gnu
 
+          # Linux ARM64 (Native). ubuntu-24.04-arm is free for public repos and
+          # is the only place aarch64-linux is exercised at all — the build job
+          # cross-compiles it, so without this job the target shipped with no
+          # test ever run against it. Pairs with darwin/arm64 to give the arch
+          # axis coverage on both OSes rather than only on macOS.
+          - os: linux
+            arch: arm64
+            runs-on: ubuntu-24.04-arm
+            target: aarch64-unknown-linux-gnu
+
           # macOS ARM64 (Apple Silicon natively runs on macos-latest)
           - os: darwin
             arch: arm64


### PR DESCRIPTION
Follow-up to #188, which documented the gap.

`aarch64-unknown-linux-gnu` is built (cross-compiled on an amd64 runner) and shipped, but the test matrix was `linux/amd64` + `darwin/arm64` only. So "Linux is covered" and "aarch64 is covered" were each true on exactly one axis, and the linux+aarch64 combination had never been exercised — most sharply for weakly-ordered atomics, where an `Ordering` mistake is invisible under x86_64's TSO and a live race on ARM.

`ubuntu-24.04-arm` is a [free hosted runner for public repositories](https://github.blog/changelog/2025-08-07-arm64-hosted-runners-for-public-repositories-are-now-generally-available/), so this is a native run, not qemu.

### Also: Nix store cache was keyed on OS only

`nix-${{ runner.os }}-…` would have handed the amd64 store to the arm64 runner, registering derivations it cannot execute — precisely the "path is not valid" eval failure the repair-and-retry step in `setup-nix` exists to fight. Now keyed on `runner.arch` too. The cargo registry cache was already keyed per target triple, so it needed nothing.

Consequence worth knowing: `save:` is master-only, so the new arm64 job runs with a cold Nix store until this lands on master and writes its first entry. Expect the first run or two to be slow.

### The build stays cross-compiled — deliberately

Worth writing down since this PR adds a native arm64 runner and the obvious next thought is "build there too". Don't. `cargo zigbuild` pins the glibc floor independent of the runner image: the shipped `heph_linux_arm64` requires at most `GLIBC_2.30`. A native build on `ubuntu-24.04-arm` would link glibc 2.39 and stop running on RHEL 9 (2.34), Debian 12 (2.36), Ubuntu 22.04 (2.35), and Amazon Linux 2023 (2.34). That is why linux/**amd64** goes through zigbuild too, on a native runner — the cross-compile is about the libc floor, not about the host arch.

Residual gap this leaves, small and accepted: the binary under test is the native one (runner glibc), while the binary shipped is the zigbuild one. Same source, different linker and libc version.

### Follow-ups, not in this PR

- `Test linux/arm64` is not in the master ruleset's required checks, so it is advisory until added. Adding it before this merges would block every PR on a check master's workflow does not yet produce — so it has to be done after.
- `darwin/amd64` is still neither built nor tested (the matrix entry is commented out — the Intel macOS runner costs money). Unchanged here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018BToKNxy78sTSZ74eh3N6M