### PR TITLE
fix(proc): bound the post-exit stdout/stderr drain in proc_exec::output

### DIFF
--- a/crates/proc/src/proc_exec/imp_linux.rs
+++ b/crates/proc/src/proc_exec/imp_linux.rs
@@ -191,38 +191,135 @@ fn make_reader<R: tokio::io::AsyncRead + Send + Unpin + 'static>(s: R) -> ChunkR
     }
 }
 
+/// Read `reader` to EOF, appending into `out` and recording the outcome in
+/// `res`.
+///
+/// Both are borrowed rather than owned so that abandoning this future on the
+/// post-exit deadline still leaves every byte read so far — and any error a
+/// stream hit before the other one stalled — in the caller's hands.
+///
+/// This deliberately stays on `ChunkReader::recv` rather than calling
+/// `AsyncReadExt::read_to_end` directly. It costs one 8 KiB allocation and
+/// one extra copy per chunk, and buys two things: `output` reads through the
+/// exact same path as the streaming consumer (`pluginexec`), and
+/// partial-data-on-drop is a property of this loop rather than an internal
+/// detail of tokio's `read_to_end` that a version bump could change under a
+/// correctness argument that depends on it.
+async fn read_into(
+    reader: Option<&mut ChunkReader>,
+    out: &mut Vec<u8>,
+    res: &mut Option<io::Result<()>>,
+) {
+    *res = Some(
+        async {
+            let Some(r) = reader else { return Ok(()) };
+            while let Some(chunk) = r.recv().await? {
+                out.extend_from_slice(&chunk);
+            }
+            Ok(())
+        }
+        .await,
+    );
+}
+
 pub(super) async fn output(
     spec: Spec,
     cancel: &(dyn Cancellable + Send + Sync),
 ) -> io::Result<Output> {
     let mut handle = spawn(spec)?;
+    let pid = handle.pid();
     let mut stdout_reader = handle.take_stdout();
     let mut stderr_reader = handle.take_stderr();
 
-    let stdout_fut = async move {
-        let mut out = Vec::new();
-        if let Some(r) = stdout_reader.as_mut() {
-            while let Some(chunk) = r.recv().await? {
-                out.extend_from_slice(&chunk);
+    let mut stdout = Vec::new();
+    let mut stderr = Vec::new();
+    // Per-stream, so a stream that finished still reports its error even when
+    // the other one is stalled behind a stray descendant. A single combined
+    // result would only exist once *both* halves completed, which is exactly
+    // the case abandonment rules out.
+    let mut stdout_res: Option<io::Result<()>> = None;
+    let mut stderr_res: Option<io::Result<()>> = None;
+
+    let (status, abandoned) = {
+        // Both pipes must be drained *while* the child runs: the kernel pipe
+        // buffer is 64 KiB, and a child that outruns it blocks in `write`
+        // forever if nobody is reading.
+        let readers = async {
+            tokio::join!(
+                read_into(stdout_reader.as_mut(), &mut stdout, &mut stdout_res),
+                read_into(stderr_reader.as_mut(), &mut stderr, &mut stderr_res),
+            );
+        };
+        tokio::pin!(readers);
+        let mut all_drained = false;
+
+        let status = {
+            let wait = handle.wait_or_cancel(cancel);
+            tokio::pin!(wait);
+            loop {
+                tokio::select! {
+                    // The readers reaching EOF does not end the wait, and the
+                    // wait ending does not (yet) end the readers — whichever
+                    // lands first, we keep polling the other. The guard is
+                    // load-bearing: polling `readers` again after it resolved
+                    // panics with "`async fn` resumed after completion".
+                    res = &mut wait => break res?,
+                    () = &mut readers, if !all_drained => all_drained = true,
+                }
             }
-        }
-        Ok::<Vec<u8>, io::Error>(out)
-    };
-    let stderr_fut = async move {
-        let mut out = Vec::new();
-        if let Some(r) = stderr_reader.as_mut() {
-            while let Some(chunk) = r.recv().await? {
-                out.extend_from_slice(&chunk);
-            }
-        }
-        Ok::<Vec<u8>, io::Error>(out)
+        };
+
+        // The child is reaped. Anything it wrote is already read or sitting
+        // in the pipe, so EOF is moments away — unless a descendant it
+        // double-forked inherited the write end, in which case it never
+        // comes. Bound the wait and abandon the readers if it does not.
+        //
+        // The timer is armed only on the success path. A cancelled wait
+        // returns above, which keeps `tokio::time` off the runtime-teardown
+        // path for the same reason `wait_or_cancel` sleeps on the blocking
+        // pool rather than the time driver.
+        let abandoned = if all_drained {
+            false
+        } else {
+            // `Timeout` polls the inner future before it polls the delay, and
+            // `read_into` loops until `recv` is `Pending`. So the poll that
+            // precedes `Elapsed` has already drained the pipe to `EAGAIN`:
+            // bytes lost here can only be bytes written *after* the child was
+            // reaped and the pipe ran dry — i.e. a descendant's, never the
+            // child's.
+            tokio::time::timeout(super::DRAIN_DEADLINE, &mut readers)
+                .await
+                .is_err()
+        };
+
+        (status, abandoned)
+        // The borrows end here. The read ends themselves close a few
+        // statements later when `stdout_reader` / `stderr_reader` drop at
+        // function exit, at which point a descendant still holding the write
+        // end gets EPIPE on its next write.
     };
 
-    let (status_res, stdout_res, stderr_res) =
-        tokio::join!(handle.wait_or_cancel(cancel), stdout_fut, stderr_fut);
-    let status = status_res?;
-    let stdout = stdout_res?;
-    let stderr = stderr_res?;
+    if abandoned {
+        tracing::warn!(
+            pid,
+            stdout_len = stdout.len(),
+            stderr_len = stderr.len(),
+            stdout_open = stdout_res.is_none(),
+            stderr_open = stderr_res.is_none(),
+            "proc_exec: pipe still open after child exit; abandoning the drain \
+             (a surviving descendant holds the write end)"
+        );
+    }
+
+    // Surface a genuine read error from either stream that ran to completion.
+    // An abandoned stream has no verdict to report; it is covered by the
+    // warning above rather than by failing the child.
+    if let Some(res) = stdout_res {
+        res?;
+    }
+    if let Some(res) = stderr_res {
+        res?;
+    }
 
     Ok(Output {
         status,

--- a/crates/proc/src/proc_exec/imp_macos.rs
+++ b/crates/proc/src/proc_exec/imp_macos.rs
@@ -32,7 +32,13 @@ const CANCEL_POLL_INTERVAL: Duration = Duration::from_millis(100);
 /// reparented to pid 1) is holding the pipe write end. We escalate with
 /// `killpg` on the pgid (relies on the spawning driver setting
 /// `setsid: true`) and grant a second budget.
-const DRAIN_JOIN_BUDGET: Duration = Duration::from_millis(500);
+///
+/// One window, taken from the cross-backend [`super::DRAIN_DEADLINE`] so the
+/// two backends share a single knob — but note this side spends it *twice*
+/// (once before the `killpg`, once after), so the worst-case post-exit drain
+/// is ~2x Linux's. See [`super::DRAIN_DEADLINE`] for what that divergence
+/// does and does not cost.
+const DRAIN_JOIN_BUDGET: Duration = super::DRAIN_DEADLINE;
 
 /// Polling interval while waiting for drain threads' "done" flags after
 /// `exit_rx`. Short enough to keep latency low; large enough not to spin.
@@ -512,31 +518,56 @@ pub(super) async fn output(
     let mut handle = spawn(spec)?;
     let stdout_rx = handle.take_stdout();
     let stderr_rx = handle.take_stderr();
-    // Collect stdout/stderr on dedicated buffer threads. We can't await the
-    // `ChunkReader::recv` here because we also want to race the wait/cancel
-    // — and `ChunkReader::recv` requires block_in_place. Collect on threads
-    // so the wait poll loop has a clean single-shot signal to wait on.
-    let stdout_handle = collect_chunks(stdout_rx);
-    let stderr_handle = collect_chunks(stderr_rx);
 
+    // No collector needed on this side: the drain threads spawned by
+    // `spawn` already read the pipes concurrently with the child (so the
+    // 64 KiB pipe buffer can never wedge it) and park the chunks in their
+    // unbounded channels. `wait_or_cancel` bounds the join on those threads
+    // via `drain_with_deadline`, so by the time it returns either every
+    // chunk has been queued or the drain has been abandoned.
+    //
+    // This drops the two `heph-proc-collect` threads a previous version
+    // spawned per subprocess. Those threads were the actual hang: the
+    // abandoned drain thread still holds its sender, so the collector's
+    // `rx.recv()` never returned and `output` joined it under
+    // `block_in_place`, parking a tokio worker for the descendant's whole
+    // lifetime. The trade is memory: chunks now sit in the channel as
+    // separate 8 KiB `Vec`s until the child exits instead of being folded
+    // into one growing buffer as they arrive, so peak is ~2x the payload
+    // while `take_queued` copies them out. Unbounded, as it was before.
     let status = handle.wait_or_cancel(cancel).await?;
 
-    let stdout = block_or_inline(|| {
-        stdout_handle.join().map_err(|panic| {
-            io::Error::other(format!("stdout collect thread panicked: {panic:?}"))
-        })?
-    })?;
-    let stderr = block_or_inline(|| {
-        stderr_handle.join().map_err(|panic| {
-            io::Error::other(format!("stderr collect thread panicked: {panic:?}"))
-        })?
-    })?;
+    let stdout = take_queued(stdout_rx)?;
+    let stderr = take_queued(stderr_rx)?;
 
     Ok(Output {
         status,
         stdout,
         stderr,
     })
+}
+
+/// Collect everything the drain thread has already queued, without blocking.
+///
+/// A finished drain has dropped its sender, so this walks the channel to
+/// `Disconnected` and returns the complete stream. An abandoned one (a
+/// descendant that outlived the child still holds the pipe write end) leaves
+/// the sender alive; we stop at `Empty` and return what the child itself
+/// wrote rather than parking on bytes that are not ours. Dropping the
+/// receiver here also releases the stuck thread the moment its `read`
+/// returns, since its next `send` fails.
+fn take_queued(reader: Option<ChunkReader>) -> io::Result<Vec<u8>> {
+    let Some(reader) = reader else {
+        return Ok(Vec::new());
+    };
+    let mut out = Vec::new();
+    loop {
+        match reader.rx.try_recv() {
+            Ok(Ok(chunk)) => out.extend_from_slice(&chunk),
+            Ok(Err(e)) => return Err(e),
+            Err(mpsc::TryRecvError::Empty | mpsc::TryRecvError::Disconnected) => return Ok(out),
+        }
+    }
 }
 
 fn spawn_drain_thread<R: io::Read + Send + 'static>(
@@ -575,74 +606,4 @@ fn spawn_drain_thread<R: io::Read + Send + 'static>(
         })
         .expect("spawn heph-proc-drain thread");
     (rx, DrainHandle { join: jh, done })
-}
-
-fn collect_chunks(reader: Option<ChunkReader>) -> JoinHandle<io::Result<Vec<u8>>> {
-    std::thread::Builder::new()
-        .name("heph-proc-collect".into())
-        .spawn(move || -> io::Result<Vec<u8>> {
-            let Some(reader) = reader else {
-                return Ok(Vec::new());
-            };
-            // ChunkReader holds an mpsc::Receiver — drain it synchronously here
-            // since this thread is std (not in the tokio runtime).
-            let mut out = Vec::new();
-            loop {
-                match reader.rx.recv() {
-                    Ok(Ok(chunk)) => out.extend_from_slice(&chunk),
-                    Ok(Err(e)) => return Err(e),
-                    Err(_disconnected) => return Ok(out),
-                }
-            }
-        })
-        .expect("spawn heph-proc-collect thread")
-}
-
-#[cfg(test)]
-mod tests {
-    use super::*;
-    use std::ffi::OsString;
-    use std::path::PathBuf;
-    use std::time::Instant;
-
-    /// Regression: a child that backgrounds a long-lived descendant
-    /// inheriting stdout/stderr must not park `Handle::wait` indefinitely.
-    /// The bounded drain join + `killpg` escalation reaps the descendant
-    /// once `setsid: true` puts the child in its own process group.
-    #[tokio::test(flavor = "multi_thread", worker_threads = 4)]
-    async fn stray_daemon_does_not_park_wait() {
-        // sh forks a 10s sleep into the background (inheriting stdout +
-        // stderr fds), then the immediate child exits. Without
-        // `setsid: true` + the bounded drain-join, the sleep would keep
-        // the pipe write end open and `Handle::wait` would block on the
-        // unbounded drain `join()` for the full 10 seconds.
-        let spec = super::super::Spec {
-            program: PathBuf::from("/bin/sh"),
-            args: vec![
-                OsString::from("-c"),
-                OsString::from("( /bin/sleep 10 ) & exit 0"),
-            ],
-            env: Vec::new(),
-            cwd: PathBuf::from("/"),
-            stdin: super::super::StdioSpec::Null,
-            stdout: super::super::StdioSpec::Piped,
-            stderr: super::super::StdioSpec::Piped,
-            setsid: true,
-            ctty: false,
-        };
-
-        let handle = spawn(spec).expect("spawn child");
-        let started = Instant::now();
-        let status = handle.wait().await.expect("wait should return");
-        let elapsed = started.elapsed();
-
-        assert!(status.success(), "child should exit 0; got {status:?}");
-        // Generous cap: two drain budgets (≈1s) + scheduling slack. The
-        // backgrounded sleep would extend this to ~10s without the
-        // killpg escalation.
-        assert!(
-            elapsed < Duration::from_secs(3),
-            "Handle::wait took {elapsed:?} — bounded drain join should escape via killpg",
-        );
-    }
 }

--- a/crates/proc/src/proc_exec/mod.rs
+++ b/crates/proc/src/proc_exec/mod.rs
@@ -45,6 +45,40 @@ pub const CHUNK_SIZE: usize = 8192;
 /// waiting on a child that ignores the interrupt.
 pub const CANCEL_GRACE: std::time::Duration = std::time::Duration::from_secs(2);
 
+/// Grace window granted to the stdout/stderr drains *after* the child has
+/// been reaped.
+///
+/// Everything the child itself wrote is, by the time it exits, either
+/// already read or sitting in the pipe buffer (64 KiB), so this window only
+/// ever needs to cover the tail of a pipe that is guaranteed to hit EOF.
+/// What it protects against is the opposite case: a descendant the child
+/// double-forked (`go list` → `git` → `git credential-cache--daemon`, which
+/// lingers for 900 s) inherited the write end and never closes it, so the
+/// drain never sees EOF. Without a bound the caller parks on a read that
+/// only the daemon's own lifetime can end, and no cancellation token is in
+/// that path — Ctrl-C cannot unstick it either.
+///
+/// Past the window the drains are abandoned and whatever was collected is
+/// returned, with a `tracing::warn!` carrying the pid and the byte counts.
+///
+/// How strong "abandoning loses nothing of the child's" is differs by
+/// backend, and the difference is worth knowing before relying on it:
+///
+/// - **Linux** — the guarantee is exact. `tokio::time::timeout` polls the
+///   readers before it polls the delay, and a reader loops until the pipe
+///   returns `EAGAIN`, so the poll immediately preceding the timeout has
+///   already drained the pipe dry. Anything lost was written after the child
+///   was reaped *and* after the pipe emptied: a descendant's bytes.
+/// - **macOS** — the guarantee is statistical. Reading happens on drain
+///   threads and completion is observed through an `AtomicBool` on a wall
+///   clock, so a drain thread starved for the whole window would look
+///   identical to one blocked on a stray descendant. It gets two windows
+///   (500 ms, `killpg`, 500 ms) against a 64 KiB pipe tail that needs a
+///   handful of `read`s, so the margin is ~4 orders of magnitude — but it is
+///   a margin, not a proof. Closing it means moving that backend off drain
+///   threads, which is its own change.
+pub const DRAIN_DEADLINE: std::time::Duration = std::time::Duration::from_millis(500);
+
 /// Stdio configuration variants supported by [`Spec`]. Mirrors
 /// `std::process::Stdio` but is `Clone` so a `Spec` can be inspected /
 /// retried without consuming inherited fds.
@@ -105,3 +139,242 @@ pub fn spawn(spec: Spec) -> io::Result<Handle> {
 }
 
 pub use imp::{ChunkReader, Handle, StdinPump};
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use hcore::hasync::StdCancellationToken;
+    use std::time::{Duration, Instant};
+
+    /// Whether the child gets its own session (`setsid`), which is what makes
+    /// the supervisor's `killpg` able to reach a descendant. Every real
+    /// caller of [`output`] passes `Inherited`; only `pluginexec`'s streaming
+    /// path uses `Own`. Named rather than a bare `bool` because which one a
+    /// test picks decides whether `killpg` can rescue it.
+    #[derive(Clone, Copy)]
+    enum Session {
+        Own,
+        Inherited,
+    }
+
+    /// Locate a tool without assuming an FHS layout. `/bin/sh` is guaranteed
+    /// everywhere we support (including NixOS, where the dev shell lives),
+    /// but `/bin/sleep` is not — so resolve it and skip rather than fail with
+    /// a bare `ENOENT` that reads like a broken test.
+    fn find_tool(name: &str) -> Option<PathBuf> {
+        let direct = PathBuf::from("/bin").join(name);
+        if direct.exists() {
+            return Some(direct);
+        }
+        std::env::var_os("PATH")
+            .iter()
+            .flat_map(std::env::split_paths)
+            .map(|dir| dir.join(name))
+            .find(|p| p.exists())
+    }
+
+    fn sh_spec(session: Session, script: &str) -> Spec {
+        Spec {
+            program: PathBuf::from("/bin/sh"),
+            args: vec![OsString::from("-c"), OsString::from(script)],
+            env: Vec::new(),
+            cwd: PathBuf::from("/"),
+            stdin: StdioSpec::Null,
+            stdout: StdioSpec::Piped,
+            stderr: StdioSpec::Piped,
+            setsid: matches!(session, Session::Own),
+            ctty: false,
+        }
+    }
+
+    /// How long the backgrounded descendant holds the pipe. Must exceed
+    /// [`STRAY_DAEMON_CAP`] by enough that a genuine regression is
+    /// unambiguous rather than a near miss.
+    const STRAY_LIFETIME_SECS: u64 = 30;
+
+    /// Worst-case bounded drain is two windows plus a `killpg` on macOS
+    /// (~1s), one window on Linux (~0.5s). 5s leaves room for a loaded CI
+    /// runner while staying far below the [`STRAY_LIFETIME_SECS`] a
+    /// regression would take.
+    const STRAY_DAEMON_CAP: Duration = Duration::from_secs(5);
+
+    /// `sh` backgrounds a long-lived descendant that inherits stdout/stderr,
+    /// runs `body`, then exits. The descendant keeps the pipe write end open
+    /// for its full lifetime, so any drain that waits for EOF is pinned to
+    /// the descendant's clock rather than the child's.
+    fn stray_daemon_script(sleep: &std::path::Path, body: &str) -> String {
+        format!(
+            "( {} {STRAY_LIFETIME_SECS} ) & {body}; exit 0",
+            sleep.display()
+        )
+    }
+
+    macro_rules! sleep_tool {
+        () => {
+            match find_tool("sleep") {
+                Some(p) => p,
+                None => {
+                    eprintln!("skipping: no `sleep` on this host");
+                    return;
+                }
+            }
+        };
+    }
+
+    /// Regression: a child that backgrounds a long-lived descendant
+    /// inheriting stdout/stderr must not park the wait indefinitely.
+    ///
+    /// Targets `wait_or_cancel`, not `wait`: that is the method `pluginexec`
+    /// actually calls, and on macOS it is the one that owns
+    /// `drain_with_deadline`. (`Handle::wait` has no production caller, and
+    /// on Linux neither method touches the readers at all — they are moved
+    /// out by `take_stdout`/`take_stderr` — so this asserts a bound that only
+    /// the macOS backend can currently violate.)
+    #[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+    async fn stray_daemon_does_not_park_wait() {
+        let sleep = sleep_tool!();
+        let spec = sh_spec(Session::Own, &stray_daemon_script(&sleep, ":"));
+        let handle = spawn(spec).expect("spawn");
+        let cancel = StdCancellationToken::new();
+        let started = Instant::now();
+        let status = handle
+            .wait_or_cancel(&cancel)
+            .await
+            .expect("wait should return");
+        let elapsed = started.elapsed();
+
+        assert!(status.success(), "child should exit 0; got {status:?}");
+        assert!(
+            elapsed < STRAY_DAEMON_CAP,
+            "wait_or_cancel took {elapsed:?} — the drain join must be bounded",
+        );
+    }
+
+    /// Regression for the batch `output()` API, which plugin-go and
+    /// plugin-nix use. It has no cancellation token on the drain side, so an
+    /// unbounded post-exit drain is unreachable by Ctrl-C: the run is stuck
+    /// until the stray descendant exits on its own.
+    ///
+    /// `Session::Inherited` mirrors every real caller — which also means the
+    /// `killpg` escalation cannot rescue this path, so the deadline is the
+    /// only thing that ends the wait.
+    #[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+    async fn stray_daemon_does_not_park_output() {
+        let sleep = sleep_tool!();
+        let script = stray_daemon_script(&sleep, "echo hello; echo problem >&2");
+        let spec = sh_spec(Session::Inherited, &script);
+        let cancel = StdCancellationToken::new();
+        let started = Instant::now();
+        let out = output(spec, &cancel).await.expect("output should return");
+        let elapsed = started.elapsed();
+
+        assert!(
+            out.status.success(),
+            "child should exit 0; got {:?}",
+            out.status
+        );
+        // Everything the child itself wrote must survive the bounded drain —
+        // on both streams. Abandoning the readers must not cost us the output
+        // we came for.
+        assert_eq!(String::from_utf8_lossy(&out.stdout), "hello\n");
+        assert_eq!(String::from_utf8_lossy(&out.stderr), "problem\n");
+        assert!(
+            elapsed < STRAY_DAEMON_CAP,
+            "output() took {elapsed:?} — the post-exit drain must be bounded",
+        );
+    }
+
+    /// The sharp edge of a bounded drain: a payload far past the 64 KiB pipe
+    /// buffer *and* a descendant holding the pipe open. Every byte is the
+    /// child's, so the deadline must not cost us any of it — this is the test
+    /// that would catch a bound that abandons the drain while real data is
+    /// still queued.
+    #[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+    async fn stray_daemon_does_not_truncate_large_output() {
+        const PAYLOAD: usize = 1_048_576;
+        let sleep = sleep_tool!();
+        let script = stray_daemon_script(
+            &sleep,
+            &format!("yes hello | head -c {PAYLOAD}; yes nope | head -c {PAYLOAD} >&2"),
+        );
+        let spec = sh_spec(Session::Inherited, &script);
+        let cancel = StdCancellationToken::new();
+        let started = Instant::now();
+        let out = output(spec, &cancel).await.expect("output should return");
+        let elapsed = started.elapsed();
+
+        assert_eq!(
+            out.stdout.len(),
+            PAYLOAD,
+            "stdout truncated by the drain bound"
+        );
+        assert_eq!(
+            out.stderr.len(),
+            PAYLOAD,
+            "stderr truncated by the drain bound"
+        );
+        assert!(
+            out.stdout.iter().all(|&b| b != b'n'),
+            "stdout got stderr's bytes"
+        );
+        assert!(
+            elapsed < STRAY_DAEMON_CAP,
+            "output() took {elapsed:?} — the post-exit drain must be bounded",
+        );
+    }
+
+    /// A failing child must still hand back both streams along with its
+    /// status — nothing may short-circuit the collection on a non-zero exit.
+    #[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+    async fn output_returns_both_streams_on_failure() {
+        let spec = sh_spec(Session::Inherited, "echo out; echo err >&2; exit 3");
+        let cancel = StdCancellationToken::new();
+        let out = output(spec, &cancel).await.expect("output should return");
+
+        assert_eq!(out.status.code(), Some(3), "status {:?}", out.status);
+        assert_eq!(String::from_utf8_lossy(&out.stdout), "out\n");
+        assert_eq!(String::from_utf8_lossy(&out.stderr), "err\n");
+    }
+
+    /// Cancelling `output()` must surface `Err` within the escalation budget
+    /// rather than riding the child's own lifetime. This is the contract both
+    /// backends have to agree on, and the reason the item exists: before the
+    /// bound, the drain could outlive the cancel indefinitely.
+    ///
+    /// The token is fired from a *separate task* on purpose. On macOS
+    /// `wait_or_cancel` parks its worker in `block_in_place`, so a canceller
+    /// `join!`ed onto the same task would never be polled and the run would
+    /// ride the child to its natural exit — which is how the real callers
+    /// work anyway (the Ctrl-C handler lives elsewhere), but it is a trap
+    /// worth naming.
+    #[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+    async fn cancelled_output_returns_within_budget() {
+        let sleep = sleep_tool!();
+        let spec = sh_spec(
+            Session::Inherited,
+            &format!("{} {STRAY_LIFETIME_SECS}", sleep.display()),
+        );
+        let cancel = std::sync::Arc::new(StdCancellationToken::new());
+        let canceller = tokio::spawn({
+            let cancel = std::sync::Arc::clone(&cancel);
+            async move {
+                tokio::time::sleep(Duration::from_millis(100)).await;
+                cancel.cancel();
+            }
+        });
+
+        let started = Instant::now();
+        let res = output(spec, cancel.as_ref()).await;
+        let elapsed = started.elapsed();
+        canceller.await.expect("canceller task");
+
+        assert!(res.is_err(), "cancelled output must not return Ok");
+        // SIGINT, then CANCEL_GRACE, then SIGKILL, then at worst two drain
+        // windows on macOS — plus slack for a loaded runner.
+        let budget = CANCEL_GRACE + DRAIN_DEADLINE * 2 + Duration::from_secs(3);
+        assert!(
+            elapsed < budget,
+            "cancelled output took {elapsed:?}, budget {budget:?}",
+        );
+    }
+}


