### PR TITLE
fix(tui): render failures at the right time for each backend

### DIFF
--- a/crates/tui/src/tui/backend/interactive.rs
+++ b/crates/tui/src/tui/backend/interactive.rs
@@ -357,7 +357,9 @@ pub async fn run<A: App + 'static>(
                     // The tick is a synchronous draw-owning point, so the
                     // EventStream teardown/restore inside has no `.await` between
                     // them — the no-race invariant holds (see stderr_backend.rs).
-                    reanchor_after_resize(&mut terminal, &mut events, &mut cols, &mut rows);
+                    reanchor_after_resize(&mut terminal, &mut events, &mut cols, &mut rows, |h| {
+                        view.rows(h)
+                    });
                     needs_resize = false;
                 }
                 drain_logs_to_terminal(&mut terminal, &mut rx, cols);
@@ -458,9 +460,10 @@ fn reanchor_after_resize(
     events: &mut Option<EventStream>,
     cols: &mut u16,
     rows: &mut u16,
+    rows_for_height: impl Fn(u16) -> u16,
 ) {
     *events = None;
-    reanchor_inline(terminal, rows, |desired, _collapsed| {
+    reanchor_inline(terminal, rows, rows_for_height, |desired, _collapsed| {
         Terminal::with_options(
             StderrBackend::new(io::stderr()),
             TerminalOptions {
@@ -474,11 +477,12 @@ fn reanchor_after_resize(
     *cols = terminal_cols(terminal);
 }
 
-/// Re-anchor the inline viewport to the backend's current size, keeping it at
-/// ~1/3 of the new terminal height. Generic over the backend and over how a
-/// new terminal is built, so the ordering below can be exercised with a
-/// `TestBackend`; `reanchor_after_resize` layers the EventStream choreography on
-/// top.
+/// Re-anchor the inline viewport to the backend's current size. `rows_for_height`
+/// is the view's own sizing policy — the same one that sized the viewport at
+/// startup, so a resize can't quietly swap a bespoke view onto the progress
+/// view's ~1/3-of-height rule. Generic over the backend and over how a new
+/// terminal is built, so the ordering below can be exercised with a `TestBackend`;
+/// `reanchor_after_resize` layers the EventStream choreography on top.
 ///
 /// Two things must happen for a resize to land without artifacts:
 ///
@@ -498,11 +502,12 @@ fn reanchor_after_resize(
 fn reanchor_inline<B: Backend>(
     terminal: &mut Terminal<B>,
     rows: &mut u16,
+    rows_for_height: impl Fn(u16) -> u16,
     rebuild: impl FnOnce(u16, &mut Terminal<B>) -> Option<Terminal<B>>,
 ) {
     reanchor_terminal(terminal);
     let term_height = terminal.size().map(|r| r.height).unwrap_or(24).max(1);
-    let desired = crate::tui::progress::rows_for_height(term_height);
+    let desired = rows_for_height(term_height);
     if desired == *rows {
         return;
     }
@@ -820,22 +825,74 @@ mod tests {
         );
     }
 
+    /// Rows carrying at least one non-blank cell. The box is the only thing ever
+    /// drawn in these tests, so this is "where the box is" — and, more usefully,
+    /// "where anything the box left behind is".
+    fn painted_rows(buf: &ratatui::buffer::Buffer) -> Vec<u16> {
+        (buf.area.top()..buf.area.bottom())
+            .filter(|&y| {
+                (buf.area.left()..buf.area.right()).any(|x| !buf[(x, y)].symbol().trim().is_empty())
+            })
+            .collect()
+    }
+
+    /// An inline terminal anchored below `origin_row` with a progress box already
+    /// drawn into it, i.e. the state a live run is in when SIGWINCH arrives.
+    fn live_inline_terminal(
+        width: u16,
+        height: u16,
+        origin_row: u16,
+        rows: u16,
+    ) -> ratatui::Terminal<ratatui::backend::TestBackend> {
+        use crate::tui::app::TUIAppView;
+        use crate::tui::progress::TuiProgressView;
+        use ratatui::backend::{Backend, TestBackend};
+        use ratatui::layout::Position;
+        use ratatui::text::Text;
+        use ratatui::widgets::Paragraph;
+        use ratatui::{Terminal, TerminalOptions, Viewport};
+
+        let mut backend = TestBackend::new(width, height);
+        // Anchor away from row 0 so "cursor is at the viewport origin" is a real
+        // assertion and not accidentally satisfied by any cursor-home.
+        backend
+            .set_cursor_position(Position::new(0, origin_row))
+            .expect("park cursor");
+        let mut terminal = Terminal::with_options(
+            backend,
+            TerminalOptions {
+                viewport: Viewport::Inline(rows),
+            },
+        )
+        .expect("terminal");
+
+        let view = TuiProgressView::new("Running //a:b");
+        let lines = view.render("⠋", 10_000, width, rows);
+        terminal
+            .draw(|f| f.render_widget(Paragraph::new(Text::from(lines)), f.area()))
+            .expect("draw");
+        terminal
+    }
+
     /// Regression: a resize that changes the viewport row count rebuilds the
     /// inline terminal, and `Terminal::with_options` anchors the new viewport at
     /// wherever the cursor happens to be. `autoresize` leaves that cursor at the
     /// *bottom* of the live box, so rebuilding straight after it walks the box a
     /// box-height down the screen on every resize and strands the rows it used to
-    /// occupy as a blank gap. The path must collapse the viewport first, parking
-    /// the cursor back at the box's origin.
+    /// occupy as leftover artifacts. The path must collapse the viewport first,
+    /// parking the cursor back at the box's origin.
     ///
-    /// The rebuild hook lets the test observe the terminal at the exact moment
-    /// the new one would be built: the cursor must be at the viewport origin
-    /// (column 0), not mid-box.
+    /// The discriminating observable is *where the rebuilt box lands*, asserted
+    /// against the origin captured before the rebuild: `autoresize` has already
+    /// erased the old region, so a skipped collapse does not leave glyphs behind —
+    /// it silently re-anchors the box a box-height lower (measured: origin 5 → 12
+    /// on one resize) and leaves the rows above it as a blank gap that grows with
+    /// every subsequent resize.
     #[test]
-    fn resize_rebuild_anchors_at_the_box_origin_not_the_live_cursor() {
+    fn resize_rebuild_anchors_at_the_old_origin_not_the_live_cursor() {
         use super::reanchor_inline;
         use crate::tui::app::TUIAppView;
-        use crate::tui::progress::{MIN_PROGRESS_ROWS, TuiProgressView, rows_for_height};
+        use crate::tui::progress::{TuiProgressView, rows_for_height};
         use ratatui::Terminal;
         use ratatui::backend::{Backend, TestBackend};
         use ratatui::layout::Position;
@@ -844,30 +901,23 @@ mod tests {
         use ratatui::{TerminalOptions, Viewport};
 
         const WIDTH: u16 = 80;
+        const ORIGIN: u16 = 5;
 
-        let mut rows = MIN_PROGRESS_ROWS;
-        let mut terminal = Terminal::with_options(
-            TestBackend::new(WIDTH, 24),
-            TerminalOptions {
-                viewport: Viewport::Inline(rows),
-            },
-        )
-        .expect("terminal");
+        let mut rows = rows_for_height(24);
+        let mut terminal = live_inline_terminal(WIDTH, 24, ORIGIN, rows);
 
-        let view = TuiProgressView::new("Running //a:b");
-        let lines = view.render("⠋", 10_000, WIDTH, rows);
-        terminal
-            .draw(|f| f.render_widget(Paragraph::new(Text::from(lines)), f.area()))
-            .expect("draw");
-
-        // The draw left the cursor at the last cell it wrote — inside the box,
-        // not at its origin. That is what a naive rebuild would anchor to.
-        let after_draw = terminal
-            .backend_mut()
-            .get_cursor_position()
-            .expect("cursor");
+        let box_before: Vec<u16> = painted_rows(terminal.backend().buffer());
+        assert!(
+            box_before.first().is_some_and(|&y| y >= ORIGIN),
+            "precondition: the box is anchored below row 0, got {box_before:?}"
+        );
+        // The draw left the cursor at the last cell it wrote — inside the box, not
+        // at its origin. That is what a naive rebuild would anchor to.
         assert_ne!(
-            after_draw,
+            terminal
+                .backend_mut()
+                .get_cursor_position()
+                .expect("cursor"),
             Position::new(0, terminal.get_frame().area().y),
             "precondition: a live box leaves the cursor away from the viewport origin"
         );
@@ -883,32 +933,132 @@ mod tests {
         );
         terminal.backend_mut().resize(WIDTH, new_height);
 
-        let mut anchor_at_rebuild = None;
-        reanchor_inline(&mut terminal, &mut rows, |desired, collapsed| {
-            let origin = collapsed.get_frame().area().y;
-            let cursor = collapsed
-                .backend_mut()
-                .get_cursor_position()
-                .expect("cursor");
-            anchor_at_rebuild = Some((cursor, origin));
-            Terminal::with_options(
-                TestBackend::new(WIDTH, new_height),
-                TerminalOptions {
-                    viewport: Viewport::Inline(desired),
-                },
-            )
-            .ok()
-        });
-
-        let (cursor, origin) = anchor_at_rebuild.expect("rebuild hook ran");
-        assert_eq!(
-            cursor,
-            Position::new(0, origin),
-            "the rebuilt viewport must anchor at the old box's origin, not the live cursor"
+        // `autoresize` (the first thing `reanchor_inline` does) recomputes the
+        // inline anchor; that is the origin the rebuilt viewport has to reuse.
+        let origin_before = terminal.get_frame().area().y;
+        reanchor_inline(
+            &mut terminal,
+            &mut rows,
+            rows_for_height,
+            |desired, collapsed| {
+                // Carry the backend across, exactly as production does — the rebuild
+                // re-wraps the same stderr, it does not get a fresh screen.
+                Terminal::with_options(
+                    collapsed.backend().clone(),
+                    TerminalOptions {
+                        viewport: Viewport::Inline(desired),
+                    },
+                )
+                .ok()
+            },
         );
+        assert_eq!(rows, expected_rows, "viewport adopts the new row count");
         assert_eq!(
-            rows, expected_rows,
-            "viewport should adopt the new row count"
+            terminal.get_frame().area().y,
+            origin_before,
+            "the rebuilt viewport must reuse the old box's rows; anchoring on the \
+             live cursor walks it down the screen instead"
+        );
+
+        let view = TuiProgressView::new("Running //a:b");
+        let lines = view.render("⠋", 10_000, WIDTH, rows);
+        terminal
+            .draw(|f| f.render_widget(Paragraph::new(Text::from(lines)), f.area()))
+            .expect("redraw");
+        assert_eq!(
+            painted_rows(terminal.backend().buffer()),
+            (origin_before..origin_before + rows).collect::<Vec<_>>(),
+            "exactly one box, starting where the old one did"
+        );
+    }
+
+    /// The common resize: a width-only drag. The row count is unchanged, so the
+    /// terminal must not be rebuilt at all — `autoresize` alone re-anchors and
+    /// resets the back buffer, and the box reflows to the new width in place.
+    #[test]
+    fn width_only_resize_reflows_without_rebuilding() {
+        use super::reanchor_inline;
+        use crate::tui::app::TUIAppView;
+        use crate::tui::progress::{TuiProgressView, rows_for_height};
+        use ratatui::backend::Backend;
+        use ratatui::text::Text;
+        use ratatui::widgets::Paragraph;
+
+        let start_rows = rows_for_height(24);
+        let mut rows = start_rows;
+        let mut terminal = live_inline_terminal(80, 24, 5, rows);
+        // Same height, so `rows_for_height` is unchanged — only the width moved.
+        terminal.backend_mut().resize(50, 24);
+
+        let mut rebuilds = 0;
+        reanchor_inline(
+            &mut terminal,
+            &mut rows,
+            rows_for_height,
+            |_desired, _collapsed| {
+                rebuilds += 1;
+                None
+            },
+        );
+        assert_eq!(rebuilds, 0, "no row-count change, no rebuild");
+        assert_eq!(rows, start_rows);
+
+        let view = TuiProgressView::new("Running //a:b");
+        let lines = view.render("⠋", 10_000, 50, rows);
+        terminal
+            .draw(|f| f.render_widget(Paragraph::new(Text::from(lines)), f.area()))
+            .expect("redraw");
+        let origin = terminal.get_frame().area().y;
+        assert_eq!(
+            painted_rows(terminal.backend().buffer()),
+            (origin..origin + rows).collect::<Vec<_>>(),
+            "the reflowed box is the only thing on screen — no stale wide-row tails"
+        );
+    }
+
+    /// `Terminal::with_options` re-queries the cursor and can fail on a terminal
+    /// that never answers. The old viewport has already been collapsed by then, so
+    /// the kept terminal must still repaint cleanly rather than sit blank.
+    #[test]
+    fn failed_rebuild_keeps_the_old_terminal_usable() {
+        use super::reanchor_inline;
+        use crate::tui::app::TUIAppView;
+        use crate::tui::progress::{TuiProgressView, rows_for_height};
+        use ratatui::backend::Backend;
+        use ratatui::text::Text;
+        use ratatui::widgets::Paragraph;
+
+        const WIDTH: u16 = 80;
+        let start_rows = rows_for_height(24);
+        let mut rows = start_rows;
+        let mut terminal = live_inline_terminal(WIDTH, 24, 5, rows);
+        terminal.backend_mut().resize(WIDTH, 60);
+        assert_ne!(rows_for_height(60), rows, "must hit the rebuild branch");
+
+        let origin_before = terminal.get_frame().area().y;
+        reanchor_inline(
+            &mut terminal,
+            &mut rows,
+            rows_for_height,
+            |_desired, _collapsed| None,
+        );
+        assert_eq!(rows, start_rows, "row count only moves on a success");
+        assert_eq!(
+            terminal.get_frame().area().y,
+            origin_before,
+            "a failed rebuild leaves the viewport where the collapse parked it"
+        );
+
+        let view = TuiProgressView::new("Running //a:b");
+        let lines = view.render("⠋", 10_000, WIDTH, rows);
+        terminal
+            .draw(|f| f.render_widget(Paragraph::new(Text::from(lines)), f.area()))
+            .expect("redraw");
+        let origin = terminal.get_frame().area().y;
+        assert_eq!(
+            painted_rows(terminal.backend().buffer()),
+            (origin..origin + rows).collect::<Vec<_>>(),
+            "the collapsed viewport repaints in full after a failed rebuild"
         );
     }
 

--- a/src/commands/errors.rs
+++ b/src/commands/errors.rs
@@ -3,6 +3,7 @@
 //! hand-rolled format: a `×` title, a `╰─▶` cause line, and (when present) the
 //! process log tail in a framed `log` box.
 
+use std::io;
 use std::sync::Arc;
 
 use crossterm::style::Stylize;
@@ -142,15 +143,17 @@ fn render_target_failure(f: &TargetFailure, color: bool) -> String {
     out
 }
 
-/// Render each recorded target failure to stderr, separated by a blank line.
-pub fn render_failures(failures: &[Arc<TargetFailure>]) {
-    let color = color_enabled();
+/// Render each recorded target failure, separated by a blank line. Pure, so the
+/// exact bytes the user sees are assertable without capturing stderr.
+fn render_failures_to_string(failures: &[Arc<TargetFailure>], color: bool) -> String {
+    let mut out = String::new();
     for (i, f) in failures.iter().enumerate() {
         if i > 0 {
-            eprintln!();
+            out.push('\n');
         }
-        eprint!("{}", render_target_failure(f, color));
+        out.push_str(&render_target_failure(f, color));
     }
+    out
 }
 
 /// True when the error chain carries a Ctrl-C cancellation. A cancellation is
@@ -169,9 +172,9 @@ pub fn is_cancelled(e: &anyhow::Error) -> bool {
 /// success output), it resolves them (pausing the TUI only for the success/error
 /// output that prints inline):
 ///
-/// - registry non-empty → carry the failures out as [`PendingFailures`], to be
-///   rendered by `render_anyhow` *after* the viewport is torn down; the returned
-///   `res` is a collateral marker, dropped;
+/// - registry non-empty → exit with [`FailedTargets`]; interactive mode defers the
+///   render to `render_anyhow` (after the viewport is torn down), non-interactive
+///   mode renders here. The returned `res` is a collateral marker, dropped;
 /// - registry empty, `res` Ok → bind the value as `$val` and run `$body` (may use
 ///   `?`), then exit `Ok`;
 /// - registry empty, `res` Err → a cancellation exits `cancelled`; any other error
@@ -195,14 +198,29 @@ macro_rules! finalize {
             .is_some_and($crate::commands::errors::is_cancelled);
         let failures = $rs.take_failures();
         if !failures.is_empty() {
-            // Do NOT render here: mid-run the TUI is only *paused*, so the resume
-            // re-anchor and the final viewport collapse would wipe the boxes off
-            // screen. Carry the failures out; `render_anyhow` in `main` prints
-            // them once the viewport is fully torn down. `res` is a collateral
-            // marker, dropped.
-            ::core::result::Result::<(), ::anyhow::Error>::Err(
-                $crate::commands::errors::PendingFailures(failures).into(),
-            )
+            // `res` is a collateral marker here — dropped either way.
+            if $ctx.interactive() {
+                // Do NOT render here: mid-run the TUI is only *paused*, so the
+                // resume re-anchor and the final viewport collapse would wipe the
+                // boxes off screen. Carry the failures out; `render_anyhow` in
+                // `main` prints them once the viewport is fully torn down.
+                ::anyhow::Result::<()>::Err(
+                    $crate::commands::errors::FailedTargets::deferred(failures).into_error(),
+                )
+            } else {
+                // No viewport, so nothing ever repaints stderr and there is no
+                // reason to defer. Print at the failure site: deferring to `main`
+                // would push the diagnostics behind the backend's end-of-run
+                // summary *and* its unbounded background-upload drain, invert the
+                // errors-then-verdict order every other build tool prints, and lose
+                // them entirely if a second ctrl-c aborts during that drain.
+                // (Interactive has no such choice — teardown must come first, so it
+                // necessarily prints verdict-then-errors.)
+                ::anyhow::Result::<()>::Err(
+                    $crate::commands::errors::FailedTargets::reported_to_stderr(failures)
+                        .into_error(),
+                )
+            }
         } else {
             let printed: ::anyhow::Result<()> = $crate::tui::paused!($ctx, {
                 match res {
@@ -221,8 +239,7 @@ macro_rules! finalize {
 pub(crate) use finalize;
 
 /// Map the cancelled flag to an exit result for the no-failures path. Registry
-/// failures never reach here — they are carried out as [`PendingFailures`] and
-/// rendered by `render_anyhow`.
+/// failures never reach here — they exit as [`FailedTargets`].
 pub(crate) fn finish_exit(cancelled: bool) -> anyhow::Result<()> {
     if cancelled {
         anyhow::bail!("cancelled");
@@ -230,43 +247,143 @@ pub(crate) fn finish_exit(cancelled: bool) -> anyhow::Result<()> {
     Ok(())
 }
 
-/// Per-target failures collected in the request registry, carried up so
-/// [`render_anyhow`] can render their rich boxes *after* the interactive viewport
-/// is fully torn down. Rendering them mid-run (while the TUI is only paused) let
-/// the resume re-anchor and the final viewport collapse wipe the boxes off
-/// screen; deferring to `main`'s post-teardown `render_anyhow` prints them on a
-/// terminal nothing repaints over. Carrying the failures — rather than a bare
-/// "already rendered" marker — is what lets that late render reproduce the boxes.
+/// The per-target failures collected in the request registry, carried up so the
+/// process exits non-zero with its diagnostics on screen. The two constructors
+/// differ only in *when* the boxes are printed:
+///
+/// - [`FailedTargets::deferred`] (interactive) — nothing is printed yet. Mid-run
+///   the TUI is only *paused*, so a render there is re-anchored over by the resume
+///   and then erased by the final viewport collapse. [`render_anyhow`], called
+///   from `main` after full teardown, prints the boxes on a terminal nothing
+///   repaints over.
+/// - [`FailedTargets::reported`] (non-interactive) — the constructor itself does
+///   the printing, at the failure site so the boxes precede the end-of-run summary
+///   and the background-work drain. `render_anyhow` only claims the error.
+///
+/// Either way the failures ride *in* the error rather than behind an opaque
+/// "already rendered" marker, so the late render can reproduce them and
+/// downcasting callers (telemetry's failure classifier) still see a target
+/// failure.
 #[derive(Debug)]
-pub struct PendingFailures(pub Vec<Arc<TargetFailure>>);
+pub struct FailedTargets {
+    failures: Vec<Arc<TargetFailure>>,
+    /// Already printed at the failure site; `render_anyhow` must not print twice.
+    rendered: bool,
+}
 
-impl std::fmt::Display for PendingFailures {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        write!(f, "build failed")
+impl FailedTargets {
+    /// Failures not yet printed — [`render_anyhow`] renders them.
+    pub fn deferred(failures: Vec<Arc<TargetFailure>>) -> Self {
+        Self {
+            failures,
+            rendered: false,
+        }
+    }
+
+    /// Print the failures to `out` and record that it happened, so
+    /// [`render_anyhow`] stays quiet later.
+    ///
+    /// Printing lives *in* the constructor on purpose: `rendered` is a promise
+    /// about what is already on the terminal, and a caller that sets it without
+    /// printing produces a non-zero exit with no diagnostics at all — the exact
+    /// bug this module exists to prevent, and one no test of the marker can see.
+    pub fn reported(
+        failures: Vec<Arc<TargetFailure>>,
+        out: &mut dyn io::Write,
+        color: bool,
+    ) -> Self {
+        // A failed write to the terminal is not actionable, and the exit code still
+        // has to carry the failure out.
+        drop(write!(
+            out,
+            "{}",
+            render_failures_to_string(&failures, color)
+        ));
+        Self {
+            failures,
+            rendered: true,
+        }
+    }
+
+    /// [`FailedTargets::reported`] against the real stderr — what `finalize!` uses.
+    pub fn reported_to_stderr(failures: Vec<Arc<TargetFailure>>) -> Self {
+        Self::reported(failures, &mut io::stderr(), color_enabled())
+    }
+
+    pub fn failures(&self) -> &[Arc<TargetFailure>] {
+        &self.failures
+    }
+
+    /// Build the `anyhow::Error` that carries these failures out of `finalize!`.
+    ///
+    /// A representative [`TargetFailure`] is the chain's root, with `FailedTargets`
+    /// layered on top as context.
+    ///
+    /// The asymmetry that makes this necessary: `anyhow::Error::chain()` traverses
+    /// `Error::source()`, but `downcast_ref` does *not* — it only walks the context
+    /// layers anyhow itself built. So a failure reachable only through `source()`,
+    /// or held in a struct field, is invisible to every caller that asks "did a
+    /// target fail?" (telemetry's classifier), which would bucket the tool's most
+    /// common failure as a generic error. `TargetFailure` is `Clone` for exactly
+    /// this kind of resurfacing.
+    pub fn into_error(self) -> anyhow::Error {
+        match self.failures.first().map(|f| f.as_ref().clone()) {
+            Some(representative) => anyhow::Error::new(representative).context(self),
+            None => anyhow::Error::new(self),
+        }
     }
 }
 
-impl std::error::Error for PendingFailures {}
+impl std::fmt::Display for FailedTargets {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "{} target(s) failed", self.failures.len())
+    }
+}
 
-/// Render an `anyhow::Error` to stderr. If a [`TargetFailure`] is in the chain
-/// it gets the rich box treatment; otherwise the error's cause chain is printed
-/// in the same `×` / `╰─▶` style. Always renders something, so callers need no
-/// fallback.
+impl std::error::Error for FailedTargets {}
+
+/// Render an `anyhow::Error` to stderr, returning whether it was claimed. If a
+/// [`TargetFailure`] is in the chain it gets the rich box treatment; otherwise the
+/// error's cause chain is printed in the same `×` / `╰─▶` style. `false` means
+/// nothing renderable was found and the caller should fall back to its own log; a
+/// claimed error may still print nothing, when it was already reported at the
+/// failure site.
 pub fn render_anyhow(e: &anyhow::Error) -> bool {
-    // Registry failures deferred from `finalize!`: render their rich boxes now
-    // that the viewport is torn down and nothing repaints over stderr.
-    if let Some(pf) = downcast_chain_ref::<PendingFailures>(e) {
-        render_failures(&pf.0);
-        return true;
+    match render_anyhow_to_string(e, color_enabled()) {
+        Some(out) => {
+            eprint!("{out}");
+            true
+        }
+        None => false,
+    }
+}
+
+/// The bytes [`render_anyhow`] would write, or `None` when the error carries
+/// nothing renderable and the caller should fall back to its own logging. Pure
+/// and colour-explicit so each arm is assertable without capturing stderr.
+///
+/// `Some("")` is a deliberate case: [`FailedTargets::reported`] already
+/// printed at the failure site, so the error is handled but adds no output.
+fn render_anyhow_to_string(e: &anyhow::Error, color: bool) -> Option<String> {
+    // Registry failures from `finalize!`. Interactive runs deferred their render
+    // to here — the viewport is torn down and nothing repaints over stderr now.
+    if let Some(ft) = downcast_chain_ref::<FailedTargets>(e) {
+        // An empty set is not a failure anyone can act on: claim nothing so the
+        // caller logs rather than exiting non-zero in silence.
+        if ft.failures().is_empty() {
+            return None;
+        }
+        if ft.rendered {
+            return Some(String::new());
+        }
+        return Some(render_failures_to_string(ft.failures(), color));
     }
     if let Some(tf) = downcast_chain_ref::<TargetFailure>(e) {
-        eprint!("{}", render_target_failure(tf, color_enabled()));
-        return true;
+        return Some(render_target_failure(tf, color));
     }
     // A frozen-check failure that arrived outside a `TargetFailure` still gets the
     // framed diff treatment so CI output is legible.
     if let Some(fc) = downcast_chain_ref::<FrozenCheckError>(e) {
-        let color = color_enabled();
         let cross = if color {
             format!("{}", "×".red())
         } else {
@@ -274,20 +391,16 @@ pub fn render_anyhow(e: &anyhow::Error) -> bool {
         };
         let mut out = format!("{cross} frozen check failed: {}\n", fc.addr.format());
         render_diff_box(&mut out, &fc.diff, color);
-        eprint!("{out}");
-        return true;
+        return Some(out);
     }
     let frames: Vec<String> = e.chain().map(|c| c.to_string()).collect();
-    let Some(top) = frames.first() else {
-        return false;
-    };
+    let top = frames.first()?;
     let mut out = format!("× {top}\n");
     let rest = frames.get(1..).unwrap_or(&[]);
     if !rest.is_empty() {
         out.push_str(&format!("╰─▶ {}\n", rest.join(": ")));
     }
-    eprint!("{out}");
-    true
+    Some(out)
 }
 
 #[cfg(test)]
@@ -325,25 +438,206 @@ mod tests {
         assert!(finish_exit(false).is_ok());
     }
 
-    #[test]
-    fn render_anyhow_renders_deferred_pending_failures() {
-        // Regression: in interactive TUI mode the registry failures used to be
-        // printed mid-run inside a `paused!` block, where the resume re-anchor +
-        // final viewport collapse wiped them. `finalize!` now carries them out as
-        // `PendingFailures`; `render_anyhow` (called post-teardown in `main`) must
-        // reproduce the rich boxes for every carried failure and claim the error
-        // as handled so nothing extra is logged.
+    /// Two registry failures, wrapped in a context frame the way `finalize!`'s
+    /// caller chain wraps them.
+    fn two_failures() -> Vec<Arc<TargetFailure>> {
         let a = crate::htaddr::parse_addr("//simple_fail:d1").unwrap();
         let b = crate::htaddr::parse_addr("//simple_fail:d2").unwrap();
-        let fa = TargetFailure::new(a, None, anyhow::anyhow!("boom a"));
-        let fb = TargetFailure::new(b, None, anyhow::anyhow!("boom b"));
-        let e = anyhow::Error::new(PendingFailures(vec![Arc::new(fa), Arc::new(fb)]))
-            .context("2 target(s) failed");
-        assert!(render_anyhow(&e));
-        // The carried failures survive the wrapping context so the late render can
-        // reach them (they would be lost if `finalize!` had only kept a marker).
-        let pf = downcast_chain_ref::<PendingFailures>(&e).expect("carried failures");
-        assert_eq!(pf.0.len(), 2);
+        vec![
+            Arc::new(TargetFailure::new(a, None, anyhow::anyhow!("boom a"))),
+            Arc::new(TargetFailure::new(b, None, anyhow::anyhow!("boom b"))),
+        ]
+    }
+
+    #[test]
+    fn render_anyhow_reproduces_every_deferred_failure_box() {
+        // Regression: in interactive TUI mode the registry failures used to be
+        // printed mid-run inside a `paused!` block, where the resume re-anchor +
+        // final viewport collapse wiped them. `finalize!` now carries them out and
+        // `render_anyhow` (called post-teardown in `main`) reproduces the boxes.
+        //
+        // Asserting the exact bytes is the point: a `render_anyhow(&e) == true`
+        // check passes even with the `FailedTargets` arm deleted, because the
+        // generic cause-chain fallback also claims the error — it just prints one
+        // plain line instead of two boxes.
+        let e = FailedTargets::deferred(two_failures()).into_error();
+        let out = render_anyhow_to_string(&e, false).expect("handled");
+        assert_eq!(
+            out,
+            "\
+× target failed: //simple_fail:d1
+╰─▶ boom a
+
+× target failed: //simple_fail:d2
+╰─▶ boom b
+"
+        );
+    }
+
+    #[test]
+    fn render_anyhow_stays_quiet_for_failures_rendered_at_the_site() {
+        // Non-interactive runs print the boxes at the failure site so they land
+        // ahead of the summary and the background drain. The error still travels up
+        // for the exit code, and `render_anyhow` must claim it — but print nothing,
+        // or every failing CI run shows its diagnostics twice.
+        let mut sink: Vec<u8> = Vec::new();
+        let e = FailedTargets::reported(two_failures(), &mut sink, false).into_error();
+        // The constructor is what printed them — the only way to make the `rendered`
+        // promise — so the flag cannot drift from what is actually on the terminal.
+        assert_eq!(
+            String::from_utf8(sink).expect("utf8"),
+            render_failures_to_string(&two_failures(), false),
+            "the boxes go out at the failure site, in full"
+        );
+        assert_eq!(render_anyhow_to_string(&e, false), Some(String::new()));
+        assert!(render_anyhow(&e), "still counts as handled");
+    }
+
+    #[test]
+    fn empty_failed_targets_is_not_claimed_as_handled() {
+        // `finalize!` guards on a non-empty registry, so this is latent — but an
+        // empty set used to render nothing *and* report itself handled, which is a
+        // non-zero exit with no output at all. Fall through to `main`'s log instead.
+        let e = FailedTargets::deferred(vec![]).into_error();
+        assert_eq!(render_anyhow_to_string(&e, false), None);
+    }
+
+    #[test]
+    fn failed_targets_stays_downcastable_as_a_target_failure() {
+        // Telemetry's classifier asks `downcast_chain_ref::<TargetFailure>`, which
+        // searches anyhow's context layers and not `Error::source()`. Holding the
+        // failures in a struct field alone would therefore report the tool's most
+        // common failure mode as a generic error; `into_error` keeps a
+        // representative failure in the chain so both downcasts land.
+        let e = FailedTargets::deferred(two_failures());
+        assert_eq!(e.to_string(), "2 target(s) failed");
+        let e = e.into_error();
+        let tf = downcast_chain_ref::<TargetFailure>(&e).expect("classifiable");
+        assert_eq!(tf.addr.format(), "//simple_fail:d1");
+        let ft = downcast_chain_ref::<FailedTargets>(&e).expect("all failures carried");
+        assert_eq!(ft.failures().len(), 2);
+        // And the render still goes through the `FailedTargets` arm — the whole set,
+        // not just the representative that makes the downcast work.
+        assert_eq!(
+            render_anyhow_to_string(&e, false),
+            Some(render_failures_to_string(&two_failures(), false))
+        );
+    }
+
+    /// `finalize!` is duck-typed over the app context and the request state — it
+    /// only ever calls `interactive()`, `pause()` and `take_failures()` — so the
+    /// branch it takes can be driven without an engine or a terminal.
+    struct FakeCtx {
+        interactive: bool,
+        pauses: std::cell::Cell<usize>,
+    }
+
+    struct FakeGuard;
+
+    impl FakeCtx {
+        fn new(interactive: bool) -> Self {
+            Self {
+                interactive,
+                pauses: std::cell::Cell::new(0),
+            }
+        }
+        fn interactive(&self) -> bool {
+            self.interactive
+        }
+        async fn pause(&self) -> FakeGuard {
+            self.pauses.set(self.pauses.get() + 1);
+            FakeGuard
+        }
+    }
+
+    struct FakeRs(std::cell::RefCell<Vec<Arc<TargetFailure>>>);
+
+    impl FakeRs {
+        fn new(failures: Vec<Arc<TargetFailure>>) -> Self {
+            Self(std::cell::RefCell::new(failures))
+        }
+        fn take_failures(&self) -> Vec<Arc<TargetFailure>> {
+            std::mem::take(&mut *self.0.borrow_mut())
+        }
+    }
+
+    #[tokio::test]
+    async fn finalize_defers_the_render_only_when_interactive() -> anyhow::Result<()> {
+        // Interactive: the boxes must NOT be printed here. Mid-run the TUI is only
+        // paused, so anything printed under `paused!` is re-anchored over by the
+        // resume and erased by the final viewport collapse. Carry them out instead,
+        // without pausing at all.
+        let ctx = FakeCtx::new(true);
+        let rs = FakeRs::new(two_failures());
+        let res: anyhow::Result<u8> = Ok(1);
+        let e = finalize!(ctx, rs, res, _v => { Ok(()) }).unwrap_err();
+        let ft = downcast_chain_ref::<FailedTargets>(&e).expect("carried out");
+        assert!(!ft.rendered, "interactive defers to render_anyhow");
+        assert_eq!(ft.failures().len(), 2);
+        assert_eq!(ctx.pauses.get(), 0, "no pause on the failure path");
+
+        // Non-interactive: no viewport, nothing repaints stderr — render here so
+        // the boxes precede the end-of-run summary and the background drain.
+        let ctx = FakeCtx::new(false);
+        let rs = FakeRs::new(two_failures());
+        let res: anyhow::Result<u8> = Ok(1);
+        let e = finalize!(ctx, rs, res, _v => { Ok(()) }).unwrap_err();
+        let ft = downcast_chain_ref::<FailedTargets>(&e).expect("carried out");
+        assert!(
+            ft.rendered,
+            "already printed; render_anyhow must stay quiet"
+        );
+        assert_eq!(ft.failures().len(), 2);
+        assert_eq!(ctx.pauses.get(), 0);
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn finalize_prefers_failures_over_cancellation() -> anyhow::Result<()> {
+        // A cancellation that arrives alongside recorded failures must still surface
+        // the failures — the targets genuinely failed, and ctrl-c after the fact
+        // does not make that less true.
+        for interactive in [true, false] {
+            let ctx = FakeCtx::new(interactive);
+            let rs = FakeRs::new(two_failures());
+            let res: anyhow::Result<u8> = Err(anyhow::Error::new(CancelledError));
+            let e = finalize!(ctx, rs, res, _v => { Ok(()) }).unwrap_err();
+            assert!(
+                downcast_chain_ref::<FailedTargets>(&e).is_some(),
+                "interactive={interactive}: failures outrank the cancellation"
+            );
+        }
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn finalize_runs_the_success_body_paused_when_the_registry_is_clean() -> anyhow::Result<()>
+    {
+        let ctx = FakeCtx::new(true);
+        let rs = FakeRs::new(vec![]);
+        let res: anyhow::Result<u8> = Ok(7);
+        let mut got = 0;
+        finalize!(ctx, rs, res, v => { got = v; Ok(()) }).unwrap();
+        assert_eq!(got, 7, "the success value reaches the body");
+        assert_eq!(
+            ctx.pauses.get(),
+            1,
+            "inline output prints with the TUI paused"
+        );
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn finalize_reports_a_clean_cancellation_without_running_the_body() -> anyhow::Result<()>
+    {
+        let ctx = FakeCtx::new(true);
+        let rs = FakeRs::new(vec![]);
+        let res: anyhow::Result<u8> = Err(anyhow::Error::new(CancelledError));
+        let mut ran = false;
+        let e = finalize!(ctx, rs, res, _v => { ran = true; Ok(()) }).unwrap_err();
+        assert_eq!(e.to_string(), "cancelled");
+        assert!(!ran);
+        Ok(())
     }
 
     #[test]


### PR DESCRIPTION
Follow-up to #145. That PR deferred every registry failure to `render_anyhow`, which runs from `main` after full teardown. That is required in interactive mode — mid-run the TUI is only *paused*, so anything printed under `paused!` is re-anchored over by the resume and then erased by the final viewport collapse. It is wrong everywhere else.

## The regression

`finalize!` runs inside the app future, so the CI backend's `view.finish()` and its background-work drain both come *after* it. Deferring unconditionally moved non-interactive output from

```
boxes → drain logs → summary
```

to

```
summary → drain (unbounded; "waiting for background cache uploads…" every 5s)
        → await_hooks → boxes
```

That inverts the errors-then-verdict order every other build tool prints, pushes time-to-first-diagnostic behind the whole upload drain, and loses the diagnostics entirely if a second ctrl-c aborts inside that window (`bootstrap.rs` exits 130 there). Since `run` has no `--json`, stderr is the only machine-readable channel for a failing run — that ordering is API.

**Fix:** gate the deferral on `ctx.interactive()`. There is no viewport in CI mode and nothing repaints stderr, so the boxes are printed at the failure site.

## Along the way

- `PendingFailures` → `FailedTargets`, with the print folded into the `reported` constructor. The `rendered` flag is a promise about what is already on the terminal; a caller that sets it without printing yields a non-zero exit with no diagnostics, and no test of the marker alone can see that. Making the constructor do the printing makes the flag unforgeable.
- `into_error` keeps a cloned representative `TargetFailure` at the root of the anyhow chain. `downcast_ref` walks anyhow's context layers but *not* `Error::source()`, so failures held only in a struct field are invisible to telemetry's classifier — which was bucketing the tool's most common failure as a generic `"error"`.
- `Display` is now `"{n} target(s) failed"`. `query`, `inspect`, `validate` and `tool gc` all finalize through this, and none of them are builds.
- An empty `FailedTargets` no longer claims to be handled — it used to print nothing and return `true`, i.e. exit non-zero in total silence.
- `render_anyhow` splits into a pure `render_anyhow_to_string(e, color)`.
- `reanchor_inline` takes the view's own `rows()` policy instead of hardcoding the progress view's, which is what sized the viewport at startup.

## Tests

Both tests in #145 were unfalsifiable.

`render_anyhow_renders_deferred_pending_failures` passed with the entire fix deleted: `assert!(render_anyhow(&e))` is satisfied by the generic cause-chain fallback, which claims the error and prints one plain line instead of two boxes. It now asserts the exact rendered bytes. `finalize!` — the actual fix site, 17 call sites — had no tests at all; it gains four branch tests over a duck-typed context, including the failures-outrank-cancellation precedence that `finish_exit` stopped covering when it lost its `no_failures` argument.

The resize test asserted `collapse_inline_viewport`'s own postcondition. `autoresize` has already erased the region by then, so a skipped collapse strands no glyphs — it silently re-anchors the box lower (measured: origin 5 → 12 on one resize) and grows a blank gap on every subsequent resize. The test now pins the origin across the rebuild, carrying the backend through so the assertion is discriminating, and covers the width-only drag and a failing rebuild.

Every new test was mutation-checked. Removing the `FailedTargets` arm reddens 4; forcing always-defer, 1; removing the collapse, 1; making `reported` stop printing, 1.

## Checks

`cargo clippy --all-targets -- -D warnings` clean, `cargo fmt --check` clean, 103 heph + 84 tui lib tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01M5FmwZ7TkZeX9ey3CTutV8