### PR TITLE
test(ci): binary e2e suite against the shipped artifacts

### DIFF
--- a/.claude/testing.md
+++ b/.claude/testing.md
@@ -6,6 +6,30 @@
 - Do not write absurd tests that assert something that was just set before — test business logic.
 - Do not add tests that assert something is not there during refactoring.
 
+## Where the test goes
+
+Default to the closest-in unit that can prove the behavior. Reach outward only when the inner layer structurally cannot.
+
+| Where | What | Run with |
+|---|---|---|
+| `#[cfg(test)]` in the crate | pure logic, parsing, a single type's contract | `cargo test <name>` |
+| `crates/e2e`, `crates/plugingo-e2e` | engine semantics end to end — providers, drivers, caching, hashing, the graph. Links `heph` in-process and drives the real `Engine`. | `cargo test <name>` |
+| `crates/bin-e2e` | **only** what has no in-process form. Spawns the release binary; links no workspace crate. | `e2e` |
+
+### The `crates/bin-e2e` bar
+
+A test belongs there only if an in-process test *cannot* cover it — not merely if it would be more realistic there. It is slow (release build), runs on three platforms in CI, and gates `release`. Keep it light.
+
+Qualifying seams:
+
+- **Dynamic loading** — `dlopen` of a real cdylib, ABI negotiation across the plugin seam, manifest/checksum resolution. In-process tests construct the plugin directly through generics and never cross the seam.
+- **The terminal** — the interactive TUI engages only when stderr is a tty, so a linked test always takes the CI line backend and passes vacuously. Assert on vt100-parsed cells, never on raw escape bytes. Terminal restore on exit is the highest-value assertion: a TUI that leaves the alternate screen behind wrecks the user's shell while every non-PTY test stays green.
+- **The process** — exit codes, signal handling, and whether the shipped binary launches at all (dyld/glibc resolution, weak-linked libfuse, the macOS libiconv rewrite). These only fail at `execve`.
+
+Not qualifying: engine semantics, cache correctness, provider or driver logic, anything about the graph. Those go in `crates/e2e`, where they run in seconds.
+
+Fixtures there use the harness in `crates/bin-e2e/tests/common/mod.rs` (`Dist`, `Workspace`, `write_manifest`) — a temp workspace with its own `HOME`, self-update and telemetry disabled. Locate artifacts through `Dist`; never hardcode a path into `target/`.
+
 ## Test Isolation
 
 Tests that touch the filesystem must use a unique temporary directory scoped to that test — never `/tmp` directly, and never a shared path that bleeds across parallel runs.

--- a/.github/workflows/heph.yml
+++ b/.github/workflows/heph.yml
@@ -504,9 +504,74 @@ jobs:
         shell: devenv shell bash -- -e {0}
         run: sccache --show-stats
 
+  # Black-box tests against the artifacts the `build` job just produced — the
+  # exact bytes that get published. Covers only what `test` structurally cannot:
+  # dlopen of the shipped plugin cdylibs, the TUI under a real PTY, and process
+  # exit status. Runs `e2e`, the same script used locally; the only CI-specific
+  # part is HEPH_E2E_FROM pointing at the downloaded artifacts.
+  #
+  # linux/arm64 matters most here: the build job cross-compiles it, so this is
+  # the only place the shipped aarch64-linux binary is ever executed.
+  bin_e2e:
+    name: Binary E2E ${{ matrix.os }}/${{ matrix.arch }}
+    runs-on: ${{ matrix.runs-on }}
+    timeout-minutes: 30
+    needs: [gen, build]
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - os: linux
+            arch: amd64
+            runs-on: ubuntu-latest
+            target: x86_64-unknown-linux-gnu
+          - os: linux
+            arch: arm64
+            runs-on: ubuntu-24.04-arm
+            target: aarch64-unknown-linux-gnu
+          - os: darwin
+            arch: arm64
+            runs-on: macos-latest
+            target: aarch64-apple-darwin
+    steps:
+      - name: Download repo
+        uses: actions/download-artifact@v7
+        with:
+          name: repo
+          path: .
+
+      # Only this platform's three artifacts: `heph_<os>_<arch>` plus the two
+      # `heph-*-plugin_<os>_<arch>.{so,dylib}`. `heph-govet` carries no
+      # os/arch suffix, so the pattern leaves it out.
+      - name: Download artifacts under test
+        uses: actions/download-artifact@v7
+        with:
+          pattern: heph*_${{ matrix.os }}_${{ matrix.arch }}*
+          path: dist
+          merge-multiple: true
+
+      - name: Setup Nix + devenv
+        uses: ./.github/actions/setup-nix
+        with:
+          cargo-target: ${{ matrix.target }}
+          cache-suffix: "-bin-e2e"
+          r2-secret: ${{ secrets.CF_SSCACHE }}
+
+      - name: E2E
+        shell: devenv shell bash -- -e {0}
+        env:
+          RUST_BACKTRACE: "1"
+          HEPH_E2E_FROM: dist
+        run: e2e
+
+      - name: sccache stats
+        if: always()
+        shell: devenv shell bash -- -e {0}
+        run: sccache --show-stats
+
   release:
     name: Release
-    needs: [gen, upload_artifacts, lint, test]
+    needs: [gen, upload_artifacts, lint, test, bin_e2e]
     if: github.ref == 'refs/heads/master'
     runs-on: ubuntu-latest
     timeout-minutes: 10
@@ -558,7 +623,7 @@ jobs:
 
   cleanup:
     name: Cleanup
-    needs: [gen, build, lint, test, upload_artifacts]
+    needs: [gen, build, lint, test, bin_e2e, upload_artifacts]
     runs-on: ubuntu-latest
     timeout-minutes: 5
     steps:

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -34,9 +34,12 @@ e2e                          # build the artifacts from this tree, then test the
 e2e tui_pty                  # one test file
 e2e -- --nocapture           # args after `--` reach cargo test
 HEPH_E2E_FROM=dist e2e       # test an already-downloaded artifact set (what CI does)
+HEPH_E2E_KEEP_DIST=1 e2e     # keep the staged artifacts instead of deleting them
 ```
 
 One script, one code path — CI runs the same `e2e`, differing only in where the artifacts come from. Do not add a parallel script or inline the steps into the workflow.
+
+Concurrency-safe: `CARGO_TARGET_DIR` is inherited from the environment and worktrees routinely share one, so the suite stages into a `mktemp -d` unique to each run rather than a fixed path two runs would fight over. It also fingerprints `release/` around the copy — if another worktree's build lands in that window, the run aborts rather than quietly testing the wrong binary. Keep it that way when editing the script; a fixed staging path reintroduces both.
 
 It builds `--release`, so it is slow and disk-hungry on a cold tree. Don't run it reflexively: the `bin_e2e` CI job runs it on all three platforms on every push, and it gates `release`. Run it locally only when changing something it covers (the loader, the TUI, CLI exit codes, the `e2e` script itself) — and expect a full release build the first time.
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -16,13 +16,31 @@ devenv shell        # enter the dev shell (provides Rust toolchain, buf, protoc 
 cargo build                          # build
 cargo test <test_name>               # run a single test by name
 
-tst                                  # run all tests
+tst                                  # run all tests (excludes bin-e2e)
+e2e                                  # binary end-to-end suite (see below)
 lint                                 # lint
 fix                                  # format & apply lint fixes
 gen                                  # regenerate protobuf bindings (runs buf generate)
 ```
 
 The `gen` script is a devenv-provided alias, assume its present. It must be run at the beginning of all sessions, or after any `.proto` file changes before building.
