### PR TITLE
fix(engine): forbid a nested hash recompute from taking the result lock

### DIFF
--- a/crates/engine/src/engine/request_state.rs
+++ b/crates/engine/src/engine/request_state.rs
@@ -569,7 +569,14 @@ impl Engine {
         log_tail_lines: usize,
         approval: Option<Arc<dyn crate::engine::approval::ApprovalHandler>>,
     ) -> Arc<RequestState> {
-        self.new_state_inner(fail_fast, events, bg_pending, log_tail_lines, approval, false)
+        self.new_state_inner(
+            fail_fast,
+            events,
+            bg_pending,
+            log_tail_lines,
+            approval,
+            false,
+        )
     }
 
     /// A request that re-reads the tree from *inside* an in-flight resolution.

--- a/crates/engine/src/engine/request_state.rs
+++ b/crates/engine/src/engine/request_state.rs
@@ -247,6 +247,23 @@ pub struct RequestStateData {
     /// fails with a clear error. Shared via `Arc<RequestStateData>`, so child
     /// states inherit it.
     pub approval: Option<Arc<dyn crate::engine::approval::ApprovalHandler>>,
+    /// This request may hash, probe and read, but must never take the exclusive
+    /// per-addr result lock.
+    ///
+    /// Set only by [`Engine::new_hash_only_state`], which is used to re-read the
+    /// tree from *inside* an in-flight resolution — the in_place write-back guard
+    /// and the fixpoint recompute. Those nested requests share the engine's one
+    /// `ResultLock` with the request they are nested inside, but not its
+    /// `mem_locked_result` — which is the memoizer that makes per-addr
+    /// acquisition idempotent within a request. So a nested write acquire
+    /// contends its own outer request's riding read guard, which is held until
+    /// the nested call returns: a self-deadlock, not contention.
+    ///
+    /// A cacheable miss therefore answers [`HashUnknownError`] instead of
+    /// building. Targets that take no lock at all (`@heph/fs`, see
+    /// `resolve_locked_inner`'s `skip_lock`) still execute normally — re-reading
+    /// the tree is the entire point of these requests.
+    pub hash_only: bool,
 }
 
 /// One frame of the live resolution path (the breadcrumb chain). Built as an
