### PR TITLE
fix(remote-cache): pin the multipart writer to one in-flight part

### DIFF
--- a/crates/engine/src/engine/remote_cache.rs
+++ b/crates/engine/src/engine/remote_cache.rs
@@ -87,7 +87,8 @@ use tracing::{debug, warn};
 /// Fanning a revision out is what makes a multi-output target fast, but it must
 /// stay bounded: each in-flight download holds an open temp file plus a live
 /// response stream, and each in-flight upload holds an `object_store` multipart
-/// buffer (10 MiB). A target with thousands of artifacts, multiplied by the
+/// buffer (10 MiB per in-flight part; the writer is pinned to one part, so 10
+/// MiB). A target with thousands of artifacts, multiplied by the
 /// engine's own target-level parallelism, would otherwise run the process out of
 /// file descriptors or memory. Requests past this bound simply queue.
 pub(crate) const REVISION_BLOB_CONCURRENCY: usize = 32;
@@ -248,10 +249,14 @@ const META_SLOT_RESERVE: usize = 32;
 /// counts.
 ///
 /// The reserve is [`META_SLOT_RESERVE`], or half the budget when that is smaller,
-/// so a deliberately tiny `concurrency` still leaves room for both classes. The
-/// two sum to the budget, so the store's own request cap (`LimitStore`) is never
-/// the binding constraint and therefore never a place where the two classes
-/// contend again.
+/// so a deliberately tiny `concurrency` still leaves room for both classes.
+///
+/// The two sum to the budget, so the store's own request cap (`LimitStore`) is
+/// never the binding constraint and therefore never a place where the two
+/// classes contend again — but that holds only while **one slot means one store
+/// request**. A multipart writer left at `object_store`'s default concurrency
+/// takes a store permit per in-flight part, and one blob slot silently becomes
+/// eight; see `ObjStoreBackend::open_write`, which pins it to one.
 fn split_request_budget(concurrency: usize) -> (usize, usize) {
     let total = concurrency.max(2);
     let reserve = META_SLOT_RESERVE.min(total / 2).max(1);

--- a/crates/engine/src/engine/remote_cache_objstore.rs
+++ b/crates/engine/src/engine/remote_cache_objstore.rs
@@ -325,10 +325,28 @@ impl RemoteCacheBackend for ObjStoreBackend {
 
     async fn open_write(&self, key: &str) -> anyhow::Result<Pin<Box<dyn AsyncWrite + Send>>> {
         let path = self.object_path(key);
-        // `BufWriter` performs a multipart upload under the hood, buffering at
-        // most one part (default 10 MiB) before flushing — bounded memory.
-        // Finalized on `poll_shutdown`.
-        Ok(Box::pin(BufWriter::new(self.store.clone(), path)))
+        // `BufWriter` performs a multipart upload under the hood, finalized on
+        // `poll_shutdown`.
+        //
+        // `with_max_concurrency(1)` is load-bearing, not tuning. At its default
+        // of 8 the writer spawns up to eight `put_part` tasks, and **each one
+        // takes its own permit from the store-wide `LimitStore`** — so one heph
+        // blob slot expands to eight store requests. That breaks the 1:1
+        // slot-to-request invariant `split_request_budget` is built on: the
+        // metadata reserve's real store headroom is only the metadata share, so
+        // a few dozen concurrent uploads exhaust the whole store budget, a
+        // manifest read then starts its `METADATA_TIMEOUT` clock while queued
+        // behind blob parts whose own stall bound is ten minutes, and three such
+        // timeouts trip the breaker — dropping a *healthy* cache for the rest of
+        // the run. That is the failure PR #178 fixed one layer out.
+        //
+        // Raising the `LimitStore` ceiling instead would defeat the connection
+        // bound it exists to impose. The cost is losing part pipelining on a
+        // high-latency link for multi-GiB blobs; `REVISION_BLOB_CONCURRENCY`
+        // still fans out across blobs, and can be raised if throughput regresses.
+        Ok(Box::pin(
+            BufWriter::new(self.store.clone(), path).with_max_concurrency(1),
+        ))
     }
 
     async fn exists(&self, key: &str) -> anyhow::Result<bool> {
@@ -480,6 +498,159 @@ mod tests {
         let mut buf = Vec::new();
         r.read_to_end(&mut buf).await.expect("read");
         Some(buf)
+    }
+
+    /// One heph blob slot must mean one store request.
+    ///
+    /// `split_request_budget` divides a cache's `concurrency` into a metadata
+    /// reserve and a bulk pool on exactly that basis, so the store's own
+    /// `LimitStore` is never the binding constraint. `BufWriter` at its default
+    /// concurrency breaks it: it spawns up to eight `put_part` tasks per writer,
+    /// each taking its own store permit, and the metadata reserve's real store
+    /// headroom collapses. A manifest read then starts its `METADATA_TIMEOUT`
+    /// clock while queued behind blob parts bounded at ten minutes, and three of
+    /// those trip the breaker on a cache that is perfectly healthy.
+    #[tokio::test]
+    async fn a_multipart_upload_takes_one_store_request_at_a_time() {
+        use object_store::{
+            GetOptions, GetResult, ListResult, MultipartUpload, ObjectMeta, PutMultipartOptions,
+            PutOptions, PutPayload, PutResult, Result as OsResult, UploadPart,
+        };
+        use std::sync::atomic::{AtomicUsize, Ordering};
+
+        /// Delegates to an in-memory store, recording peak concurrent parts.
+        #[derive(Debug)]
+        struct PartCountingStore {
+            inner: Arc<dyn ObjectStore>,
+            inflight: Arc<AtomicUsize>,
+            peak: Arc<AtomicUsize>,
+        }
+
+        impl std::fmt::Display for PartCountingStore {
+            fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+                f.write_str("PartCountingStore")
+            }
+        }
+
+        struct CountingUpload {
+            inner: Box<dyn MultipartUpload>,
+            inflight: Arc<AtomicUsize>,
+            peak: Arc<AtomicUsize>,
+        }
+
+        impl std::fmt::Debug for CountingUpload {
+            fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+                f.write_str("CountingUpload")
+            }
+        }
+
+        #[async_trait::async_trait]
+        impl MultipartUpload for CountingUpload {
+            fn put_part(&mut self, data: PutPayload) -> UploadPart {
+                let n = self.inflight.fetch_add(1, Ordering::SeqCst) + 1;
+                self.peak.fetch_max(n, Ordering::SeqCst);
+                let part = self.inner.put_part(data);
+                let inflight = Arc::clone(&self.inflight);
+                Box::pin(async move {
+                    // Slow enough that overlapping parts overlap observably.
+                    tokio::time::sleep(Duration::from_millis(20)).await;
+                    let r = part.await;
+                    inflight.fetch_sub(1, Ordering::SeqCst);
+                    r
+                })
+            }
+            async fn complete(&mut self) -> OsResult<PutResult> {
+                self.inner.complete().await
+            }
+            async fn abort(&mut self) -> OsResult<()> {
+                self.inner.abort().await
+            }
+        }
+
+        #[async_trait::async_trait]
+        impl ObjectStore for PartCountingStore {
+            async fn put_opts(
+                &self,
+                location: &ObjPath,
+                payload: PutPayload,
+                opts: PutOptions,
+            ) -> OsResult<PutResult> {
+                self.inner.put_opts(location, payload, opts).await
+            }
+            async fn put_multipart_opts(
+                &self,
+                location: &ObjPath,
+                opts: PutMultipartOptions,
+            ) -> OsResult<Box<dyn MultipartUpload>> {
+                let inner = self.inner.put_multipart_opts(location, opts).await?;
+                Ok(Box::new(CountingUpload {
+                    inner,
+                    inflight: Arc::clone(&self.inflight),
+                    peak: Arc::clone(&self.peak),
+                }))
+            }
+            async fn get_opts(&self, location: &ObjPath, opts: GetOptions) -> OsResult<GetResult> {
+                self.inner.get_opts(location, opts).await
+            }
+            fn delete_stream(
+                &self,
+                locations: futures::stream::BoxStream<'static, OsResult<ObjPath>>,
+            ) -> futures::stream::BoxStream<'static, OsResult<ObjPath>> {
+                self.inner.delete_stream(locations)
+            }
+            fn list(
+                &self,
+                prefix: Option<&ObjPath>,
+            ) -> futures::stream::BoxStream<'static, OsResult<ObjectMeta>> {
+                self.inner.list(prefix)
+            }
+            async fn list_with_delimiter(&self, prefix: Option<&ObjPath>) -> OsResult<ListResult> {
+                self.inner.list_with_delimiter(prefix).await
+            }
+            async fn copy_opts(
+                &self,
+                from: &ObjPath,
+                to: &ObjPath,
+                opts: object_store::CopyOptions,
+            ) -> OsResult<()> {
+                self.inner.copy_opts(from, to, opts).await
+            }
+        }
+
+        let (inflight, peak) = (Arc::new(AtomicUsize::new(0)), Arc::new(AtomicUsize::new(0)));
+        let backend = ObjStoreBackend {
+            store: Arc::new(PartCountingStore {
+                inner: Arc::new(object_store::memory::InMemory::new()),
+                inflight: Arc::clone(&inflight),
+                peak: Arc::clone(&peak),
+            }),
+            prefix: ObjPath::from("repo"),
+        };
+
+        // Several parts' worth: `BufWriter`'s default part size is 10 MiB, and
+        // at its default concurrency of 8 these would overlap.
+        //
+        // Written in chunks rather than one 45 MiB call, because that is what
+        // the upload path does (`stream_file_to_backend` copies chunk by chunk)
+        // and because the bound applies *between* writes: a single `write` of
+        // several parts' worth splits them internally with no capacity check.
+        let blob = vec![0u8; 45 * 1024 * 1024];
+        let mut w = backend.open_write("big.blob").await.expect("open_write");
+        for chunk in blob.chunks(256 * 1024) {
+            w.write_all(chunk).await.expect("write");
+        }
+        w.shutdown().await.expect("shutdown");
+        assert_eq!(get(&backend, "big.blob").await.expect("present"), blob);
+
+        assert!(
+            peak.load(Ordering::SeqCst) > 0,
+            "the upload must actually have gone multipart"
+        );
+        assert_eq!(
+            peak.load(Ordering::SeqCst),
+            1,
+            "one blob slot must never expand into several store requests",
+        );
     }
 
     #[tokio::test]


