### PR TITLE
fix(lock): frame the holder-pid stamp so a torn read cannot name a wrong pid

### DIFF
--- a/crates/engine/src/engine/result_lock.rs
+++ b/crates/engine/src/engine/result_lock.rs
@@ -240,29 +240,49 @@ fn inner_lock_path(dir: &Path, addr: &Addr) -> PathBuf {
 /// Writes through the gateway guard's *already-open* file description rather
 /// than re-opening the lock file by path: it drops the `open`/`close` pair (and
 /// the path resolution that comes with them) from every gateway acquire, and it
-/// makes the stamp structurally incapable of landing on a file this process
-/// does not hold.
+/// makes the stamp structurally incapable of landing on a file this process does
+/// not hold. That last part is robustness, not a bug fixed — at the instant this
+/// runs we hold the gateway exclusively and are the only party that unlinks it,
+/// so path and locked inode cannot yet diverge here. They are *allowed* to in
+/// this design (`release_write` unlinks while still holding the lock), so the
+/// stronger form is worth having before some future caller opens that window.
+///
+/// The payload is newline-framed. `write_contents` writes positionally and only
+/// then truncates, so between those two syscalls a reader in another process
+/// sees the new pid followed by the tail of a longer previous one — all digits,
+/// and therefore a perfectly parseable pid belonging to nobody. The terminator
+/// bounds the frame: a torn read yields the real pid or nothing (see
+/// [`read_pid`]).
 fn stamp_pid(gateway: Option<&FWriteGuard>) {
+    debug_assert!(
+        gateway.is_some(),
+        "pid stamp with no held gateway guard: the guard owns the gateway for \
+         its whole observable lifetime"
+    );
     let Some(gateway) = gateway else {
-        // Unreachable in practice: the guard owns the gateway for its whole
-        // observable lifetime.
         tracing::debug!("gateway guard unavailable for pid stamp");
         return;
     };
-    if let Err(err) = gateway.write_contents(std::process::id().to_string().as_bytes()) {
+    let stamp = format!("{}\n", std::process::id());
+    if let Err(err) = gateway.write_contents(stamp.as_bytes()) {
         tracing::debug!(error = %err, "stamping pid into gateway lock file");
     }
 }
 
 /// Read a pid previously stamped by the lock holder. `None` on any read/parse
-/// failure (missing file, empty, non-numeric).
+/// failure (missing file, empty, non-numeric) and on a torn read.
+///
+/// Only the bytes before the first newline are a pid: everything after it is
+/// either absent or the unreclaimed tail of a longer previous stamp (see
+/// [`stamp_pid`]). An unterminated payload is a half-visible write, never a
+/// holder — reporting a pid the user might `kill` is worse than reporting none.
 fn read_pid(path: &Path) -> Option<u32> {
     let mut s = String::new();
     std::fs::File::open(path)
         .ok()?
         .read_to_string(&mut s)
         .ok()?;
-    s.trim().parse().ok()
+    s.split_once('\n')?.0.trim().parse().ok()
 }
 
 impl std::fmt::Debug for ResultLock {
@@ -473,12 +493,91 @@ mod tests {
         drop(held);
     }
 
+    // The two live production stamp sites. `upgradable_read` above has no
+    // production caller today, so without these the whole
+    // `outer_guard()` → `stamp_pid` → `write_contents` chain would be asserted
+    // only through a path nothing but a test walks — a mis-wired guard on either
+    // live site would ship green.
+    #[tokio::test]
+    async fn fs_holder_pid_reports_the_pid_stamped_by_write() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let lock = fs(&dir);
+
+        assert_eq!(lock.holder_pid(&addr("a")), None, "no holder yet");
+
+        let held = lock.write(&addr("a"), &ct()).await.expect("write");
+        assert_eq!(lock.holder_pid(&addr("a")), Some(std::process::id()));
+
+        // Releasing the write unlinks the gateway file, so the holder is
+        // unknown again rather than stale.
+        drop(held);
+        assert_eq!(lock.holder_pid(&addr("a")), None, "unknown after release");
+    }
+
+    #[tokio::test]
+    async fn fs_holder_pid_reports_the_pid_stamped_by_try_write() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let lock = fs(&dir);
+
+        assert_eq!(lock.holder_pid(&addr("a")), None, "no holder yet");
+
+        let held = lock
+            .try_write(&addr("a"))
+            .expect("try_write ok")
+            .expect("free addr acquires");
+        assert_eq!(lock.holder_pid(&addr("a")), Some(std::process::id()));
+
+        drop(held);
+        assert_eq!(lock.holder_pid(&addr("a")), None, "unknown after release");
+    }
+
+    // `write_contents` writes positionally and truncates second, so a reader in
+    // another process can catch the gateway file mid-stamp. A killed holder
+    // leaves a 7-digit pid behind (Linux `pid_max` defaults to 4194304); the
+    // next holder stamps a 3-digit one over it, and this is what a third process
+    // sees before the truncate lands. Unframed, `4214304` parses cleanly and the
+    // TUI names a pid the user might kill.
+    #[test]
+    fn holder_pid_ignores_a_torn_stamp_rather_than_reporting_a_wrong_pid() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let lock = fs(&dir);
+        let a = addr("a");
+
+        std::fs::write(outer_lock_path(dir.path(), &a), b"421\n304\n").expect("torn stamp");
+
+        assert_eq!(
+            lock.holder_pid(&a),
+            Some(421),
+            "the framed pid, never the concatenation with the stale tail"
+        );
+    }
+
+    #[test]
+    fn holder_pid_is_unknown_for_an_unterminated_stamp() {
+        // A write only half visible has no terminator. Naming `42` while the
+        // holder is really `4211592` is worse than naming nobody.
+        let dir = tempfile::tempdir().expect("tempdir");
+        let lock = fs(&dir);
+        let a = addr("a");
+
+        std::fs::write(outer_lock_path(dir.path(), &a), b"42").expect("partial stamp");
+
+        assert_eq!(
+            lock.holder_pid(&a),
+            None,
+            "an unframed payload is not a pid"
+        );
+    }
+
     // The stamp must go through the gateway guard's open fd, never a second
     // `open` of the path. Proven by swapping a decoy inode in at the path while
     // the guard holds the original: a path-based stamp would land on the decoy.
