### PR TITLE
fix(engine): pass the request by value to drain_bg so the tests compile

### DIFF
--- a/crates/engine/src/engine/result.rs
+++ b/crates/engine/src/engine/result.rs
@@ -4580,7 +4580,7 @@ mod tests {
         let (seeder, _seeder_home) = engine_with_remote_bash(targets(), &remote_uri)?;
         let seed_rs = seeder.new_state();
         resolve(&seeder, &seed_rs, &app, OutputMatcher::All).await?;
-        drain_bg(&seed_rs).await;
+        drain_bg(seed_rs).await;
 
         let backend = Arc::new(CountingRemoteBackend::new(remote.path()));
         let (engine, _home) = engine_with_remote_bash(targets(), &remote_uri)?;
@@ -4589,11 +4589,11 @@ mod tests {
         // Run 1: cold local cache, so both manifests are fetched and mirrored.
         let rs1 = engine.new_state();
         resolve(&engine, &rs1, &app, OutputMatcher::All).await?;
-        drain_bg(&rs1).await;
         // A run ends by dropping its state — which releases the riding read locks
         // its results hold. Run 2 must start from the same footing a fresh process
-        // would.
-        drop(rs1);
+        // would. `drain_bg` takes the state by value and drops it before waiting,
+        // so handing it over *is* that drop.
+        drain_bg(rs1).await;
         let after_run1 = backend.metadata();
         assert!(
             after_run1 > 0,
@@ -4607,7 +4607,7 @@ mod tests {
         // Run 2: every manifest is local and every blob anyone reads is local.
         let rs2 = engine.new_state();
         resolve(&engine, &rs2, &app, OutputMatcher::All).await?;
-        drain_bg(&rs2).await;
+        drain_bg(rs2).await;
         assert_eq!(
             backend.metadata(),
             after_run1,
@@ -4635,7 +4635,7 @@ mod tests {
             engine_with_remote_bash(vec![out_target("//pkg:t")], &remote_uri)?;
         let seed_rs = seeder.new_state();
         resolve(&seeder, &seed_rs, &addr, OutputMatcher::All).await?;
-        drain_bg(&seed_rs).await;
+        drain_bg(seed_rs).await;
 
         let backend = Arc::new(CountingRemoteBackend::new(remote.path()));
         let (engine, _home) = engine_with_remote_bash(vec![out_target("//pkg:t")], &remote_uri)?;
@@ -4644,7 +4644,10 @@ mod tests {
         // Run 1 — hashout only. The manifest is mirrored; no blob is pulled.
         let rs1 = engine.new_state();
         let folded = resolve(&engine, &rs1, &addr, OutputMatcher::None).await?;
-        drain_bg(&rs1).await;
+        // End of run 1: `drain_bg` takes the state by value and drops it before
+        // waiting, which is what releases its riding read locks — so run 2 starts
+        // from the same footing a fresh process would.
+        drain_bg(rs1).await;
         let promised = hashouts(&folded);
         assert!(
             !promised.is_empty(),
@@ -4655,10 +4658,8 @@ mod tests {
             "a hashout-only resolve must carry no artifact"
         );
         assert_eq!(backend.blobs(), 0, "no byte may move for a hashout");
-        // End of run 1: dropping the state releases its riding read locks, so run
-        // 2 starts from the same footing a fresh process would.
+        // The result carries the riding read guards too, so it has to go as well.
         drop(folded);
-        drop(rs1);
 
         // The remote loses the bytes but keeps the manifest — an object-store
         // lifecycle rule expiring blobs is exactly this.
@@ -4725,7 +4726,7 @@ mod tests {
             engine_with_remote_bash(vec![out_target("//pkg:t")], &remote_uri)?;
         let seed_rs = seeder.new_state();
         resolve(&seeder, &seed_rs, &addr, OutputMatcher::All).await?;
-        drain_bg(&seed_rs).await;
+        drain_bg(seed_rs).await;
 
         let real = retag_remote_hashouts(remote.path(), "deadbeefdeadbeef");
         assert!(!real.is_empty(), "the seeded manifest must be rewritten");
@@ -4737,10 +4738,12 @@ mod tests {
         // A dependent folds the (now wrong) hashout, mirroring the manifest.
         let rs1 = engine.new_state();
         let folded = resolve(&engine, &rs1, &addr, OutputMatcher::None).await?;
-        drain_bg(&rs1).await;
+        // Takes the state by value and drops it before waiting — that drop is
+        // what releases the run's riding read locks.
+        drain_bg(rs1).await;
         assert_eq!(hashouts(&folded), vec!["deadbeefdeadbeef".to_string()]);
+        // The result carries the riding read guards too, so it has to go as well.
         drop(folded);
-        drop(rs1);
 
         assert!(evict_remote_blobs(remote.path()) > 0);
 


### PR DESCRIPTION
`cargo test -p engine` has not compiled since #224 (`ca4a7000`). Seven `drain_bg(&rs)` call sites were added against a signature that takes the `Arc` by value:

```
error[E0308]: mismatched types
   --> crates/engine/src/engine/result.rs:4583:18
    |
4583|         drain_bg(&seed_rs).await;
    |         -------- ^^^^ expected `Arc<RequestState>`, found `&Arc<RequestState>`
```

Every open PR against the engine is currently red for this reason, including two of mine (#231, #232).

## Why the callers move, not the signature

By-value is deliberate and load-bearing. `drain_bg` drops the request *before* waiting:

```rust
// Takes the request by value and releases it before waiting. Some
// background work is only *submitted* when the request state drops (the
// post-write cache trim) and holds a slot until then, so a waiter that
// keeps `rs` alive waits on a counter that cannot reach zero.
drop(rs);
```

Relaxing it to `&Arc` — or having callers pass `Arc::clone` — would leave the caller holding a reference, so the counter could never reach zero and the 5s deadline inside would fire. The 12 pre-existing call sites already pass by value; this makes all 15 consistent.

## The three redundant drops

Three of the seven were followed by an explicit `drop(rs)` a few lines later, with a comment explaining that dropping the state is what releases the run's riding read locks before the next run starts:

```rust
drain_bg(&rs1).await;
// A run ends by dropping its state — which releases the riding read locks
// its results hold. Run 2 must start from the same footing a fresh process
// would.
drop(rs1);
```

Handing the state to `drain_bg` *is* that drop, so these are removed and the comments move onto the `drain_bg` call. `drop(folded)` stays — the result carries the riding read guards too, and that is a separate release.

I checked each of the seven variables for uses after its `drain_bg` within the enclosing test: there are none, so moving ownership is safe at every site.

## Verification

The three tests this unblocks have never run since they were written. All three pass:

```
test engine::result::tests::a_folded_hashout_survives_the_bytes_going_away ... ok
test engine::result::tests::a_second_run_over_a_remote_served_graph_issues_no_metadata_requests ... ok
test engine::result::tests::a_rebuild_that_changes_the_hashout_fails_loudly ... ok
```

Full engine lib suite: **395 passed, 0 failed**. `lint` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019SohmU1Z8pGPuAWPpY4hwV
