### PR TITLE
fix(engine): make sandbox teardown survive a cancelled execute

### DIFF
--- a/crates/engine/src/engine/execute.rs
+++ b/crates/engine/src/engine/execute.rs
@@ -10,7 +10,6 @@ use anyhow::Context;
 use async_recursion::async_recursion;
 use enclose::enclose;
 use hmodel::htaddr::Addr;
-use std::io;
 use std::sync::Arc;
 
 impl Engine {
@@ -30,7 +29,7 @@ impl Engine {
         shell: bool,
     ) -> anyhow::Result<(
         Vec<OutputArtifact>,
-        Option<crate::engine::sandbox_cleaner::SandboxCleanupJob>,
+        crate::engine::sandbox_cleaner::SandboxTeardown,
         Vec<hplugin::driver::SandboxGuard>,
     )> {
         let driver = self
@@ -89,71 +88,134 @@ impl Engine {
                         dir.join(format!("__target_{}_{}", addr.name, addr.hash_str()))
                     }
                 };
-                // Stale cleanup only — the driver bridge owns the create step
-                // because it may redirect this path into a FUSE mount (v2 single-
-                // mount mode). Creating here would waste an inode + leave an
-                // orphan empty dir when the bridge picks the FUSE side.
-                hcore::hmemoizer::set_phase("execute:sandbox_remove");
-                sync_fs_op_on_thread(enclose!((sandbox_dir) move || {
-                    match crate::engine::sandbox_cleaner::remove_dir_all(&sandbox_dir) {
-                        Ok(_) => Ok(()),
-                        Err(err) if err.kind() == io::ErrorKind::NotFound => Ok(()),
-                        Err(err) => Err(err),
-                    }
-                }))
-                .await
-                .with_context(|| format!("remove stale sandbox dir {}", sandbox_dir.display()))?;
+                // Claim the sandbox path for this execute — inline, before any
+                // removal job is queued. The claim is what orders this run
+                // against every straggler: it happens synchronously here, so a
+                // predecessor's queued job (in any queue, under any lock-grant
+                // order) that runs after this line sees a stale claim and
+                // declines. See `sandbox_cleaner::generation`; `claim` takes
+                // only the fast generation lock, never the walk lock, so it is
+                // safe on the async path.
+                let sandbox_generation =
+                    crate::engine::sandbox_cleaner::generation::claim(&sandbox_dir);
+                // From the moment the path is claimed, its teardown is owned,
+                // and every exit resolves it exactly once, three ways:
+                // completion hands the bridge's cleanup job to `complete()` in
+                // `execute_and_cache_inner`; a *failing* run resolves it as
+                // `leave_for_diagnostics` in the match below (the failure
+                // renderer reads the log tail lazily from the sandbox, so a
+                // failed target's tree must survive until its next run — its
+                // documented pre-teardown behaviour); and a bare drop —
+                // cancellation or an unwind, and only those — queues a
+                // generation-checked reclaim of the directory. Without that
+                // last leg, mass fail-fast leaves one abandoned sandbox tree
+                // per *cancelled* execute and nothing ever collects them
+                // (`gc` has no sandbox sweep).
+                let mut sandbox_teardown = crate::engine::sandbox_cleaner::SandboxTeardown::arm(
+                    sandbox_dir.clone(),
+                    sandbox_generation,
+                    rs.bg_pending(),
+                );
 
-                let exec_wrapper: InteractiveWrapper = exec_wrapper.unwrap_or_else(|| {
-                    Arc::new(|inner: InteractiveInner| {
-                        Box::pin(async move { inner(None, None, None).await })
-                    })
-                });
-
-                let (tx, rx) = tokio::sync::oneshot::channel::<RunResponse>();
-
-                let hashin = hashin.to_owned();
-
-                let inner: InteractiveInner = Box::new(enclose!(
-                    (driver, def, rs, self => engine, sandbox_dir)
-                    move |stdin, stdout, stderr| {
-                        Box::pin(async move {
-                            let req = RunRequest {
-                                request_id: rs.request_id(),
-                                target: &def.target,
-                                tree_root_path: engine.cfg.root.clone(),
-                                inputs: deps_result,
-                                hashin: &hashin,
-                                stdin,
-                                stdout,
-                                stderr,
-                                sandbox_dir,
-                            };
-                            let res = if shell {
-                                driver.driver.run_shell(req, rs.ctoken()).await?
-                            } else {
-                                driver.driver.run(req, rs.ctoken()).await?
-                            };
-                            drop(tx.send(res));
-                            Ok(())
-                        })
-                    }
-                ));
-
-                hcore::hmemoizer::set_phase("execute:driver_run");
-                exec_wrapper(inner).await.with_context(|| "run")?;
-
-                hcore::hmemoizer::set_phase("execute:oneshot_rx");
-                let res = rx
+                // Everything fallible between the claim and the run response
+                // lives in this block, so an `Err` — a failing target above
+                // all — can be told apart from a drop: the error leaves the
+                // sandbox for diagnostics, the drop reclaims it.
+                let run = async {
+                    // Stale cleanup only — the driver bridge owns the create
+                    // step because it may redirect this path into a FUSE mount
+                    // (v2 single-mount mode). Creating here would waste an
+                    // inode + leave an orphan empty dir when the bridge picks
+                    // the FUSE side.
+                    //
+                    // Queued with this run's claim: if this future is cancelled
+                    // at the await below (the production wedge's phase), the
+                    // job still runs eventually — and by then a successor may
+                    // own the path, in which case the job declines rather than
+                    // deleting the successor's live sandbox.
+                    hcore::hmemoizer::set_phase("execute:sandbox_remove");
+                    sync_fs_op_on_thread(enclose!(
+                        (sandbox_dir) move ||
+                            crate::engine::sandbox_cleaner::generation::remove_stale(
+                                &sandbox_dir,
+                                sandbox_generation,
+                            )
+                    ))
                     .await
-                    .map_err(|_recv_err| anyhow::anyhow!("wrapper never invoked inner"))?;
+                    .with_context(|| {
+                        format!("remove stale sandbox dir {}", sandbox_dir.display())
+                    })?;
+
+                    let exec_wrapper: InteractiveWrapper = exec_wrapper.unwrap_or_else(|| {
+                        Arc::new(|inner: InteractiveInner| {
+                            Box::pin(async move { inner(None, None, None).await })
+                        })
+                    });
+
+                    let (tx, rx) = tokio::sync::oneshot::channel::<RunResponse>();
+
+                    let hashin = hashin.to_owned();
+
+                    let inner: InteractiveInner = Box::new(enclose!(
+                        (driver, def, rs, self => engine, sandbox_dir)
+                        move |stdin, stdout, stderr| {
+                            Box::pin(async move {
+                                let req = RunRequest {
+                                    request_id: rs.request_id(),
+                                    target: &def.target,
+                                    tree_root_path: engine.cfg.root.clone(),
+                                    inputs: deps_result,
+                                    hashin: &hashin,
+                                    stdin,
+                                    stdout,
+                                    stderr,
+                                    sandbox_dir,
+                                };
+                                let res = if shell {
+                                    driver.driver.run_shell(req, rs.ctoken()).await?
+                                } else {
+                                    driver.driver.run(req, rs.ctoken()).await?
+                                };
+                                drop(tx.send(res));
+                                Ok(())
+                            })
+                        }
+                    ));
+
+                    hcore::hmemoizer::set_phase("execute:driver_run");
+                    exec_wrapper(inner).await.with_context(|| "run")?;
+
+                    hcore::hmemoizer::set_phase("execute:oneshot_rx");
+                    rx.await
+                        .map_err(|_recv_err| anyhow::anyhow!("wrapper never invoked inner"))
+                }
+                .await;
+
+                let res = match run {
+                    Ok(res) => res,
+                    Err(err) => {
+                        // The target failed. Its sandbox *is* the diagnostic —
+                        // the failure paragraph reads the process's last log
+                        // lines from it lazily, at render time — so nothing may
+                        // be queued against it, or the diagnostic races its own
+                        // cleanup and a failing target reports an exit status
+                        // with no output. The tree survives until this target's
+                        // next run, whose `remove_stale` reclaims it.
+                        sandbox_teardown.leave_for_diagnostics();
+                        return Err(err);
+                    }
+                };
 
                 // Bridge owns the cleanup closure (knows whether the sandbox
                 // lives in the plain `<home>/sandbox/...` tree or under the
-                // FUSE upper-side dir). Slot guards travel with the response
-                // so result.rs can drop them in the same defer that fires
-                // sandbox cleanup.
-                Ok((res.artifacts, res.sandbox_cleanup, res.sandbox_guards))
+                // FUSE upper-side dir). It rides inside the teardown guard from
+                // here: `execute_and_cache_inner` completes the teardown after
+                // `cache_locally` (which reads from the sandbox), and any drop
+                // on the way there queues the generation-checked reclaim
+                // instead. Slot guards travel with the response so result.rs
+                // can drop them before completing the teardown.
+                sandbox_teardown.set_job(res.sandbox_cleanup);
+                Ok((res.artifacts, sandbox_teardown, res.sandbox_guards))
             },
         )
         .await;
