### PR TITLE
feat(diag): report parked futures, not just parked threads

### DIFF
--- a/crates/core/src/hmemoizer/cell.rs
+++ b/crates/core/src/hmemoizer/cell.rs
@@ -194,6 +194,47 @@ impl<V> Cell<V> {
             waker.wake();
         }
     }
+
+    /// Whether the value has been published.
+    pub(crate) fn is_done(&self) -> bool {
+        self.done.get().is_some()
+    }
+
+    /// How many awaiters are attached to this cell, or `None` if the waker set
+    /// was locked when sampled.
+    ///
+    /// Counts *allocated slots*, not slots currently holding a `Waker`. The two
+    /// differ exactly when it matters: waking an awaiter `take`s its waker and
+    /// leaves the slot empty until that awaiter re-polls and re-registers. So a
+    /// live-waker count reads zero for the population this diagnostic exists to
+    /// find — tasks that were woken, never re-polled, and are therefore parked
+    /// forever. A slot is returned to the free list only by [`Await::drop`], so
+    /// `slots - free` is the number of awaiters that still exist.
+    ///
+    /// `try_lock`, never `lock`: this is read by the stall watchdog and the
+    /// `SIGQUIT` dump, and a diagnostic that can block is a diagnostic that can
+    /// hang the process it exists to explain. A missed sample costs one cell in
+    /// one report; the next fire re-reads it.
+    pub(crate) fn waiters(&self) -> Option<usize> {
+        let guard = match self.wakers.try_lock() {
+            Ok(g) => g,
+            // Same stance as `wakers()`: a poisoned set is structurally intact.
+            Err(std::sync::TryLockError::Poisoned(e)) => e.into_inner(),
+            Err(std::sync::TryLockError::WouldBlock) => return None,
+        };
+        Some(guard.slots.len().saturating_sub(guard.free.len()))
+    }
+
+    /// Whether an awaiter is currently elected to re-poll the inner future.
+    ///
+    /// `false` together with a non-zero [`waiters`](Self::waiters) is the
+    /// signature of a lost wake-up: tasks are parked on this cell and nobody is
+    /// on the hook to poll it. Transiently normal (abdication clears the driver
+    /// and wakes everyone to re-elect); a standing condition on a build that has
+    /// made no progress for a minute is not.
+    pub(crate) fn has_driver(&self) -> bool {
+        self.driver.load(Ordering::Relaxed) != NO_DRIVER
+    }
 }
 
 /// The inner future is polled with this, so a wake from deep inside it lands on