### PR DESCRIPTION
## The bug

`proc_exec::output` drained both pipes to EOF with **no deadline**, on both backends.

A child that double-forks a descendant which inherits stdout and stderr resolves `wait_or_cancel` — the immediate child *is* reaped — and then parks forever on a read that only the descendant's own lifetime can end. The real case is `go list` shelling out to `git`, which spawns `git credential-cache--daemon` with a 900 s idle lifetime.

Nothing could unstick it. The reader side takes no cancellation token, and the engine does not race the driver against it, so **Ctrl-C did not reach it either**. `pluginexec`'s streaming path has been bounded at 50 ms for a while; only the batch `output()` API — the one plugin-go and plugin-nix use — was unguarded.

## The fix

Both backends give the drain a bounded window after the child is reaped, then abandon it and return what was collected, with a `warn!` carrying the pid and the byte counts. One shared constant, `proc_exec::DRAIN_DEADLINE` (500 ms).

Returning early is not a lossy truncation of the child's output — but how strong that claim is differs by backend, and the constant's docs now say so rather than implying parity:

- **Linux — exact.** `tokio::time::timeout` polls the readers *before* it polls the delay, and a reader loops until the pipe gives `EAGAIN`. The poll preceding the timeout has therefore already drained the pipe dry; anything lost was written after the child was reaped *and* after the pipe emptied, which only a descendant can do.
- **macOS — statistical.** Reading happens on drain threads observed through an `AtomicBool` on a wall clock, so a drain thread starved for the whole window is indistinguishable from one blocked on a stray descendant. It gets two windows against a 64 KiB pipe tail that needs a handful of reads — a ~4-order-of-magnitude margin, but a margin, not a proof. Closing it means moving that backend off drain threads, which is a separate change.