@@ -212,9 +274,10 @@ impl Engine {
 /// Not `tokio::fs::*` (which routes through `spawn_blocking`, observed to lose
 /// wake-ups on macOS under heavy load) and not inline on the worker (which parks
 /// it without telling the runtime). See `hcore::blocking`.
-async fn sync_fs_op_on_thread<F>(f: F) -> std::io::Result<()>
+async fn sync_fs_op_on_thread<F, T>(f: F) -> std::io::Result<T>
 where
-    F: FnOnce() -> std::io::Result<()> + Send + 'static,
+    F: FnOnce() -> std::io::Result<T> + Send + 'static,
+    T: Send + 'static,
 {
     hcore::blocking::run(f).await
 }

--- a/crates/engine/src/engine/result.rs
+++ b/crates/engine/src/engine/result.rs
@@ -27,7 +27,6 @@ use crate::engine::remote_cache::RemoteRevision;
 use crate::engine::result_lock::ResultReadGuard;
 use anyhow::Context;
 use futures::{StreamExt, TryStreamExt};
-use hcore::defer;
 use hcore::hartifactcontent::{Content, ReadSeek, WalkEntry, WalkEntryKind};
 use hmodel::htmatcher::Matcher;
 use std::future::Future;
@@ -2651,13 +2650,13 @@ impl Engine {
                         .await
                         .with_context(|| format!("approval {addr}"))?;
                     hcore::hmemoizer::set_phase("execute_cache:engine_execute");
-                    let (artifacts, sandbox_cleanup, sandbox_guards) = engine
+                    let (artifacts, sandbox_teardown, sandbox_guards) = engine
                         .clone()
                         .execute(rs.clone(), &addr, &spec, &def, &hashin, interactive, shell)
                         .await
                         .with_context(|| format!("execute {addr}"))?;
 
-                    let artifacts_meta = artifacts
+                    let artifacts_meta = match artifacts
                         .iter()
                         .filter(|a| matches!(
                             a.r#type,
@@ -2665,22 +2664,21 @@ impl Engine {
                         ))
                         .map(|a| Ok(ArtifactMeta { hashout: a.hashout()? }))
                         .collect::<anyhow::Result<Vec<_>>>()
-                        .with_context(|| format!("read artifact metas for {addr}"))?;
-
-                    // SlotGuards drop here too — moved into the defer so
-                    // they live across cache_locally (which reads from
-                    // the FUSE-side sandbox) and only deregister after
-                    // cleanup is enqueued. The cleanup closure is owned
-                    // by the bridge that built the sandbox; it knows
-                    // whether to rm the plain dir or the FUSE upper.
-                    let cleanup_label = format!("{addr}");
-                    let bg_pending = rs.bg_pending();
-                    defer! {
-                        drop(sandbox_guards);
-                        if let Some(job) = sandbox_cleanup {
-                            crate::engine::sandbox_cleaner::enqueue(cleanup_label, job, bg_pending);
+                        .with_context(|| format!("read artifact metas for {addr}"))
+                    {
+                        Ok(metas) => metas,
+                        Err(err) => {
+                            // A target failure, like any `Err` leaving the
+                            // execute: the sandbox stays on disk for the
+                            // failure diagnostic (which reads it lazily) and
+                            // for a post-mortem of the artifacts it failed to
+                            // hash. A bare `?` here would fall into the drop
+                            // path, which reclaims — that path must mean
+                            // cancellation only.
+                            sandbox_teardown.leave_for_diagnostics();
+                            return Err(err);
                         }
-                    }
+                    };
 
                     hcore::hmemoizer::set_phase("execute_cache:cache_locally");
 
@@ -2772,6 +2770,41 @@ impl Engine {
                     if out.is_ok() && !use_tmp_cache {
                         rs.defer_trim(&addr, def.target.cache.history, hashin);
                     }
+
+                    // Completion path of the sandbox teardown. The teardown is
+                    // an RAII guard armed in `Engine::execute` when the path
+                    // was claimed, and every exit resolves it exactly once,
+                    // three ways:
+                    //
+                    // * Reaching this line enqueues the bridge-owned cleanup
+                    //   closure, generation-guarded. That includes a *failed
+                    //   cache write* (`out` is `Err` here after a successful
+                    //   run) — deliberately, matching the old `defer!`: the
+                    //   run itself succeeded, so there is no process log tail
+                    //   riding on this sandbox's survival.
+                    // * A *failing target* never gets here: the run error in
+                    //   `Engine::execute` and the `artifacts_meta` error above
+                    //   both resolve as `leave_for_diagnostics`, keeping the
+                    //   sandbox (and its log) on disk for the lazily-rendered
+                    //   failure diagnostic, exactly as before teardown
+                    //   ownership existed.
+                    // * A bare drop — cancellation or an unwind, and only
+                    //   those — enqueues a generation-checked reclaim.
+                    //
+                    // The old `defer!` here also enqueued at drop time in this
+                    // window, but *unguarded*: with cancellation now routine
+                    // (cancel-on-abandonment), that handed the cleaner a
+                    // `remove_dir_all` at an arbitrarily later time, racing the
+                    // next execute of the same addr as it recreates this very
+                    // directory. The generation check is what makes drop-time
+                    // teardown safe in every ordering.
+                    //
+                    // Runs after `cache_locally`, which reads from the sandbox
+                    // (`project_sandbox_cleanup_ordering`). SlotGuards drop
+                    // first, having lived across that read; the bridge closure
+                    // knows whether to rm the plain dir or the FUSE upper.
+                    drop(sandbox_guards);
+                    sandbox_teardown.complete(format!("{addr}"));
 
                     hcore::hmemoizer::clear_phase();
                     out

--- a/crates/engine/src/engine/sandbox_cleaner.rs
+++ b/crates/engine/src/engine/sandbox_cleaner.rs
@@ -17,6 +17,7 @@
 //! the queue, jobs are processed in FIFO order on one thread.
 use crossbeam_channel::{Sender, unbounded};
 use std::panic::{AssertUnwindSafe, catch_unwind};
+use std::path::PathBuf;
 use std::sync::Arc;
 use std::sync::OnceLock;
 use std::sync::atomic::{AtomicUsize, Ordering};
@@ -89,6 +90,282 @@ fn sender() -> &'static Sender<Job> {
             .expect("spawn sandbox-cleaner thread");
         tx
     })
+}
+
+/// Per-sandbox-path generations, serializing destructive jobs against the
+/// execute that owns the path now.
+///
+/// The hazard: a sandbox-removal job is detached the moment it is queued — the
+/// pre-run stale-remove runs on `hcore::blocking`'s pool and its awaiter can be
+/// cancelled (cancel-on-abandonment makes that routine, and the production
+/// wedge was parked at exactly that await), and the post-run cleanup runs
+/// fire-and-forget on the cleaner thread. A later execute of the same target
+/// recreates the very directory such a straggler is about to delete, and a
+/// `remove_dir_all` landing on a live sandbox silently eats freshly written
+/// outputs.
+///
+/// The scheme: **claim at queue time, check at walk time.** Every destructive
+/// job is queued carrying the generation its execute [`claim`]ed, and when the
+/// job finally runs it re-reads the path's current generation and declines if
+/// the path has moved on. This holds in *every* ordering — queue order, pool
+/// order, and lock-acquisition order are all irrelevant, because the claim
+/// happens synchronously on the execute's own path before the successor can
+/// exist, and the check happens under the gate at the last moment:
+///
+/// * A stale job that starts after the successor's claim sees `current !=
+///   claimed` and declines. Declining is always safe: whatever it would have
+///   removed was already removed (or is about to be) by the successor's own
+///   [`remove_stale`].
+/// * A job that passed its check is walking under the `walk` lock, so the
+///   successor's own [`remove_stale`] queues behind it — and everything the
+///   in-flight walk touches predates the successor's creation, because
+///   creation only happens after the successor's awaited [`remove_stale`]
+///   returns.
+/// * A cancelled execute with no successor keeps the current claim, so its own
+///   queued jobs still run and reclaim its mess.
+///
+/// Two locks per path, and the split is load-bearing: [`claim`] takes only the
+/// `generation` mutex (an increment — microseconds even while a walk is in
+/// flight), so it is safe to call inline on a tokio worker at queue time.
+/// Walks hold the `walk` mutex for their whole duration and take `generation`
+/// only for the staleness check; walk holders are dedicated OS threads (the
+/// blocking pool, the cleaner thread), never tokio workers. Lock order is
+/// `walk` then `generation`, and nothing takes them in the other order.
+///
+/// Executes for one addr are serialized (in-process by the per-addr result
+/// lock, cross-process by the flock), so the generation cannot advance under a
+/// *live* run — only past a cancelled or completed one.
+///
+/// Not covered: a straggler from *another process*. The flock serializes the
+/// executes themselves but not their detached jobs, and this registry is
+/// process-local. That exposure predates cancel-on-abandonment (any process
+/// exit with queued jobs had it) and is bounded by process lifetime — queued
+/// jobs die with the process that queued them.
+pub mod generation {
+    use std::collections::HashMap;
+    use std::io;
+    use std::path::{Path, PathBuf};
+    use std::sync::{Arc, Mutex, MutexGuard, OnceLock};
+
+    /// One path's gate. `walk` serializes destructive walks; `generation` is
+    /// the claim counter, held only for increments and comparisons so
+    /// [`claim`](super::generation::claim) never blocks behind a walk.
+    #[derive(Default)]
+    struct PathGate {
+        walk: Mutex<()>,
+        generation: Mutex<u64>,
+    }
+
+    /// Outer registry lock is held only to fetch/insert the per-path gate —
+    /// never across a walk, so unrelated sandboxes do not serialize each other.
+    ///
+    /// Never pruned, deliberately: one entry per distinct sandbox path (≈ per
+    /// executed target addr) for the life of the process, ~a hundred bytes
+    /// each. Pruning would need proof that no queued job still references the
+    /// path, which is exactly the bookkeeping this module exists to avoid.
+    static GATES: OnceLock<Mutex<HashMap<PathBuf, Arc<PathGate>>>> = OnceLock::new();
+
+    fn gate_for(dir: &Path) -> Arc<PathGate> {
+        let mut gates = GATES
+            .get_or_init(|| Mutex::new(HashMap::new()))
+            .lock()
+            .unwrap_or_else(|e| e.into_inner());
+        Arc::clone(gates.entry(dir.to_path_buf()).or_default())
+    }
+
+    /// A panicking job poisons only its own path's locks; both protect plain
+    /// values that are always consistent.
+    fn lock<T>(m: &Mutex<T>) -> MutexGuard<'_, T> {
+        m.lock().unwrap_or_else(|e| e.into_inner())
+    }
+
+    /// Claim `dir` for a new execute. Advances the generation and returns it;
+    /// every removal job this execute queues carries the returned value. No
+    /// filesystem work and no walk lock — safe to call inline on the async
+    /// path at queue time, which is what makes the claim ordered *before* any
+    /// successor can exist.
+    pub fn claim(dir: &Path) -> u64 {
+        let gate = gate_for(dir);
+        let mut generation = lock(&gate.generation);
+        *generation += 1;
+        *generation
+    }
+
+    /// Run `f` under `dir`'s walk lock iff the path still belongs to the
+    /// execute that claimed `claimed`; a superseded job declines with `Ok(())`.
+    fn run_if_current(
+        dir: &Path,
+        claimed: u64,
+        what: &str,
+        f: impl FnOnce() -> io::Result<()>,
+    ) -> io::Result<()> {
+        let gate = gate_for(dir);
+        let _walk = lock(&gate.walk);
+        let current = *lock(&gate.generation);
+        if current != claimed {
+            tracing::debug!(
+                dir = %dir.display(),
+                claimed,
+                current,
+                "skipping {what} superseded by a newer execute",
+            );
+            return Ok(());
+        }
+        f()
+    }
+
+    /// The pre-run stale removal, run on the blocking pool with the claim its
+    /// execute took at queue time. Declines if a successor has reclaimed the
+    /// path — a queued job whose awaiter was cancelled must never delete the
+    /// successor's live sandbox.
+    pub fn remove_stale(dir: &Path, claimed: u64) -> io::Result<()> {
+        run_if_current(
+            dir,
+            claimed,
+            "stale sandbox removal",
+            || match super::remove_dir_all(dir) {
+                Ok(()) => Ok(()),
+                Err(err) if err.kind() == io::ErrorKind::NotFound => Ok(()),
+                Err(err) => Err(err),
+            },
+        )
+    }
+
+    /// Wrap a bridge-owned cleanup job so it runs only if `dir` still belongs
+    /// to the execute that claimed `claimed`.
+    pub fn guarded(
+        dir: PathBuf,
+        claimed: u64,
+        job: super::SandboxCleanupJob,
+    ) -> super::SandboxCleanupJob {
+        Box::new(move || run_if_current(&dir, claimed, "sandbox cleanup", job))
+    }
+
+    #[cfg(test)]
+    pub(super) fn current_generation(dir: &Path) -> u64 {
+        *lock(&gate_for(dir).generation)
+    }
+}
+
+/// Owns a claimed sandbox's teardown from claim to resolution, so that
+/// **every** exit makes exactly one teardown decision — and the right one.
+///
+/// Armed in `Engine::execute` the moment the path is [`generation::claim`]ed,
+/// carried back to `execute_and_cache_inner`. Three exits, three behaviours:
+///
+/// * [`complete`](Self::complete) — **success** (the run and its cache write
+///   finished, or the cache write failed with an error value): the
+///   bridge-owned cleanup job is enqueued, guarded by this run's generation.
+///   The bridge job knows the real layout (plain dir vs FUSE upper side).
+/// * [`leave_for_diagnostics`](Self::leave_for_diagnostics) — **the target
+///   failed** (an `Err` is propagating out of the execute): the sandbox is
+///   left on disk, untouched, deliberately. The failure diagnostic reads the
+///   process's last log lines *lazily* from the on-disk log when it renders —
+///   a failed target's sandbox surviving until that target's next run is
+///   pre-existing, documented behaviour, and reclaiming it here turns the
+///   diagnostic into a race against its own cleanup (output present or absent
+///   depending on cleaner-lane load). The next execute's
+///   [`generation::remove_stale`] reclaims it, exactly as it always has. This
+///   is retention by design, not a leak: at most one tree per failed addr,
+///   the same bound as before teardown ownership existed.
+/// * `Drop` without either — **cancellation or abandonment only** (the future
+///   was dropped or unwound without resolving): a generation-checked
+///   [`generation::remove_stale`] reclaim is enqueued. If a successor already
+///   reclaimed the path it declines; otherwise it removes this run's
+///   half-written tree. Without this, mass fail-fast (the wedge run had 1,135
+///   and 1,949 cancellations) leaves one abandoned sandbox tree per cancelled
+///   execute with nothing to collect them — `gc` has no sandbox sweep, and
+///   unlike a failure, a cancelled target has no failure diagnostic that
+///   needs the tree.
+///
+/// The drop path deliberately enqueues the reclaim rather than the bridge job:
+/// the bridge job's ordering contract (slot guards deregistered first) is
+/// only guaranteed on the completion path, while the reclaim touches nothing
+/// but the logical directory — the same operation the next execute's
+/// `remove_stale` would perform, just sooner.
+pub struct SandboxTeardown {
+    dir: PathBuf,
+    generation: u64,
+    pending: PendingCounter,
+    /// The bridge-owned cleanup closure, handed over once the run responded.
+    job: Option<SandboxCleanupJob>,
+    armed: bool,
+}
+
+/// Hand-written because the bridge's cleanup closure is not `Debug`; the
+/// closure is reported as present/absent, which is the part worth seeing in a
+/// log. Written out rather than skipped so the type still satisfies the
+/// derive-`Debug`-on-public-types rule.
+impl std::fmt::Debug for SandboxTeardown {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("SandboxTeardown")
+            .field("dir", &self.dir)
+            .field("generation", &self.generation)
+            .field("armed", &self.armed)
+            .field("job", &self.job.is_some())
+            .finish()
+    }
+}
+
+impl SandboxTeardown {
+    /// Take ownership of tearing down `dir`, which the caller has just
+    /// [`generation::claim`]ed as `generation`.
+    pub fn arm(dir: PathBuf, generation: u64, pending: PendingCounter) -> Self {
+        Self {
+            dir,
+            generation,
+            pending,
+            job: None,
+            armed: true,
+        }
+    }
+
+    /// Hand over the bridge's cleanup closure once the run has responded.
+    pub fn set_job(&mut self, job: Option<SandboxCleanupJob>) {
+        self.job = job;
+    }
+
+    /// The run completed (with a success or an error value): enqueue the
+    /// bridge cleanup, generation-guarded. Call only after every reader of the
+    /// sandbox is done — `cache_locally` reads from it.
+    pub fn complete(mut self, label: String) {
+        self.armed = false;
+        if let Some(job) = self.job.take() {
+            enqueue(
+                label,
+                generation::guarded(self.dir.clone(), self.generation, job),
+                Arc::clone(&self.pending),
+            );
+        }
+    }
+
+    /// The target failed: leave the sandbox on disk for the failure
+    /// diagnostic, which reads the process's log tail lazily from it. Nothing
+    /// is enqueued — not the bridge job, not a reclaim — and the tree survives
+    /// until this target's next run removes it, the documented pre-teardown
+    /// behaviour. See the type docs for why this must never be folded into
+    /// `Drop`: a drop-time reclaim here made the diagnostic race its own
+    /// cleanup, surfacing a failed target's exit status with its output
+    /// already deleted.
+    pub fn leave_for_diagnostics(mut self) {
+        self.armed = false;
+        self.job = None;
+    }
+}
+
+impl Drop for SandboxTeardown {
+    fn drop(&mut self) {
+        if !self.armed {
+            return;
+        }
+        let (dir, generation) = (self.dir.clone(), self.generation);
+        let label = format!("reclaim {}", dir.display());
+        enqueue(
+            label,
+            Box::new(move || generation::remove_stale(&dir, generation)),
+            Arc::clone(&self.pending),
+        );
+    }
 }
 
 /// Enqueue a cleanup job for asynchronous execution. `label` is used only for