@@ -391,6 +432,52 @@ mod tests {
 
     fn poll_with(waiter: &mut Await<u32>, waker: &Waker) -> Poll<u32> {
         Pin::new(waiter).poll(&mut Context::from_waker(waker))
+    }
+
+    /// The shape a lost wake-up leaves behind, which is what the inventory reads.
+    ///
+    /// A driven cell has waiters *and* a driver. When the driver goes away
+    /// without the cell completing, the driver is cleared — and if the wake it
+    /// broadcasts on the way out never lands, what remains is waiters parked on
+    /// a cell nobody is on the hook to poll. That is the state a wedged build
+    /// sits in, and until it was observable the only evidence was 250 threads
+    /// idle in `futex_wait`.
+    #[test]
+    fn a_cell_reports_waiters_and_whether_anyone_will_poll_it() {
+        let (cell, _stashed, ready) = stash_cell(3);
+
+        let (_pc, pw) = counting();
+        let mut parked = Await::new(Arc::clone(&cell));
+        assert!(poll_with(&mut parked, &pw).is_pending());
+
+        let (_dc, dw) = counting();
+        let mut driver = Await::new(Arc::clone(&cell));
+        assert!(poll_with(&mut driver, &dw).is_pending());
+
+        assert_eq!(cell.waiters(), Some(2));
+        assert!(cell.has_driver(), "the last poller is on the hook");
+        assert!(!cell.is_done());
+
+        // The driver goes away mid-flight — a fail-fast sibling drop or Ctrl-C.
+        // Abdication wakes the rest, which `take`s their wakers; the awaiters
+        // themselves are still attached and still parked, and that is what must
+        // be reported. Counting live wakers here would read 0 and hide the very
+        // population this exists to find.
+        drop(driver);
+        assert!(
+            !cell.has_driver(),
+            "abdication must clear the driver so another awaiter can re-elect"
+        );
+        assert_eq!(
+            cell.waiters(),
+            Some(1),
+            "the departing awaiter releases its slot; the parked one is still attached"
+        );
+
+        // Completion is what takes a cell out of the inventory.
+        ready.store(true, Ordering::SeqCst);
+        assert!(poll_with(&mut parked, &pw).is_ready());
+        assert!(cell.is_done());
     }
 
     /// **The reason this module exists.** A wake from inside the shared future

--- a/crates/core/src/hmemoizer/mod.rs
+++ b/crates/core/src/hmemoizer/mod.rs
@@ -217,7 +217,7 @@ pub fn clear_phase() {
     phases().lock().expect("phases mutex poisoned").remove(&inv);
 }
 
-fn dump_phases() -> String {
+pub fn dump_phases() -> String {
     if !phase_trace_enabled() {
         return "  (phase trace disabled — set heph_PHASE_TRACE=1)".to_string();
     }
@@ -415,8 +415,180 @@ pub fn downcast_chain_ref<T: std::error::Error + Send + Sync + 'static>(
     }
 }
 
+// ---- Stuck-cell inventory ----
+//
+// A thread dump answers "what is each *thread* doing", which for this engine is
+// the wrong question: the work lives in parked futures on the heap, and a wedged
+// build shows every thread idle and says nothing about the thousands of awaits
+// that are stuck. The inventory answers the question the dump cannot — *which*
+// cells are incomplete, how many tasks are parked on each, and whether anybody
+// is still on the hook to poll them.
+//
+// Unlike cycle detection and phase tracing, this is always on. It costs one
+// registration per `Memoizer` construction (a handful per request, not per
+// target) and nothing at all per `once` call; everything else happens only when
+// a dump is requested. A diagnostic that has to be switched on cannot help with
+// the hang you did not anticipate — the same argument `src/diag.rs` makes for
+// installing the `SIGQUIT` handler unconditionally.
+
+/// One incomplete cell, as reported by [`inventory`].
+#[derive(Debug, Clone)]
+pub struct StuckCell {
+    /// Which memoizer it belongs to (`result`, `spec`, `def`, …).
+    pub tag: &'static str,
+    /// `format!("{:?}")` of the cell key — for `mem_result` this is the addr.
+    pub key: String,
+    /// Registered awaiters, or `None` if the waker set was locked when sampled.
+    pub waiters: Option<usize>,
+    /// Whether an awaiter is elected to re-poll the inner future. See
+    /// [`cell::Cell::has_driver`] for why `false` here is the interesting case.
+    pub has_driver: bool,
+}
+
+impl StuckCell {
+    /// Waiters are parked on this cell and nobody is going to poll it.
+    pub fn is_stranded(&self) -> bool {
+        !self.has_driver && self.waiters.is_some_and(|n| n > 0)
+    }
+}
+
+/// Type-erased handle on one live `Memoizer`'s cache.
+trait CellSource: Send + Sync {
+    /// Append this memoizer's incomplete cells. Returns `false` once the
+    /// memoizer is gone, so the registry can drop the entry.
+    fn collect(&self, out: &mut Vec<StuckCell>) -> bool;
+}
+
+struct Source<K, V> {
+    tag: &'static str,
+    cache: std::sync::Weak<Mutex<FxHashMap<K, Arc<cell::Cell<V>>>>>,
+}
+
+impl<K, V> CellSource for Source<K, V>
+where
+    K: fmt::Debug + Send + Sync + 'static,
+    V: Send + Sync + 'static,
+{
+    fn collect(&self, out: &mut Vec<StuckCell>) -> bool {
+        let Some(cache) = self.cache.upgrade() else {
+            return false;
+        };
+        // `try_lock` for the same reason as `Cell::waiters`: never block a dump
+        // on the process being dumped.
+        let map = match cache.try_lock() {
+            Ok(m) => m,
+            Err(std::sync::TryLockError::Poisoned(e)) => e.into_inner(),
+            Err(std::sync::TryLockError::WouldBlock) => return true,
+        };
+        for (key, cell) in map.iter() {
+            if cell.is_done() {
+                continue;
+            }
+            out.push(StuckCell {
+                tag: self.tag,
+                key: format!("{key:?}"),
+                waiters: cell.waiters(),
+                has_driver: cell.has_driver(),
+            });
+        }
+        true
+    }
+}
+
+static SOURCES: Mutex<Vec<Box<dyn CellSource>>> = Mutex::new(Vec::new());
+
+/// Registry length at which the next prune of dead entries happens. Doubles
+/// each time, so pruning is amortised O(1) per registration rather than a walk
+/// of the whole registry on every `Memoizer` construction.
+static PRUNE_AT: std::sync::atomic::AtomicUsize = std::sync::atomic::AtomicUsize::new(64);
+
+fn sources() -> std::sync::MutexGuard<'static, Vec<Box<dyn CellSource>>> {
+    SOURCES.lock().unwrap_or_else(|e| e.into_inner())
+}
+
+fn register_source(source: Box<dyn CellSource>) {
+    let mut sources = sources();
+    sources.push(source);
+    // Every request builds its own memoizers, so without this the registry
+    // grows for the life of the process even though most entries are dead.
+    if sources.len() >= PRUNE_AT.load(Ordering::Relaxed) {
+        let mut scratch = Vec::new();
+        sources.retain(|s| s.collect(&mut scratch));
+        PRUNE_AT.store(sources.len().saturating_mul(2).max(64), Ordering::Relaxed);
+    }
+}
+
+/// Every incomplete cell across every live memoizer.
+///
+/// Ordered stranded-first, then by descending waiter count, so the head of the
+/// list is the part of a wedged graph worth reading.
+pub fn inventory() -> Vec<StuckCell> {
+    let mut out = Vec::new();
+    {
+        let mut sources = sources();
+        sources.retain(|s| s.collect(&mut out));
+    }
+    out.sort_by(|a, b| {
+        b.is_stranded()
+            .cmp(&a.is_stranded())
+            .then(b.waiters.unwrap_or(0).cmp(&a.waiters.unwrap_or(0)))
+            .then(a.tag.cmp(b.tag))
+            .then(a.key.cmp(&b.key))
+    });
+    out
+}
+
+/// Render an [`inventory`] as diagnostic text, listing at most `limit` cells.
+///
+/// Diagnostic text, not an interface — nothing should parse it.
+pub fn render_inventory(cells: &[StuckCell], limit: usize) -> String {
+    let mut out = String::new();
+    if cells.is_empty() {
+        out.push_str("  in-flight    none — no memoizer cell is incomplete\n");
+        return out;
+    }
+
+    let stranded = cells.iter().filter(|c| c.is_stranded()).count();
+    let mut by_tag: Vec<(&'static str, usize)> = Vec::new();
+    for cell in cells {
+        match by_tag.iter_mut().find(|(t, _)| *t == cell.tag) {
+            Some((_, n)) => *n += 1,
+            None => by_tag.push((cell.tag, 1)),
+        }
+    }
+    by_tag.sort_by_key(|(_, n)| std::cmp::Reverse(*n));
+    let parts: Vec<String> = by_tag.iter().map(|(tag, n)| format!("{n} {tag}")).collect();
+    out.push_str(&format!("  in-flight    {}\n", parts.join(", ")));
+
+    if stranded > 0 {
+        // The headline: waiters with no driver is a lost wake-up, not slow work.
+        out.push_str(&format!(
+            "  stranded     {stranded} cell(s) have waiters but no driver — nobody will poll them\n"
+        ));
+    }
+
+    for cell in cells.iter().take(limit) {
+        let waiters = match cell.waiters {
+            Some(n) => n.to_string(),
+            None => "?".to_string(),
+        };
+        let mark = if cell.is_stranded() { " STRANDED" } else { "" };
+        out.push_str(&format!(
+            "    [{}] {} waiters={waiters} driver={}{mark}\n",
+            cell.tag, cell.key, cell.has_driver
+        ));
+    }
+    if cells.len() > limit {
+        out.push_str(&format!("    … and {} more\n", cells.len() - limit));
+    }
+    out
+}
+
 pub struct Memoizer<K, V> {
-    cache: Mutex<FxHashMap<K, Arc<cell::Cell<V>>>>,
+    /// Behind an `Arc` so the inventory can hold a `Weak` to it: a `Memoizer`
+    /// lives in a `RequestState` field, not an `Arc`, so there is nothing else
+    /// for the registry to keep a non-owning handle on.
+    cache: Arc<Mutex<FxHashMap<K, Arc<cell::Cell<V>>>>>,
     /// Tag used in stall warnings to identify which memoizer is stuck.
     tag: &'static str,
 }
@@ -463,10 +635,12 @@ where
     }
 
     pub fn with_tag(tag: &'static str) -> Self {
-        Self {
-            cache: Mutex::new(FxHashMap::default()),
+        let cache = Arc::new(Mutex::new(FxHashMap::default()));
+        register_source(Box::new(Source {
             tag,
-        }
+            cache: Arc::downgrade(&cache),
+        }));
+        Self { cache, tag }
     }
 
     /// Non-inserting peek: returns the memoized value only if it is already
