### PR TITLE
perf(tui): run the app on its own task in the CI backend

### DIFF
--- a/crates/engine/src/engine/grow_stack.rs
+++ b/crates/engine/src/engine/grow_stack.rs
@@ -81,4 +81,26 @@ mod tests {
             .expect("spawn small-stack thread");
         assert_eq!(handle.join().expect("thread must not overflow"), 20_000);
     }
+
+    /// `maybe_grow` has to work on a *tokio worker*, not just on a thread we sized
+    /// ourselves: `remaining_stack()` must resolve the bounds of a runtime-owned
+    /// thread, and the segment switch must survive being driven through a task.
+    /// That is the shape every caller uses — `Engine::result` spawns each target,
+    /// and both TUI backends spawn the app future — so the wrapper is load-bearing
+    /// exactly here.
+    ///
+    /// The stack size is set explicitly rather than left to tokio's 2 MiB default:
+    /// the default honours `RUST_MIN_STACK`, and under a large value this would
+    /// pass with the wrapper removed — a test that cannot fail.
+    #[test]
+    fn grow_stack_survives_deep_recursion_on_a_tokio_worker() {
+        const DEPTH: usize = 20_000;
+        let rt = tokio::runtime::Builder::new_multi_thread()
+            .worker_threads(1)
+            .thread_stack_size(2 * 1024 * 1024)
+            .build()
+            .expect("build runtime");
+        let reached = rt.block_on(async { tokio::spawn(grow_stack(deep(DEPTH))).await });
+        assert_eq!(reached.expect("app task"), DEPTH);
+    }
 }

--- a/crates/tui/src/tui/backend/ci.rs
+++ b/crates/tui/src/tui/backend/ci.rs
@@ -5,7 +5,7 @@ use crate::tui::log_sink::LogSink;
 use hcore::events::EventReceiver;
 use hcore::shutdown::ShutdownTrigger;
 
