### PR TITLE
fix(plugin): guard the last two stabby dyn constructions

### DIFF
--- a/crates/plugin-sdk/src/supervisor.rs
+++ b/crates/plugin-sdk/src/supervisor.rs
@@ -116,7 +116,7 @@ mod tests {
     }
 
     fn wrap(sup: RecordingSupervisor) -> DynSupervisor {
-        stabby::boxed::Box::new(sup).into()
+        hplugin_stabby::vtable::dynify(stabby::boxed::Box::new(sup))
     }
 
     #[test]

--- a/crates/plugin-stabby/src/host.rs
+++ b/crates/plugin-stabby/src/host.rs
@@ -127,7 +127,7 @@ pub struct HostSupervisor;
 impl HostSupervisor {
     /// Wrap as an ABI-stable [`DynSupervisor`] to pass over the seam.
     pub fn wrap() -> DynSupervisor {
-        stabby::boxed::Box::new(HostSupervisor).into()
+        dynify(stabby::boxed::Box::new(HostSupervisor))
     }
 }
 
@@ -365,5 +365,64 @@ impl StableExecutor for HostExecutor {
                 },
             }
         }))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{HostLogSink, HostSupervisor};
+    use crate::abi::{DynRead, StableRead, StableReadDyn};
+    use stabby::vec::Vec as SVec;
+
+    /// A distinct `StableRead` implementor per `N`: each monomorphization is its
+    /// own source type, so each construction is a FIRST-USE insert into stabby's
+    /// process-global vtable registry. This is the mutation side of the race.
+    struct Churn<const N: usize>;
+
+    impl<const N: usize> StableRead for Churn<N> {
+        extern "C" fn read_chunk(&self) -> SVec<u8> {
+            SVec::from([N as u8].as_slice())
+        }
+    }
+
+    /// Keep the registry mutating while other threads read it.
+    macro_rules! churn {
+        ($($n:literal),* $(,)?) => {
+            $({
+                let handle: DynRead = crate::vtable::dynify(stabby::boxed::Box::new(Churn::<$n>));
+                let got = handle.read_chunk();
+                assert_eq!(got.as_slice(), [$n as u8], "vtable dispatched to the wrong impl");
+            })*
+        };
+    }
+
+    /// The host's `wrap` constructors run on the plugin-load path, which is driven
+    /// under `rayon::into_par_iter` — so they race sibling first-use vtable inserts
+    /// coming from other plugins loading concurrently. Built with a bare `.into()`
+    /// a `wrap` reads the registry root without the guard and can clone a node
+    /// another thread just freed, coming back with a null vtable slice and
+    /// aborting the process (non-unwinding, so it is not catchable). Every one of
+    /// them must go through `dynify`.
+    #[test]
+    fn host_wrap_constructors_are_registry_safe_under_concurrent_first_use() {
+        std::thread::scope(|scope| {
+            for i in 0..16 {
+                scope.spawn(move || {
+                    if i % 2 == 0 {
+                        // Reader side: repeated lookups of an already-registered
+                        // vtable, which is what a freed root corrupts.
+                        for _ in 0..256 {
+                            let _sup = HostSupervisor::wrap();
+                            let _sink = HostLogSink::wrap();
+                        }
+                    } else {
+                        churn!(
+                            0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19,
+                            20, 21, 22, 23, 24, 25, 26, 27, 28, 29, 30, 31,
+                        );
+                    }
+                });
+            }
+        });
     }
 }


### PR DESCRIPTION
## Problem

`HostSupervisor::wrap` (`crates/plugin-stabby/src/host.rs:130`) built its `DynSupervisor` with a bare `.into()` instead of `vtable::dynify`, so it read stabby's process-global `VTABLES` root **without the registry lock**.

`plugin_load.rs:91-98` drives plugin loads under `rayon::into_par_iter`, so that read races a sibling plugin's first-use vtable insert — which compare-exchanges a new root in and drops the old one. The reader clones a node that was just freed, walks it, and can come back with a null vtable slice: a **non-unwinding abort** in `NonNull::new_unchecked`, at engine construction, before any target runs.

`vtable.rs:1-28` already documents this exact hazard and states the rule: *"EVERY stabby dyn construction in the workspace must go through this instead of a bare `.into()`"*.

## Fix

These were the only two unguarded constructions left — the other 30 already use `dynify`:

- `plugin-stabby/src/host.rs:130` — `HostSupervisor::wrap`, on the plugin-load path.
- `plugin-sdk/src/supervisor.rs:119` — test-only `wrap`, building into plugin-sdk's own copy of the registry.

## Test

The existing `vtable::tests::concurrent_first_use_vtable_registration_is_sound` only exercises `dynify`, so it structurally could not catch this.

The new `host::tests::host_wrap_constructors_are_registry_safe_under_concurrent_first_use` drives the **real** host `wrap` entry points as the reader side against a churn of first-use inserts from sibling threads.

Verified by reverting the fix:

| | failures |
|---|---|
| bare `.into()` | **11 / 30** |
| `dynify` | 0 / 30 |

## Notes

Found by a concurrency audit of the threading model at 100k-target scale; this was the only finding in the process-abort class.

Lint enforcement is left to a follow-up: `disallowed-methods` cannot target this today, because every legitimate call site also names `stabby::boxed::Box::new` as `dynify`'s argument. Making it lintable means changing `dynify` to box internally and updating all 30 call sites — a mechanical refactor that does not belong in a soundness fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01A76DChMohieGMbRbnV1E7x