### PR TITLE
fix(engine): group members are dependencies; they never get the terminal

### DIFF
--- a/crates/engine/src/engine/result.rs
+++ b/crates/engine/src/engine/result.rs
@@ -2,8 +2,8 @@ use crate::engine::Engine;
 use crate::engine::driver::targetdef::{Input, TargetDef};
 use crate::engine::driver::{ApplyTransitiveRequest, ParseRequest, outputartifact};
 use crate::engine::error::{
-    CancelledError, CycleError, HashUnknownError, MultiError, ProcessFailed, TargetFailure,
-    TargetNotFoundError, UpstreamFailed,
+    CancelledError, CycleError, HashUnknownError, MultiError, ProcessFailed,
+    ShellNeedsSingleTarget, TargetFailure, TargetNotFoundError, UpstreamFailed,
 };
 use crate::engine::provider::{
     GetError, GetRequest, GetResponse, ListRequest, ProbeRequest, ProviderExecutor, State,
@@ -681,6 +681,34 @@ struct ExecutedArtifacts {
     meta: Vec<ArtifactMeta>,
 }
 
+/// Whether a transparent target's inputs name exactly one distinct member addr.
+///
+/// The unit is the *executing target*, not the input entry: a group may list one
+/// member twice under different output filters, and both entries resolve to the
+/// same addr-keyed `mem_locked_result` / `mem_execute_cache` cell, so only one
+/// execute — and therefore only one terminal wrapper — ever runs. Allocation-free
+/// on the hot path; the deduplicated list is materialized only for diagnostics.
+fn has_single_member(inputs: &[Input]) -> bool {
+    let mut members = inputs.iter().map(|input| &input.r#ref.r#ref);
+    match members.next() {
+        Some(first) => members.all(|member| member == first),
+        None => false,
+    }
+}
+
+/// The distinct member addrs of a transparent target, in declaration order.
+/// Diagnostics only — quadratic in the member count, which is why the hot-path
+/// check is [`has_single_member`].
+fn distinct_members(inputs: &[Input]) -> Vec<Addr> {
+    let mut out: Vec<Addr> = Vec::with_capacity(inputs.len());
+    for input in inputs {
+        if !out.contains(&input.r#ref.r#ref) {
+            out.push(input.r#ref.r#ref.clone());
+        }
+    }
+    out
+}
+
 /// Single classifier chokepoint for any target error.
 ///
 /// Decides whether an error is this target's **own** failure (record it once in
@@ -718,6 +746,15 @@ fn classify_failure(
         return e;
     }
 
+    // "--shell needs one target" is a property of the request, not a failure of
+    // the target that raised it — nothing ran. Propagate unchanged so a group
+    // nested inside a single-member group doesn't record the user's own input
+    // error as a failed target and render a failure box for something that never
+    // executed.
+    if downcast_chain_ref::<ShellNeedsSingleTarget>(&e).is_some() {
+        return e;
+    }
+
     // Already a collateral marker: reuse the existing root, do not record.
     if let Some(uf) = downcast_chain_ref::<UpstreamFailed>(&e) {
         return UpstreamFailed {
@@ -735,6 +772,14 @@ fn classify_failure(
     // through and record the whole aggregation against this target so the detail
     // (every broken input) isn't lost.
     if let Some(multi) = downcast_chain_ref::<MultiError>(&e) {
+        // A request-shape error aggregated with `fail_fast = false` is still a
+        // request error, not this target's failure. Surface it alone: every
+        // sibling raised the identical one.
+        for inner in &multi.0 {
+            if let Some(shell) = downcast_chain_ref::<ShellNeedsSingleTarget>(inner) {
+                return anyhow::Error::new(shell.clone());
+            }
+        }
         let all_collateral = multi.0.iter().all(|inner| {
             downcast_chain_ref::<UpstreamFailed>(inner).is_some()
                 || downcast_chain_ref::<CancelledError>(inner).is_some()
@@ -899,8 +944,63 @@ impl Engine {
         };
         if def.target_def.transparent {
             let mut opts = opts.clone();
-            if opts.shell {
-                opts.interactive = None;
+            // Dependencies are never interactive. The terminal goes to the
+            // single target the user named — never to something the engine
+            // pulled in on its behalf.
+            //
+            // A transparent group with two or more members is exactly that
+            // case: inlining is an implementation detail, and what the members
+            // *are* is the run's dependencies. So this gate and the
+            // `ResultOptions::default()` that dependency resolution already uses
+            // are one principle enforced at two points, not two rules that
+            // happen to agree — which is why `deps_never_inherit_the_terminal`
+            // guards the general form of what this line is an instance of.
+            // (Dependency resolution is doubly safe: deps are built by `meta`
+            // while computing the parent's `hashin`, and `meta` is memoized per
+            // addr with no `opts` in scope at all, so it *cannot* propagate a
+            // wrapper; `inputs_result_exec` then re-fetches them with
+            // `ResultOptions::default()`.)
+            //
+            // A group of one is a *name*, not a fan-out — there is nothing to
+            // call a dependency — so inlining hands the terminal straight
+            // through and `heph run //:dev` behaves like running its one member.
+            //
+            // The third enforcement point is `Engine::result`, which clears
+            // `interactive` for any non-`Addr` matcher: a selection names no
+            // single target to give the terminal to. Together the three
+            // guarantee at most one live terminal wrapper per request, at any
+            // nesting depth.
+            //
+            // Sharing the terminal between siblings is not merely untidy: each
+            // member's wrapper builds its own `TtyReader` on fd 0, the first
+            // member to finish resumes the TUI (re-enabling raw mode and
+            // clearing Ctrl-C suppression) underneath its live siblings, and
+            // `TtyReader::drop` restores blocking mode on fd 0 while a sibling
+            // still drives it through `AsyncFd` — leaving a blocking `read(0)`
+            // on a tokio worker that the request's cancellation token cannot
+            // reach.
+            if !has_single_member(&def.target_def.inputs) {
+                if opts.shell {
+                    return Err(ShellNeedsSingleTarget::Group {
+                        addr: addr.clone(),
+                        members: distinct_members(&def.target_def.inputs),
+                    }
+                    .into());
+                }
+                // `debug!`, not `info!` or a warning: nothing surprising
+                // happened. Dependencies have never been interactive, and these
+                // members are dependencies — there is no expectation to correct,
+                // only a "why didn't I get a prompt?" to answer under `-v`.
+                let dropped_terminal = opts.interactive.take().is_some();
+                if dropped_terminal {
+                    tracing::debug!(
+                        addr = %addr.format(),
+                        members = def.target_def.inputs.len(),
+                        reason = "group_multi_member",
+                        "group members are dependencies of the run; the terminal is not \
+                         forwarded to them",
+                    );
+                }
             }
 
             let futures: Vec<_> = def
@@ -985,7 +1085,20 @@ impl Engine {
         opts: &ResultOptions,
     ) -> anyhow::Result<BatchResult> {
         let mut opts = opts.clone();
+        // First leg of the one-target rule: a selection is many targets, so no
+        // target gets the terminal (see the transparent-group gate in
+        // `result_addr_impl` for the full rationale). `--shell` has nothing to
+        // attach to once it is gone, so refuse it here — once, naming the
+        // selection — rather than letting every matched target hit the
+        // "non-interactive mode" guard below and tell a user sitting at a
+        // terminal that they are not on one.
         if !matches!(matcher, Matcher::Addr(_)) {
+            if opts.shell && opts.interactive.is_some() {
+                return Err(ShellNeedsSingleTarget::Selection {
+                    query: hmodel::htquery::format(matcher),
+                }
+                .into());
+            }
             opts.interactive = None;
         }
 
@@ -6772,6 +6885,827 @@ mod tests {
             gen_def.target_def.cache.history, 1,
             "copy target keeps its declared history",
         );
+        Ok(())
+    }
+
+    // ----------------------------------------------------------------------
+    // Terminal forwarding across transparent groups.
+    //
+    // `TtyReader` (crates/tui/src/tui/tty.rs) owns fd 0 exclusively and the TUI
+    // pause is not refcounted, so at most one target per request may hold the
+    // terminal. These tests pin the rule that enforces it: a run is interactive
+    // only when it resolves to exactly one target that executes.
+    // ----------------------------------------------------------------------
+
+    /// Observes the [`InteractiveWrapper`] the way fd 0 experiences it: how many
+    /// targets asked for the terminal, and how many held it *at the same time*.
+    /// `max_live > 1` is the two-`TtyReader`s-on-one-fd bug.
+    #[derive(Default)]
+    struct TerminalProbe {
+        calls: AtomicUsize,
+        live: AtomicUsize,
+        max_live: AtomicUsize,
+    }
+
+    /// Wrapper that records its own concurrency, then runs the target.
+    ///
+    /// The assertions that matter are on `calls`, which is 0-or-1 by
+    /// construction and so deterministic. The sleep only sharpens `max_live`:
+    /// it is an await point every sibling reaches before any of them finishes,
+    /// so with enough execute-semaphore permits (hence `parallelism: Some(4)`)
+    /// a shared terminal reads as 2 rather than 1. It cannot turn a red
+    /// `calls` assertion green.
+    fn probe_wrapper(probe: SArc<TerminalProbe>) -> InteractiveWrapper {
+        SArc::new(move |inner: InteractiveInner| {
+            let probe = SArc::clone(&probe);
+            Box::pin(async move {
+                probe.calls.fetch_add(1, Ordering::SeqCst);
+                let live = probe.live.fetch_add(1, Ordering::SeqCst) + 1;
+                probe.max_live.fetch_max(live, Ordering::SeqCst);
+                tokio::time::sleep(Duration::from_millis(50)).await;
+                let res = inner(None, None, None).await;
+                probe.live.fetch_sub(1, Ordering::SeqCst);
+                res
+            })
+        })
+    }
+
+    /// Test driver for the terminal tests. A spec carrying `group = [addr, …]`
+    /// parses as a transparent group over those addrs; anything else is a leaf
+    /// that executes (and so reaches the interactive wrapper). A leaf carrying
+    /// `fail = true` returns a [`ProcessFailed`] over a real log file, so the
+    /// recorded failure's log tail can be asserted.
+    struct TerminalDriver {
+        runs: SArc<AtomicUsize>,
+        shell_runs: SArc<AtomicUsize>,
+        log_path: std::path::PathBuf,
+    }
+
+    /// Label the driver stamps on a leaf whose `run` must fail; `TargetSpec`
+    /// config is not visible from `run`, so the marker rides on the `TargetDef`.
+    const FAIL_LABEL: &str = "terminal-test:fail";
+
+    #[async_trait]
+    impl RawDriver for TerminalDriver {
+        fn config(&self, _req: DriverConfigRequest) -> anyhow::Result<DriverConfigResponse> {
+            Ok(DriverConfigResponse {
+                name: "terminal".to_string(),
+            })
+        }
+        fn schema(&self) -> crate::engine::driver::DriverSchema {
+            crate::engine::driver::DriverSchema::default()
+        }
+        async fn parse(
+            &self,
+            req: ParseRequest,
+            _ctoken: &(dyn Cancellable + Send + Sync),
+        ) -> anyhow::Result<ParseResponse> {
+            let transparent = req.target_spec.config.contains_key("group");
+            let key = if transparent { "group" } else { "deps" };
+            let members = match req.target_spec.config.get(key) {
+                Some(hcore::htvalue::Value::List(items)) => items
+                    .iter()
+                    .map(|v| match v {
+                        hcore::htvalue::Value::String(s) => {
+                            crate::engine::driver::TargetAddr::parse(
+                                s,
+                                &req.target_spec.addr.package,
+                            )
+                        }
+                        other => anyhow::bail!("member must be a string, got {other:?}"),
+                    })
+                    .collect::<anyhow::Result<Vec<_>>>()?,
+                _ => vec![],
+            };
+            let inputs = members
+                .into_iter()
+                .enumerate()
+                .map(|(i, r#ref)| Input {
+                    r#ref,
+                    mode: crate::engine::driver::targetdef::InputMode::Standard,
+                    origin_id: format!("group:{i}"),
+                    annotations: BTreeMap::new(),
+                    hashed: true,
+                    runtime: true,
+                })
+                .collect();
+            let fails = matches!(
+                req.target_spec.config.get("fail"),
+                Some(hcore::htvalue::Value::Bool(true))
+            );
+            Ok(ParseResponse {
+                target_def: TargetDef {
+                    addr: req.target_spec.addr.clone(),
+                    labels: if fails {
+                        vec![FAIL_LABEL.to_string()]
+                    } else {
+                        vec![]
+                    },
+                    raw_def: SArc::new(()),
+                    inputs,
+                    outputs: if transparent {
+                        vec![]
+                    } else {
+                        vec![Output {
+                            group: "main".to_string(),
+                            paths: vec![],
+                        }]
+                    },
+                    support_files: vec![],
+                    cache: if transparent {
+                        CacheConfig::off()
+                    } else {
+                        CacheConfig::on(false)
+                    },
+                    pty: false,
+                    hash: req.target_spec.addr.format().into_bytes(),
+                    transparent,
+                },
+            })
+        }
+        async fn apply_transitive(
+            &self,
+            req: ApplyTransitiveRequest,
+            _ctoken: &(dyn Cancellable + Send + Sync),
+        ) -> anyhow::Result<ApplyTransitiveResponse> {
+            Ok(ApplyTransitiveResponse {
+                target_def: req.target_def,
+            })
+        }
+        async fn run<'a, 'io>(
+            &self,
+            req: RunRequest<'a, 'io>,
+            _ctoken: &(dyn Cancellable + Send + Sync),
+        ) -> anyhow::Result<RunResponse> {
+            self.runs.fetch_add(1, Ordering::SeqCst);
+            if req.target.labels.iter().any(|l| l == FAIL_LABEL) {
+                return Err(anyhow::Error::new(crate::engine::error::ProcessFailed {
+                    status: "exit status: 1".to_string(),
+                    log: SArc::new(hcore::hartifactcontent::FileContent::new(&self.log_path)),
+                })
+                .context("driver run"));
+            }
+            Ok(RunResponse {
+                artifacts: vec![outputartifact::OutputArtifact {
+                    group: "main".to_string(),
+                    name: "out".to_string(),
+                    r#type: outputartifact::Type::Output,
+                    content: outputartifact::Content::Raw(outputartifact::ContentRaw {
+                        data: b"hi".to_vec(),
+                        path: "out".to_string(),
+                        x: false,
+                    }),
+                    hashout: "feedface".to_string(),
+                }],
+                sandbox_cleanup: None,
+                sandbox_guards: vec![],
+            })
+        }
+        async fn run_shell<'a, 'io>(
+            &self,
+            _req: RunRequest<'a, 'io>,
+            _ctoken: &(dyn Cancellable + Send + Sync),
+        ) -> anyhow::Result<RunResponse> {
+            self.shell_runs.fetch_add(1, Ordering::SeqCst);
+            Ok(RunResponse {
+                artifacts: vec![],
+                sandbox_cleanup: None,
+                sandbox_guards: vec![],
+            })
+        }
+    }
+
+    /// Provider serving a fixed set of `TargetSpec`s. Listable, so the batch
+    /// (matcher) path can be driven through it as well as `result_addr`.
+    struct SpecsProvider {
+        targets: Vec<TargetSpec>,
+    }
+
+    impl crate::engine::provider::Provider for SpecsProvider {
+        fn config(&self, _req: ConfigRequest) -> anyhow::Result<ConfigResponse> {
+            Ok(ConfigResponse {
+                name: "specs".to_string(),
+            })
+        }
+        fn list<'a>(
+            &'a self,
+            req: ListRequest,
+            _ctoken: &'a (dyn Cancellable + Send + Sync),
+        ) -> BoxFuture<
+            'a,
+            anyhow::Result<Box<dyn Iterator<Item = anyhow::Result<ListResponse>> + Send>>,
+        > {
+            let items: Vec<anyhow::Result<ListResponse>> = self
+                .targets
+                .iter()
+                .filter(|t| t.addr.package == req.package)
+                .map(|t| {
+                    Ok(ListResponse {
+                        addr: t.addr.clone(),
+                    })
+                })
+                .collect();
+            Box::pin(async move {
+                Ok(Box::new(items.into_iter()) as Box<dyn Iterator<Item = _> + Send>)
+            })
+        }
+        fn list_packages<'a>(
+            &'a self,
+            _req: ListPackagesRequest,
+            _ctoken: &'a (dyn Cancellable + Send + Sync),
+        ) -> BoxFuture<
+            'a,
+            anyhow::Result<Box<dyn Iterator<Item = anyhow::Result<ListPackageResponse>> + Send>>,
+        > {
+            let mut pkgs: Vec<PkgBuf> = Vec::new();
+            for t in &self.targets {
+                if !pkgs.contains(&t.addr.package) {
+                    pkgs.push(t.addr.package.clone());
+                }
+            }
+            let items: Vec<anyhow::Result<ListPackageResponse>> = pkgs
+                .into_iter()
+                .map(|pkg| Ok(ListPackageResponse { pkg }))
+                .collect();
+            Box::pin(async move {
+                Ok(Box::new(items.into_iter()) as Box<dyn Iterator<Item = _> + Send>)
+            })
+        }
+        fn get<'a>(
+            &'a self,
+            req: GetRequest,
+            _ctoken: &'a (dyn Cancellable + Send + Sync),
+        ) -> BoxFuture<'a, Result<GetResponse, GetError>> {
+            let found = self.targets.iter().find(|t| t.addr == req.addr).cloned();
+            Box::pin(async move {
+                match found {
+                    Some(target_spec) => Ok(GetResponse { target_spec }),
+                    None => Err(GetError::NotFound),
+                }
+            })
+        }
+        fn probe<'a>(
+            &'a self,
+            _req: ProbeRequest,
+            _ctoken: &'a (dyn Cancellable + Send + Sync),
+        ) -> BoxFuture<'a, anyhow::Result<ProbeResponse>> {
+            Box::pin(async { Ok(ProbeResponse { states: vec![] }) })
+        }
+    }
+
+    /// A transparent group over `members`.
+    fn group_spec(addr: &str, members: &[&str]) -> anyhow::Result<TargetSpec> {
+        Ok(TargetSpec {
+            addr: hmodel::htaddr::parse_addr(addr)?,
+            driver: "terminal".to_string(),
+            config: HashMap::from([(
+                "group".to_string(),
+                hcore::htvalue::Value::List(
+                    members
+                        .iter()
+                        .map(|m| hcore::htvalue::Value::String((*m).to_string()))
+                        .collect(),
+                ),
+            )]),
+            ..Default::default()
+        })
+    }
+
+    /// An executable leaf; `fail` makes its `run` return a `ProcessFailed`.
+    fn leaf_spec(addr: &str, fail: bool) -> anyhow::Result<TargetSpec> {
+        let mut config = HashMap::new();
+        if fail {
+            config.insert("fail".to_string(), hcore::htvalue::Value::Bool(true));
+        }
+        Ok(TargetSpec {
+            addr: hmodel::htaddr::parse_addr(addr)?,
+            driver: "terminal".to_string(),
+            config,
+            ..Default::default()
+        })
+    }
+
+    /// An executable leaf with real (non-group) dependencies — the path
+    /// `inputs_result_exec` resolves with `ResultOptions::default()`.
+    fn leaf_with_deps_spec(addr: &str, deps: &[&str]) -> anyhow::Result<TargetSpec> {
+        Ok(TargetSpec {
+            addr: hmodel::htaddr::parse_addr(addr)?,
+            driver: "terminal".to_string(),
+            config: HashMap::from([(
+                "deps".to_string(),
+                hcore::htvalue::Value::List(
+                    deps.iter()
+                        .map(|d| hcore::htvalue::Value::String((*d).to_string()))
+                        .collect(),
+                ),
+            )]),
+            ..Default::default()
+        })
+    }
+
+    struct TerminalHarness {
+        engine: Arc<Engine>,
+        probe: SArc<TerminalProbe>,
+        runs: SArc<AtomicUsize>,
+        shell_runs: SArc<AtomicUsize>,
+        _root: tempfile::TempDir,
+        _logs: tempfile::TempDir,
+    }
+
+    /// Engine wired to [`TerminalDriver`] + [`SpecsProvider`], with a 12-line
+    /// process log on disk for the failing-leaf case.
+    fn terminal_harness(targets: Vec<TargetSpec>) -> anyhow::Result<TerminalHarness> {
+        let root = tempdir()?;
+        let logs = tempdir()?;
+        let log_path = logs.path().join("log.txt");
+        std::fs::write(
+            &log_path,
+            (1..=12).map(|i| format!("line{i}\n")).collect::<String>(),
+        )?;
+
+        let runs = SArc::new(AtomicUsize::new(0));
+        let shell_runs = SArc::new(AtomicUsize::new(0));
+        let mut engine = Engine::new(Config {
+            root: root.path().to_path_buf(),
+            home_dir: std::path::PathBuf::new(),
+            // Enough workers that concurrent members are genuinely concurrent —
+            // otherwise the execute semaphore would serialize them and hide the
+            // shared-terminal overlap this suite is looking for.
+            parallelism: Some(4),
+            ..Default::default()
+        })?;
+        engine.register_driver(enclose!((runs, shell_runs, log_path) move |_| {
+            Box::new(TerminalDriver {
+                runs,
+                shell_runs,
+                log_path,
+            })
+        }))?;
+        engine.register_provider(move |_| Box::new(SpecsProvider { targets }))?;
+        Ok(TerminalHarness {
+            engine: Arc::new(engine),
+            probe: SArc::new(TerminalProbe::default()),
+            runs,
+            shell_runs,
+            _root: root,
+            _logs: logs,
+        })
+    }
+
+    impl TerminalHarness {
+        fn opts(&self, shell: bool) -> ResultOptions {
+            ResultOptions {
+                shell,
+                interactive: Some(probe_wrapper(SArc::clone(&self.probe))),
+                ..Default::default()
+            }
+        }
+    }
+
+    /// Reproduction for the shared-tty bug: a group with two uncached members
+    /// used to propagate `interactive` to both, so both built a `TtyReader` on
+    /// fd 0, both paused/resumed the TUI, and whichever finished first restored
+    /// blocking mode on the fd its sibling was still reading. No member may get
+    /// the terminal — and in particular two of them may never hold it at once.
+    #[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+    async fn multi_member_group_forwards_the_terminal_to_no_member() -> anyhow::Result<()> {
+        let h = terminal_harness(vec![
+            group_spec("//pkg:g", &["//pkg:a", "//pkg:b"])?,
+            leaf_spec("//pkg:a", false)?,
+            leaf_spec("//pkg:b", false)?,
+        ])?;
+        let rs = h.engine.new_state();
+        let addr = hmodel::htaddr::parse_addr("//pkg:g")?;
+
+        Arc::clone(&h.engine)
+            .result_addr(rs, &addr, OutputMatcher::All, &h.opts(false))
+            .await?;
+
+        assert_eq!(
+            h.runs.load(Ordering::SeqCst),
+            2,
+            "both members must still execute",
+        );
+        assert_eq!(
+            h.probe.max_live.load(Ordering::SeqCst),
+            0,
+            "no group member may own the terminal",
+        );
+        assert_eq!(
+            h.probe.calls.load(Ordering::SeqCst),
+            0,
+            "the interactive wrapper must not reach any group member",
+        );
+        Ok(())
+    }
+
+    /// The rule is "exactly one target that executes", not "groups are never
+    /// interactive": a group used as an alias is its member, at any nesting
+    /// depth. `//pkg:g0` → `//pkg:g1` → `//pkg:a` must hand the terminal to
+    /// `//pkg:a` exactly once.
+    #[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+    async fn single_member_group_forwards_the_terminal_through_nesting() -> anyhow::Result<()> {
+        let h = terminal_harness(vec![
+            group_spec("//pkg:g0", &["//pkg:g1"])?,
+            group_spec("//pkg:g1", &["//pkg:a"])?,
+            leaf_spec("//pkg:a", false)?,
+        ])?;
+        let rs = h.engine.new_state();
+        let addr = hmodel::htaddr::parse_addr("//pkg:g0")?;
+
+        Arc::clone(&h.engine)
+            .result_addr(rs, &addr, OutputMatcher::All, &h.opts(false))
+            .await?;
+
+        assert_eq!(
+            h.probe.calls.load(Ordering::SeqCst),
+            1,
+            "a nested single-member group is its member: it keeps the terminal",
+        );
+        assert_eq!(
+            h.probe.max_live.load(Ordering::SeqCst),
+            1,
+            "…and exactly one holder at a time",
+        );
+        Ok(())
+    }
+
+    /// `--shell` on a group that is not a single target is refused at the group
+    /// frame, with a message naming the group, its members, and the command to
+    /// run instead. Previously the member frames bailed with "cannot use --shell
+    /// in non-interactive mode", which is false — the user *is* on a terminal.
+    #[tokio::test]
+    async fn shell_on_multi_member_group_names_the_members() -> anyhow::Result<()> {
+        let h = terminal_harness(vec![
+            group_spec("//pkg:g", &["//pkg:a", "//pkg:b"])?,
+            leaf_spec("//pkg:a", false)?,
+            leaf_spec("//pkg:b", false)?,
+        ])?;
+        let rs = h.engine.new_state();
+        let addr = hmodel::htaddr::parse_addr("//pkg:g")?;
+
+        let err = Arc::clone(&h.engine)
+            .result_addr(rs, &addr, OutputMatcher::All, &h.opts(true))
+            .await
+            .err()
+            .expect("--shell on a multi-member group must fail");
+        let msg = format!("{err:#}");
+        assert!(
+            msg.contains("--shell needs exactly one target"),
+            "msg: {msg}"
+        );
+        assert!(
+            msg.contains("//pkg:g is a group with 2 members"),
+            "msg: {msg}"
+        );
+        assert!(msg.contains("members: //pkg:a, //pkg:b"), "msg: {msg}");
+        assert!(msg.contains("try: heph run --shell //pkg:a"), "msg: {msg}");
+        assert_eq!(
+            h.probe.calls.load(Ordering::SeqCst),
+            0,
+            "no member may be entered once --shell is refused",
+        );
+        Ok(())
+    }
+
+    /// …and `--shell` on a single-member group shells into that member, because
+    /// an alias *is* its target.
+    #[tokio::test]
+    async fn shell_on_single_member_group_shells_into_the_member() -> anyhow::Result<()> {
+        let h = terminal_harness(vec![
+            group_spec("//pkg:g", &["//pkg:a"])?,
+            leaf_spec("//pkg:a", false)?,
+        ])?;
+        let rs = h.engine.new_state();
+        let addr = hmodel::htaddr::parse_addr("//pkg:g")?;
+
+        Arc::clone(&h.engine)
+            .result_addr(rs, &addr, OutputMatcher::All, &h.opts(true))
+            .await?;
+
+        assert_eq!(
+            h.shell_runs.load(Ordering::SeqCst),
+            1,
+            "the single member must be shelled into",
+        );
+        assert_eq!(
+            h.probe.calls.load(Ordering::SeqCst),
+            1,
+            "…through the interactive wrapper, exactly once",
+        );
+        Ok(())
+    }
+
+    /// `classify_failure` drops the captured log tail for interactive targets on
+    /// the grounds that their output already streamed to the terminal. A group
+    /// member never streamed anything, so while `interactive` was propagated to
+    /// members a failing one lost its log tail — `heph run //pkg:group` gave
+    /// *worse* diagnostics than `heph run //...`. Not forwarding the terminal
+    /// restores it.
+    #[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+    async fn failing_member_of_multi_member_group_keeps_its_log_tail() -> anyhow::Result<()> {
+        let h = terminal_harness(vec![
+            group_spec("//pkg:g", &["//pkg:a", "//pkg:b"])?,
+            leaf_spec("//pkg:a", true)?,
+            leaf_spec("//pkg:b", false)?,
+        ])?;
+        let rs = h.engine.new_state();
+        let addr = hmodel::htaddr::parse_addr("//pkg:g")?;
+        let failing = hmodel::htaddr::parse_addr("//pkg:a")?;
+
+        Arc::clone(&h.engine)
+            .result_addr(rs.clone(), &addr, OutputMatcher::All, &h.opts(false))
+            .await
+            .err()
+            .expect("a failing member must fail the group");
+
+        let recorded = rs.get_failure(&failing).expect("failure must be recorded");
+        let tail = recorded
+            .log_tail
+            .as_ref()
+            .expect("a non-interactive member keeps its process log tail");
+        assert!(tail.text.contains("line12"), "tail: {}", tail.text);
+        Ok(())
+    }
+
+    /// The general rule the transparent-group gate is an instance of:
+    /// dependencies never inherit the terminal.
+    ///
+    /// Characterization rather than a mutation-provable assertion —
+    /// deps are built by `meta` while computing the parent's `hashin`, and
+    /// `meta` is memoized per addr with no `opts` in scope, so there is no line
+    /// to flip. (Verified: deliberately handing the wrapper to
+    /// `inputs_result_exec` changes nothing, because by then every dep is
+    /// already a memoizer hit.) The test guards against a future refactor that
+    /// threads the caller's options into either path.
+    #[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+    async fn deps_never_inherit_the_terminal() -> anyhow::Result<()> {
+        let h = terminal_harness(vec![
+            leaf_with_deps_spec("//pkg:root", &["//pkg:a", "//pkg:b"])?,
+            leaf_spec("//pkg:a", false)?,
+            leaf_spec("//pkg:b", false)?,
+        ])?;
+        let rs = h.engine.new_state();
+        let addr = hmodel::htaddr::parse_addr("//pkg:root")?;
+
+        Arc::clone(&h.engine)
+            .result_addr(rs, &addr, OutputMatcher::All, &h.opts(false))
+            .await?;
+
+        assert_eq!(h.runs.load(Ordering::SeqCst), 3, "root plus both deps run");
+        assert_eq!(
+            h.probe.calls.load(Ordering::SeqCst),
+            1,
+            "only the requested target may own the terminal",
+        );
+        assert_eq!(h.probe.max_live.load(Ordering::SeqCst), 1);
+        Ok(())
+    }
+
+    /// Third leg: a batch (matcher) request is many targets, so none of them
+    /// gets the terminal — `Engine::result` clears `interactive` up front.
+    #[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+    async fn batch_matcher_forwards_the_terminal_to_nobody() -> anyhow::Result<()> {
+        let h = terminal_harness(vec![
+            leaf_spec("//pkg:a", false)?,
+            leaf_spec("//pkg:b", false)?,
+        ])?;
+        let rs = h.engine.new_state();
+        let matcher = Matcher::Package(PkgBuf::from("pkg"));
+
+        Arc::clone(&h.engine)
+            .result(rs, &matcher, OutputMatcher::All, &h.opts(false))
+            .await?;
+
+        assert_eq!(h.runs.load(Ordering::SeqCst), 2, "both targets must run");
+        assert_eq!(
+            h.probe.calls.load(Ordering::SeqCst),
+            0,
+            "a multi-target selection gives the terminal to nobody",
+        );
+        Ok(())
+    }
+
+    /// The composition the commit claims to handle "at any nesting depth": the
+    /// terminal is forwarded through a single-member group and then dropped by
+    /// the multi-member group beneath it. This is the only path where the
+    /// `take()` runs on a wrapper that was actually forwarded.
+    #[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+    async fn multi_member_group_under_single_member_group_drops_the_terminal() -> anyhow::Result<()>
+    {
+        let h = terminal_harness(vec![
+            group_spec("//pkg:g0", &["//pkg:g1"])?,
+            group_spec("//pkg:g1", &["//pkg:a", "//pkg:b"])?,
+            leaf_spec("//pkg:a", false)?,
+            leaf_spec("//pkg:b", false)?,
+        ])?;
+        let rs = h.engine.new_state();
+        let addr = hmodel::htaddr::parse_addr("//pkg:g0")?;
+
+        Arc::clone(&h.engine)
+            .result_addr(rs, &addr, OutputMatcher::All, &h.opts(false))
+            .await?;
+
+        assert_eq!(h.runs.load(Ordering::SeqCst), 2, "both members must run");
+        assert_eq!(
+            h.probe.calls.load(Ordering::SeqCst),
+            0,
+            "the forwarded terminal must be dropped at the multi-member frame",
+        );
+        Ok(())
+    }
+
+    /// A group listing the same member twice (different output filters) is
+    /// still one executing target: both entries share the addr-keyed
+    /// `mem_locked_result` / `mem_execute_cache` cells, so there is exactly one
+    /// execute and exactly one terminal holder. Counting input *entries* rather
+    /// than distinct members would drop the terminal here and print "a group
+    /// with 2 members: //pkg:a, //pkg:a".
+    #[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+    async fn group_listing_one_member_twice_is_still_a_single_target() -> anyhow::Result<()> {
+        let h = terminal_harness(vec![
+            group_spec("//pkg:g", &["//pkg:a", "//pkg:a"])?,
+            leaf_spec("//pkg:a", false)?,
+        ])?;
+        let rs = h.engine.new_state();
+        let addr = hmodel::htaddr::parse_addr("//pkg:g")?;
+
+        Arc::clone(&h.engine)
+            .result_addr(rs, &addr, OutputMatcher::All, &h.opts(false))
+            .await?;
+
+        assert_eq!(h.runs.load(Ordering::SeqCst), 1, "one target, one execute");
+        assert_eq!(
+            h.probe.calls.load(Ordering::SeqCst),
+            1,
+            "one distinct member is one target: it keeps the terminal",
+        );
+        Ok(())
+    }
+
+    /// An empty group is legal (`group(name = "g")` with no `deps`). It runs
+    /// nothing, so it needs no terminal — and nothing may index `inputs[0]`.
+    #[tokio::test]
+    async fn empty_group_runs_nothing_and_takes_no_terminal() -> anyhow::Result<()> {
+        let h = terminal_harness(vec![group_spec("//pkg:g", &[])?])?;
+        let rs = h.engine.new_state();
+        let addr = hmodel::htaddr::parse_addr("//pkg:g")?;
+
+        Arc::clone(&h.engine)
+            .result_addr(rs, &addr, OutputMatcher::All, &h.opts(false))
+            .await?;
+
+        assert_eq!(h.runs.load(Ordering::SeqCst), 0);
+        assert_eq!(h.probe.calls.load(Ordering::SeqCst), 0);
+        Ok(())
+    }
+
+    /// …and `--shell` on it still says something actionable, even with no
+    /// member to name.
+    #[tokio::test]
+    async fn shell_on_empty_group_reports_zero_members() -> anyhow::Result<()> {
+        let h = terminal_harness(vec![group_spec("//pkg:g", &[])?])?;
+        let rs = h.engine.new_state();
+        let addr = hmodel::htaddr::parse_addr("//pkg:g")?;
+
+        let err = Arc::clone(&h.engine)
+            .result_addr(rs, &addr, OutputMatcher::All, &h.opts(true))
+            .await
+            .err()
+            .expect("--shell on an empty group must fail");
+        let msg = format!("{err:#}");
+        assert!(msg.contains("is a group with 0 members"), "msg: {msg}");
+        assert!(msg.contains("the group is empty"), "msg: {msg}");
+        assert!(
+            msg.contains("try: heph run --shell"),
+            "an actionable message must still name an action: {msg}",
+        );
+        Ok(())
+    }
+
+    /// `--shell` on a group nested inside a single-member group is the *same*
+    /// user error as at the top, and must render the same way. It is a property
+    /// of the request, not a target failure: `classify_failure` propagates it
+    /// unchanged, so no failure is recorded and the CLI does not print a
+    /// failed-target box for a group that never executed.
+    #[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+    async fn shell_error_from_a_nested_group_is_not_recorded_as_a_target_failure()
+    -> anyhow::Result<()> {
+        let h = terminal_harness(vec![
+            group_spec("//pkg:g0", &["//pkg:g1"])?,
+            group_spec("//pkg:g1", &["//pkg:a", "//pkg:b"])?,
+            leaf_spec("//pkg:a", false)?,
+            leaf_spec("//pkg:b", false)?,
+        ])?;
+        let rs = h.engine.new_state();
+        let addr = hmodel::htaddr::parse_addr("//pkg:g0")?;
+
+        let err = Arc::clone(&h.engine)
+            .result_addr(rs.clone(), &addr, OutputMatcher::All, &h.opts(true))
+            .await
+            .err()
+            .expect("--shell on a nested multi-member group must fail");
+        assert!(
+            downcast_chain_ref::<ShellNeedsSingleTarget>(&err).is_some(),
+            "the request-shape error must survive the nesting: {err:#}",
+        );
+        assert!(
+            msg_names_group(&err, "//pkg:g1"),
+            "the message must name the group that is not a single target: {err:#}",
+        );
+        assert!(
+            rs.take_failures().is_empty(),
+            "a request-shape error is nobody's target failure",
+        );
+        Ok(())
+    }
+
+    fn msg_names_group(err: &anyhow::Error, addr: &str) -> bool {
+        format!("{err:#}").contains(addr)
+    }
+
+    /// `--shell` with a multi-target selection is refused once, naming the
+    /// selection — not once per matched target with "cannot use --shell in
+    /// non-interactive mode", which is false for a user sitting at a terminal.
+    #[tokio::test]
+    async fn shell_with_a_multi_target_selection_names_the_selection() -> anyhow::Result<()> {
+        let h = terminal_harness(vec![
+            leaf_spec("//pkg:a", false)?,
+            leaf_spec("//pkg:b", false)?,
+        ])?;
+        let rs = h.engine.new_state();
+        let matcher = Matcher::Package(PkgBuf::from("pkg"));
+
+        let err = Arc::clone(&h.engine)
+            .result(rs, &matcher, OutputMatcher::All, &h.opts(true))
+            .await
+            .err()
+            .expect("--shell on a selection must fail");
+        let msg = format!("{err:#}");
+        assert!(
+            msg.contains("--shell needs exactly one target"),
+            "msg: {msg}"
+        );
+        assert!(msg.contains("selects many"), "msg: {msg}");
+        assert!(
+            !msg.contains("non-interactive mode"),
+            "the user is on a terminal; do not claim otherwise: {msg}",
+        );
+        assert_eq!(
+            h.runs.load(Ordering::SeqCst),
+            0,
+            "nothing may run once --shell is refused",
+        );
+        Ok(())
+    }
+
+    /// The warm path: a single-member group whose member is already cached
+    /// executes nothing, so it takes no terminal — `probe.calls` counts
+    /// executes, and the whole suite rests on that. `--shell` still shells in,
+    /// because the shell path is never served from cache.
+    #[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+    async fn cached_single_member_group_takes_no_terminal_but_still_shells() -> anyhow::Result<()> {
+        let h = terminal_harness(vec![
+            group_spec("//pkg:g", &["//pkg:a"])?,
+            leaf_spec("//pkg:a", false)?,
+        ])?;
+        let addr = hmodel::htaddr::parse_addr("//pkg:g")?;
+
+        // Cold: executes, and takes the terminal.
+        let rs = h.engine.new_state();
+        Arc::clone(&h.engine)
+            .result_addr(rs, &addr, OutputMatcher::All, &h.opts(false))
+            .await?;
+        assert_eq!(h.runs.load(Ordering::SeqCst), 1);
+        assert_eq!(h.probe.calls.load(Ordering::SeqCst), 1);
+
+        // Warm: cache hit, nothing executes, nothing needs the terminal.
+        let rs = h.engine.new_state();
+        Arc::clone(&h.engine)
+            .result_addr(rs, &addr, OutputMatcher::All, &h.opts(false))
+            .await?;
+        assert_eq!(
+            h.runs.load(Ordering::SeqCst),
+            1,
+            "warm run must not execute"
+        );
+        assert_eq!(
+            h.probe.calls.load(Ordering::SeqCst),
+            1,
+            "a cache hit needs no terminal",
+        );
+
+        // …but `--shell` is never a cache hit.
+        let rs = h.engine.new_state();
+        Arc::clone(&h.engine)
+            .result_addr(rs, &addr, OutputMatcher::All, &h.opts(true))
+            .await?;
+        assert_eq!(
+            h.shell_runs.load(Ordering::SeqCst),
+            1,
+            "--shell on a cached alias still shells into the member",
+        );
+        assert_eq!(h.probe.calls.load(Ordering::SeqCst), 2);
         Ok(())
     }
 }

