### PR TITLE
fix(engine): actually enforce cache.history during a run

### DIFF
--- a/crates/core/src/blocking.rs
+++ b/crates/core/src/blocking.rs
@@ -118,14 +118,31 @@ pub fn backstop(waker: Waker) {
 /// alive past the request that made it.
 ///
 /// Waking early is always sound: a spurious wake costs one poll, and a waiter
-/// still genuinely pending re-registers from that poll.
-pub fn flush_backstop() {
+/// still genuinely pending re-registers from that poll. That re-registration is
+/// the invariant this rests on — [`run`] below and the sqlite cache's
+/// write-behind waiter both register on *every* pending poll. A future
+/// registrant that registers once and relies on the tick would be stranded by a
+/// flush; register per pending poll.
+///
+/// Returns how many registrations were taken, so a caller can tell its own flush
+/// from a tick that happened to land first.
+pub fn flush_backstop() -> usize {
     // Taken before waking, and the lock released first, so a waker that
     // re-registers from inside `wake` cannot deadlock against us.
     let due = std::mem::take(&mut *lock_pending());
+    let n = due.len();
     for waker in due {
-        waker.wake();
+        // Callers reach this from `Drop` on a teardown path. A panicking waker
+        // there would unwind out of a destructor — and abort outright if that
+        // drop is itself already unwinding — so one bad waker is contained
+        // rather than allowed to take the process with it. The panic is still
+        // reported by the default hook before this returns, and this crate has
+        // no `tracing` (it is linked into cdylib plugins, where no subscriber is
+        // ever installed), so there is nothing further to say about it here.
+        // `lock_pending` already contemplates this case for the tick thread.
+        drop(catch_unwind(AssertUnwindSafe(|| waker.wake())));
     }
+    n
 }
 
 /// A waker panicking mid-`wake` would poison the list and strand every later
@@ -305,8 +322,12 @@ mod tests {
         let owned = Arc::new(());
         let started = std::time::Instant::now();
         backstop(futures::task::waker(Arc::new(Owning(Arc::clone(&owned)))));
-        flush_backstop();
+        let taken = flush_backstop();
 
+        assert!(
+            taken >= 1,
+            "the flush itself must have taken our registration, not a tick",
+        );
         assert_eq!(
             Arc::strong_count(&owned),
             1,
@@ -315,6 +336,38 @@ mod tests {
         assert!(
             started.elapsed() < WAKE_BACKSTOP,
             "the release must not have come from a backstop tick",
+        );
+    }
+
+    /// A waiter that is genuinely still pending must survive a flush: it is
+    /// woken, re-polls, finds its job unfinished and re-registers. This is the
+    /// invariant that makes `flush_backstop` safe to call from anywhere.
+    #[test]
+    fn flush_backstop_does_not_strand_a_still_pending_waiter() {
+        let out = futures::executor::block_on(async {
+            let job = run(|| {
+                thread::sleep(WAKE_BACKSTOP / 2);
+                "done"
+            });
+            futures::pin_mut!(job);
+            // Flush repeatedly while the job is still running; each one takes the
+            // waiter's registration out from under it.
+            loop {
+                let mut flushed = 0;
+                let polled = futures::poll!(&mut job);
+                if let Poll::Ready(v) = polled {
+                    break v;
+                }
+                while flushed < 3 {
+                    flush_backstop();
+                    flushed += 1;
+                    thread::sleep(Duration::from_millis(20));
+                }
+            }
+        });
+        assert_eq!(
+            out, "done",
+            "a flushed-but-pending waiter must still finish"
         );
     }
 

--- a/crates/core/src/blocking.rs
+++ b/crates/core/src/blocking.rs
@@ -102,6 +102,32 @@ pub fn backstop(waker: Waker) {
     lock_pending().push(waker);
 }
 
+/// Wake every registered backstop waiter now rather than on the next tick.
+///
+/// A registration outlives the future that made it. [`backstop`] is a
+/// fire-and-forget push: a waiter re-registers on every pending poll and never
+/// unregisters, so once its result arrives its last registration simply sits in
+/// [`PENDING`] until a tick sweeps it — and a `Waker` owns its task, which owns
+/// everything that task's state holds. For up to [`WAKE_BACKSTOP`] after a piece
+/// of work is completely finished, its state is still reachable from this list.
+///
+/// Usually that is invisible: it is bounded, and it costs a little memory. It is
+/// *not* invisible to a caller that must observe those values actually released
+/// — the post-run cache trim needs the request's cache read guards gone before
+/// it can take a write lock, and a stale registration here is enough to keep one
+/// alive past the request that made it.
+///
+/// Waking early is always sound: a spurious wake costs one poll, and a waiter
+/// still genuinely pending re-registers from that poll.
+pub fn flush_backstop() {
+    // Taken before waking, and the lock released first, so a waker that
+    // re-registers from inside `wake` cannot deadlock against us.
+    let due = std::mem::take(&mut *lock_pending());
+    for waker in due {
+        waker.wake();
+    }
+}
+
 /// A waker panicking mid-`wake` would poison the list and strand every later
 /// waiter, so poisoning is ignored — the `Vec` is still consistent.
 fn lock_pending() -> std::sync::MutexGuard<'static, Vec<Waker>> {
@@ -262,6 +288,34 @@ mod tests {
             "done"
         }));
         assert_eq!(out, "done");
+    }
+
+    /// A registration owns its waker, and a waker owns its task — so anything a
+    /// finished task still holds stays reachable from `PENDING` until a tick
+    /// sweeps it. `flush_backstop` is how a caller that needs those values
+    /// *actually* released gets them back without waiting out the tick, which is
+    /// what the post-run cache trim depends on.
+    #[test]
+    fn flush_backstop_releases_registered_wakers_without_waiting_for_a_tick() {
+        struct Owning(#[expect(dead_code, reason = "held to observe the refcount")] Arc<()>);
+        impl futures::task::ArcWake for Owning {
+            fn wake_by_ref(_: &Arc<Self>) {}
+        }
+
+        let owned = Arc::new(());
+        let started = std::time::Instant::now();
+        backstop(futures::task::waker(Arc::new(Owning(Arc::clone(&owned)))));
+        flush_backstop();
+
+        assert_eq!(
+            Arc::strong_count(&owned),
+            1,
+            "flushing must drop the registration, not just wake it",
+        );
+        assert!(
+            started.elapsed() < WAKE_BACKSTOP,
+            "the release must not have come from a backstop tick",
+        );
     }
 
     /// A waiter must be re-woken while its job is still running — that spare

--- a/crates/e2e/tests/common/mod.rs
+++ b/crates/e2e/tests/common/mod.rs
@@ -1,6 +1,6 @@
 #![allow(dead_code, unused_imports)]
 
-use anyhow::Result;
+use anyhow::{Context as _, Result};
 use heph::engine::{Config, Engine};
 use heph::pluginbuildfile;
 use heph::pluginexec;
@@ -11,12 +11,30 @@ use std::sync::Arc;
 
 pub use htestkit::{artifact_bytes, artifact_paths, artifact_string, root};
 
-pub struct Workspace(htestkit::Workspace);
+pub struct Workspace {
+    inner: htestkit::Workspace,
+    /// The configuration [`reopen`](Workspace::reopen) must reproduce. `None`
+    /// for a workspace whose engine it cannot rebuild.
+    reopen_with: Option<ReopenConfig>,
+}
+
+/// Everything `reopen` needs to build an engine that resolves the same targets
+/// from the same inputs as the one the workspace was built with.
+///
+/// Held explicitly rather than re-derived: `Config` fields like `fs_skip` decide
+/// which files a tree-walking plugin sees, i.e. the declared inputs, i.e. the
+/// `hashin`. An engine that silently dropped them would write into the same
+/// on-disk cache under different keys, and a test asserting a cache hit across
+/// the two would be comparing two different targets and proving nothing.
+struct ReopenConfig {
+    parallelism: Option<usize>,
+    fs_skip: Vec<String>,
+}
 
 impl std::ops::Deref for Workspace {
     type Target = htestkit::Workspace;
     fn deref(&self) -> &Self::Target {
-        &self.0
+        &self.inner
     }
 }
 
@@ -38,29 +56,57 @@ impl Workspace {
         } else {
             builder
         };
-        Self(builder.build().expect("build workspace"))
+        Self {
+            inner: builder.build().expect("build workspace"),
+            reopen_with: Some(ReopenConfig {
+                parallelism: p,
+                fs_skip: Vec::new(),
+            }),
+        }
     }
 
     /// A second `Engine` over this workspace's root — what the *next* `heph`
-    /// invocation sees: the same on-disk cache and lock directory, but empty
-    /// in-memory provider/driver caches.
+    /// invocation sees: the same on-disk cache and lock directory, the same
+    /// providers, drivers and input-visibility config, but empty in-memory
+    /// provider/driver caches.
     ///
     /// Needed by any test that must observe a *changed* BUILD file. The spec a
     /// target resolves to is memoized per engine, so rewriting the BUILD file
     /// and re-running through the same engine replays the original definition
     /// and produces no new cache revision.
+    ///
+    /// Only workspaces built by [`new`](Workspace::new) /
+    /// [`with_parallelism`](Workspace::with_parallelism) can be reopened;
+    /// [`with_static`](Workspace::with_static) owns a provider instance this
+    /// cannot reconstruct, and silently substituting a different provider set
+    /// would resolve different targets into the same cache.
     pub fn reopen(&self) -> Result<Arc<Engine>> {
-        let root = self.dir.path().to_path_buf();
+        let cfg = self.reopen_with.as_ref().ok_or_else(|| {
+            anyhow::anyhow!(
+                "this workspace's provider set cannot be rebuilt; reopen is unsupported"
+            )
+        })?;
+        let root = self.inner.dir.path().to_path_buf();
         let mut engine = Engine::new(Config {
             root: root.clone(),
             home_dir: std::path::PathBuf::new(),
-            parallelism: None,
+            parallelism: cfg.parallelism,
+            fs_skip: cfg.fs_skip.clone(),
             ..Default::default()
-        })?;
-        engine.register_provider(move |_| Box::new(pluginbuildfile::Provider::new(root)))?;
-        engine.register_managed_driver(|_| Box::new(pluginexec::Driver::new_exec()))?;
-        engine.register_managed_driver(|_| Box::new(pluginexec::Driver::new_bash()))?;
-        engine.register_managed_driver(|_| Box::new(pluginhttp::Driver))?;
+        })
+        .context("reopen: build engine over the existing workspace root")?;
+        engine
+            .register_provider(move |_| Box::new(pluginbuildfile::Provider::new(root)))
+            .context("reopen: register buildfile provider")?;
+        engine
+            .register_managed_driver(|_| Box::new(pluginexec::Driver::new_exec()))
+            .context("reopen: register exec driver")?;
+        engine
+            .register_managed_driver(|_| Box::new(pluginexec::Driver::new_bash()))
+            .context("reopen: register bash driver")?;
+        engine
+            .register_managed_driver(|_| Box::new(pluginhttp::Driver))
+            .context("reopen: register http driver")?;
         Ok(Arc::new(engine))
     }
 
