### PR TITLE
perf(plugin): encode hook event frames outside the state lock

### DIFF
--- a/crates/plugin-sdk/src/serve.rs
+++ b/crates/plugin-sdk/src/serve.rs
@@ -1875,6 +1875,159 @@ mod tests {
         );
     }
 
+    // The event stream is one-shot. `StableRemoteHook` is registered on the
+    // *engine* but `on_close` fires per *request*, so in a long-lived host every
+    // event after the first request ends reaches a closed stream. Those events
+    // must be dropped — never resurrect the stream, never reach the plugin — and
+    // must not pay for a frame encode on the way out.
+    #[test]
+    fn hook_events_after_close_are_dropped_and_never_reopen_the_stream() {
+        use hcore::events::{BuildEvent, BuildEventKind};
+        use hplugin::hook::Hook;
+        use hplugin_stabby::load_stable::StableRemoteHook;
+        use std::sync::Mutex;
+        use std::sync::atomic::{AtomicUsize, Ordering};
+
+        #[derive(Default)]
+        struct Recorder {
+            seen: Mutex<Vec<u64>>,
+            closes: AtomicUsize,
+        }
+        impl Hook for Recorder {
+            fn name(&self) -> String {
+                "rec".into()
+            }
+            fn on_event(&self, ev: &BuildEvent) {
+                self.seen
+                    .lock()
+                    .unwrap_or_else(|e| e.into_inner())
+                    .push(ev.at_unix_ms);
+            }
+            fn on_close(&self) {
+                self.closes.fetch_add(1, Ordering::Release);
+            }
+        }
+
+        let rec = Arc::new(Recorder::default());
+        let remote = StableRemoteHook::new(make_dyn_hook(Arc::clone(&rec) as Arc<dyn Hook>), "rec");
+
+        let rt = tokio::runtime::Builder::new_multi_thread()
+            .worker_threads(2)
+            .enable_all()
+            .build()
+            .expect("rt");
+        rt.block_on(async {
+            let mk = |at| BuildEvent {
+                at_unix_ms: at,
+                kind: BuildEventKind::ResultStart {
+                    addr: "//a:b".into(),
+                },
+            };
+            remote.on_event(&mk(1));
+            remote.drain().await;
+            // Second request's worth of events, arriving after the close.
+            remote.on_event(&mk(2));
+            remote.on_event(&mk(3));
+            // A second drain must be a no-op, not a second stream.
+            remote.drain().await;
+        });
+
+        assert_eq!(
+            rec.seen.lock().unwrap_or_else(|e| e.into_inner()).clone(),
+            vec![1],
+            "events emitted after the stream closed must not reach the plugin"
+        );
+        assert_eq!(
+            rec.closes.load(Ordering::Acquire),
+            1,
+            "the stream is one-shot: no second stream is opened, so on_close fires once"
+        );
+    }
+
+    // Concurrent emitters all deliver. Guards the encode-outside-the-lock change
+    // in `StableRemoteHook::on_event`: the state mutex guards only the lazily
+    // opened stream handle, so exactly one stream must still be opened and every
+    // frame must arrive, regardless of how many threads race the first event.
+    #[test]
+    fn hook_concurrent_emitters_open_one_stream_and_lose_nothing() {
+        use hcore::events::{BuildEvent, BuildEventKind};
+        use hplugin::hook::Hook;
+        use hplugin_stabby::load_stable::StableRemoteHook;
+        use std::sync::Mutex;
+        use std::sync::atomic::{AtomicUsize, Ordering};
+
+        #[derive(Default)]
+        struct Recorder {
+            seen: Mutex<Vec<u64>>,
+            closes: AtomicUsize,
+        }
+        impl Hook for Recorder {
+            fn name(&self) -> String {
+                "rec".into()
+            }
+            fn on_event(&self, ev: &BuildEvent) {
+                self.seen
+                    .lock()
+                    .unwrap_or_else(|e| e.into_inner())
+                    .push(ev.at_unix_ms);
+            }
+            fn on_close(&self) {
+                self.closes.fetch_add(1, Ordering::Release);
+            }
+        }
+
+        const EMITTERS: u64 = 8;
+        const PER_EMITTER: u64 = 32;
+
+        let rec = Arc::new(Recorder::default());
+        let remote = Arc::new(StableRemoteHook::new(
+            make_dyn_hook(Arc::clone(&rec) as Arc<dyn Hook>),
+            "rec",
+        ));
+
+        let rt = tokio::runtime::Builder::new_multi_thread()
+            .worker_threads(4)
+            .enable_all()
+            .build()
+            .expect("rt");
+        rt.block_on(async {
+            // `on_event` lazily `tokio::spawn`s the stream driver, so every
+            // emitter needs runtime context — the engine always emits from one.
+            let handle = tokio::runtime::Handle::current();
+            std::thread::scope(|scope| {
+                for t in 0..EMITTERS {
+                    let remote = Arc::clone(&remote);
+                    let handle = handle.clone();
+                    scope.spawn(move || {
+                        let _guard = handle.enter();
+                        for i in 0..PER_EMITTER {
+                            remote.on_event(&BuildEvent {
+                                at_unix_ms: t * PER_EMITTER + i,
+                                kind: BuildEventKind::ResultStart {
+                                    addr: "//a:b".into(),
+                                },
+                            });
+                        }
+                    });
+                }
+            });
+            remote.drain().await;
+        });
+
+        let mut seen = rec.seen.lock().unwrap_or_else(|e| e.into_inner()).clone();
+        seen.sort_unstable();
+        assert_eq!(
+            seen,
+            (0..EMITTERS * PER_EMITTER).collect::<Vec<_>>(),
+            "every concurrently emitted event must cross the seam exactly once"
+        );
+        assert_eq!(
+            rec.closes.load(Ordering::Acquire),
+            1,
+            "racing emitters must open exactly one stream"
+        );
+    }
+
     // Provider functions survive the guest→host stable-ABI round trip: the host
     // sees the same name/signature/doc, and invoking the proxied handler carries
     // both the arguments and the FnCallContext across the seam.