@@ -305,6 +322,12 @@ impl RequestState {
     /// `sandbox_cleaner::enqueue`, or to the renderer so it can poll for drain.
     pub fn bg_pending(&self) -> crate::engine::sandbox_cleaner::PendingCounter {
         Arc::clone(&self.data.bg_pending)
+    }
+
+    /// True when this request may hash, probe and read but must never take the
+    /// exclusive per-addr result lock. See [`RequestStateData::hash_only`].
+    pub fn hash_only(&self) -> bool {
+        self.data.hash_only
     }
 
     /// Records a genuinely-failing target's rich diagnostic. First-writer-wins:
@@ -546,6 +569,41 @@ impl Engine {
         log_tail_lines: usize,
         approval: Option<Arc<dyn crate::engine::approval::ApprovalHandler>>,
     ) -> Arc<RequestState> {
+        self.new_state_inner(fail_fast, events, bg_pending, log_tail_lines, approval, false)
+    }
+
+    /// A request that re-reads the tree from *inside* an in-flight resolution.
+    ///
+    /// `parent` is the addr being resolved, and is not optional: `meta`'s dep walk
+    /// derives `is_top` from `RequestState::parent`, so a parent-less nested
+    /// request would promote every direct dep to a top-level frame — running each
+    /// one's own in_place write-back guard, which spins yet another nested
+    /// request per level.
+    ///
+    /// The returned request is [`hash_only`](RequestStateData::hash_only): it may
+    /// not build, so it can never contend the per-addr result lock its own caller
+    /// is holding.
+    pub fn new_hash_only_state(self: &Arc<Self>, parent: Addr) -> Arc<RequestState> {
+        self.new_state_inner(
+            true,
+            None,
+            Arc::new(std::sync::atomic::AtomicUsize::new(0)),
+            Self::DEFAULT_LOG_TAIL_LINES,
+            None,
+            true,
+        )
+        .with_parent(parent)
+    }
+
+    fn new_state_inner(
+        self: &Arc<Self>,
+        fail_fast: bool,
+        events: Option<crate::engine::event::EventSender>,
+        bg_pending: crate::engine::sandbox_cleaner::PendingCounter,
+        log_tail_lines: usize,
+        approval: Option<Arc<dyn crate::engine::approval::ApprovalHandler>>,
+        hash_only: bool,
+    ) -> Arc<RequestState> {
         // Unique per top-level request. `with_parent`/`with_skip_provider`
         // children share this `RequestStateData` (and thus this id), so a request
         // subtree keys into one bucket of any per-request cache (e.g. pluginfs's
@@ -579,6 +637,7 @@ impl Engine {
             bg_pending,
             failures: Mutex::new(indexmap::IndexMap::new()),
             approval,
+            hash_only,
         });
 
         let state = Arc::new(RequestState {

--- a/crates/engine/src/engine/result.rs
+++ b/crates/engine/src/engine/result.rs
@@ -2,8 +2,8 @@ use crate::engine::Engine;
 use crate::engine::driver::targetdef::{Input, TargetDef};
 use crate::engine::driver::{ApplyTransitiveRequest, ParseRequest, outputartifact};
 use crate::engine::error::{
-    CancelledError, CycleError, MultiError, ProcessFailed, TargetFailure, TargetNotFoundError,
-    UpstreamFailed,
+    CancelledError, CycleError, HashUnknownError, MultiError, ProcessFailed, TargetFailure,
+    TargetNotFoundError, UpstreamFailed,
 };
 use crate::engine::provider::{
     GetError, GetRequest, GetResponse, ListRequest, ProbeRequest, ProviderExecutor, State,
@@ -700,6 +700,15 @@ fn classify_failure(
     // so the cycle surfaces directly to the caller (and never gets masked behind
     // an `UpstreamFailed` marker or duplicated into the failure registry).
     if downcast_chain_ref::<CycleError>(&e).is_some() {
+        return e;
+    }
+
+    // "This hash-only request may not build" is a property of the request, not a
+    // failure of the target. Nothing is wrong with the dep; we simply declined to
+    // build it. Propagate unchanged so the caller can recognise it — the fixpoint
+    // recompute treats it as "skip", and the in_place write-back guard needs to
+    // say "could not confirm", not "dependency failed".
+    if downcast_chain_ref::<HashUnknownError>(&e).is_some() {
         return e;
     }
 
@@ -1530,6 +1539,13 @@ impl Engine {
             let _w = if skip_lock {
                 None
             } else {
+                // A hash-only request must not take the write lock — its own
+                // caller is holding guards it will not release until we return.
+                // Reading the tree is what these requests are for, and that is
+                // exactly the `skip_lock` branch above; anything else is a build.
+                if rs.hash_only() {
+                    return Err(HashUnknownError { addr: addr.clone() }.into());
+                }
                 Some(
                     self.acquire_with_notice(&rs, addr, self.result_lock().write(addr, ctoken))
                         .await?,
@@ -1570,6 +1586,14 @@ impl Engine {
         //    write lock directly — after a miss we'll almost certainly execute,
         //    so this skips the upgradable→upgrade two-step. It also serializes
         //    the execute phase per addr, replacing the old exclusive result lock.
+        //
+        //    Unless this is a hash-only request. Then the write acquire below
+        //    would contend a riding read held by the very request we are nested
+        //    inside, which cannot release it until we return. Answer "unknown"
+        //    and let the caller decide — that is a deadlock, not contention.
+        if rs.hash_only() {
+            return Err(HashUnknownError { addr: addr.clone() }.into());
+        }
         drop(read);
         let write = self
             .acquire_with_notice(&rs, addr, self.result_lock().write(addr, ctoken))
@@ -2165,7 +2189,7 @@ impl Engine {
 
         let addr = &opts.def.target.addr;
         let current = Arc::clone(&self)
-            .meta(self.new_state(), addr)
+            .meta(self.new_hash_only_state(addr.clone()), addr)
             .await
             .with_context(|| {
                 format!(
@@ -2236,11 +2260,18 @@ impl Engine {
         let addr = opts.def.target.addr.clone();
         // Fresh request → fs inputs re-stat the post-write-back tree, yielding the
         // exact hashin the NEXT run will compute.
-        let fresh = self.new_state();
+        let fresh = self.new_hash_only_state(addr.clone());
         let fixpoint = match Arc::clone(&self).meta(fresh, &addr).await {
             Ok(m) => m.hashin,
             Err(e) => {
                 // Optimization only: the primary entry is already cached.
+                //
+                // `HashUnknownError` lands here whenever a cacheable dep is not
+                // cached at its post-write-back inputs — which is exactly the
+                // shape whose fixpoint would be unsound anyway: the recomputed
+                // key folds that dep's NEW hashout, while the artifacts being
+                // filed under it were produced from the old one. Skipping is
+                // both the safe answer and the correct one.
                 tracing::debug!(error = %format!("{e:#}"), %addr, "fixpoint: meta recompute failed");
                 return Ok(());
             }
@@ -5783,6 +5814,135 @@ mod tests {
             labels: vec![],
             ..Default::default()
         }
+    }
+
+    /// Like [`codegen_run_target`] but with extra deps beyond the introspect
+    /// target — used to put a *cacheable* sibling in an in_place target's dep
+    /// closure.
+    fn codegen_run_target_with_deps(
+        addr: &str,
+        codegen: &str,
+        paths: &[&str],
+        run: &str,
+        extra_deps: &[&str],
+    ) -> pluginstatictarget::Target {
+        let mut t = codegen_run_target(addr, codegen, paths, run);
+        if let Some(d) = t.deps.get_mut("") {
+            d.extend(extra_deps.iter().map(|s| (*s).to_string()));
+        }
+        t
+    }
+
+    /// Cacheable bash target that takes `deps` and does nothing else. Its `hashin`
+    /// therefore tracks those deps exactly.
+    fn bash_target(addr: &str, deps: &[&str]) -> pluginstatictarget::Target {
+        let mut deps_map = HashMap::new();
+        deps_map.insert("".to_string(), deps.iter().map(|s| (*s).to_string()).collect());
+        pluginstatictarget::Target {
+            addr: addr.to_string(),
+            driver: "bash".to_string(),
+            run: Some("true".to_string()),
+            out: HashMap::new(),
+            codegen: None,
+            deps: deps_map,
+            labels: vec![],
+            ..Default::default()
+        }
+    }
+
+    /// The invariant behind the fix, on its own: a hash-only request answers
+    /// `HashUnknownError` for a cacheable target it is not already cached for,
+    /// rather than taking the exclusive per-addr lock to build it.
+    ///
+    /// This is what makes nesting one inside a live resolution safe — the nested
+    /// request shares the engine's single `ResultLock` with its caller but not
+    /// the `mem_locked_result` memoizer that makes per-addr acquisition
+    /// idempotent, so any write acquire is a self-deadlock.
+    #[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+    async fn a_hash_only_request_refuses_to_build_instead_of_locking() -> anyhow::Result<()> {
+        // `meta` hashes a target from its INPUTS, so the uncached cacheable
+        // target has to be a dep — that is the one a real recompute would build.
+        let (engine, _root) = engine_with_home(vec![
+            static_target("//pkg:dep", &[], &[]),
+            static_target("//pkg:top", &[], &["//pkg:dep"]),
+        ])?;
+        let addr = hmodel::htaddr::parse_addr("//pkg:top")?;
+
+        // Nothing is cached yet, so resolving for real would execute `//pkg:dep`.
+        let err = Arc::clone(&engine)
+            .meta(engine.new_hash_only_state(addr.clone()), &addr)
+            .await
+            .err()
+            .expect("a hash-only request must not build an uncached target");
+        assert!(
+            downcast_chain_ref::<HashUnknownError>(&err).is_some(),
+            "expected HashUnknownError, got: {err:#}"
+        );
+
+        // And it is not a blanket refusal: once the target IS cached, the same
+        // hash-only request answers from the cache under a shared read.
+        let rs = engine.new_state();
+        Arc::clone(&engine)
+            .result_addr(rs.clone(), &addr, OutputMatcher::All, &ResultOptions::default())
+            .await
+            .expect("real resolve");
+        drop(rs);
+        Arc::clone(&engine)
+            .meta(engine.new_hash_only_state(addr.clone()), &addr)
+            .await
+            .expect("a cached target is answerable without building");
+        Ok(())
+    }
+
+    /// An in_place target whose dep closure contains a **cacheable** target
+    /// hashing the same file it rewrites must not deadlock against itself.
+    ///
+    /// `maybe_store_fixpoint` recomputes the target's `hashin` on a *fresh*
+    /// `RequestState` — deliberately, so the `@heph/fs` inputs re-read the
+    /// just-written tree. But the outer request is still holding a riding **read**
+    /// guard on every cacheable addr it resolved, including `//pkg:probe`. The
+    /// write-back changed `in.txt`, so on the fresh request `//pkg:probe` hashes
+    /// differently, misses, and asks for the exclusive **write** lock on an addr
+    /// the outer request will not release until this call returns. The fresh
+    /// request also runs on its own uncancelled token, so Ctrl-C cannot break it.
+    ///
+    /// `go_lint_fix` is exactly this shape: an in_place fixer over the same files
+    /// its cacheable analyze dep hashes.
+    #[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+    async fn in_place_fixpoint_does_not_deadlock_on_a_cacheable_dep_it_rewrote()
+    -> anyhow::Result<()> {
+        let src = hbuiltins::pluginfs::file_addr("pkg/in.txt").format();
+        let (engine, root) = engine_with_home_fs(vec![
+            bash_target("//pkg:probe", &[&src]),
+            codegen_run_target_with_deps(
+                "//pkg:fmt",
+                "in_place",
+                &["in.txt"],
+                "printf '%s\\n' \"$(tr a-z A-Z < in.txt)\" > in.txt.tmp && mv in.txt.tmp in.txt",
+                &["//pkg:probe"],
+            ),
+        ])?;
+        let pkg_dir = root.path().join("pkg");
+        std::fs::create_dir_all(&pkg_dir)?;
+        // Lowercase and newline-less, so run 1 provably changes the bytes — which
+        // is what moves `//pkg:probe`'s hashin on the fixpoint recompute.
+        std::fs::write(pkg_dir.join("in.txt"), b"hello")?;
+
+        let addr = hmodel::htaddr::parse_addr("//pkg:fmt")?;
+        let (res, _events) = tokio::time::timeout(
+            Duration::from_secs(60),
+            resolve_collecting_events(&engine, &addr),
+        )
+        .await
+        .expect("in_place fixpoint recompute deadlocked against its own riding read locks");
+        res.expect("fmt resolves");
+
+        assert_eq!(
+            std::fs::read(pkg_dir.join("in.txt"))?,
+            b"HELLO\n",
+            "the in_place write-back must still land",
+        );
+        Ok(())
     }
 
     /// in_place does NOT restrict outputs to pre-existing inputs: a run that

--- a/crates/engine/src/engine/result.rs
+++ b/crates/engine/src/engine/result.rs
@@ -5837,7 +5837,10 @@ mod tests {
     /// therefore tracks those deps exactly.
     fn bash_target(addr: &str, deps: &[&str]) -> pluginstatictarget::Target {
         let mut deps_map = HashMap::new();
-        deps_map.insert("".to_string(), deps.iter().map(|s| (*s).to_string()).collect());
+        deps_map.insert(
+            "".to_string(),
+            deps.iter().map(|s| (*s).to_string()).collect(),
+        );
         pluginstatictarget::Target {
             addr: addr.to_string(),
             driver: "bash".to_string(),
@@ -5883,7 +5886,12 @@ mod tests {
         // hash-only request answers from the cache under a shared read.
         let rs = engine.new_state();
         Arc::clone(&engine)
-            .result_addr(rs.clone(), &addr, OutputMatcher::All, &ResultOptions::default())
+            .result_addr(
+                rs.clone(),
+                &addr,
+                OutputMatcher::All,
+                &ResultOptions::default(),
+            )
             .await
             .expect("real resolve");
         drop(rs);

--- a/crates/plugin/src/error.rs
+++ b/crates/plugin/src/error.rs
@@ -36,6 +36,35 @@ pub fn is_cancelled(e: &anyhow::Error) -> bool {
     hcore::hmemoizer::downcast_chain_ref::<CancelledError>(e).is_some()
 }
 
+/// A hash-only request reached a target it would have had to *build* to answer.
+///
+/// Hash-only requests exist to re-read the tree from inside an in-flight
+/// resolution (the in_place write-back guard and the fixpoint recompute). They
+/// are forbidden from taking the exclusive per-addr result lock, because the
+/// request they are nested inside is already holding riding **read** guards that
+/// it will not release until the nested call returns — so a write acquire is a
+/// self-deadlock, not contention.
+///
+/// So a cache miss under such a request answers "unknown" instead of building.
+/// Callers decide what that means: the fixpoint recompute skips (it is an
+/// optimization), the write-back guard refuses to write (it cannot confirm).
+#[derive(Debug, Clone)]
+pub struct HashUnknownError {
+    pub addr: Addr,
+}
+
+impl fmt::Display for HashUnknownError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(
+            f,
+            "{} is not cached at its current inputs, and this hash-only resolution may not build it",
+            self.addr.format()
+        )
+    }
+}
+
+impl std::error::Error for HashUnknownError {}
+
 #[derive(Debug, Clone)]
 pub struct CycleError {
     pub from: Addr,


### PR DESCRIPTION
## The deadlock

`Engine::execute_and_cache` runs two recomputes *inside* a live resolution, each on a request minted by `self.new_state()`:

- `check_in_place_inputs_unchanged` (`result.rs:2168`) — the in_place write-back guard
- `maybe_store_fixpoint` (`result.rs:2239`) — the fixpoint registration

Both re-hash the target so the `@heph/fs` inputs re-read the tree. That part is deliberate and correct: those inputs are cache-off and memoized *per request*, so only a new request re-reads them.

The problem is that a fresh request shares the engine's single `ResultLock` (`engine.rs:104`) while **not** sharing `mem_locked_result` — and `mem_locked_result` is exactly what makes per-addr acquisition idempotent within a request (`request_state.rs:176-181`). So the nested request is a second lock-holder identity over a non-reentrant per-addr lock, contending guards its own caller is holding and will not release until the nested call returns.

It fires whenever a cacheable dep's `hashin` moved: the nested request misses, `resolve_locked_inner` drops its read (`:1573`) and asks for the exclusive write (`:1574-1576`) on an addr the outer request is riding a read on. `poll_acquire` (`hlock/flock.rs:260`) then backs off at `MAX_BACKOFF = 100ms` forever.

`go_lint_fix` is exactly this shape — an in_place fixer over the files its cacheable analyze dep hashes (`plugin-go/driver_lint.rs:1112` + `:305`).

Ctrl-C *does* escape it (the nested state is registered in `engine.requests`, so `cancel_all_requests` reaches it). **Fail-fast does not**: `Engine::result` cancels only `rs.ctoken()` (`:1068`), so a sibling target failing while another is parked leaves the run hung *after* printing the failure. Embeddings with no SIGINT handler — `crates/e2e`, `crates/testkit`, the LSP — never break out at all.

## The fix

A hash-only request answers `HashUnknownError` for a cacheable miss instead of building it. Targets that take no lock at all (`@heph/fs`, via `skip_lock` at `:1529`) still execute normally — re-reading the tree is the entire reason these requests exist, and `fixpoint_hit` still passes, which is the end-to-end proof.

`classify_failure` passes the error through unwrapped, alongside cancellation and cycles: nothing is wrong with the dep, we declined to build it, and `dependency failed (root: ...)` is the wrong thing to tell a user about a write-back guard.

**Skipping is also the correct answer, not merely the safe one.** The recompute can only need to build a dep when that dep's `hashin` moved — which is precisely when the fixpoint would be *unsound*: the recomputed key folds the dep's NEW hashout, while the artifacts being filed under it were produced from the old one. For `go_lint_fix` that means run 1 stores `fix(T0, R0)` under a key folding `R1`, so a second-round diagnostic (routine for `go/analysis` — one fix exposes the next) gets served as already-fixed and is never applied. The lock inversion was the soundness condition surfacing as a lock conflict.

`new_hash_only_state` takes the parent addr rather than defaulting it. `meta`'s dep walk derives `is_top` from `RequestState::parent` (`:858`), and `inner_meta`'s own doc states the precondition ("invoked from inner_result_addr after parent was already set to addr", `meta.rs:45`). A parent-less nested request violated it and promoted every direct dep to a top-level frame — running each one's own in_place guard, spinning yet another nested request per level.

## Cost

An in_place target whose deps it rewrites pays **one extra execution per tree change**, not per run: run N+1 re-runs the fixer, produces byte-identical output, `wrote == false`, and caches at the new hashin; run N+2 onward is a plain hit. The work is the dep rebuild run N+1 had to do anyway — it was merely being prefetched inside run N, on an uncancellable token, holding locks it must not hold.

## Tests

- `in_place_fixpoint_does_not_deadlock_on_a_cacheable_dep_it_rewrote` — the reproducer. `//pkg:fmt` (in_place over `in.txt`) deps `//pkg:probe` (cacheable, hashes `in.txt`). Before: hangs, 60s timeout fires. After: 0.18s.
- `a_hash_only_request_refuses_to_build_instead_of_locking` — the invariant on its own, both directions: uncached cacheable dep → `HashUnknownError`; same request against a cached target → answers from the cache under a shared read.

`cargo test -p engine`: 307 passed. `lint` clean.

## Review

Consulted the `hermeticity` and `code-quality` agents at design stage. Both **rejected** the two obvious fixes:

- **A held-addr collision set** is TOCTOU-racy by construction: `Memoizer::peek` reports only *completed* cells, so an addr whose guard is already held reads as "not held" while its cell is in flight, and a sibling frame can insert after the check either way.
- **Deferring the recompute** past the request keys artifacts on a tree state the target never saw. Concretely: build starts, `//pkg:fmt` writes back at t=5s, user saves a file it owns at t=60s, drain runs at t=180s and files fmt's *pre-edit* artifacts under a key that includes the edit. Next run hits and `materialize_codegen` writes the pre-edit bytes back over it — the edit silently reverted, no diff, no event. It also has no viable drain point inside the engine: `BatchResult` hands out `GuardedArtifact`s that still hold the read guards.

## Follow-ups (not in this PR)

- `check_in_place_inputs_unchanged` still recomputes the whole `hashin` when its actual question is "are the files I am about to overwrite still the bytes I transformed?" Re-hashing only the `CodegenMode::InPlace` output paths would answer it with no request at all, and would also remove a full cold re-resolution of the input closure that currently runs on every top-level in_place resolution *including a 100% cache hit* (`:1332` is unconditional).
- `StdCancellationToken` has no child/link API, so the nested request's token is still independent. Not needed for correctness now that it cannot block on a lock, but worth having.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01A76DChMohieGMbRbnV1E7x