**Linux** reads into `&mut Vec<u8>` locals with per-stream results, so abandoning one stream still surfaces an error from the other and leaves every byte read so far in the caller's hands. Phase one runs the wait and both readers concurrently in a `select!` loop; phase two wraps the remainder in `timeout`. The timer only ever arms on the success path — a cancelled wait returns before it, keeping `tokio::time` off the runtime-teardown path for the same reason `wait_or_cancel` uses a `spawn_blocking` sleep.

**macOS** loses its two `heph-proc-collect` threads, which were the actual block: `drain_with_deadline` already bounded the drain threads, but the collector then blocked forever in `rx.recv()` because the abandoned drain thread still held the sender, and `output` joined it under `block_in_place` — parking a tokio worker for the descendant's whole lifetime. The drain threads already buffer into unbounded channels, so `output` now just walks what is queued with `try_recv`. Two fewer OS threads per subprocess, traded against ~2x peak memory for large payloads (chunks sit in the channel instead of being folded into one growing `Vec`). Noted in the code.

`TrackGuard` needs no special handling: both backends only return after `wait_or_cancel` has consumed the `Handle` and the pid has been reaped, so untracking the pgid cannot orphan a live tree.

## Tests

All in `proc_exec/mod.rs` so **both backends compile them** — Linux previously shipped the defect *and* had no test.

