### PR TITLE
fix(diag): sample limiters when the report is rendered, not at the last acquire

### DIFF
--- a/crates/engine/src/engine/diag.rs
+++ b/crates/engine/src/engine/diag.rs
@@ -189,6 +189,16 @@ pub struct Limiter {
     pub name: &'static str,
     /// Millis at which this limiter last went from "has permits" to "none", or 0.
     saturated_since_ms: AtomicU64,
+    /// Reads the limiter's *current* free permits, when one has been attached.
+    ///
+    /// Without it a limiter is only ever sampled from its own acquire path, so
+    /// the reading freezes the moment nothing acquires any more — which is
+    /// exactly when the stall watchdog fires. A wedged build then reported
+    /// "workers saturated for 90s" from a stamp left by the last acquire
+    /// attempt, indistinguishable from a pool that is still fully held.
+    /// Telling those two apart is the whole question at a stall: permits held
+    /// means deadlocked on the pool, permits free means wedged elsewhere.
+    gauge: std::sync::OnceLock<Box<dyn Fn() -> usize + Send + Sync>>,
 }
 
 impl Limiter {
@@ -196,6 +206,24 @@ impl Limiter {
         Self {
             name,
             saturated_since_ms: AtomicU64::new(0),
+            gauge: std::sync::OnceLock::new(),
+        }
+    }
+
+    /// Attach a live reader of this limiter's free permits.
+    ///
+    /// Idempotent: the first attachment wins and later ones are dropped, so a
+    /// call site on a hot path can arm it without a separate one-time hook.
+    /// Only read when a report is being rendered, never on the acquire path.
+    pub fn attach_gauge(&self, gauge: impl Fn() -> usize + Send + Sync + 'static) {
+        drop(self.gauge.set(Box::new(gauge)));
+    }
+
+    /// Re-read the live gauge, if there is one, so a report reflects the present
+    /// rather than the last acquire.
+    fn refresh(&self, now_ms: u64) {
+        if let Some(gauge) = self.gauge.get() {
+            self.observe(gauge(), now_ms);
         }
     }
 
@@ -459,7 +487,13 @@ impl DiagState {
         let mut v: Vec<_> = self
             .limiters
             .iter()
-            .filter_map(|l| l.saturated_for(now_ms).map(|d| (l.name, d)))
+            .filter_map(|l| {
+                // Sample now, not at the last acquire. A stall report is rendered
+                // precisely when nothing is acquiring, so an acquire-only reading
+                // is frozen at whatever it was when work stopped.
+                l.refresh(now_ms);
+                l.saturated_for(now_ms).map(|d| (l.name, d))
+            })
             .collect();
         v.sort_by_key(|(_, d)| std::cmp::Reverse(*d));
         v
@@ -1705,6 +1739,85 @@ mod tests {
         );
         l.observe(3, 50_000);
         assert!(s.saturated(60_000).is_empty());
+    }
+
+    /// A limiter sampled only from its own acquire path freezes exactly when it
+    /// matters.
+    ///
+    /// A stall report is rendered *because* nothing is acquiring any more, so
+    /// the last acquire-time reading is by definition stale. A real wedge
+    /// reported "workers saturated for 90s" from a stamp left behind when work
+    /// stopped, while zero `execute` spans were open — the pool was in fact
+    /// free, and the paragraph could not say so. Permits held means deadlocked
+    /// on the pool; permits free means wedged elsewhere. That is the whole
+    /// question at a stall, and the two must not look identical.
+    #[test]
+    fn a_live_gauge_reports_the_present_not_the_last_acquire() {
+        let s = state();
+        let l = &s.limiters()[0];
+        let free = std::sync::Arc::new(AtomicU64::new(0));
+
+        l.attach_gauge({
+            let free = std::sync::Arc::clone(&free);
+            move || usize::try_from(free.load(Ordering::Relaxed)).unwrap_or(0)
+        });
+
+        // Exhausted, and nothing has acquired since.
+        l.observe(0, 1_000);
+        assert_eq!(
+            s.saturated(48_000),
+            vec![("workers", Duration::from_millis(47_000))]
+        );
+
+        // Permits come back with no acquire to notice — the frozen reading would
+        // still claim saturation here.
+        free.store(4, Ordering::Relaxed);
+        assert!(
+            s.saturated(60_000).is_empty(),
+            "a live gauge must retract a stale saturation claim"
+        );
+
+        // And the reverse: it can go saturated between reports, without an
+        // acquire, and still be reported.
+        free.store(0, Ordering::Relaxed);
+        assert_eq!(
+            s.saturated(61_000)
+                .iter()
+                .map(|(n, _)| *n)
+                .collect::<Vec<_>>(),
+            vec!["workers"]
+        );
+    }
+
+    /// Without a gauge the old acquire-only behaviour is untouched, so a limiter
+    /// nobody has wired up cannot start reporting phantom saturation.
+    #[test]
+    fn a_limiter_without_a_gauge_keeps_its_acquire_only_reading() {
+        let s = state();
+        let l = &s.limiters()[0];
+        l.observe(0, 1_000);
+        assert_eq!(
+            s.saturated(5_000),
+            vec![("workers", Duration::from_millis(4_000))]
+        );
+    }
+
+    /// First attachment wins, so arming it from a hot path is safe.
+    #[test]
+    fn attaching_a_gauge_twice_keeps_the_first() {
+        let s = state();
+        let l = &s.limiters()[0];
+        l.attach_gauge(|| 0);
+        l.attach_gauge(|| 7);
+        l.observe(9, 1_000);
+        assert_eq!(
+            s.saturated(2_000)
+                .iter()
+                .map(|(n, _)| *n)
+                .collect::<Vec<_>>(),
+            vec!["workers"],
+            "the first gauge (0 permits) must still be the one consulted"
+        );
     }
 
     /// The paragraph must name the subsystem, the count and the age, and must not

--- a/crates/engine/src/engine/engine.rs
+++ b/crates/engine/src/engine/engine.rs
@@ -388,7 +388,19 @@ impl Engine {
             drivers_by_name: HashMap::new(),
             hooks: vec![],
             requests: Mutex::new(HashMap::new()),
-            result_semaphore: Arc::new(Semaphore::new(max_workers)),
+            result_semaphore: {
+                let sem = Arc::new(Semaphore::new(max_workers));
+                // Let the stall watchdog read the pool's free permits when it
+                // renders, instead of inferring them from the last acquire. The
+                // gauge is only called while a report is being built.
+                crate::engine::diag::global()
+                    .limiter("workers")
+                    .attach_gauge({
+                        let sem = Arc::clone(&sem);
+                        move || sem.available_permits()
+                    });
+                sem
+            },
             max_workers,
             provider_factories: HashMap::new(),
             driver_factories: HashMap::new(),

--- a/crates/engine/src/engine/remote_cache.rs
+++ b/crates/engine/src/engine/remote_cache.rs
@@ -183,8 +183,12 @@ where
     // moment a permit came free. `codec` is declared by `diag::global()` and was
     // never fed, so its saturation was structurally unreportable.
     let d = crate::engine::diag::global();
-    d.limiter("codec")
-        .observe(CODEC_SLOTS.available_permits(), d.now_ms());
+    let codec = d.limiter("codec");
+    // Idempotent, so arming it here costs one atomic load per call and saves a
+    // separate one-time hook. `CODEC_SLOTS` is a process-wide static, so the
+    // closure captures nothing.
+    codec.attach_gauge(|| CODEC_SLOTS.available_permits());
+    codec.observe(CODEC_SLOTS.available_permits(), d.now_ms());
     let _permit = CODEC_SLOTS
         .acquire()
         .await


### PR DESCRIPTION
`Limiter::observe` was only ever called from a limiter's own acquire path, so its reading froze the moment nothing acquired any more — which is precisely when the stall watchdog fires.

A wedged build reported:

```
open ops     542 result
limits       workers saturated for 90s
```

with **zero** `execute` spans open. Both cannot be live: the permit is taken immediately before `ExecuteStart` with no await between, so a held permit implies an open execute span. The "90s" was a stamp left by the last acquire attempt before work stopped — indistinguishable from a pool that is still fully held.

Telling those two apart is the whole question at a stall. Permits held means deadlocked on the pool; permits free means wedged elsewhere and the reader should be looking somewhere else entirely.

## Change

`Limiter` gains an optional live gauge, read by `DiagState::saturated` when a report is built and never on the acquire path:

- `workers` → wired to the result semaphore at construction (`engine.rs`)
- `codec` → wired to `CODEC_SLOTS` (`remote_cache.rs`)

Attachment is idempotent, so a hot path can arm it without a separate one-time hook. A limiter with no gauge keeps exactly its old acquire-only behaviour, so nothing starts reporting phantom saturation.

## Tests

- `a_live_gauge_reports_the_present_not_the_last_acquire` — retracts a stale claim when permits come back with no acquire to notice, and reports fresh saturation that happened between reports.
- `a_limiter_without_a_gauge_keeps_its_acquire_only_reading`
- `attaching_a_gauge_twice_keeps_the_first`

## ⚠️ CI will be red for a pre-existing reason

`cargo test -p engine` does **not compile on master** right now, independently of this PR:

```
error[E0308]: mismatched types
   --> crates/engine/src/engine/result.rs:4583:18
    |
4583|         drain_bg(&seed_rs).await;
    |         -------- ^^^^ expected `Arc<RequestState>`, found `&Arc<RequestState>`
note: function defined here
   --> crates/engine/src/engine/result.rs:4148:14
    |
4148|     async fn drain_bg(rs: Arc<crate::engine::request_state::RequestState>) {
```

7 call sites, all added by #224 (`ca4a7000`), against a by-value signature that already existed at that commit. This PR touches only `diag.rs`, `engine.rs` and `remote_cache.rs` — none of the errors are in files it modifies. Worth fixing on its own (it is a 7-character change), but I have left it alone here rather than fold an unrelated repair into this diff.

Verified locally by applying the fix out-of-band: engine `diag::` tests pass with the new gauge tests included.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019SohmU1Z8pGPuAWPpY4hwV