-pub async fn run<A: App>(
+pub async fn run<A: App + 'static>(
     app: A,
     sink: LogSink,
     _shutdown: ShutdownTrigger,
@@ -24,14 +24,58 @@ pub async fn run<A: App>(
     // exiting the process out from under the cleaner thread).
     let bg_pending = std::sync::Arc::new(std::sync::atomic::AtomicUsize::new(0));
     let ctx = AppContext::direct(sink, Some(event_tx), std::sync::Arc::clone(&bg_pending));
-    let app_fut = app.run(ctx);
-    tokio::pin!(app_fut);
+    // App runs on its own task, as on the interactive backend. Sharing one task
+    // with the loop below means every synchronous stretch inside the app — a
+    // filesystem walk, Starlark eval, a cache-warm `result_addr` descent — stalls
+    // event folding and the blocking `stderr` writes the view does, until the app
+    // happens to yield. Spawning lets the fold loop be re-polled on another worker.
+    //
+    // This also moves the app off the 8 MiB main-thread stack `bootstrap::block_on`
+    // runs on and onto a 2 MiB tokio worker stack. That matters: `heph run` on a
+    // single address awaits `Engine::result_addr` directly on this future
+    // (`commands/run.rs`), and a cache-warm descent resolves the whole dependency
+    // subtree inside one `poll`, ~100 KiB of stack per level.
+    //
+    // What makes the descent safe is `GrowStack`: `Engine::result_addr` returns one,
+    // and it is the only way into `result_addr_impl`, so every level of the result
+    // spine — the outermost included — polls under `stacker::maybe_grow` and takes a
+    // fresh segment when headroom runs low. The spine therefore cannot overflow.
+    // Recursion nested *inside* one level (`plugingo::import_closure`,
+    // `expand_inputs`, `collect_transitive_deps`) is not wrapped and is bounded only
+    // by `RED_ZONE`, exactly as it already is on the batch path — `Engine::result`
+    // spawns each target — and on the interactive backend. See `engine::grow_stack`.
+    //
+    // `Engine::drop` (FUSE unmount, SQLite flush, sandbox rmdir) now runs on the
+    // worker that polled the app to completion rather than on the main thread; it
+    // blocks on plain OS threads, never on the runtime, so it parks a worker during
+    // teardown but cannot deadlock. Same as the interactive backend already does.
+    let mut app_handle = tokio::spawn(app.run(ctx));
 
     let result = loop {
         tokio::select! {
-            // Bias toward draining events so the final summary reflects the
-            // full stream, but the app future is what terminates the loop.
-            out = &mut app_fut => break out,
+            // Events keep being folded until the app task resolves; whatever the
+            // app queued before finishing is picked up by the drain below.
+            //
+            // Events emitted *after* that — a `bg_pending`-tracked remote-cache
+            // upload keeps a sender clone and emits from its own task
+            // (`remote_cache.rs`) — are not folded and do not reach the summary.
+            // Pre-existing and deliberate here: `view.finish()` prints once, before
+            // the background drain. The interactive backend keeps its event arm live
+            // across that window and does fold them, so the two backends differ.
+            // Changing it means changing what a CI run prints, which is a separate
+            // call from this one.
+            out = &mut app_handle => break match out {
+                Ok(inner) => inner,
+                // Preserve the pre-spawn behaviour: an app panic unwound straight
+                // out of `run`. Re-raise it here rather than turning it into an
+                // ordinary error, so the panic hook and exit code are unchanged.
+                Err(join_err) if join_err.is_panic() => {
+                    std::panic::resume_unwind(join_err.into_panic())
+                }
+                Err(join_err) => {
+                    Err(anyhow::Error::new(join_err).context("joining the app task"))
+                }
+            },
             maybe_evt = async {
                 match events.as_mut() {
                     Some(r) => r.recv().await,
@@ -101,3 +145,355 @@ const DRAIN_POLL: std::time::Duration = std::time::Duration::from_millis(10);
 /// normal run says nothing at all, short enough that a slow drain never looks like
 /// a hang.
 const DRAIN_REPORT_EVERY: std::time::Duration = std::time::Duration::from_secs(5);
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::tui::app::TUIAppView;
+    use async_trait::async_trait;
+    use futures::FutureExt;
+    use hcore::events::{BuildEvent, BuildEventKind, now_unix_ms};
+    use ratatui::text::Line;
+    use std::sync::atomic::{AtomicUsize, Ordering};
+    use std::sync::{Arc, Mutex};
+    use std::time::{Duration, Instant};
+
+    /// How long `Behavior::BlockUntilFolded` spins before giving up. Only paid on
+    /// a regression — the fold lands in microseconds when the app has its own task.
+    const FOLD_DEADLINE: Duration = Duration::from_secs(5);
+
+    /// How long `Behavior::LeavesBackgroundWork` keeps its ticket outstanding.
+    /// Comfortably above the backend's 10 ms `DRAIN_POLL` so "did `run` wait?" is
+    /// not a scheduler coin flip.
+    const BG_WORK_DELAY: Duration = Duration::from_millis(150);
+
+    fn result_start(addr: &str) -> BuildEvent {
+        BuildEvent {
+            at_unix_ms: now_unix_ms(),
+            kind: BuildEventKind::ResultStart {
+                addr: addr.to_string(),
+            },
+        }
+    }
+
+    /// The CI backend never builds a TUI view; this exists only to satisfy the
+    /// associated type.
+    struct NoTuiView;
+
+    impl TUIAppView for NoTuiView {
+        fn apply(&mut self, _ev: &BuildEvent) {}
+        fn rows(&self, _term_height: u16) -> u16 {
+            0
+        }
+        fn render(&self, _spinner: &str, _now_ms: u64, _w: u16, _h: u16) -> Vec<Line<'static>> {
+            Vec::new()
+        }
+    }
+
+    /// Records what the backend folded, in the order it folded it. The counters
+    /// are shared with the app so it can observe folding progress while running.
+    #[derive(Clone, Default)]
+    struct RecordingView {
+        addrs: Arc<Mutex<Vec<String>>>,
+        folded: Arc<AtomicUsize>,
+        begun: Arc<AtomicUsize>,
+        finished: Arc<AtomicUsize>,
+    }
+
+    impl CIAppView for RecordingView {
+        fn begin(&self) {
+            self.begun.fetch_add(1, Ordering::SeqCst);
+        }
+
+        fn apply(&mut self, ev: &BuildEvent) {
+            if let BuildEventKind::ResultStart { addr } = &ev.kind {
+                self.addrs
+                    .lock()
+                    .expect("recording view poisoned")
+                    .push(addr.clone());
+            }
+            self.folded.fetch_add(1, Ordering::SeqCst);
+        }
+
+        fn finish(&self) {
+            self.finished.fetch_add(1, Ordering::SeqCst);
+        }
+    }
+
+    /// Flips its flag when dropped. Used to prove the app's owned state — in the
+    /// real thing the last `Arc<Engine>`, whose `Drop` unmounts FUSE and flushes
+    /// SQLite — is released before `run` returns. `bootstrap::block_on` documents
+    /// that as a precondition; before this change it was structural (the future
+    /// lived in `run`'s frame), now it rests on tokio dropping a task's future
+    /// before waking its `JoinHandle`.
+    struct DropProbe(Arc<AtomicUsize>);
+
+    impl Drop for DropProbe {
+        fn drop(&mut self) {
+            self.0.fetch_add(1, Ordering::SeqCst);
+        }
+    }
+
+    enum Behavior {
+        /// Emit `n` events back to back, then finish.
+        Emit(usize),
+        /// Emit `n` events, then fail. The failing-build path in CI mode.
+        EmitThenFail(usize),
+        /// Emit one event, then hold the thread synchronously until the backend
+        /// has folded it. Resolves to whether the fold was observed.
+        BlockUntilFolded,
+        /// Register one unit of background work and hand it to a detached task
+        /// that clears it after a delay — a sandbox cleanup or a cache upload
+        /// outliving the app.
+        LeavesBackgroundWork,
+        /// Unwind out of the app task.
+        Panic,
+    }
+
+    struct TestApp {
+        view: RecordingView,
+        behavior: Behavior,
+        /// Dropped with the app's future, i.e. when the app task completes.
+        probe: Option<DropProbe>,
+    }
+
+    impl TestApp {
+        fn new(view: RecordingView, behavior: Behavior) -> Self {
+            Self {
+                view,
+                behavior,
+                probe: None,
+            }
+        }
+
+        fn with_probe(mut self, probe: DropProbe) -> Self {
+            self.probe = Some(probe);
+            self
+        }
+    }
+
+    #[async_trait]
+    impl App for TestApp {
+        type Output = bool;
+        type TuiView = NoTuiView;
+        type CiView = RecordingView;
+
+        fn tui_view(&self) -> NoTuiView {
+            NoTuiView
+        }
+
+        fn ci_view(&self) -> RecordingView {
+            self.view.clone()
+        }
+
+        async fn run(self, ctx: AppContext) -> anyhow::Result<bool> {
+            let tx = ctx
+                .event_sender()
+                .expect("the CI backend must plumb an event sender through AppContext");
+            match self.behavior {
+                Behavior::Emit(n) => {
+                    for i in 0..n {
+                        tx.send(result_start(&format!("//p:t{i}")))
+                            .expect("backend must still hold the receiver");
+                    }
+                    Ok(true)
+                }
+                Behavior::BlockUntilFolded => {
+                    tx.send(result_start("//p:probe"))
+                        .expect("backend must still hold the receiver");
+                    // Synchronous on purpose: this is what a filesystem walk,
+                    // Starlark eval, or a cache-warm `result_addr` descent looks
+                    // like from the backend's side — a stretch of the app's poll
+                    // with no await point in it.
+                    let deadline = Instant::now() + FOLD_DEADLINE;
+                    while Instant::now() < deadline {
+                        if self.view.folded.load(Ordering::SeqCst) > 0 {
+                            return Ok(true);
+                        }
+                        std::thread::sleep(Duration::from_millis(1));
+                    }
+                    Ok(false)
+                }
+                Behavior::EmitThenFail(n) => {
+                    for i in 0..n {
+                        tx.send(result_start(&format!("//p:t{i}")))
+                            .expect("backend must still hold the receiver");
+                    }
+                    Err(anyhow::anyhow!("build failed"))
+                }
+                Behavior::LeavesBackgroundWork => {
+                    let bg = ctx.bg_pending();
+                    bg.fetch_add(1, Ordering::AcqRel);
+                    tokio::spawn(async move {
+                        tokio::time::sleep(BG_WORK_DELAY).await;
+                        bg.fetch_sub(1, Ordering::AcqRel);
+                    });
+                    Ok(true)
+                }
+                Behavior::Panic => panic!("app blew up"),
+            }
+        }
+    }
+
+    /// The app must not share a task with the fold loop. While it holds its
+    /// thread without yielding, the backend has to keep draining the event
+    /// channel; sharing one `select!` task means nothing is folded until the app
+    /// gives the task back, and this deadlocks against the app's own deadline.
+    #[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+    async fn folds_events_while_the_app_holds_its_thread() {
+        let view = RecordingView::default();
+        let (shutdown, _shutdown_rx) = ShutdownTrigger::new();
+        let observed = run(
+            TestApp::new(view.clone(), Behavior::BlockUntilFolded),
+            LogSink::new_direct(),
+            shutdown,
+        )
+        .await
+        .expect("backend must return the app's output");
+
+        assert!(
+            observed,
+            "the backend must fold events while the app is still running; \
+             it saw none in {FOLD_DEADLINE:?}"
+        );
+        assert_eq!(
+            view.addrs
+                .lock()
+                .expect("recording view poisoned")
+                .as_slice(),
+            ["//p:probe"]
+        );
+    }
+
+    /// Racing the app against the fold loop must not drop or reorder events: what
+    /// the loop misses before the app task resolves is picked up by the post-loop
+    /// drain, and `begin`/`finish` still bracket the run exactly once.
+    #[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+    async fn events_are_folded_in_order_and_none_are_lost() {
+        const N: usize = 500;
+        let view = RecordingView::default();
+        let (shutdown, _shutdown_rx) = ShutdownTrigger::new();
+        run(
+            TestApp::new(view.clone(), Behavior::Emit(N)),
+            LogSink::new_direct(),
+            shutdown,
+        )
+        .await
+        .expect("backend must return the app's output");
+
+        let expected: Vec<String> = (0..N).map(|i| format!("//p:t{i}")).collect();
+        assert_eq!(
+            *view.addrs.lock().expect("recording view poisoned"),
+            expected,
+            "every event must be folded exactly once, in emission order"
+        );
+        assert_eq!(view.begun.load(Ordering::SeqCst), 1, "begin runs once");
+        assert_eq!(view.finished.load(Ordering::SeqCst), 1, "finish runs once");
+    }
+
+    /// A panicking app used to unwind straight out of `run`. Now that it runs on
+    /// its own task the panic arrives as a `JoinError`, and the backend must
+    /// re-raise it rather than turn it into an ordinary `Err` — the panic hook and
+    /// the process exit code both hang off the unwind.
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn app_panic_unwinds_out_of_the_backend() {
+        let (shutdown, _shutdown_rx) = ShutdownTrigger::new();
+        let outcome = std::panic::AssertUnwindSafe(run(
+            TestApp::new(RecordingView::default(), Behavior::Panic),
+            LogSink::new_direct(),
+            shutdown,
+        ))
+        .catch_unwind()
+        .await;
+
+        let payload = outcome
+            .err()
+            .expect("an app panic must unwind out of the backend, not become an error");
+        // The *original* payload has to survive: it is what the panic hook renders.
+        // Re-panicking with a message of our own would satisfy `is_err` and lose it.
+        let message = payload
+            .downcast_ref::<&str>()
+            .map(|s| (*s).to_string())
+            .or_else(|| payload.downcast_ref::<String>().cloned())
+            .expect("panic payload must still be the app's");
+        assert!(
+            message.contains("app blew up"),
+            "the app's own panic payload must be re-raised verbatim, got {message:?}"
+        );
+    }
+
+    /// The failing-build path — by far the most common outcome in CI mode. The
+    /// error has to propagate out of `run`, but only *after* the events emitted
+    /// before the failure are folded and the summary is printed.
+    #[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+    async fn app_failure_still_folds_events_and_prints_the_summary() {
+        let view = RecordingView::default();
+        let (shutdown, _shutdown_rx) = ShutdownTrigger::new();
+        let err = run(
+            TestApp::new(view.clone(), Behavior::EmitThenFail(3)),
+            LogSink::new_direct(),
+            shutdown,
+        )
+        .await
+        .expect_err("the app's error must reach the caller");
+
+        assert!(err.to_string().contains("build failed"), "got {err:?}");
+        assert_eq!(
+            *view.addrs.lock().expect("recording view poisoned"),
+            ["//p:t0", "//p:t1", "//p:t2"],
+            "events emitted before the failure must still be folded"
+        );
+        assert_eq!(
+            view.finished.load(Ordering::SeqCst),
+            1,
+            "the summary must be printed on a failed run, not skipped"
+        );
+    }
+
+    /// `run` must not return while background work is outstanding: the process
+    /// exiting here tears the sandbox-cleanup thread out mid-rmdir and abandons
+    /// in-flight cache uploads.
+    #[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+    async fn run_waits_for_background_work_to_drain() {
+        let (shutdown, _shutdown_rx) = ShutdownTrigger::new();
+        let started = Instant::now();
+        run(
+            TestApp::new(RecordingView::default(), Behavior::LeavesBackgroundWork),
+            LogSink::new_direct(),
+            shutdown,
+        )
+        .await
+        .expect("backend must return the app's output");
+
+        assert!(
+            started.elapsed() >= BG_WORK_DELAY,
+            "run returned after {:?}, before the {BG_WORK_DELAY:?} of background work drained",
+            started.elapsed()
+        );
+    }
+
+    /// `bootstrap::block_on` relies on the app's state — in the real thing the last
+    /// `Arc<Engine>`, whose `Drop` unmounts FUSE and flushes SQLite — being gone by
+    /// the time `run` returns. Spawning made that a property of tokio (it drops a
+    /// task's future before waking the `JoinHandle`) rather than of this function's
+    /// frame, so freeze it.
+    #[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+    async fn app_state_is_dropped_before_run_returns() {
+        let drops = Arc::new(AtomicUsize::new(0));
+        let (shutdown, _shutdown_rx) = ShutdownTrigger::new();
+        run(
+            TestApp::new(RecordingView::default(), Behavior::Emit(2))
+                .with_probe(DropProbe(Arc::clone(&drops))),
+            LogSink::new_direct(),
+            shutdown,
+        )
+        .await
+        .expect("backend must return the app's output");
+
+        assert_eq!(
+            drops.load(Ordering::SeqCst),
+            1,
+            "the app's owned state must be dropped by the time run returns"
+        );
+    }
+}