@@ -71,6 +117,9 @@ impl Workspace {
             .with_managed_driver(Box::new(pluginexec::Driver::new_exec()))
             .with_managed_driver(Box::new(pluginexec::Driver::new_bash()))
             .build()?;
-        Ok(Self(ws))
+        Ok(Self {
+            inner: ws,
+            reopen_with: None,
+        })
     }
 }

--- a/crates/e2e/tests/common/mod.rs
+++ b/crates/e2e/tests/common/mod.rs
@@ -1,11 +1,13 @@
 #![allow(dead_code, unused_imports)]
 
 use anyhow::Result;
+use heph::engine::{Config, Engine};
 use heph::pluginbuildfile;
 use heph::pluginexec;
 use heph::pluginhttp;
 use heph::pluginstatictarget;
 use htestkit::WorkspaceBuilder;
+use std::sync::Arc;
 
 pub use htestkit::{artifact_bytes, artifact_paths, artifact_string, root};
 
@@ -37,6 +39,29 @@ impl Workspace {
             builder
         };
         Self(builder.build().expect("build workspace"))
+    }
+
+    /// A second `Engine` over this workspace's root — what the *next* `heph`
+    /// invocation sees: the same on-disk cache and lock directory, but empty
+    /// in-memory provider/driver caches.
+    ///
+    /// Needed by any test that must observe a *changed* BUILD file. The spec a
+    /// target resolves to is memoized per engine, so rewriting the BUILD file
+    /// and re-running through the same engine replays the original definition
+    /// and produces no new cache revision.
+    pub fn reopen(&self) -> Result<Arc<Engine>> {
+        let root = self.dir.path().to_path_buf();
+        let mut engine = Engine::new(Config {
+            root: root.clone(),
+            home_dir: std::path::PathBuf::new(),
+            parallelism: None,
+            ..Default::default()
+        })?;
+        engine.register_provider(move |_| Box::new(pluginbuildfile::Provider::new(root)))?;
+        engine.register_managed_driver(|_| Box::new(pluginexec::Driver::new_exec()))?;
+        engine.register_managed_driver(|_| Box::new(pluginexec::Driver::new_bash()))?;
+        engine.register_managed_driver(|_| Box::new(pluginhttp::Driver))?;
+        Ok(Arc::new(engine))
     }
 
     pub fn with_static(targets: Vec<pluginstatictarget::Target>) -> Result<Self> {

--- a/crates/e2e/tests/engine_core.rs
+++ b/crates/e2e/tests/engine_core.rs
@@ -203,3 +203,99 @@ async fn test_output_selection_unknown_name_errors() -> anyhow::Result<()> {
     assert!(msg.contains("output not found"), "got: {msg}");
     Ok(())
 }
+
+/// `cache.history` must be enforced *by the run that broke the budget*, not
+/// left for the next `heph gc`.
+///
+/// Three runs of one target, each with a different script, write three cache
+/// revisions; the default history budget is 1, so by the end of the third run
+/// the two older revisions owe us their disk back. Observed through `gc_all`:
+/// a post-run sweep that still finds revisions to reclaim is proof the in-run
+/// trim never happened.
+///
+/// Each run gets a fresh engine over the same root — the next `heph run`'s view
+/// of the same on-disk cache. That is not incidental: an in-process re-run
+/// replays the memoized spec, so the rewritten BUILD file would produce the
+/// same `hashin` and no second revision, and the test could not fail.
+///
+/// The run is driven through `result_addr` rather than `Workspace::run` so the
+/// test owns the two things that decide the outcome, exactly as `heph run`
+/// does: the result is released before the request state, and the run is not
+/// over until the background queue drains.
+#[tokio::test]
+async fn cache_history_is_enforced_by_the_end_of_the_run() -> anyhow::Result<()> {
+    use heph::engine::{Engine, OutputMatcher, ResultOptions};
+    use heph::htaddr::parse_addr;
+    use std::sync::Arc;
+    use std::sync::atomic::{AtomicUsize, Ordering};
+
+    let ws = Workspace::new();
+    let addr = parse_addr("//hist:t")?;
+
+    for v in ["v1", "vv22", "vvv333"] {
+        // A different script is a different def hash, hence a different
+        // `hashin` — a genuinely new revision rather than a re-hit.
+        ws.write_build_file(
+            "hist",
+            &format!(
+                r#"target(name = "t", driver = "bash", run = "printf '{v}' > $OUT", out = "out.txt")"#
+            ),
+        );
+
+        let engine = ws.reopen()?;
+        let bg: Arc<AtomicUsize> = Arc::new(AtomicUsize::new(0));
+        let rs = engine.new_state_full(
+            true,
+            None,
+            Arc::clone(&bg),
+            Engine::DEFAULT_LOG_TAIL_LINES,
+            None,
+        );
+        let result = engine
+            .clone()
+            .result_addr(
+                rs.clone(),
+                &addr,
+                OutputMatcher::All,
+                &ResultOptions::default(),
+            )
+            .await?;
+        // Precondition: each run really did rebuild. If this ever reports a
+        // stale value the runs are sharing a revision and the assertions below
+        // become vacuous.
+        assert_eq!(
+            common::artifact_string(&result),
+            v,
+            "each run must produce its own revision"
+        );
+        // Release the artifacts, then the request — the order `heph run`'s
+        // locals unwind in, and the order that frees the addr's riding read.
+        drop(result);
+        drop(rs);
+
+        // `bg` is the counter the CLI blocks on before exiting; the run's
+        // background cache work is not finished until it reads zero.
+        let deadline = std::time::Instant::now() + std::time::Duration::from_secs(60);
+        while bg.load(Ordering::Acquire) > 0 {
+            assert!(
+                std::time::Instant::now() < deadline,
+                "background work never drained"
+            );
+            tokio::time::sleep(std::time::Duration::from_millis(5)).await;
+        }
+        drop(engine);
+    }
+
+    let engine = ws.reopen()?;
+    let stats = engine.clone().gc_all(engine.new_state()).await?;
+    assert_eq!(
+        stats.revisions_kept, 1,
+        "exactly the newest revision survives: {stats:?}"
+    );
+    assert_eq!(
+        stats.revisions_removed, 0,
+        "a post-run sweep still found revisions to reclaim, so `cache.history` \
+         was never enforced during the run: {stats:?}"
+    );
+    Ok(())
+}

--- a/crates/e2e/tests/engine_core.rs
+++ b/crates/e2e/tests/engine_core.rs
@@ -284,18 +284,29 @@ async fn cache_history_is_enforced_by_the_end_of_the_run() -> anyhow::Result<()>
             tokio::time::sleep(std::time::Duration::from_millis(5)).await;
         }
         drop(engine);