### PR DESCRIPTION
**P3.1** of the threading/scale remediation. Independent of the other phases.

## Problem

`split_request_budget` divides a cache's `concurrency` into a metadata reserve and a bulk pool, and documents that the store's own `LimitStore` is therefore never the binding constraint. That holds only while **one heph slot means one store request**.

`BufWriter` at object_store's default concurrency of 8 spawns up to eight `put_part` tasks per writer, and *each one takes its own permit from the store-wide `LimitStore`*. One blob slot silently became eight store requests. True for GET and LIST; false for multipart PUT.

The consequence is not slow uploads, it is a **dropped cache**. The metadata reserve's real store headroom collapses to the metadata share alone, so a few dozen concurrent uploads exhaust the budget. A manifest read then takes its reserve slot, starts its 60 s `METADATA_TIMEOUT` clock, and queues behind blob parts whose own stall bound is ten minutes. Three of those trip the circuit breaker and a perfectly healthy cache is skipped for the rest of the run — the failure #178 fixed one layer out, reappearing underneath it.

## Change

`.with_max_concurrency(1)` on the writer. Restores the documented 1:1 slot-to-request invariant and caps per-writer buffer at one part.

Raising the `LimitStore` ceiling to `32 + 224×8` instead would defeat the connection bound it exists to impose.

