### PR TITLE
perf(engine): split the sandbox cleaner into reclaim and bookkeeping lanes

### DIFF
--- a/crates/engine/src/engine/request_state.rs
+++ b/crates/engine/src/engine/request_state.rs
@@ -422,7 +422,17 @@ impl Drop for DeferredTrims {
         // One job for the batch: `try_trim_after_write` is non-blocking and
         // short, and a job per target would allocate a boxed closure per
         // written revision — which is exactly what this replaces.
+        //
+        // Bookkeeping lane, never the reclaim one. This lands at request-state
+        // drop, which is exactly when the reclaim backlog is deepest — every
+        // sandbox the run finished with is still queued for `remove_dir_all`. On
+        // a shared queue the batch would sit behind all of them, so
+        // `cache.history` would only be enforced after the last 5k-50k-inode
+        // removal, and process exit (gated on `bg_pending`, which both lanes
+        // feed) would pay the rmdir drain *plus* the trim instead of the max of
+        // the two.
         crate::engine::sandbox_cleaner::enqueue(
+            crate::engine::sandbox_cleaner::Lane::Bookkeeping,
             format!("gc trim {} target(s)", trims.len()),
             Box::new(move || {
                 for (addr, trim) in trims {

--- a/crates/engine/src/engine/result.rs
+++ b/crates/engine/src/engine/result.rs
@@ -2765,7 +2765,7 @@ impl Engine {
                     // here means its `try_write` can never succeed, which is
                     // exactly how `cache.history` came to be unenforced during a
                     // run. `RequestState::defer_trim` submits it once the guards
-                    // are gone, still on the background lane and still
+                    // are gone, onto the bookkeeping lane and still
                     // fire-and-forget.
                     if out.is_ok() && !use_tmp_cache {
                         rs.defer_trim(&addr, def.target.cache.history, hashin);
@@ -6679,6 +6679,11 @@ mod tests {
         exec_count: SArc<AtomicUsize>,
         /// `(output group, artifact name)` pairs this target emits.
         outputs: SArc<Vec<(String, String)>>,
+        /// When set, `run` hands `execute_cache` a sandbox-cleanup job (the way a
+        /// real sandboxing bridge does) whose body records the name of the thread
+        /// it ran on. That name is the only direct evidence of which background
+        /// lane the rmdir was routed to.
+        cleanup_thread: Option<SArc<std::sync::OnceLock<String>>>,
     }
 
     #[async_trait]
@@ -6749,7 +6754,16 @@ mod tests {
                         hashout: "feedface".to_string(),
                     })
                     .collect(),
-                sandbox_cleanup: None,
+                sandbox_cleanup: self.cleanup_thread.clone().map(|cell| {
+                    Box::new(move || {
+                        let name = std::thread::current()
+                            .name()
+                            .unwrap_or("<unnamed>")
+                            .to_string();
+                        drop(cell.set(name));
+                        Ok(())
+                    }) as crate::engine::driver::SandboxCleanupJob
+                }),
                 sandbox_guards: vec![],
             })
         }
@@ -6834,6 +6848,26 @@ mod tests {
         exec_count: SArc<AtomicUsize>,
         outputs: Vec<(String, String)>,
     ) -> anyhow::Result<(Arc<Engine>, tempfile::TempDir, Addr)> {
+        blocking_engine_full(exec_count, outputs, "a", None, None)
+    }
+
+    /// Full form.
+    ///
+    /// `target_name` names the single target under `//pkg`. `cleanup_thread`
+    /// makes the driver hand back a sandbox-cleanup job that records the thread
+    /// it ran on. `wrap_cache` wraps the engine's `LocalCache`, which is how a
+    /// test observes the thread the post-write trim ran on.
+    fn blocking_engine_full(
+        exec_count: SArc<AtomicUsize>,
+        outputs: Vec<(String, String)>,
+        target_name: &str,
+        cleanup_thread: Option<SArc<std::sync::OnceLock<String>>>,
+        wrap_cache: Option<
+            &dyn Fn(
+                SArc<dyn crate::engine::local_cache::LocalCache>,
+            ) -> SArc<dyn crate::engine::local_cache::LocalCache>,
+        >,
+    ) -> anyhow::Result<(Arc<Engine>, tempfile::TempDir, Addr)> {
         let dir = tempdir()?;
         let mut engine = Engine::new(Config {
             root: dir.path().to_path_buf(),
@@ -6848,13 +6882,21 @@ mod tests {
             },
             ..Default::default()
         })?;
+        if let Some(wrap) = wrap_cache {
+            engine.local_cache = wrap(engine.local_cache.clone());
+        }
         engine.register_driver(|_| {
             Box::new(BlockingDriver {
                 exec_count,
                 outputs: SArc::new(outputs),
+                cleanup_thread,
             })
         })?;
-        let addr = Addr::new(PkgBuf::from("pkg"), "a".to_string(), Default::default());
+        let addr = Addr::new(
+            PkgBuf::from("pkg"),
+            target_name.to_string(),
+            Default::default(),
+        );
         let spec = TargetSpec {
             addr: addr.clone(),
             driver: "blocking".to_string(),
@@ -6862,6 +6904,137 @@ mod tests {
         };
         engine.register_provider(move |_| Box::new(OneTargetProvider { spec }))?;
         Ok((Arc::new(engine), dir, addr))
+    }
+
+    /// P6.2: each background job class must reach its own lane.
+    ///
+    /// The two `Lane::` literals — the sandbox rmdir in `execute_cache`'s
+    /// `defer!` and the batched post-write trim in `DeferredTrims::drop` — are the
+    /// whole of the routing decision, and every other lane test drives `enqueue`
+    /// with a lane the test itself supplies. Swap those two literals and the lanes
+    /// invert while the rest of the suite stays green.
+    ///
+    /// Asserted on the *thread each job actually ran on*, not on the argument
+    /// passed to `enqueue`, so a `sender()` that ignored its lane would fail here
+    /// too. `Thread::name` reports the requested name on every supported target
+    /// (Linux's 16-byte `PR_SET_NAME` truncation affects `/proc`, not this).
+    #[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+    async fn each_background_job_class_runs_on_its_own_lane() {
+        use crate::engine::local_cache::{Existence, LocalCache, SizedReader, TargetStream};
+
+        /// Records the thread of the first `list_target_entries` call. In this
+        /// test that call can only come from `try_trim_after_write`, which starts
+        /// with an unlocked revision count — so it is reached whether or not the
+        /// trim goes on to take the write lock.
+        struct TrimThreadCache {
+            inner: SArc<dyn LocalCache>,
+            thread: SArc<std::sync::OnceLock<String>>,
+        }
+        impl LocalCache for TrimThreadCache {
+            fn reader(&self, addr: &Addr, hashin: &str, name: &str) -> anyhow::Result<SizedReader> {
+                self.inner.reader(addr, hashin, name)
+            }
+            fn writer(
+                &self,
+                addr: &Addr,
+                hashin: &str,
+                name: &str,
+            ) -> anyhow::Result<Box<dyn std::io::Write>> {
+                self.inner.writer(addr, hashin, name)
+            }
+            fn exists(&self, addr: &Addr, hashin: &str, name: &str) -> anyhow::Result<bool> {
+                self.inner.exists(addr, hashin, name)
+            }
+            fn existence(
+                &self,
+                addr: &Addr,
+                hashin: &str,
+                name: &str,
+            ) -> anyhow::Result<Existence> {
+                self.inner.existence(addr, hashin, name)
+            }
+            fn delete(&self, addr: &Addr, hashin: &str, name: &str) -> anyhow::Result<()> {
+                self.inner.delete(addr, hashin, name)
+            }
+            fn list_targets(&self) -> anyhow::Result<TargetStream> {
+                self.inner.list_targets()
+            }
+            fn list_target_entries(&self, addr: &Addr) -> anyhow::Result<Vec<String>> {
+                drop(
+                    self.thread.set(
+                        std::thread::current()
+                            .name()
+                            .unwrap_or("<unnamed>")
+                            .to_string(),
+                    ),
+                );
+                self.inner.list_target_entries(addr)
+            }
+            fn seekable_reader(
+                &self,
+                addr: &Addr,
+                hashin: &str,
+                name: &str,
+            ) -> anyhow::Result<Option<Box<dyn hcore::hartifactcontent::ReadSeek + Send>>>
+            {
+                self.inner.seekable_reader(addr, hashin, name)
+            }
+        }
+
+        let exec_count = SArc::new(AtomicUsize::new(0));
+        let rmdir_thread: SArc<std::sync::OnceLock<String>> = SArc::new(std::sync::OnceLock::new());
+        let trim_thread: SArc<std::sync::OnceLock<String>> = SArc::new(std::sync::OnceLock::new());
+        let wrap_trim = SArc::clone(&trim_thread);
+        let (engine, _dir, addr) = blocking_engine_full(
+            SArc::clone(&exec_count),
+            vec![("main".to_string(), "out".to_string())],
+            "p62_lane_routing",
+            Some(SArc::clone(&rmdir_thread)),
+            Some(&|inner| {
+                SArc::new(TrimThreadCache {
+                    inner,
+                    thread: SArc::clone(&wrap_trim),
+                })
+            }),
+        )
+        .expect("engine");
+
+        let rs = engine.new_state();
+        engine
+            .clone()
+            .result_addr(
+                rs.clone(),
+                &addr,
+                OutputMatcher::All,
+                &ResultOptions::default(),
+            )
+            .await
+            .expect("cold build resolves");
+        assert_eq!(exec_count.load(Ordering::SeqCst), 1, "target executed once");
+
+        // The trim is only *submitted* when the request state drops, so it cannot
+        // have run yet. This is the deferral the lane split has to compose with —
+        // if it ever regresses to running inline, the assertion below would be
+        // measuring the calling thread instead of a lane.
+        assert!(
+            trim_thread.get().is_none(),
+            "post-write trim must not run before the request state drops"
+        );
+
+        // Releases the request, which submits the trim batch, then waits for both
+        // lanes to drain through the counter they share.
+        drain_bg(rs).await;
+
+        assert_eq!(
+            rmdir_thread.get().map(String::as_str),
+            Some("heph-sandbox-cleaner"),
+            "the sandbox rmdir must run on the reclaim lane"
+        );
+        assert_eq!(
+            trim_thread.get().map(String::as_str),
+            Some("heph-cache-gc"),
+            "the batched post-write cache.history trim must run on the bookkeeping lane"
+        );
     }
 
     #[tokio::test(flavor = "multi_thread", worker_threads = 4)]
@@ -7156,6 +7329,7 @@ mod tests {
                     Box::new(BlockingDriver {
                         exec_count,
                         outputs: SArc::new(vec![("main".to_string(), "out".to_string())]),
+                        cleanup_thread: None,
                     })
                 }
             ))

--- a/crates/engine/src/engine/sandbox_cleaner.rs
+++ b/crates/engine/src/engine/sandbox_cleaner.rs
@@ -1,7 +1,7 @@
-//! Fire-and-forget sandbox cleanup on a dedicated OS thread.
+//! Fire-and-forget background cleanup on dedicated OS threads.
 //!
-//! Posting to the queue is a non-blocking `crossbeam_channel::send`. A
-//! single long-lived worker thread drains the queue and runs each job
+//! Posting to a queue is a non-blocking `crossbeam_channel::send`. A
+//! long-lived worker thread drains that queue and runs each job
 //! inline. No tokio waker is involved (avoids the macOS cross-thread
 //! waker bug — see `RCA_MACOS_WAKER.md`), and no tokio runtime worker
 //! is parked for the cleanup (avoids the `block_in_place` concurrency
@@ -12,9 +12,49 @@
 //! rms its upper-side dir directly (bypassing the live mount); the OS
 //! bridge rms the plain sandbox dir. The cleaner doesn't branch.
 //!
+//! ## Two lanes, one job class each
+//!
+//! There are two classes of background job and they must not share a
+//! queue. [`Lane::Reclaim`] is disk reclamation — a `remove_dir_all` of
+//! 5k–50k inodes for a finished Go sandbox, one job per executed target —
+//! and it is what keeps a build from running the disk out from under
+//! itself. [`Lane::Bookkeeping`] is cache housekeeping: today exactly one
+//! job, the batched post-write `cache.history` trim that
+//! `RequestStateData`'s drop submits, dominated by sqlite round-trips and
+//! reclaiming comparatively little per target.
+//!
+//! What makes them incompatible on one queue is *when* the bookkeeping job
+//! arrives. It is submitted at request-state drop — precisely the moment
+//! the reclaim backlog is deepest, since every sandbox the run finished
+//! with is still queued for removal. On a shared FIFO the trim batch lands
+//! behind all of them, so `cache.history` is only enforced after the last
+//! 5k–50k-inode removal completes, and process exit — gated on
+//! `bg_pending`, which both lanes feed — pays the rmdir drain *plus* the
+//! trim rather than the max of the two. Separate threads make the two
+//! costs concurrent, and keep a stalled sqlite round-trip from costing
+//! anything but bookkeeping latency.
+//!
+//! The split also keeps the classes separated structurally. Before the
+//! deferred-trim work the trim was enqueued *per target, mid-run, ahead of
+//! that same target's rmdir* (the rmdir rides a `defer!` firing at the end
+//! of the same scope), which put every removal behind a sqlite wait exactly
+//! when execution peaked. That specific shape is gone, but nothing except
+//! this lane boundary stops the next per-target bookkeeping job from
+//! recreating it.
+//!
+//! Lanes stay dedicated OS threads rather than moving onto
+//! `hcore::blocking`: that pool is sized for *bounded* jobs and already
+//! carries the cache writes (tar/gzip/borsh), so queued sqlite waits
+//! would contend with the very work they are bookkeeping for. Neither lane
+//! may move onto a tokio runtime — see the waker note above.
+//!
 //! Ordering: callers must invoke `enqueue` only *after* any read of the
-//! sandbox completes (per `project_sandbox_cleanup_ordering.md`). Within
-//! the queue, jobs are processed in FIFO order on one thread.
+//! sandbox completes (per `project_sandbox_cleanup_ordering.md`). Within a
+//! lane, jobs run in FIFO order on that lane's one thread. There is no
+//! ordering guarantee *between* lanes — that is the point.
+//!
+//! Both lanes decrement the same per-request `bg_pending` counter, so the
+//! shutdown path that blocks on it drains both.
 use crossbeam_channel::{Sender, unbounded};
 use std::panic::{AssertUnwindSafe, catch_unwind};
 use std::path::PathBuf;
@@ -52,44 +92,19 @@ pub type PendingCounter = Arc<AtomicUsize>;
 /// decrement when it completes.
 type Job = (String, SandboxCleanupJob, PendingCounter);
 
-static CLEANER: OnceLock<Sender<Job>> = OnceLock::new();
-
-fn sender() -> &'static Sender<Job> {
-    CLEANER.get_or_init(|| {
-        let (tx, rx) = unbounded::<Job>();
-        thread::Builder::new()
-            .name("heph-sandbox-cleaner".into())
-            .spawn(move || {
-                for (label, job, pending) in rx.iter() {
-                    // catch_unwind so a panicking job doesn't kill the
-                    // long-lived cleaner thread and silently drop every
-                    // subsequent cleanup for the process lifetime.
-                    let outcome = catch_unwind(AssertUnwindSafe(job));
-                    // Decrement after the job runs (not on dequeue) so the
-                    // counter only hits zero once the work is genuinely done.
-                    pending.fetch_sub(1, Ordering::AcqRel);
-                    match outcome {
-                        Ok(Ok(())) => (),
-                        Ok(Err(err)) if err.kind() == io::ErrorKind::NotFound => (),
-                        Ok(Err(err)) => {
-                            tracing::error!(
-                                error = %err,
-                                label = %label,
-                                "failed to clean up sandbox",
-                            );
-                        }
-                        Err(_) => {
-                            tracing::error!(
-                                label = %label,
-                                "sandbox cleanup job panicked",
-                            );
-                        }
-                    }
-                }
-            })
-            .expect("spawn sandbox-cleaner thread");
-        tx
-    })
+/// Which worker thread a job runs on.
+///
+/// The two classes have very different cost profiles and one must never be able
+/// to queue behind the other; see the module docs for why. Every job picks its
+/// lane explicitly so a third class cannot be added by accident.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum Lane {
+    /// Disk reclamation — `remove_dir_all` of a finished sandbox. Latency here
+    /// is the build's peak disk footprint and its post-build serial tail.
+    Reclaim,
+    /// Cache bookkeeping — the post-write GC trim. Blocks on sqlite; reclaims
+    /// little. Delaying it is cheap, so it never shares a queue with `Reclaim`.
+    Bookkeeping,
 }
 
 /// Per-sandbox-path generations, serializing destructive jobs against the