@@ -600,7 +774,7 @@ where
 /// Format the full wait-for graph for diagnostics. Includes every live cell
 /// (owner + debug key) and every task currently registered as a waiter. Used
 /// only by the stall-panic dump.
-fn dump_wait_graph() -> String {
+pub fn dump_wait_graph() -> String {
     if !cycle_detection_enabled() {
         return "  (cycle detection disabled — set HEPH_DEBUG_MEMOIZER_CYCLE=1)".to_string();
     }
@@ -873,6 +1047,160 @@ mod tests {
     use std::sync::Arc;
     use std::sync::atomic::{AtomicUsize, Ordering};
     use tokio::time::{Duration, sleep};
+
+    /// Only cells that are still computing. A completed cell is not stuck, and
+    /// a report that listed every warm hit on a 27k-target build would bury the
+    /// handful that matter.
+    #[tokio::test]
+    async fn inventory_lists_incomplete_cells_and_drops_completed_ones() {
+        let m: Memoizer<String, u32> = Memoizer::with_tag("inv-complete-test");
+        let gate = Arc::new(tokio::sync::Notify::new());
+
+        let held = m.process("stuck".to_string(), {
+            let gate = Arc::clone(&gate);
+            move || async move {
+                gate.notified().await;
+                1
+            }
+        });
+        tokio::pin!(held);
+        // One poll to insert the cell and park on it.
+        assert!(
+            futures::poll!(&mut held).is_pending(),
+            "the gated cell must not resolve yet"
+        );
+
+        let ours = |tag: &str| -> Vec<StuckCell> {
+            inventory().into_iter().filter(|c| c.tag == tag).collect()
+        };
+
+        let listed = ours("inv-complete-test");
+        assert_eq!(listed.len(), 1, "the in-flight cell must be listed");
+        assert!(
+            listed[0].key.contains("stuck"),
+            "the key names the work: {:?}",
+            listed[0].key
+        );
+
+        gate.notify_waiters();
+        assert_eq!(held.await, 1);
+        assert!(
+            ours("inv-complete-test").is_empty(),
+            "a completed cell is not stuck"
+        );
+    }
+
+    /// Waiters with no driver is the signature the stall paragraph headlines.
+    #[tokio::test]
+    async fn a_cell_with_waiters_and_no_driver_is_stranded() {
+        let m: Memoizer<String, u32> = Memoizer::with_tag("inv-stranded-test");
+        let gate = Arc::new(tokio::sync::Notify::new());
+
+        // Two awaiters on one cell: the second to poll is the driver.
+        let mut parked = Box::pin(m.process("wedged".to_string(), {
+            let gate = Arc::clone(&gate);
+            move || async move {
+                gate.notified().await;
+                1
+            }
+        }));
+        assert!(futures::poll!(&mut parked).is_pending());
+        let mut driver = Box::pin(m.process("wedged".to_string(), || async { 0 }));
+        assert!(futures::poll!(&mut driver).is_pending());
+
+        let ours = || -> Vec<StuckCell> {
+            inventory()
+                .into_iter()
+                .filter(|c| c.tag == "inv-stranded-test")
+                .collect()
+        };
+
+        let listed = ours();
+        assert_eq!(listed.len(), 1, "one cell, two awaiters");
+        assert!(
+            !listed[0].is_stranded(),
+            "a driven cell is not stranded: {listed:?}"
+        );
+
+        // The driver goes away without the cell completing — a fail-fast sibling
+        // drop, or Ctrl-C. If the abdication wake fails to land, what is left is
+        // a task parked on a cell nobody will poll: the wedge, exactly.
+        drop(driver);
+        let listed = ours();
+        assert_eq!(listed.len(), 1, "the cell is still incomplete");
+        assert_eq!(
+            listed[0].waiters,
+            Some(1),
+            "the parked awaiter is still attached"
+        );
+        assert!(!listed[0].has_driver, "nobody is elected to poll it");
+        assert!(listed[0].is_stranded(), "{listed:?}");
+    }
+
+    /// The registry holds `Weak`s: a request's memoizers must not keep reporting
+    /// after the request is gone, or a long-lived process accumulates the whole
+    /// history of every build it ever ran.
+    #[tokio::test]
+    async fn inventory_drops_memoizers_that_are_gone() {
+        {
+            let m: Memoizer<String, u32> = Memoizer::with_tag("inv-dropped-test");
+            let mut held = Box::pin(m.process("x".to_string(), || async {
+                futures::future::pending::<u32>().await
+            }));
+            assert!(futures::poll!(&mut held).is_pending());
+            assert!(
+                inventory().iter().any(|c| c.tag == "inv-dropped-test"),
+                "listed while the memoizer is alive"
+            );
+        }
+        assert!(
+            !inventory().iter().any(|c| c.tag == "inv-dropped-test"),
+            "a dead memoizer must be pruned from the registry"
+        );
+    }
+
+    #[test]
+    fn render_inventory_headlines_stranded_cells() {
+        let cells = vec![
+            StuckCell {
+                tag: "result",
+                key: "//a:b".to_string(),
+                waiters: Some(3),
+                has_driver: false,
+            },
+            StuckCell {
+                tag: "spec",
+                key: "//c:d".to_string(),
+                waiters: Some(1),
+                has_driver: true,
+            },
+        ];
+        let text = render_inventory(&cells, 10);
+        assert!(text.contains("1 result, 1 spec"), "{text}");
+        assert!(text.contains("stranded     1 cell(s)"), "{text}");
+        assert!(
+            text.contains("[result] //a:b waiters=3 driver=false STRANDED"),
+            "{text}"
+        );
+        assert!(
+            !text.contains("[spec] //c:d waiters=1 driver=true STRANDED"),
+            "a driven cell must not be marked stranded: {text}"
+        );
+    }
+
+    #[test]
+    fn render_inventory_caps_the_listing_but_says_so() {
+        let cells: Vec<StuckCell> = (0..5)
+            .map(|i| StuckCell {
+                tag: "result",
+                key: format!("//p:{i}"),
+                waiters: Some(1),
+                has_driver: true,
+            })
+            .collect();
+        let text = render_inventory(&cells, 2);
+        assert!(text.contains("… and 3 more"), "{text}");
+    }
 
     /// A panicking memoized computation must fail every awaiter, not hang them.
     ///

--- a/crates/engine/src/engine/diag.rs
+++ b/crates/engine/src/engine/diag.rs
@@ -96,6 +96,19 @@ impl Op {
     pub const fn tracks_oldest(self) -> bool {
         !matches!(self, Op::Result)
     }
+
+    /// Whether [`DiagState::add_bytes`] is ever called for this op.
+    ///
+    /// Only the remote-cache read path moves bytes through a counter. For every
+    /// other op the window is structurally zero, which makes "0 B in the last
+    /// 60s" both meaningless as a line and *actively misleading* as evidence:
+    /// [`StallReport::dominant_is_starved`] would read that hard zero as proof
+    /// of starvation and print a confident hypothesis derived from a counter
+    /// that cannot move. A wrong automated hypothesis costs more credibility
+    /// than a missing one, so ops that do not report bytes say nothing.
+    pub const fn reports_bytes(self) -> bool {
+        matches!(self, Op::RemoteCacheRead)
+    }
 }
 
 /// Per-op slots for oldest-open tracking.
@@ -138,6 +151,17 @@ struct OpState {
     /// Bytes at the start of the current window, and when that window opened.
     bytes_window_base: AtomicU64,
     window_opened_ms: AtomicU64,
+}
+
+/// Age of the oldest span still holding a slot on `st`.
+fn oldest_of(st: &OpState, now_ms: u64) -> Option<Duration> {
+    st.slot_key
+        .iter()
+        .zip(st.slot_start.iter())
+        .filter(|(k, _)| k.load(Ordering::Acquire) != FREE)
+        .map(|(_, start)| start.load(Ordering::Acquire))
+        .min()
+        .map(|s| Duration::from_millis(now_ms.saturating_sub(s)))
 }
 
 impl OpState {
@@ -211,6 +235,21 @@ pub struct DiagState {
     /// Completed / failed targets, for the progress line.
     done: AtomicU64,
     failed: AtomicU64,
+    /// Blocked acquisitions of the per-addr result lock.
+    ///
+    /// Not an [`Op`]: `Op` is the vocabulary of the TUI's per-target operation
+    /// timeline, and a lock wait is not an operation the target is performing —
+    /// it is the target being prevented from performing one. Tracked separately
+    /// so the stall paragraph can name it without perturbing what `Op` means.
+    ///
+    /// The wait is what makes cross-*process* contention diagnosable at all: the
+    /// filesystem lock backend is the default, so the holder can be another heph
+    /// on the same machine, and no amount of introspection into this process
+    /// would ever find it.
+    lock_wait: OpState,
+    /// Pid believed to hold the lock at the most recent blocked acquisition;
+    /// `0` for none/unknown. Last-writer-wins — a diagnostic hint, not a census.
+    lock_holder_pid: AtomicU64,
 }
 
 impl DiagState {
@@ -228,7 +267,38 @@ impl DiagState {
             limiters,
             done: AtomicU64::new(0),
             failed: AtomicU64::new(0),
+            lock_wait: OpState::new(),
+            lock_holder_pid: AtomicU64::new(0),
         }
+    }
+
+    /// Record the start of a blocked result-lock acquisition.
+    pub fn lock_wait_start(&self, addr: &str, holder_pid: Option<u32>, now_ms: u64) {
+        if let Some(pid) = holder_pid {
+            self.lock_holder_pid
+                .store(u64::from(pid), Ordering::Relaxed);
+        }
+        self.span_start(&self.lock_wait, addr, now_ms);
+    }
+
+    /// Record the end of a blocked result-lock acquisition (acquired or
+    /// cancelled — `ResultLockWaitEnd` fires for both).
+    pub fn lock_wait_end(&self, addr: &str, now_ms: u64) {
+        self.span_end(&self.lock_wait, addr, now_ms);
+    }
+
+    /// `(open waits, oldest age, holder pid)` — `None` when nothing is blocked.
+    pub fn lock_waits(&self, now_ms: u64) -> Option<(u64, Option<Duration>, Option<u32>)> {
+        let open = u64::try_from(self.lock_wait.open.load(Ordering::Relaxed).max(0)).unwrap_or(0);
+        if open == 0 {
+            return None;
+        }
+        let pid = self.lock_holder_pid.load(Ordering::Relaxed);
+        Some((
+            open,
+            oldest_of(&self.lock_wait, now_ms),
+            (pid != 0).then(|| u32::try_from(pid).unwrap_or(0)),
+        ))
     }
 
     /// Infallible by construction (`ops` is sized to `Op::ALL`), but resolved
@@ -261,13 +331,10 @@ impl DiagState {
         h.finish() | 1
     }
 
-    fn op_start(&self, op: Op, addr: &str, now_ms: u64) {
-        let Some(st) = self.op(op) else { return };
+    /// Open a span on `st`, claiming an oldest-tracking slot for `addr`.
+    fn span_start(&self, st: &OpState, addr: &str, now_ms: u64) {
         st.open.fetch_add(1, Ordering::Relaxed);
         self.touch(now_ms);
-        if !op.tracks_oldest() {
-            return;
-        }
         let key = Self::key_of(addr);
         for (slot, start) in st.slot_key.iter().zip(st.slot_start.iter()) {
             if slot
@@ -281,13 +348,10 @@ impl DiagState {
         // All slots busy: the count is still exact, only the age is unknown.
     }
 
-    fn op_end(&self, op: Op, addr: &str, now_ms: u64) {
-        let Some(st) = self.op(op) else { return };
+    /// Close a span on `st`, releasing `addr`'s slot.
+    fn span_end(&self, st: &OpState, addr: &str, now_ms: u64) {
         st.open.fetch_sub(1, Ordering::Relaxed);
         self.touch(now_ms);
-        if !op.tracks_oldest() {
-            return;
-        }
         let key = Self::key_of(addr);
         for slot in st.slot_key.iter() {
             if slot.load(Ordering::Acquire) == key
@@ -297,6 +361,28 @@ impl DiagState {
             {
                 return;
             }
+        }
+    }
+
+    fn op_start(&self, op: Op, addr: &str, now_ms: u64) {
+        let Some(st) = self.op(op) else { return };
+        if op.tracks_oldest() {
+            self.span_start(st, addr, now_ms);
+        } else {
+            // Unbounded op: count only. A slot array would silently evict the
+            // span whose age we care about.
+            st.open.fetch_add(1, Ordering::Relaxed);
+            self.touch(now_ms);
+        }
+    }
+
+    fn op_end(&self, op: Op, addr: &str, now_ms: u64) {
+        let Some(st) = self.op(op) else { return };
+        if op.tracks_oldest() {
+            self.span_end(st, addr, now_ms);
+        } else {
+            st.open.fetch_sub(1, Ordering::Relaxed);
+            self.touch(now_ms);
         }
     }
 
@@ -325,15 +411,7 @@ impl DiagState {
         if !op.tracks_oldest() {
             return None;
         }
-        let st = self.op(op)?;
-        let oldest = st
-            .slot_key
-            .iter()
-            .zip(st.slot_start.iter())
-            .filter(|(k, _)| k.load(Ordering::Acquire) != FREE)
-            .map(|(_, start)| start.load(Ordering::Acquire))
-            .min();
-        oldest.map(|s| Duration::from_millis(now_ms.saturating_sub(s)))
+        oldest_of(self.op(op)?, now_ms)
     }
 
     /// Bytes moved by `op` within the rolling window, and the cumulative total.
@@ -438,6 +516,9 @@ impl DiagState {
             saturated: self.saturated(now_ms),
             done: self.done(),
             failed: self.failed(),
+            lock_waits: self.lock_waits(now_ms),
+            delta: None,
+            stuck: Vec::new(),
         })
     }
 }
@@ -470,6 +551,13 @@ pub struct StallReport {
     pub saturated: Vec<(&'static str, Duration)>,
     pub done: u64,
     pub failed: u64,
+    /// `(open waits, oldest age, holder pid)` when the result lock is blocking.
+    pub lock_waits: Option<(u64, Option<Duration>, Option<u32>)>,
+    /// Change since the previous fire; `None` on the first.
+    pub delta: Option<StallDelta>,
+    /// Incomplete memoizer cells. Filled in by [`Watchdog`] after `evaluate`,
+    /// which stays pure — see its docs.
+    pub stuck: Vec<hcore::hmemoizer::StuckCell>,
 }
 
 impl StallReport {
@@ -496,10 +584,35 @@ impl StallReport {
         let Some((op, _)) = self.dominant() else {
             return false;
         };
+        // An op with no byte counter is not "starved", it is unmeasured. See
+        // [`Op::reports_bytes`].
+        if !op.reports_bytes() {
+            return false;
+        }
         self.bytes
             .iter()
             .find(|(o, _)| *o == op)
             .is_some_and(|(_, b)| *b == 0)
+    }
+}
+
+/// How the run changed between two consecutive fires of the watchdog.
+///
+/// Two stall paragraphs that are byte-identical are the strongest signal the
+/// log can carry — "wedged", not "slow" — and until this existed the only way
+/// to see it was to diff them by eye. Filled in by [`Watchdog`], which is the
+/// only thing that knows what the previous fire looked like.
+#[derive(Debug, Clone, Copy)]
+pub struct StallDelta {
+    pub since: Duration,
+    pub done: i64,
+    pub open: i64,
+}
+
+impl StallDelta {
+    /// Nothing at all moved since the previous report.
+    pub fn is_flat(&self) -> bool {
+        self.done == 0 && self.open == 0
     }
 }
 
@@ -540,6 +653,26 @@ impl hplugin::hook::Hook for DiagHook {
             BuildEventKind::RemoteCacheReadEnd { addr, .. } => {
                 s.op_end(Op::RemoteCacheRead, addr, now);
             }
+            // The cache-write spans. Unwired until now, which cut both ways: a
+            // build wedged in a cache write reported "0 open" for it, and — worse
+            // — a build *progressing* through the write-heavy tail of a cached
+            // run never touched the quiet clock and so read as stalled.
+            BuildEventKind::LocalCacheWriteStart { addr } => {
+                s.op_start(Op::LocalCacheWrite, addr, now);
+            }
+            BuildEventKind::LocalCacheWriteEnd { addr, .. } => {
+                s.op_end(Op::LocalCacheWrite, addr, now);
+            }
+            BuildEventKind::RemoteCacheWriteStart { addr } => {
+                s.op_start(Op::RemoteCacheWrite, addr, now);
+            }
+            BuildEventKind::RemoteCacheWriteEnd { addr, .. } => {
+                s.op_end(Op::RemoteCacheWrite, addr, now);
+            }
+            BuildEventKind::ResultLockWaitStart { addr, holder_pid } => {
+                s.lock_wait_start(addr, *holder_pid, now);
+            }
+            BuildEventKind::ResultLockWaitEnd { addr } => s.lock_wait_end(addr, now),
             // Cache hit/miss carry no span but are unambiguous progress.
             BuildEventKind::LocalCacheHit { .. }
             | BuildEventKind::LocalCacheMiss { .. }
@@ -553,8 +686,19 @@ impl hplugin::hook::Hook for DiagHook {
     fn on_close(&self) {}
 }
 
+/// Cells listed individually in a stall paragraph. The paragraph repeats on
+/// every escalation, so the full inventory (thousands of cells on a big graph)
+/// would bury the run's own output; the `SIGQUIT` dump prints all of them.
+const INVENTORY_LINES: usize = 20;
+
 fn secs(d: Duration) -> String {
     format!("{}s", d.as_secs())
+}
+
+/// Render a delta with an explicit sign, so `+0` reads as "measured, no change"
+/// rather than as a missing value.
+fn signed(n: i64) -> String {
+    format!("{n:+}")
 }
 
 fn human_bytes(b: u64) -> String {
@@ -600,7 +744,10 @@ pub fn render_stall(r: &StallReport) -> String {
     }
 
     for (op, b) in &r.bytes {
-        if r.open.iter().any(|(o, _, _)| o == op) {
+        // Only ops that actually move bytes through a counter. Printing a hard
+        // zero for the rest reads as evidence of starvation when it is evidence
+        // of nothing — see [`Op::reports_bytes`].
+        if op.reports_bytes() && r.open.iter().any(|(o, _, _)| o == op) {
             out.push_str(&format!(
                 "  bytes        {} in the last {}s on {}\n",
                 human_bytes(*b),
@@ -608,6 +755,22 @@ pub fn render_stall(r: &StallReport) -> String {
                 op.label()
             ));
         }
+    }
+
+    // Cross-process contention: the holder may be another heph on this machine,
+    // which nothing else in this report could ever surface.
+    if let Some((n, oldest, pid)) = r.lock_waits {
+        let age = match oldest {
+            Some(a) => format!(", oldest {}", secs(a)),
+            None => String::new(),
+        };
+        let holder = match pid {
+            Some(p) => format!(", holder pid {p}"),
+            None => String::new(),
+        };
+        out.push_str(&format!(
+            "  lock waits   {n} on the result lock{age}{holder}\n"
+        ));
     }
 
     if !r.saturated.is_empty() {
@@ -627,10 +790,41 @@ pub fn render_stall(r: &StallReport) -> String {
         r.done, r.failed
     ));
 
+    // The escalation *is* the diagnostic: identical consecutive paragraphs mean
+    // wedged where either alone means only slow. Stating the delta saves the
+    // reader diffing two tables by eye — and is the difference between a build
+    // that is crawling and one that has stopped.
+    if let Some(d) = r.delta {
+        out.push_str(&format!(
+            "  since last   {} done, {} open, over {}\n",
+            signed(d.done),
+            signed(d.open),
+            secs(d.since)
+        ));
+    }
+
+    // What a thread dump structurally cannot show: the parked futures. On a
+    // wedged build every thread is idle and this is the only place the stuck
+    // work is visible at all.
+    out.push_str(&hcore::hmemoizer::render_inventory(
+        &r.stuck,
+        INVENTORY_LINES,
+    ));
+
     // Only volunteer a cause when one op clearly dominates *and* something
     // corroborates it. A wrong automated hypothesis costs more credibility than
     // no hypothesis — better to show the table and let the reader conclude.
-    if let Some((op, _)) = r.dominant()
+    let stranded = r.stuck.iter().filter(|c| c.is_stranded()).count();
+    if stranded > 0 && r.delta.is_some_and(|d| d.is_flat()) {
+        // Evidence, not inference: tasks are parked on a cell that has no
+        // driver, and nothing moved between two fires. Neither alone would be
+        // enough — a driverless cell is momentarily normal during re-election.
+        out.push_str(&format!(
+            "\n  {stranded} cell(s) have tasks parked on them with nobody elected to poll\n  \
+             them, and nothing moved since the last report. That is a lost wake-up,\n  \
+             not slow work.\n"
+        ));
+    } else if let Some((op, _)) = r.dominant()
         && r.dominant_is_starved()
     {
         out.push_str(&format!(
@@ -641,6 +835,16 @@ pub fn render_stall(r: &StallReport) -> String {
             op.label()
         ));
     }
+
+    // Ctrl-C is what a human reaches for on a frozen build, and on a wedged run
+    // it is exactly what cannot help — the TUI clears ISIG, so the terminal
+    // never raises SIGINT. Name the escalation that does work, here, where it is
+    // read, rather than leaving it to be rediscovered per incident.
+    out.push_str(&format!(
+        "\n  Still stuck? `kill -QUIT {}` writes every thread's backtrace plus the\n  \
+         full in-flight inventory next to this file; it does not kill the process.\n",
+        std::process::id()
+    ));
 
     out.push_str("  (diagnostic text, not a stable interface)\n");
     out
@@ -729,11 +933,13 @@ impl Watchdog {
             .name("heph-stall-watchdog".to_string())
             .spawn(move || {
                 let mut last_fired: Option<u64> = None;
+                let mut last_seen: Option<(u64, i64, u64)> = None;
                 while !stop_thread.load(Ordering::Relaxed) {
                     std::thread::sleep(tick);
                     let now = state.now_ms();
-                    let Some(report) = state.evaluate(now, threshold) else {
+                    let Some(mut report) = state.evaluate(now, threshold) else {
                         last_fired = None;
+                        last_seen = None;
                         continue;
                     };
                     // Escalate rather than repeat every tick: a stall that lasts
@@ -743,8 +949,28 @@ impl Watchdog {
                             >= u64::try_from(threshold.as_millis()).unwrap_or(60_000) * 2
                     });
                     if due {
+                        let open: i64 = report
+                            .open
+                            .iter()
+                            .map(|(_, n, _)| i64::try_from(*n).unwrap_or(i64::MAX))
+                            .sum();
+                        let done = report.done;
+                        if let Some((prev_done, prev_open, at)) = last_seen {
+                            report.delta = Some(StallDelta {
+                                since: Duration::from_millis(now.saturating_sub(at)),
+                                done: i64::try_from(done.saturating_sub(prev_done))
+                                    .unwrap_or(i64::MAX),
+                                open: open - prev_open,
+                            });
+                        }
+                        // Collected here rather than in `evaluate` so that stays
+                        // pure and testable by passing a time: this walks live
+                        // maps and formats keys, which is affordable once a stall
+                        // is already confirmed and not on every tick.
+                        report.stuck = hcore::hmemoizer::inventory();
                         emit(&report);
                         last_fired = Some(now);
+                        last_seen = Some((done, open, now));
                     }
                 }
             })
@@ -821,6 +1047,182 @@ mod tests {
             r.dominant(),
             None,
             "heph cannot see inside a subprocess, so it must not blame one"
+        );
+    }
+
+    /// The cache-write spans reach the table at all.
+    ///
+    /// They are emitted by the engine and consumed by the TUI, but the diag hook
+    /// dropped them on the floor, so a build wedged in a cache write reported
+    /// "0 open" for the subsystem it was stuck in.
+    #[test]
+    fn cache_write_spans_are_counted() {
+        let s = state();
+        let hook = DiagHook::new(std::sync::Arc::clone(&s));
+        hook.on_event(&ev(BuildEventKind::LocalCacheWriteStart {
+            addr: "//a:b".into(),
+        }));
+        hook.on_event(&ev(BuildEventKind::RemoteCacheWriteStart {
+            addr: "//c:d".into(),
+        }));
+        assert_eq!(s.open_count(Op::LocalCacheWrite), 1);
+        assert_eq!(s.open_count(Op::RemoteCacheWrite), 1);
+
+        hook.on_event(&ev(BuildEventKind::LocalCacheWriteEnd {
+            addr: "//a:b".into(),
+            error: None,
+        }));
+        assert_eq!(s.open_count(Op::LocalCacheWrite), 0);
+    }
+
+    /// The sharper half of the same bug: because the write spans never touched
+    /// the quiet clock, a run *progressing* through the write-heavy tail of a
+    /// mostly-cached build looked silent and got reported as stalled. A stall
+    /// notice that fires on a healthy build stops being read.
+    #[test]
+    fn a_build_progressing_through_cache_writes_is_not_a_stall() {
+        let s = state();
+        let hook = DiagHook::new(std::sync::Arc::clone(&s));
+        s.op_start(Op::Result, "//root:all", 0);
+
+        for i in 0..20 {
+            // Only cache-write activity, spaced under the threshold.
+            std::thread::sleep(std::time::Duration::from_millis(1));
+            hook.on_event(&ev(BuildEventKind::LocalCacheWriteStart {
+                addr: format!("//t:{i}"),
+            }));
+            hook.on_event(&ev(BuildEventKind::LocalCacheWriteEnd {
+                addr: format!("//t:{i}"),
+                error: None,
+            }));
+            assert!(
+                s.evaluate(s.now_ms(), T).is_none(),
+                "cache writes are progress; iteration {i} read as a stall"
+            );
+        }
+    }
+
+    /// A blocked result lock is named, with the holder — which for the default
+    /// filesystem backend can be a different heph process entirely, something no
+    /// amount of introspection into this one would ever find.
+    #[test]
+    fn a_blocked_result_lock_is_reported_with_its_holder() {
+        let s = state();
+        let hook = DiagHook::new(std::sync::Arc::clone(&s));
+        hook.on_event(&ev(BuildEventKind::ResultLockWaitStart {
+            addr: "//a:b".into(),
+            holder_pid: Some(4242),
+        }));
+        s.op_start(Op::Result, "//a:b", 0);
+
+        let r = s.evaluate(61_000, T).expect("stalled");
+        let (n, _, pid) = r.lock_waits.expect("the wait must be reported");
+        assert_eq!(n, 1);
+        assert_eq!(pid, Some(4242));
+        let text = render_stall(&r);
+        assert!(text.contains("lock waits   1"), "{text}");
+        assert!(text.contains("holder pid 4242"), "{text}");
+
+        hook.on_event(&ev(BuildEventKind::ResultLockWaitEnd {
+            addr: "//a:b".into(),
+        }));
+        assert!(
+            s.evaluate(200_000, T)
+                .expect("still stalled")
+                .lock_waits
+                .is_none(),
+            "an acquired (or cancelled) wait must stop being reported"
+        );
+    }
+
+    /// `add_bytes` is only ever called for remote-cache reads, so for every other
+    /// op the window is a structural zero. Printing it reads as evidence of
+    /// starvation when it is evidence of nothing.
+    #[test]
+    fn no_byte_line_or_starvation_claim_for_ops_that_never_report_bytes() {
+        let s = state();
+        for i in 0..98 {
+            s.op_start(Op::Result, &format!("//pkg:{i}"), 0);
+        }
+        let r = s.evaluate(61_000, T).expect("stalled");
+        assert_eq!(
+            r.dominant().map(|(op, _)| op),
+            Some(Op::Result),
+            "result dominates this report"
+        );
+        assert!(
+            !r.dominant_is_starved(),
+            "an op with no byte counter is unmeasured, not starved"
+        );
+
+        let text = render_stall(&r);
+        assert!(
+            !text.contains("bytes"),
+            "no byte line for an op that cannot move the counter: {text}"
+        );
+        assert!(
+            !text.contains("Nothing has been read"),
+            "no hypothesis derived from a counter that cannot move: {text}"
+        );
+    }
+
+    /// The escalation is the diagnostic: two identical paragraphs mean wedged,
+    /// where either alone means only slow. Say it rather than making the reader
+    /// diff two tables by eye.
+    #[test]
+    fn the_delta_since_the_last_report_is_stated() {
+        let s = state();
+        s.op_start(Op::Result, "//a:b", 0);
+        let mut r = s.evaluate(61_000, T).expect("stalled");
+        r.delta = Some(StallDelta {
+            since: Duration::from_secs(120),
+            done: 0,
+            open: 0,
+        });
+        let text = render_stall(&r);
+        assert!(
+            text.contains("since last   +0 done, +0 open, over 120s"),
+            "{text}"
+        );
+        assert!(r.delta.expect("delta").is_flat());
+    }
+
+    /// Waiters parked on a cell with nobody elected to poll it, plus a flat
+    /// delta, is a lost wake-up — and unlike the byte-starvation claim it is
+    /// backed by two independent observations rather than one structural zero.
+    #[test]
+    fn a_stranded_cell_with_a_flat_delta_is_called_a_lost_wakeup() {
+        let s = state();
+        s.op_start(Op::Result, "//a:b", 0);
+        let mut r = s.evaluate(61_000, T).expect("stalled");
+        r.delta = Some(StallDelta {
+            since: Duration::from_secs(120),
+            done: 0,
+            open: 0,
+        });
+        r.stuck = vec![hcore::hmemoizer::StuckCell {
+            tag: "result",
+            key: "//a:b".to_string(),
+            waiters: Some(4),
+            has_driver: false,
+        }];
+        let text = render_stall(&r);
+        assert!(text.contains("That is a lost wake-up"), "{text}");
+        assert!(text.contains("[result] //a:b waiters=4"), "{text}");
+    }
+
+    /// A frozen TUI swallows Ctrl-C (raw mode clears ISIG), so the paragraph must
+    /// name the escalation that does work instead of leaving it to be
+    /// rediscovered per incident.
+    #[test]
+    fn the_paragraph_names_the_next_step() {
+        let s = state();
+        s.op_start(Op::Result, "//a:b", 0);
+        let text = render_stall(&s.evaluate(61_000, T).expect("stalled"));
+        assert!(text.contains("kill -QUIT"), "{text}");
+        assert!(
+            text.contains(&std::process::id().to_string()),
+            "the pid must be filled in, not left as a placeholder: {text}"
         );
     }
 

--- a/src/diag.rs
+++ b/src/diag.rs
@@ -136,10 +136,48 @@ fn sweep() {
     }
 
     let n = sweep_threads();
+    write_inventory(fd);
     // `warn!`, not `info!`: someone pressed `Ctrl-\` on a frozen build and the one
     // thing they need back is where the dump went. At `info!` that line sits in
     // the same stream as ordinary build chatter and scrolls past unread.
     warn!(threads = n, path = %path.display(), "Wrote thread backtraces");
+}
+
+/// Append the parked-future state to the dump, after the thread backtraces.
+///
+/// Thread backtraces answer "what is each *thread* doing", which for this engine
+/// is the wrong question. The work lives in futures parked on the heap: a wedged
+/// build shows every worker idle in `futex_wait` and every blocking-pool thread
+/// on an empty queue, and not one frame names the thousands of awaits that are
+/// actually stuck. The inventory is the other half of the dump, and on a lost
+/// wake-up it is the *only* half that says anything.
+///
+/// Runs on the sweeper thread, after every signalled thread has written its
+/// frames — never inside the signal handler, and never with a blocking lock (see
+/// `hmemoizer::inventory`).
+fn inventory_report() -> String {
+    let cells = hcore::hmemoizer::inventory();
+    format!(
+        "\n=== heph in-flight inventory ({} incomplete cells) ===\n{}\n\
+         === memoizer wait-for graph ===\n{}\n\
+         === memoizer phases ===\n{}\n",
+        cells.len(),
+        // No cap: this file is read once, by a human or an agent, on a build
+        // that has already gone wrong. Truncating it here is how you end up
+        // needing a second incident to see the line you cut.
+        hcore::hmemoizer::render_inventory(&cells, usize::MAX),
+        hcore::hmemoizer::dump_wait_graph(),
+        hcore::hmemoizer::dump_phases(),
+    )
+}
+
+fn write_inventory(fd: libc::c_int) {
+    let text = inventory_report();
+    let bytes = text.as_bytes();
+    // SAFETY: appending an owned, initialised byte buffer to the diag fd.
+    unsafe {
+        libc::write(fd, bytes.as_ptr() as *const libc::c_void, bytes.len());
+    }
 }
 
 /// Signal used to make each thread dump itself. `SIGUSR1` is free here —
@@ -268,5 +306,28 @@ extern "C" fn on_dump_signal(_sig: libc::c_int) {
     // SAFETY: appending an owned, initialised byte buffer to the diag fd.
     unsafe {
         libc::write(fd, bytes.as_ptr() as *const libc::c_void, bytes.len());
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// The dump carries the parked-future state, and says how to turn on the
+    /// two views that are still gated.
+    ///
+    /// Thread backtraces alone answered "every thread is idle" on a wedged run
+    /// — true, and useless. The inventory is the half that names the stuck work,
+    /// and the gated sections must announce themselves rather than being absent,
+    /// or the next reader has no way to know a deeper view exists.
+    #[test]
+    fn the_dump_carries_the_in_flight_state_and_names_its_gated_sections() {
+        let text = inventory_report();
+        assert!(text.contains("heph in-flight inventory"), "{text}");
+        assert!(text.contains("memoizer wait-for graph"), "{text}");
+        assert!(text.contains("memoizer phases"), "{text}");
+        // Unset in a test process, so both must self-describe.
+        assert!(text.contains("HEPH_DEBUG_MEMOIZER_CYCLE"), "{text}");
+        assert!(text.contains("heph_PHASE_TRACE"), "{text}");
     }
 }


### PR DESCRIPTION
## Why

A wedged 10k-target run produced a stall log that named the subsystem and nothing else:

```
heph: no progress for 180s
  open ops     249 result, 3 execute (oldest 188s)
  bytes        0 B in the last 60s on result
  progress     10164 done, 19 unsuccessful

  Nothing has been read on result in the last 60s, so this looks like a
  stuck result rather than slow work.
```

A `SIGQUIT` dump of the same process — 59 threads — showed:

| Count | Where | State |
|---|---|---|
| ~24 | `blocking.rs:139` — `for job in rx.iter()` | hcore pool, **empty queue** |
| ~12 | tokio `multi_thread::worker` | parked in `futex_wait` |
| ~13 | tokio blocking pool | parked |
| 2 | `select` → `turn` | tokio IO driver, parked |
| 1 | `local_cache_sqlite.rs:639` — `rx.recv()` | idle |
| 3 | `nanosleep` | the three backstop/watchdog threads |

Zero frames in `engine/result`, `pluginexec`, `proc_exec`, `flock`, or `waitpid`. The process was **entirely idle** with 249 result futures parked on it — a lost wake-up. The dump ruled out four hypotheses (hung subprocess, blocked flock, saturated runtime, blocking-pool starvation) and could not point at the fifth, because the state lives in futures on the heap and a thread dump cannot see them.

## What was wrong

- **`LocalCacheWrite` / `RemoteCacheWrite` / `ResultLockWait` were dropped by `DiagHook`.** All three are emitted by the engine and consumed by the TUI; the diag hook had no arms for them. That hid a stall *in* a cache write — and, because those spans never called `touch()`, made a run progressing through the write-heavy tail of a mostly-cached build read as **stalled**. A notice that fires on a healthy build stops being read.
- **The starvation hypothesis was a tautology.** `add_bytes` is only ever called with `Op::RemoteCacheRead`, so for every other op the window is a structural zero — which `dominant_is_starved` read as proof of starvation.
- **Escalated paragraphs were byte-identical**, the strongest signal in the file, and the only way to see it was to diff two tables by eye.
- **The in-flight memoizer state was unreachable** except from a panic inside `await_with_stall_check`, behind `HEPH_MEMOIZER_STALL_SECS` — an env var nobody sets on the run they don't yet know will hang.

## What this does

Same paragraph, after:

```
heph: no progress for 61s
  open ops     1 result
  progress     0 done, 0 unsuccessful
  since last   +0 done, +0 open, over 120s
  in-flight    1 result
  stranded     1 cell(s) have waiters but no driver — nobody will poll them
    [result] //a:b waiters=4 driver=false STRANDED

  1 cell(s) have tasks parked on them with nobody elected to poll
  them, and nothing moved since the last report. That is a lost wake-up,
  not slow work.

  Still stuck? `kill -QUIT 51602` writes every thread's backtrace plus the
  full in-flight inventory next to this file; it does not kill the process.
```

- **Always-on cell inventory** (`hmemoizer::inventory`) — every incomplete cell, its key, its waiter count, and whether anyone is elected to poll it. Waiters count *attached awaiters*, not live wakers: waking an awaiter `take`s its waker, so a live-waker count reads zero for exactly the population this exists to find.
- **Lock waits tracked separately from `Op`**, with the holder pid. `Op` is the TUI's timeline vocabulary and a wait is not an operation the target performs; keeping it separate means no TUI change. The holder matters because the default lock backend is `flock(2)` — the holder can be a different heph process, which nothing else in the report could ever surface.
- **`Op::reports_bytes()`** gates both the byte line and the starvation claim.
- **`StallDelta`** on each escalation. `+0 done, +0 open` says wedged; `+412 done` says slow.
- **SIGQUIT dump carries the inventory**, plus the wait-for graph and phase map, which self-describe when still gated — so the deeper views are discoverable instead of being rediscovered per incident.
- **The paragraph names the next step.** Ctrl-C is what a human reaches for on a frozen build and is exactly what cannot help: the TUI clears ISIG, so the terminal never raises SIGINT.

## Cost

One registration per `Memoizer` construction (a handful per request, not per target); nothing per `once` call. The registry holds `Weak`s and prunes amortised, so a long-lived process does not accumulate dead requests. All sampling is `try_lock` — a diagnostic that can block is one that can hang the process it exists to explain. Everything else runs only after a stall is already confirmed.

## Deliberately not fixed here

**The lost wake-up itself.** The memoizer cell is the only await in the result path with no backstop — `hcore::blocking::run` arms one on every pending poll, the sqlite write-behind reuses it, and the cell's own `stall_backstop` exists but sits behind `HEPH_MEMOIZER_STALL_SECS`. Arming it would convert this class of wedge into a hiccup, and would also **mask the underlying race before it has been found**. Worth doing after the next incident produces a stranded-cell listing that names the culprit.

## Tests

13 new tests. The ones that matter:

- `a_build_progressing_through_cache_writes_is_not_a_stall` — the false-positive half of the hook gap.
- `no_byte_line_or_starvation_claim_for_ops_that_never_report_bytes` — kills the tautology.
- `a_cell_reports_waiters_and_whether_anyone_will_poll_it` / `a_cell_with_waiters_and_no_driver_is_stranded` — the lost-wake signature. The first caught a real weakness in the initial implementation (counting live wakers read 0 in exactly the wedged case) and drove the switch to counting attached awaiters.
- `inventory_drops_memoizers_that_are_gone` — the registry does not leak requests.
- `a_blocked_result_lock_is_reported_with_its_holder`, `the_delta_since_the_last_report_is_stated`, `the_paragraph_names_the_next_step`.

`lint` clean. Full suite green except `plugingo-e2e`, which fails locally on `No space left on device` staging the Go std toolchain (2.8 GB free on this host) — unrelated to this change; CI has the disk for it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019SohmU1Z8pGPuAWPpY4hwV
