### PR TITLE
fix(engine): enforce package ordering in Engine::packages

### DIFF
--- a/crates/engine/src/engine/packages.rs
+++ b/crates/engine/src/engine/packages.rs
@@ -31,6 +31,38 @@ fn narrowing_prefix(m: &htmatcher::Matcher) -> PkgBuf {
 }
 
 impl Engine {
+    /// Every package matching `m`'s narrowing prefix, deduped, in an order that
+    /// does not depend on the order any provider returned: each provider's block
+    /// is sorted, then the blocks are concatenated in provider-registration
+    /// order.
+    ///
+    /// The order is load-bearing, not cosmetic. It reaches a def hash by more
+    /// than one route — `query` → `pluginquery`'s `deps` → `plugingroup` folds
+    /// them in order, and `EngineProviderExecutor::states_under` accumulates
+    /// package-major so it also drives `ListRequest::states` order — and it
+    /// reaches the sandbox as list-file line order. A provider is meanwhile free
+    /// to hand back `HashSet` iteration order, i.e. a per-process hash seed.
+    /// In-tree that was a live bug (fixed at the buildfile provider in #218); a
+    /// third-party cdylib provider is outside our reach entirely, so the engine
+    /// enforces rather than documenting a contract it cannot check.
+    ///
+    /// Sorted per provider, not globally, because `query` walks `self.providers`
+    /// *inside* its per-package loop: the addr order it produces is
+    /// package-major / provider-minor and so already rests on registration
+    /// order. That order is config-declared and deterministic for a given
+    /// workspace config — the always-on `query` and `fs`, then `plugins:`
+    /// entries in the order written — so a global sort would buy no determinism
+    /// the per-provider sort doesn't already give, while re-interleaving every
+    /// provider's block, re-keying every multi-provider query target for
+    /// nothing. (Reordering `plugins:` therefore re-keys those targets. That is
+    /// a user editing the build, not a per-process seed.)
+    ///
+    /// Deliberately no `debug_assert!` / `warn!` when a provider hands back an
+    /// unsorted list: `plugingo` legitimately returns a pre-order DFS, which is
+    /// deterministic but not lexicographic once a sibling name is a
+    /// punctuation-extended prefix of another (`-` is 0x2D, `/` is 0x2F). So
+    /// sortedness is the wrong predicate; the invariant worth checking is
+    /// *determinism*, which a single (memoized) call cannot observe.
     pub async fn packages(
         &self,
         m: &htmatcher::Matcher,
@@ -40,11 +72,8 @@ impl Engine {
 
         let mut all_packages = Vec::new();
         // Different providers can list the same package; dedup so callers
-        // (e.g. `query`) don't scan a package more than once. First-seen order
-        // is preserved — but that only *propagates* determinism, it does not
-        // create it: this order reaches a def hash (`query` → `pluginquery`'s
-        // `deps` → `plugingroup` folds them in order), so each provider owes a
-        // stable `list_packages` order of its own.
+        // (e.g. `query`) don't scan a package more than once. A package listed
+        // by two providers keeps the position of the first one that listed it.
         let mut seen: FxHashSet<String> = FxHashSet::default();
 
         for provider in &self.providers {
@@ -67,6 +96,27 @@ impl Engine {
                         for res in it {
                             pkgs.push(res?.pkg.to_string());
                         }
+                        // Canonicalize the provider's block rather than trusting
+                        // it to be ordered — see this method's docs for why the
+                        // order matters and why the sort is per provider.
+                        // Inside the memoizer, so it is paid once per
+                        // (provider, prefix) per request, not once per call.
+                        //
+                        // This is the canonical package ordering for the whole
+                        // engine, and it must stay a byte-lexicographic
+                        // `String` compare. A collation-aware or case-folding
+                        // comparator would make `LC_COLLATE` an undeclared hash
+                        // input: two machines would order the same tree
+                        // differently and could never share a remote-cache
+                        // entry for a query-backed target.
+                        //
+                        // `dedup` is free once sorted (adjacent, no hashing) and
+                        // shrinks the `Arc<Vec<String>>` shared for the rest of
+                        // the request. The cross-provider dedup below still
+                        // needs its own set: `Vec::dedup` only collapses
+                        // adjacent equals, and the blocks are memoized apart.
+                        pkgs.sort_unstable();
+                        pkgs.dedup();
                         Ok(Arc::new(pkgs))
                     }),
                 )
@@ -95,17 +145,64 @@ mod tests {
     use futures::future::BoxFuture;
     use hcore::hasync::Cancellable;
     use hmodel::htmatcher::Matcher;
+    use std::sync::atomic::{AtomicUsize, Ordering};
 
     fn pkg(s: &str) -> PkgBuf {
         PkgBuf::from(s)
     }
 
-    /// Fake provider: `name`, and the exact package sequence it lists.
-    struct DupPkgs(&'static str, &'static [&'static str]);
-    impl crate::engine::provider::Provider for DupPkgs {
+    /// Fake provider: a name plus the exact package sequence it lists.
+    ///
+    /// `rotating` makes it rotate that sequence by one more position on every
+    /// call — a deterministic stand-in for a provider whose order is not stable
+    /// between calls (`HashSet` iteration order being the real-world shape).
+    /// `calls` is shared with the test so it can assert the provider really was
+    /// re-asked, rather than trusting the memoizer to be per-request.
+    struct ListsPkgs {
+        name: &'static str,
+        pkgs: &'static [&'static str],
+        rotating: bool,
+        calls: Arc<AtomicUsize>,
+    }
+
+    impl ListsPkgs {
+        fn new(name: &'static str, pkgs: &'static [&'static str]) -> Self {
+            Self {
+                name,
+                pkgs,
+                rotating: false,
+                calls: Arc::new(AtomicUsize::new(0)),
+            }
+        }
+
+        fn rotating(
+            name: &'static str,
+            pkgs: &'static [&'static str],
+            calls: Arc<AtomicUsize>,
+        ) -> Self {
+            Self {
+                name,
+                pkgs,
+                rotating: true,
+                calls,
+            }
+        }
+
+        fn listing(&self) -> Vec<&'static str> {
+            let n = self.calls.fetch_add(1, Ordering::Relaxed);
+            let mut v = self.pkgs.to_vec();
+            if self.rotating && !v.is_empty() {
+                let by = n % v.len();
+                v.rotate_left(by);
+            }
+            v
+        }
+    }
+
+    impl crate::engine::provider::Provider for ListsPkgs {
         fn config(&self, _req: ConfigRequest) -> anyhow::Result<ConfigResponse> {
             Ok(ConfigResponse {
-                name: self.0.to_string(),
+                name: self.name.to_string(),
             })
         }
         fn list<'a>(
@@ -131,13 +228,13 @@ mod tests {
             'a,
             anyhow::Result<Box<dyn Iterator<Item = anyhow::Result<ListPackageResponse>> + Send>>,
         > {
-            Box::pin(async {
-                let items: Vec<anyhow::Result<ListPackageResponse>> = self
-                    .1
-                    .iter()
+            let listing = self.listing();
+            Box::pin(async move {
+                let items: Vec<anyhow::Result<ListPackageResponse>> = listing
+                    .into_iter()
                     .map(|p| {
                         Ok(ListPackageResponse {
-                            pkg: PkgBuf::from(*p),
+                            pkg: PkgBuf::from(p),
                         })
                     })
                     .collect();
@@ -182,8 +279,8 @@ mod tests {
             ..Default::default()
         })?;
         // Each provider lists `foo` twice; two providers list it again.
-        engine.register_provider(move |_| Box::new(DupPkgs("p1", &["foo", "foo"])))?;
-        engine.register_provider(move |_| Box::new(DupPkgs("p2", &["foo", "foo"])))?;
+        engine.register_provider(move |_| Box::new(ListsPkgs::new("p1", &["foo", "foo"])))?;
+        engine.register_provider(move |_| Box::new(ListsPkgs::new("p2", &["foo", "foo"])))?;
         let engine = Arc::new(engine);
         let rs = engine.new_state();
 
@@ -199,24 +296,35 @@ mod tests {
         Ok(())
     }
 
-    /// The dedup must preserve each provider's listing order verbatim. This
-    /// order is not cosmetic: it reaches a def hash through `query` →
-    /// `pluginquery`'s `deps` → `plugingroup`, which folds `deps` in order.
-    /// Collecting into a hash set here — the obvious way to write a dedup —
-    /// would put the engine's own hasher seed into a build definition.
-    #[tokio::test]
-    async fn packages_preserves_each_providers_listing_order() -> anyhow::Result<()> {
-        let root = tempfile::tempdir()?;
-        let mut engine = Engine::new(Config {
+    fn engine_with_builtins(root: &tempfile::TempDir) -> anyhow::Result<Engine> {
+        Engine::new(Config {
             root: root.path().to_path_buf(),
             home_dir: std::path::PathBuf::new(),
             parallelism: None,
             ..Default::default()
+        })
+    }
+
+    /// Supersedes `packages_preserves_each_providers_listing_order`, which
+    /// asserted the opposite: that the engine imposes no order and hands a
+    /// provider's sequence through verbatim. That was only safe while every
+    /// provider honored a *documented* ordering contract — which a third-party
+    /// cdylib provider is under no obligation to do, and which the in-tree
+    /// buildfile provider itself violated until #218. The engine now sorts each
+    /// provider's block, so the output no longer depends on it.
+    ///
+    /// The order is not cosmetic: it reaches a def hash through `query` →
+    /// `pluginquery`'s `deps` → `plugingroup`, which folds `deps` in order, and
+    /// the sandbox's list-file line order.
+    #[tokio::test]
+    async fn packages_sorts_each_providers_listing() -> anyhow::Result<()> {
+        let root = tempfile::tempdir()?;
+        let mut engine = engine_with_builtins(&root)?;
+        // Deliberately reverse-sorted: the engine must impose its own order.
+        engine.register_provider(move |_| {
+            Box::new(ListsPkgs::new("p1", &["zeta", "mid", "alpha"]))
         })?;
-        // Deliberately not in sorted order: the engine must not impose one, and
-        // must not lose the one it was given.
-        engine.register_provider(move |_| Box::new(DupPkgs("p1", &["zeta", "alpha", "mid"])))?;
-        engine.register_provider(move |_| Box::new(DupPkgs("p2", &["mid", "beta"])))?;
+        engine.register_provider(move |_| Box::new(ListsPkgs::new("p2", &["mid", "beta"])))?;
         let engine = Arc::new(engine);
         let rs = engine.new_state();
 
@@ -226,8 +334,88 @@ mod tests {
             .collect::<anyhow::Result<Vec<_>>>()?;
 
         // `@heph/fs` from the always-on built-in provider, registered first;
-        // then p1's order untouched; then p2's only new package.
-        assert_eq!(pkgs, vec!["@heph/fs", "zeta", "alpha", "mid", "beta"]);
+        // then p1's block sorted; then p2's only new package. Note `beta` lands
+        // *after* `zeta`: the result is deliberately not one global sort. The
+        // per-package loop in `query` already walks providers in registration
+        // order, so sorting globally would re-interleave every provider's block
+        // — re-keying every multi-provider query target — for no determinism
+        // that sorting per provider doesn't already give.
+        assert_eq!(pkgs, vec!["@heph/fs", "alpha", "mid", "zeta", "beta"]);
+        Ok(())
+    }
+
+    /// Two engines given the same packages in different listing orders must
+    /// produce byte-identical output. This is the property a documented contract
+    /// could not enforce: a provider is free to return anything.
+    #[tokio::test]
+    async fn packages_order_is_independent_of_how_a_provider_lists() -> anyhow::Result<()> {
+        async fn run(
+            p1: &'static [&'static str],
+            p2: &'static [&'static str],
+        ) -> anyhow::Result<Vec<String>> {
+            let root = tempfile::tempdir()?;
+            let mut engine = engine_with_builtins(&root)?;
+            engine.register_provider(move |_| Box::new(ListsPkgs::new("p1", p1)))?;
+            engine.register_provider(move |_| Box::new(ListsPkgs::new("p2", p2)))?;
+            let engine = Arc::new(engine);
+            let rs = engine.new_state();
+            engine
+                .packages(&Matcher::PackagePrefix(pkg("")), &rs)
+                .await?
+                .collect::<anyhow::Result<Vec<_>>>()
+        }
+
+        let expected = vec!["@heph/fs", "alpha", "delta", "mid", "zeta", "beta"];
+
+        // Reverse-sorted.
+        assert_eq!(
+            run(&["zeta", "mid", "delta", "alpha"], &["mid", "beta"]).await?,
+            expected
+        );
+        // Shuffled, and the shared package listed from the other side first.
+        assert_eq!(
+            run(&["mid", "alpha", "zeta", "delta"], &["beta", "mid"]).await?,
+            expected
+        );
+        // Already sorted — the compliant provider's result is unchanged.
+        assert_eq!(
+            run(&["alpha", "delta", "mid", "zeta"], &["beta", "mid"]).await?,
+            expected
+        );
+        Ok(())
+    }
+
+    /// A provider whose order drifts between calls — the shape of the #218 bug,
+    /// where `HashSet` iteration order made the same tree list differently on
+    /// every run — must not make the engine's output drift with it. A fresh
+    /// `RequestState` per iteration bypasses the per-request memoizer, so the
+    /// provider really is re-asked and really does return a different order each
+    /// time. The call count is asserted, not assumed: if `mem_packages` ever
+    /// became engine-level, the loop would collapse to one call at rotation 0 and
+    /// this would silently degrade into a copy of the test above.
+    #[tokio::test]
+    async fn packages_is_stable_across_requests_when_a_provider_reorders() -> anyhow::Result<()> {
+        let root = tempfile::tempdir()?;
+        let mut engine = engine_with_builtins(&root)?;
+        let calls = Arc::new(AtomicUsize::new(0));
+        engine.register_provider(enclose!((calls) move |_| {
+            Box::new(ListsPkgs::rotating("p1", &["zeta", "mid", "alpha", "delta"], calls))
+        }))?;
+        let engine = Arc::new(engine);
+
+        for _ in 0..5 {
+            let rs = engine.new_state();
+            let pkgs: Vec<String> = engine
+                .packages(&Matcher::PackagePrefix(pkg("")), &rs)
+                .await?
+                .collect::<anyhow::Result<Vec<_>>>()?;
+            assert_eq!(pkgs, vec!["@heph/fs", "alpha", "delta", "mid", "zeta"]);
+        }
+        assert_eq!(
+            calls.load(Ordering::Relaxed),
+            5,
+            "provider was not re-asked"
+        );
         Ok(())
     }
 

--- a/crates/plugin/src/provider.rs
+++ b/crates/plugin/src/provider.rs
@@ -348,20 +348,44 @@ pub struct StateSchema {
 
 pub trait Provider: Send + Sync {
     fn config(&self, req: ConfigRequest) -> anyhow::Result<ConfigResponse>;
+    /// The addrs this provider defines in `req.package`, in a **deterministic
+    /// order**.
+    ///
+    /// Unlike [`Provider::list_packages`], this order is *not* canonicalized by
+    /// the engine: `Engine::query` yields these addrs as it receives them, they
+    /// become `pluginquery`'s `deps`, and they reach the sandbox as the line
+    /// order of the staged `input_<origin>.list` / `dep_<group>.list` files.
+    /// Returning `HashSet` iteration order — the natural shape when the addrs
+    /// come off a filesystem walk — therefore gives the same tree a different
+    /// build definition, and a different list-file order, on every run. Sort, or
+    /// preserve a stable walk order.
     fn list<'a>(
         &'a self,
         req: ListRequest,
         ctoken: &'a (dyn Cancellable + Send + Sync),
     ) -> BoxFuture<'a, anyhow::Result<Box<dyn Iterator<Item = anyhow::Result<ListResponse>> + Send>>>;
-    /// The packages this provider knows about, in a **deterministic order**.
+    /// The packages this provider knows about.
     ///
-    /// The order is part of the contract, not a detail: the engine preserves it
-    /// through `Engine::packages` into `query`, which feeds `pluginquery`'s
-    /// `deps`, which `plugingroup` folds into its def hash *in order*. Returning
-    /// `HashSet` iteration order — the natural shape when the packages come from
-    /// a filesystem walk — therefore gives the same tree a different build
-    /// definition on every run, and a different `LIST_*` line order inside the
-    /// sandbox. Sort, or preserve a stable walk order.
+    /// The order returned here is **not** observable: `Engine::packages` sorts
+    /// each provider's block before merging it, so a `HashSet`-order listing is
+    /// as good as a sorted one. That was not always true — this order reaches a
+    /// def hash (`query` → `pluginquery`'s `deps` → `plugingroup` folds them in
+    /// order) and the sandbox's list-file line order, so a per-process hash seed
+    /// used to leak straight into a build definition. The engine now canonicalizes
+    /// it centrally rather than trusting every provider, in-tree or third-party,
+    /// to get it right.
+    ///
+    /// Notes for plugin authors:
+    ///
+    /// - The guarantee covers *this return value* and nothing else. A provider
+    ///   that surfaces the same list through another channel that reaches a spec
+    ///   or def — as the buildfile provider does via the `heph.core.packages()`
+    ///   builtin, whose result lands in a target's config verbatim — still owns
+    ///   the order on that channel. Do not drop a sort that is feeding one.
+    /// - The guarantee is a property of the *host*, and there is no version
+    ///   negotiation for it. A plugin that stops sorting because the host sorts
+    ///   will behave nondeterministically again under a host older than this
+    ///   change.
     fn list_packages<'a>(
         &'a self,
         req: ListPackagesRequest,


### PR DESCRIPTION
Follow-up to #218 (P5.3). The user's call: enforce the package ordering centrally instead of trusting a documented provider contract.

## Why

#218 fixed a live def-hash nondeterminism — `plugin-buildfile` collected a `HashSet<String>` into a `Vec`, and `RandomState` is seeded per process, so the same tree listed its packages in a different order on every run. That order reaches a def hash (`Engine::packages` → `Engine::query` → `pluginquery`'s `deps` → `plugingroup`, which folds `deps` **in order**) and the sandbox's list-file line order.

#218 fixed it at the buildfile provider and documented the requirement on `Provider::list_packages`. The `hermeticity` consult flagged that as MAJOR: a doc contract is not airtight against a third-party cdylib provider, which can return any order it likes.

## What changed

`Engine::packages` now sorts (and dedups) each provider's block inside the per-`(provider, prefix)` memoizer, then concatenates the blocks in provider-registration order with the existing first-seen cross-provider dedup.

**Sorted per provider, not globally.** `Engine::query` walks `self.providers` *inside* its per-package loop, so the addr order it produces is already package-major / provider-minor — it already rests on registration order, which is config-declared and deterministic for a given workspace config (always-on `query`/`fs`, then `plugins:` entries in the order written). A global sort would therefore buy no determinism the per-provider sort doesn't already give, while re-interleaving every provider's block and re-keying every multi-provider query target. Both officers independently reached the same conclusion.

The old comment claimed *"First-seen order is preserved for determinism"* — it preserved an order that was never deterministic. It is gone; the replacement states what the code actually guarantees.

## Does it re-key anything in-tree?

**No.** Every `list_packages` implementation was checked, and the walk was replayed over this tree:

| provider | order | changes? |
|---|---|---|
| `pluginbuildfile` | sorted since #218 | no |
| `pluginfs`, `pluginhostbin` | one hardcoded package each | no |
| `pluginquery` | empty | no |
| `plugingo` | pre-order DFS over name-sorted dirs | only in the punctuation-prefix case — not hit today |
| `pluginstatictarget` | first-seen over its target vec, **not** sorted | test scaffolding, never registered in production |
| third-party cdylib | unknown | **yes, if it wasn't sorting** |

Two things worth knowing rather than burying:

- **The plugingo caveat is empirical, not structural.** DFS over per-directory-sorted entries equals a lexicographic sort *except* where a sibling name is a punctuation-extended prefix of another (`-` is 0x2D, `/` is 0x2F, so `pkg/auth-v2` sorts before `pkg/auth/token` but DFS emits it after). No in-tree Go module hits it — `example/go/embed` plus the three `tools/` modules have no punctuation-adjacent siblings — but `crates/` itself is full of that shape (`plugin` / `plugin-abi` / `plugin-go`…); only the `go.mod` boundary keeps plugingo away from it. A user with `pkg/auth` + `pkg/auth-v2` in a Go tree **will** re-key once. If a future in-tree Go fixture adds sibling dirs like that, this is the change that makes their order shift.
- **A re-key here is a miss, never a stale hit.** `plugingroup` folds `deps` sequentially and `pluginexec` hashes `dep_group_inputs` in order, so a changed order always changes the key. That is why there is **no `EXEC_DEF_FORMAT_VERSION` bump**: the format version exists to invalidate keys whose *meaning* changed at a fixed key, which is not what happens here, and a bump would cost every user a full rebuild of every exec target for no safety return.

## It hides a misbehaving provider — deliberately, with no diagnostic

That is the cost of defensiveness, and I looked hard at keeping the signal. **No `debug_assert!`, no `warn!`, no `debug!`**, for a concrete reason: `plugingo` legitimately returns a non-lexicographic order, so an `is_sorted` check is a standing false positive that panics dev builds (`debug_assert!`) or gets tuned out on day one (`warn!`/`debug!`). Sortedness is the wrong predicate — the invariant worth checking is *determinism*, and a single memoized call cannot observe it. A hard error was never on the table: it would be a new failure mode for third-party providers. `hermeticity` suggested the right home for a real check — a `heph validate` check that calls `list_packages` twice and compares — which is off the hot path, has no false positive, and would also catch the `Provider::list` half. Not in this PR.

## Tests

- `packages_sorts_each_providers_listing` — provider lists reverse-sorted; asserts the exact list. Note `beta` lands after `zeta`: the output is deliberately *not* one global sort.
- `packages_order_is_independent_of_how_a_provider_lists` — three engines, same package sets, listed reverse / shuffled / already-sorted; all three must produce the same exact list.
- `packages_is_stable_across_requests_when_a_provider_reorders` — a provider that rotates its order on every call (the #218 bug shape, made deterministic); five fresh `RequestState`s, exact list each time, **and the call count is asserted** so the test can't silently degrade if the memoizer ever moves engine-level.

All three verified red against `origin/master` with only `sort_unstable()`/`dedup()` removed, after committing. `test_list_packages_is_sorted_and_agrees_with_the_starlark_builtin` and `test_heph_core_packages_order_is_stable_across_runs` are untouched and green — they test the buildfile provider directly and the `heph.core.packages()` builtin, neither of which routes through `Engine::packages`.

**`packages_preserves_each_providers_listing_order` is gone, not edited.** It asserted the *opposite* contract — that the engine imposes no order and hands a provider's sequence through verbatim — which is exactly what this change removes. It is superseded by `packages_sorts_each_providers_listing`, whose doc comment says so and says why the old contract was unsafe.

## Trait docs

`Provider::list_packages` no longer claims the order is part of the contract. It now says the engine canonicalizes it, plus two author caveats: the guarantee covers *that return value only* (buildfile still owns the order of the same list surfaced through `heph.core.packages()`, which lands in a target's config verbatim — dropping that sort would reintroduce #218), and the guarantee is a host property with no version negotiation, so a plugin that stops sorting misbehaves again on an older host.

The still-live, still-unenforced contract moved onto `Provider::list`, which previously had no docs at all.

## Known gap, not fixed here

`Provider::list` addr order is the same defect one loop deeper. It reaches the same sinks — `pluginquery`'s `deps`, and `dep_<group>.list` / `input_<origin>.list` line order — while `hashin` sorts hashouts, so the key does not move when the order does: same key, different artifact. No in-tree provider diverges today, so it is an unenforced contract rather than a live bug. `hermeticity` raised it as a BLOCKER at design stage and downgraded it to a documented smell at review. **Explicitly overruled as out of scope**: the user's decision was `Engine::packages`, and canonicalizing `list` is itself a def-hash-affecting change that is theirs to make.

## Review verdicts

- `hermeticity` — **HERMETIC WITH EXEMPTIONS**, no BLOCKER, no MAJOR. Its one requested comment (the sort must stay byte-lexicographic, or `LC_COLLATE` becomes an undeclared hash input) is in. Its `states_under` MAJOR was withdrawn after tracing — that path inherits the sort.
- `compatibility` — **COMPATIBLE**, no findings. No `ABI_SEMVER`, cache-format, proto, or CLI bump. `heph inspect packages` output is unchanged.
- `code-quality` — **PASS WITH NITS**, nothing blocking. All three MINORs fixed: the "not observable" absolute, the "engine-owned" registration-order provenance (it is config-owned), and the unasserted call count.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01A76DChMohieGMbRbnV1E7x