+
+### `e2e` — testing the shipped binary
+
+`e2e` runs `crates/bin-e2e`: black-box tests that spawn the **release binary and plugin cdylibs** as a child process, rather than linking the crates. It is the only way to cover things that have no in-process form — `dlopen` of a real cdylib, the TUI under a PTY, process exit codes, whether the binary launches at all on this host.
+
+```bash
+e2e                          # build the artifacts from this tree, then test them
+e2e tui_pty                  # one test file
+e2e -- --nocapture           # args after `--` reach cargo test
+HEPH_E2E_FROM=dist e2e       # test an already-downloaded artifact set (what CI does)
+```
+
+One script, one code path — CI runs the same `e2e`, differing only in where the artifacts come from. Do not add a parallel script or inline the steps into the workflow.
+
+It builds `--release`, so it is slow and disk-hungry on a cold tree. Don't run it reflexively: the `bin_e2e` CI job runs it on all three platforms on every push, and it gates `release`. Run it locally only when changing something it covers (the loader, the TUI, CLI exit codes, the `e2e` script itself) — and expect a full release build the first time.
+
+`tst` excludes `bin-e2e` deliberately: those tests need staged artifacts and hard-fail without `HEPH_E2E_DIST`, so a suite that never ran can't read as a suite that passed. See `.claude/testing.md` for what belongs there versus `crates/e2e`.
 
 ## Workflow
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -364,6 +364,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3a8241f3ebb85c056b509d4327ad0358fbbba6ffb340bf388f26350aeda225b1"
 
 [[package]]
+name = "bin-e2e"
+version = "0.1.0"
+dependencies = [
+ "anyhow",
+ "hex",
+ "portable-pty",
+ "serde_json",
+ "sha2 0.10.9",
+ "tempfile",
+ "vt100",
+]
+
+[[package]]
 name = "bit-set"
 version = "0.5.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1287,6 +1300,12 @@ checksum = "d4b8a88685455ed29a21542a33abd9cb6510b6b129abadabdcef0f4c55bc8f61"
 dependencies = [
  "litrs",
 ]
+
+[[package]]
+name = "downcast-rs"
+version = "1.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "75b325c5dbd37f80359721ad39aca5a29fb04c89279657cffdda8736d0c0b9d2"
 
 [[package]]
 name = "driver-bridge"
@@ -4012,6 +4031,27 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c33a9471896f1c69cecef8d20cbe2f7accd12527ce60845ff44c153bb2a21b49"
 
 [[package]]
+name = "portable-pty"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b4a596a2b3d2752d94f51fac2d4a96737b8705dddd311a32b9af47211f08671e"
+dependencies = [
+ "anyhow",
+ "bitflags 1.3.2",
+ "downcast-rs",
+ "filedescriptor",
+ "lazy_static",
+ "libc",
+ "log",
+ "nix 0.28.0",
+ "serial2",
+ "shared_library",
+ "shell-words",
+ "winapi",
+ "winreg",
+]
+
+[[package]]
 name = "postcard"
 version = "1.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5173,6 +5213,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "serial2"
+version = "0.2.37"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9eb6ea5562eeaed6936b8b54e086aa0f88b9e5b1bef45beb038e2519fa1185b1"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
 name = "sha1"
 version = "0.10.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5219,6 +5270,22 @@ checksum = "f40ca3c46823713e0d4209592e8d6e826aa57e928f09752619fc696c499637f6"
 dependencies = [
  "lazy_static",
 ]
+
+[[package]]
+name = "shared_library"
+version = "0.1.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5a9e7e0f2bfae24d8a5b5a66c5b257a83c7412304311512a0c054cd5e619da11"
+dependencies = [
+ "lazy_static",
+ "libc",
+]
+
+[[package]]
+name = "shell-words"
+version = "1.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dc6fe69c597f9c37bfeeeeeb33da3530379845f10be461a66d16d03eca2ded77"
 
 [[package]]
 name = "shlex"
@@ -6311,6 +6378,27 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0b928f33d975fc6ad9f86c8f283853ad26bdd5b10b7f1542aa2fa15e2289105a"
 
 [[package]]