--- a/crates/plugin-stabby/src/load_stable.rs
+++ b/crates/plugin-stabby/src/load_stable.rs
@@ -761,6 +761,13 @@ pub struct StableRemoteHook {
     inner: Arc<DynHook>,
     name: String,
     state: std::sync::Mutex<HookStreamState>,
+    /// Set once the stream has been ended by `on_close` / `drain`.
+    ///
+    /// Read before encoding so a closed hook costs an atomic load per event
+    /// instead of a serialization. The hook is engine-level while `on_close`
+    /// fires per *request*, so in a long-lived host (the LSP) every event after
+    /// the first request ends would otherwise be encoded only to be dropped.
+    closed: std::sync::atomic::AtomicBool,
 }
 
 impl StableRemoteHook {
@@ -769,6 +776,7 @@ impl StableRemoteHook {
             inner: Arc::new(inner),
             name: name.into(),
             state: std::sync::Mutex::new(HookStreamState::default()),
+            closed: std::sync::atomic::AtomicBool::new(false),
         }
     }
 }
@@ -779,6 +787,19 @@ impl Hook for StableRemoteHook {
     }
 
     fn on_event(&self, ev: &hcore::events::BuildEvent) {
+        // The stream is one-shot: once ended, nothing reopens it, so there is
+        // nothing to encode for.
+        if self.closed.load(std::sync::atomic::Ordering::Acquire) {
+            return;
+        }
+        // Encode BEFORE taking the lock. This is the engine's emit chokepoint —
+        // every event of every target passes through it — and `event_frame` is a
+        // serde-JSON render plus a prost encode. Holding the state mutex across
+        // that serializes all emitters behind the slowest one, which is exactly
+        // what `hplugin::hook`'s contract says a hook must not do. The lock only
+        // guards the lazily-opened stream handle; it does not order frames (the
+        // channel does), so encoding outside it changes nothing observable.
+        let frame = event_frame(ev);
         let mut st = self.state.lock().unwrap_or_else(|e| e.into_inner());
         if !st.started {
             st.started = true;
@@ -800,12 +821,14 @@ impl Hook for StableRemoteHook {
         }
         if let Some(tx) = &st.tx {
             // Plugin gone / stream closed => receiver dropped; best-effort.
-            drop(tx.send(event_frame(ev)));
+            drop(tx.send(frame));
         }
     }
 
     fn on_close(&self) {
         // Drop the sender so the plugin's pull sees end-of-stream and flushes.
+        self.closed
+            .store(true, std::sync::atomic::Ordering::Release);
         let mut st = self.state.lock().unwrap_or_else(|e| e.into_inner());
         st.tx = None;
     }
@@ -814,6 +837,8 @@ impl Hook for StableRemoteHook {
         Box::pin(async move {
             // Ensure the stream is closed, then await the plugin's ack so its final
             // write lands before the host exits.
+            self.closed
+                .store(true, std::sync::atomic::Ordering::Release);
             let join = {
                 let mut st = self.state.lock().unwrap_or_else(|e| e.into_inner());
                 st.tx = None;


### PR DESCRIPTION
## Problem

`StableRemoteHook::on_event` (`crates/plugin-stabby/src/load_stable.rs:781-805`) held a `std::sync::Mutex` across `event_frame(ev)` — a serde-JSON render plus a prost encode:

```rust
let mut st = self.state.lock()...;
...
if let Some(tx) = &st.tx {
    drop(tx.send(event_frame(ev)));   // encode under the lock
}
```

This is the engine's emit chokepoint — every event of every target passes through it — so every emitter serialized behind the slowest one. `crates/plugin/src/hook.rs:19-22` states the contract this violates.

## Fix

Encode before taking the lock. The lock guards only the lazily-opened stream handle; it does not order frames (the `mpsc` channel does), so encoding outside it changes nothing observable.

Frames are **not** dropped — GhaHook pairs start/end events, so a drop policy would report phantom stuck targets.

The one thing now skipped is encoding for an already-closed stream, behind an `AtomicBool`. That is not a micro-optimization: the hook is registered on the *engine* while `on_close` fires per *request*, so in a long-lived host (the LSP) every event after the first request ends was being encoded only to be discarded by the `st.tx.is_none()` check.

## Tests

Two added to the existing host→guest seam harness in `plugin-sdk/src/serve.rs`:

- `hook_events_after_close_are_dropped_and_never_reopen_the_stream` — pins the one-shot contract the new early-return depends on: post-close events reach neither the plugin nor a second stream, and a second `drain()` is a no-op.
- `hook_concurrent_emitters_open_one_stream_and_lose_nothing` — 8 threads × 32 events; exactly one stream opened, every frame delivered exactly once. Guards the hoist against a botched lock scope.

`cargo test -p plugin-sdk --all-features`: 19 passed. `lint` clean.

Honest scope note: that the encode now happens outside the lock is verified by inspection, not by a test — `event_frame` is a free function with no seam to observe, and a timing-based assertion would be flaky. The tests cover the behavior change this PR actually introduces.

## Incidental finding (not fixed here)

`on_event` lazily `tokio::spawn`s the stream driver, so calling it from a thread with no runtime context panics — and a panic on this path is a non-unwinding abort at the ABI seam. Pre-existing; the engine always emits from a runtime today. Worth a follow-up guard.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01A76DChMohieGMbRbnV1E7x