### PR DESCRIPTION
THREADING_PLAN P8.3.

`ci::run` polled the app future inline (`tokio::pin!` + `select!`), so one task
drove the entire target graph *and* folded build events *and* did the view's
blocking stderr writes. Any synchronous stretch inside the app stalled event
folding until it reached an await point. It now `tokio::spawn`s the app, matching
`interactive.rs`.

### The risk: stack depth

This is not a no-op refactor. It moves the app off the 8 MiB main-thread stack
`bootstrap::block_on` runs on and onto a 2 MiB tokio worker stack, and takes the
deep synchronous cached descent with it — `heph run //pkg:target` on a single
`Addr` awaits `Engine::result_addr` inline on the app future, unlike the batch
path where `Engine::result` already spawns every target.

Safe **only** because `GrowStack` exists, and that was verified, not assumed:
`Engine::result_addr` returns `GrowStack<BoxedResultFuture>` and is the sole path
into `result_addr_impl` (private, one call site), with every recursive result edge
routing back through it. The memoizer polls cells on the awaiter's stack, so the
descent is one physical stack with a `stacker::maybe_grow` check at every level
including the outermost. The result spine cannot overflow.

The comment says exactly that and no more — `async_recursion` chains nested
*inside* a level (`import_closure`, `expand_inputs`, `collect_transitive_deps`)
are bounded only by `RED_ZONE`, unchanged here since they were already exposed to
a 2 MiB worker stack via the batch path and the interactive backend.

### Recorded, not fixed

- `Engine::drop` now runs on a worker rather than the main thread. Blocks on plain
  OS threads, never the runtime; interactive has always done this.
- Events emitted *after* the app resolves (a `bg_pending`-tracked cache upload
  emitting from its own task) are still not folded in CI mode, where interactive
  does fold them. Pre-existing; changing it changes what a CI run prints. The
  comment now states this instead of claiming the summary covers the full stream.

### Tests

Seven, each verified red without the code it covers — including
`folds_events_while_the_app_holds_its_thread` (fails after 5 s with nothing folded
if the spawn is reverted) and `grow_stack_survives_deep_recursion_on_a_tokio_worker`
(aborts with `thread 'tokio-rt-worker' has overflowed its stack` without the
wrapper; runtime built with an explicit 2 MiB `thread_stack_size` because the
default honours `RUST_MIN_STACK`, under which it could not fail).

### Review board

`code-quality` PASS WITH NITS — its MAJOR (safety comment overstated GrowStack's
coverage) is fixed. `feature-quality` BLOCKED on the untested app-failure arm and
the same overstated drain claim; both addressed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01A76DChMohieGMbRbnV1E7x