+name = "vt100"
+version = "0.16.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "054ff75fb8fa83e609e685106df4faeffdf3a735d3c74ebce97ec557d5d36fd9"
+dependencies = [
+ "itoa",
+ "unicode-width 0.2.2",
+ "vte",
+]
+
+[[package]]
+name = "vte"
+version = "0.15.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a5924018406ce0063cd67f8e008104968b74b563ee1b85dde3ed1f7cb87d3dbd"
+dependencies = [
+ "arrayvec",
+ "memchr",
+]
+
+[[package]]
 name = "vtparse"
 version = "0.6.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6869,6 +6957,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0592e1c9d151f854e6fd382574c3a0855250e1d9b2f99d9281c6e6391af352f1"
 dependencies = [
  "memchr",
+]
+
+[[package]]
+name = "winreg"
+version = "0.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "80d0f4e272c85def139476380b12f9ac60926689dd2e01d4923222f40580869d"
+dependencies = [
+ "winapi",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,7 +4,7 @@ version = "0.1.0"
 edition = "2024"
 
 [workspace]
-members = ["gen/proto", "crates/e2e", "crates/testkit", "crates/plugingo-e2e", "crates/htspec-derive", "crates/core", "crates/config", "crates/walk", "crates/proc", "crates/model", "crates/sandboxfuse", "crates/plugin", "crates/plugin-abi", "crates/plugin-stabby", "crates/plugin-sdk", "crates/plugin-go-cdylib", "crates/builtins", "crates/plugin-buildfile", "crates/driver-support", "crates/driver-bridge", "crates/plugin-exec", "crates/plugin-nix", "crates/plugin-http", "crates/plugin-query", "crates/plugin-go", "crates/plugin-gha", "crates/plugin-gha-cdylib", "crates/telemetry", "crates/tui", "crates/lock", "crates/selfupdate", "crates/engine", "crates/xstarlark-fmt"]
+members = ["gen/proto", "crates/e2e", "crates/bin-e2e", "crates/testkit", "crates/plugingo-e2e", "crates/htspec-derive", "crates/core", "crates/config", "crates/walk", "crates/proc", "crates/model", "crates/sandboxfuse", "crates/plugin", "crates/plugin-abi", "crates/plugin-stabby", "crates/plugin-sdk", "crates/plugin-go-cdylib", "crates/builtins", "crates/plugin-buildfile", "crates/driver-support", "crates/driver-bridge", "crates/plugin-exec", "crates/plugin-nix", "crates/plugin-http", "crates/plugin-query", "crates/plugin-go", "crates/plugin-gha", "crates/plugin-gha-cdylib", "crates/telemetry", "crates/tui", "crates/lock", "crates/selfupdate", "crates/engine", "crates/xstarlark-fmt"]
 
 [profile.profiling]
 inherits = "release"

--- a/crates/bin-e2e/Cargo.toml
+++ b/crates/bin-e2e/Cargo.toml
@@ -1,0 +1,24 @@
+[package]
+name = "bin-e2e"
+version = "0.1.0"
+edition = "2024"
+publish = false
+
+[lints]
+workspace = true
+
+# Deliberately NO dependency on `heph` or any workspace crate: this suite drives
+# the shipped artifacts as a child process. Linking them would defeat the point
+# (and would test *this* build rather than the one CI publishes). Anything that
+# can be proven in-process belongs in `crates/e2e`.
+[dev-dependencies]
+anyhow = "1"
+tempfile = "3"
+serde_json = "1.0"
+sha2 = "0.10"
+hex = "0.4"
+# Real PTY + terminal emulator: the interactive TUI only engages when stderr is
+# a terminal, and its output is escape sequences — asserting on cells of a
+# parsed screen is the only way to test it that isn't asserting on raw bytes.
+portable-pty = "0.9"
+vt100 = "0.16"

--- a/crates/bin-e2e/tests/cli.rs
+++ b/crates/bin-e2e/tests/cli.rs
@@ -1,0 +1,113 @@
+//! Process-level guarantees of the shipped binary: that it launches at all on
+//! this host, and that a run's outcome reaches the shell as an exit status.
+//!
+//! None of this is reachable in-process — a linked test observes an
+//! `anyhow::Result`, never an exit code, and it exercises the *test* build's
+//! link closure rather than the artifact CI publishes.
+
+mod common;
+
+use common::{Dist, Workspace, describe};
+
+/// The published artifact must launch on a stock host. This is the canary for
+/// the whole class of link-time portability breakage that only shows at
+/// `execve` time: the macOS `libiconv` /nix/store hard-link (dyld aborts),
+/// weak-linked libfuse with no macFUSE installed, and a glibc floor raised
+/// above the oldest supported distro. Every one of those passes `cargo test`
+/// and fails here.
+///
+/// `version` is the right probe: it is the one command that runs outside a
+/// workspace, so a failure is unambiguously about the binary, not the fixture.
+#[test]
+fn shipped_binary_launches_outside_a_workspace() {
+    let dist = Dist::locate();
+    let home = tempfile::tempdir().expect("home tempdir");
+    let cwd = tempfile::tempdir().expect("cwd tempdir");
+
+    let out = std::process::Command::new(dist.heph())
+        .arg("version")
+        .current_dir(cwd.path())
+        .env("HOME", home.path())
+        .env("HEPH_NO_SELF_UPDATE", "1")
+        .env("HEPH_DISABLE_TELEMETRY", "1")
+        .output()
+        .expect("spawn heph version");
+
+    assert!(out.status.success(), "{}", describe(&out));
+    assert!(
+        !String::from_utf8_lossy(&out.stdout).trim().is_empty(),
+        "version printed nothing: {}",
+        describe(&out)
+    );
+}
+
+/// A target that exits non-zero must make `heph` exit non-zero. The mapping
+/// from a failed build to `ExitCode` lives in `main`, past the last function an
+/// in-process test can call.
+#[test]
+fn failing_target_exits_nonzero() {
+    let dist = Dist::locate();
+    let ws = Workspace::new().expect("workspace");
+    ws.write(
+        "pkg/BUILD",
+        "target(name = \"boom\", driver = \"bash\", run = \"exit 3\", cache = False)\n",
+    )
+    .expect("write BUILD");
+
+    let out = ws.run(&dist, &["run", "//pkg:boom"]).expect("run");
+
+    assert!(
+        !out.status.success(),
+        "a failing target must not exit 0: {}",
+        describe(&out)
+    );
+}
+
+/// The inverse, so the previous test can't pass because the fixture is broken:
+/// the same shape of target succeeding exits 0.
+#[test]
+fn succeeding_target_exits_zero() {
+    let dist = Dist::locate();
+    let ws = Workspace::new().expect("workspace");
+    ws.write(
+        "pkg/BUILD",
+        "target(name = \"ok\", driver = \"bash\", run = \"echo e2e-ok\", cache = False)\n",
+    )
+    .expect("write BUILD");
+
+    let out = ws.run(&dist, &["run", "//pkg:ok"]).expect("run");
+
+    assert!(out.status.success(), "{}", describe(&out));
+}
+
+/// With stderr piped rather than attached to a terminal, the interactive
+/// renderer must stay off: no alternate-screen switch, no raw mode. A tool that
+/// grabs the alternate screen when its output is being captured corrupts every
+/// CI log and every `heph … | tee` — and the tty check that prevents it is
+/// unobservable from a linked test, which has no controlling terminal either
+/// way and so passes vacuously.
+#[test]
+fn piped_output_does_not_enter_the_alternate_screen() {
+    let dist = Dist::locate();
+    let ws = Workspace::new().expect("workspace");
+    ws.write(
+        "pkg/BUILD",
+        "target(name = \"ok\", driver = \"bash\", run = \"echo e2e-ok\", cache = False)\n",
+    )
+    .expect("write BUILD");
+
+    let out = ws.run(&dist, &["run", "//pkg:ok"]).expect("run");
+    assert!(out.status.success(), "{}", describe(&out));
+
+    // CSI ?1049h — enter alternate screen. The PTY suite asserts the opposite.
+    const ALT_SCREEN: &[u8] = b"\x1b[?1049h";
+    assert!(
+        !contains(&out.stderr, ALT_SCREEN) && !contains(&out.stdout, ALT_SCREEN),
+        "entered the alternate screen with no tty attached: {}",
+        describe(&out)
+    );
+}
+
+fn contains(haystack: &[u8], needle: &[u8]) -> bool {
+    haystack.windows(needle.len()).any(|w| w == needle)
+}

--- a/crates/bin-e2e/tests/cli.rs
+++ b/crates/bin-e2e/tests/cli.rs
@@ -81,13 +81,12 @@ fn succeeding_target_exits_zero() {
 }
 
 /// With stderr piped rather than attached to a terminal, the interactive
-/// renderer must stay off: no alternate-screen switch, no raw mode. A tool that
-/// grabs the alternate screen when its output is being captured corrupts every
-/// CI log and every `heph … | tee` — and the tty check that prevents it is
-/// unobservable from a linked test, which has no controlling terminal either
-/// way and so passes vacuously.
+/// renderer must stay off. A tool that drives a viewport when its output is
+/// being captured corrupts every CI log and every `heph … | tee` — and the tty
+/// check that prevents it is unobservable from a linked test, which has no
+/// controlling terminal either way and so passes vacuously.
 #[test]
-fn piped_output_does_not_enter_the_alternate_screen() {
+fn piped_output_stays_plain() {
     let dist = Dist::locate();
     let ws = Workspace::new().expect("workspace");
     ws.write(
@@ -99,13 +98,19 @@ fn piped_output_does_not_enter_the_alternate_screen() {
     let out = ws.run(&dist, &["run", "//pkg:ok"]).expect("run");
     assert!(out.status.success(), "{}", describe(&out));
 
-    // CSI ?1049h — enter alternate screen. The PTY suite asserts the opposite.
-    const ALT_SCREEN: &[u8] = b"\x1b[?1049h";
-    assert!(
-        !contains(&out.stderr, ALT_SCREEN) && !contains(&out.stdout, ALT_SCREEN),
-        "entered the alternate screen with no tty attached: {}",
-        describe(&out)
-    );
+    // The two things only the interactive backend does: ask the terminal where
+    // the cursor is (to place its inline viewport) and take the cursor. The PTY
+    // suite asserts both are present when a tty *is* attached.
+    for (name, seq) in [
+        ("cursor-position query", b"\x1b[6n".as_slice()),
+        ("cursor hide", b"\x1b[?25l".as_slice()),
+    ] {
+        assert!(
+            !contains(&out.stderr, seq) && !contains(&out.stdout, seq),
+            "emitted a {name} with no tty attached: {}",
+            describe(&out)
+        );
+    }
 }
 
 fn contains(haystack: &[u8], needle: &[u8]) -> bool {

--- a/crates/bin-e2e/tests/common/mod.rs
+++ b/crates/bin-e2e/tests/common/mod.rs
@@ -1,0 +1,201 @@
+//! Harness for the binary end-to-end suite.
+//!
+//! Every test here drives the *shipped* artifacts — the `heph` binary CI
+//! uploads and the plugin cdylibs published alongside it — as a child process.
+//! Nothing in this crate links a workspace crate.
+//!
+//! Scope rule: a test belongs here only if an in-process test structurally
+//! cannot cover it. Today that means three seams:
+//!
+//! - **the loader** — `dlopen` of a real cdylib, ABI negotiation across the
+//!   stabby seam, manifest/checksum resolution. An in-process test constructs
+//!   the plugin directly and never crosses the seam.
+//! - **the terminal** — the interactive TUI only engages when stderr is a tty,
+//!   and it takes over the alternate screen. Needs a real PTY.
+//! - **the process** — exit status, and the fact that the binary launches at
+//!   all on this host (dyld/glibc resolution of the shipped bytes).
+//!
+//! Engine semantics, caching, provider logic: `crates/e2e`, not here.
+
+#![allow(
+    dead_code,
+    reason = "this module is compiled into every test binary; each uses a subset of it"
+)]
+
+use anyhow::{Context as _, Result};
+use std::path::{Path, PathBuf};
+use std::process::{Command, Output, Stdio};
+use tempfile::TempDir;
+
+/// Env var naming the staged artifact directory.
+///
+/// Set by the `e2e` devenv script, which is the only supported entrypoint —
+/// locally and in CI alike. When it is missing the tests fail rather than skip:
+/// a suite that never ran must not read as a suite that passed.
+pub const DIST_ENV: &str = "HEPH_E2E_DIST";
+
+/// Native shared-library extension for the host, matching the suffix the build
+/// job gives the published plugin cdylibs.
+pub const DYLIB_EXT: &str = if cfg!(target_os = "macos") {
+    "dylib"
+} else {
+    "so"
+};
+
+/// The staged artifact directory: a normalized layout (`heph`,
+/// `heph-<name>-plugin.<ext>`) that the `e2e` script produces identically from
+/// a local release build and from CI's downloaded artifacts.
+pub struct Dist {
+    root: PathBuf,
+}
+
+impl Dist {
+    pub fn locate() -> Self {
+        let root = PathBuf::from(std::env::var_os(DIST_ENV).expect(
+            "HEPH_E2E_DIST is not set — run this suite through the `e2e` devenv script \
+             (it stages the artifacts and sets it), not `cargo test` directly",
+        ));
+        assert!(
+            root.join("heph").is_file(),
+            "{DIST_ENV}={} does not contain a `heph` binary",
+            root.display()
+        );
+        Self { root }
+    }
+
+    pub fn heph(&self) -> PathBuf {
+        self.root.join("heph")
+    }
+
+    /// Path to a published plugin cdylib, e.g. `plugin("go")` →
+    /// `<dist>/heph-go-plugin.<ext>`.
+    pub fn plugin(&self, name: &str) -> PathBuf {
+        self.root.join(format!("heph-{name}-plugin.{DYLIB_EXT}"))
+    }
+}
+
+/// A throwaway workspace: a temp tree with a `.hephconfig`, plus a temp `HOME`
+/// so nothing the run does can touch the developer's real one.
+pub struct Workspace {
+    dir: TempDir,
+    home: TempDir,
+}
+
+/// The plugin set every fixture starts from — enough to declare and run a
+/// trivial target, nothing more.
+pub const BASE_CONFIG: &str = "plugins:\n  - builtin: buildfile\n    options:\n      patterns:\n        - BUILD\n  - builtin: exec\n  - builtin: bash\n";
+
+impl Workspace {
+    pub fn new() -> Result<Self> {
+        let ws = Self {
+            dir: tempfile::tempdir().context("create workspace tempdir")?,
+            home: tempfile::tempdir().context("create home tempdir")?,
+        };
+        ws.config(BASE_CONFIG)?;
+        Ok(ws)
+    }
+
+    pub fn root(&self) -> &Path {
+        self.dir.path()
+    }
+
+    /// Overwrite `.hephconfig`. Callers that need a plugin append to
+    /// [`BASE_CONFIG`] rather than restating the builtins.
+    pub fn config(&self, yaml: &str) -> Result<()> {
+        std::fs::write(self.root().join(".hephconfig"), yaml).context("write .hephconfig")
+    }
+
+    pub fn write(&self, rel: impl AsRef<Path>, contents: &str) -> Result<()> {
+        let path = self.root().join(rel);
+        if let Some(parent) = path.parent() {
+            std::fs::create_dir_all(parent)
+                .with_context(|| format!("create {}", parent.display()))?;
+        }
+        std::fs::write(&path, contents).with_context(|| format!("write {}", path.display()))
+    }
+
+    /// A `heph` invocation rooted at this workspace, with the ambient
+    /// environment neutralized: self-update off (a run must not re-exec into
+    /// some other binary mid-test), telemetry off, `HOME` redirected.
+    pub fn cmd(&self, dist: &Dist, args: &[&str]) -> Command {
+        let mut cmd = Command::new(dist.heph());
+        cmd.args(args)
+            .current_dir(self.root())
+            .env("HOME", self.home.path())
+            .env("HEPH_CWD", self.root())
+            .env("HEPH_NO_SELF_UPDATE", "1")
+            .env("HEPH_DISABLE_TELEMETRY", "1")
+            .env("RUST_BACKTRACE", "1");
+        cmd
+    }
+
+    /// Run to completion with both streams captured (so stderr is *not* a tty
+    /// and the CI line renderer is selected).
+    pub fn run(&self, dist: &Dist, args: &[&str]) -> Result<Output> {
+        self.cmd(dist, args)
+            .stdin(Stdio::null())
+            .output()
+            .with_context(|| format!("spawn heph {}", args.join(" ")))
+    }
+}
+
+/// Render a captured run for an assertion message. Test failures here are
+/// investigated from CI logs, so the whole output goes in the panic.
+pub fn describe(out: &Output) -> String {
+    format!(
+        "status: {}\n--- stdout ---\n{}\n--- stderr ---\n{}",
+        out.status,
+        String::from_utf8_lossy(&out.stdout),
+        String::from_utf8_lossy(&out.stderr),
+    )
+}
+
+/// Write a plugin distribution manifest (`*-plugin.json`) naming `dylib` as the
+/// artifact for this host — the same shape `tools/pluginmanifest` emits, built
+/// here so the suite needs no Go toolchain.
+///
+/// `checksum` is what heph verifies the artifact bytes against before loading;
+/// [`sha256_file`] produces the honest one, and a wrong value is how the
+/// rejection path gets tested.
+pub fn write_manifest(path: &Path, name: &str, dylib: &Path, checksum: Option<&str>) -> Result<()> {
+    let (os, arch) = host_os_arch();
+    let mut artifact = serde_json::Map::new();
+    artifact.insert("os".into(), os.into());
+    artifact.insert("arch".into(), arch.into());
+    artifact.insert("path".into(), dylib.to_string_lossy().into_owned().into());
+    if let Some(sum) = checksum {
+        artifact.insert("checksum".into(), sum.into());
+    }
+    let manifest = serde_json::json!({
+        "name": name,
+        "version": "e2e",
+        "artifacts": [artifact],
+    });
+    let bytes = serde_json::to_vec_pretty(&manifest).context("encode plugin manifest")?;
+    std::fs::write(path, bytes).with_context(|| format!("write {}", path.display()))
+}
+
+/// `sha256:<hex>` of a file, in the spelling the manifest's `checksum` field
+/// takes.
+pub fn sha256_file(path: &Path) -> Result<String> {
+    use sha2::{Digest as _, Sha256};
+
+    let bytes = std::fs::read(path).with_context(|| format!("read {}", path.display()))?;
+    Ok(format!("sha256:{}", hex::encode(Sha256::digest(&bytes))))
+}
+
+/// Host os/arch in the published-artifact spelling heph's manifest resolver
+/// matches on (`darwin`/`linux`, `amd64`/`arm64`).
+pub fn host_os_arch() -> (&'static str, &'static str) {
+    let os = if cfg!(target_os = "macos") {
+        "darwin"
+    } else {
+        "linux"
+    };
+    let arch = if cfg!(target_arch = "aarch64") {
+        "arm64"
+    } else {
+        "amd64"
+    };
+    (os, arch)
+}

--- a/crates/bin-e2e/tests/plugin_dylib.rs
+++ b/crates/bin-e2e/tests/plugin_dylib.rs
@@ -69,8 +69,9 @@ fn shipped_gha_cdylib_loads() {
     .expect("write BUILD");
 
     // A query still resolving the workspace graph means the hook registered and
-    // the engine came up with it attached.
-    let out = ws.run(&dist, &["query", "//pkg/..."]).expect("run");
+    // the engine came up with it attached. Subtree selection needs `-e`: a bare
+    // positional argument is parsed strictly as an address.
+    let out = ws.run(&dist, &["query", "-e", "//pkg/..."]).expect("run");
     assert!(out.status.success(), "{}", describe(&out));
     assert!(
         String::from_utf8_lossy(&out.stdout).contains("//pkg:ok"),

--- a/crates/bin-e2e/tests/plugin_dylib.rs
+++ b/crates/bin-e2e/tests/plugin_dylib.rs
@@ -1,0 +1,114 @@
+//! The cdylib plugin loader, against the cdylibs CI actually publishes.
+//!
+//! In-process tests construct `plugin-go` / `plugin-gha` directly and call
+//! them through Rust generics — the dynamic seam is never crossed. Everything
+//! that can only break at the seam is invisible to them: a symbol missing from
+//! the built `.so`/`.dylib`, an ABI version the host refuses, a plugin whose
+//! own statically-linked tokio/tracing misbehaves once loaded into a foreign
+//! process, and the manifest → checksum → `dlopen` resolution chain.
+
+mod common;
+
+use common::{BASE_CONFIG, Dist, Workspace, describe, sha256_file, write_manifest};
+
+/// A shipped cdylib must load *and answer*. Merely dlopening proves little —
+/// `inspect functions` makes the host call `functions()` on the loaded provider
+/// and render the signature it returns, so a passing assertion means a real
+/// round trip across the ABI seam with real data coming back.
+#[test]
+fn shipped_go_cdylib_loads_and_answers_across_the_abi() {
+    let dist = Dist::locate();
+    let ws = Workspace::new().expect("workspace");
+    let dylib = dist.plugin("go");
+    assert!(dylib.is_file(), "missing {}", dylib.display());
+
+    let manifest = ws.root().join("heph-go-plugin.json");
+    let sum = sha256_file(&dylib).expect("hash go cdylib");
+    write_manifest(&manifest, "go", &dylib, Some(&sum)).expect("write manifest");
+
+    // `gotool: host` keeps the fixture offline: toolchain resolution is lazy, so
+    // nothing is downloaded and no `go` is executed unless a Go target is built
+    // — and none is. This test is about the loader, not about Go.
+    ws.config(&format!(
+        "{BASE_CONFIG}  - path: {}\n    options:\n      gotool: \"host\"\n",
+        manifest.display()
+    ))
+    .expect("write config");
+
+    let out = ws.run(&dist, &["inspect", "functions"]).expect("run");
+    assert!(out.status.success(), "{}", describe(&out));
+
+    let stdout = String::from_utf8_lossy(&out.stdout);
+    assert!(
+        stdout.contains("build_addr"),
+        "go provider's `build_addr` did not come back across the seam: {}",
+        describe(&out)
+    );
+}
+
+/// The second shipped cdylib, exporting a hook rather than a provider — a
+/// different export kind over the same seam, so a loader that only handles
+/// providers fails here and nowhere else.
+#[test]
+fn shipped_gha_cdylib_loads() {
+    let dist = Dist::locate();
+    let ws = Workspace::new().expect("workspace");
+    let dylib = dist.plugin("gha");
+    assert!(dylib.is_file(), "missing {}", dylib.display());
+
+    let manifest = ws.root().join("heph-gha-plugin.json");
+    let sum = sha256_file(&dylib).expect("hash gha cdylib");
+    write_manifest(&manifest, "gha", &dylib, Some(&sum)).expect("write manifest");
+
+    ws.config(&format!("{BASE_CONFIG}  - path: {}\n", manifest.display()))
+        .expect("write config");
+    ws.write(
+        "pkg/BUILD",
+        "target(name = \"ok\", driver = \"bash\", run = \"echo e2e-ok\", cache = False)\n",
+    )
+    .expect("write BUILD");
+
+    // A query still resolving the workspace graph means the hook registered and
+    // the engine came up with it attached.
+    let out = ws.run(&dist, &["query", "//pkg/..."]).expect("run");
+    assert!(out.status.success(), "{}", describe(&out));
+    assert!(
+        String::from_utf8_lossy(&out.stdout).contains("//pkg:ok"),
+        "{}",
+        describe(&out)
+    );
+}
+
+/// The checksum in the manifest is the supply-chain guard on a dylib that is
+/// about to be mapped into the process with full privileges. It must reject,
+/// loudly, before loading. Nothing about this path exists in a linked test —
+/// there is no manifest and no artifact to verify.
+#[test]
+fn manifest_checksum_mismatch_is_rejected() {
+    let dist = Dist::locate();
+    let ws = Workspace::new().expect("workspace");
+    let dylib = dist.plugin("go");
+
+    let manifest = ws.root().join("heph-go-plugin.json");
+    let wrong = format!("sha256:{}", "0".repeat(64));
+    write_manifest(&manifest, "go", &dylib, Some(&wrong)).expect("write manifest");
+
+    ws.config(&format!(
+        "{BASE_CONFIG}  - path: {}\n    options:\n      gotool: \"host\"\n",
+        manifest.display()
+    ))
+    .expect("write config");
+
+    let out = ws.run(&dist, &["inspect", "functions"]).expect("run");
+    assert!(
+        !out.status.success(),
+        "loaded a cdylib whose checksum did not match: {}",
+        describe(&out)
+    );
+    let stderr = String::from_utf8_lossy(&out.stderr);
+    assert!(
+        stderr.contains("checksum"),
+        "rejection did not say why: {}",
+        describe(&out)
+    );
+}

--- a/crates/bin-e2e/tests/tui_pty.rs
+++ b/crates/bin-e2e/tests/tui_pty.rs
@@ -3,12 +3,17 @@
 //! The interactive renderer engages only when stderr is a terminal, so a linked
 //! test — which has no controlling terminal — always takes the CI line backend
 //! and never executes a single line of this code. What is tested here is what
-//! only a terminal can show: that the TUI takes the alternate screen, renders
-//! the run to actual cells, and hands the terminal back on exit.
+//! only a terminal can show: that the TUI builds its viewport, renders the run
+//! to actual cells, and hands the terminal back on exit.
 //!
-//! Terminal restore is the one that matters most in practice. A TUI that dies
-//! without leaving the alternate screen and raw mode leaves the user's shell
-//! unusable, and every non-PTY test in the repo passes while it does.
+//! The TUI uses a ratatui *inline* viewport, not the alternate screen — it
+//! draws in place below the prompt and clears itself on exit. So the signals
+//! are the inline handshake (a cursor-position query the terminal must answer)
+//! and the cursor hide/show pair, not `?1049h`.
+//!
+//! Terminal restore is the one that matters most in practice. A TUI that exits
+//! leaving the cursor hidden and the viewport painted leaves the user's shell a
+//! mess, and every non-PTY test in the repo passes while it does.
 
 mod common;
 
@@ -18,13 +23,16 @@ use std::io::{Read as _, Write as _};
 use std::sync::{Arc, Mutex};
 use std::time::{Duration, Instant};
 
-/// CSI ?1049h / ?1049l — enter and leave the alternate screen.
-const ALT_SCREEN_ENTER: &[u8] = b"\x1b[?1049h";
-const ALT_SCREEN_LEAVE: &[u8] = b"\x1b[?1049l";
-
-/// CSI 6n — Device Status Report, "where is the cursor?". The child blocks on
-/// the reply, so the harness must answer it the way a real terminal would.
+/// CSI 6n — Device Status Report, "where is the cursor?". The inline viewport
+/// needs the answer to know where to draw, and the child blocks until it gets
+/// one, so the harness must reply the way a real terminal would. Only the
+/// interactive backend ever asks, which also makes it the marker for "the TUI
+/// engaged".
 const DSR_CURSOR: &[u8] = b"\x1b[6n";
+
+/// CSI ?25l / ?25h — hide and show the cursor, around the TUI's lifetime.
+const CURSOR_HIDE: &[u8] = b"\x1b[?25l";
+const CURSOR_SHOW: &[u8] = b"\x1b[?25h";
 
 /// Generous: this spawns a release binary that builds a target, on a shared CI
 /// runner. Long enough never to be the flake, short enough to fail the job
@@ -52,18 +60,29 @@ fn tui_renders_the_run_and_restores_the_terminal() {
         session.report()
     );
     assert!(
-        contains(&session.raw, ALT_SCREEN_ENTER),
+        contains(&session.raw, DSR_CURSOR),
         "interactive TUI never engaged with a tty attached\n{}",
-        session.report()
-    );
-    assert!(
-        contains(&session.raw, ALT_SCREEN_LEAVE),
-        "left the terminal in the alternate screen\n{}",
         session.report()
     );
     assert!(
         session.rendered.contains("//pkg:ok"),
         "the target never appeared on the rendered screen\n{}",
+        session.report()
+    );
+
+    // Handed the terminal back: the last thing the TUI does with the cursor is
+    // show it again. A crash or a missing teardown leaves the final hide
+    // unmatched and the user typing blind into an invisible prompt.
+    let hid = last_index(&session.raw, CURSOR_HIDE);
+    let shown = last_index(&session.raw, CURSOR_SHOW);
+    assert!(
+        hid.is_some(),
+        "TUI never hid the cursor\n{}",
+        session.report()
+    );
+    assert!(
+        shown > hid,
+        "exited with the cursor still hidden\n{}",
         session.report()
     );
 }
@@ -86,8 +105,13 @@ fn no_tui_flag_wins_over_an_attached_terminal() {
 
     assert!(session.status_success, "{}", session.report());
     assert!(
-        !contains(&session.raw, ALT_SCREEN_ENTER),
-        "--no-tui still entered the alternate screen\n{}",
+        !contains(&session.raw, DSR_CURSOR),
+        "--no-tui still built the inline viewport\n{}",
+        session.report()
+    );
+    assert!(
+        !contains(&session.raw, CURSOR_HIDE),
+        "--no-tui still took the cursor\n{}",
         session.report()
     );
 }
@@ -232,4 +256,8 @@ fn run_in_pty(dist: &Dist, cwd: &std::path::Path, args: &[&str]) -> Session {
 
 fn contains(haystack: &[u8], needle: &[u8]) -> bool {
     haystack.windows(needle.len()).any(|w| w == needle)
+}
+
+fn last_index(haystack: &[u8], needle: &[u8]) -> Option<usize> {
+    haystack.windows(needle.len()).rposition(|w| w == needle)
 }

--- a/crates/bin-e2e/tests/tui_pty.rs
+++ b/crates/bin-e2e/tests/tui_pty.rs
@@ -1,0 +1,202 @@
+//! The interactive TUI, driven through a real PTY.
+//!
+//! The interactive renderer engages only when stderr is a terminal, so a linked
+//! test — which has no controlling terminal — always takes the CI line backend
+//! and never executes a single line of this code. What is tested here is what
+//! only a terminal can show: that the TUI takes the alternate screen, renders
+//! the run to actual cells, and hands the terminal back on exit.
+//!
+//! Terminal restore is the one that matters most in practice. A TUI that dies
+//! without leaving the alternate screen and raw mode leaves the user's shell
+//! unusable, and every non-PTY test in the repo passes while it does.
+
+mod common;
+
+use common::Dist;
+use portable_pty::{CommandBuilder, PtySize, native_pty_system};
+use std::io::Read as _;
+use std::sync::{Arc, Mutex};
+use std::time::{Duration, Instant};
+
+/// CSI ?1049h / ?1049l — enter and leave the alternate screen.
+const ALT_SCREEN_ENTER: &[u8] = b"\x1b[?1049h";
+const ALT_SCREEN_LEAVE: &[u8] = b"\x1b[?1049l";
+
+/// Generous: this spawns a release binary that builds a target, on a shared CI
+/// runner. Long enough never to be the flake, short enough to fail the job
+/// rather than hang it.
+const DEADLINE: Duration = Duration::from_secs(180);
+
+#[test]
+fn tui_renders_the_run_and_restores_the_terminal() {
+    let dist = Dist::locate();
+    let ws = common::Workspace::new().expect("workspace");
+    // The sleep guarantees the run is observable: without it the target can
+    // finish inside a single frame interval and the in-flight rendering this
+    // test is about never happens.
+    ws.write(
+        "pkg/BUILD",
+        "target(name = \"ok\", driver = \"bash\", run = \"sleep 1; echo e2e-ok\", cache = False)\n",
+    )
+    .expect("write BUILD");
+
+    let session = run_in_pty(&dist, ws.root(), &["run", "//pkg:ok"]);
+
+    assert!(
+        session.status_success,
+        "run failed under a tty\n{}",
+        session.report()
+    );
+    assert!(
+        contains(&session.raw, ALT_SCREEN_ENTER),
+        "interactive TUI never engaged with a tty attached\n{}",
+        session.report()
+    );
+    assert!(
+        contains(&session.raw, ALT_SCREEN_LEAVE),
+        "left the terminal in the alternate screen\n{}",
+        session.report()
+    );
+    assert!(
+        session.rendered.contains("//pkg:ok"),
+        "the target never appeared on the rendered screen\n{}",
+        session.report()
+    );
+}
+
+/// With `--no-tui` the interactive renderer must stay off even though stderr
+/// *is* a terminal — the escape hatch for users piping through a tool that
+/// allocates a tty, and the only configuration in which the flag can be
+/// observed to do anything at all.
+#[test]
+fn no_tui_flag_wins_over_an_attached_terminal() {
+    let dist = Dist::locate();
+    let ws = common::Workspace::new().expect("workspace");
+    ws.write(
+        "pkg/BUILD",
+        "target(name = \"ok\", driver = \"bash\", run = \"echo e2e-ok\", cache = False)\n",
+    )
+    .expect("write BUILD");
+
+    let session = run_in_pty(&dist, ws.root(), &["run", "--no-tui", "//pkg:ok"]);
+
+    assert!(session.status_success, "{}", session.report());
+    assert!(
+        !contains(&session.raw, ALT_SCREEN_ENTER),
+        "--no-tui still entered the alternate screen\n{}",
+        session.report()
+    );
+}
+
+struct Session {
+    status_success: bool,
+    /// Every byte the child wrote to the pty.
+    raw: Vec<u8>,
+    /// Concatenation of the screen as rendered after each read — so an
+    /// assertion sees text that was actually painted into cells at some point,
+    /// not text that merely passed through as bytes.
+    rendered: String,
+}
+
+impl Session {
+    fn report(&self) -> String {
+        format!(
+            "--- rendered screens ---\n{}\n--- raw (lossy) ---\n{}",
+            self.rendered,
+            String::from_utf8_lossy(&self.raw)
+        )
+    }
+}
+
+fn run_in_pty(dist: &Dist, cwd: &std::path::Path, args: &[&str]) -> Session {
+    const ROWS: u16 = 40;
+    const COLS: u16 = 140;
+
+    let pair = native_pty_system()
+        .openpty(PtySize {
+            rows: ROWS,
+            cols: COLS,
+            pixel_width: 0,
+            pixel_height: 0,
+        })
+        .expect("open pty");
+
+    let home = tempfile::tempdir().expect("home tempdir");
+    let mut cmd = CommandBuilder::new(dist.heph());
+    for arg in args {
+        cmd.arg(arg);
+    }
+    cmd.cwd(cwd);
+    cmd.env("HOME", home.path());
+    cmd.env("HEPH_CWD", cwd);
+    cmd.env("HEPH_NO_SELF_UPDATE", "1");
+    cmd.env("HEPH_DISABLE_TELEMETRY", "1");
+    cmd.env("RUST_BACKTRACE", "1");
+    // crossterm needs a terminfo-resolvable TERM; the CI runner's inherited
+    // value may be `dumb` or unset.
+    cmd.env("TERM", "xterm-256color");
+
+    let mut child = pair.slave.spawn_command(cmd).expect("spawn under pty");
+    // Drop the slave handle so the reader sees EOF once the child exits;
+    // otherwise this process keeps the write end open forever.
+    drop(pair.slave);
+
+    let mut reader = pair.master.try_clone_reader().expect("clone pty reader");
+    let captured = Arc::new(Mutex::new((Vec::<u8>::new(), String::new())));
+    let sink = Arc::clone(&captured);
+    let pump = std::thread::spawn(move || {
+        let mut parser = vt100::Parser::new(ROWS, COLS, 0);
+        let mut buf = [0u8; 8192];
+        loop {
+            match reader.read(&mut buf) {
+                Ok(0) | Err(_) => break,
+                Ok(n) => {
+                    let Some(chunk) = buf.get(..n) else { break };
+                    parser.process(chunk);
+                    let screen = parser.screen().contents();
+                    let mut guard = sink.lock().expect("capture lock");
+                    guard.0.extend_from_slice(chunk);
+                    guard.1.push_str(&screen);
+                    guard.1.push('\n');
+                }
+            }
+        }
+    });
+
+    let started = Instant::now();
+    let status = loop {
+        match child.try_wait().expect("wait on pty child") {
+            Some(status) => break Some(status),
+            None => {
+                if started.elapsed() > DEADLINE {
+                    child.kill().expect("kill timed-out pty child");
+                    break None;
+                }
+                std::thread::sleep(Duration::from_millis(50));
+            }
+        }
+    };
+
+    // The child is gone; dropping the master closes the read end so the pump
+    // thread finishes and every byte it captured is visible here.
+    drop(pair.master);
+    assert!(pump.join().is_ok(), "pty reader thread panicked");
+
+    let exited = status.is_some();
+    let guard = captured.lock().expect("capture lock");
+    let session = Session {
+        status_success: status.is_some_and(|s| s.success()),
+        raw: guard.0.clone(),
+        rendered: guard.1.clone(),
+    };
+    assert!(
+        exited,
+        "child did not exit within {DEADLINE:?}\n{}",
+        session.report()
+    );
+    session
+}
+
+fn contains(haystack: &[u8], needle: &[u8]) -> bool {
+    haystack.windows(needle.len()).any(|w| w == needle)
+}

--- a/crates/bin-e2e/tests/tui_pty.rs
+++ b/crates/bin-e2e/tests/tui_pty.rs
@@ -14,13 +14,17 @@ mod common;
 
 use common::Dist;
 use portable_pty::{CommandBuilder, PtySize, native_pty_system};
-use std::io::Read as _;
+use std::io::{Read as _, Write as _};
 use std::sync::{Arc, Mutex};
 use std::time::{Duration, Instant};
 
 /// CSI ?1049h / ?1049l — enter and leave the alternate screen.
 const ALT_SCREEN_ENTER: &[u8] = b"\x1b[?1049h";
 const ALT_SCREEN_LEAVE: &[u8] = b"\x1b[?1049l";
+
+/// CSI 6n — Device Status Report, "where is the cursor?". The child blocks on
+/// the reply, so the harness must answer it the way a real terminal would.
+const DSR_CURSOR: &[u8] = b"\x1b[6n";
 
 /// Generous: this spawns a release binary that builds a target, on a shared CI
 /// runner. Long enough never to be the flake, short enough to fail the job
@@ -142,17 +146,46 @@ fn run_in_pty(dist: &Dist, cwd: &std::path::Path, args: &[&str]) -> Session {
     drop(pair.slave);
 
     let mut reader = pair.master.try_clone_reader().expect("clone pty reader");
+    let mut writer = pair.master.take_writer().expect("take pty writer");
     let captured = Arc::new(Mutex::new((Vec::<u8>::new(), String::new())));
     let sink = Arc::clone(&captured);
     let pump = std::thread::spawn(move || {
         let mut parser = vt100::Parser::new(ROWS, COLS, 0);
         let mut buf = [0u8; 8192];
+        // A pty is a pipe, not a terminal: nothing on this end answers queries.
+        // The TUI asks where the cursor is (DSR) while setting up its inline
+        // viewport and blocks until the terminal replies, so a harness that only
+        // reads deadlocks the child. `tail` carries the last few bytes across
+        // reads in case a request straddles a chunk boundary.
+        let mut tail = Vec::<u8>::new();
         loop {
             match reader.read(&mut buf) {
                 Ok(0) | Err(_) => break,
                 Ok(n) => {
                     let Some(chunk) = buf.get(..n) else { break };
                     parser.process(chunk);
+
+                    tail.extend_from_slice(chunk);
+                    let replies = tail
+                        .windows(DSR_CURSOR.len())
+                        .filter(|w| *w == DSR_CURSOR)
+                        .count();
+                    for _ in 0..replies {
+                        // Cursor at row 1, column 1 — the state a fresh terminal
+                        // is in. The value only positions the inline viewport.
+                        if writer.write_all(b"\x1b[1;1R").is_err() || writer.flush().is_err() {
+                            break;
+                        }
+                    }
+                    // Keep only enough tail to catch a split request, and drop
+                    // anything already answered.
+                    if replies > 0 {
+                        tail.clear();
+                    } else if tail.len() > DSR_CURSOR.len() {
+                        let keep = tail.len() - (DSR_CURSOR.len() - 1);
+                        tail.drain(..keep);
+                    }
+
                     let screen = parser.screen().contents();
                     let mut guard = sink.lock().expect("capture lock");
                     guard.0.extend_from_slice(chunk);

--- a/devenv.nix
+++ b/devenv.nix
@@ -170,7 +170,10 @@ in
     chmod +x "$dist/heph"
 
     export HEPH_E2E_DIST="$dist"
-    cargo test --locked -p bin-e2e "''${@}"
+    # --no-fail-fast: each test file is a separate binary, and cargo stops at the
+    # first one that fails. A CI run that spends 20 minutes building artifacts
+    # should report every broken seam it found, not just the first.
+    cargo test --locked -p bin-e2e --no-fail-fast "''${@}"
   '';
 
   scripts.build-profile.exec = ''cargo build --profile profiling'';

--- a/devenv.nix
+++ b/devenv.nix
@@ -90,9 +90,9 @@ in
   #   e2e                      # build them from this tree (local default)
   #   HEPH_E2E_FROM=dist e2e   # use an already-downloaded set (CI)
   #
-  # Both branches converge on the same normalized layout under
-  # $CARGO_TARGET_DIR/e2e-dist, so the tests never learn which one ran. Extra
-  # args pass through to cargo test (e.g. `e2e tui_pty -- --nocapture`).
+  # Both branches converge on the same normalized layout, so the tests never
+  # learn which one ran. Extra args pass through to cargo test (e.g.
+  # `e2e tui_pty -- --nocapture`).
   scripts.e2e.exec = ''
     set -euo pipefail
 
@@ -105,9 +105,22 @@ in
       *)             arch=amd64 ;;
     esac
 
-    dist="$CARGO_TARGET_DIR/e2e-dist"
-    rm -rf "$dist"
-    mkdir -p "$dist"
+    # Stage into a directory unique to THIS run. CARGO_TARGET_DIR is inherited
+    # from the environment (see enterShell) and worktrees routinely share one,
+    # so a fixed path under it is not private to this run: a second `e2e` — in
+    # another worktree, or just another terminal — would `rm -rf` the binaries
+    # the first one is still running tests against, and the failure would
+    # surface as an unrelated test blowing up somewhere else. mktemp costs one
+    # copy of three files and removes the whole class.
+    dist_root="$CARGO_TARGET_DIR/e2e-dist"
+    mkdir -p "$dist_root"
+    dist="$(mktemp -d "$dist_root/run.XXXXXXXX")"
+    # Keep the staged artifacts for inspection with HEPH_E2E_KEEP_DIST=1.
+    if [ -z "''${HEPH_E2E_KEEP_DIST:-}" ]; then
+      trap 'rm -rf "$dist"' EXIT
+    else
+      trap 'echo "staged artifacts kept at $dist"' EXIT
+    fi
 
     if [ -n "''${HEPH_E2E_FROM:-}" ]; then
       # CI: artifacts downloaded from the `build` job, still carrying their
@@ -121,9 +134,29 @@ in
       # (one invocation so cargo overlaps the three LTO tails — see heph.yml).
       cargo build --release --locked --bin heph --lib -p heph -p plugin-go-cdylib -p plugin-gha-cdylib
       out="$CARGO_TARGET_DIR/release"
+
+      # `release/` is shared across worktrees too, and cargo's build lock only
+      # covers the build — not the gap between it and the copy below. A build in
+      # another worktree landing in that gap would hand this run some other
+      # branch's binary, and every assertion would still pass. Fingerprint the
+      # artifacts around the copy so that becomes a loud failure instead of a
+      # green run against the wrong bytes.
+      fingerprint() {
+        if [ "$os" = "darwin" ]; then stat -f '%i %z %m' "$@"; else stat -c '%i %s %Y' "$@"; fi
+      }
+      before="$(fingerprint "$out/heph" "$out/libplugin_go_cdylib.$ext" "$out/libplugin_gha_cdylib.$ext")"
+
       cp "$out/heph"                       "$dist/heph"
       cp "$out/libplugin_go_cdylib.$ext"   "$dist/heph-go-plugin.$ext"
       cp "$out/libplugin_gha_cdylib.$ext"  "$dist/heph-gha-plugin.$ext"
+
+      after="$(fingerprint "$out/heph" "$out/libplugin_go_cdylib.$ext" "$out/libplugin_gha_cdylib.$ext")"
+      if [ "$before" != "$after" ]; then
+        echo "e2e: $out changed while staging — another build (likely another" >&2
+        echo "e2e: worktree sharing CARGO_TARGET_DIR) raced this one. Re-run." >&2
+        exit 1
+      fi
+
       if [ "$os" = "darwin" ]; then
         # Same post-processing the shipped macOS artifacts get, so a local run
         # tests the same bytes CI would publish.

--- a/devenv.nix
+++ b/devenv.nix
@@ -2,7 +2,7 @@
 
 let
   binLocation = "$HOME/.local/bin/heph3";
-  qualityCrates = "-p heph -p e2e -p testkit -p plugingo-e2e -p htspec-derive -p core -p config -p walk -p proc -p model -p sandboxfuse -p plugin -p plugin-abi -p plugin-sdk -p plugin-stabby -p plugin-go-cdylib -p builtins -p plugin-buildfile -p driver-support -p driver-bridge -p plugin-exec -p plugin-nix -p plugin-http -p plugin-query -p plugin-go -p plugin-gha -p plugin-gha-cdylib -p telemetry -p tui -p lock -p selfupdate -p engine -p xstarlark-fmt";
+  qualityCrates = "-p heph -p e2e -p bin-e2e -p testkit -p plugingo-e2e -p htspec-derive -p core -p config -p walk -p proc -p model -p sandboxfuse -p plugin -p plugin-abi -p plugin-sdk -p plugin-stabby -p plugin-go-cdylib -p builtins -p plugin-buildfile -p driver-support -p driver-bridge -p plugin-exec -p plugin-nix -p plugin-http -p plugin-query -p plugin-go -p plugin-gha -p plugin-gha-cdylib -p telemetry -p tui -p lock -p selfupdate -p engine -p xstarlark-fmt";
 in
 {
   # https://devenv.sh/basics/
@@ -79,7 +79,66 @@ in
   # targeted passes exercise the feature-gated transport code, off by default:
   # the stabby host loader/adapters (plugin-stabby `host`) and the stabby guest
   # serving (plugin-sdk `stabby` — the SDK is transport-agnostic by default).
-  scripts.tst.exec = "cargo test --locked --all && cargo test --locked -p plugin-stabby --features host && cargo test --locked -p plugin-sdk --features stabby";
+  # `bin-e2e` is excluded on purpose: it drives *shipped artifacts*, not this
+  # source tree, and has no meaning without a staged dist. Run it with `e2e`.
+  scripts.tst.exec = "cargo test --locked --workspace --exclude bin-e2e && cargo test --locked -p plugin-stabby --features host && cargo test --locked -p plugin-sdk --features stabby";
+
+  # Binary end-to-end suite: black-box tests against the artifacts CI publishes
+  # (the `heph` binary + the go/gha plugin cdylibs). ONE entrypoint, identical
+  # locally and in CI — the only difference is where the artifacts come from:
+  #
+  #   e2e                      # build them from this tree (local default)
+  #   HEPH_E2E_FROM=dist e2e   # use an already-downloaded set (CI)
+  #
+  # Both branches converge on the same normalized layout under
+  # $CARGO_TARGET_DIR/e2e-dist, so the tests never learn which one ran. Extra
+  # args pass through to cargo test (e.g. `e2e tui_pty -- --nocapture`).
+  scripts.e2e.exec = ''
+    set -euo pipefail
+
+    case "$(uname -s)" in
+      Darwin) os=darwin; ext=dylib ;;
+      *)      os=linux;  ext=so ;;
+    esac
+    case "$(uname -m)" in
+      arm64|aarch64) arch=arm64 ;;
+      *)             arch=amd64 ;;
+    esac
+
+    dist="$CARGO_TARGET_DIR/e2e-dist"
+    rm -rf "$dist"
+    mkdir -p "$dist"
+
+    if [ -n "''${HEPH_E2E_FROM:-}" ]; then
+      # CI: artifacts downloaded from the `build` job, still carrying their
+      # per-platform names. Strip the suffix so the tests see one layout.
+      src="$HEPH_E2E_FROM"
+      cp "$src/heph_''${os}_''${arch}"                 "$dist/heph"
+      cp "$src/heph-go-plugin_''${os}_''${arch}.$ext"  "$dist/heph-go-plugin.$ext"
+      cp "$src/heph-gha-plugin_''${os}_''${arch}.$ext" "$dist/heph-gha-plugin.$ext"
+    else
+      # Local: build the same three artifacts the build job builds, the same way
+      # (one invocation so cargo overlaps the three LTO tails — see heph.yml).
+      cargo build --release --locked --bin heph --lib -p heph -p plugin-go-cdylib -p plugin-gha-cdylib
+      out="$CARGO_TARGET_DIR/release"
+      cp "$out/heph"                       "$dist/heph"
+      cp "$out/libplugin_go_cdylib.$ext"   "$dist/heph-go-plugin.$ext"
+      cp "$out/libplugin_gha_cdylib.$ext"  "$dist/heph-gha-plugin.$ext"
+      if [ "$os" = "darwin" ]; then
+        # Same post-processing the shipped macOS artifacts get, so a local run
+        # tests the same bytes CI would publish.
+        for f in "$dist/heph" "$dist/heph-go-plugin.$ext" "$dist/heph-gha-plugin.$ext"; do
+          bash "$DEVENV_ROOT/scripts/macos-portable.sh" "$f"
+        done
+      fi
+    fi
+
+    # download-artifact does not preserve the executable bit.
+    chmod +x "$dist/heph"
+
+    export HEPH_E2E_DIST="$dist"
+    cargo test --locked -p bin-e2e "''${@}"
+  '';
 
   scripts.build-profile.exec = ''cargo build --profile profiling'';
   scripts.run-profile.exec = ''$CARGO_TARGET_DIR/profiling/heph "''${@}"'';


### PR DESCRIPTION
Adds `crates/bin-e2e`, a black-box suite that drives the artifacts CI publishes — the `heph` binary and the go/gha plugin cdylibs — as a child process.

It links **no workspace crate**, on purpose: linking would test a fresh build of this tree rather than the bytes that ship.

## Scope

Deliberately narrow. A test belongs here only if an in-process test *structurally* cannot reach it. Today that is three seams:

| File | Covers | Why `crates/e2e` can't |
|---|---|---|
| `tests/cli.rs` | binary launches outside a workspace; failing target → non-zero exit; piped output never grabs the alternate screen | a linked test sees an `anyhow::Result`, never an exit code, and never `execve`s the shipped bytes |
| `tests/plugin_dylib.rs` | `dlopen` of the real go/gha cdylibs, manifest → checksum → load chain, `inspect functions` round-tripping `build_addr` back across the ABI, checksum mismatch rejected | in-process tests construct the plugin directly through generics; the seam is never crossed |
| `tests/tui_pty.rs` | TUI under a real PTY: enters the alternate screen, renders the target into actual cells (vt100-parsed), **restores the terminal on exit**; `--no-tui` overrides an attached tty | the interactive backend engages only when stderr is a tty, so a linked test always takes the CI line backend and passes vacuously |

`version` is the canary for the class of link-time breakage that only shows at `execve`: the macOS libiconv `/nix/store` hard-link, weak-linked libfuse without macFUSE, a glibc floor raised past the oldest supported distro. Every one of those passes `cargo test` and fails here.

Terminal restore is the assertion that matters most in practice — a TUI that dies without leaving the alternate screen and raw mode leaves the user's shell unusable, and every non-PTY test in the repo stays green while it does.

Engine semantics, caching and provider logic stay in `crates/e2e`.

## One entrypoint, no duplicated steps

Identical locally and in CI. The only difference is where the artifacts come from:

```
e2e                      # build them from this tree
HEPH_E2E_FROM=dist e2e   # use an already-downloaded set (CI)
```

Both branches converge on the same normalized layout under `$CARGO_TARGET_DIR/e2e-dist` and export `HEPH_E2E_DIST`, so the tests cannot tell which one ran and there is no second copy of the steps to keep in sync. The CI step is literally `run: e2e`. A local macOS build gets the same `macos-portable.sh` treatment the shipped artifacts do.

## CI

New `bin_e2e` job, needs `build`, matrix linux/amd64 + linux/arm64 (`ubuntu-24.04-arm`) + darwin/arm64. **The arm64-linux row is the first time the cross-compiled aarch64 binary is ever executed rather than merely built.** Gates `release`.

`tst` now runs `--workspace --exclude bin-e2e`: the suite is meaningless without a staged dist. It fails rather than skips when `HEPH_E2E_DIST` is absent, so a suite that never ran cannot be mistaken for one that passed.

## Not yet run

The local disk was full (233M free of 927G) and reclaiming space was blocked, so **this suite has never been executed end to end**. It is clippy/fmt-clean only — CI is the first real run. Two things I expect may need a follow-up commit:

- whether `gotool: "host"` is genuinely lazy at plugin construction (the fixture relies on it so nothing is downloaded);
- whether the rendered-screen assertion catches `//pkg:ok` before the frame scrolls.

New dev-deps: `portable-pty`, `vt100`, `sha2`, `hex`, `serde_json`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01AUHDCkYMVL81mP5TMu8Xte