### PR TITLE
feat(diag): write stall reports to a file, log the path

### DIFF
--- a/crates/engine/src/engine/diag.rs
+++ b/crates/engine/src/engine/diag.rs
@@ -567,12 +567,13 @@ fn human_bytes(b: u64) -> String {
     "0 B".to_string()
 }
 
-/// Render a stall report as the paragraph printed to stderr.
+/// Render a stall report as the paragraph appended to the [`StallLog`].
 ///
 /// The wording deliberately avoids the vocabulary of a *failure* — no "error",
-/// no "failed". This lands in the CI log of every slow build, and a log processor
-/// grepping stderr for failure signatures must not match a progress notice. It
-/// says "no progress", never "hung": the run may well be fine.
+/// no "failed". The file is read (and often catted into a CI log) on every slow
+/// build, and a log processor grepping for failure signatures must not match a
+/// progress notice. It says "no progress", never "hung": the run may well be
+/// fine.
 ///
 /// The text is a diagnostic, not an interface. Nothing should parse it — that is
 /// what the machine-readable surface is for.
@@ -645,16 +646,69 @@ pub fn render_stall(r: &StallReport) -> String {
     out
 }
 
-/// Poll [`DiagState::evaluate`] and emit a paragraph when it reports a stall.
+/// Where stall paragraphs are appended.
+///
+/// A file rather than the terminal, because the two readers want opposite
+/// things. The paragraph is six lines of table that repeats as the stall
+/// escalates; inlined into a TUI frame or a CI log it buries the build output it
+/// is meant to annotate, and in CI it lands in the middle of whatever the
+/// compiler was printing. A file keeps the full history, keeps it in one place
+/// across every fire of the run, and leaves the terminal with a single line
+/// naming the path.
+///
+/// It sits next to the `SIGQUIT` thread dumps (`<home>/diag/`) — the two are read
+/// together when diagnosing the same hang, and `heph tool gc` already sweeps that
+/// directory. Per-pid, so concurrent heph processes in one workspace do not
+/// interleave their reports into one unreadable file.
+pub struct StallLog {
+    path: std::path::PathBuf,
+}
+
+impl StallLog {
+    pub fn new(home: &std::path::Path) -> Self {
+        Self {
+            path: home
+                .join("diag")
+                .join(format!("stall-{}.log", std::process::id())),
+        }
+    }
+
+    pub fn path(&self) -> &std::path::Path {
+        &self.path
+    }
+
+    /// Append one rendered report, creating the directory on first write.
+    ///
+    /// Appends rather than truncates: the escalation sequence *is* the
+    /// diagnostic — "98 open, oldest 60s" followed by "98 open, oldest 512s" says
+    /// wedged, where either line alone says only slow.
+    pub fn append(&self, text: &str) -> std::io::Result<()> {
+        use std::io::Write as _;
+        if let Some(dir) = self.path.parent() {
+            std::fs::create_dir_all(dir)?;
+        }
+        let mut f = std::fs::OpenOptions::new()
+            .create(true)
+            .append(true)
+            .open(&self.path)?;
+        f.write_all(text.as_bytes())
+    }
+}
+
+/// Poll [`DiagState::evaluate`] and emit a report when it detects a stall.
 ///
 /// Runs on a plain OS thread, never a tokio timer: the whole point is to keep
 /// working when the runtime is saturated or the reactor is not turning, which is
 /// the condition being diagnosed. It is deliberately *not* merged into
 /// `hcore::blocking`'s backstop thread — that one is a correctness mechanism for
-/// dropped wake-ups, and this one ends in a blocking `write` to stderr. In CI
-/// stderr is a pipe; a stalled consumer would fill the 64 KiB buffer and block
-/// forever, freezing waker delivery for the entire blocking pool. The watchdog
-/// would then hang the process it exists to diagnose.
+/// dropped wake-ups, and this one ends in blocking I/O. In CI stderr is a pipe;
+/// a stalled consumer would fill the 64 KiB buffer and block forever, freezing
+/// waker delivery for the entire blocking pool. The watchdog would then hang the
+/// process it exists to diagnose.
+///
+/// `emit` takes the report, not the rendered text: the caller decides what goes
+/// to the file and what goes to the terminal, and rendering inside the watchdog
+/// would fix that policy here.
 pub struct Watchdog {
     stop: std::sync::Arc<std::sync::atomic::AtomicBool>,
 }
