### PR TITLE
feat(diag): report worker saturation and keep the in-flight state on disk

### DIFF
--- a/crates/core/src/hmemoizer/mod.rs
+++ b/crates/core/src/hmemoizer/mod.rs
@@ -176,12 +176,23 @@ fn format_frame_stack(top: &Arc<Frame>) -> Vec<String> {
 // where each stuck invocation is parked when the hang is on a non-memoizer
 // await (semaphore acquire, fs op, subprocess wait, cache_locally, …).
 //
-// Opt in via `heph_PHASE_TRACE=1`. Disabled by default — `set_phase` and
+// Opt in via `HEPH_PHASE_TRACE=1`. Disabled by default — `set_phase` and
 // `clear_phase` are O(1) early-returns when the flag is off.
+
+/// Spelled like every other knob (`HEPH_DEBUG_MEMOIZER_CYCLE`,
+/// `HEPH_MEMOIZER_STALL_SECS`).
+const PHASE_TRACE_VAR: &str = "HEPH_PHASE_TRACE";
+
+/// The decision, separated from the process environment so it is testable — the
+/// real one caches in a `OnceLock`, so a test that set the var would be at the
+/// mercy of whichever test ran first.
+fn phase_trace_from(get: impl Fn(&str) -> Option<String>) -> bool {
+    get(PHASE_TRACE_VAR).as_deref() == Some("1")
+}
 
 fn phase_trace_enabled() -> bool {
     static FLAG: OnceLock<bool> = OnceLock::new();
-    *FLAG.get_or_init(|| matches!(std::env::var("heph_PHASE_TRACE").as_deref(), Ok("1")))
+    *FLAG.get_or_init(|| phase_trace_from(|name| std::env::var(name).ok()))
 }
 
 static PHASES: OnceLock<Mutex<HashMap<u64, &'static str>>> = OnceLock::new();
@@ -191,7 +202,7 @@ fn phases() -> &'static Mutex<HashMap<u64, &'static str>> {
 }
 
 /// Tag the calling invocation with its next-await `phase`. No-op when
-/// `heph_PHASE_TRACE` is unset or when invoked outside any `once()` scope.
+/// `HEPH_PHASE_TRACE` is unset or when invoked outside any `once()` scope.
 pub fn set_phase(phase: &'static str) {
     if !phase_trace_enabled() {
         return;
@@ -219,7 +230,7 @@ pub fn clear_phase() {
 
 pub fn dump_phases() -> String {
     if !phase_trace_enabled() {
-        return "  (phase trace disabled — set heph_PHASE_TRACE=1)".to_string();
+        return format!("  (phase trace disabled — set {PHASE_TRACE_VAR}=1)");
     }
     let map = phases().lock().expect("phases mutex poisoned");
     if map.is_empty() {
@@ -582,6 +593,28 @@ pub fn render_inventory(cells: &[StuckCell], limit: usize) -> String {
         out.push_str(&format!("    … and {} more\n", cells.len() - limit));
     }
     out
+}
+
+/// The complete in-flight picture: every incomplete cell, the wait-for graph,
+/// and each invocation's next-await label.
+///
+/// Uncapped, and rendered identically wherever it is written — the `SIGQUIT`
+/// dump and the stall watchdog's companion file are the same text, so a reader
+/// does not have to learn two formats or wonder which one is truncated.
+///
+/// The gated sections self-describe when off rather than being absent, because
+/// a missing section reads as "nothing to report" when it means "not recorded".
+pub fn render_full_report() -> String {
+    let cells = inventory();
+    format!(
+        "=== in-flight inventory ({} incomplete cells) ===\n{}\n\
+         === memoizer wait-for graph ===\n{}\n\
+         === memoizer phases (invocation -> next await) ===\n{}\n",
+        cells.len(),
+        render_inventory(&cells, usize::MAX),
+        dump_wait_graph(),
+        dump_phases(),
+    )
 }
 
 pub struct Memoizer<K, V> {
@@ -1156,6 +1189,32 @@ mod tests {
         assert!(
             !inventory().iter().any(|c| c.tag == "inv-dropped-test"),
             "a dead memoizer must be pruned from the registry"
+        );
+    }
+
+    /// The knob is spelled like every other one, and the old spelling still
+    /// works.
+    ///
+    /// Dropping the legacy name would fail silently in the worst place: someone
+    /// re-runs a wedged build with the spelling they used last time, gets an
+    /// empty phase map, and reads that as "the trace had nothing to say".
+    #[test]
+    fn phase_trace_is_opt_in_under_the_canonical_name() {
+        let only = |want: &'static str| move |name: &str| (name == want).then(|| "1".to_string());
+
+        assert!(phase_trace_from(only("HEPH_PHASE_TRACE")));
+        assert!(
+            !phase_trace_from(only("heph_PHASE_TRACE")),
+            "the old lowercase spelling is gone, not aliased"
+        );
+        assert!(!phase_trace_from(|_| None));
+        assert!(
+            !phase_trace_from(|_| Some("0".to_string())),
+            "only an explicit 1 enables it"
+        );
+        assert!(
+            PHASE_TRACE_VAR.starts_with("HEPH_"),
+            "the canonical spelling must match HEPH_DEBUG_MEMOIZER_CYCLE et al"
         );
     }
 

--- a/crates/engine/src/engine/diag.rs
+++ b/crates/engine/src/engine/diag.rs
@@ -594,6 +594,22 @@ impl StallReport {
             .find(|(o, _)| *o == op)
             .is_some_and(|(_, b)| *b == 0)
     }
+
+    /// Nothing is actually *doing* anything: no subprocess, no cache transfer,
+    /// no cache write, no blocked lock.
+    ///
+    /// [`Op::Result`] is excluded deliberately — a result span is bookkeeping for
+    /// "this addr is being resolved", and every ancestor holds one open while
+    /// awaiting its children. Thousands of them open says nothing about whether
+    /// work is happening. Every *other* op is a real operation in flight, so
+    /// "only result spans are open" means the process has nothing to do.
+    pub fn no_work_in_flight(&self) -> bool {
+        self.lock_waits.is_none()
+            && self
+                .open
+                .iter()
+                .all(|(op, n, _)| matches!(op, Op::Result) || *n == 0)
+    }
 }
 
 /// How the run changed between two consecutive fires of the watchdog.
@@ -815,14 +831,36 @@ pub fn render_stall(r: &StallReport) -> String {
     // corroborates it. A wrong automated hypothesis costs more credibility than
     // no hypothesis — better to show the table and let the reader conclude.
     let stranded = r.stuck.iter().filter(|c| c.is_stranded()).count();
-    if stranded > 0 && r.delta.is_some_and(|d| d.is_flat()) {
-        // Evidence, not inference: tasks are parked on a cell that has no
-        // driver, and nothing moved between two fires. Neither alone would be
-        // enough — a driverless cell is momentarily normal during re-election.
+    if r.delta.is_some_and(|d| d.is_flat()) && !r.stuck.is_empty() && r.no_work_in_flight() {
+        // Three independent observations: nothing changed between two fires, no
+        // operation of any kind is in flight, and cells are still incomplete. A
+        // build with work to do would have *something* open.
+        //
+        // Keyed on "no work in flight" rather than on the driver bit, because a
+        // parked driver still occupies the driver slot: a cell whose awaiter was
+        // woken and never re-polled reads `driver=true` forever. Keying on that
+        // alone reported nothing on a build wedged with 578 result cells and all
+        // drivers populated.
         out.push_str(&format!(
-            "\n  {stranded} cell(s) have tasks parked on them with nobody elected to poll\n  \
-             them, and nothing moved since the last report. That is a lost wake-up,\n  \
-             not slow work.\n"
+            "\n  Nothing is executing, transferring, or waiting on a lock, {} cell(s) are\n  \
+             still incomplete, and nothing moved since the last report. The process is\n  \
+             idle with work outstanding — a lost wake-up or a dependency cycle, not\n  \
+             slow work.\n",
+            r.stuck.len()
+        ));
+        if stranded > 0 {
+            // Sharper still when present: these have waiters and no driver at
+            // all, so not even a re-poll is pending.
+            out.push_str(&format!(
+                "  {stranded} of them have waiters with no driver elected.\n"
+            ));
+        }
+        out.push_str(&format!(
+            "  The full list, the wait-for graph and each invocation's next await are in\n  \
+             `inflight-{}.log` beside this file, refreshed on every report. Re-run with\n  \
+             `HEPH_DEBUG_MEMOIZER_CYCLE=1 HEPH_PHASE_TRACE=1` to populate the last two,\n  \
+             and to fail a real cycle instead of hanging on it.\n",
+            std::process::id()
         ));
     } else if let Some((op, _)) = r.dominant()
         && r.dominant_is_starved()
@@ -864,6 +902,49 @@ pub fn render_stall(r: &StallReport) -> String {
 /// together when diagnosing the same hang, and `heph tool gc` already sweeps that
 /// directory. Per-pid, so concurrent heph processes in one workspace do not
 /// interleave their reports into one unreadable file.
+/// The full in-flight state, rewritten on every stall fire.
+///
+/// Separate from [`StallLog`] because the two want opposite things. The stall
+/// log is a short, readable paragraph that *appends*, so the escalation history
+/// survives; this is the complete uncapped dump — every incomplete cell, the
+/// wait-for graph, every invocation's next-await label — which is thousands of
+/// lines on a large graph and would bury that history if appended fourteen
+/// times.
+///
+/// Truncated on each write, so it always holds the *current* state rather than a
+/// stack of stale ones. The stall log's own history says how the run got here.
+///
+/// Written by the watchdog, without anyone having to catch the process alive:
+/// the first incident this machinery was built for ended with the process dying
+/// before a `SIGQUIT` could be sent, and every byte of in-flight state went with
+/// it. `SIGQUIT` still produces the same report on demand — this one just does
+/// not require someone to be watching.
+pub struct InflightLog {
+    path: std::path::PathBuf,
+}
+
+impl InflightLog {
+    pub fn new(home: &std::path::Path) -> Self {
+        Self {
+            path: home
+                .join("diag")
+                .join(format!("inflight-{}.log", std::process::id())),
+        }
+    }
+
+    pub fn path(&self) -> &std::path::Path {
+        &self.path
+    }
+
+    /// Replace the file with the current in-flight report.
+    pub fn write(&self, text: &str) -> std::io::Result<()> {
+        if let Some(dir) = self.path.parent() {
+            std::fs::create_dir_all(dir)?;
+        }
+        std::fs::write(&self.path, text)
+    }
+}
+
 pub struct StallLog {
     path: std::path::PathBuf,
 }
@@ -1207,8 +1288,200 @@ mod tests {
             has_driver: false,
         }];
         let text = render_stall(&r);
-        assert!(text.contains("That is a lost wake-up"), "{text}");
+        assert!(text.contains("The process is"), "{text}");
+        assert!(text.contains("idle with work outstanding"), "{text}");
+        assert!(
+            text.contains("1 of them have waiters with no driver elected"),
+            "the sharper sub-case is called out when present: {text}"
+        );
         assert!(text.contains("[result] //a:b waiters=4"), "{text}");
+    }
+
+    /// The shape the driver-keyed check missed.
+    ///
+    /// A real wedge had 578 result cells, 455 meta, 123 locked_result — and
+    /// `driver=true` on every one of them, because an awaiter that is woken and
+    /// never re-polled keeps occupying the driver slot forever. Keying the
+    /// headline on "no driver" reported nothing at all on 25 minutes of a
+    /// completely idle process.
+    #[test]
+    fn a_wedge_is_reported_even_when_every_cell_still_has_a_driver() {
+        let s = state();
+        for i in 0..578 {
+            s.op_start(Op::Result, &format!("//pkg:{i}"), 0);
+        }
+        let mut r = s.evaluate(61_000, T).expect("stalled");
+        r.delta = Some(StallDelta {
+            since: Duration::from_secs(120),
+            done: 0,
+            open: 0,
+        });
+        r.stuck = (0..3)
+            .map(|i| hcore::hmemoizer::StuckCell {
+                tag: "locked_result",
+                key: format!("@heph/fs:file {i}"),
+                waiters: Some(1),
+                has_driver: true,
+            })
+            .collect();
+
+        assert_eq!(
+            r.stuck.iter().filter(|c| c.is_stranded()).count(),
+            0,
+            "none are stranded by the narrow definition — that is the point"
+        );
+        assert!(r.no_work_in_flight(), "only result spans are open");
+
+        let text = render_stall(&r);
+        assert!(text.contains("idle with work outstanding"), "{text}");
+        assert!(
+            !text.contains("have waiters with no driver elected"),
+            "the sub-case line must not appear when nothing is stranded: {text}"
+        );
+        assert!(
+            text.contains("HEPH_DEBUG_MEMOIZER_CYCLE=1"),
+            "the paragraph must name the two vars that resolve it: {text}"
+        );
+    }
+
+    /// The claim is "nothing is happening", so any real operation in flight
+    /// must retract it — otherwise it fires on a build that is merely slow.
+    #[test]
+    fn work_in_flight_retracts_the_idle_claim() {
+        let s = state();
+        s.op_start(Op::Result, "//a:b", 0);
+        s.op_start(Op::Execute, "//a:b", 0);
+        let mut r = s
+            .evaluate(T.as_millis() as u64 * QUIET_EXEC_FACTOR + 1, T)
+            .expect("stalled");
+        r.delta = Some(StallDelta {
+            since: Duration::from_secs(120),
+            done: 0,
+            open: 0,
+        });
+        r.stuck = vec![hcore::hmemoizer::StuckCell {
+            tag: "result",
+            key: "//a:b".to_string(),
+            waiters: Some(1),
+            has_driver: true,
+        }];
+        assert!(!r.no_work_in_flight(), "an execute span is real work");
+        let text = render_stall(&r);
+        assert!(!text.contains("idle with work outstanding"), "{text}");
+    }
+
+    /// A blocked lock is work in flight too — the process is waiting on
+    /// something real, quite possibly another process, and calling that "idle"
+    /// would point the reader at the wrong subsystem entirely.
+    #[test]
+    fn a_blocked_lock_retracts_the_idle_claim() {
+        let s = state();
+        let hook = DiagHook::new(std::sync::Arc::clone(&s));
+        s.op_start(Op::Result, "//a:b", 0);
+        hook.on_event(&ev(BuildEventKind::ResultLockWaitStart {
+            addr: "//a:b".into(),
+            holder_pid: Some(99),
+        }));
+        let mut r = s.evaluate(61_000, T).expect("stalled");
+        r.delta = Some(StallDelta {
+            since: Duration::from_secs(120),
+            done: 0,
+            open: 0,
+        });
+        r.stuck = vec![hcore::hmemoizer::StuckCell {
+            tag: "locked_result",
+            key: "//a:b".to_string(),
+            waiters: Some(1),
+            has_driver: true,
+        }];
+        assert!(!r.no_work_in_flight());
+        let text = render_stall(&r);
+        assert!(!text.contains("idle with work outstanding"), "{text}");
+    }
+
+    /// The paragraph points at the companion file by name, so the reader does
+    /// not have to already know it exists.
+    #[test]
+    fn the_paragraph_names_the_inflight_companion_file() {
+        let s = state();
+        s.op_start(Op::Result, "//a:b", 0);
+        let mut r = s.evaluate(61_000, T).expect("stalled");
+        r.delta = Some(StallDelta {
+            since: Duration::from_secs(120),
+            done: 0,
+            open: 0,
+        });
+        r.stuck = vec![hcore::hmemoizer::StuckCell {
+            tag: "result",
+            key: "//a:b".to_string(),
+            waiters: Some(1),
+            has_driver: true,
+        }];
+        let text = render_stall(&r);
+        assert!(
+            text.contains(&format!("inflight-{}.log", std::process::id())),
+            "{text}"
+        );
+    }
+
+    /// The companion file holds the *current* state, not a pile of stale ones.
+    ///
+    /// It is the uncapped dump — thousands of lines on a large graph — so
+    /// appending it on all fourteen fires of a 25-minute wedge would bury the
+    /// stall log's own escalation history, which is the thing that says "wedged"
+    /// rather than "slow". The stall log appends; this one replaces.
+    #[test]
+    fn the_inflight_log_is_replaced_not_appended() {
+        let home = tempfile::tempdir().expect("tempdir");
+        let log = InflightLog::new(home.path());
+
+        log.write("first report").expect("write");
+        log.write("second report").expect("write");
+
+        let body = std::fs::read_to_string(log.path()).expect("read");
+        assert_eq!(body, "second report");
+        assert!(
+            log.path().to_string_lossy().contains("diag"),
+            "it sits beside the stall log and the SIGQUIT dumps: {:?}",
+            log.path()
+        );
+    }
+
+    /// It carries all three sections, and the gated ones announce themselves
+    /// rather than being silently absent — "no wait-for graph" and "wait-for
+    /// graph not recorded" are very different messages to someone reading this
+    /// during an incident.
+    #[test]
+    fn the_inflight_report_carries_every_section() {
+        let text = hcore::hmemoizer::render_full_report();
+        assert!(text.contains("in-flight inventory"), "{text}");
+        assert!(text.contains("memoizer wait-for graph"), "{text}");
+        assert!(text.contains("memoizer phases"), "{text}");
+        assert!(text.contains("HEPH_DEBUG_MEMOIZER_CYCLE"), "{text}");
+        assert!(text.contains("HEPH_PHASE_TRACE"), "{text}");
+    }
+
+    /// The `workers` limiter is declared by `global()` and, until now, fed by
+    /// nothing — so `saturated_for` was permanently `None` and an exhausted
+    /// worker pool could not appear in the paragraph at any threshold. The
+    /// permit is taken after dep resolution but before `ExecuteStart`, so a
+    /// target queued there shows up as neither an open `execute` span nor a
+    /// limits line: completely invisible.
+    #[test]
+    fn a_saturated_worker_pool_reaches_the_paragraph() {
+        let s = state();
+        s.op_start(Op::Result, "//a:b", 0);
+        let d = s.limiter("workers");
+        d.observe(0, 1_000);
+
+        let r = s.evaluate(61_000, T).expect("stalled");
+        assert!(
+            r.saturated.iter().any(|(name, _)| *name == "workers"),
+            "workers must be reportable: {:?}",
+            r.saturated
+        );
+        let text = render_stall(&r);
+        assert!(text.contains("workers saturated for"), "{text}");
     }
 
     /// A frozen TUI swallows Ctrl-C (raw mode clears ISIG), so the paragraph must

--- a/crates/engine/src/engine/diag.rs
+++ b/crates/engine/src/engine/diag.rs
@@ -855,12 +855,17 @@ pub fn render_stall(r: &StallReport) -> String {
                 "  {stranded} of them have waiters with no driver elected.\n"
             ));
         }
+        // The full path, not a bare filename: this is read later, often by
+        // someone who did not start the build and has no idea what its cwd was.
+        let inflight = INFLIGHT_PATH.get().map_or_else(
+            || format!("inflight-{}.log beside this file", std::process::id()),
+            |p| p.display().to_string(),
+        );
         out.push_str(&format!(
             "  The full list, the wait-for graph and each invocation's next await are in\n  \
-             `inflight-{}.log` beside this file, refreshed on every report. Re-run with\n  \
+             {inflight}, refreshed on every report. Re-run with\n  \
              `HEPH_DEBUG_MEMOIZER_CYCLE=1 HEPH_PHASE_TRACE=1` to populate the last two,\n  \
-             and to fail a real cycle instead of hanging on it.\n",
-            std::process::id()
+             and to fail a real cycle instead of hanging on it.\n"
         ));
     } else if let Some((op, _)) = r.dominant()
         && r.dominant_is_starved()
@@ -902,6 +907,23 @@ pub fn render_stall(r: &StallReport) -> String {
 /// together when diagnosing the same hang, and `heph tool gc` already sweeps that
 /// directory. Per-pid, so concurrent heph processes in one workspace do not
 /// interleave their reports into one unreadable file.
+/// `<home>/diag/<name>`, made absolute.
+///
+/// Absolute because these paths are *reported* — the stall paragraph names the
+/// in-flight file, a `warn!` names the stall log, and both are read later, often
+/// by someone who was not the one who started the build and has no idea what its
+/// cwd was. `home` is normally absolute already; this makes it so when a caller
+/// passes a relative root (tests, `--home` with a relative path) rather than
+/// emitting a path that resolves differently depending on where you stand.
+///
+/// `std::path::absolute` rather than `canonicalize`: the directory does not exist
+/// until the first write, and `canonicalize` fails on a path that is not already
+/// there.
+fn diag_path(home: &std::path::Path, name: &str) -> std::path::PathBuf {
+    let path = home.join("diag").join(name);
+    std::path::absolute(&path).unwrap_or(path)
+}
+
 /// The full in-flight state, rewritten on every stall fire.
 ///
 /// Separate from [`StallLog`] because the two want opposite things. The stall
@@ -923,13 +945,19 @@ pub struct InflightLog {
     path: std::path::PathBuf,
 }
 
+/// Where the in-flight report is being written, for the stall paragraph to name.
+///
+/// A static rather than a field threaded through `StallReport`: `render_stall`
+/// is called from the watchdog thread, which builds the report from
+/// [`DiagState`] alone and has no handle on the log. Same shape as
+/// [`global`].
+static INFLIGHT_PATH: std::sync::OnceLock<std::path::PathBuf> = std::sync::OnceLock::new();
+
 impl InflightLog {
     pub fn new(home: &std::path::Path) -> Self {
-        Self {
-            path: home
-                .join("diag")
-                .join(format!("inflight-{}.log", std::process::id())),
-        }
+        let path = diag_path(home, &format!("inflight-{}.log", std::process::id()));
+        drop(INFLIGHT_PATH.set(path.clone()));
+        Self { path }
     }
 
     pub fn path(&self) -> &std::path::Path {
@@ -952,9 +980,7 @@ pub struct StallLog {
 impl StallLog {
     pub fn new(home: &std::path::Path) -> Self {
         Self {
-            path: home
-                .join("diag")
-                .join(format!("stall-{}.log", std::process::id())),
+            path: diag_path(home, &format!("stall-{}.log", std::process::id())),
         }
     }
 
@@ -1397,6 +1423,35 @@ mod tests {
         assert!(!r.no_work_in_flight());
         let text = render_stall(&r);
         assert!(!text.contains("idle with work outstanding"), "{text}");
+    }
+
+    /// Both diagnostic paths are absolute, whatever root they were given.
+    ///
+    /// These paths get *reported* — the paragraph names the in-flight file, a
+    /// `warn!` names the stall log — and are read later, often by someone who did
+    /// not start the build. A path relative to the process's cwd resolves
+    /// differently depending on where the reader stands, which is worth nothing
+    /// when the process it described is already gone.
+    #[test]
+    fn diagnostic_paths_are_absolute_even_from_a_relative_home() {
+        let stall = StallLog::new(std::path::Path::new("rel/home"));
+        assert!(
+            stall.path().is_absolute(),
+            "stall log path must be absolute: {:?}",
+            stall.path()
+        );
+        assert!(
+            stall
+                .path()
+                .ends_with(format!("stall-{}.log", std::process::id()))
+        );
+
+        let inflight = InflightLog::new(std::path::Path::new("rel/home"));
+        assert!(
+            inflight.path().is_absolute(),
+            "in-flight log path must be absolute: {:?}",
+            inflight.path()
+        );
     }
 
     /// The paragraph points at the companion file by name, so the reader does

--- a/crates/engine/src/engine/execute.rs
+++ b/crates/engine/src/engine/execute.rs
@@ -50,6 +50,15 @@ impl Engine {
         // waiting for a leaf that also needs a permit.
         hcore::hmemoizer::set_phase("execute:semaphore_acquire");
         let semaphore = Arc::clone(&self.result_semaphore);
+        // Observed *before* the acquire, so the stamp times the wait rather than
+        // its end. This queue is invisible everywhere else: the permit is taken
+        // after dep resolution but before `ExecuteStart`, so a target parked here
+        // has no open `execute` span and shows only as an open `result`. A build
+        // wedged with every worker held reported "N result" and no limits line at
+        // all, because the `workers` limiter was declared and never fed.
+        let d = crate::engine::diag::global();
+        d.limiter("workers")
+            .observe(semaphore.available_permits(), d.now_ms());
         let _permit = semaphore
             .acquire()
             .await

--- a/crates/engine/src/engine/remote_cache.rs
+++ b/crates/engine/src/engine/remote_cache.rs
@@ -179,6 +179,12 @@ where
     F: FnOnce() -> anyhow::Result<R> + Send + 'static,
     R: Send + 'static,
 {
+    // Observe before queueing, so "saturated" times the wait rather than the
+    // moment a permit came free. `codec` is declared by `diag::global()` and was
+    // never fed, so its saturation was structurally unreportable.
+    let d = crate::engine::diag::global();
+    d.limiter("codec")
+        .observe(CODEC_SLOTS.available_permits(), d.now_ms());
     let _permit = CODEC_SLOTS
         .acquire()
         .await

--- a/src/commands/bootstrap.rs
+++ b/src/commands/bootstrap.rs
@@ -181,6 +181,11 @@ pub fn new_engine() -> anyhow::Result<(Arc<engine::Engine>, ShutdownTrigger)> {
         remote_cache_backends,
     );
 
+    // Point `SIGQUIT` dumps at the resolved home, so they land beside the stall
+    // log and the in-flight report instead of under whatever cwd the process was
+    // launched from. Every command routes through here, so every command gets it.
+    crate::diag::set_dump_dir(&engine.home.join("diag"));
+
     let (trigger, rx) = ShutdownTrigger::new();
     spawn_sigint_producer(trigger.clone());
     spawn_shutdown_handler(Arc::downgrade(&engine), rx);

--- a/src/commands/run.rs
+++ b/src/commands/run.rs
@@ -295,10 +295,22 @@ async fn execute_async(args: RunArgs, sink: LogSink, global: GlobalOptions) -> a
         let threshold = global.stall_notice;
         let diag_sink = sink.clone();
         let log = hengine::engine::diag::StallLog::new(&engine.home);
+        let inflight = hengine::engine::diag::InflightLog::new(&engine.home);
         hengine::engine::diag::Watchdog::spawn(
             std::sync::Arc::clone(hengine::engine::diag::global()),
             threshold,
             move |report| {
+                // Best-effort and first: the paragraph points at this file, and
+                // a hang that ends with the process being killed takes every
+                // byte of in-flight state with it unless it was already on disk.
+                // A failure here must not cost us the paragraph itself.
+                if let Err(e) = inflight.write(&hcore::hmemoizer::render_full_report()) {
+                    tracing::warn!(
+                        path = %inflight.path().display(),
+                        error = %e,
+                        "Cannot write the in-flight report"
+                    );
+                }
                 let text = hengine::engine::diag::render_stall(report);
                 if let Err(e) = log.append(&text) {
                     // Read-only fs, full disk, gc'd home. The paragraph is the

--- a/src/diag.rs
+++ b/src/diag.rs
@@ -63,9 +63,45 @@ extern "C" fn on_sigquit(_sig: libc::c_int) {
     DUMP_REQUESTED.store(true, Ordering::Relaxed);
 }
 
+/// The directory dumps land in, once the engine has resolved its home.
+static DUMP_DIR: std::sync::OnceLock<std::path::PathBuf> = std::sync::OnceLock::new();
+
+/// Point dumps at the engine's `<home>/diag`, so they land beside the stall log
+/// and the in-flight report rather than wherever the process happened to start.
+///
+/// Called once the home is known; before that, [`dump_dir`] falls back to the
+/// launch directory. The fallback matters — a hang during startup still has to
+/// produce a dump somewhere findable.
+pub fn set_dump_dir(dir: &std::path::Path) {
+    drop(DUMP_DIR.set(absolute(dir)));
+}
+
+/// Make `path` absolute without touching the filesystem.
+///
+/// `std::path::absolute` rather than `canonicalize`: the directory does not
+/// exist yet on the first dump, and `canonicalize` fails on a path that is not
+/// already there. Symlink resolution is not wanted here anyway — the point is a
+/// path the reader can paste, not the shortest one.
+fn absolute(path: &std::path::Path) -> std::path::PathBuf {
+    std::path::absolute(path).unwrap_or_else(|_| path.to_path_buf())
+}
+
+fn dump_dir() -> std::path::PathBuf {
+    DUMP_DIR
+        .get()
+        .cloned()
+        .unwrap_or_else(|| absolute(std::path::Path::new(".heph3/diag")))
+}
+
 /// Where a dump lands. In-workspace so `heph tool gc` can sweep it.
+///
+/// **Absolute.** It used to be `.heph3/diag/dump-<pid>.txt`, resolved against
+/// whatever the process's cwd happened to be — which is not something the person
+/// reading a stall log, or an agent handed the file an hour later, has any way to
+/// know. "Your dump is at a relative path, good luck" costs a round trip in
+/// exactly the situation where the process may already be gone.
 fn dump_path() -> std::path::PathBuf {
-    std::path::PathBuf::from(".heph3/diag").join(format!("dump-{}.txt", std::process::id()))
+    dump_dir().join(format!("dump-{}.txt", std::process::id()))
 }
 
 /// Poll for a requested dump and perform the sweep off the signal handler.
@@ -320,6 +356,27 @@ mod tests {
         // Unset in a test process, so both must self-describe.
         assert!(text.contains("HEPH_DEBUG_MEMOIZER_CYCLE"), "{text}");
         assert!(text.contains("HEPH_PHASE_TRACE"), "{text}");
+    }
+
+    /// The dump lands at an absolute path.
+    ///
+    /// It used to be `.heph3/diag/dump-<pid>.txt`, resolved against whatever cwd
+    /// the process was launched from — so telling someone where their dump went
+    /// meant telling them "under the directory you started the build in", which
+    /// is a round trip in exactly the situation where the process may already be
+    /// gone.
+    #[test]
+    fn the_dump_path_is_absolute() {
+        let path = dump_path();
+        assert!(path.is_absolute(), "dump path must be absolute: {path:?}");
+        assert!(
+            path.ends_with(format!("dump-{}.txt", std::process::id())),
+            "{path:?}"
+        );
+        assert!(
+            path.parent().is_some_and(|p| p.ends_with("diag")),
+            "it sits in a diag dir beside the stall log: {path:?}"
+        );
     }
 
     /// The `SIGQUIT` dump and the watchdog's companion file must be the same

--- a/src/diag.rs
+++ b/src/diag.rs
@@ -156,19 +156,10 @@ fn sweep() {
 /// frames — never inside the signal handler, and never with a blocking lock (see
 /// `hmemoizer::inventory`).
 fn inventory_report() -> String {
-    let cells = hcore::hmemoizer::inventory();
-    format!(
-        "\n=== heph in-flight inventory ({} incomplete cells) ===\n{}\n\
-         === memoizer wait-for graph ===\n{}\n\
-         === memoizer phases ===\n{}\n",
-        cells.len(),
-        // No cap: this file is read once, by a human or an agent, on a build
-        // that has already gone wrong. Truncating it here is how you end up
-        // needing a second incident to see the line you cut.
-        hcore::hmemoizer::render_inventory(&cells, usize::MAX),
-        hcore::hmemoizer::dump_wait_graph(),
-        hcore::hmemoizer::dump_phases(),
-    )
+    // Same renderer the stall watchdog writes to its companion file, so the two
+    // are byte-identical and neither is the "truncated" one. No cap: this is
+    // read once, on a build that has already gone wrong.
+    format!("\n{}", hcore::hmemoizer::render_full_report())
 }
 
 fn write_inventory(fd: libc::c_int) {
@@ -323,11 +314,23 @@ mod tests {
     #[test]
     fn the_dump_carries_the_in_flight_state_and_names_its_gated_sections() {
         let text = inventory_report();
-        assert!(text.contains("heph in-flight inventory"), "{text}");
+        assert!(text.contains("in-flight inventory"), "{text}");
         assert!(text.contains("memoizer wait-for graph"), "{text}");
         assert!(text.contains("memoizer phases"), "{text}");
         // Unset in a test process, so both must self-describe.
         assert!(text.contains("HEPH_DEBUG_MEMOIZER_CYCLE"), "{text}");
-        assert!(text.contains("heph_PHASE_TRACE"), "{text}");
+        assert!(text.contains("HEPH_PHASE_TRACE"), "{text}");
+    }
+
+    /// The `SIGQUIT` dump and the watchdog's companion file must be the same
+    /// text. Two formats for one thing means a reader has to work out which of
+    /// them is the truncated one, during an incident, which is exactly when
+    /// nobody should be reverse-engineering a diagnostic.
+    #[test]
+    fn the_dump_and_the_watchdog_companion_file_render_identically() {
+        assert_eq!(
+            inventory_report().trim(),
+            hcore::hmemoizer::render_full_report().trim()
+        );
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -42,6 +42,10 @@ pub use htui::tui;
 pub use hwalk as htwalk;
 
 pub mod commands;
+/// Lives in the library, not the binary, because `commands::bootstrap` points it
+/// at the engine's resolved home once that is known — and `bootstrap` is library
+/// code. The `SIGQUIT` handler is still installed from `main`.
+pub mod diag;
 pub mod fdlimit;
 pub mod log;
 #[cfg(test)]

--- a/src/main.rs
+++ b/src/main.rs
@@ -5,7 +5,7 @@ use heph::log;
 use std::process::ExitCode;
 use tracing::error;
 
-mod diag;
+use heph::diag;
 mod pprof_dump;
 
 #[derive(Parser)]


### PR DESCRIPTION
Follow-up to #216, driven by a second wedge that #216's inventory narrowed but could not explain.

## The incident

14 fires over 25 minutes, every count byte-identical:

```
open ops     578 result
since last   +0 done, +0 open, over 120s
in-flight    578 result, 455 meta, 123 locked_result, 118 execute_cache, 1 spec
```

Thread dump: 59 threads, all parked, hcore pool on an empty queue. Process entirely idle.

The inventory got us a long way. The chain reads directly — `spec(worker:build_lib)` → `result(worker:_golist)` → `meta(worker:_golist)` — and the frontier is the **123 `locked_result` cells, 99 of them `@heph/fs:file`** source reads, parked past `meta` and short of `Driver::run`. But the paragraph could not say why, because of three gaps.

## 1. `workers` and `codec` were declared and never fed

```
Limiter::observe call sites:
  remote_cache.rs:545   → remote-cache-metadata
  remote_cache.rs:1308  → remote-cache-transfer
  (nothing else)
```

`diag::global()` declares four limiters. Two of them were fed by nothing, so `saturated_for()` was permanently `None`.

That matters most for `workers`: the permit is taken **after** dep resolution and **before** `ExecuteStart` (`execute.rs:53`). A target queued there has no open `execute` span *and* no limits line — invisible in both places it could have shown up, which is exactly where those 99 fs:file cells sit.

Observed before the acquire, so "saturated for 47s" times the wait rather than the moment a permit came free.

## 2. The lost-wake headline keyed on the wrong bit

It required `!has_driver && waiters > 0`. Every cell in this wedge had `driver=true` — an awaiter that is woken and never re-polled keeps occupying the driver slot forever. So the check said nothing across 25 minutes of a completely idle process.

Now keyed on three independent observations: flat delta, cells still incomplete, and no operation of any kind in flight. `Op::Result` is excluded from that last test deliberately — a result span is bookkeeping for "being resolved", not work, and every ancestor holds one open while awaiting children. The stranded sub-case is still called out when present.

```
  Nothing is executing, transferring, or waiting on a lock, 3 cell(s) are
  still incomplete, and nothing moved since the last report. The process is
  idle with work outstanding — a lost wake-up or a dependency cycle, not
  slow work.
  The full list, the wait-for graph and each invocation's next await are in
  `inflight-36381.log` beside this file, refreshed on every report. Re-run with
  `HEPH_DEBUG_MEMOIZER_CYCLE=1 HEPH_PHASE_TRACE=1` to populate the last two,
  and to fail a real cycle instead of hanging on it.
```

## 3. The in-flight state needed someone watching

It was only reachable by sending `SIGQUIT` to a live process. The first incident ended with the process killed before anyone could, and every byte went with it.

The watchdog now writes the same report to `<home>/diag/inflight-<pid>.log` on every fire — uncapped, **truncated** each time so it holds the current state, while the stall log keeps appending the escalation history (which is the part that says "wedged" rather than "slow"). `SIGQUIT` still produces it on demand; it just no longer requires someone to be watching.

Both paths share one renderer (`hmemoizer::render_full_report`), asserted byte-identical by a test — two formats for one thing means working out which is truncated, during an incident.

## Also

`heph_PHASE_TRACE` → `HEPH_PHASE_TRACE`, matching `HEPH_DEBUG_MEMOIZER_CYCLE` and `HEPH_MEMOIZER_STALL_SECS`. Lowercase spelling removed, not aliased.

## Tests

- `a_wedge_is_reported_even_when_every_cell_still_has_a_driver` — the exact shape the old check missed; asserts zero cells are "stranded" and it fires anyway.
- `work_in_flight_retracts_the_idle_claim` / `a_blocked_lock_retracts_the_idle_claim` — the claim is "nothing is happening", so a real op or a blocked lock must retract it.
- `a_saturated_worker_pool_reaches_the_paragraph` — limiter → report → text.
- `the_inflight_log_is_replaced_not_appended`, `the_inflight_report_carries_every_section`, `the_dump_and_the_watchdog_companion_file_render_identically`.
- `phase_trace_is_opt_in_under_the_canonical_name` — asserts the lowercase form no longer works.

## Verification status

Honest accounting, because this host is currently saturated (100+ cargo processes from other worktrees sharing `CARGO_TARGET_DIR`):

- **Green as of the second-to-last commit state**: 34 core + 32 engine unit tests, 2 bin tests, `lint` clean, and a full workspace run at **1229 passed / 0 failed** (excluding `plugingo-e2e`, which fails locally on `No space left on device` staging the Go std toolchain — unrelated, CI has the disk).
- **Not re-run locally**: the final edit, which removes the legacy env-var constant, collapses `phase_trace_from` to a single lookup, and renames one test. I could not get a build slot; CI gates it.

Two `observe()` call sites are also not covered by an automated test — asserting the real acquire site observes correctly needs genuine contention and would be flaky. Both are three-line mirrors of the proven `remote-cache-metadata` pattern.

## Still open

The wedge itself is undiagnosed. Next step is a run with `HEPH_DEBUG_MEMOIZER_CYCLE=1 HEPH_PHASE_TRACE=1` — `execute.rs` is already instrumented with `set_phase("execute:inputs_result_exec")`, `"execute:semaphore_acquire"`, `"execute:sandbox_remove"` (16 sites across the engine), so the phase map will name the exact await each of the 123 is parked at, and cycle detection will fail a real cycle instead of hanging on it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019SohmU1Z8pGPuAWPpY4hwV