@@ -264,6 +541,364 @@ mod tests {
 
         remove_dir_all(&root).expect("chmod-retry removal must succeed");
         assert!(!root.exists(), "directory should be gone");
+    }
+
+    /// Round-2 review's red test: the *pre-run* removal of a superseded
+    /// execute must decline too — an earlier version generation-guarded only
+    /// the post-run cleanup.
+    ///
+    /// The hazard: execute N queues its pre-run removal on the blocking pool,
+    /// then N is cancelled at that very await — the production wedge's phase.
+    /// The job is `'static` and runs regardless, whenever the pool gets to it.
+    /// Execute N+1 for the same addr meanwhile reclaims the path, creates the
+    /// sandbox, and starts writing. When N's job finally runs — the pool was
+    /// backlogged, or its thread was descheduled between dequeue and the gate
+    /// (std `Mutex` is not FIFO, so "queued behind" has no order guarantee) —
+    /// it must see the stale claim and decline, not advance the generation and
+    /// remove the successor's live sandbox mid-run. Hence the claim/walk
+    /// split: [`generation::claim`] at queue time on the async path, and the
+    /// queued walk re-checks at run time.
+    #[test]
+    fn a_superseded_pre_run_removal_declines_instead_of_deleting_the_new_sandbox() {
+        let tmp = tempfile::tempdir().expect("tempdir");
+        let sandbox = tmp.path().join("sandbox");
+        std::fs::create_dir_all(&sandbox).expect("mkdir");
+
+        // Execute N's pre-run removal job, constructed exactly as
+        // `execute.rs` queues it, at the moment N queues it: the claim is
+        // taken inline, the walk is deferred. N is then cancelled; the job
+        // stays queued on the pool.
+        let claim_n = generation::claim(&sandbox);
+        let n_job = {
+            let sandbox = sandbox.clone();
+            move || generation::remove_stale(&sandbox, claim_n)
+        };
+
+        // Execute N+1 reclaims the path and starts writing.
+        let claim_n1 = generation::claim(&sandbox);
+        assert!(claim_n1 > claim_n, "claims must advance");
+        generation::remove_stale(&sandbox, claim_n1).expect("N+1 stale removal");
+        std::fs::create_dir_all(&sandbox).expect("recreate N+1");
+        std::fs::write(sandbox.join("fresh-output"), b"x").expect("write");
+
+        // The pool finally runs N's job.
+        n_job().expect("a superseded pre-run removal reports success without acting");
+
+        assert!(
+            sandbox.join("fresh-output").exists(),
+            "a superseded execute's pre-run removal must not delete the \
+             successor's live sandbox"
+        );
+    }
+
+    /// A cleanup job from a superseded execute must not touch the path.
+    ///
+    /// The exact hazard: execute N is cancelled after its cleanup job is
+    /// queued (or the job simply has not run yet); execute N+1 reclaims the
+    /// path, removes stale bytes, and starts writing. When N's job finally
+    /// runs, the generation has moved on and the job must decline — running it
+    /// would delete N+1's freshly written outputs.
+    #[test]
+    fn a_superseded_cleanup_job_declines_instead_of_deleting_the_new_sandbox() {
+        let tmp = tempfile::tempdir().expect("tempdir");
+        let sandbox = tmp.path().join("sandbox");
+
+        // Execute N claims the path and queues its cleanup with generation N.
+        std::fs::create_dir_all(&sandbox).expect("mkdir N");
+        let gen_n = generation::claim(&sandbox);
+        generation::remove_stale(&sandbox, gen_n).expect("N stale removal");
+        std::fs::create_dir_all(&sandbox).expect("recreate N");
+        let stale_job = generation::guarded(
+            sandbox.clone(),
+            gen_n,
+            Box::new({
+                let sandbox = sandbox.clone();
+                move || std::fs::remove_dir_all(&sandbox)
+            }),
+        );
+
+        // Execute N+1 reclaims the path and writes fresh output.
+        let gen_n1 = generation::claim(&sandbox);
+        assert!(gen_n1 > gen_n, "generations must advance");
+        generation::remove_stale(&sandbox, gen_n1).expect("N+1 stale removal");
+        std::fs::create_dir_all(&sandbox).expect("recreate N+1");
+        std::fs::write(sandbox.join("fresh-output"), b"x").expect("write");
+
+        // N's straggler runs now — after the reclaim.
+        stale_job().expect("a superseded job reports success without acting");
+        assert!(
+            sandbox.join("fresh-output").exists(),
+            "a superseded cleanup job must not delete the newer execute's sandbox"
+        );
+
+        // The current generation's own job still cleans up.
+        let live_job = generation::guarded(
+            sandbox.clone(),
+            gen_n1,
+            Box::new({
+                let sandbox = sandbox.clone();
+                move || std::fs::remove_dir_all(&sandbox)
+            }),
+        );
+        live_job().expect("current-generation cleanup runs");
+        assert!(
+            !sandbox.exists(),
+            "the owning generation's cleanup must run"
+        );
+    }
+
+    /// `remove_stale` queues behind a cleanup walk already in progress on the
+    /// same path, instead of racing it.
+    #[test]
+    fn remove_stale_waits_for_an_in_flight_cleanup_walk() {
+        let tmp = tempfile::tempdir().expect("tempdir");
+        let sandbox = tmp.path().join("sandbox");
+        std::fs::create_dir_all(&sandbox).expect("mkdir");
+        let generation_now = generation::claim(&sandbox);
+        generation::remove_stale(&sandbox, generation_now).expect("stale removal");
+        std::fs::create_dir_all(&sandbox).expect("recreate");
+
+        let entered = Arc::new(AtomicBool::new(false));
+        let release = Arc::new(AtomicBool::new(false));
+        let walk = generation::guarded(
+            sandbox.clone(),
+            generation_now,
+            Box::new({
+                let (entered, release) = (Arc::clone(&entered), Arc::clone(&release));
+                let sandbox = sandbox.clone();
+                move || {
+                    entered.store(true, Ordering::SeqCst);
+                    while !release.load(Ordering::SeqCst) {
+                        std::thread::sleep(Duration::from_millis(2));
+                    }
+                    std::fs::remove_dir_all(&sandbox)
+                }
+            }),
+        );
+        let walker = std::thread::spawn(move || walk());
+        assert!(
+            wait_for(&entered, Duration::from_secs(2)),
+            "cleanup walk did not start"
+        );
+
+        // The successor claims immediately (inline, never blocked by the
+        // walk) but its own removal must queue behind the in-flight walk.
+        let claim_next = generation::claim(&sandbox);
+        assert!(claim_next > generation_now);
+        let reclaimed = Arc::new(AtomicBool::new(false));
+        let reclaimer = std::thread::spawn({
+            let (sandbox, reclaimed) = (sandbox.clone(), Arc::clone(&reclaimed));
+            move || {
+                generation::remove_stale(&sandbox, claim_next).expect("reclaim");
+                reclaimed.store(true, Ordering::SeqCst);
+            }
+        });
+
+        std::thread::sleep(Duration::from_millis(50));
+        assert!(
+            !reclaimed.load(Ordering::SeqCst),
+            "remove_stale must wait for the in-flight walk, not race it"
+        );
+
+        release.store(true, Ordering::SeqCst);
+        walker.join().expect("walker").expect("walk result");
+        reclaimer.join().expect("reclaimer");
+        assert!(
+            wait_for(&reclaimed, Duration::from_secs(2)),
+            "remove_stale must proceed once the walk finishes"
+        );
+    }
+
+    /// The gate registry is per-path: one sandbox's walk must not serialize an
+    /// unrelated sandbox's reclaim.
+    #[test]
+    fn generations_are_independent_per_path() {
+        let tmp = tempfile::tempdir().expect("tempdir");
+        let a = tmp.path().join("a");
+        let b = tmp.path().join("b");
+        let gen_a = generation::claim(&a);
+        let before_b = generation::current_generation(&b);
+        assert_eq!(
+            generation::current_generation(&a),
+            gen_a,
+            "a claim must advance its own path"
+        );
+        assert_eq!(
+            generation::current_generation(&b),
+            before_b,
+            "and leave other paths untouched"
+        );
+    }
+
+    /// Spin until `pending` drains to zero — the cleaner ran everything queued.
+    fn wait_drained(pending: &PendingCounter, timeout: Duration) {
+        let deadline = Instant::now() + timeout;
+        while pending.load(Ordering::Acquire) > 0 {
+            assert!(Instant::now() < deadline, "cleaner did not drain in time");
+            std::thread::sleep(Duration::from_millis(2));
+        }
+    }
+
+    /// The three-way contract, failure leg: a *failed* execute leaves its
+    /// sandbox on disk, untouched — bridge job dropped unused, no reclaim
+    /// queued.
+    ///
+    /// The failure diagnostic reads the process's last log lines lazily from
+    /// the on-disk log when it renders. Folding failure into the drop-reclaim
+    /// path made that a race against the cleaner lane: with siblings running
+    /// the reclaim landed late and the tail survived; alone (and on the CI
+    /// runners) it landed first and a failing target reported its exit status
+    /// with no output (`test_failure_surfaces_process_log_tail`, e2e). The
+    /// deterministic proof here is the pending counter: it was never bumped,
+    /// so nothing was queued and nothing can delete the tree later.
+    #[test]
+    fn a_failed_execute_leaves_its_sandbox_for_diagnostics() {
+        let tmp = tempfile::tempdir().expect("tempdir");
+        let sandbox = tmp.path().join("sandbox");
+        std::fs::create_dir_all(&sandbox).expect("mkdir");
+        std::fs::write(sandbox.join("log.txt"), b"distinctive-marker-line\n").expect("write");
+
+        let pending = counter();
+        let claim = generation::claim(&sandbox);
+        let mut teardown = SandboxTeardown::arm(sandbox.clone(), claim, Arc::clone(&pending));
+        // Even a bridge job already handed over must be dropped unused — the
+        // failure decision outranks it.
+        let bridge_ran = Arc::new(AtomicBool::new(false));
+        teardown.set_job(Some(Box::new({
+            let (bridge_ran, sandbox) = (Arc::clone(&bridge_ran), sandbox.clone());
+            move || {
+                bridge_ran.store(true, Ordering::SeqCst);
+                std::fs::remove_dir_all(&sandbox)
+            }
+        })));
+
+        teardown.leave_for_diagnostics();
+
+        assert_eq!(
+            pending.load(Ordering::Acquire),
+            0,
+            "a failed target's teardown must enqueue nothing — neither the \
+             bridge job nor a reclaim"
+        );
+        assert!(
+            !bridge_ran.load(Ordering::SeqCst),
+            "the bridge job must be dropped unused on the failure path"
+        );
+        assert!(
+            sandbox.join("log.txt").exists(),
+            "a failed target's sandbox (and its log) must survive for the \
+             failure diagnostic"
+        );
+    }
+
+    /// A cancelled execute's teardown reclaims its half-written sandbox.
+    ///
+    /// This is the disk-leak fix: under mass fail-fast (the wedge run had
+    /// 1,135 and 1,949 *cancellations*) every cancelled execute drops its
+    /// `SandboxTeardown`, and each drop must queue a reclaim — `gc` has no
+    /// sandbox sweep, so nothing else would ever collect these trees. A
+    /// *failed* execute is the deliberate exception: see
+    /// `a_failed_execute_leaves_its_sandbox_for_diagnostics`.
+    #[test]
+    fn a_dropped_teardown_reclaims_its_sandbox() {
+        let tmp = tempfile::tempdir().expect("tempdir");
+        let sandbox = tmp.path().join("sandbox");
+        std::fs::create_dir_all(&sandbox).expect("mkdir");
+        std::fs::write(sandbox.join("half-written"), b"x").expect("write");
+
+        let pending = counter();
+        let claim = generation::claim(&sandbox);
+        let teardown = SandboxTeardown::arm(sandbox.clone(), claim, Arc::clone(&pending));
+
+        // Cancelled mid-run: dropped without `complete`, no bridge job yet.
+        drop(teardown);
+
+        wait_drained(&pending, Duration::from_secs(2));
+        assert!(
+            !sandbox.exists(),
+            "a dropped teardown with a current claim must reclaim the sandbox"
+        );
+    }
+
+    /// A dropped teardown whose path was reclaimed by a successor declines.
+    ///
+    /// Pairs with `a_dropped_teardown_reclaims_its_sandbox` and must not be
+    /// deleted without it: on its own this would also pass if `Drop` enqueued
+    /// *nothing at all* (pending stays 0 and the drain returns immediately).
+    /// The sibling is what proves the enqueue happens, so together they pin
+    /// "enqueues, and declines when superseded".
+    #[test]
+    fn a_superseded_teardown_reclaim_declines() {
+        let tmp = tempfile::tempdir().expect("tempdir");
+        let sandbox = tmp.path().join("sandbox");
+
+        let pending = counter();
+        let claim_n = generation::claim(&sandbox);
+        let teardown = SandboxTeardown::arm(sandbox.clone(), claim_n, Arc::clone(&pending));
+
+        // The successor reclaims and writes before N's drop-reclaim runs.
+        let claim_n1 = generation::claim(&sandbox);
+        generation::remove_stale(&sandbox, claim_n1).expect("successor stale removal");
+        std::fs::create_dir_all(&sandbox).expect("recreate");
+        std::fs::write(sandbox.join("fresh-output"), b"x").expect("write");
+
+        drop(teardown);
+
+        wait_drained(&pending, Duration::from_secs(2));
+        assert!(
+            sandbox.join("fresh-output").exists(),
+            "a superseded teardown's reclaim must not touch the successor's sandbox"
+        );
+    }
+
+    /// `complete` enqueues the bridge job (generation-guarded) exactly once —
+    /// consuming the teardown, so no reclaim can follow.
+    #[test]
+    fn a_completed_teardown_enqueues_the_bridge_job_once() {
+        let tmp = tempfile::tempdir().expect("tempdir");
+        let sandbox = tmp.path().join("sandbox");
+        std::fs::create_dir_all(&sandbox).expect("mkdir");
+
+        let pending = counter();
+        let claim = generation::claim(&sandbox);
+        let mut teardown = SandboxTeardown::arm(sandbox.clone(), claim, Arc::clone(&pending));
+
+        let ran = Arc::new(AtomicBool::new(false));
+        teardown.set_job(Some(Box::new({
+            let (ran, sandbox) = (Arc::clone(&ran), sandbox.clone());
+            move || {
+                ran.store(true, Ordering::SeqCst);
+                std::fs::remove_dir_all(&sandbox)
+            }
+        })));
+        teardown.complete("test".to_string());
+
+        assert!(
+            wait_for(&ran, Duration::from_secs(2)),
+            "the bridge job must run on completion"
+        );
+        wait_drained(&pending, Duration::from_secs(2));
+        assert!(
+            !sandbox.exists(),
+            "the bridge job's removal must have applied"
+        );
+    }
+
+    /// Completing with no bridge job enqueues nothing — the status quo for
+    /// drivers that hand back no cleanup closure.
+    #[test]
+    fn a_completed_teardown_without_a_job_enqueues_nothing() {
+        let tmp = tempfile::tempdir().expect("tempdir");
+        let sandbox = tmp.path().join("sandbox");
+        let pending = counter();
+        let claim = generation::claim(&sandbox);
+        let teardown = SandboxTeardown::arm(sandbox.clone(), claim, Arc::clone(&pending));
+        teardown.complete("test".to_string());
+        assert_eq!(
+            pending.load(Ordering::Acquire),
+            0,
+            "no job, no queue entry — and no reclaim either, complete consumed it"
+        );
     }
 
     #[test]