+    // Asserted in both directions — the pid reached the held inode, and the
+    // decoy was untouched — so a `stamp_pid` that wrote nothing cannot pass.
     #[tokio::test]
     async fn stamp_pid_writes_through_the_held_fd_not_the_path() {
         use hlock::hlock::Lock;
+        use std::os::unix::fs::FileExt as _;
 
         let dir = tempfile::tempdir().expect("tempdir");
         let path = dir.path().join("gateway.lock");
@@ -488,11 +587,24 @@ mod tests {
             .await
             .expect("gateway");
 
+        // A second handle on the held inode, opened before the unlink, so what
+        // lands there stays readable once the path names a different file.
+        let held_inode = std::fs::File::open(&path).expect("reopen held inode");
         std::fs::remove_file(&path).expect("unlink held lock file");
         std::fs::write(&path, b"decoy").expect("decoy");
 
         stamp_pid(Some(&held));
 
+        let expected = format!("{}\n", std::process::id());
+        let mut buf = vec![0u8; expected.len()];
+        held_inode
+            .read_exact_at(&mut buf, 0)
+            .expect("stamp landed on the held inode");
+        assert_eq!(
+            buf,
+            expected.as_bytes(),
+            "the framed pid must land on the held inode"
+        );
         assert_eq!(
             std::fs::read(&path).expect("decoy readable"),
             b"decoy",

--- a/crates/engine/src/engine/result_lock.rs
+++ b/crates/engine/src/engine/result_lock.rs
@@ -247,12 +247,21 @@ fn inner_lock_path(dir: &Path, addr: &Addr) -> PathBuf {
 /// this design (`release_write` unlinks while still holding the lock), so the
 /// stronger form is worth having before some future caller opens that window.
 ///
-/// The payload is newline-framed. `write_contents` writes positionally and only
-/// then truncates, so between those two syscalls a reader in another process
-/// sees the new pid followed by the tail of a longer previous one — all digits,
-/// and therefore a perfectly parseable pid belonging to nobody. The terminator
-/// bounds the frame: a torn read yields the real pid or nothing (see
-/// [`read_pid`]).
+/// The payload is newline-framed, and `write_contents` empties the file before
+/// writing. Together those two make every state a concurrent reader can observe
+/// either a complete stamp or an unterminated prefix — never a *blend* that
+/// parses. Without the frame, a shorter pid written over a longer stale one left
+/// `<new><stale tail>`, all digits and perfectly parseable, naming a pid that
+/// belongs to nobody; without the truncate-first order, a partially visible
+/// write could still land inside the old frame. See [`read_pid`].
+///
+/// This bounds what a *torn* read can report. It does not make the pid fresh: a
+/// stamp outlives the process that wrote it whenever the holder is killed
+/// without running `Drop` (nothing unlinks the gateway file then), and the stamp
+/// lands only after the acquire completes, so a waiter can also read the
+/// previous holder's pid while the current one is still parked on the inner
+/// lock. Both are pre-existing and unaddressed here; a liveness check on the
+/// pid, or blanking the stamp at acquire, would be the fix.
 fn stamp_pid(gateway: Option<&FWriteGuard>) {
     debug_assert!(
         gateway.is_some(),
@@ -270,16 +279,24 @@ fn stamp_pid(gateway: Option<&FWriteGuard>) {
 }
 
 /// Read a pid previously stamped by the lock holder. `None` on any read/parse
-/// failure (missing file, empty, non-numeric) and on a torn read.
+/// failure (missing file, empty, non-numeric, not UTF-8, past `u32`) and on a
+/// torn read.
 ///
-/// Only the bytes before the first newline are a pid: everything after it is
-/// either absent or the unreclaimed tail of a longer previous stamp (see
-/// [`stamp_pid`]). An unterminated payload is a half-visible write, never a
-/// holder — reporting a pid the user might `kill` is worse than reporting none.
+/// Only the bytes before the first newline are a pid; an unterminated payload is
+/// not one. That covers a half-visible write, and also a stamp left by a binary
+/// from before the frame existed — the two are indistinguishable from here, so
+/// both read as "holder unknown". That costs a correct pid in the second case,
+/// during a rollout, on a file that is transient anyway; naming a pid the user
+/// might `kill` in the first case costs more.
+///
+/// The read is capped: the payload is a pid and a newline, while the directory
+/// it sits in could hold a stray or corrupted file of any size.
 fn read_pid(path: &Path) -> Option<u32> {
+    const MAX_STAMP: u64 = 64;
     let mut s = String::new();
     std::fs::File::open(path)
         .ok()?
+        .take(MAX_STAMP)
         .read_to_string(&mut s)
         .ok()?;
     s.split_once('\n')?.0.trim().parse().ok()
@@ -567,6 +584,36 @@ mod tests {
             None,
             "an unframed payload is not a pid"
         );
+    }
+
+    // Everything `read_pid` documents as `None`, in one place. The interesting
+    // half is that a malformed payload must not become a pid: `holder_pid` feeds
+    // a number the user may act on.
+    #[test]
+    fn read_pid_accepts_only_a_framed_pid() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let cases: &[(&[u8], Option<u32>, &str)] = &[
+            (b"", None, "fresh gateway file, not yet stamped"),
+            (b"\n", None, "frame around an empty pid"),
+            (b"abc\n", None, "non-numeric"),
+            (b"99999999999\n", None, "past u32"),
+            (&[0xff, 0xfe, b'\n'], None, "not UTF-8"),
+            (b"42", None, "unterminated: a half-visible write"),
+            (b"  42\n", Some(42), "surrounding whitespace tolerated"),
+            (
+                b"421\n304\n",
+                Some(421),
+                "torn: new pid over a longer stale tail",
+            ),
+        ];
+
+        for (i, (bytes, want, why)) in cases.iter().enumerate() {
+            let path = dir.path().join(format!("case{i}.lock"));
+            std::fs::write(&path, bytes).expect("case bytes");
+            assert_eq!(read_pid(&path), *want, "{why}");
+        }
+
+        assert_eq!(read_pid(&dir.path().join("absent.lock")), None, "no file");
     }
 
     // The stamp must go through the gateway guard's open fd, never a second

--- a/crates/lock/src/hlock/bridge.rs
+++ b/crates/lock/src/hlock/bridge.rs
@@ -81,9 +81,11 @@ impl<O: Lock, I: RWLock> TBridgeUpgradableGuard<O, I> {
     /// gateway lock itself — e.g. write through its already-open file
     /// description instead of re-opening the lock file by path.
     ///
-    /// `Some` for this guard's whole observable lifetime: the option is emptied
-    /// only by [`upgrade`](TUpgradableReadGuard::upgrade) and `drop`, both of
-    /// which consume `self`.
+    /// `Some` for this guard's whole observable lifetime. Two things empty the
+    /// option: [`upgrade`](TUpgradableReadGuard::upgrade), which consumes `self`
+    /// and hands the gateway to the write guard it returns, and `Drop`, which
+    /// takes `&mut self` but is the end of the guard — nothing can call this
+    /// accessor after it.
     pub fn outer_guard(&self) -> Option<&O::Guard> {
         self.outer_guard.as_ref()
     }
@@ -91,7 +93,9 @@ impl<O: Lock, I: RWLock> TBridgeUpgradableGuard<O, I> {
 
 impl<O: Lock, I: RWLock> TBridgeWriteGuard<O, I> {
     /// Borrow the held outer (gateway) guard. See
-    /// [`TBridgeUpgradableGuard::outer_guard`].
+    /// [`TBridgeUpgradableGuard::outer_guard`] — same invariant, with
+    /// [`downgrade`](TWriteGuard::downgrade) in place of `upgrade` as the
+    /// transition that moves the gateway on.
     pub fn outer_guard(&self) -> Option<&O::Guard> {
         self.outer_guard.as_ref()
     }
@@ -375,6 +379,47 @@ mod tests {
 
         drop(u);
         assert!(l.try_write().unwrap().is_some(), "writer after read drains");
+    }
+
+    // The gateway guard is *moved* between guard types by `upgrade` and
+    // `downgrade`, and callers reach through `outer_guard()` to write the holder
+    // pid into the gateway lock file. A transition that dropped it on the floor
+    // would turn that stamp into a permanent silent no-op with nothing failing,
+    // so pin the invariant the accessor's doc comment claims.
+    #[tokio::test]
+    async fn outer_guard_survives_every_acquire_and_transition() {
+        let l = mem_tlock();
+
+        let u = l.upgradable_read(&ct()).await.unwrap();
+        assert!(
+            u.outer_guard().is_some(),
+            "upgradable_read holds the gateway"
+        );
+        let w = u.upgrade(&ct()).await.unwrap();
+        assert!(
+            w.outer_guard().is_some(),
+            "upgrade carries the gateway over"
+        );
+        let u = w.downgrade(&ct()).await.unwrap();
+        assert!(
+            u.outer_guard().is_some(),
+            "downgrade carries the gateway back"
+        );
+        drop(u);
+
+        let w = l.write(&ct()).await.unwrap();
+        assert!(w.outer_guard().is_some(), "write holds the gateway");
+        drop(w);
+
+        let w = l.try_write().unwrap().expect("lock is free");
+        assert!(w.outer_guard().is_some(), "try_write holds the gateway");
+        drop(w);
+
+        let u = l.try_upgradable_read().unwrap().expect("lock is free");
+        assert!(
+            u.outer_guard().is_some(),
+            "try_upgradable_read holds the gateway"
+        );
     }
 
     #[tokio::test]

--- a/crates/lock/src/hlock/flock.rs
+++ b/crates/lock/src/hlock/flock.rs
@@ -194,8 +194,17 @@ impl FLockState {
 
     /// Overwrite the lock file's contents through the already-open lock fd
     /// (no second `open`). Only valid while a guard is held — the fd is open
-    /// exactly then. Truncates to `bytes.len()` so stale trailing bytes from a
-    /// prior, longer payload do not linger.
+    /// exactly then.
+    ///
+    /// **Truncate first, then write.** Both orders leave the same final bytes and
+    /// cost the same two syscalls, but they differ in what a concurrent reader in
+    /// another process can observe in between. Writing first leaves the tail of a
+    /// longer previous payload in place, so every intermediate state is a *blend*
+    /// of the new payload and the old one — and a blend can be indistinguishable
+    /// from a complete, well-formed payload. Truncating first makes every
+    /// intermediate state a strict prefix of the new payload over an empty file,
+    /// which a framed reader can always reject. See `result_lock::read_pid`, whose
+    /// whole framing argument rests on this order.
     ///
     /// Positioned (`pwrite`) rather than seek-then-write: it saves the `lseek`,
     /// and no reader of this fd depends on the offset today — `pwrite` keeps it
@@ -211,14 +220,10 @@ impl FLockState {
             .file
             .as_ref()
             .context("write_contents requires a held lock (fd open)")?;
+        f.set_len(0)
+            .with_context(|| format!("emptying lock file {}", self.path.display()))?;
         f.write_all_at(bytes, 0)
-            .with_context(|| format!("writing lock file contents {}", self.path.display()))?;
-        f.set_len(bytes.len() as u64).with_context(|| {
-            format!(
-                "truncating lock file {} to payload length",
-                self.path.display()
-            )
-        })?;
+            .with_context(|| format!("writing contents of lock file {}", self.path.display()))?;
         Ok(())
     }
 
@@ -555,8 +560,8 @@ mod tests {
         drop(g);
     }
 
-    #[tokio::test]
-    async fn write_contents_error_names_the_lock_file() {
+    #[test]
+    fn write_contents_error_names_the_lock_file() {
         // Callers reach `write_contents` holding only a guard, so they have no
         // path of their own to log. The error must carry the lock file's
         // identity or an ENOSPC/EIO with several addrs in flight cannot be
@@ -566,13 +571,15 @@ mod tests {
         std::fs::write(&path, b"x").unwrap();
 
         let state = FLockState::new(path.clone());
-        // A read-only file description fails the positioned write with EBADF,
-        // which beats filling a disk to reach the same branch.
+        // A read-only file description fails on the first syscall that mutates
+        // the file, which beats filling a disk to reach the same branch. Which
+        // of the two it is depends on their order, so the assertion pins the
+        // identity rather than the wording — both carry the path.
         state.fd.lock().file = Some(std::fs::File::open(&path).unwrap());
 
         let err = state
             .write_contents(b"42")
-            .expect_err("a read-only description cannot be written");
+            .expect_err("a read-only description cannot be modified");
         assert!(
             format!("{err}").contains(&path.display().to_string()),
             "error must name the lock file, got: {err}"

--- a/crates/lock/src/hlock/flock.rs
+++ b/crates/lock/src/hlock/flock.rs
@@ -197,9 +197,14 @@ impl FLockState {
     /// exactly then. Truncates to `bytes.len()` so stale trailing bytes from a
     /// prior, longer payload do not linger.
     ///
-    /// Positioned (`pwrite`) rather than seek-then-write: it saves the `lseek`
-    /// and leaves the fd's shared file offset alone, which matters because the
-    /// same open file description is shared by every in-process guard.
+    /// Positioned (`pwrite`) rather than seek-then-write: it saves the `lseek`,
+    /// and no reader of this fd depends on the offset today — `pwrite` keeps it
+    /// that way, since the same open file description is shared by every
+    /// in-process guard and a seek here would move it under all of them.
+    ///
+    /// Both syscalls name the lock file in their context: the caller holds only
+    /// a guard, so with several addrs in flight an `ENOSPC`/`EIO` here is
+    /// otherwise unattributable to a lock.
     fn write_contents(&self, bytes: &[u8]) -> Result<()> {
         let st = self.fd.lock();
         let f = st
@@ -207,9 +212,13 @@ impl FLockState {
             .as_ref()
             .context("write_contents requires a held lock (fd open)")?;
         f.write_all_at(bytes, 0)
-            .context("writing lock file contents")?;
-        f.set_len(bytes.len() as u64)
-            .context("truncating lock file to payload length")?;
+            .with_context(|| format!("writing lock file contents {}", self.path.display()))?;
+        f.set_len(bytes.len() as u64).with_context(|| {
+            format!(
+                "truncating lock file {} to payload length",
+                self.path.display()
+            )
+        })?;
         Ok(())
     }
 
@@ -243,6 +252,19 @@ impl FLockState {
     fn counts(&self) -> (usize, bool, bool) {
         let st = self.fd.lock();
         (st.readers, st.writer, st.file.is_some())
+    }
+
+    /// Current offset of the shared open file description. Exists so tests can
+    /// pin the invariant [`write_contents`](Self::write_contents) documents:
+    /// stamping contents must not move the offset every in-process guard shares.
+    #[cfg(test)]
+    fn stream_pos(&self) -> u64 {
+        let st = self.fd.lock();
+        let mut f = st
+            .file
+            .as_ref()
+            .expect("fd must be open to read its offset");
+        std::io::Seek::stream_position(&mut f).expect("stream_position on lock fd")
     }
 }
 
@@ -483,22 +505,78 @@ mod tests {
     async fn write_contents_targets_the_held_inode_not_the_path() {
         // The guard writes through its open file description. Proven by swapping
         // a decoy inode in at the path: a write that re-resolved the path would
-        // land on the decoy.
+        // land on the decoy. Both halves are asserted — that the bytes reached
+        // the held inode, and that the decoy was left alone — so a
+        // `write_contents` that wrote nothing at all cannot pass.
         let dir = tempfile::tempdir().expect("tempdir");
         let path = dir.path().join("lock");
         let l = FLock::new(&path);
 
         let g = l.lock(&ct()).await.unwrap();
+        // A second handle on the *held* inode, opened before the unlink, so what
+        // lands there stays readable once the path names a different file.
+        let held_inode = std::fs::File::open(&path).unwrap();
         std::fs::remove_file(&path).unwrap();
         std::fs::write(&path, b"decoy").unwrap();
 
         g.write_contents(b"held").unwrap();
+
+        let mut buf = [0u8; 4];
+        held_inode
+            .read_exact_at(&mut buf, 0)
+            .expect("payload landed on the held inode");
+        assert_eq!(&buf, b"held", "write_contents must write the held inode");
         assert_eq!(
             std::fs::read(&path).unwrap(),
             b"decoy",
             "write_contents must not re-open the lock path"
         );
         drop(g);
+    }
+
+    #[tokio::test]
+    async fn write_contents_leaves_the_shared_file_offset_untouched() {
+        // The open file description is shared by every in-process guard on this
+        // lock, so stamping contents must be positioned (`pwrite`) rather than
+        // seek-then-write: a `rewind` + `write_all` leaves the offset at the
+        // payload length, silently relocating any other guard's next read.
+        let dir = tempfile::tempdir().expect("tempdir");
+        let l = FLock::new(dir.path().join("lock"));
+
+        let g = l.lock(&ct()).await.unwrap();
+        assert_eq!(l.state.stream_pos(), 0, "a fresh fd starts at offset 0");
+
+        g.write_contents(b"42").unwrap();
+        assert_eq!(
+            l.state.stream_pos(),
+            0,
+            "write_contents must not move the shared file offset"
+        );
+        drop(g);
+    }
+
+    #[tokio::test]
+    async fn write_contents_error_names_the_lock_file() {
+        // Callers reach `write_contents` holding only a guard, so they have no
+        // path of their own to log. The error must carry the lock file's
+        // identity or an ENOSPC/EIO with several addrs in flight cannot be
+        // attributed to a lock.
+        let dir = tempfile::tempdir().expect("tempdir");
+        let path = dir.path().join("lock");
+        std::fs::write(&path, b"x").unwrap();
+
+        let state = FLockState::new(path.clone());
+        // A read-only file description fails the positioned write with EBADF,
+        // which beats filling a disk to reach the same branch.
+        state.fd.lock().file = Some(std::fs::File::open(&path).unwrap());
+
+        let err = state
+            .write_contents(b"42")
+            .expect_err("a read-only description cannot be written");
+        assert!(
+            format!("{err}").contains(&path.display().to_string()),
+            "error must name the lock file, got: {err}"
+        );
     }
 
     #[tokio::test]


### PR DESCRIPTION
Follow-up to #220, which merged before its review board ran. `feature-quality` then came back **BLOCKED** and `code-quality` **PASS WITH NITS**. This fixes the regression they found, closes the coverage gaps, and restores a diagnostic #220 dropped.

## The regression: a torn read could name a *wrong* pid

Before #220, `stamp_pid` was `std::fs::write` — `O_TRUNC` at open, then one write. A reader in another process saw either an empty file or the complete new pid, never a blend.

#220 routed the stamp through `FWriteGuard::write_contents`, which is `pwrite` and *then* `ftruncate`. Between those two syscalls the file holds `<new pid><stale tail of a longer previous pid>`. Every byte of that is a digit, so `read_pid`'s `s.trim().parse()` **succeeded** and returned a pid belonging to nobody.

Reachable, not theoretical:

1. A SIGKILLed holder leaves the gateway file un-unlinked — release runs from `Drop`, which a kill skips — carrying up to a 7-digit pid (Linux's default `pid_max` is 4194304).
2. The next holder stamps a 3-digit pid over it.
3. A third process whose wait outlives `RESULT_LOCK_NOTICE` reads the concatenation, and `ResultLockWaitStart` names it to the user — who may well `kill` it.

The *final* state was always correct, and `write_contents_persists_and_truncates_through_held_fd` kept passing. What regressed is the newly observable intermediate state.

**Fix, in two parts.** `stamp_pid` writes `<pid>\n` and `read_pid` trusts only the bytes before the first newline; and `write_contents` now empties the file *before* writing rather than truncating after. The frame alone closed only the case where the whole new payload is visible — because every stamp ends in `\n`, the stale tail always carries a terminator, so a partially visible write could still land inside the old frame (`4194304\n` + a 2-byte-visible `421\n` reads as `4294304\n`). Truncate-first makes every intermediate state a strict prefix over an empty file, and a prefix cannot carry a terminator it has not reached. Same final bytes, same two syscalls, same offset invariant.

## Coverage gaps in #220

| Gap | Now covered by | Verified red against |
|---|---|---|
| The `pwrite` change had **no test** | `write_contents_leaves_the_shared_file_offset_untouched` + `#[cfg(test)] FLockState::stream_pos` | pre-#220 `rewind`+`write_all` (offset 2, expected 0) |
| Neither **live** stamp site asserted | `fs_holder_pid_reports_the_pid_stamped_by_{write,try_write}` | deleting each `stamp_pid` call |
| `outer_guard()` had no direct test | `outer_guard_survives_every_acquire_and_transition` | nulling the guard in `downgrade` |
| Torn read | `holder_pid_ignores_a_torn_stamp_…`, `holder_pid_is_unknown_for_an_unterminated_stamp`, `read_pid_accepts_only_a_framed_pid` | unframed master form (`None` / `Some(42)`) |
| Diagnostic lost its path | `write_contents_error_names_the_lock_file` | pathless context |

Two of those deserve a note:

- **`write_contents_targets_the_held_inode_not_the_path` is green on master byte-for-byte.** Master's `write_contents` was *already* fd-based — `rewind`/`write_all` operate on the held `File`, not the path — so the decoy swap proves a property that already held. Confirmed by reverting `write_contents` to the seek form: the test stays green. The only semantic difference between the two forms is the shared file offset, which nothing asserted.

- **`ResultLock::upgradable_read` has no production caller anywhere in the tree.** The live sites are `ResultLock::write` (`result.rs:1581`, `result.rs:1630`, `gc.rs:428`) and `ResultLock::try_write` (`gc.rs:197`), both rewired by #220. Yet `fs_holder_pid_reports_stamped_pid` — the one test proving the `outer_guard()` → `stamp_pid` → `write_contents` chain lands the pid — went exclusively through the dead path. A mis-wired `outer_guard()` on either live site would have shipped green. Confirmed: deleting each stamp call reddens only the two new tests; the `upgradable_read` one stays green.

Both #220 tests also asserted only a negative — that a decoy was *not* touched — so an implementation returning `Ok(())` without writing anything passed both. That is the shape `.claude/testing.md` warns against. Both now also assert the expected bytes landed on the held inode, read back through a second handle opened before the unlink.

## Diagnostic regression: the stamp failure lost its path

#220 dropped the `path` field from the stamp-failure log. The old line emitted `path=<home>/lock/<hash>.outer.lock`; the new one emitted only `error=writing lock file contents: No space left on device`. `stamp_pid` no longer has a path to log, and `write_contents` carried none in its context, so on ENOSPC/EIO with N addrs in flight an operator could not tell which lock failed. Fixed at the flock layer, which covers every caller.

## Corrections to claims #220 made

- The "strictly safer" argument is right in direction but overstated for this call site: when `stamp_pid` runs we hold the gateway exclusively and are the only party that unlinks it, so the path/inode divergence window is not open today. Robustness against future callers, not a live bug fixed.
- The pwrite rationale said the shared offset "was a latent surprise", implying a live bug. It now says no reader of this fd depends on the offset today and `pwrite` keeps it that way.
- `TBridgeWriteGuard::outer_guard`'s doc named `upgrade` as the emptying transition when for the write guard it is `downgrade`, and claimed both emptying operations "consume `self`" when `Drop::drop` takes `&mut self`.

## Known gaps, deliberately not fixed here

- **The stamp is not a liveness check.** The framing bounds what a *torn* read can report; it does not make the pid fresh. A stamp outlives the process that wrote it whenever the holder is killed without running `Drop`, and the stamp lands only after the acquire completes — so a waiter parked on the inner lock can read the *previous* holder's pid for as long as that wait lasts, a window bounded by a build rather than by two adjacent syscalls. Both reviewers raised this independently and both judged it pre-existing and non-blocking. The fix (`kill(pid, 0)` → `ESRCH` ⇒ `None`, or blanking the stamp at exclusive acquire) changes the diagnostic contract, so it belongs in front of the user rather than smuggled into a regression fix. Now stated plainly in `stamp_pid`'s doc instead of implied away.

- **`stale_inode_is_rejected_and_reopened` never reaches the stale-retry branch it names.** Pre-existing, surfaced by review. It creates, removes and recreates the lock file *before* `lock()`, so at acquire time the path holds a live inode, `fd_matches_path` matches on the first iteration, and `discard_fd` never runs — a `fd_matches_path` hardwired to `Ok(true)` passes it. That check is the entire defense against two processes holding the same lock. `STALE_RETRIES` exhaustion is likewise uncovered.

- **Declined:** splitting a `close_fd` helper out of `discard_fd`; and removing the bridge guards' `Drop` impls so field order carries the release ordering and `outer_guard` becomes total. The latter is the stronger guarantee in the abstract, but the explicit `Drop` impls are what make inner-before-outer legible at the point it matters, and that ordering is the bridge's whole deadlock-freedom argument.

## Cost

No hot-path delta. `ResultLock::read` — the cache-hit guard — never stamps, so a warm run adds zero syscalls and zero allocations. Per gateway acquire, `format!("{}\n", pid)` allocates exactly as `pid.to_string()` did; syscalls unchanged at two. Both new `with_context` closures are lazy. `debug_assert!` compiles out in release, `stream_pos` is `#[cfg(test)]`. `read_pid` runs only past `RESULT_LOCK_NOTICE`. Nothing here is worth a benchmark.

For the record, #220's own unmeasured saving was per *gateway acquire*: an `open`+`write`+`close` plus a `format!` String and a PathBuf became a `pwrite`+`ftruncate` plus one uncontended `parking_lot` acquire — and gateway acquires happen only when a build may be needed, never per cache hit.

## Verification

- `cargo test -p lock` — 32 passed (29 on master + 3 new)
- `cargo test -p engine --lib result_lock::` — 16 passed (11 on master + 5 new)
- `cargo clippy --all-targets --locked -- -D warnings` from the workspace root — clean
- `cargo fmt` — clean
- Every new test verified red against the specific mutation it guards (table above)
- No `cfg(target_os)` / `cfg(target_arch)` anywhere in the diff; `pwrite`/`ftruncate`/`flock`/`stream_position` behave identically on all three supported targets

## Review

| Agent | Verdict |
|---|---|
| `code-quality` | PASS WITH NITS — no blocker |
| `feature-quality` | PASS WITH FOLLOW-UPS — the two MAJORs are pre-existing, listed above |

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01A76DChMohieGMbRbnV1E7x
