### PR TITLE
perf(engine): prune non-matching packages before probe and list

### DIFF
--- a/crates/engine/src/engine/packages.rs
+++ b/crates/engine/src/engine/packages.rs
@@ -19,6 +19,8 @@ use std::sync::Arc;
 fn narrowing_prefix(m: &htmatcher::Matcher) -> PkgBuf {
     match m {
         htmatcher::Matcher::Package(p) | htmatcher::Matcher::PackagePrefix(p) => p.clone(),
+        // An exact addr lives in exactly one package.
+        htmatcher::Matcher::Addr(a) => a.package.clone(),
         htmatcher::Matcher::And(ms) => ms
             .iter()
             .map(narrowing_prefix)
@@ -207,6 +209,12 @@ mod tests {
             narrowing_prefix(&Matcher::PackagePrefix(pkg("foo"))),
             pkg("foo")
         );
+    }
+
+    #[test]
+    fn addr_returns_its_package() {
+        let a = hmodel::htaddr::Addr::new(pkg("foo/bar"), "baz".to_string(), Default::default());
+        assert_eq!(narrowing_prefix(&Matcher::Addr(a)), pkg("foo/bar"));
     }
 
     #[test]

--- a/crates/engine/src/engine/query.rs
+++ b/crates/engine/src/engine/query.rs
@@ -37,6 +37,17 @@ impl Engine {
             for pkg_result in self.packages(m, &rs).await? {
                 let pkg = PkgBuf::from(pkg_result?);
 
+                // Prune before probing or listing. `list` is a whole-package
+                // Starlark evaluation for the buildfile provider, so without
+                // this a scoped query (`//foo/...`, `label(l) && //foo/...`,
+                // a bare `//foo:bar`) still pays to evaluate every BUILD file
+                // in the repo and then throws the results away at the addr
+                // check below. Providers are free to ignore `ListPackagesRequest::prefix`
+                // — most do — so the narrowing has to happen here too.
+                if m.matches_pkg(&pkg) == MatchResult::MatchNo {
+                    continue;
+                }
+
                 let states = Arc::clone(&self).probe_segments(&rs, &pkg).await?;
 
                 for provider in &self.providers {
@@ -457,6 +468,184 @@ mod tests {
             .expect("list called for queried package a/b/c");
         let pkgs: Vec<String> = abc.iter().map(|s| s.package.as_str().to_string()).collect();
         assert_eq!(pkgs, vec!["a/b/c", "a/b", "a", ""]);
+        Ok(())
+    }
+
+    /// A provider over a fixed package set that records every package `list`
+    /// was actually asked for — the cost a scoped query must not pay.
+    struct ListSpy {
+        pkgs: Vec<&'static str>,
+        listed: Arc<std::sync::Mutex<Vec<String>>>,
+    }
+
+    impl crate::engine::provider::Provider for ListSpy {
+        fn config(
+            &self,
+            _req: crate::engine::provider::ConfigRequest,
+        ) -> anyhow::Result<crate::engine::provider::ConfigResponse> {
+            Ok(crate::engine::provider::ConfigResponse {
+                name: "spy".to_string(),
+            })
+        }
+        fn list<'a>(
+            &'a self,
+            req: ListRequest,
+            _ctoken: &'a (dyn hcore::hasync::Cancellable + Send + Sync),
+        ) -> futures::future::BoxFuture<
+            'a,
+            anyhow::Result<
+                Box<
+                    dyn Iterator<Item = anyhow::Result<crate::engine::provider::ListResponse>>
+                        + Send,
+                >,
+            >,
+        > {
+            let pkg = req.package.clone();
+            let listed = Arc::clone(&self.listed);
+            Box::pin(async move {
+                listed.lock().unwrap().push(pkg.as_str().to_string());
+                let items: Vec<anyhow::Result<crate::engine::provider::ListResponse>> =
+                    vec![Ok(crate::engine::provider::ListResponse {
+                        addr: Addr::new(pkg, "t".to_string(), Default::default()),
+                    })];
+                Ok(Box::new(items.into_iter()) as Box<dyn Iterator<Item = _> + Send>)
+            })
+        }
+        fn list_packages<'a>(
+            &'a self,
+            _req: crate::engine::provider::ListPackagesRequest,
+            _ctoken: &'a (dyn hcore::hasync::Cancellable + Send + Sync),
+        ) -> futures::future::BoxFuture<
+            'a,
+            anyhow::Result<
+                Box<
+                    dyn Iterator<
+                            Item = anyhow::Result<crate::engine::provider::ListPackageResponse>,
+                        > + Send,
+                >,
+            >,
+        > {
+            // Deliberately ignores `req.prefix`, like every real provider in
+            // the tree: the engine must do the narrowing itself.
+            let items: Vec<anyhow::Result<crate::engine::provider::ListPackageResponse>> = self
+                .pkgs
+                .iter()
+                .map(|p| {
+                    Ok(crate::engine::provider::ListPackageResponse {
+                        pkg: PkgBuf::from(*p),
+                    })
+                })
+                .collect();
+            Box::pin(async move {
+                Ok(Box::new(items.into_iter()) as Box<dyn Iterator<Item = _> + Send>)
+            })
+        }
+        fn get<'a>(
+            &'a self,
+            _req: crate::engine::provider::GetRequest,
+            _ctoken: &'a (dyn hcore::hasync::Cancellable + Send + Sync),
+        ) -> futures::future::BoxFuture<
+            'a,
+            Result<crate::engine::provider::GetResponse, crate::engine::provider::GetError>,
+        > {
+            Box::pin(async { Err(crate::engine::provider::GetError::NotFound) })
+        }
+        fn probe<'a>(
+            &'a self,
+            req: crate::engine::provider::ProbeRequest,
+            _ctoken: &'a (dyn hcore::hasync::Cancellable + Send + Sync),
+        ) -> futures::future::BoxFuture<'a, anyhow::Result<crate::engine::provider::ProbeResponse>>
+        {
+            let pkg = req.package.clone();
+            Box::pin(async move {
+                Ok(crate::engine::provider::ProbeResponse {
+                    states: vec![crate::engine::provider::State {
+                        package: pkg,
+                        provider: "spy".to_string(),
+                        state: Default::default(),
+                    }],
+                })
+            })
+        }
+    }
+
+    async fn listed_packages_for(m: Matcher) -> anyhow::Result<Vec<String>> {
+        let root = tempdir()?;
+        let listed = Arc::new(std::sync::Mutex::new(Vec::new()));
+        let spy_listed = Arc::clone(&listed);
+        let mut engine = Engine::new(Config {
+            root: root.path().to_path_buf(),
+            home_dir: std::path::PathBuf::new(),
+            parallelism: None,
+            ..Default::default()
+        })?;
+        engine.register_provider(move |_| {
+            Box::new(ListSpy {
+                pkgs: vec!["foo", "foo/deep", "bar", "bar/deep", "unrelated"],
+                listed: Arc::clone(&spy_listed),
+            })
+        })?;
+        let engine = Arc::new(engine);
+        let rs = engine.new_state();
+
+        let _: Vec<Addr> = engine.query(rs, &m).try_collect().await?;
+
+        let mut out = listed.lock().unwrap().clone();
+        out.sort();
+        Ok(out)
+    }
+
+    #[tokio::test]
+    async fn scoped_query_does_not_list_packages_outside_its_scope() -> anyhow::Result<()> {
+        // `label(lint) && //foo/...`: the label arm can never prune, but the
+        // package arm must keep `list` (a whole-package Starlark evaluation
+        // for the buildfile provider) off every package outside `foo`.
+        let listed = listed_packages_for(Matcher::And(vec![
+            Matcher::Label("lint".to_string()),
+            Matcher::PackagePrefix(PkgBuf::from("foo")),
+        ]))
+        .await?;
+        assert_eq!(listed, vec!["foo".to_string(), "foo/deep".to_string()]);
+
+        // Arm order must not change what gets paid for.
+        let flipped = listed_packages_for(Matcher::And(vec![
+            Matcher::PackagePrefix(PkgBuf::from("foo")),
+            Matcher::Label("lint".to_string()),
+        ]))
+        .await?;
+        assert_eq!(flipped, listed);
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn addr_query_lists_only_the_owning_package() -> anyhow::Result<()> {
+        let listed = listed_packages_for(Matcher::Addr(Addr::new(
+            PkgBuf::from("bar"),
+            "t".to_string(),
+            Default::default(),
+        )))
+        .await?;
+        assert_eq!(listed, vec!["bar".to_string()]);
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn unprunable_matcher_still_scans_everything() -> anyhow::Result<()> {
+        // A bare label has no package information — pruning must not invent any.
+        // The always-on built-in `fs` provider contributes `@heph/fs`, and every
+        // provider is listed for every surviving package.
+        let listed = listed_packages_for(Matcher::Label("lint".to_string())).await?;
+        assert_eq!(
+            listed,
+            vec![
+                "@heph/fs".to_string(),
+                "bar".to_string(),
+                "bar/deep".to_string(),
+                "foo".to_string(),
+                "foo/deep".to_string(),
+                "unrelated".to_string(),
+            ]
+        );
         Ok(())
     }
 

--- a/crates/engine/src/engine/result.rs
+++ b/crates/engine/src/engine/result.rs
@@ -174,6 +174,12 @@ impl ProviderExecutor for EngineProviderExecutor {
             for pkg_str in pkgs {
                 let pkg = PkgBuf::from(pkg_str.as_str());
 
+                // Same pruning as `Engine::query`: skip packages the matcher
+                // cannot select before paying for probe + list.
+                if m.matches_pkg(&pkg) == hmodel::htmatcher::MatchResult::MatchNo {
+                    continue;
+                }
+
                 let states = Arc::clone(&engine).probe_segments(&rs, &pkg).await?;
 
                 for provider in &engine.providers {

--- a/crates/engine/src/engine/states.rs
+++ b/crates/engine/src/engine/states.rs
@@ -4,10 +4,8 @@ use crate::engine::request_state::RequestState;
 use enclose::enclose;
 use futures::StreamExt;
 use futures::stream::FuturesOrdered;
-use hmodel::htaddr::Addr;
 use hmodel::htmatcher::{MatchResult, Matcher};
 use hmodel::htpkg::PkgBuf;
-use std::collections::BTreeMap;
 use std::sync::Arc;
 
 /// What [`Engine::states`] should collect.
@@ -38,8 +36,7 @@ pub struct PackageStates {
 /// can only shrug — those are treated as selecting the package, keeping the
 /// scan inclusive rather than silently dropping declarations.
 fn matches_package(m: &Matcher, pkg: &PkgBuf) -> bool {
-    let probe = Addr::new(pkg.clone(), String::new(), BTreeMap::new());
-    m.matches_addr(&probe) != MatchResult::MatchNo
+    m.matches_pkg(pkg) != MatchResult::MatchNo
 }
 
 impl Engine {

--- a/crates/model/src/htmatcher/matcher.rs
+++ b/crates/model/src/htmatcher/matcher.rs
@@ -27,6 +27,92 @@ pub enum Matcher {
 }
 
 impl Matcher {
+    /// Whether package `pkg` can hold a match, decided from the package path
+    /// alone — no `list`, no `probe`, no spec or def resolution.
+    ///
+    /// The tri-state is about the *whole package*, not one target:
+    /// `MatchNo` — no addr in `pkg` can match, so the package can be skipped
+    /// outright; `MatchYes` — every addr in it matches; `MatchShrug` — it
+    /// depends on the individual target.
+    ///
+    /// Only `MatchNo` is load-bearing: callers use it to prune a package
+    /// before paying for it, and every arm that cannot decide shrugs, so an
+    /// over-inclusive answer costs time and never correctness.
+    pub fn matches_pkg(&self, pkg: &PkgBuf) -> MatchResult {
+        match self {
+            // One addr out of the package matches — never all of them.
+            Matcher::Addr(a) => {
+                if &a.package == pkg {
+                    MatchResult::MatchShrug
+                } else {
+                    MatchResult::MatchNo
+                }
+            }
+            // Labels live on the target, not the package.
+            Matcher::Label(_) => MatchResult::MatchShrug,
+            // Same reasoning as `matches_addr`: a codegen tree rooted at the
+            // target's package can only reach packages on the same root path.
+            Matcher::TreeOutputTo(matcher_pkg) => {
+                if pkg.has_prefix(matcher_pkg) || matcher_pkg.has_prefix(pkg) {
+                    MatchResult::MatchShrug
+                } else {
+                    MatchResult::MatchNo
+                }
+            }
+            Matcher::Package(p) => {
+                if pkg == p {
+                    MatchResult::MatchYes
+                } else {
+                    MatchResult::MatchNo
+                }
+            }
+            Matcher::PackagePrefix(prefix) => {
+                if pkg.has_prefix(prefix) {
+                    MatchResult::MatchYes
+                } else {
+                    MatchResult::MatchNo
+                }
+            }
+            Matcher::Or(matchers) => {
+                let mut shrug = false;
+                for m in matchers {
+                    match m.matches_pkg(pkg) {
+                        MatchResult::MatchYes => return MatchResult::MatchYes,
+                        MatchResult::MatchShrug => shrug = true,
+                        MatchResult::MatchNo => {}
+                    }
+                }
+                if shrug {
+                    MatchResult::MatchShrug
+                } else {
+                    MatchResult::MatchNo
+                }
+            }
+            Matcher::And(matchers) => {
+                let mut shrug = false;
+                for m in matchers {
+                    match m.matches_pkg(pkg) {
+                        MatchResult::MatchNo => return MatchResult::MatchNo,
+                        MatchResult::MatchShrug => shrug = true,
+                        MatchResult::MatchYes => {}
+                    }
+                }
+                if shrug {
+                    MatchResult::MatchShrug
+                } else {
+                    MatchResult::MatchYes
+                }
+            }
+            // Sound under the all/none reading: "no addr matches" negates to
+            // "every addr matches", and vice versa.
+            Matcher::Not(m) => match m.matches_pkg(pkg) {
+                MatchResult::MatchYes => MatchResult::MatchNo,
+                MatchResult::MatchNo => MatchResult::MatchYes,
+                MatchResult::MatchShrug => MatchResult::MatchShrug,
+            },
+        }
+    }
+
     pub fn matches_addr(&self, addr: &Addr) -> MatchResult {
         match self {
             Matcher::Addr(a) => {
@@ -291,5 +377,173 @@ mod tests {
             Matcher::TreeOutputTo(PkgBuf::from("bar")).matches_addr(&a),
             MatchResult::MatchNo
         );
+    }
+
+    fn pkg(s: &str) -> PkgBuf {
+        PkgBuf::from(s)
+    }
+
+    #[test]
+    fn pkg_package_and_prefix_decide_outright() {
+        assert_eq!(
+            Matcher::Package(pkg("foo/bar")).matches_pkg(&pkg("foo/bar")),
+            MatchResult::MatchYes
+        );
+        assert_eq!(
+            Matcher::Package(pkg("foo/bar")).matches_pkg(&pkg("foo")),
+            MatchResult::MatchNo
+        );
+        assert_eq!(
+            Matcher::PackagePrefix(pkg("foo")).matches_pkg(&pkg("foo/bar")),
+            MatchResult::MatchYes
+        );
+        assert_eq!(
+            Matcher::PackagePrefix(pkg("foo")).matches_pkg(&pkg("foobar")),
+            MatchResult::MatchNo
+        );
+        assert_eq!(
+            Matcher::PackagePrefix(pkg("")).matches_pkg(&pkg("anything")),
+            MatchResult::MatchYes
+        );
+    }
+
+    #[test]
+    fn pkg_addr_prunes_every_other_package() {
+        let m = Matcher::Addr(addr("foo/bar", "baz"));
+        // Its own package holds one match out of possibly many targets.
+        assert_eq!(m.matches_pkg(&pkg("foo/bar")), MatchResult::MatchShrug);
+        // Nothing else can hold it — not even a parent or child package.
+        assert_eq!(m.matches_pkg(&pkg("foo")), MatchResult::MatchNo);
+        assert_eq!(m.matches_pkg(&pkg("foo/bar/deep")), MatchResult::MatchNo);
+        assert_eq!(m.matches_pkg(&pkg("other")), MatchResult::MatchNo);
+    }
+
+    #[test]
+    fn pkg_label_shrugs_everywhere() {
+        assert_eq!(
+            Matcher::Label("lint".to_string()).matches_pkg(&pkg("foo")),
+            MatchResult::MatchShrug
+        );
+    }
+
+    #[test]
+    fn pkg_and_prunes_on_the_deciding_arm() {
+        // The motivating query: `label(lint) && //foo/...`. The label arm can
+        // never prune, but the package arm must still prune the whole graph
+        // outside `foo` — regardless of which arm is written first.
+        let m = Matcher::And(vec![
+            Matcher::Label("lint".to_string()),
+            Matcher::PackagePrefix(pkg("foo")),
+        ]);
+        assert_eq!(m.matches_pkg(&pkg("bar")), MatchResult::MatchNo);
+        assert_eq!(m.matches_pkg(&pkg("foo/deep")), MatchResult::MatchShrug);
+
+        let flipped = Matcher::And(vec![
+            Matcher::PackagePrefix(pkg("foo")),
+            Matcher::Label("lint".to_string()),
+        ]);
+        assert_eq!(flipped.matches_pkg(&pkg("bar")), MatchResult::MatchNo);
+        assert_eq!(
+            flipped.matches_pkg(&pkg("foo/deep")),
+            MatchResult::MatchShrug
+        );
+    }
+
+    #[test]
+    fn pkg_and_yes_only_when_every_arm_is_yes() {
+        let m = Matcher::And(vec![
+            Matcher::PackagePrefix(pkg("foo")),
+            Matcher::Package(pkg("foo/bar")),
+        ]);
+        assert_eq!(m.matches_pkg(&pkg("foo/bar")), MatchResult::MatchYes);
+        assert_eq!(m.matches_pkg(&pkg("foo/other")), MatchResult::MatchNo);
+    }
+
+    #[test]
+    fn pkg_or_keeps_the_union() {
+        let m = Matcher::Or(vec![
+            Matcher::PackagePrefix(pkg("foo")),
+            Matcher::PackagePrefix(pkg("bar")),
+        ]);
+        assert_eq!(m.matches_pkg(&pkg("foo/x")), MatchResult::MatchYes);
+        assert_eq!(m.matches_pkg(&pkg("bar/y")), MatchResult::MatchYes);
+        assert_eq!(m.matches_pkg(&pkg("baz")), MatchResult::MatchNo);
+
+        // One unknowable arm makes the whole union unknowable, never prunable.
+        let with_label = Matcher::Or(vec![
+            Matcher::PackagePrefix(pkg("foo")),
+            Matcher::Label("lint".to_string()),
+        ]);
+        assert_eq!(with_label.matches_pkg(&pkg("baz")), MatchResult::MatchShrug);
+    }
+
+    #[test]
+    fn pkg_not_inverts_all_and_none() {
+        // `!//foo/...` prunes exactly the foo subtree.
+        let m = Matcher::Not(Box::new(Matcher::PackagePrefix(pkg("foo"))));
+        assert_eq!(m.matches_pkg(&pkg("foo/x")), MatchResult::MatchNo);
+        assert_eq!(m.matches_pkg(&pkg("bar")), MatchResult::MatchYes);
+
+        // `!label(x)` is still per-target, so it prunes nothing.
+        let l = Matcher::Not(Box::new(Matcher::Label("x".to_string())));
+        assert_eq!(l.matches_pkg(&pkg("foo")), MatchResult::MatchShrug);
+
+        // `!//foo:bar` must NOT prune `foo` — the package's other targets match.
+        let a = Matcher::Not(Box::new(Matcher::Addr(addr("foo", "bar"))));
+        assert_eq!(a.matches_pkg(&pkg("foo")), MatchResult::MatchShrug);
+        assert_eq!(a.matches_pkg(&pkg("other")), MatchResult::MatchYes);
+    }
+
+    #[test]
+    fn pkg_tree_output_to_keeps_the_whole_root_path() {
+        let m = Matcher::TreeOutputTo(pkg("foo/gen"));
+        // A target in an ancestor package can codegen down into `foo/gen`.
+        assert_eq!(m.matches_pkg(&pkg("foo")), MatchResult::MatchShrug);
+        assert_eq!(m.matches_pkg(&pkg("foo/gen/deep")), MatchResult::MatchShrug);
+        assert_eq!(m.matches_pkg(&pkg("bar")), MatchResult::MatchNo);
+    }
+
+    #[test]
+    fn pkg_never_prunes_a_package_holding_an_addr_level_match() {
+        // Exhaustive consistency check: if any addr in a package matches,
+        // `matches_pkg` must not answer MatchNo for that package.
+        let pkgs = ["", "foo", "foo/bar", "foo/bar/baz", "other"];
+        let names = ["a", "b"];
+        let matchers = vec![
+            Matcher::Addr(addr("foo/bar", "a")),
+            Matcher::Label("l".to_string()),
+            Matcher::Package(pkg("foo/bar")),
+            Matcher::PackagePrefix(pkg("foo")),
+            Matcher::TreeOutputTo(pkg("foo/bar")),
+            Matcher::And(vec![
+                Matcher::Label("l".to_string()),
+                Matcher::PackagePrefix(pkg("foo")),
+            ]),
+            Matcher::Or(vec![
+                Matcher::Package(pkg("other")),
+                Matcher::Addr(addr("foo", "b")),
+            ]),
+            Matcher::Not(Box::new(Matcher::Addr(addr("foo", "a")))),
+            Matcher::Not(Box::new(Matcher::PackagePrefix(pkg("foo")))),
+            Matcher::And(vec![
+                Matcher::PackagePrefix(pkg("foo")),
+                Matcher::Not(Box::new(Matcher::Package(pkg("foo/bar")))),
+            ]),
+        ];
+
+        for m in &matchers {
+            for p in pkgs {
+                if m.matches_pkg(&pkg(p)) != MatchResult::MatchNo {
+                    continue;
+                }
+                for n in names {
+                    assert_eq!(
+                        m.matches_addr(&addr(p, n)),
+                        MatchResult::MatchNo,
+                        "matcher {m:?} pruned package {p:?} but //{p}:{n} is not a definite non-match",
+                    );
+                }
+            }
+        }
     }
 }


### PR DESCRIPTION
## The claim

> `label(lint) && //foo/...` does analysis non-optimally — it resolves `label(x)` first, which is more expensive than `//foo/...`.

Half right, and the real problem is one layer up.

**Arm order was never the issue.** `Matcher::matches_addr` is pure — `Label` returns `MatchShrug` immediately with no IO, and `And` short-circuits on the first `MatchNo` regardless of position. The expensive step (`get_spec` → `get_def`) runs once, after the whole conjunction evaluates, and only if it shrugs. So `label(lint) && //foo/...` never resolved a spec for a target outside `foo`.

**The real cost is the package scan.** `Engine::query` looped over every package the providers reported and ran `probe_segments` + `provider.list(pkg)` for each *before* consulting the matcher. For `plugin-buildfile`, `list` is `run_pkg` — a whole-package Starlark evaluation. So `//foo/...` alone evaluated every BUILD file in the repo and threw the results away at the addr check.

`narrowing_prefix` already computed the correct prefix and passed it as `ListPackagesRequest::prefix`, but **no provider in the tree reads it** — it is `_req` everywhere. The narrowing was computed and dropped.

## The fix

`Matcher::matches_pkg(&PkgBuf) -> MatchResult`, decided from the package path alone — no `list`, no `probe`, no resolution. The tri-state is about the whole package:

- `MatchNo` — no addr in the package can match, skip it
- `MatchYes` — every addr in it matches
- `MatchShrug` — depends on the individual target

The tri-state is what keeps `Not` sound: `!//foo:bar` must not prune `foo`, because the package's other targets do match. Only `MatchNo` is load-bearing, so an over-inclusive answer costs time and never correctness.

Wired into both scan loops — `Engine::query` and `EngineProviderExecutor::query` — ahead of probe + list.

## Also fixed

`Engine::states` faked package matching by constructing a probe `Addr` with an empty name and calling `matches_addr`. A `Matcher::Addr` compared against `//foo:` answers `MatchNo`, so `heph states //foo:bar` dropped the very package holding the addr. It now shares `matches_pkg`.

`narrowing_prefix` gains an `Addr` arm — an exact addr lives in exactly one package. Inert until a provider honors `prefix`, correct in the meantime.

## Effect

| Query | Before | After |
|---|---|---|
| `//foo/...` | Starlark-evaluate every BUILD file in the repo | only packages under `foo` |
| `label(lint) && //foo/...` | same | only packages under `foo`, either arm order |
| `//foo:bar` | same | only `foo` |
| `label(lint)` | whole graph | whole graph — no package info to prune with, and it must not invent any |

## Tests

- `matches_pkg` unit tests per arm, plus `pkg_never_prunes_a_package_holding_an_addr_level_match` — an exhaustive cross-check that no matcher/package pair pruned by `matches_pkg` contains an addr that `matches_addr` would have accepted.
- Engine tests spy on which packages `list` was actually called for: `scoped_query_does_not_list_packages_outside_its_scope` (both arm orders), `addr_query_lists_only_the_owning_package`, `unprunable_matcher_still_scans_everything`.
- The spy provider deliberately ignores `ListPackagesRequest::prefix`, like every real provider, so the test proves the engine does the narrowing itself.

Ran locally: matcher unit tests, `engine::query` / `engine::packages` / `engine::states`, and `lint`. Leaving the rest to CI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Y1Xme6tHPnzBSuQ6BFCGSq