@@ -663,7 +717,7 @@ impl Watchdog {
     pub fn spawn(
         state: std::sync::Arc<DiagState>,
         threshold: Duration,
-        emit: impl Fn(&str) + Send + 'static,
+        emit: impl Fn(&StallReport) + Send + 'static,
     ) -> Self {
         let stop = std::sync::Arc::new(std::sync::atomic::AtomicBool::new(false));
         let stop_thread = std::sync::Arc::clone(&stop);
@@ -689,7 +743,7 @@ impl Watchdog {
                             >= u64::try_from(threshold.as_millis()).unwrap_or(60_000) * 2
                     });
                     if due {
-                        emit(&render_stall(&report));
+                        emit(&report);
                         last_fired = Some(now);
                     }
                 }
@@ -968,6 +1022,40 @@ mod tests {
         let s = state();
         let text = render_stall(&s.evaluate(120_000, T).expect("stalled"));
         assert!(text.contains("still resolving targets"), "{text}");
+    }
+
+    /// The log lands under the home dir's `diag/` — beside the `SIGQUIT` thread
+    /// dumps, which is where a reader chasing a hang already looks — and creates
+    /// that directory itself, since nothing else does before the first stall.
+    #[test]
+    fn stall_log_writes_under_the_home_diag_dir() {
+        let home = tempfile::tempdir().expect("tempdir");
+        let log = StallLog::new(home.path());
+        assert_eq!(
+            log.path().parent(),
+            Some(home.path().join("diag").as_path())
+        );
+
+        log.append("first\n").expect("append into a missing dir");
+        assert_eq!(
+            std::fs::read_to_string(log.path()).expect("read back"),
+            "first\n"
+        );
+    }
+
+    /// Successive fires accumulate. The escalation sequence is the diagnostic —
+    /// "oldest 60s" then "oldest 512s" says wedged, where either alone says only
+    /// slow — so a truncating write would destroy the signal.
+    #[test]
+    fn stall_log_appends_rather_than_truncating() {
+        let home = tempfile::tempdir().expect("tempdir");
+        let log = StallLog::new(home.path());
+        log.append("oldest 60s\n").expect("append");
+        log.append("oldest 512s\n").expect("append");
+        assert_eq!(
+            std::fs::read_to_string(log.path()).expect("read back"),
+            "oldest 60s\noldest 512s\n"
+        );
     }
 
     /// The hook folds the real event stream, and `ResultEnd` counts failures.

--- a/src/commands/global.rs
+++ b/src/commands/global.rs
@@ -25,12 +25,13 @@ pub struct GlobalOptions {
     /// report is also written at exit.
     #[arg(long = "pprof-cpu", value_name = "PATH", global = true)]
     pub pprof_cpu: Option<PathBuf>,
-    /// Print a diagnostic when a run makes no progress for this long
+    /// Write a diagnostic when a run makes no progress for this long
     ///
     /// heph watches its own event stream and, if nothing at all advances for the
-    /// given duration while work is outstanding, prints one paragraph to stderr
-    /// naming what is open, for how long, and whether any bytes are moving. Off
-    /// with `--stall-notice=off`. Default: 60s.
+    /// given duration while work is outstanding, appends one paragraph naming
+    /// what is open, for how long, and whether any bytes are moving to
+    /// `<home>/diag/stall-<pid>.log`, and logs the path at `warn`. Off with
+    /// `--stall-notice=off`. Default: 60s.
     ///
     /// The text is a diagnostic, not a stable interface — parse the JSON surface
     /// instead.

--- a/src/commands/run.rs
+++ b/src/commands/run.rs
@@ -279,11 +279,14 @@ async fn execute_async(args: RunArgs, sink: LogSink, global: GlobalOptions) -> a
     };
     let interactive = tui::should_use_tui(global.no_tui);
 
-    // Stall watchdog. Registered before the run so it observes the whole stream,
-    // and it emits through the same `LogSink` the logs use rather than a bare
-    // `eprintln!` — while the TUI owns the terminal a raw stderr write from an
-    // unrelated OS thread interleaves mid-frame and corrupts the display, which
-    // would make the paragraph unreadable in exactly the interactive case.
+    // Stall watchdog. Registered before the run so it observes the whole stream.
+    //
+    // The paragraph goes to `<home>/diag/stall-<pid>.log` and the terminal gets
+    // one `warn!` naming it. Inline, the table repeated on every escalation
+    // buries the build output it is meant to annotate — and it grows exactly when
+    // the terminal is least readable. The `warn!` goes through `tracing`, hence
+    // the same `LogSink` as every other log, so while the TUI owns the terminal
+    // it lands as a proper line instead of interleaving mid-frame.
     //
     // It runs in both TUI and `--no-tui` mode: the CI backend creates the same
     // event channel, so the fold is already paid for, and a hung CI build is
