### PR TITLE
perf(lock): stamp the holder pid through the held gateway fd

### DIFF
--- a/crates/engine/src/engine/result_lock.rs
+++ b/crates/engine/src/engine/result_lock.rs
@@ -23,9 +23,9 @@
 use anyhow::Result;
 use hcore::hasync::Cancellable;
 use hlock::hlock::{
-    FLock, FRWLock, KeyedGuard, KeyedTLock, MemLock, MemRWLock, TBridge, TBridgeReadGuard,
-    TBridgeUpgradableGuard, TBridgeWriteGuard, TUpgradableReadGuard, TWriteGuard, fs_tlock,
-    mem_tlock,
+    FLock, FRWLock, FWriteGuard, KeyedGuard, KeyedTLock, MemLock, MemRWLock, TBridge,
+    TBridgeReadGuard, TBridgeUpgradableGuard, TBridgeWriteGuard, TUpgradableReadGuard, TWriteGuard,
+    fs_tlock, mem_tlock,
 };
 use hmodel::htaddr::Addr;
 use std::io::Read as _;
@@ -166,9 +166,9 @@ impl ResultLock {
         ctoken: &(dyn Cancellable + Send + Sync),
     ) -> Result<ResultUpgradableGuard> {
         match self {
-            ResultLock::Fs { dir, lock } => {
+            ResultLock::Fs { lock, .. } => {
                 let guard = lock.upgradable_read(addr.clone(), ctoken).await?;
-                stamp_pid(&outer_lock_path(dir, addr));
+                stamp_pid(guard.outer_guard());
                 Ok(ResultUpgradableGuard::Fs(guard))
             }
             ResultLock::Mem(kl) => Ok(ResultUpgradableGuard::Mem(
@@ -186,9 +186,9 @@ impl ResultLock {
         ctoken: &(dyn Cancellable + Send + Sync),
     ) -> Result<ResultWriteGuard> {
         match self {
-            ResultLock::Fs { dir, lock } => {
+            ResultLock::Fs { lock, .. } => {
                 let guard = lock.write(addr.clone(), ctoken).await?;
-                stamp_pid(&outer_lock_path(dir, addr));
+                stamp_pid(guard.outer_guard());
                 Ok(ResultWriteGuard::Fs(guard))
             }
             ResultLock::Mem(kl) => Ok(ResultWriteGuard::Mem(kl.write(addr.clone(), ctoken).await?)),
@@ -201,9 +201,9 @@ impl ResultLock {
     /// path. Stamps pid on success like [`write`](ResultLock::write).
     pub fn try_write(&self, addr: &Addr) -> Result<Option<ResultWriteGuard>> {
         match self {
-            ResultLock::Fs { dir, lock } => match lock.try_write(addr.clone())? {
+            ResultLock::Fs { lock, .. } => match lock.try_write(addr.clone())? {
                 Some(guard) => {
-                    stamp_pid(&outer_lock_path(dir, addr));
+                    stamp_pid(guard.outer_guard());
                     Ok(Some(ResultWriteGuard::Fs(guard)))
                 }
                 None => Ok(None),
@@ -235,11 +235,22 @@ fn inner_lock_path(dir: &Path, addr: &Addr) -> PathBuf {
 }
 
 /// Best-effort stamp of this process's pid into the gateway lock file, for
-/// cross-process contention diagnostics. Only called while the gateway is held
-/// (cold path), so it never burdens cache hits. A failure is logged, not fatal.
-fn stamp_pid(path: &Path) {
-    if let Err(err) = std::fs::write(path, std::process::id().to_string().as_bytes()) {
-        tracing::debug!(error = %err, path = %path.display(), "stamping pid into lock file");
+/// cross-process contention diagnostics. A failure is logged, not fatal.
+///
+/// Writes through the gateway guard's *already-open* file description rather
+/// than re-opening the lock file by path: it drops the `open`/`close` pair (and
+/// the path resolution that comes with them) from every gateway acquire, and it
+/// makes the stamp structurally incapable of landing on a file this process
+/// does not hold.
+fn stamp_pid(gateway: Option<&FWriteGuard>) {
+    let Some(gateway) = gateway else {
+        // Unreachable in practice: the guard owns the gateway for its whole
+        // observable lifetime.
+        tracing::debug!("gateway guard unavailable for pid stamp");
+        return;
+    };
+    if let Err(err) = gateway.write_contents(std::process::id().to_string().as_bytes()) {
+        tracing::debug!(error = %err, "stamping pid into gateway lock file");
     }
 }
 
@@ -459,6 +470,34 @@ mod tests {
             .await
             .expect("acquire");
         assert_eq!(lock.holder_pid(&addr("a")), Some(std::process::id()));
+        drop(held);
+    }
+
+    // The stamp must go through the gateway guard's open fd, never a second
+    // `open` of the path. Proven by swapping a decoy inode in at the path while
+    // the guard holds the original: a path-based stamp would land on the decoy.
+    #[tokio::test]
+    async fn stamp_pid_writes_through_the_held_fd_not_the_path() {
+        use hlock::hlock::Lock;
+
+        let dir = tempfile::tempdir().expect("tempdir");
+        let path = dir.path().join("gateway.lock");
+        let gateway = FLock::new(&path);
+        let held = gateway
+            .lock(&StdCancellationToken::new())
+            .await
+            .expect("gateway");
+
+        std::fs::remove_file(&path).expect("unlink held lock file");
+        std::fs::write(&path, b"decoy").expect("decoy");
+
+        stamp_pid(Some(&held));
+
+        assert_eq!(
+            std::fs::read(&path).expect("decoy readable"),
+            b"decoy",
+            "stamp_pid must not re-open the lock path"
+        );
         drop(held);
     }
 

--- a/crates/lock/src/hlock/bridge.rs
+++ b/crates/lock/src/hlock/bridge.rs
@@ -76,6 +76,27 @@ pub struct TBridgeWriteGuard<O: Lock, I: RWLock> {
     inner_write: Option<I::WriteGuard>,
 }
 
+impl<O: Lock, I: RWLock> TBridgeUpgradableGuard<O, I> {
+    /// Borrow the held outer (gateway) guard, so a caller can act on the
+    /// gateway lock itself — e.g. write through its already-open file
+    /// description instead of re-opening the lock file by path.
+    ///
+    /// `Some` for this guard's whole observable lifetime: the option is emptied
+    /// only by [`upgrade`](TUpgradableReadGuard::upgrade) and `drop`, both of
+    /// which consume `self`.
+    pub fn outer_guard(&self) -> Option<&O::Guard> {
+        self.outer_guard.as_ref()
+    }
+}
+
+impl<O: Lock, I: RWLock> TBridgeWriteGuard<O, I> {
+    /// Borrow the held outer (gateway) guard. See
+    /// [`TBridgeUpgradableGuard::outer_guard`].
+    pub fn outer_guard(&self) -> Option<&O::Guard> {
+        self.outer_guard.as_ref()
+    }
+}
+
 impl<O: Lock, I: RWLock> Drop for TBridgeUpgradableGuard<O, I> {
     fn drop(&mut self) {
         // Release inner first, then outer (matches the write-guard order).

--- a/crates/lock/src/hlock/flock.rs
+++ b/crates/lock/src/hlock/flock.rs
@@ -42,9 +42,8 @@ use hplugin::error::CancelledError;
 use libc::c_int;
 use parking_lot::Mutex;
 use std::fs::{File, OpenOptions};
-use std::io::{Seek, Write};
 use std::os::fd::{AsRawFd, RawFd};
-use std::os::unix::fs::MetadataExt;
+use std::os::unix::fs::{FileExt, MetadataExt};
 use std::path::{Path, PathBuf};
 use std::sync::Arc;
 use std::time::Duration;
@@ -142,7 +141,12 @@ impl FLockState {
         for _ in 0..STALE_RETRIES {
             let fd = self.ensure_open(st)?;
             if !flock_nb(fd, op)? {
-                self.discard_fd(st);
+                // Would-block: this fd never acquired anything, so there is
+                // nothing to `LOCK_UN`. Just close it — dropping the last fd of
+                // an open file description releases any lock anyway, and the
+                // extra `flock` would be a wasted syscall on *every* failed poll
+                // of a contended acquire.
+                st.file = None;
                 return Ok(false);
             }
             if self.fd_matches_path(st)? {
@@ -192,14 +196,18 @@ impl FLockState {
     /// (no second `open`). Only valid while a guard is held — the fd is open
     /// exactly then. Truncates to `bytes.len()` so stale trailing bytes from a
     /// prior, longer payload do not linger.
+    ///
+    /// Positioned (`pwrite`) rather than seek-then-write: it saves the `lseek`
+    /// and leaves the fd's shared file offset alone, which matters because the
+    /// same open file description is shared by every in-process guard.
     fn write_contents(&self, bytes: &[u8]) -> Result<()> {
         let st = self.fd.lock();
-        let mut f = st
+        let f = st
             .file
             .as_ref()
             .context("write_contents requires a held lock (fd open)")?;
-        f.rewind().context("seeking lock file to start")?;
-        f.write_all(bytes).context("writing lock file contents")?;
+        f.write_all_at(bytes, 0)
+            .context("writing lock file contents")?;
         f.set_len(bytes.len() as u64)
             .context("truncating lock file to payload length")?;
         Ok(())
@@ -468,6 +476,28 @@ mod tests {
         // A shorter payload truncates the trailing bytes of the longer one.
         g.write_contents(b"42").unwrap();
         assert_eq!(std::fs::read(&path).unwrap(), b"42");
+        drop(g);
+    }
+
+    #[tokio::test]
+    async fn write_contents_targets_the_held_inode_not_the_path() {
+        // The guard writes through its open file description. Proven by swapping
+        // a decoy inode in at the path: a write that re-resolved the path would
+        // land on the decoy.
+        let dir = tempfile::tempdir().expect("tempdir");
+        let path = dir.path().join("lock");
+        let l = FLock::new(&path);
+
+        let g = l.lock(&ct()).await.unwrap();
+        std::fs::remove_file(&path).unwrap();
+        std::fs::write(&path, b"decoy").unwrap();
+
+        g.write_contents(b"held").unwrap();
+        assert_eq!(
+            std::fs::read(&path).unwrap(),
+            b"decoy",
+            "write_contents must not re-open the lock path"
+        );
         drop(g);
     }
 


### PR DESCRIPTION
P9.1 of the threading remediation plan.

`stamp_pid` re-opened the gateway lock file by path (`std::fs::write`) on every `upgradable_read` / `write` / `try_write` acquire, even though the guard just handed back already owns an open, writable fd for exactly that inode. That is an `open` (with full path resolution) plus a `close` per gateway acquire, plus a `format!`-built `PathBuf` to feed it, for a diagnostic that writes a handful of bytes.

It now writes through the guard. `TBridgeUpgradableGuard` and `TBridgeWriteGuard` gain an `outer_guard()` accessor borrowing the held outer guard; `KeyedGuard` already derefs to the bridge guard, so `result_lock` reaches the existing, already-tested `FWriteGuard::write_contents` without touching the path. The accessor acquires nothing and releases nothing — the two-file bridge's outer→inner ordering is untouched.

**This is also strictly safer, not just cheaper.** A path-based stamp writes to whatever inode sits at the path at that instant; the fd-based one writes to the inode this process verifiably holds the flock on. Since `release_write` unlinks the lock file while still holding the lock, "the path" and "the locked inode" are genuinely allowed to diverge, so the old form could in principle stamp a file it did not own.

Two further semantics-preserving syscall reductions:

- `write_contents` uses `pwrite` (`FileExt::write_all_at`) instead of `rewind` + `write_all`. Drops the `lseek`, and stops moving the shared file offset — the open file description is shared by every in-process guard on that lock, so mutating its offset was a latent surprise for any future reader on the same fd.
- `try_lock_fresh` no longer issues `flock(LOCK_UN)` on the would-block path. That fd never acquired anything; `close` releases regardless. The contended acquire polls this branch once per backoff iteration (up to every 100 ms) for as long as contention lasts. The stale-inode retry branch, where the lock *is* held, keeps its explicit unlock.

## Tests

`write_contents_targets_the_held_inode_not_the_path` and `stamp_pid_writes_through_the_held_fd_not_the_path` swap a decoy inode in at the lock path while the guard keeps the original open, and assert the write lands on the held inode. **Both verified red against a path-based write.** The positive direction stays covered by the existing `fs_holder_pid_reports_stamped_pid` and `write_contents_persists_and_truncates_through_held_fd`.

No per-platform divergence: `pwrite`, `flock`, and writing through an fd whose path has been unlinked are uniform across the three supported targets.

## Out of scope, by explicit instruction

- Treating `EMFILE` as would-block in `poll_acquire` — the fds are pinned for the whole request, so nothing frees during the backoff and the target would livelock instead of erroring.
- The retained-fd / `RLIMIT_NOFILE` question, which is a pending user decision.

## ⚠️ Review board incomplete

The authoring agent committed this and was starting its `code-quality` and `feature-quality` consults when it was terminated by a session limit. **Those consults never ran.** The code, tests, and red-verification above are the agent's own work and were completed; the independent review was not. Treat accordingly before merging.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01A76DChMohieGMbRbnV1E7x