**Cost**: loses part pipelining on a high-latency link for multi-GiB blobs. `REVISION_BLOB_CONCURRENCY` still fans out across blobs and can be raised if throughput regresses.

Also corrects two stale claims the audit flagged: the request-budget doc now states the 1:1 invariant as a precondition rather than a fact, and `REVISION_BLOB_CONCURRENCY` says *why* a writer's buffer is 10 MiB instead of asserting it.

## Test

The existing saturation guard test stubs `open_write` as `bail!("unused")`, so it structurally could not catch this. The new test goes through the real `ObjStoreBackend` against an `ObjectStore` double that wraps `InMemory` and counts concurrent `put_part`.

One subtlety worth recording: the bound applies **between** writes. A single `write` carrying several parts' worth splits them internally with no capacity check, so a test that hands the writer 45 MiB in one call sees 5 concurrent parts even when pinned. The test writes in 256 KiB chunks, which is what `stream_file_to_backend` actually does. Verified peak 5 at the default concurrency, 1 pinned.

## Consults the plan asked for and I did not run

`compatibility` (remote-cache wire behaviour) and `perf-measurement` (throughput regression). This changes upload *pacing*, not the wire format — objects, keys and the manifest are byte-identical, and a cache written by either version is readable by the other. The throughput question is real and I have no number for it; the shape of the answer is a multi-GiB blob over a high-latency link, before and after.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01A76DChMohieGMbRbnV1E7x