--- a/crates/plugin/src/error.rs
+++ b/crates/plugin/src/error.rs
@@ -65,6 +65,77 @@ impl fmt::Display for HashUnknownError {
 
 impl std::error::Error for HashUnknownError {}
 
+/// How many group members the `--shell` diagnostic lists before eliding.
+const SHELL_MEMBERS_SHOWN: usize = 5;
+
+/// `--shell` was asked for on something that does not resolve to a single
+/// executing target — a multi-target selection, or a transparent group that is
+/// not an alias for one target.
+///
+/// A property of the *request*, not a failure of any target: nothing ran, and
+/// nothing was going to. So `classify_failure` propagates it unchanged rather
+/// than recording it against whichever frame happened to raise it — a nested
+/// group would otherwise render the same user error as a failed-target box for
+/// a group that never executed.
+///
+/// The fields stay structured so a caller can render or serialize them; the
+/// `Display` is the human-facing form and always names the next command to run,
+/// so the message is recoverable on its own by a human or an agent.
+#[derive(Debug, Clone)]
+pub enum ShellNeedsSingleTarget {
+    /// A query or label/package matcher that selects more than one target.
+    Selection {
+        /// The selection as the user wrote it.
+        query: String,
+    },
+    /// A transparent group whose inputs are not exactly one distinct member.
+    Group {
+        addr: Addr,
+        /// The group's distinct members, in declaration order.
+        members: Vec<Addr>,
+    },
+}
+
+impl fmt::Display for ShellNeedsSingleTarget {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.write_str("--shell needs exactly one target; ")?;
+        match self {
+            Self::Selection { query } => write!(
+                f,
+                "{query} selects many\n  try: heph run --shell //pkg:name with one address"
+            ),
+            Self::Group { addr, members } => {
+                write!(
+                    f,
+                    "{} is a group with {} members",
+                    addr.format(),
+                    members.len()
+                )?;
+                let Some(first) = members.first() else {
+                    return f.write_str(
+                        "\n  the group is empty — there is nothing to shell into\
+                         \n  try: heph run --shell //pkg:name with a target address",
+                    );
+                };
+                f.write_str("\n  members: ")?;
+                for (i, member) in members.iter().take(SHELL_MEMBERS_SHOWN).enumerate() {
+                    if i > 0 {
+                        f.write_str(", ")?;
+                    }
+                    f.write_str(&member.format())?;
+                }
+                let rest = members.len().saturating_sub(SHELL_MEMBERS_SHOWN);
+                if rest > 0 {
+                    write!(f, " … and {rest} more")?;
+                }
+                write!(f, "\n  try: heph run --shell {}", first.format())
+            }
+        }
+    }
+}
+
+impl std::error::Error for ShellNeedsSingleTarget {}
+
 #[derive(Debug, Clone)]
 pub struct CycleError {
     pub from: Addr,

--- a/src/commands/run.rs
+++ b/src/commands/run.rs
@@ -70,6 +70,13 @@ pub struct RunArgs {
     #[arg(long = "force")]
     pub force: bool,
     /// Drop into an interactive shell in the target's sandbox instead of running it
+    ///
+    /// The terminal goes to the single target you name, never to its
+    /// dependencies. A group of exactly one member *is* that member, so it can
+    /// be shelled into; a group of two or more inlines its members as
+    /// dependencies of the run, and dependencies are not interactive. Shell
+    /// into the member you want instead. Likewise for a multi-target selection,
+    /// which names no single target at all.
     #[arg(long = "shell", num_args = 0..=1, require_equals = true, default_missing_value = "", value_name = "TARGET",)]
     pub shell: Option<String>,
     /// Print output artifacts to stdout


### PR DESCRIPTION
## The bug

`heph run <addr>` on a terminal hands the target a real stdin: the wrapper in `src/commands/run.rs` pauses the TUI, builds a `TtyReader` on fd 0, and runs the target attached to it. `TtyReader` documents that only one may exist at a time, and the TUI pause it depends on is a plain `bool`, not a refcount.

The transparent-group fan-out in `result_addr_impl` propagated `opts.interactive` to **every** member (only `--shell` cleared it). So `heph run //pkg:group` with ≥2 uncached members built a `TtyReader` per member on the same fd. The first to finish resumed the TUI — re-enabling raw mode, restarting the crossterm `EventStream`, clearing Ctrl-C suppression — underneath its still-running siblings, and `TtyReader::drop` restored blocking mode on fd 0 while a sibling was still driving it through `AsyncFd`, leaving a blocking `read(0)` on a tokio worker that the request's cancellation token cannot reach.

`multi_member_group_forwards_the_terminal_to_no_member` reproduces it: with the fix reverted, the wrapper's concurrency high-water mark is **2**.

## Not a new rule

Dependencies have never been interactive. The terminal goes to the single target the user named, never to something the engine pulled in on its behalf.

A transparent group of two or more members is exactly that case: inlining is an implementation detail, and what the members *are* is the run's dependencies. The group gate added here and the `ResultOptions::default()` that dependency resolution already uses are **one principle enforced at two points**, not two rules that happen to agree.

A group of one is a *name*, not a fan-out — there is nothing to call a dependency — so it hands the terminal straight through and `heph run //:dev` keeps behaving like running its one member, at any nesting depth. That is why the gate is "one distinct member", not "not a group".

The third enforcement point is `Engine::result`, which clears `interactive` for any non-`Addr` matcher: a selection names no single target to give the terminal to. Together the three guarantee at most one live terminal wrapper per request. **Each now has a regression test; before this PR only the matcher leg existed and none was covered.**

Deliberately **not** refcounting the pause: that makes two writers on one fd deterministic rather than absent.

## Behavior changes

- A group with ≥2 members runs its members as the dependencies they are: no stdin (reads see EOF, per `pluginexec`'s `StdioSpec::Null`) and no live stdout/stderr, with each member's output in its sandbox `log.txt`, surfaced on failure and kept as an artifact. Same as any other dependency.
- `heph run --shell //pkg:alias` now **works**. It previously failed: the group branch cleared `interactive` while keeping `shell`, and the member frame then hit the "cannot use --shell in non-interactive mode" guard.
- `--shell` on a group that is not a single target, and `--shell` on a multi-target selection, are both refused by a new typed `ShellNeedsSingleTarget` naming what was asked for and the exact command to run instead. Both previously produced "cannot use --shell in non-interactive mode" — actively misleading, since the user *is* on a terminal. The selection form is now refused once, up front, instead of once per matched target.
- That error is a property of the request, not a target failure, so `classify_failure` propagates it unchanged (like `CycleError`/`HashUnknownError`), including out of a `MultiError` aggregation. Without it, `--shell` on a group nested inside a single-member group recorded the user's own input error as the outer group's failure and printed a failed-target box for a group that never executed.
- The gate counts **distinct member addrs**, not input entries: a group listing one member twice under different output filters is still one executing target (both entries share the addr-keyed `mem_locked_result`/`mem_execute_cache` cells), so it keeps the terminal instead of being told it is "a group with 2 members: //pkg:a, //pkg:a".
- An empty group is legal; `--shell` on it now says so and still names an action.
- A failing member of a multi-member group keeps its process log tail. `classify_failure` drops the tail for interactive targets on the grounds their output already streamed; a group member never streamed anything, so propagating `interactive` had been silently making `heph run //pkg:group` diagnose **worse** than `heph run //...`.

## Diagnosability

The drop is a `debug!` (`addr`, `members`, `reason`) — not an `info!` or a warning. Nothing surprising happened: dependencies have never been interactive, so there is no expectation to correct, only a "why didn't I get a prompt?" to answer under `-v`. The `--shell` refusals are self-explaining, and `heph run --help` states the rule next to `--shell`.

## Verification

13 new tests (19 targeted pass), in-crate fake driver/provider harness, no subprocesses, ~1s total. `cargo fmt --check` and the CI clippy invocation clean.

**Mutation-verified red** — the group gate (concurrency high-water 2), the matcher leg, the `--shell` selection refusal, the `classify_failure` pass-through, and the distinct-member counting each fail with their fix reverted.

One honest gap: the dependency leg is not mutation-provable. `meta` builds deps while computing the parent's `hashin` and has no `opts` in scope at all, so deliberately handing the wrapper to `inputs_result_exec` changes nothing — every dep is already a memoizer hit by then. `deps_never_inherit_the_terminal` guards a future refactor rather than a flippable line, and the comment says so.

## Review board

- **`product-vision`: SHIP WITH CHANGES** — asked for the single-member carve-out over an unconditional clear, deleting the `--shell` special case in favour of one rule, the reworded `--shell` error, a `debug!` rather than a user-visible warning, and the log-tail regression test. All five are in.
- **`code-quality`: PASS WITH NITS** — traced the invariant closed, no soundness bug. Its MAJOR (dropping the wrapper drops stdout/stderr, not just stdin) was escalated to the user, who confirmed the behavior on the dependency framing above. Its `classify_failure`-bypass, entry-vs-target-counting and empty-group-message findings are fixed.
- **`feature-quality`: PASS WITH FOLLOW-UPS** — judged the fix correct, cheap and correctly placed, and cleared the 50 ms probe sleep as flake-free (`probe.calls` is 0-or-1 by construction; the sleep only sharpens `max_live`). Its four coverage MAJORs are closed.

## Noted, not fixed

- **`--shell=TARGET` silently discards its value** (`run.rs`: `require_equals = true` + `default_missing_value = ""`, and `args.shell.is_some()` is the only consumer). Pre-existing, and against this repo's fail-or-fix rule — but out of scope here.
- **The one-root invariant is not type-enforced.** `run.rs` routes `Matcher::Addr` to `result_addr` and everything else to `result`; a future caller passing `Matcher::Addr` to `Engine::result` would keep `interactive` and spawn one `result_addr` per matched addr. Dormant today.

No per-platform divergence: engine control flow, no `cfg`, nothing in `tui/tty.rs` touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01A76DChMohieGMbRbnV1E7x