- `stray_daemon_does_not_park_wait` — moved up from `imp_macos.rs`, and retargeted from `Handle::wait` to `wait_or_cancel`. `wait` has no production caller at all; `wait_or_cancel` is what `pluginexec` uses and what owns `drain_with_deadline`.
- `stray_daemon_does_not_park_output` — the batch API with `setsid: false`, mirroring every real caller, which also means `killpg` cannot rescue it.
- `stray_daemon_does_not_truncate_large_output` — 1 MiB on each stream, far past the 64 KiB pipe buffer, **and** a stray descendant holding the pipe. Every byte is the child's, so the bound must not cost any.
- `output_returns_both_streams_on_failure` — non-zero exit still returns both streams.
- `cancelled_output_returns_within_budget` — the cancel contract. Fired from a separate task on purpose: on macOS `wait_or_cancel` parks its worker in `block_in_place`, so a canceller `join!`ed onto the same task is never polled.

**Both backends were confirmed RED before the fix, not merely green after.** macOS at 10.03 s on the original test; the Linux path at 30.1 s on both drain tests, reproduced by temporarily pointing the module `cfg` at `imp_linux` and reverting only `imp_linux::output` to its `origin/master` form.

## Review board

`code-quality` **PASS WITH NITS**, `feature-quality` **BLOCKED**.

Its blockers on missing coverage (complete stdout+stderr, large payload, cancellation) are fixed. Its third — that an abandoned drain returns `Ok` with a possibly truncated buffer instead of failing — is **overruled with reason**: on Linux the `EAGAIN` argument makes truncation of the child's own bytes unreachable, and on macOS making it an error would fail every `go list` behind a stray credential daemon, which is exactly the case this change exists to keep working. The residual macOS window is documented on `DRAIN_DEADLINE` rather than papered over.

## Per-backend divergence — flagged, not decided

Worst-case post-exit drain is **one window on Linux, two plus a `killpg` on macOS**, and only macOS signals the surviving descendant. Uniform semantics (bounded, partial-safe, warned) hold on both; the timing and the escalation do not. Per the portability rule this is yours to settle, not the implementation's.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01A76DChMohieGMbRbnV1E7x