-    }
 
-    let engine = ws.reopen()?;
-    let stats = engine.clone().gc_all(engine.new_state()).await?;
-    assert_eq!(
-        stats.revisions_kept, 1,
-        "exactly the newest revision survives: {stats:?}"
-    );
-    assert_eq!(
-        stats.revisions_removed, 0,
-        "a post-run sweep still found revisions to reclaim, so `cache.history` \
-         was never enforced during the run: {stats:?}"
-    );
+        // Assert per run, not once at the end. A single check after the last run
+        // cannot tell "every run enforced its budget" from "only the last one
+        // did" — run 3's trim protects its own revision and deletes both older
+        // ones, so an end-only assertion passes even when two of the three trims
+        // silently lost their lock.
+        //
+        // `gc_all` is the oracle because it reports what a sweep still finds to
+        // reclaim; anything above zero is a trim that did not happen. It is also
+        // destructive, which is what makes it a *tight* check — it leaves the
+        // cache in the state the trim should already have produced, so the next
+        // iteration starts clean and any failure is attributable to one run.
+        let sweeper = ws.reopen()?;
+        let stats = sweeper.clone().gc_all(sweeper.new_state()).await?;
+        assert_eq!(
+            stats.revisions_removed, 0,
+            "after the `{v}` run a sweep still found revisions to reclaim, so \
+             that run's post-write trim never ran: {stats:?}"
+        );
+        assert_eq!(
+            stats.revisions_kept, 1,
+            "exactly the newest revision survives the `{v}` run: {stats:?}"
+        );
+    }
     Ok(())
 }

--- a/crates/e2e/tests/remote_cache.rs
+++ b/crates/e2e/tests/remote_cache.rs
@@ -63,6 +63,12 @@ async fn run_drain(engine: &Arc<Engine>, addr: &str) -> String {
         .expect("run target");
 
     let bg = rs.bg_pending();
+    // Release the request before waiting on its counter. Some background work is
+    // only *submitted* when the request state drops (the post-write cache trim),
+    // and holds a slot until then — so a waiter that keeps `rs` alive waits on a
+    // counter that cannot reach zero. `heph run` unwinds in this order too: the
+    // drain loop runs after the app future, which owns the request, has returned.
+    drop(rs);
     let deadline = Instant::now() + Duration::from_secs(10);
     while bg.load(Ordering::Acquire) > 0 {
         assert!(Instant::now() < deadline, "background upload never drained");

--- a/crates/engine/src/engine/gc.rs
+++ b/crates/engine/src/engine/gc.rs
@@ -10,7 +10,10 @@
 //!   trimmed to its `cache.history` newest revisions.
 //! - [`Engine::try_trim_after_write`] — the post-write trim. Non-blocking: it
 //!   trims the just-written target only if its lock is free, and never deletes
-//!   the revision that was just written.
+//!   the revision that was just written. Deferred to the end of the request
+//!   that wrote the revision (see `RequestState::defer_trim`) — a request holds
+//!   a read on every addr it resolved, so a trim run inline could never take
+//!   the write lock.
 //!
 //! Revision recency comes from each group's `manifest-v1.borsh`
 //! (`created_at_nanos`); the full artifact name list to delete comes from the

--- a/crates/engine/src/engine/gc.rs
+++ b/crates/engine/src/engine/gc.rs
@@ -192,8 +192,15 @@ impl Engine {
                     tracing::debug!(error = %format!("{e:#}"), %addr, "post-write gc trim");
                 }
             }
-            // Contended — another request holds the lock; skip without blocking.
-            Ok(None) => {}
+            // Contended — another request or process holds the lock. Skip
+            // without blocking, but say so: a silent skip here is exactly how
+            // `cache.history` went unenforced for so long. `debug`, not `warn`,
+            // because a concurrent build of the same target is ordinary and this
+            // fires per addr; the revision is reclaimed by the next write's trim
+            // or by `heph gc`.
+            Ok(None) => {
+                tracing::debug!(%addr, "post-write gc contended; history not enforced this run")
+            }
             Err(e) => tracing::debug!(error = %format!("{e:#}"), %addr, "post-write gc try_write"),
         }
     }
@@ -289,6 +296,11 @@ impl Engine {
             Self::DEFAULT_LOG_TAIL_LINES,
             None,
         );
+        // Phase 1 resolves, and resolving executes shared cacheable deps — each
+        // of which would otherwise record a post-write trim that fires when this
+        // state drops, i.e. concurrently with phase 2's write locks. This sweep
+        // is the authoritative trim; it does not need a second one racing it.
+        resolve_rs.suppress_deferred_trims();
         let targets = match self.local_cache.list_targets() {
             Ok(t) => t,
             Err(e) => {

--- a/crates/engine/src/engine/remote_cache.rs
+++ b/crates/engine/src/engine/remote_cache.rs
@@ -1591,6 +1591,14 @@ impl Engine {
                 addr: addr.format(),
                 error: None,
             });
+
+            // Release the request before `_dec` gives its slot back. This task
+            // can be the last owner of the `RequestStateData` — it outlives the
+            // app future — and dropping it is what submits the request's
+            // deferred cache-history trims (`RequestState::defer_trim`). Letting
+            // `_dec` go first would leave a window where the counter reads zero
+            // and the shutdown drain exits with those trims never enqueued.
+            drop(rs);
         });
     }
 