### PR DESCRIPTION
Stacked on #236. Prep for #241 (cancel-on-abandonment) — but it stands on its own: both defects are reachable today via Ctrl-C and fail-fast, and merely become far more reachable once cancellation is routine.

Split out of #241 at review recommendation so the riskier memoizer half gets its own revert line. The reverse order is not available: landing cancellation without this makes the corruption race live.

## 1. A cancelled execute's queued removal can delete a successor's live sandbox

The pre-run `remove_dir_all` is queued on the blocking pool and awaited — and that await is exactly where production futures get cancelled. The job is `'static` and runs regardless.

Execute N queues its removal and is cancelled. Execute N+1 for the same addr recreates the sandbox and starts writing. N's job — backlogged, or descheduled between dequeue and gate — then deletes the **live** sandbox mid-run; N+1's own cleanup declines as stale, leaving half-written remains. **Silent output corruption.**

`sandbox_cleaner::generation` gates each path: a claim (increment/compare, no I/O) is taken inline before the removal is queued; the walk runs under a second lock and declines if the path was since reclaimed.

Two locks because **the claim runs on a tokio worker and must never block behind a multi-second `remove_dir_all`**; the walk lock is held only by dedicated OS threads. Order `GATES → walk → generation`, verified to have no reverse edge at any site. The argument deliberately does not rest on FIFO lock acquisition (`std::sync::Mutex` does not provide it): the claim happens before any successor can exist, because executes of one addr are serialized by the per-addr result lock, and every queued job re-checks under the gate when it runs.

