### PR TITLE
fix(engine): hand a worker permit only to a task that is running

### DIFF
--- a/crates/engine/src/engine/engine.rs
+++ b/crates/engine/src/engine/engine.rs
@@ -15,7 +15,6 @@ use hsandboxfuse as sandboxfuse;
 use std::collections::HashMap;
 use std::path::{Path, PathBuf};
 use std::sync::{Arc, Mutex, Weak};
-use tokio::sync::Semaphore;
 use tracing::warn;
 
 /// Context the engine injects when constructing any plugin (provider, driver, or
@@ -83,8 +82,8 @@ pub struct Engine {
 
     pub requests: Mutex<HashMap<String, Weak<RequestState>>>,
     pub home: PathBuf,
-    pub(crate) result_semaphore: Arc<Semaphore>,
-    /// Maximum concurrent executes (the `result_semaphore` permit count). Cached
+    pub(crate) result_permits: Arc<crate::engine::worker_pool::WorkerPool>,
+    /// Maximum concurrent executes (the `result_permits` capacity). Cached
     /// here so it can be announced to clients via a `MaxWorkers` build event
     /// without reaching into the semaphore (whose live `available_permits` only
     /// reflects the *free* count, not the configured max).
@@ -388,21 +387,21 @@ impl Engine {
             drivers_by_name: HashMap::new(),
             hooks: vec![],
             requests: Mutex::new(HashMap::new()),
-            result_semaphore: {
-                let sem = Arc::new(Semaphore::new(max_workers));
+            result_permits: {
+                let pool = crate::engine::worker_pool::WorkerPool::new(max_workers);
                 // Two readers of the same pool, for two different lines: the
                 // permit accounting (`N max, N free, N running`) and the
                 // `workers` limiter's saturation age. Both must sample when the
                 // report is rendered, not at the last acquire.
                 let free = {
-                    let sem = Arc::clone(&sem);
-                    move || sem.available_permits()
+                    let pool = Arc::clone(&pool);
+                    move || pool.available()
                 };
                 crate::engine::diag::global().register_worker_pool(max_workers, free.clone());
                 crate::engine::diag::global()
                     .limiter("workers")
                     .attach_gauge(free);
-                sem
+                pool
             },
             max_workers,
             provider_factories: HashMap::new(),

--- a/crates/engine/src/engine/execute.rs
+++ b/crates/engine/src/engine/execute.rs
@@ -49,24 +49,17 @@ impl Engine {
         // deps — prevents the classic diamond deadlock where mid-nodes hold permits while
         // waiting for a leaf that also needs a permit.
         hcore::hmemoizer::set_phase("execute:semaphore_acquire");
-        let semaphore = Arc::clone(&self.result_semaphore);
+        let pool = Arc::clone(&self.result_permits);
         // Observed *before* the acquire, so the stamp times the wait rather than
         // its end. This queue is invisible everywhere else: the permit is taken
         // after dep resolution but before `ExecuteStart`, so a target parked here
-        // has no open `execute` span and shows only as an open `result`. A build
-        // wedged with every worker held reported "N result" and no limits line at
-        // all, because the `workers` limiter was declared and never fed.
+        // has no open `execute` span and shows only as an open `result`.
         let d = crate::engine::diag::global();
-        d.limiter("workers")
-            .observe(semaphore.available_permits(), d.now_ms());
-        let _permit = semaphore
-            .acquire()
-            .await
-            .context("result semaphore closed")?;
-        // Counted only once `acquire` has *returned*. A permit handed to a
-        // waiter that is never polled again never reaches this line, which is
-        // precisely what makes the pool's free count and this counter disagree
-        // — see `WorkerPermits::unaccounted`.
+        d.limiter("workers").observe(pool.available(), d.now_ms());
+        // Parks holding nothing until a permit is genuinely free — see
+        // `worker_pool`. A caller abandoned mid-wait strands no permit.
+        let _permit = pool.acquire().await.context("worker pool closed")?;
+        // Counted once the permit is actually in hand.
         let _running = crate::engine::diag::RunningPermit::new();
 
         let addr_str = addr.format();

--- a/crates/engine/src/engine/mod.rs
+++ b/crates/engine/src/engine/mod.rs
@@ -83,3 +83,4 @@ pub mod matcher_target;
 mod meta;
 pub mod sandbox_cleaner;
 pub mod validate;
+pub mod worker_pool;

--- a/crates/engine/src/engine/worker_pool.rs
+++ b/crates/engine/src/engine/worker_pool.rs
@@ -1,0 +1,211 @@
+//! The execute-concurrency pool: at most `capacity` targets running at once.
+//!
+//! A plain `tokio::sync::Semaphore` is the obvious fit and is the wrong one
+//! here, for a reason that only shows up in this engine.
+//!
+//! `Semaphore::acquire` is fair and queueing: on release, tokio takes the permit
+//! and **assigns** it to the first waiter in its queue, then wakes that waiter.
+//! The permit belongs to that waiter's `Acquire` future from that moment on,
+//! before the waiter has run — so if the waiter is never polled again, the
+//! permit is spent and held by nobody. It cannot be re-granted, and dropping it
+//! requires dropping a future nobody owns.
+//!
+//! In this engine, futures that are never polled again are routine. Every level
+//! from the CLI down to `execute` runs inside a `hmemoizer` cell, and a cell
+//! keeps its in-flight future when its last awaiter goes away — which fail-fast
+//! (drop every sibling on the first error) and Ctrl-C both do wholesale. That
+//! parked future keeps its place in the semaphore's queue.
+//!
+//! A wedged build measured exactly that: 99 targets queued for a permit, 21 of
+//! them in chains reachable only from abandoned cells, against a pool of 12.
+//! Every permit had been handed to a waiter that would never run, so the pool
+//! read as fully busy while nothing at all was executing.
+//!
+//! So this pool never queues. A permit is taken with `try_acquire` by a task
+//! that is *running the poll*, and a task that finds none parks on a `Notify`
+//! holding nothing. An abandoned future parks there forever and costs the pool
+//! nothing, because there is no permit to strand.
+//!
+//! # Why every waiter is woken
+//!
+//! Release wakes **all** parked waiters and they race for the permit. Waking one
+//! would be cheaper and is not safe: an abandoned future is a registered waiter
+//! like any other, so `notify_one` can hand the only notification to a task that
+//! will never retry — and the permit then sits *free* while live waiters park
+//! forever. That is the same failure with a different shape.
+//!
+//! The cost is a wake per waiter per release. That is real, and it is bounded by
+//! work that is already this coarse (one release per executed target), where the
+//! alternative is a build that stops.
+
+use anyhow::Result;
+use std::sync::Arc;
+use tokio::sync::{Notify, OwnedSemaphorePermit, Semaphore};
+
+/// Bounds how many targets execute concurrently.
+#[derive(Debug)]
+pub struct WorkerPool {
+    permits: Arc<Semaphore>,
+    /// Signalled after a permit is returned. Never `notify_one` — see module
+    /// docs.
+    released: Notify,
+    capacity: usize,
+}
+
+impl WorkerPool {
+    pub fn new(capacity: usize) -> Arc<Self> {
+        Arc::new(Self {
+            permits: Arc::new(Semaphore::new(capacity)),
+            released: Notify::new(),
+            capacity,
+        })
+    }
+
+    pub fn capacity(&self) -> usize {
+        self.capacity
+    }
+
+    /// Permits nobody is holding, right now.
+    pub fn available(&self) -> usize {
+        self.permits.available_permits()
+    }
+
+    /// Take a permit, parking until one is free.
+    ///
+    /// Holds nothing while parked: a caller dropped or abandoned mid-wait leaves
+    /// the pool exactly as it found it.
+    pub async fn acquire(self: &Arc<Self>) -> Result<WorkerPermit> {
+        loop {
+            // Registered *before* the attempt, so a release landing between the
+            // failed attempt and the park is not missed. `notify_waiters` only
+            // reaches waiters already registered when it runs.
+            let parked = self.released.notified();
+            tokio::pin!(parked);
+            parked.as_mut().enable();
+
+            if let Ok(permit) = Arc::clone(&self.permits).try_acquire_owned() {
+                return Ok(WorkerPermit {
+                    permit: Some(permit),
+                    pool: Arc::clone(self),
+                });
+            }
+
+            parked.await;
+        }
+    }
+}
+
+/// A held execute slot. Returns it to the pool on drop and wakes the waiters.
+#[derive(Debug)]
+pub struct WorkerPermit {
+    /// `Option` so [`Drop`] can return the permit *before* announcing it.
+    permit: Option<OwnedSemaphorePermit>,
+    pool: Arc<WorkerPool>,
+}
+
+impl Drop for WorkerPermit {
+    fn drop(&mut self) {
+        // Order matters: a waiter woken before the permit is back finds nothing,
+        // parks again, and never hears about it — `notify_waiters` leaves no
+        // notification behind for anyone who was not already registered.
+        drop(self.permit.take());
+        self.pool.released.notify_waiters();
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::time::Duration;
+
+    #[tokio::test]
+    async fn bounds_concurrency_to_its_capacity() {
+        let pool = WorkerPool::new(2);
+        let a = pool.acquire().await.expect("first");
+        let b = pool.acquire().await.expect("second");
+        assert_eq!(pool.available(), 0);
+
+        // A third caller must wait, and must not be holding anything while it
+        // does — the whole point of the type.
+        let mut third = Box::pin(pool.acquire());
+        assert!(futures::poll!(&mut third).is_pending());
+        assert_eq!(pool.available(), 0, "a waiter must hold no permit");
+
+        drop(a);
+        let c = third.await.expect("third");
+        assert_eq!(pool.available(), 0);
+        drop((b, c));
+        assert_eq!(pool.available(), 2);
+    }
+
+    /// **The regression this type exists for.**
+    ///
+    /// A waiter that is dropped, or simply never polled again, must not consume
+    /// a permit. `Semaphore::acquire` fails this: on release it assigns the
+    /// permit to the queued waiter, so abandoning that waiter strands it.
+    #[tokio::test]
+    async fn an_abandoned_waiter_strands_no_permit() {
+        let pool = WorkerPool::new(1);
+        let held = pool.acquire().await.expect("held");
+
+        // Three waiters that are polled once and then never again — the shape a
+        // memoizer cell leaves behind when its last awaiter goes away.
+        let mut abandoned: Vec<_> = (0..3).map(|_| Box::pin(pool.acquire())).collect();
+        for w in &mut abandoned {
+            assert!(futures::poll!(w).is_pending());
+        }
+
+        drop(held);
+
+        // The permit is back and claimable, even though three futures are still
+        // parked on the pool and none of them will ever run again.
+        assert_eq!(
+            pool.available(),
+            1,
+            "a released permit was handed to a waiter that will never use it"
+        );
+        let live = tokio::time::timeout(Duration::from_secs(5), pool.acquire())
+            .await
+            .expect("a live caller must not be blocked by abandoned waiters")
+            .expect("acquire");
+        drop(live);
+        drop(abandoned);
+        assert_eq!(pool.available(), 1);
+    }
+
+    /// Dropping a waiter mid-wait leaves the pool untouched.
+    #[tokio::test]
+    async fn a_cancelled_waiter_leaves_no_trace() {
+        let pool = WorkerPool::new(1);
+        let held = pool.acquire().await.expect("held");
+        let mut cancelled = Box::pin(pool.acquire());
+        assert!(futures::poll!(&mut cancelled).is_pending());
+        drop(cancelled);
+        drop(held);
+        assert_eq!(pool.available(), 1);
+    }
+
+    /// Every parked waiter is woken on release, so the one that gets the permit
+    /// is never decided by a notification that a dead waiter swallowed.
+    #[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+    async fn many_waiters_all_make_progress() {
+        let pool = WorkerPool::new(2);
+        let mut tasks = tokio::task::JoinSet::new();
+        for _ in 0..32 {
+            let pool = Arc::clone(&pool);
+            tasks.spawn(async move {
+                let permit = pool.acquire().await.expect("acquire");
+                tokio::task::yield_now().await;
+                drop(permit);
+            });
+        }
+        let done = tokio::time::timeout(Duration::from_secs(30), async {
+            while let Some(r) = tasks.join_next().await {
+                r.expect("task");
+            }
+        })
+        .await;
+        assert!(done.is_ok(), "waiters starved");
+        assert_eq!(pool.available(), 2);
+    }
+}


### PR DESCRIPTION
**Stacked on #237** (it uses `RunningPermit` and `register_worker_pool` from there), so the diff shows only this change. Re-target to `master` once #237 lands.

## The mechanism, demonstrated

`tokio::sync::Semaphore::acquire` is fair and queueing: on release it takes the permit and **assigns** it to the first queued waiter *before that waiter has run*. If the waiter is never polled again, the permit is spent and held by nobody — it cannot be re-granted, and returning it would mean dropping a future nobody owns.

Not inferred. A throwaway test against a plain `Semaphore` — hold the only permit, park three waiters, drop it:

```rust
drop(held);
assert_eq!(sem.available_permits(), 0);   // passes
```

The permit is gone, into a waiter that will never run.

## Why this engine hits it constantly

Every level from the CLI down to `execute` runs inside a `hmemoizer` cell (`mem_result` → `mem_locked_result` → `mem_execute_cache`), and a cell **keeps its in-flight future when its last awaiter goes away** — deliberately, so another awaiter can take over. Fail-fast (drop every sibling on the first error) and Ctrl-C both produce abandoned cells wholesale. That parked future keeps its place in the semaphore's queue.

Measured on the wedged build (PID 1910570), walking the wait-for graph upward from every target queued for a permit:

```
execute_cache cells queued on the semaphore: 99
  live-rooted (a real caller still wants it): 78
  dead-rooted (every root is abandoned):      21
```

The dump has 24 blocking-pool threads and `pool_size() = cores * 2` → 12 cores → `max_workers = 12`. **21 ≥ 12**: every permit could be absorbed by a chain nobody would ever poll. Which is exactly what was observed — pool fully busy, nothing executing, 78 live waiters queued forever.

## Change

A small `WorkerPool` replacing the bare semaphore. It never queues: `acquire` takes a permit with `try_acquire` from the task that is *running the poll*, and a task that finds none parks on a `Notify` holding nothing. An abandoned future parks there forever and costs the pool nothing.

The `Notified` future is registered **before** the attempt, so a release landing between the failed attempt and the park is not missed.

## Why every waiter is woken, not one

`notify_one` would be cheaper and is not safe here: an abandoned future is a registered waiter like any other, so it can receive the only notification and never retry — leaving the permit *free* while live waiters park forever. Same failure, different shape.

The cost is a wake per waiter per release, bounded by work that is already this coarse (one release per executed target). **This is the part worth a second opinion** — it is a real change in wake volume on a hot path, and I have not measured it. A `perf-measurement` pass before merge would be well spent; if the herd bites, the answer is probably a bounded hand-off list rather than reverting to `acquire`.

## Tests

- `an_abandoned_waiter_strands_no_permit` — the regression test: three waiters polled once and never again, permit still claimable by a live caller.
- `a_cancelled_waiter_leaves_no_trace` — dropping a waiter mid-wait leaves the pool untouched.
- `bounds_concurrency_to_its_capacity` — including that a waiter holds nothing while waiting.
- `many_waiters_all_make_progress` — 32 waiters over 2 permits, multi-threaded, no starvation.

Local: engine lib 406 passed, full `e2e` green (10 suites), `lint` clean.

## Scope

This fixes permits specifically. It does **not** reclaim abandoned futures — they still sit in their cells holding memory and whatever else they captured. That is the broader question of whether abandoned computations should be cancelled outright, which I would rather take separately now that the build no longer wedges on it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019SohmU1Z8pGPuAWPpY4hwV