@@ -291,10 +294,31 @@ async fn execute_async(args: RunArgs, sink: LogSink, global: GlobalOptions) -> a
     let watchdog = (!global.stall_notice.is_zero()).then(|| {
         let threshold = global.stall_notice;
         let diag_sink = sink.clone();
+        let log = hengine::engine::diag::StallLog::new(&engine.home);
         hengine::engine::diag::Watchdog::spawn(
             std::sync::Arc::clone(hengine::engine::diag::global()),
             threshold,
-            move |text| diag_sink.write_diagnostic(text),
+            move |report| {
+                let text = hengine::engine::diag::render_stall(report);
+                if let Err(e) = log.append(&text) {
+                    // Read-only fs, full disk, gc'd home. The paragraph is the
+                    // whole point of the watchdog, so print it rather than lose
+                    // it to the failure of its own delivery mechanism.
+                    tracing::warn!(
+                        path = %log.path().display(),
+                        error = %e,
+                        "Cannot write the stall diagnostic; printing it instead"
+                    );
+                    diag_sink.write_diagnostic(&text);
+                    return;
+                }
+                tracing::warn!(
+                    path = %log.path().display(),
+                    quiet_for_s = report.quiet_for.as_secs(),
+                    open = report.open.iter().map(|(_, n, _)| n).sum::<u64>(),
+                    "No progress; wrote a stall diagnostic"
+                );
+            },
         )
     });
 

--- a/src/diag.rs
+++ b/src/diag.rs
@@ -31,7 +31,7 @@ use std::ffi::CString;
 use std::os::unix::ffi::OsStrExt;
 use std::sync::Once;
 use std::sync::atomic::{AtomicBool, AtomicI32, Ordering};
-use tracing::{info, warn};
+use tracing::warn;
 
 /// File descriptor the handler appends dumps to; `-1` until [`install`] opens it.
 static DIAG_FD: AtomicI32 = AtomicI32::new(-1);
@@ -136,7 +136,10 @@ fn sweep() {
     }
 
     let n = sweep_threads();
-    info!(threads = n, path = %path.display(), "Wrote thread backtraces");
+    // `warn!`, not `info!`: someone pressed `Ctrl-\` on a frozen build and the one
+    // thing they need back is where the dump went. At `info!` that line sits in
+    // the same stream as ordinary build chatter and scrolls past unread.
+    warn!(threads = n, path = %path.display(), "Wrote thread backtraces");
 }
 
 /// Signal used to make each thread dump itself. `SIGUSR1` is free here —


### PR DESCRIPTION
## What

The stall watchdog printed its six-line table into the terminal on every escalation, which buries the build output it is meant to annotate — and it grows exactly when the terminal is least readable.

It now appends the paragraph to `<home>/diag/stall-<pid>.log` and logs that path at `warn`:

```
WARN No progress; wrote a stall diagnostic path=.heph3/diag/stall-4711.log quiet_for_s=512 open=98
```

## Details

- The log sits beside the `SIGQUIT` thread dumps (`<home>/diag/`), which is where a reader chasing a hang already looks, and `heph tool gc` sweeps that directory.
- It **appends** rather than truncates: the escalation sequence is the diagnostic — "oldest 60s" then "oldest 512s" says wedged, where either line alone says only slow. Per-pid, so concurrent heph processes in one workspace do not interleave into one unreadable file.
- `Watchdog::spawn`'s callback takes the `StallReport` instead of pre-rendered text, so the caller decides what goes to the file and what goes to the terminal.
- When the file cannot be written (read-only fs, full disk) the paragraph is printed to the sink instead — the diagnostic must not be lost to the failure of its own delivery mechanism.
- The `SIGQUIT` thread-dump path moves from `info!` to `warn!` for the same reason: someone pressed `Ctrl-\` on a frozen build and the one thing they need back is where the dump went.
- `--stall-notice` help text updated to describe the file.

## Tests

Two new unit tests in `crates/engine/src/engine/diag.rs`: the log lands under `<home>/diag/` and creates that directory on first write, and successive fires accumulate rather than truncate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MZu4RA4aoSB7J1ztdcBgNJ