### PR TITLE
perf(tui): fold matched progress incrementally instead of rescanning per frame

### DIFF
--- a/crates/tui/src/tui/progress.rs
+++ b/crates/tui/src/tui/progress.rs
@@ -515,10 +515,10 @@ pub struct BuildState {
 /// The header's count fields for one frame, as rendered strings.
 ///
 /// Every consumer — the split header, the plain-text summary — goes through
-/// [`BuildState::counts`], which walks the matched set exactly once per
-/// intersection it needs. That is the point of the type: two callers each
-/// asking for "their" subset of the fields is how the same `matched ∩ finished`
-/// scan ended up running twice on every frame of every view.
+/// [`BuildState::counts`]. The done count is kept split from its denominator
+/// because the header binds each half to a different view tab, while the
+/// plain-text summary wants them joined; carrying both shapes in one value is
+/// what lets the two renderings share a single computation and stay in step.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct Counts {
     /// The finished count, bound to the [`ViewMode::Done`] tab.
@@ -748,10 +748,9 @@ impl BuildState {
         ))
     }
 
-    /// The count fields for one frame — see [`Counts`]. Runs one
-    /// `matched ∩ finished` pass (via [`BuildState::matched_progress`]) and one
-    /// `matched ∩ cache_hit` pass (via [`BuildState::cached_count`]), never two
-    /// of either.
+    /// The count fields for one frame — see [`Counts`]. `O(1)`: every field is
+    /// either a `len()` or a counter folded in [`BuildState::apply`], so this is
+    /// four reads and the `format!`s, with no walk of any target set.
     pub fn counts(&self, scope: CountScope) -> Counts {
         let (done, total) = match scope {
             // All-targets scope: every observed target (`finished ∪ in_flight`),
@@ -1111,10 +1110,10 @@ impl BuildHeader {
 
 impl ProgressHeader for BuildHeader {
     fn header(&self, core: &BuildState, scope: CountScope) -> Vec<HeaderItem> {
-        // One `counts` call per frame: it is the only place the matched set is
-        // walked, and it walks it once per intersection. Asking for the done
-        // segment and the other fields separately is what made the
-        // `matched ∩ finished` scan run twice on every frame of every view.
+        // One `counts` call per frame, and it is `O(1)` — the matched
+        // intersections behind `done` and `cached` are counters folded in
+        // `BuildState::apply`, not scans. Keep the whole header on this one call
+        // so the fields cannot disagree about the frame they describe.
         let Counts {
             done,
             total,

--- a/crates/tui/src/tui/progress.rs
+++ b/crates/tui/src/tui/progress.rs
@@ -464,10 +464,22 @@ pub struct BuildState {
     /// Whether the matched set is final (matcher fully resolved). While false
     /// the total is provisional and rendered with a `~` prefix.
     matched_complete: bool,
-    /// Every addr that reached `ResultEnd` (deduped). Used to compute matched
-    /// progress as `matched ∩ finished` — order-independent, since `Matched`
-    /// events can arrive after some matched results already finished.
+    /// Every addr that reached `ResultEnd` (deduped). Matched progress is
+    /// `matched ∩ finished` — order-independent, since `Matched` events can
+    /// arrive after some matched results already finished.
     finished: HashSet<String>,
+    /// `|matched ∩ finished|`, folded incrementally by [`BuildState::apply`].
+    ///
+    /// The header reads this on every frame, and rescanning `matched` there cost
+    /// ~21-24 ms at 100k targets. Maintained at **both** edges of the
+    /// intersection — a `Matched` event that names an already-finished addr, and
+    /// a `ResultEnd` for an already-matched addr — because neither event is
+    /// guaranteed to arrive first. Each edge fires only when its `HashSet::insert`
+    /// reports the addr was new, so duplicate events cannot double-count.
+    matched_finished: usize,
+    /// `|matched ∩ cache_hit|`, folded on the same two-edge rule as
+    /// [`BuildState::matched_finished`].
+    matched_cached: usize,
     completed: usize,
     errored: usize,
     /// Failed targets in failure order, each with its error message (if the
@@ -582,7 +594,23 @@ impl BuildState {
             }
             BuildEventKind::Matched { addrs, complete } => {
                 self.matched_seen = true;
-                self.matched.extend(addrs.iter().cloned());
+                // The loop below replaced an `extend`, which reserved off the
+                // iterator's size hint; keep that so a wide `Matched` batch does
+                // not rehash its way up.
+                self.matched.reserve(addrs.len());
+                for addr in addrs {
+                    // The matched-set edge of both intersections: an addr can be
+                    // named here *after* it finished or hit cache, so fold those
+                    // in now. `insert` guards against a repeated addr.
+                    if self.matched.insert(addr.clone()) {
+                        if self.finished.contains(addr) {
+                            self.matched_finished += 1;
+                        }
+                        if self.cache_hit.contains(addr) {
+                            self.matched_cached += 1;
+                        }
+                    }
+                }
                 if *complete {
                     self.matched_complete = true;
                 }
@@ -600,10 +628,12 @@ impl BuildState {
                         self.done.push(addr.clone());
                     }
                 }
-                // Record every terminal addr; matched progress is computed as
-                // `matched ∩ finished` so it works regardless of whether the
-                // `Matched` event arrived before or after this result.
-                self.finished.insert(addr.clone());
+                // Record every terminal addr. This is the result edge of
+                // `matched ∩ finished`; the `Matched` arm covers the other one,
+                // so the count is right whichever event arrives first.
+                if self.finished.insert(addr.clone()) && self.matched.contains(addr) {
+                    self.matched_finished += 1;
+                }
             }
             // The op timeline (folded above) tracks Execute's duration; here we
             // keep only the `built` counter side effect on a successful end.
@@ -615,12 +645,12 @@ impl BuildState {
             }
             BuildEventKind::LocalCacheHit { addr } => {
                 self.local_hits += 1;
-                self.cache_hit.insert(addr.clone());
+                self.note_cache_hit(addr);
             }
             BuildEventKind::LocalCacheMiss { .. } => self.local_misses += 1,
             BuildEventKind::RemoteCacheHit { addr } => {
                 self.remote_hits += 1;
-                self.cache_hit.insert(addr.clone());
+                self.note_cache_hit(addr);
             }
             BuildEventKind::RemoteCacheMiss { .. } => self.remote_misses += 1,
             BuildEventKind::ResultLockWaitStart { addr, holder_pid } => {
@@ -642,6 +672,16 @@ impl BuildState {
             // elapsed-clock anchor at the top of `apply` still runs, so the
             // clock works during a gc sweep.
             BuildEventKind::GcTargetSwept { .. } => {}
+        }
+    }
+
+    /// Record a cache hit (local or remote). This is the cache edge of
+    /// `matched ∩ cache_hit`; the `Matched` arm of [`BuildState::apply`] covers
+    /// the other one, so the count is right whichever event arrives first. A
+    /// repeat hit on an addr already in the set does not re-count.
+    fn note_cache_hit(&mut self, addr: &str) {
+        if self.cache_hit.insert(addr.to_string()) && self.matched.contains(addr) {
+            self.matched_cached += 1;
         }
     }
 
@@ -685,16 +725,27 @@ impl BuildState {
     /// top-level targets have finished, the total matched so far, and whether the
     /// matcher fully resolved (`false` ⇒ the total is provisional). `None` until
     /// a `Matched` event arrives (e.g. a single-target `result_addr` entry).
+    ///
+    /// `O(1)` — the intersection is folded in [`BuildState::apply`], not scanned
+    /// here. This runs on every frame.
     pub fn matched_progress(&self) -> Option<(usize, usize, bool)> {
         if !self.matched_seen {
             return None;
         }
-        let done = self
-            .matched
-            .iter()
-            .filter(|a| self.finished.contains(*a))
-            .count();
-        Some((done, self.matched.len(), self.matched_complete))
+        // A subset-count that has drifted above the set it counts into is the
+        // observable symptom of a missed fold edge. Free in release; turns a
+        // desync into a failure across the whole suite, not just one test.
+        debug_assert!(
+            self.matched_finished <= self.matched.len(),
+            "matched_finished {} exceeds matched {}",
+            self.matched_finished,
+            self.matched.len(),
+        );
+        Some((
+            self.matched_finished,
+            self.matched.len(),
+            self.matched_complete,
+        ))
     }
 
     /// The count fields for one frame — see [`Counts`]. Runs one
@@ -852,15 +903,22 @@ impl BuildState {
     /// (`matched ∩ cache_hit`), falling back to all cache hits before any
     /// `Matched` event arrives, or to every cached addr under
     /// [`CountScope::All`].
+    ///
+    /// `O(1)` — the intersection is folded in [`BuildState::apply`], not scanned
+    /// here. This runs on every frame.
     pub fn cached_count(&self, scope: CountScope) -> usize {
         match scope {
             // All-targets scope: every addr that hit cache (deduped), deps included.
             CountScope::All => self.cache_hit.len(),
-            CountScope::Matched if self.matched_seen => self
-                .matched
-                .iter()
-                .filter(|a| self.cache_hit.contains(*a))
-                .count(),
+            CountScope::Matched if self.matched_seen => {
+                debug_assert!(
+                    self.matched_cached <= self.matched.len(),
+                    "matched_cached {} exceeds matched {}",
+                    self.matched_cached,
+                    self.matched.len(),
+                );
+                self.matched_cached
+            }
             CountScope::Matched => self.local_hits + self.remote_hits,
         }
     }
@@ -907,17 +965,13 @@ impl BuildState {
     pub fn summary(&self) -> String {
         let hits = self.local_hits + self.remote_hits;
         let misses = self.local_misses + self.remote_misses;
-        let matched = if self.matched_seen {
-            let done = self
-                .matched
-                .iter()
-                .filter(|a| self.finished.contains(*a))
-                .count();
+        let matched = match self.matched_progress() {
             // `~` marks a provisional total while the matcher is still streaming.
-            let tilde = if self.matched_complete { "" } else { "~" };
-            format!("matched {done} / {tilde}{}, ", self.matched.len())
-        } else {
-            String::new()
+            Some((done, total, complete)) => {
+                let tilde = if complete { "" } else { "~" };
+                format!("matched {done} / {tilde}{total}, ")
+            }
+            None => String::new(),
         };
         format!(
             "{matched}done {}, err {}, running {}, cache {} hit / {} miss",
@@ -2383,6 +2437,110 @@ mod tests {
 
     fn local_cache_hit(addr: &str) -> BuildEventKind {
         BuildEventKind::LocalCacheHit { addr: addr.into() }
+    }
+
+    fn remote_cache_hit(addr: &str) -> BuildEventKind {
+        BuildEventKind::RemoteCacheHit { addr: addr.into() }
+    }
+
+    /// The two matched intersections computed the slow way, straight off the
+    /// sets. The oracle for the counters folded in `apply`.
+    fn scan_matched(s: &BuildState) -> (usize, usize) {
+        (
+            s.matched.iter().filter(|a| s.finished.contains(*a)).count(),
+            s.matched
+                .iter()
+                .filter(|a| s.cache_hit.contains(*a))
+                .count(),
+        )
+    }
+
+    /// The same two intersections as the render path reports them.
+    fn rendered_matched(s: &BuildState) -> (usize, usize) {
+        let (done, _, _) = s.matched_progress().expect("a Matched event has landed");
+        (done, s.cached_count(CountScope::Matched))
+    }
+
+    #[test]
+    fn matched_counters_track_the_full_scan_under_out_of_order_events() {
+        // `matched ∩ finished` and `matched ∩ cache_hit` are folded incrementally
+        // rather than rescanned every frame, so they have to be maintained at
+        // *both* edges of each intersection. `Engine::result` really does emit a
+        // target's `ResultEnd` before the `Matched` event that names it, so a
+        // counter folded only on the result edge undercounts. Pin both against a
+        // full scan of the same sets, after every interleaving.
+        let mut s = BuildState::new();
+        let mut clock = 0u64;
+        let mut apply = |s: &mut BuildState, kind| {
+            clock += 1;
+            s.apply(&ev(clock, kind));
+        };
+
+        // Edge 1: these finish (and one hits cache) BEFORE anything is matched.
+        apply(&mut s, result_start("//early:a"));
+        apply(&mut s, local_cache_hit("//early:a"));
+        apply(&mut s, result_end("//early:a", None));
+        apply(&mut s, result_start("//early:b"));
+        apply(&mut s, result_end("//early:b", None));
+        // A transitive dep that is never matched — proves these are
+        // intersections, not running totals.
+        apply(&mut s, result_start("//dep:x"));
+        apply(&mut s, remote_cache_hit("//dep:x"));
+        apply(&mut s, result_end("//dep:x", None));
+
+        apply(
+            &mut s,
+            matched(
+                &["//early:a", "//early:b", "//late:c", "//late:d", "//late:e"],
+                false,
+            ),
+        );
+        assert_eq!(
+            rendered_matched(&s),
+            scan_matched(&s),
+            "matched arrives last"
+        );
+        assert_eq!(rendered_matched(&s), (2, 1));
+
+        // Edge 2: these finish AFTER the Matched event that named them.
+        apply(&mut s, result_start("//late:c"));
+        apply(&mut s, remote_cache_hit("//late:c"));
+        apply(&mut s, result_end("//late:c", None));
+        assert_eq!(
+            rendered_matched(&s),
+            scan_matched(&s),
+            "matched arrives first"
+        );
+        assert_eq!(rendered_matched(&s), (3, 2));
+
+        // A cache hit on a matched target that has not finished: the cached
+        // counter moves, the done counter does not.
+        apply(&mut s, local_cache_hit("//late:d"));
+        assert_eq!(
+            rendered_matched(&s),
+            scan_matched(&s),
+            "cache hit, no result"
+        );
+        assert_eq!(rendered_matched(&s), (3, 3));
+
+        // A matched target that *fails* still advances the done count — the
+        // header reads `4 / 5 done · … · 1 failed`, and `finished` is recorded
+        // outside the success branch precisely so it does. The scan oracle cannot
+        // see a regression here (it reads the same `finished` set), so this one
+        // needs the literal.
+        apply(&mut s, result_start("//late:e"));
+        apply(&mut s, result_end("//late:e", Some("boom".into())));
+        assert_eq!(rendered_matched(&s), scan_matched(&s), "matched failure");
+        assert_eq!(rendered_matched(&s), (4, 3));
+
+        // Repeats on every path are idempotent: a duplicate `ResultEnd`, a second
+        // cache hit on an already-cached addr, and a `Matched` event re-naming an
+        // addr already in the set.
+        apply(&mut s, result_end("//early:a", None));
+        apply(&mut s, remote_cache_hit("//early:a"));
+        apply(&mut s, matched(&["//early:a", "//late:c"], true));
+        assert_eq!(rendered_matched(&s), scan_matched(&s), "duplicate events");
+        assert_eq!(rendered_matched(&s), (4, 3));
     }
 
     #[test]


### PR DESCRIPTION
> Stacked on #214. Review that one first; the diff here is only the second commit.

`matched_progress` and `cached_count` each walked the whole matched set on **every rendered frame**: `|matched ∩ finished|` and `|matched ∩ cache_hit|`, `O(|matched|)` with a SipHash lookup per element. At 100k matched targets that is ~21–24 ms per frame, ~31% of a core at 12.5 fps. `summary` carried a third hand-rolled copy of the first scan.

**This does not slow the build.** The interactive backend polls the app on its own task; the CI backend never renders. It burns a core and lags the UI at exactly the scale where there is most to look at.

## Both edges, or it undercounts

Both intersections become `usize` counters folded in `apply`. The subtle part is that each has to be maintained at *both* edges:

- the `Matched` arm, for an addr named **after** it already finished or hit cache — `Engine::result` genuinely emits a target's `ResultEnd` before the `Matched` event that names it, which is why the sets were used in the first place (see the pre-existing `matched_progress_is_order_independent`);
- the `ResultEnd` arm and the new `note_cache_hit` helper, for an addr that finishes or hits cache **after** it was matched.

A counter folded on only one edge undercounts, silently, in real runs.

## Why it cannot drift

Every increment is gated on the `HashSet::insert` return value, so a duplicate `ResultEnd`, a second cache hit on an already-cached addr, or a `Matched` batch re-naming an addr cannot double-count.

Correctness is by construction rather than by argument: the three sets are **insert-only** for the life of a `BuildState` — no `remove`, no `clear`, no reset — and the three insert sites are the only writes, each carrying its fold. The counters are therefore monotone and cannot drift.

## Cost

Two `usize` per `BuildState` (one per view, not per target), and about three extra hash lookups per target across the whole run — each gated on an insert that returns true exactly once. Against that, two `O(|matched|)` scans come off every frame.

The `Matched` arm changed from `extend` to an explicit loop, which loses the size-hint reservation `Extend for HashSet` performs, so it reserves explicitly; without that a wide `Matched` batch rehashes its way up.

`summary` now goes through `matched_progress` instead of repeating the scan, so the `~`-provisional rule lives in one place.

## Test

`matched_counters_track_the_full_scan_under_out_of_order_events` drives the public event API and asserts on the public render surface, cross-checking against a full scan of the same sets after every interleaving — and, because that oracle re-derives from the same sets and would follow any change to what "finished" *means*, it pins a literal tuple at each checkpoint too.

Covered: results and cache hits landing before the `Matched` event and after it, both cache kinds, a cache hit on a matched target that never finishes, a never-matched transitive dep (so the counts are intersections and not running totals), an errored matched target (which does advance the done count), and duplicates on every path.

**Mutation-checked**: deleting the `Matched`-arm fold fails it at `"matched arrives last"`; deleting the `ResultEnd` and cache-hit folds fails it at `"matched arrives first"`. Neither edge is redundant.

Two `debug_assert!`s on the reader side catch a subset-count that has drifted above the set it counts into, so a future missed edge fails across the whole suite rather than only in this one test.

## Verification

- `cargo test -p tui` — 86 passed.
- `cargo clippy --all-targets --locked -- -D warnings` (workspace root) — clean.
- `cargo fmt --all -- --check` — clean.

## Review board

`code-quality` and `feature-quality` consulted. **feature-quality: PASS WITH FOLLOW-UPS**, no blockers — its two findings (the lost `extend` reservation, the missing errored-matched-target assertion) are fixed here, along with its optional debug-assert suggestion.

It flags as the **next item**, not addressed here: `matched_lines` / `cached_lines` / `done_lines` build and sort the *full* list every frame before the viewport clips it to ~20 rows. On a warm 100k-target run with the user on the Matched or Cached tab that is 100k `String` allocations plus a 100k-element sort per frame — plausibly a larger per-frame cost than the one this PR removes.

This is **P8.2** of the concurrency/CPU remediation plan.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01A76DChMohieGMbRbnV1E7x