--- a/crates/engine/src/engine/request_state.rs
+++ b/crates/engine/src/engine/request_state.rs
@@ -237,14 +237,20 @@ pub struct RequestStateData {
     /// each cleanup job so the cleaner decrements it on completion; the shutdown
     /// path keeps the TUI open — and the process alive — until it drains to zero.
     ///
-    /// **Wait on this only after releasing the request.** Not all of it is
-    /// already submitted: once this request has written a cacheable revision,
-    /// [`DeferredTrims`] holds a slot that is handed to the cleaner when the
-    /// request state drops (see there for why the trim cannot run any earlier).
-    /// A waiter that keeps its `Arc<RequestState>` alive therefore waits on a
-    /// counter that cannot reach zero. `heph run` unwinds in the right order
+    /// **Wait on this only after releasing the request.** A request's last piece
+    /// of background work — its [`DeferredTrims`] batch — is submitted *by*
+    /// `RequestStateData`'s drop, so a waiter that keeps its
+    /// `Arc<RequestState>` alive can see zero and conclude the run is finished
+    /// while a trim is still owed. `heph run` unwinds in the right order
     /// already: the drain loops in `tui::backend` run after the app future,
     /// which owns the request, has returned.
+    ///
+    /// The counter deliberately never counts work that has not been handed to
+    /// the cleaner yet — see [`sandbox_cleaner::enqueue`] for why a
+    /// reserve-now/submit-later split would make a pinned request an unexitable
+    /// process rather than a leak.
+    ///
+    /// [`sandbox_cleaner::enqueue`]: crate::engine::sandbox_cleaner::enqueue
     pub bg_pending: crate::engine::sandbox_cleaner::PendingCounter,
     /// Per-request registry of genuinely-failing targets, keyed by addr. Populated
     /// by the `result_addr` classifier (first-writer-wins dedup) and drained once
@@ -313,29 +319,34 @@ struct PendingTrim {
 struct DeferredTrims {
     engine: Weak<Engine>,
     bg_pending: crate::engine::sandbox_cleaner::PendingCounter,
-    /// Keyed by addr so a target written more than once in a request is trimmed
-    /// once, protecting the last revision written for it.
+    /// Keyed by addr. At most one entry per addr can be recorded anyway —
+    /// `execute_and_cache_inner` runs inside the addr-keyed `mem_locked_result`
+    /// cell, so one request writes at most one revision per addr — but the map
+    /// makes that structural rather than assumed.
+    ///
+    /// The one case that *does* file two revisions under one addr, the in_place
+    /// fixpoint (`maybe_store_fixpoint` → `duplicate_cache_revision`), never
+    /// reaches here. It survives the trim on its own terms: the duplicate is
+    /// stamped strictly newer than the primary, and an in_place def's
+    /// `cache.history` is doubled. Both are documented at their own sites; if
+    /// either changes, this is one of the places that finds out.
     trims: Mutex<FxHashMap<Addr, PendingTrim>>,
+    /// Set by the `heph gc` sweep for its own phase-1 resolution state. That
+    /// sweep *is* the authoritative trim: letting phase 1 also submit background
+    /// trims would race phase 2's write locks, make `GcStats` report whichever
+    /// of the two got there first, and surface a contended-lock notice naming
+    /// this very process as the holder.
+    suppressed: std::sync::atomic::AtomicBool,
 }
 
 impl DeferredTrims {
-    fn push(&self, addr: &Addr, keep: u32, hashin: &str) {
-        let mut trims = self.trims.lock();
-        if trims.is_empty() {
-            // One background slot for the whole batch, taken the first time
-            // there is anything to submit. Reserved *now* rather than at submit
-            // time because the submit happens in `Drop`, by which point this
-            // request's other background work may already have drained the
-            // counter to zero — and the shutdown path exits on zero.
-            crate::engine::sandbox_cleaner::reserve(&self.bg_pending);
+    fn push(&self, addr: &Addr, keep: u32, hashin: String) {
+        if self.suppressed.load(std::sync::atomic::Ordering::Relaxed) {
+            return;
         }
-        trims.insert(
-            addr.clone(),
-            PendingTrim {
-                keep,
-                hashin: hashin.to_string(),
-            },
-        );
+        self.trims
+            .lock()
+            .insert(addr.clone(), PendingTrim { keep, hashin });
     }
 }
 
@@ -345,6 +356,13 @@ impl Drop for DeferredTrims {
         if trims.is_empty() {
             return;
         }
+        let Some(engine) = self.engine.upgrade() else {
+            tracing::debug!(
+                trims = trims.len(),
+                "engine dropped before its deferred cache-history trims ran"
+            );
+            return;
+        };
         // Hand back the blocking pool's stale backstop registrations first.
         // Each one is a `Waker` that still owns its (finished) task, and one of
         // those tasks is this request's `mem_locked_result` cell — which holds
@@ -353,20 +371,23 @@ impl Drop for DeferredTrims {
         // find its target contended and skip. See `hcore::blocking::backstop`.
         hcore::blocking::flush_backstop();
 
-        let Some(engine) = self.engine.upgrade() else {
-            // The engine is gone, so nothing can run these. Give the slot back
-            // rather than hold shutdown open on work that will never happen.
-            crate::engine::sandbox_cleaner::release_reservation(&self.bg_pending);
-            return;
-        };
         // One job for the batch: `try_trim_after_write` is non-blocking and
         // short, and a job per target would allocate a boxed closure per
         // written revision — which is exactly what this replaces.
-        crate::engine::sandbox_cleaner::enqueue_reserved(
+        crate::engine::sandbox_cleaner::enqueue(
             format!("gc trim {} target(s)", trims.len()),
             Box::new(move || {
                 for (addr, trim) in trims {
-                    engine.try_trim_after_write(&addr, trim.keep, &trim.hashin);
+                    // Per target, not per batch: the cleaner's own `catch_unwind`
+                    // wraps the whole job, so one panicking target would discard
+                    // every trim after it with nothing to say which one it was.
+                    if std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
+                        engine.try_trim_after_write(&addr, trim.keep, &trim.hashin);
+                    }))
+                    .is_err()
+                    {
+                        tracing::error!(%addr, "post-write gc trim panicked, continuing");
+                    }
                 }
                 Ok(())
             }),
@@ -437,8 +458,32 @@ impl RequestState {
     /// request's cache read guards are released. `hashin` is the revision just
     /// written, which the trim will preserve. See [`DeferredTrims`] for why it
     /// cannot run inline.
-    pub(crate) fn defer_trim(&self, addr: &Addr, keep: u32, hashin: &str) {
+    ///
+    /// A [`hash_only`](RequestStateData::hash_only) request is refused: it drops
+    /// *inside* the resolution it is nested in, while that outer request still
+    /// holds the addr's riding read, so its trim would be contended by
+    /// construction — and its `bg_pending` is a private counter no drain loop
+    /// ever observes. Unreachable today (such a request cannot build a cacheable
+    /// target), asserted so it stays that way.
+    pub(crate) fn defer_trim(&self, addr: &Addr, keep: u32, hashin: String) {
+        debug_assert!(
+            !self.hash_only(),
+            "a hash_only request must never write a cacheable revision"
+        );
+        if self.hash_only() {
+            tracing::debug!(%addr, "hash_only request: post-write trim not deferred");
+            return;
+        }
         self.data.deferred_trims.push(addr, keep, hashin);
+    }
+
+    /// Stop this request recording post-write trims. Used by the `heph gc`
+    /// sweep for its phase-1 resolution state — see [`DeferredTrims::suppressed`].
+    pub(crate) fn suppress_deferred_trims(&self) {
+        self.data
+            .deferred_trims
+            .suppressed
+            .store(true, std::sync::atomic::Ordering::Relaxed);
     }
 
     /// True when this request may hash, probe and read but must never take the
@@ -766,6 +811,7 @@ impl Engine {
                 engine: Arc::downgrade(self),
                 bg_pending,
                 trims: Mutex::new(FxHashMap::default()),
+                suppressed: std::sync::atomic::AtomicBool::new(false),
             },
         });
 
@@ -810,17 +856,14 @@ mod tests {
         Ok((dir, engine))
     }
 
-    /// A recorded trim must hold the request's background slot from the moment
-    /// it is recorded, not from the moment it is submitted. The shutdown path
-    /// exits when that counter reads zero, and the submit only happens when the
-    /// request state drops — so a slot taken only at submit time leaves a window
-    /// where the process can exit with trims still owed.
-    #[tokio::test]
-    async fn deferred_trim_holds_the_background_slot_until_it_runs() -> anyhow::Result<()> {
-        use std::sync::atomic::{AtomicUsize, Ordering};
-
-        let (_dir, engine) = test_engine()?;
-        let bg: Arc<AtomicUsize> = Arc::new(AtomicUsize::new(0));
+    fn bg_state(
+        engine: &Arc<Engine>,
+    ) -> (
+        Arc<std::sync::atomic::AtomicUsize>,
+        Arc<crate::engine::request_state::RequestState>,
+    ) {
+        let bg: Arc<std::sync::atomic::AtomicUsize> =
+            Arc::new(std::sync::atomic::AtomicUsize::new(0));
         let rs = engine.new_state_full(
             true,
             None,
@@ -828,49 +871,98 @@ mod tests {
             Engine::DEFAULT_LOG_TAIL_LINES,
             None,
         );
+        (bg, rs)
+    }
 
-        rs.defer_trim(&addr("t"), 1, "h1");
-        assert_eq!(
-            bg.load(Ordering::Acquire),
-            1,
-            "a recorded trim holds a slot before it is submitted"
-        );
-        // A second target joins the same batch — one slot, not two.
-        rs.defer_trim(&addr("u"), 1, "h1");
-        assert_eq!(bg.load(Ordering::Acquire), 1, "the batch holds one slot");
-
-        drop(rs);
-
-        // Submitted on drop and released by the cleaner once it has run.
+    async fn wait_drained(bg: &std::sync::atomic::AtomicUsize) {
+        use std::sync::atomic::Ordering;
         let deadline = std::time::Instant::now() + std::time::Duration::from_secs(30);
         while bg.load(Ordering::Acquire) > 0 {
             assert!(
                 std::time::Instant::now() < deadline,
-                "the deferred trim never ran"
+                "background work never drained"
             );
             tokio::time::sleep(std::time::Duration::from_millis(2)).await;
         }
+    }
+
+    /// Recording a trim must *not* take a background slot: the slot is taken
+    /// when the batch is handed to the cleaner, which is what `Drop` does.
+    ///
+    /// This is load-bearing, not incidental. `bg_pending` gates process exit
+    /// through an untimed loop in both TUI backends, and a `RequestStateData`
+    /// can be pinned indefinitely by an abandoned memoizer cell — so a slot held
+    /// on behalf of work that has not been submitted yet would turn that leak
+    /// into a process that never exits.
+    #[tokio::test]
+    async fn recording_a_trim_takes_no_background_slot() -> anyhow::Result<()> {
+        use std::sync::atomic::Ordering;
+
+        let (_dir, engine) = test_engine()?;
+        let (bg, rs) = bg_state(&engine);
+
+        rs.defer_trim(&addr("t"), 1, "h1".to_string());
+        rs.defer_trim(&addr("u"), 1, "h1".to_string());
+        assert_eq!(
+            bg.load(Ordering::Acquire),
+            0,
+            "an unsubmitted batch must not gate shutdown"
+        );
+
+        drop(rs);
+        // Submitted on drop, released by the cleaner once it has run.
+        wait_drained(&bg).await;
         Ok(())
     }
 
-    /// A request that never wrote a cacheable revision must not touch the
-    /// counter at all — otherwise every `hash_only` / query request would hold
-    /// shutdown open on an empty batch.
+    /// A request that never wrote a cacheable revision must not enqueue anything.
     #[tokio::test]
-    async fn no_deferred_trim_means_no_background_slot() -> anyhow::Result<()> {
-        use std::sync::atomic::{AtomicUsize, Ordering};
+    async fn no_deferred_trim_means_no_background_work() -> anyhow::Result<()> {
+        use std::sync::atomic::Ordering;
 
         let (_dir, engine) = test_engine()?;
-        let bg: Arc<AtomicUsize> = Arc::new(AtomicUsize::new(0));
-        let rs = engine.new_state_full(
-            true,
-            None,
-            Arc::clone(&bg),
-            Engine::DEFAULT_LOG_TAIL_LINES,
-            None,
-        );
+        let (bg, rs) = bg_state(&engine);
         drop(rs);
         assert_eq!(bg.load(Ordering::Acquire), 0);
+        Ok(())
+    }
+
+    /// The `heph gc` sweep suppresses its phase-1 resolution state's trims — that
+    /// sweep is itself the authoritative trim, and a background one would race
+    /// its phase-2 write locks.
+    #[tokio::test]
+    async fn suppressed_request_records_no_trims() -> anyhow::Result<()> {
+        use std::sync::atomic::Ordering;
+
+        let (_dir, engine) = test_engine()?;
+        let (bg, rs) = bg_state(&engine);
+        rs.suppress_deferred_trims();
+        rs.defer_trim(&addr("t"), 1, "h1".to_string());
+        drop(rs);
+        assert_eq!(
+            bg.load(Ordering::Acquire),
+            0,
+            "a suppressed request must enqueue nothing"
+        );
+        Ok(())
+    }
+
+    /// Dropping the engine before the request must release the batch rather than
+    /// enqueue work that can never run.
+    #[tokio::test]
+    async fn engine_dropped_first_discards_the_batch() -> anyhow::Result<()> {
+        use std::sync::atomic::Ordering;
+
+        let (_dir, engine) = test_engine()?;
+        let (bg, rs) = bg_state(&engine);
+        rs.defer_trim(&addr("t"), 1, "h1".to_string());
+        drop(engine);
+        drop(rs);
+        assert_eq!(
+            bg.load(Ordering::Acquire),
+            0,
+            "no slot may be left outstanding when the engine is gone"
+        );
         Ok(())
     }
 

--- a/crates/engine/src/engine/request_state.rs
+++ b/crates/engine/src/engine/request_state.rs
@@ -236,6 +236,15 @@ pub struct RequestStateData {
     /// finished (queued + in-flight on the global cleaner thread). Carried into
     /// each cleanup job so the cleaner decrements it on completion; the shutdown
     /// path keeps the TUI open — and the process alive — until it drains to zero.
+    ///
+    /// **Wait on this only after releasing the request.** Not all of it is
+    /// already submitted: once this request has written a cacheable revision,
+    /// [`DeferredTrims`] holds a slot that is handed to the cleaner when the
+    /// request state drops (see there for why the trim cannot run any earlier).
+    /// A waiter that keeps its `Arc<RequestState>` alive therefore waits on a
+    /// counter that cannot reach zero. `heph run` unwinds in the right order
+    /// already: the drain loops in `tui::backend` run after the app future,
+    /// which owns the request, has returned.
     pub bg_pending: crate::engine::sandbox_cleaner::PendingCounter,
     /// Per-request registry of genuinely-failing targets, keyed by addr. Populated
     /// by the `result_addr` classifier (first-writer-wins dedup) and drained once
@@ -264,6 +273,106 @@ pub struct RequestStateData {
     /// `resolve_locked_inner`'s `skip_lock`) still execute normally — re-reading
     /// the tree is the entire point of these requests.
     pub hash_only: bool,
+    /// Post-write `cache.history` trims held back until this request's cache
+    /// read guards are gone.
+    ///
+    /// **Must stay the last field.** See [`DeferredTrims`] — being last is what
+    /// makes the drop order correct, not a stylistic choice.
+    deferred_trims: DeferredTrims,
+}
+
+/// One deferred post-write trim: how many revisions of a target to keep, and
+/// the revision this request wrote (which the trim must never delete).
+#[derive(Debug)]
+struct PendingTrim {
+    keep: u32,
+    hashin: String,
+}
+
+/// The request's post-write `cache.history` trims, submitted once the request
+/// state — and every cache read guard it holds — is gone.
+///
+/// Trimming deletes revisions, so it needs the target's **write** lock; the
+/// lock is per-addr, not per-revision, and `gc.rs` documents why a read is not
+/// enough. Running the trim inline, where `cache_locally` finishes, therefore
+/// could never succeed: the addr's riding read guard lives in
+/// [`RequestStateData::mem_locked_result`] and is cloned into every artifact
+/// handed out, and the memoizer only evicts on a cycle error. The read is held
+/// for the whole request, so the trim's non-blocking `try_write` always lost
+/// and `cache.history` was silently never enforced *during* a run — only by the
+/// next `heph gc`.
+///
+/// So the decision is recorded here as the revision is written and executed
+/// afterwards, on the background cleaner lane.
+///
+/// **This must stay the last field of [`RequestStateData`].** Rust drops a
+/// struct's fields in declaration order *after* its own `Drop::drop` returns,
+/// so being last is exactly what guarantees every memoizer — and every riding
+/// read guard it holds — has already dropped by the time this one's `Drop`
+/// submits the trims. Moving it earlier reinstates the bug silently.
+struct DeferredTrims {
+    engine: Weak<Engine>,
+    bg_pending: crate::engine::sandbox_cleaner::PendingCounter,
+    /// Keyed by addr so a target written more than once in a request is trimmed
+    /// once, protecting the last revision written for it.
+    trims: Mutex<FxHashMap<Addr, PendingTrim>>,
+}
+
+impl DeferredTrims {
+    fn push(&self, addr: &Addr, keep: u32, hashin: &str) {
+        let mut trims = self.trims.lock();
+        if trims.is_empty() {
+            // One background slot for the whole batch, taken the first time
+            // there is anything to submit. Reserved *now* rather than at submit
+            // time because the submit happens in `Drop`, by which point this
+            // request's other background work may already have drained the
+            // counter to zero — and the shutdown path exits on zero.
+            crate::engine::sandbox_cleaner::reserve(&self.bg_pending);
+        }
+        trims.insert(
+            addr.clone(),
+            PendingTrim {
+                keep,
+                hashin: hashin.to_string(),
+            },
+        );
+    }
+}
+
+impl Drop for DeferredTrims {
+    fn drop(&mut self) {
+        let trims = std::mem::take(&mut *self.trims.lock());
+        if trims.is_empty() {
+            return;
+        }
+        // Hand back the blocking pool's stale backstop registrations first.
+        // Each one is a `Waker` that still owns its (finished) task, and one of
+        // those tasks is this request's `mem_locked_result` cell — which holds
+        // the addr's riding cache read. Left alone it is released on the
+        // backstop's next tick, up to 250ms from now, and every trim below would
+        // find its target contended and skip. See `hcore::blocking::backstop`.
+        hcore::blocking::flush_backstop();
+
+        let Some(engine) = self.engine.upgrade() else {
+            // The engine is gone, so nothing can run these. Give the slot back
+            // rather than hold shutdown open on work that will never happen.
+            crate::engine::sandbox_cleaner::release_reservation(&self.bg_pending);
+            return;
+        };
+        // One job for the batch: `try_trim_after_write` is non-blocking and
+        // short, and a job per target would allocate a boxed closure per
+        // written revision — which is exactly what this replaces.
+        crate::engine::sandbox_cleaner::enqueue_reserved(
+            format!("gc trim {} target(s)", trims.len()),
+            Box::new(move || {
+                for (addr, trim) in trims {
+                    engine.try_trim_after_write(&addr, trim.keep, &trim.hashin);
+                }
+                Ok(())
+            }),
+            Arc::clone(&self.bg_pending),
+        );
+    }
 }
 
 /// One frame of the live resolution path (the breadcrumb chain). Built as an
@@ -322,6 +431,14 @@ impl RequestState {
     /// `sandbox_cleaner::enqueue`, or to the renderer so it can poll for drain.
     pub fn bg_pending(&self) -> crate::engine::sandbox_cleaner::PendingCounter {
         Arc::clone(&self.data.bg_pending)
+    }
+
+    /// Record a post-write `cache.history` trim for `addr`, to run once this
+    /// request's cache read guards are released. `hashin` is the revision just
+    /// written, which the trim will preserve. See [`DeferredTrims`] for why it
+    /// cannot run inline.
+    pub(crate) fn defer_trim(&self, addr: &Addr, keep: u32, hashin: &str) {
+        self.data.deferred_trims.push(addr, keep, hashin);
     }
 
     /// True when this request may hash, probe and read but must never take the
@@ -641,10 +758,15 @@ impl Engine {
             hooks: self.hooks(),
             workers_announced: std::sync::atomic::AtomicBool::new(false),
             matched_announced: std::sync::atomic::AtomicBool::new(false),
-            bg_pending,
+            bg_pending: Arc::clone(&bg_pending),
             failures: Mutex::new(indexmap::IndexMap::new()),
             approval,
             hash_only,
+            deferred_trims: DeferredTrims {
+                engine: Arc::downgrade(self),
+                bg_pending,
+                trims: Mutex::new(FxHashMap::default()),
+            },
         });
 
         let state = Arc::new(RequestState {
@@ -686,6 +808,70 @@ mod tests {
             ..Default::default()
         })?);
         Ok((dir, engine))
+    }
+
+    /// A recorded trim must hold the request's background slot from the moment
+    /// it is recorded, not from the moment it is submitted. The shutdown path
+    /// exits when that counter reads zero, and the submit only happens when the
+    /// request state drops — so a slot taken only at submit time leaves a window
+    /// where the process can exit with trims still owed.
+    #[tokio::test]
+    async fn deferred_trim_holds_the_background_slot_until_it_runs() -> anyhow::Result<()> {
+        use std::sync::atomic::{AtomicUsize, Ordering};
+
+        let (_dir, engine) = test_engine()?;
+        let bg: Arc<AtomicUsize> = Arc::new(AtomicUsize::new(0));
+        let rs = engine.new_state_full(
+            true,
+            None,
+            Arc::clone(&bg),
+            Engine::DEFAULT_LOG_TAIL_LINES,
+            None,
+        );
+
+        rs.defer_trim(&addr("t"), 1, "h1");
+        assert_eq!(
+            bg.load(Ordering::Acquire),
+            1,
+            "a recorded trim holds a slot before it is submitted"
+        );
+        // A second target joins the same batch — one slot, not two.
+        rs.defer_trim(&addr("u"), 1, "h1");
+        assert_eq!(bg.load(Ordering::Acquire), 1, "the batch holds one slot");
+
+        drop(rs);
+
+        // Submitted on drop and released by the cleaner once it has run.
+        let deadline = std::time::Instant::now() + std::time::Duration::from_secs(30);
+        while bg.load(Ordering::Acquire) > 0 {
+            assert!(
+                std::time::Instant::now() < deadline,
+                "the deferred trim never ran"
+            );
+            tokio::time::sleep(std::time::Duration::from_millis(2)).await;
+        }
+        Ok(())
+    }
+
+    /// A request that never wrote a cacheable revision must not touch the
+    /// counter at all — otherwise every `hash_only` / query request would hold
+    /// shutdown open on an empty batch.
+    #[tokio::test]
+    async fn no_deferred_trim_means_no_background_slot() -> anyhow::Result<()> {
+        use std::sync::atomic::{AtomicUsize, Ordering};
+
+        let (_dir, engine) = test_engine()?;
+        let bg: Arc<AtomicUsize> = Arc::new(AtomicUsize::new(0));
+        let rs = engine.new_state_full(
+            true,
+            None,
+            Arc::clone(&bg),
+            Engine::DEFAULT_LOG_TAIL_LINES,
+            None,
+        );
+        drop(rs);
+        assert_eq!(bg.load(Ordering::Acquire), 0);
+        Ok(())
     }
 
     #[test]

--- a/crates/engine/src/engine/result.rs
+++ b/crates/engine/src/engine/result.rs
@@ -2144,21 +2144,21 @@ impl Engine {
                         engine.spawn_remote_upload(&rs, addr.clone(), hashin.clone());
                     }
 
-                    // Post-write GC: trim this target's stale revisions in the
-                    // background (same lane as sandbox cleanup), skipping
-                    // uncacheable/tmp entries which are ephemeral and would be
-                    // dropped anyway. Fire-and-forget; the trim runs only if the
-                    // addr's lock is free, so it never blocks the hot path.
+                    // Post-write GC: record that this target's stale revisions
+                    // are due a trim, skipping uncacheable/tmp entries which are
+                    // ephemeral and would be dropped anyway.
+                    //
+                    // Recorded, not run: the trim needs the addr's write lock,
+                    // and this request is holding a read on it — the riding read
+                    // in `mem_locked_result`, plus a clone in every artifact
+                    // handed out — until the request state drops. Running it
+                    // here means its `try_write` can never succeed, which is
+                    // exactly how `cache.history` came to be unenforced during a
+                    // run. `RequestState::defer_trim` submits it once the guards
+                    // are gone, still on the background lane and still
+                    // fire-and-forget.
                     if out.is_ok() && !use_tmp_cache {
-                        let keep = def.target.cache.history;
-                        crate::engine::sandbox_cleaner::enqueue(
-                            format!("gc {addr}"),
-                            Box::new(enclose!((engine, addr, hashin) move || {
-                                engine.try_trim_after_write(&addr, keep, &hashin);
-                                Ok(())
-                            })),
-                            rs.bg_pending(),
-                        );
+                        rs.defer_trim(&addr, def.target.cache.history, &hashin);
                     }
 
                     hcore::hmemoizer::clear_phase();
@@ -3562,8 +3562,15 @@ mod tests {
 
     /// Drain background uploads tracked by the request's `bg_pending` counter so
     /// the remote-cache assertions observe a settled state.
-    async fn drain_bg(rs: &Arc<crate::engine::request_state::RequestState>) {
+    async fn drain_bg(rs: Arc<crate::engine::request_state::RequestState>) {
         let bg = rs.bg_pending();
+        // Takes the request by value and releases it before waiting. Some
+        // background work is only *submitted* when the request state drops (the
+        // post-write cache trim) and holds a slot until then, so a waiter that
+        // keeps `rs` alive waits on a counter that cannot reach zero. `heph run`
+        // unwinds in this order too — the drain loop runs after the app future,
+        // which owns the request, has returned.
+        drop(rs);
         let deadline = std::time::Instant::now() + Duration::from_secs(5);
         while bg.load(Ordering::Acquire) > 0 {
             assert!(
@@ -3596,7 +3603,7 @@ mod tests {
                 &ResultOptions::default(),
             )
             .await?;
-        drain_bg(&rs).await;
+        drain_bg(rs).await;
         assert_eq!(
             count_files(remote.path()),
             0,
@@ -3620,7 +3627,7 @@ mod tests {
                 &ResultOptions::default(),
             )
             .await?;
-        drain_bg(&rs).await;
+        drain_bg(rs).await;
         assert!(
             count_files(remote_on.path()) > 0,
             "remote-enabled target must upload to the remote cache"
@@ -3652,7 +3659,7 @@ mod tests {
                 &ResultOptions::default(),
             )
             .await?;
-        drain_bg(&rs).await;
+        drain_bg(rs).await;
         assert!(
             count_files(remote.path()) > 0,
             "seed must populate the remote"
@@ -3819,7 +3826,7 @@ mod tests {
                 &ResultOptions::default(),
             )
             .await?;
-        drain_bg(&seed_rs).await;
+        drain_bg(seed_rs).await;
 
         // Cold engine whose remote serves the manifest, claims the blobs exist,
         // and then cannot produce them.
@@ -3889,7 +3896,7 @@ mod tests {
                 &ResultOptions::default(),
             )
             .await?;
-        drain_bg(&seed_rs).await;
+        drain_bg(seed_rs).await;
         assert!(
             count_files(remote.path()) > 0,
             "seed must populate the remote"
@@ -4635,8 +4642,7 @@ mod tests {
             "the gate must have opened because every target parked, not by timing out"
         );
 
-        drain_bg(&rs).await;
-        drop(rs);
+        drain_bg(rs).await;
 
         assert!(
             engine.requests.lock().expect("requests lock").is_empty(),
@@ -5913,19 +5919,13 @@ mod tests {
             "cold build executes once"
         );
 
-        // The cold build's cache write enqueues a fire-and-forget history-trim GC
+        // The cold build's cache write records a fire-and-forget history-trim GC
         // on the background lane (see `try_trim_after_write`), which itself reads
         // the manifest. Drain it before resetting the counter so that lagging read
         // is never attributed to the hit below — otherwise the count races to 2.
-        let pending = cold_rs.bg_pending();
-        let deadline = std::time::Instant::now() + std::time::Duration::from_secs(10);
-        while pending.load(Ordering::SeqCst) > 0 {
-            assert!(
-                std::time::Instant::now() < deadline,
-                "background GC did not drain"
-            );
-            tokio::time::sleep(std::time::Duration::from_millis(5)).await;
-        }
+        // The trim is only *submitted* when the request state drops, and holds a
+        // background slot until then, so the request goes first.
+        drain_bg(cold_rs).await;
 
         // Fresh request → full cache hit. The manifest backing read must happen
         // exactly once for the whole resolution.

--- a/crates/engine/src/engine/result.rs
+++ b/crates/engine/src/engine/result.rs
@@ -2158,7 +2158,7 @@ impl Engine {
                     // are gone, still on the background lane and still
                     // fire-and-forget.
                     if out.is_ok() && !use_tmp_cache {
-                        rs.defer_trim(&addr, def.target.cache.history, &hashin);
+                        rs.defer_trim(&addr, def.target.cache.history, hashin);
                     }
 
                     hcore::hmemoizer::clear_phase();

--- a/crates/engine/src/engine/sandbox_cleaner.rs
+++ b/crates/engine/src/engine/sandbox_cleaner.rs
@@ -98,9 +98,33 @@ fn sender() -> &'static Sender<Job> {
 pub fn enqueue(label: String, job: SandboxCleanupJob, pending: PendingCounter) {
     // Count before sending so the counter can never observe an enqueued job as
     // already drained. The worker decrements once the job has run.
+    reserve(&pending);
+    enqueue_reserved(label, job, pending);
+}
+
+/// Take a slot in `pending` for a job that will only be submitted later.
+///
+/// The counter is what the shutdown path polls to decide the process may exit
+/// (`tui::backend::ci`, `tui::backend::interactive`), so work that is *decided*
+/// now but *submitted* later has to hold its slot across the gap — otherwise
+/// the drain can read zero in between and exit out from under it. The
+/// reservation must end up in exactly one [`enqueue_reserved`], or be given
+/// back with [`release_reservation`].
+pub fn reserve(pending: &PendingCounter) {
     pending.fetch_add(1, Ordering::AcqRel);
+}
+
+/// Give back a slot taken by [`reserve`] when the job will never be submitted.
+/// Without this the shutdown drain would wait forever on work that cannot run.
+pub fn release_reservation(pending: &PendingCounter) {
+    pending.fetch_sub(1, Ordering::AcqRel);
+}
+
+/// [`enqueue`] for a job whose slot was already taken by [`reserve`]. The
+/// worker drops the slot once the job has run, exactly as for [`enqueue`].
+pub fn enqueue_reserved(label: String, job: SandboxCleanupJob, pending: PendingCounter) {
     if let Err(err) = sender().send((label, job, Arc::clone(&pending))) {
-        pending.fetch_sub(1, Ordering::AcqRel);
+        release_reservation(&pending);
         tracing::error!(error = %err, "sandbox cleaner channel closed");
     }
 }

--- a/crates/engine/src/engine/sandbox_cleaner.rs
+++ b/crates/engine/src/engine/sandbox_cleaner.rs
@@ -98,33 +98,18 @@ fn sender() -> &'static Sender<Job> {
 pub fn enqueue(label: String, job: SandboxCleanupJob, pending: PendingCounter) {
     // Count before sending so the counter can never observe an enqueued job as
     // already drained. The worker decrements once the job has run.
-    reserve(&pending);
-    enqueue_reserved(label, job, pending);
-}
-
-/// Take a slot in `pending` for a job that will only be submitted later.
-///
-/// The counter is what the shutdown path polls to decide the process may exit
-/// (`tui::backend::ci`, `tui::backend::interactive`), so work that is *decided*
-/// now but *submitted* later has to hold its slot across the gap — otherwise
-/// the drain can read zero in between and exit out from under it. The
-/// reservation must end up in exactly one [`enqueue_reserved`], or be given
-/// back with [`release_reservation`].
-pub fn reserve(pending: &PendingCounter) {
+    //
+    // Deliberately *not* split into a reserve-now / submit-later pair. The
+    // counter gates process exit through an untimed loop in both TUI backends,
+    // so a slot taken before the work is submitted is only ever released by
+    // whatever was supposed to submit it — and a `RequestStateData` pinned by an
+    // abandoned memoizer cell (a live hazard, see `hmemoizer::cell`'s retained
+    // future and the `fail_fast` fanout that drops in-flight awaiters) would
+    // then turn a silent leak into a process that never exits. A slot exists
+    // only for work already in this queue.
     pending.fetch_add(1, Ordering::AcqRel);
-}
-
-/// Give back a slot taken by [`reserve`] when the job will never be submitted.
-/// Without this the shutdown drain would wait forever on work that cannot run.
-pub fn release_reservation(pending: &PendingCounter) {
-    pending.fetch_sub(1, Ordering::AcqRel);
-}
-
-/// [`enqueue`] for a job whose slot was already taken by [`reserve`]. The
-/// worker drops the slot once the job has run, exactly as for [`enqueue`].
-pub fn enqueue_reserved(label: String, job: SandboxCleanupJob, pending: PendingCounter) {
     if let Err(err) = sender().send((label, job, Arc::clone(&pending))) {
-        release_reservation(&pending);
+        pending.fetch_sub(1, Ordering::AcqRel);
         tracing::error!(error = %err, "sandbox cleaner channel closed");
     }
 }

--- a/crates/tui/src/tui/backend/ci.rs
+++ b/crates/tui/src/tui/backend/ci.rs
@@ -78,7 +78,7 @@ pub async fn run<A: App>(
             tracing::info!(
                 pending = bg_pending.load(std::sync::atomic::Ordering::Acquire),
                 elapsed_secs = started.elapsed().as_secs(),
-                "waiting for background cache uploads and sandbox cleanup to finish",
+                "waiting for background cache uploads, history trims and sandbox cleanup to finish",
             );
             announced = true;
         }


### PR DESCRIPTION
Item **P6.3** of the concurrency remediation plan (`ai-docs/THREADING_PLAN.md`). Based on `master`, independent of #219 (P6.1), which has since merged.

## `cache.history` has never been enforced by a build

The post-write trim deletes cache revisions, so it needs the target's **write** lock — `gc.rs` documents why a read is not enough, and the lock is per-addr, not per-revision. But it ran inline, on the background lane, the moment `cache_locally` finished, while the request that wrote the revision was still alive.

That request holds a *read* on the same addr. The riding read guard lives in the addr-keyed `mem_locked_result` cell and is cloned into every artifact handed out, and `Memoizer` only evicts on a cycle error — so the read is held for the whole run. `try_write` is non-blocking by design, so it returned `Ok(None)` into a bare empty match arm and skipped. Every time, silently.

Verified against `master` before writing anything, and re-verified against current `master` (which now includes #219): three runs of one target with `cache.history = 1` leave all three revisions on disk, and a following `gc_all` sweep reclaims two of them.

## Behavior restoration — read this part

**This changes observable disk behavior for existing users.** It is not a refactor and not a pure optimization.

A build that rebuilds a target now reclaims that target's revisions beyond `cache.history` **before the process exits**. Previously they accumulated until someone ran `heph gc`. Concretely:

- Cache directories will shrink on the first run after upgrading — possibly a lot, on a repo that has never been swept.
- A workflow that was unknowingly relying on more revisions being present than `cache.history` allows — revert a change, expect an instant cache hit on the older revision — will now see a rebuild instead.

That is the documented meaning of `cache.history`. It simply has not been true until now. Anyone who wants the old effective behavior should raise `cache.history`, which is what it is for.

## The fix

Record `(addr, keep, hashin)` as the revision is written; submit the batch when `RequestStateData` drops. Two things make that work, and both are load-bearing:

**`DeferredTrims` is the last field of `RequestStateData`.** Rust drops a struct's fields in declaration order *after* its own `Drop::drop` returns, so being last is what guarantees every memoizer — and every riding read it holds — is already gone when the trims are submitted. Moving the field earlier reinstates the bug with no other symptom. Called out in doc comments on both the field and the type.

**Dropping the request is still not sufficient on its own** — this was the surprise, and it took a `Backtrace` in `LockedResolution::drop` to find. `hcore::blocking::backstop` registrations are never unregistered: a waiter re-registers on every pending poll, and its last registration sits in the global `PENDING` list until a tick sweeps it, up to 250 ms later. A `Waker` owns its task, and one of those tasks is the `mem_locked_result` cell — so the riding read outlives the request that created it by up to a backstop period, and every trim still found its target contended. `flush_backstop()` hands those registrations back explicitly. Waking early is always sound: a genuinely pending waiter re-registers from the poll it provokes.

The batch takes its `bg_pending` slot when it is **handed to the cleaner**, not when a trim is recorded — see the review section below for why that distinction is the difference between a leak and an unexitable process.

## `bg_pending` gains a contract

Wait on it **only after releasing the request**, because a request's last piece of background work is submitted by its own drop. `heph run` already unwinds that way — the drain loops in `tui::backend` run after the app future, which owns the request, returns — but three in-tree test helpers waited while holding `rs` and are updated to drop it first. Documented on the field.

## Tests

- **`cache_history_is_enforced_by_the_end_of_the_run`** (`crates/e2e`) — three runs, three revisions, `history = 1`, asserting **after every run** that a fresh `gc_all` finds nothing to reclaim. Checking only once at the end would not distinguish "every run enforced its budget" from "only the last one did", since run 3's trim deletes both older revisions anyway.

  Each run uses a fresh engine over the same root (new `Workspace::reopen`), because an in-process re-run replays the memoized spec: the rewritten BUILD file produces the same `hashin` and no second revision. The first draft of this test passed on `master` for exactly that reason and could not have failed — worth knowing, because this shape of test is silently vacuous without the fresh engine.
- `recording_a_trim_takes_no_background_slot`, `no_deferred_trim_means_no_background_work`, `suppressed_request_records_no_trims`, `engine_dropped_first_discards_the_batch` — the counter contract and the teardown corners.
- `flush_backstop_releases_registered_wakers_without_waiting_for_a_tick` and `flush_backstop_does_not_strand_a_still_pending_waiter` — that flushing *drops* registrations rather than merely waking them, and that the re-registration invariant the whole mechanism rests on actually holds.

## Review board

`code-quality` PASS WITH NITS · `hermeticity` HERMETIC · `feature-quality` BLOCKED. All actioned in the second commit.

### The one that mattered: the reservation could have made a failed build unexitable

`code-quality` found it, and it is worse than the race it was protecting against. The batch originally took its `bg_pending` slot when a trim was *recorded* and only gave it back from `DeferredTrims::drop`. But `RequestStateData` can be pinned indefinitely by a reference cycle: an abandoned memoizer cell keeps its incomplete future (`hmemoizer::cell`'s `slot`), that future holds `Arc<RequestState>`, and the memoizer that owns the cell is a field of `RequestStateData`. `fail_fast` fanout drops in-flight awaiters at every fanout site, so this is reachable on ordinary build-failure paths — there is already a regression test in the tree for one instance of it.

Before this PR that leaked memory and an uncancelled token, silently. With the reservation it would have leaked an exit-gating slot, and both TUI drain loops are untimed: `heph run` would never exit after a failed build. SIGKILL only.

Removed. The slot is taken when the batch is handed to the cleaner, exactly as `enqueue` has always worked, and `reserve`/`release_reservation`/`enqueue_reserved` are gone with it — `sandbox_cleaner` no longer exposes an unguarded manual balance protocol whose imbalance is a hang.

`hermeticity` independently argued the *opposite* — that reserve-at-record was necessary, because `spawn_remote_upload`'s `_dec` drops before its captured `rs` and a submit-time reservation exposes a zero window. Both are right about their own half. The window is real, but it is a **drop-order bug in `spawn_remote_upload`**, not something the counter should be contorted to paper over. So it is fixed there: the task now drops its `Arc<RequestState>` before the `Decrement` guard, so the request's trims are submitted while the upload still holds its own slot. No zero window, and no hang.

### Diagnosability

`hermeticity` and `feature-quality` made the same point, and it is the sharpest one in the set: **this fix's failure mode and the bug it fixes were byte-identical in the logs.** `Ok(None) => {}` — a bare empty arm — is exactly how `cache.history` went unenforced for so long without anyone noticing. It now says so, at `debug` (a concurrent build of the same target is ordinary, this fires per addr, and the revision is reclaimed by the next write's trim or by `heph gc`). The engine-already-dropped path was equally silent and now logs too.

### Also fixed

- **`Workspace::reopen` silently dropped `fs_skip`** (`hermeticity`, `code-quality`). `fs_skip` decides which files a tree-walking plugin sees — the declared inputs, hence the `hashin`. A reopened engine that dropped it would write into the same on-disk cache under different keys, and a test asserting a hit across the two would prove nothing. Config is carried explicitly now, and `with_static` workspaces refuse to reopen rather than silently substituting a different provider set.
- **`heph gc` phase 1 raced its own phase 2** (`hermeticity`). Resolution executes shared cacheable deps, each recording a trim that fired when the phase-1 state dropped — concurrently with phase 2's write locks, making `GcStats` report whichever got there first and surfacing a contended-lock notice naming this very process as the holder. The sweep now suppresses its resolution state's trims; it *is* the authoritative trim.
- **A panic in one trim discarded every trim after it** (`code-quality`), since the cleaner's `catch_unwind` wraps the whole job and the label named none of them. Contained per target.
- **`flush_backstop` runs from `Drop`**, where a panicking waker would unwind out of a destructor — and abort if that drop were itself unwinding. Contained. It also returns how many registrations it took, so its test can tell its own flush from a tick that landed first.
- **`hash_only` requests refuse to defer trims.** Unreachable today, asserted so it stays that way.
- `defer_trim` takes `hashin` by value; the drain report names history trims.

### Deliberately not done, with reasons

**Blocking `write` instead of `try_write`** (`feature-quality`). Overruled. The lock is a cross-process `flock`, so a blocking acquire can wait on *another `heph` process* arbitrarily long — on the single FIFO cleaner thread that also owes every sandbox `rm -rf`, on the path that gates process exit. `ResultLock::write` is also `async` and that thread has no runtime. A skip is recoverable (next run, or `heph gc`); an unbounded stall of all cleanup is not.

**The end-of-run serial tail** (both reviewers, MAJOR). Real, and the largest remaining item. The missing within-budget pre-check is exactly what #219 added — with it, a cold run's trims cost one `list_target_entries` each and take no lock at all, which is the dominant term — and sharding the batch across lanes is P6.2's subject. Nothing here is measured for tail latency; that is a `perf-measurement` job on a cold 100k run, timed from summary to exit.

**Making the last-field invariant mechanical** (all three, MINOR). Both alternatives replace it with explicit memoizer teardown in `RequestStateData::drop`. Declining: enumerating "every memoizer that can hold a read guard" is fragile in a quieter way — one added later is silently missed, where last-field is total by construction. The per-run e2e assertion is what catches a violation.

**Draining `bg_pending` outside `heph run`** (`feature-quality`). Real and pre-existing — sandbox rmdirs and remote uploads have always been enqueued on counters no non-`run` command drains. Now that the slot is only taken at submit, the failure mode is "the process may exit before a trim runs", not a hang. Draining in `bootstrap::block_on` would cover every command in one place, but it changes exit behaviour for all of them and deserves its own change.

## Open question — a user decision, not mine

`hermeticity` flags that the trim's success has no formal happens-before edge: `flush_backstop()` wakes, the cleaner's `try_write` follows, and nothing sequences "the woken tasks actually released their read guards" in between.

In the case that actually caused this bug the release *is* synchronous — the registered waker is the `hmemoizer::Cell` itself, and `ArcWake::wake` drops the last `Arc` inline (that is what the backtrace showed). But that is a property of who happens to be awaiting, not a guarantee, and the platform where dropped wakes are a documented hazard is macOS — which is precisely why `hcore::blocking`'s backstop exists at all.

So the honest position: this may be best-effort rather than guaranteed, and if it degrades it degrades on one OS. That is an OS-axis behaviour split, and per `CLAUDE.md` it is yours to settle, not mine.

- **A — accept best-effort.** Zero cost. A lost race is now visible in `debug` logs and reclaimed by the next run or `heph gc`.
- **B — bound the race.** The batch retries only the contended subset, once, after a single short delay for the whole batch. Deterministic; costs one delay on the exit path, and only when something was actually contended.

B is not implemented. The three-platform CI on this PR is the evidence either way — the per-run assertion is what would surface a live race.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01A76DChMohieGMbRbnV1E7x
