### PR TITLE
ci: run on every pull request, not only those targeting master

### DIFF
--- a/.github/workflows/heph.yml
+++ b/.github/workflows/heph.yml
@@ -3,8 +3,17 @@ name: CI
 on:
   push:
     branches: ["master"]
+  # Every pull request, whatever it targets. Deliberately unfiltered: a
+  # `branches:` filter here matches the PR's *base*, so restricting it to
+  # master silently gives zero CI to any PR stacked on another branch — no
+  # runs queued, no failed checks, nothing to notice. The upper layers of a
+  # stack are exactly the changes that most want testing before the layer
+  # below them merges.
+  #
+  # The ABI guard diffs against `github.base_ref` rather than a hardcoded
+  # master, so it keeps working here and reports the ABI delta for that layer
+  # alone.
   pull_request:
-    branches: ["master"]
 
 # Cancel superseded runs on a branch/PR so a new push doesn't leave the old run
 # burning runners (and showing up as a noisy "cancelled"). master is never


### PR DESCRIPTION
`pull_request.branches` filters on the PR's **base**, so pinning it to `master` gave **zero CI to any PR stacked on another branch**.

Not a failing check, not a skipped job — no workflow run is queued at all, so there is nothing on the PR to notice:

```
$ gh pr checks 238
no checks reported on the 'raphaelvigee/permit-only-to-live-waiters' branch
$ gh run list --branch raphaelvigee/permit-only-to-live-waiters
[]
```

That is backwards. The upper layers of a stack are exactly the changes that most want testing, since they merge into a branch that is itself about to merge.

## Change

```diff
   pull_request:
-    branches: ["master"]
```

Dropped rather than widened to a pattern. A pattern would have to be guessed per branch-naming convention and would fail silently the same way the moment someone picked a different prefix.

`push` keeps its master-only filter — that is what publishes releases and should not fire on branch pushes.

## Checked before making it unconditional

- **ABI guard** already diffs against `origin/${{ github.base_ref }}`, not a hardcoded master, and checks out with `fetch-depth: 0`. On a stacked PR it reports the ABI delta for that layer alone, which is the right answer.
- **Concurrency group** keys on `github.ref`, which is `refs/pull/N/merge` for a PR — already unique per PR, so stacked PRs don't cancel each other.
- **Release job** is gated on `github.ref == 'refs/heads/master'`, so it stays push-only.

## Cost

An upper stack layer runs the full matrix (3 platforms) while its diff still contains the layers below it, so those tests run twice across a two-PR stack. That is the trade for not merging the bottom of a stack having never seen the top tested. If it becomes expensive, the narrower fix is a paths filter or a cheaper job set for non-master bases — but that is worth doing on evidence rather than pre-emptively.

Verified `on:` still parses with the `pull_request:` key left null (`yq '.on'`), which is the documented way to say "all pull requests".

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019SohmU1Z8pGPuAWPpY4hwV