@@ -332,6 +347,7 @@ impl SandboxTeardown {
         self.armed = false;
         if let Some(job) = self.job.take() {
             enqueue(
+                Lane::Reclaim,
                 label,
                 generation::guarded(self.dir.clone(), self.generation, job),
                 Arc::clone(&self.pending),
@@ -361,6 +377,7 @@ impl Drop for SandboxTeardown {
         let (dir, generation) = (self.dir.clone(), self.generation);
         let label = format!("reclaim {}", dir.display());
         enqueue(
+            Lane::Reclaim,
             label,
             Box::new(move || generation::remove_stale(&dir, generation)),
             Arc::clone(&self.pending),
@@ -368,11 +385,101 @@ impl Drop for SandboxTeardown {
     }
 }
 
-/// Enqueue a cleanup job for asynchronous execution. `label` is used only for
-/// log lines emitted if the job fails. `pending` is the request's in-flight
-/// counter, bumped here and dropped back by the cleaner once the job has run.
-/// Non-blocking.
-pub fn enqueue(label: String, job: SandboxCleanupJob, pending: PendingCounter) {
+impl Lane {
+    /// This lane's queue.
+    ///
+    /// One `OnceLock` per lane rather than one for both: a lane is only spawned
+    /// when something is actually enqueued onto it (a run with no cacheable
+    /// target never starts the bookkeeping thread), and a spawn failure on one
+    /// lane cannot take the other's already-created sender down with it.
+    fn cell(self) -> &'static OnceLock<Sender<Job>> {
+        static RECLAIM: OnceLock<Sender<Job>> = OnceLock::new();
+        static BOOKKEEPING: OnceLock<Sender<Job>> = OnceLock::new();
+        match self {
+            Lane::Reclaim => &RECLAIM,
+            Lane::Bookkeeping => &BOOKKEEPING,
+        }
+    }
+
+    /// The OS thread name this lane's worker carries.
+    ///
+    /// The reclaim lane keeps the historical name — it is what
+    /// `RCA_MACOS_WAKER.md` refers to and what shows up in existing stack dumps.
+    /// It is 20 bytes, so Linux's 16-byte `PR_SET_NAME` limit has always
+    /// truncated it to `heph-sandbox-cl` in `/proc/*/comm`, `gdb` and `perf`;
+    /// `heph-cache-gc` fits. Rust's own `Thread::name` reports the full string on
+    /// every target either way.
+    fn thread_name(self) -> &'static str {
+        match self {
+            Lane::Reclaim => "heph-sandbox-cleaner",
+            Lane::Bookkeeping => "heph-cache-gc",
+        }
+    }
+}
+
+/// Spawn one lane's worker thread and return its queue.
+fn spawn_lane(lane: Lane) -> io::Result<Sender<Job>> {
+    let name = lane.thread_name();
+    let (tx, rx) = unbounded::<Job>();
+    thread::Builder::new()
+        .name(name.into())
+        .spawn(move || {
+            for (label, job, pending) in rx.iter() {
+                // catch_unwind so a panicking job doesn't kill the
+                // long-lived cleaner thread and silently drop every
+                // subsequent cleanup for the process lifetime.
+                let outcome = catch_unwind(AssertUnwindSafe(job));
+                // Decrement after the job runs (not on dequeue) so the
+                // counter only hits zero once the work is genuinely done.
+                pending.fetch_sub(1, Ordering::AcqRel);
+                match outcome {
+                    Ok(Ok(())) => (),
+                    Ok(Err(err)) if err.kind() == io::ErrorKind::NotFound => (),
+                    // `?lane` here and in `enqueue`, never the thread name: one
+                    // `lane` field with one value space, or a log query for
+                    // `lane=Reclaim` silently misses every failure line.
+                    Ok(Err(err)) => {
+                        tracing::error!(
+                            error = %err,
+                            label = %label,
+                            ?lane,
+                            "background cleanup job failed",
+                        );
+                    }
+                    Err(_) => {
+                        tracing::error!(
+                            label = %label,
+                            ?lane,
+                            "background cleanup job panicked",
+                        );
+                    }
+                }
+            }
+        })
+        // Name the lane in the error: `sender` resolves both lanes through one
+        // expression, so the panic location alone doesn't say which one failed.
+        .map_err(|e| io::Error::new(e.kind(), format!("spawn {name} thread: {e}")))?;
+    Ok(tx)
+}
+
+fn sender(lane: Lane) -> &'static Sender<Job> {
+    // Same stance as `hcore::blocking`: a process that cannot spawn its worker
+    // threads has nothing to fall back to.
+    lane.cell()
+        .get_or_init(|| spawn_lane(lane).expect("spawn background cleanup lane"))
+}
+
+/// Enqueue a cleanup job onto `lane` for asynchronous execution. `label` is used
+/// only for log lines emitted if the job fails. `pending` is the request's
+/// in-flight counter, bumped here and dropped back by the lane's worker once the
+/// job has run — both lanes share one counter, so a shutdown blocking on it
+/// drains both. Non-blocking.
+pub fn enqueue(lane: Lane, label: String, job: SandboxCleanupJob, pending: PendingCounter) {
+    // Resolve the queue *before* counting: `sender` spawns the lane's thread on
+    // first use and panics if that fails. Bumping first would leave `bg_pending`
+    // permanently above zero, and the shutdown path only breaks when it reaches
+    // zero — a failed spawn would hang the run instead of ending it.
+    let tx = sender(lane);
     // Count before sending so the counter can never observe an enqueued job as
     // already drained. The worker decrements once the job has run.
     //
@@ -385,16 +492,16 @@ pub fn enqueue(label: String, job: SandboxCleanupJob, pending: PendingCounter) {
     // then turn a silent leak into a process that never exits. A slot exists
     // only for work already in this queue.
     pending.fetch_add(1, Ordering::AcqRel);
-    if let Err(err) = sender().send((label, job, Arc::clone(&pending))) {
+    if let Err(err) = tx.send((label, job, Arc::clone(&pending))) {
         pending.fetch_sub(1, Ordering::AcqRel);
-        tracing::error!(error = %err, "sandbox cleaner channel closed");
+        tracing::error!(error = %err, ?lane, "background cleanup lane closed");
     }
 }
 
 #[cfg(test)]
 mod tests {
     use super::*;
-    use std::sync::Arc;
+    use std::sync::Mutex;
     use std::sync::atomic::{AtomicBool, Ordering};
     use std::time::{Duration, Instant};
 
@@ -413,22 +520,59 @@ mod tests {
         Arc::new(AtomicUsize::new(0))
     }
 
+    /// Opens a gate on drop, so a failing assertion cannot leave a lane's worker
+    /// thread parked for the rest of the test binary.
+    struct OpenOnDrop(Arc<AtomicBool>);
+
+    impl Drop for OpenOnDrop {
+        fn drop(&mut self) {
+            self.0.store(true, Ordering::SeqCst);
+        }
+    }
+
+    /// A job that occupies its lane's thread until `gate` opens, raising
+    /// `started` as soon as it is genuinely running rather than merely queued.
+    fn gated_job(started: Arc<AtomicBool>, gate: Arc<AtomicBool>) -> SandboxCleanupJob {
+        Box::new(move || {
+            started.store(true, Ordering::SeqCst);
+            while !gate.load(Ordering::SeqCst) {
+                std::thread::sleep(Duration::from_millis(2));
+            }
+            Ok(())
+        })
+    }
+
+    const ALL_LANES: [Lane; 2] = [Lane::Reclaim, Lane::Bookkeeping];
+
+    /// The lane threads are process-global, so a test that deliberately parks one
+    /// would make any *other* test waiting on that lane look like a lane-split
+    /// failure. Every test that parks a lane holds this first, so at most one
+    /// does at a time.
+    static PARKED: Mutex<()> = Mutex::new(());
+
+    fn park_lock() -> std::sync::MutexGuard<'static, ()> {
+        PARKED.lock().unwrap_or_else(|e| e.into_inner())
+    }
+
     #[test]
-    fn enqueue_runs_job_on_cleaner_thread() {
-        let ran = Arc::new(AtomicBool::new(false));
-        let ran_clone = Arc::clone(&ran);
-        enqueue(
-            "enqueue_runs_job_on_cleaner_thread".to_string(),
-            Box::new(move || {
-                ran_clone.store(true, Ordering::SeqCst);
-                Ok(())
-            }),
-            counter(),
-        );
-        assert!(
-            wait_for(&ran, Duration::from_secs(2)),
-            "job did not run within 2s"
-        );
+    fn enqueue_runs_job_on_every_lane() {
+        for lane in ALL_LANES {
+            let ran = Arc::new(AtomicBool::new(false));
+            let ran_clone = Arc::clone(&ran);
+            enqueue(
+                lane,
+                format!("enqueue_runs_job_on_every_lane {lane:?}"),
+                Box::new(move || {
+                    ran_clone.store(true, Ordering::SeqCst);
+                    Ok(())
+                }),
+                counter(),
+            );
+            assert!(
+                wait_for(&ran, Duration::from_secs(5)),
+                "job did not run on {lane:?}"
+            );
+        }
     }
 
     #[test]
@@ -442,6 +586,7 @@ mod tests {
         let done = Arc::new(AtomicBool::new(false));
         let done_clone = Arc::clone(&done);
         enqueue(
+            Lane::Reclaim,
             "enqueue_removes_tempdir_via_closure".to_string(),
             Box::new(move || {
                 let res = std::fs::remove_dir_all(&target_for_job);
@@ -451,8 +596,8 @@ mod tests {
             counter(),
         );
         assert!(
-            wait_for(&done, Duration::from_secs(2)),
-            "job did not run within 2s"
+            wait_for(&done, Duration::from_secs(5)),
+            "job did not run within 5s"
         );
         assert!(!target.exists(), "cleanup closure did not remove target");
     }
@@ -460,49 +605,48 @@ mod tests {
     #[test]
     fn enqueue_swallows_notfound() {
         // No assertion on log output (tracing is global); the
-        // important behavior is that the cleaner thread doesn't die
+        // important behavior is that a lane's worker thread doesn't die
         // when a job returns NotFound. We follow up with another job
         // that must run on the same thread.
-        enqueue(
-            "enqueue_swallows_notfound_first".to_string(),
-            Box::new(|| Err(io::Error::from(io::ErrorKind::NotFound))),
-            counter(),
-        );
-        let ran = Arc::new(AtomicBool::new(false));
-        let ran_clone = Arc::clone(&ran);
-        enqueue(
-            "enqueue_swallows_notfound_followup".to_string(),
-            Box::new(move || {
-                ran_clone.store(true, Ordering::SeqCst);
-                Ok(())
-            }),
-            counter(),
-        );
-        assert!(
-            wait_for(&ran, Duration::from_secs(2)),
-            "cleaner thread stopped processing after NotFound"
-        );
+        for lane in ALL_LANES {
+            enqueue(
+                lane,
+                format!("enqueue_swallows_notfound_first {lane:?}"),
+                Box::new(|| Err(io::Error::from(io::ErrorKind::NotFound))),
+                counter(),
+            );
+            let ran = Arc::new(AtomicBool::new(false));
+            let ran_clone = Arc::clone(&ran);
+            enqueue(
+                lane,
+                format!("enqueue_swallows_notfound_followup {lane:?}"),
+                Box::new(move || {
+                    ran_clone.store(true, Ordering::SeqCst);
+                    Ok(())
+                }),
+                counter(),
+            );
+            assert!(
+                wait_for(&ran, Duration::from_secs(5)),
+                "{lane:?} stopped processing after NotFound"
+            );
+        }
     }
 
     #[test]
     fn pending_counter_drains_to_zero_after_job_runs() {
         // A blocked job holds the request counter at 1 until released, then drops
-        // it back to 0 once the cleaner finishes it. This is the signal the
+        // it back to 0 once the lane finishes it. This is the signal the
         // shutdown path waits on to keep the TUI/process alive during drain.
+        let _parked = park_lock();
         let pending = counter();
         let gate = Arc::new(AtomicBool::new(false));
-        let gate_job = Arc::clone(&gate);
-        let done = Arc::new(AtomicBool::new(false));
-        let done_job = Arc::clone(&done);
+        let _release = OpenOnDrop(Arc::clone(&gate));
+        let started = Arc::new(AtomicBool::new(false));
         enqueue(
+            Lane::Reclaim,
             "pending_counter_drains_to_zero_after_job_runs".to_string(),
-            Box::new(move || {
-                while !gate_job.load(Ordering::SeqCst) {
-                    std::thread::sleep(Duration::from_millis(2));
-                }
-                done_job.store(true, Ordering::SeqCst);
-                Ok(())
-            }),
+            gated_job(Arc::clone(&started), Arc::clone(&gate)),
             Arc::clone(&pending),
         );
         assert_eq!(
@@ -511,11 +655,120 @@ mod tests {
             "counter must rise while job is in flight"
         );
         gate.store(true, Ordering::SeqCst);
-        assert!(wait_for(&done, Duration::from_secs(2)), "job did not run");
+        assert!(
+            wait_for(&started, Duration::from_secs(5)),
+            "job did not run"
+        );
         // Spin until the worker's post-job decrement lands.
-        let deadline = Instant::now() + Duration::from_secs(2);
+        let deadline = Instant::now() + Duration::from_secs(5);
         while pending.load(Ordering::Acquire) > 0 {
             assert!(Instant::now() < deadline, "counter did not drain to zero");
+            std::thread::sleep(Duration::from_millis(2));
+        }
+    }
+
+    /// P6.2: neither lane may be gated by the other, in either direction.
+    ///
+    /// The direction that matters in production is a blocked bookkeeping job
+    /// delaying a reclaim: it mirrors the execute path's real ordering — the
+    /// post-write GC trim is enqueued first, because the sandbox rmdir rides a
+    /// `defer!` that only fires at the end of the same scope — and the trim blocks
+    /// on a sqlite round-trip. With both classes on one FIFO thread the rmdir
+    /// cannot start until that round-trip returns; with a lane per class it runs
+    /// immediately. The mirror direction is asserted too so a future collapse onto
+    /// *either* single queue is caught.
+    #[test]
+    fn a_blocked_lane_does_not_delay_the_other() {
+        for (blocked, observed) in [
+            (Lane::Bookkeeping, Lane::Reclaim),
+            (Lane::Reclaim, Lane::Bookkeeping),
+        ] {
+            let _parked = park_lock();
+            let gate = Arc::new(AtomicBool::new(false));
+            // Opens the gate even if an assertion below unwinds, so a failing run
+            // does not wedge a lane for the rest of the test binary.
+            let _release = OpenOnDrop(Arc::clone(&gate));
+
+            let started = Arc::new(AtomicBool::new(false));
+            enqueue(
+                blocked,
+                format!("a_blocked_lane_does_not_delay_the_other/blocked {blocked:?}"),
+                gated_job(Arc::clone(&started), Arc::clone(&gate)),
+                counter(),
+            );
+            // Only enqueue onto the observed lane once the blocked job genuinely
+            // owns a worker thread. Otherwise a shared queue could drain the second
+            // job first by luck and the test would pass against a single queue.
+            assert!(
+                wait_for(&started, Duration::from_secs(5)),
+                "{blocked:?} job never started"
+            );
+
+            let ran = Arc::new(AtomicBool::new(false));
+            let ran_job = Arc::clone(&ran);
+            enqueue(
+                observed,
+                format!("a_blocked_lane_does_not_delay_the_other/observed {observed:?}"),
+                Box::new(move || {
+                    ran_job.store(true, Ordering::SeqCst);
+                    Ok(())
+                }),
+                counter(),
+            );
+            // Generous on purpose. On a genuinely shared queue `ran` can never
+            // fire until `_release` drops, so this budget bounds only the failing
+            // case; it costs nothing when passing. A tight budget would instead
+            // turn ordinary CI load — the lanes are process-global and every other
+            // test in this binary feeds them — into a "the lanes share a queue"
+            // verdict that sends the reader to the wrong file.
+            assert!(
+                wait_for(&ran, Duration::from_secs(30)),
+                "{observed:?} did not run while {blocked:?} was parked — the lanes share a queue"
+            );
+        }
+    }
+
+    /// Shutdown blocks until `bg_pending` reaches zero. Splitting the lanes must
+    /// not let a job on either one escape that counter, or the process can exit
+    /// out from under an in-progress rmdir or trim.
+    #[test]
+    fn both_lanes_drain_the_same_pending_counter() {
+        let _parked = park_lock();
+        let pending = counter();
+        let gate = Arc::new(AtomicBool::new(false));
+        let _release = OpenOnDrop(Arc::clone(&gate));
+
+        let started = ALL_LANES.map(|lane| {
+            let started = Arc::new(AtomicBool::new(false));
+            enqueue(
+                lane,
+                format!("both_lanes_drain_the_same_pending_counter {lane:?}"),
+                gated_job(Arc::clone(&started), Arc::clone(&gate)),
+                Arc::clone(&pending),
+            );
+            started
+        });
+        // Both jobs must genuinely be running, not merely queued, or "in flight"
+        // below would be an assertion about the enqueue side alone.
+        for (lane, started) in ALL_LANES.iter().zip(&started) {
+            assert!(
+                wait_for(started, Duration::from_secs(30)),
+                "{lane:?} job never started"
+            );
+        }
+        assert_eq!(
+            pending.load(Ordering::Acquire),
+            ALL_LANES.len(),
+            "every lane must count into the request's single bg_pending"
+        );
+
+        gate.store(true, Ordering::SeqCst);
+        let deadline = Instant::now() + Duration::from_secs(5);
+        while pending.load(Ordering::Acquire) > 0 {
+            assert!(
+                Instant::now() < deadline,
+                "bg_pending did not drain: shutdown would exit before cleanup finished"
+            );
             std::thread::sleep(Duration::from_millis(2));
         }
     }
@@ -903,33 +1156,37 @@ mod tests {
 
     #[test]
     fn enqueue_survives_panicking_job() {
-        // Same shape as the NotFound case: panic shouldn't kill the
+        // Same shape as the NotFound case: a panic shouldn't kill a lane's
         // thread; subsequent jobs still run.
-        let pending = counter();
-        enqueue(
-            "enqueue_survives_panicking_job_panicker".to_string(),
-            Box::new(|| panic!("boom")),
-            Arc::clone(&pending),
-        );
-        let ran = Arc::new(AtomicBool::new(false));
-        let ran_clone = Arc::clone(&ran);
-        enqueue(
-            "enqueue_survives_panicking_job_followup".to_string(),
-            Box::new(move || {
-                ran_clone.store(true, Ordering::SeqCst);
-                Ok(())
-            }),
-            Arc::clone(&pending),
-        );
-        assert!(
-            wait_for(&ran, Duration::from_secs(2)),
-            "cleaner thread stopped processing after panic"
-        );
-        // A panicking job must still decrement the counter (catch_unwind path).
-        let deadline = Instant::now() + Duration::from_secs(2);
-        while pending.load(Ordering::Acquire) > 0 {
-            assert!(Instant::now() < deadline, "counter leaked after panic");
-            std::thread::sleep(Duration::from_millis(2));
+        for lane in ALL_LANES {
+            let pending = counter();
+            enqueue(
+                lane,
+                format!("enqueue_survives_panicking_job_panicker {lane:?}"),
+                Box::new(|| panic!("boom")),
+                Arc::clone(&pending),
+            );
+            let ran = Arc::new(AtomicBool::new(false));
+            let ran_clone = Arc::clone(&ran);
+            enqueue(
+                lane,
+                format!("enqueue_survives_panicking_job_followup {lane:?}"),
+                Box::new(move || {
+                    ran_clone.store(true, Ordering::SeqCst);
+                    Ok(())
+                }),
+                Arc::clone(&pending),
+            );
+            assert!(
+                wait_for(&ran, Duration::from_secs(5)),
+                "{lane:?} stopped processing after panic"
+            );
+            // A panicking job must still decrement the counter (catch_unwind path).
+            let deadline = Instant::now() + Duration::from_secs(5);
+            while pending.load(Ordering::Acquire) > 0 {
+                assert!(Instant::now() < deadline, "counter leaked after panic");
+                std::thread::sleep(Duration::from_millis(2));
+            }
         }
     }
 }


### PR DESCRIPTION
**Plan item P6.2.** Rebased onto `dfc4e5cc`. Two upstream changes reshaped this PR and are called out below: **#222** (deferred trims) invalidated the original problem statement, and **#242** (sandbox teardown surviving cancellation) moved the reclaim enqueue sites into `SandboxTeardown`.

## Problem

One `heph-sandbox-cleaner` thread drained a single unbounded FIFO carrying two classes of background job with very different cost profiles:

- **`Lane::Reclaim`** — `remove_dir_all` of a finished sandbox, 5k–50k inodes for a Go target, **one job per executed target**. This is what keeps a large build from running the disk out from under itself. It covers both of `SandboxTeardown`'s enqueueing exits: the bridge job from `complete`, and the generation-guarded reclaim from `Drop`.
- **`Lane::Bookkeeping`** — cache housekeeping. Today exactly one job: the batched post-write `cache.history` trim that `RequestStateData`'s drop submits, dominated by sqlite round-trips.

What makes them incompatible on one queue is **when the bookkeeping job arrives**. It is submitted at request-state drop — precisely the moment the reclaim backlog is deepest, since every sandbox the run finished with is still queued for removal. On a shared FIFO the trim batch lands behind all of them, so:

- `cache.history` is only enforced after the last 5k–50k-inode removal completes, and
- process exit — gated on `bg_pending`, which both lanes feed — pays `rmdir_drain + trim` instead of `max(rmdir_drain, trim)`.

## What #222 changed, and why the original P6.2 rationale no longer holds

The plan filed P6.2 describing the trim as enqueued **per target, mid-run, ahead of that same target's rmdir** (the rmdir rides a `defer!` firing at the end of the same scope), which put every removal behind a sqlite wait exactly when execution peaked. That was accurate when the item was written, and I verified it in the code at the time.

**It is no longer true.** #222 moved the trim out of `execute_cache` entirely into `DeferredTrims::drop`, so nothing per-target enters the queue mid-run any more. The original pathology was fixed as a side effect of #222.

The split still earns its place, for the exit-time serialization above, and for keeping the two classes separated so the next per-target bookkeeping job cannot recreate the original shape. The module docs state this rationale rather than repeating the stale one.

## Design notes

**Why not `hcore::blocking` for the trims.** That pool is documented for *bounded* jobs and already carries the cache writes themselves (tar, gzip, borsh), so queued sqlite waits would contend with the very work they are bookkeeping for; staying fire-and-forget would also need a `tokio::spawn` plus hand-rolled `bg_pending` accounting. A second dedicated thread is one thread and keeps the existing enqueue/counter contract verbatim.

**Neither lane moves onto a tokio runtime.** The single-thread, no-waker choice here is deliberate and documented against the macOS cross-thread waker bug and the measured `block_in_place` concurrency regression; the split preserves both properties for both lanes.

**Shutdown is unchanged.** Both lanes decrement the same per-request `bg_pending`, so the exit path that blocks until it drains still waits for both — including #222's batch, which is submitted by the drop that precedes the drain loop.

**One `OnceLock` per lane**, so a lane spawns only when something is enqueued onto it (a fully warm run starts neither thread) and a spawn failure on one cannot drop the other's sender. `sender(lane)` resolves *before* `pending.fetch_add`, because `sender` panics on spawn failure and bumping first would strand `bg_pending` above zero — the shutdown path only breaks at zero, so a failed spawn would hang the run instead of ending it.

`gc.rs` is untouched: this changes which lane the trim runs on, not what it does. #242's generation gate is likewise untouched — the guarded closures it builds are routed, not rewritten.

**Re-verified against the reworked blocking pool** (#232 / #234 / #235, where `flush_backstop` now also releases still-pending registrations). `bg_pending` is a plain shared `AtomicUsize` that neither `flush_backstop` nor the `Backstop` RAII registrations touch, so the drain contract is independent of that rework — and mutation 3 below confirms it empirically rather than by argument.

## Tests — three mutations verified red after the rebase

| Mutation | Caught by | Message |
|---|---|---|
| both lanes → one sender | `a_blocked_lane_does_not_delay_the_other` | `Reclaim did not run while Bookkeeping was parked — the lanes share a queue` |
| swap the two `Lane::` literals | `each_background_job_class_runs_on_its_own_lane` | `left: Some("heph-cache-gc"), right: Some("heph-sandbox-cleaner")` |
| bookkeeping lane skips its decrement | `both_lanes_drain_the_same_pending_counter` | `bg_pending did not drain: shutdown would exit before cleanup finished` |

`each_background_job_class_runs_on_its_own_lane` drives a **real cold build** and asserts on the thread each job *actually ran on*, not the argument passed to `enqueue` — so a `sender()` that ignored its lane fails it too. The rmdir is observed through a cleanup job the test driver hands back (now flowing through `SandboxTeardown::complete`); the trim through a `LocalCache` wrapper on `list_target_entries`, which `try_trim_after_write` reaches unconditionally via its unlocked pre-count (#219). It also asserts the trim has **not** run before the request state drops — the #222 deferral this split has to compose with.

## Portability

No `cfg(target_os)` / `cfg(target_arch)` in the diff; same mechanism on all three targets. One pre-existing, observability-only difference is now documented at `Lane::thread_name`: `heph-sandbox-cleaner` is 20 bytes, so Linux's 16-byte `PR_SET_NAME` limit has always truncated it to `heph-sandbox-cl` in `/proc/*/comm`, `gdb` and `perf`; `heph-cache-gc` fits. Rust's own `Thread::name` reports the full string everywhere.

## Review board

Reviewed before the rebase, on the pre-#222 shape:

- **`feature-quality`** — BLOCKED (routing untested) → **PASS WITH FOLLOW-UPS** after a routing test, the `fetch_add`-before-`sender` fix, and the per-lane `OnceLock`. All three survive the rebase.
- **`code-quality`** — **PASS WITH NITS**. Its one MAJOR was that the split made `try_trim_after_write` reliably inert; **#222 resolves that outright**, and the `KNOWN INERT` comment written for it has been deleted rather than carried forward.

## Expected conflict

#249 (`fix(engine): retry a deferred trim that lost its lock, once`) touches the same `DeferredTrims::drop` enqueue site. Whichever of us merges first forces the other to rebase; the resolution is mechanical (keep the `Lane::Bookkeeping` first argument).

## Follow-ups (not in this PR)

- Surface both lanes' `Sender::len()` (O(1)) in the diag snapshot — reclaim queue depth is literally the count of finished sandboxes still on disk.
- Negative-path routing tests: `use_tmp_cache`, `out.is_err()`, and cancellation should each enqueue reclaim only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01A76DChMohieGMbRbnV1E7x
