### PR TITLE
chore: ignore CodeGraph index

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -40,3 +40,6 @@ gen
 example/go/large
 
 ai-docs
+
+# CodeGraph
+.codegraph/


### PR DESCRIPTION
Ignores the local `.codegraph/` directory created by [CodeGraph](https://colbymchenry.github.io/codegraph/).