## 2. Three exits, three resolutions

`SandboxTeardown` gives an execute **exactly one** resolution, and the three cases are deliberately different:

| exit | resolution |
|---|---|
| **success** | `complete()` — enqueues the bridge-owned cleanup, generation-guarded |
| **target failure** | `leave_for_diagnostics()` — enqueues **nothing**; the tree survives to that target's next run |
| **cancellation / unwind** | bare `Drop` — enqueues the generation-checked reclaim, counted in `bg_pending` so shutdown drains it |

The failure leg exists because **the failure diagnostic reads the process log tail lazily from the on-disk sandbox**. That retention is pre-existing documented behaviour; it is now an explicit resolution rather than an accident of where a `defer!` happened to be registered.

The cancellation leg is the new behaviour, and the **only** case the disk-leak rationale applies to: the old `defer!` fired at drop time but *unguarded*, and `gc` has **no `<home>/sandbox` sweep at all` — so a cancelled target never re-executed leaked its tree indefinitely. A *failed* target retaining its tree is by design and bounded at one per failed addr.

## Provenance — two defects found by review, one by CI

1. The **corruption** defect (item 1) was found by adversarial review of an earlier version that advanced the generation unconditionally with no decline path. Reviewer's red test included and green: `a_superseded_pre_run_removal_declines_instead_of_deleting_the_new_sandbox`.
2. The **failure/cancellation collapse** was found by **CI**, after three review rounds missed it — including a round that explicitly discussed that `?` exit and classified it as handled by design. An earlier version reclaimed on every unresolved exit, deleting a *failed* target's sandbox before its diagnostic rendered, so a failing target reported an exit status with no output. It raced the cleaner lane: 0/6 in isolation, 11/11 in the suite, 67/67 in the full e2e run. `a_failed_execute_leaves_its_sandbox_for_diagnostics` now pins it deterministically by asserting nothing is ever enqueued.

Review verified the partition is exhaustive and disjoint path by path, and proved the one judgment call (a **cache-write** failure still uses `complete()`) correct *by construction*: `extract_log_tail` opens with `downcast_chain_ref::<ProcessFailed>(e)?`, and a cache-write failure's chain cannot contain a `ProcessFailed`, so no diagnostic can read that sandbox.

## Known residuals, recorded on the module

- **skip-lock (`@heph/fs`)** targets bypass the per-addr lock, so two live same-addr executes can overlap and race. Pre-existing, and *strictly less destructive* now — previously both walks deleted unconditionally.
- **Cross-process stragglers**: registry is process-local. Pre-existing; follow-up is having the reclaim try-flock the addr and decline if held.

## Verification

engine **415**, core **89** (untouched by this layer), e2e **10 suites**, lint clean — with the memoizer changes *absent*, confirming this layer stands alone. The regression test passes **6/6 in isolation**, which is the condition that exposed the bug; a suite-level pass is explicitly not sufficient evidence here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019SohmU1Z8pGPuAWPpY4hwV