### PR TITLE
fix(walk): reject non-UTF-8 entry names instead of dropping them silently

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3805,6 +3805,7 @@ dependencies = [
  "tempfile",
  "tokio",
  "tower-lsp-server",
+ "tracing",
  "walk",
  "xstarlark-fmt",
 ]

--- a/crates/engine/src/engine/engine.rs
+++ b/crates/engine/src/engine/engine.rs
@@ -730,7 +730,7 @@ impl Engine {
     /// plus the glob `fs.skip` entries (e.g. `**/node_modules/**`). All are
     /// root-relative.
     pub fn skip_globs(&self) -> Vec<String> {
-        std::iter::once("**/.git/**".to_string())
+        std::iter::once(hwalk::GIT_SKIP_GLOB.to_string())
             .chain(
                 self.cfg
                     .fs_skip

--- a/crates/plugin-buildfile/Cargo.toml
+++ b/crates/plugin-buildfile/Cargo.toml
@@ -30,6 +30,7 @@ allocative = "0.3"
 lsp-server = "0.7"
 lsp-types = "0.97"
 tower-lsp-server = "0.22"
+tracing = "0.1"
 tokio = { version = "1.52.3", features = ["rt", "rt-multi-thread", "macros", "sync", "io-util", "io-std", "process", "fs"] }
 
 [dev-dependencies]

--- a/crates/plugin-buildfile/src/pluginbuildfile/lsp/context.rs
+++ b/crates/plugin-buildfile/src/pluginbuildfile/lsp/context.rs
@@ -116,14 +116,21 @@ impl HephLspContext {
             // Fresh package list per call, for the same reason: a session-lifetime
             // one would freeze editor results — create a package and it would
             // never appear. Within one buffer evaluation it still dedupes the
-            // walk. Note this passes `Ignore::default()` (prunes nothing) where
-            // the build passes the configured `fs.skip`, so the editor can see
+            // walk. Note this passes only the always-on `.git` prune where the
+            // build passes the configured `fs.skip`, so the editor can see
             // packages the build does not; a pre-existing divergence, now at least
             // confined to a cell that is never shared with the build's.
+            //
+            // `.git` specifically must be pruned, not merely skipped as an
+            // optimization: a ref file's name is the branch name's raw bytes, so
+            // one `git checkout -b $'\xe9'` puts a name in `.git/refs/heads` that
+            // the walker refuses. Walking `.git` would fail the whole package
+            // list — and with it every completion — over something no build
+            // would ever have read.
             Arc::new(PackageList::new(
                 self.root.clone(),
                 self.patterns.clone(),
-                Arc::new(hwalk::Ignore::default()),
+                Arc::new(hwalk::Ignore::git_only()),
                 walker,
             )),
             Arc::default(),
@@ -146,7 +153,13 @@ impl HephLspContext {
                 .map(|r| r.pkg.to_string())
                 .filter(|p| p.starts_with(prefix))
                 .collect(),
-            Err(_) => Vec::new(),
+            // Completion degrades to "no suggestions" rather than failing the
+            // request, but the walk error is the only explanation the user will
+            // ever get for an empty list — never drop it.
+            Err(e) => {
+                tracing::warn!(error = ?e, prefix, "lsp: package walk failed");
+                Vec::new()
+            }
         }
     }
 

--- a/crates/plugin-buildfile/src/pluginbuildfile/provider.rs
+++ b/crates/plugin-buildfile/src/pluginbuildfile/provider.rs
@@ -100,6 +100,14 @@ pub const DEFAULT_INDENT: usize = 4;
 /// Every file directly inside `dir` whose name matches one of `patterns`
 /// (handles literal names like `BUILD` and globs like `*.BUILD`), sorted for
 /// deterministic order. A package may have more than one BUILD file.
+///
+/// **Diverges from the build.** This reads `std::fs` directly and pattern-matches
+/// a *lossy* name, where the engine's `find_build_files` goes through
+/// [`CachedWalker`], which rejects a non-UTF-8 name outright. So a
+/// `caf\xe9.BUILD` matches `*.BUILD` here (as `caf\u{FFFD}.BUILD`) and the
+/// formatter and LSP would open a file the build hard-refuses to see. Its
+/// callers are editor-side only, so this is a diagnosability trap rather than a
+/// hash route — but it should be routed through the walker.
 pub fn build_files_in_dir(dir: &Path, patterns: &[glob::Pattern]) -> Vec<PathBuf> {
     let Ok(entries) = std::fs::read_dir(dir) else {
         return Vec::new();
@@ -297,6 +305,28 @@ impl Provider {
 /// def hash, here it is a correctness one — a stale list is a stale *definition*.
 /// `HEPH_DEBUG_CACHED_WALKER=0` bypasses the cache and can likewise compute a
 /// different def hash from the same tree.
+///
+/// # Unicode: names are taken byte-for-byte, deliberately
+///
+/// A package name is the directory name exactly as `readdir` returns it. heph
+/// applies **no Unicode normalization**, and none is intended.
+///
+/// That is uniform on the supported targets: for one commit checked out by git
+/// onto a local ext4/btrfs/APFS volume, `readdir` returns identical bytes on all
+/// three, so the sorted list and its def hash are identical. APFS is
+/// normalization-*preserving* (an NFD directory name reads back as NFD); it is
+/// only *lookup* that is normalization- and case-insensitive, which is a
+/// property of address resolution, not of this list. Legacy HFS+ *does*
+/// normalize to NFD on store, and so do some network and container-VM mounts —
+/// those produce a **different** def hash, which is a cache miss and never a
+/// wrong artifact, because every file input is content-hashed independently.
+///
+/// Normalizing here would be worse, not better: on a byte-preserving filesystem
+/// a tree can legitimately hold both the NFC and the NFD spelling as two
+/// distinct package directories, and folding them to one name would silently
+/// merge two packages — trading a cache miss on an exotic mount for a name
+/// collision on a supported one. It would also re-key every target of every
+/// workspace with a non-ASCII package name.
 pub(crate) struct PackageList {
     root: PathBuf,
     patterns: Vec<glob::Pattern>,
@@ -407,7 +437,22 @@ fn find_packages_sync(
     if has_build_file {
         let mut current = path;
         while let Ok(rel) = current.strip_prefix(root) {
-            let pkg_name = rel.to_string_lossy().to_string();
+            // `to_str`, never `to_string_lossy`: this string is a package name,
+            // and the sorted package list is a def-hash input. A lossy render
+            // would fold `x\xffy` and `x\xfey` into one `x\u{FFFD}y` package and
+            // hash two different trees the same. `CachedWalker::read_dir` already
+            // refuses a non-UTF-8 entry name, and every component below `root`
+            // comes from it, so this holds today — the check keeps it from
+            // becoming a silent assumption if that ever changes.
+            let pkg_name = rel
+                .to_str()
+                .with_context(|| {
+                    format!(
+                        "package directory name is not valid UTF-8: '{}'",
+                        current.display()
+                    )
+                })?
+                .to_string();
             packages.insert(pkg_name);
 
             if let Some(parent) = current.parent() {
@@ -1135,6 +1180,176 @@ mod tests {
         assert!(packages.contains(&"a/b".to_string()));
         assert!(packages.contains(&"a".to_string())); // parent of a/b
         assert!(packages.contains(&"c".to_string()));
+    }
+
+    /// Create a directory whose name is the raw byte sequence `raw`, or `None`
+    /// when the filesystem refuses it. APFS rejects names that are not valid
+    /// UTF-8 with `EILSEQ`, so this fixture cannot be built on
+    /// `aarch64-apple-darwin`; callers skip loudly rather than assert on a
+    /// package directory that was never created.
+    fn try_create_non_utf8_package(root: &Path, raw: &[u8]) -> Option<PathBuf> {
+        use std::os::unix::ffi::OsStrExt;
+        let dir = root.join(std::ffi::OsStr::from_bytes(raw));
+        match fs::create_dir(&dir) {
+            Ok(()) => {
+                fs::write(dir.join("BUILD"), "").unwrap();
+                Some(dir)
+            }
+            Err(e) => {
+                // Expected only on macOS. On Linux — the one target that
+                // exercises the fix — a refusal means `$TMPDIR` cannot host the
+                // fixture, and skipping would make the only real coverage a
+                // silent green.
+                assert!(
+                    cfg!(target_os = "macos"),
+                    "the non-UTF-8 package fixture must be constructible on this target, \
+                     but {root:?} refused it: {e}"
+                );
+                eprintln!(
+                    "SKIP: this filesystem refuses non-UTF-8 directory names ({e}); \
+                     the non-UTF-8 package fixture cannot be built here"
+                );
+                None
+            }
+        }
+    }
+
+    /// A package directory heph cannot name must fail the walk. Dropping it
+    /// silently removed the package — and every ancestor it would have inserted
+    /// — from the sorted list that feeds the def hash, so adding or editing a
+    /// BUILD file under it changed nothing anywhere.
+    #[tokio::test]
+    async fn list_packages_rejects_a_non_utf8_package_dir() {
+        let tmp_dir = tempdir().unwrap();
+        let root = tmp_dir.path();
+        fs::write(root.join("BUILD"), "").unwrap();
+        let Some(_bad) = try_create_non_utf8_package(root, b"caf\xe9") else {
+            return;
+        };
+
+        let provider = Provider {
+            root: root.to_path_buf(),
+            ..Provider::default()
+        };
+        let ctoken = StdCancellationToken::new();
+        let err = provider
+            .list_packages(
+                ListPackagesRequest {
+                    prefix: PkgBuf::from(""),
+                },
+                &ctoken,
+            )
+            .await
+            .err()
+            .expect("a package dir heph cannot name must fail, not disappear from the list");
+        assert!(
+            format!("{err:#}").contains("not valid UTF-8"),
+            "error should say why, got: {err:#}"
+        );
+    }
+
+    /// Two package directories whose names `to_string_lossy` would both render
+    /// as `caf\u{FFFD}` — one package name for two distinct trees, hence one
+    /// def hash for two distinct definitions. Neither fusing them nor dropping
+    /// them is acceptable.
+    #[tokio::test]
+    async fn list_packages_rejects_package_dirs_that_would_fuse_under_lossy_rendering() {
+        let tmp_dir = tempdir().unwrap();
+        let root = tmp_dir.path();
+        fs::write(root.join("BUILD"), "").unwrap();
+        let Some(_a) = try_create_non_utf8_package(root, b"caf\xe9") else {
+            return;
+        };
+        let Some(_b) = try_create_non_utf8_package(root, b"caf\xe8") else {
+            return;
+        };
+
+        let provider = Provider {
+            root: root.to_path_buf(),
+            ..Provider::default()
+        };
+        let ctoken = StdCancellationToken::new();
+        let err = provider
+            .list_packages(
+                ListPackagesRequest {
+                    prefix: PkgBuf::from(""),
+                },
+                &ctoken,
+            )
+            .await
+            .err()
+            .expect("two directories that render to one lossy name must not become one package");
+        // The report has to distinguish them, or it names a directory the user
+        // cannot tell from its neighbour — the very fusion being rejected.
+        let msg = format!("{err:#}");
+        assert!(
+            msg.contains(r"\xE9") || msg.contains(r"\xE8"),
+            "error must name the offending bytes escaped, got: {msg}"
+        );
+    }
+
+    /// Package names are the directory bytes verbatim — heph applies no Unicode
+    /// normalization, on any supported target. Pins the exemption documented on
+    /// [`PackageList`]: a normalization pass here would fold the NFC and NFD
+    /// spellings of a name into one package, and would re-key every target in a
+    /// workspace with non-ASCII package names. Both filesystems in the supported
+    /// set store the bytes they were given (APFS is normalization-preserving; it
+    /// is only *lookup* that is insensitive), so this holds identically on
+    /// Linux and macOS.
+    #[tokio::test]
+    async fn package_names_are_the_directory_bytes_not_a_normalized_form() {
+        // "café" decomposed: `e` + U+0301 COMBINING ACUTE ACCENT.
+        let nfd = "cafe\u{301}";
+        let nfc = "caf\u{e9}";
+        assert_ne!(nfd, nfc);
+
+        let tmp_dir = tempdir().unwrap();
+        let root = tmp_dir.path();
+        fs::write(root.join("BUILD"), "").unwrap();
+        let pkg = root.join(nfd);
+        fs::create_dir(&pkg).unwrap();
+        fs::write(pkg.join("BUILD"), "").unwrap();
+
+        // `$TMPDIR` may sit on one of the mounts the exemption names as *not*
+        // byte-preserving (HFS+, SMB, a container-VM share). Assert what heph
+        // does with the bytes the filesystem kept, not what the filesystem did.
+        let stored = fs::read_dir(root)
+            .unwrap()
+            .filter_map(Result::ok)
+            .map(|e| e.file_name().to_string_lossy().into_owned())
+            .find(|n| n != "BUILD");
+        if stored.as_deref() != Some(nfd) {
+            eprintln!(
+                "SKIP: this filesystem did not preserve the decomposed name \
+                 (stored {stored:?}); nothing to pin here"
+            );
+            return;
+        }
+
+        let provider = Provider {
+            root: root.to_path_buf(),
+            ..Provider::default()
+        };
+        let ctoken = StdCancellationToken::new();
+        let res = provider
+            .list_packages(
+                ListPackagesRequest {
+                    prefix: PkgBuf::from(""),
+                },
+                &ctoken,
+            )
+            .await
+            .unwrap();
+        let packages: Vec<String> = res.map(|r| r.unwrap().pkg.to_string()).collect();
+
+        assert!(
+            packages.iter().any(|p| p == nfd),
+            "expected the decomposed name verbatim, got {packages:?}"
+        );
+        assert!(
+            !packages.iter().any(|p| p == nfc),
+            "package names must not be normalized, got {packages:?}"
+        );
     }
 
     #[tokio::test]

--- a/crates/plugin-go/src/plugingo/provider.rs
+++ b/crates/plugin-go/src/plugingo/provider.rs
@@ -325,9 +325,30 @@ fn collect_go_packages(
 
     if is_under {
         let rel = dir.strip_prefix(workspace_root).unwrap_or(dir);
-        result.push(Ok(ListPackageResponse {
-            pkg: PkgBuf::from(rel.to_string_lossy().as_ref()),
-        }));
+        // A package identifier, so `to_str` rather than a lossy render that could
+        // fold two distinct directories onto one `\u{FFFD}` name — see the same
+        // check in the buildfile provider. Unreachable while every walked
+        // component comes from `CachedWalker::read_dir`, which rejects non-UTF-8
+        // names; kept so the invariant is asserted rather than assumed.
+        match rel.to_str() {
+            Some(pkg) => result.push(Ok(ListPackageResponse {
+                pkg: PkgBuf::from(pkg),
+            })),
+            // Blames the workspace root, not the package directory: every
+            // component below the root comes from the walker, which rejects
+            // non-UTF-8 names, so the root is the only thing left that can make
+            // this relative path undecodable.
+            None => {
+                result.push(Err(anyhow::anyhow!(
+                    "package path is not valid UTF-8: '{}' (under workspace root '{}')",
+                    dir.display(),
+                    workspace_root.display()
+                )));
+                // Same as the `read_dir` arm below: stop here rather than emit
+                // one copy of the same error for every descendant.
+                return;
+            }
+        }
     }
 
     // Read through the shared walker: an unchanged tree skips the `readdir`

--- a/crates/walk/src/cached_walker.rs
+++ b/crates/walk/src/cached_walker.rs
@@ -20,6 +20,14 @@
 //! correct-by-fallback — a missing/locked db, a decode error, or any mismatch
 //! just re-reads from disk.
 //!
+//! Entry names are UTF-8 by construction: a directory holding a name that is not
+//! valid UTF-8 fails [`read_dir`] rather than listing without it, so no
+//! walker-backed consumer can hash, glob, or name a path the rest of heph cannot
+//! represent. See [`DIR_LISTING_VERSION`] for how that guarantee survives a warm
+//! cache. It binds only what goes through here: code that calls `std::fs` and
+//! matches on a lossy name — `pluginbuildfile`'s `build_files_in_dir`, used by
+//! the formatter and the LSP — can still act on a file the build refuses.
+//!
 //! Backed by a dedicated `fswalk.db` (separate from the artifact cache so it can
 //! be pruned independently). Rows carry a last-access stamp; [`prune`] drops
 //! stale and orphaned rows so the db cannot grow without bound.
@@ -42,6 +50,25 @@ use xxhash_rust::xxh3::Xxh3;
 /// Default time-to-live for fswalk rows: entries untouched for this long are
 /// dropped by [`CachedWalker::prune`].
 pub const DEFAULT_TTL: std::time::Duration = std::time::Duration::from_secs(14 * 24 * 60 * 60);
+
+/// Semantic version of a cached `dirs` listing — **bump on any change to which
+/// entries [`read_dir_uncached`] puts in a [`DirListing`]**.
+///
+/// A `dirs` row is otherwise revalidated by directory mtime alone, and a
+/// filtering change does not touch any mtime. Without this, a row written by an
+/// older binary that silently dropped an entry would be decoded and served
+/// verbatim by a newer one that would have refused it — the fix would be inert
+/// on every warm cache, and the same tree would build on a machine with a stale
+/// db and fail on a freshly-cloned one, decided by a per-machine sqlite file
+/// that is in nobody's hash. Same rationale as `GO_TESTMAIN_FORMAT_VERSION`.
+///
+/// Compared per row rather than stamped db-wide so that a mixed fleet is safe in
+/// both directions: an older binary's `INSERT` omits the column and lands on the
+/// `DEFAULT 0`, which no current version accepts.
+///
+/// - 1: `read_dir_uncached` errors on a non-UTF-8 entry name instead of dropping
+///   it (rows written before this may be missing entries).
+const DIR_LISTING_VERSION: i64 = 1;
 
 /// Escape hatch: set `HEPH_DEBUG_CACHED_WALKER=0` to bypass caching entirely and
 /// fall back to reading every directory listing and file hash straight from disk
@@ -385,10 +412,42 @@ fn read_dir_uncached(dir: &Path) -> Result<DirListing> {
     let mut entries = Vec::new();
     for entry in rd {
         let entry = entry.with_context(|| format!("read dir entry in '{}'", dir.display()))?;
-        let Ok(ft) = entry.file_type() else { continue };
-        let Ok(name) = entry.file_name().into_string() else {
-            continue;
+        // `d_type` is free on Linux, but a `DT_UNKNOWN` filesystem makes this an
+        // `lstat`, which can fail. Only a vanished entry is skippable — it is
+        // genuinely not in the tree, and a concurrent delete must not fail a
+        // walk. Anything else (EACCES, EIO) is a real entry this listing would
+        // otherwise silently omit, and the omission would then be cached under
+        // the directory's current mtime and outlive the run.
+        let ft = match entry.file_type() {
+            Ok(ft) => ft,
+            Err(e) if e.kind() == std::io::ErrorKind::NotFound => continue,
+            Err(e) => {
+                return Err(e)
+                    .with_context(|| format!("stat dir entry '{}'", entry.path().display()));
+            }
         };
+        // A name that is not valid UTF-8 is a hard error, not a skipped entry.
+        // Dropping it silently removed a real path from every consumer's view:
+        // a `*.BUILD` file that names a package (so the package, and its
+        // ancestors, vanish from the def-hash-bearing package list) or a source
+        // file a glob would have matched (so its content hash never reaches the
+        // parent's `hashin` — edit it and the stale artifact is served). heph
+        // represents every path as UTF-8 all the way to addresses and cache
+        // manifests, so such a name cannot be built with; refusing to walk past
+        // it is the only outcome that is neither wrong nor silent.
+        let name = entry.file_name().into_string().map_err(|raw| {
+            anyhow::anyhow!(
+                // `{:?}` on the `OsStr`, not a lossy render: `caf\xe9` and
+                // `caf\xea` both *display* as `caf\u{FFFD}`, so the one message
+                // that has to identify a name precisely must not use the
+                // rendering this whole change exists to reject. Debug escapes
+                // the invalid bytes, which is injective and pasteable.
+                "directory entry name is not valid UTF-8: {:?} (in '{}'); heph paths must be \
+                 UTF-8 — rename it, or `fs.skip` the containing directory",
+                raw,
+                dir.display(),
+            )
+        })?;
         entries.push(DirEntry {
             name,
             kind: entry_kind(ft),
@@ -398,9 +457,20 @@ fn read_dir_uncached(dir: &Path) -> Result<DirListing> {
     Ok(DirListing { entries })
 }
 
-/// A path's db key. Lossy is fine — a non-UTF-8 path just gets a stable lossy
-/// key; the worst case is a cache miss, never an incorrect hit (the on-disk
-/// mtime/size still gate every reuse).
+/// A path's db key.
+///
+/// `to_string_lossy` is **not** injective — `x\xffy` and `x\xfey` both render to
+/// `x\u{FFFD}y`, and `path` is the `dirs`/`files` PRIMARY KEY, so two distinct
+/// paths would share one row and could serve each other's listing or content
+/// hash under a matching mtime. What rules that out is not the mtime/size guard
+/// (mtime collides routinely after `tar -x`, `cp -p`, or `rsync -t`) but the
+/// walk's own invariant: every walked path is `root.join(<name from
+/// read_dir_uncached>)`, and that function rejects non-UTF-8 names outright, so
+/// the only possible source of lossiness is `root` itself — and a single root
+/// mangles to a single consistent prefix, while each workspace's db lives under
+/// its own heph home, so two roots that render alike never share a `dirs` table.
+/// The one way to break that is to point two roots at one db by hand, which
+/// `crates/plugin-go-cdylib`'s `walk_db` option makes possible.
 fn path_key(p: &Path) -> String {
     p.to_string_lossy().into_owned()
 }
@@ -442,7 +512,8 @@ impl FsWalkStore {
                      path        TEXT PRIMARY KEY,
                      mtime_ns    INTEGER NOT NULL,
                      entries     BLOB NOT NULL,
-                     accessed_ns INTEGER NOT NULL
+                     accessed_ns INTEGER NOT NULL,
+                     listing_version INTEGER NOT NULL DEFAULT 0
                  );
                  CREATE TABLE IF NOT EXISTS files (
                      path        TEXT PRIMARY KEY,
@@ -454,6 +525,28 @@ impl FsWalkStore {
                  );",
             )
             .context("initialising fswalk schema")?;
+        // Migration for a db created before `listing_version` existed. Probed
+        // rather than attempted-and-ignored: on a fresh db the `CREATE TABLE`
+        // above already declares the column, so an unconditional `ALTER` fails
+        // every time and swallowing that failure would also swallow a real one —
+        // and a real one leaves `get_dir`/`put_dir` unable to prepare, which
+        // disables the durable listing cache silently and forever.
+        let mut cols = write
+            .prepare("PRAGMA table_info(dirs)")
+            .context("inspecting the fswalk dirs schema")?;
+        let has_listing_version = cols
+            .query_map([], |r| r.get::<_, String>(1))
+            .context("reading the fswalk dirs columns")?
+            .filter_map(std::result::Result::ok)
+            .any(|name| name == "listing_version");
+        drop(cols);
+        if !has_listing_version {
+            write
+                .execute_batch(
+                    "ALTER TABLE dirs ADD COLUMN listing_version INTEGER NOT NULL DEFAULT 0;",
+                )
+                .context("adding listing_version to the fswalk dirs table")?;
+        }
 
         let manager = SqliteConnectionManager::file(db_path)
             .with_flags(OpenFlags::SQLITE_OPEN_READ_ONLY)
@@ -479,10 +572,15 @@ impl FsWalkStore {
     fn get_dir(&self, path: &Path) -> Option<(i64, Vec<u8>)> {
         let conn = self.read_pool.get().ok()?;
         let mut stmt = conn
-            .prepare_cached("SELECT mtime_ns, entries FROM dirs WHERE path = ?1")
+            .prepare_cached(
+                "SELECT mtime_ns, entries FROM dirs WHERE path = ?1 AND listing_version = ?2",
+            )
             .ok()?;
-        stmt.query_row([path_key(path)], |r| Ok((r.get(0)?, r.get(1)?)))
-            .ok()
+        stmt.query_row(
+            rusqlite::params![path_key(path), DIR_LISTING_VERSION],
+            |r| Ok((r.get(0)?, r.get(1)?)),
+        )
+        .ok()
     }
 
     fn put_dir(&self, path: &Path, mtime_ns: i64, entries: &[u8], now: i64) {
@@ -494,12 +592,18 @@ impl FsWalkStore {
         // `synchronous = OFF`, so the implicit commit is a WAL append and it is
         // the parse, not the transaction, that is worth removing.
         let Ok(mut stmt) = conn.prepare_cached(
-            "INSERT OR REPLACE INTO dirs (path, mtime_ns, entries, accessed_ns) \
-             VALUES (?1, ?2, ?3, ?4)",
+            "INSERT OR REPLACE INTO dirs (path, mtime_ns, entries, accessed_ns, listing_version) \
+             VALUES (?1, ?2, ?3, ?4, ?5)",
         ) else {
             return;
         };
-        drop(stmt.execute(rusqlite::params![path_key(path), mtime_ns, entries, now]));
+        drop(stmt.execute(rusqlite::params![
+            path_key(path),
+            mtime_ns,
+            entries,
+            now,
+            DIR_LISTING_VERSION
+        ]));
     }
 
     fn get_file(&self, path: &Path) -> Option<FileHash> {
@@ -601,6 +705,220 @@ mod tests {
 
     fn walker(dir: &Path) -> CachedWalker {
         CachedWalker::open(&dir.join("fswalk.db"))
+    }
+
+    /// Create a file whose name is the raw byte sequence `raw`, or `None` when
+    /// the filesystem refuses it. APFS rejects names that are not valid UTF-8
+    /// with `EILSEQ`, so this fixture is unconstructible on
+    /// `aarch64-apple-darwin` — the caller must skip loudly rather than assert
+    /// on a file it never created.
+    fn try_create_non_utf8_file(dir: &Path, raw: &[u8]) -> Option<PathBuf> {
+        use std::os::unix::ffi::OsStrExt;
+        let path = dir.join(std::ffi::OsStr::from_bytes(raw));
+        match std::fs::write(&path, b"") {
+            Ok(()) => Some(path),
+            Err(e) => {
+                // macOS is the only supported target where this is expected. On
+                // Linux — the one platform that exercises the fix at all — a
+                // refusal means `$TMPDIR` is on a filesystem that cannot host
+                // the fixture, and skipping would turn the only real coverage
+                // into a silent green.
+                assert!(
+                    cfg!(target_os = "macos"),
+                    "the non-UTF-8 fixture must be constructible on this target, \
+                     but {dir:?} refused it: {e}"
+                );
+                eprintln!(
+                    "SKIP: this filesystem refuses non-UTF-8 file names ({e}); \
+                     the non-UTF-8 fixture cannot be built here"
+                );
+                None
+            }
+        }
+    }
+
+    #[test]
+    fn read_dir_rejects_a_non_utf8_entry_name() {
+        let tmp = tempdir().unwrap();
+        let dir = tmp.path().join("pkg");
+        std::fs::create_dir(&dir).unwrap();
+        std::fs::write(dir.join("ok.txt"), b"").unwrap();
+        let Some(_bad) = try_create_non_utf8_file(&dir, b"caf\xe9.txt") else {
+            return;
+        };
+
+        let w = walker(tmp.path());
+        let err = w
+            .read_dir(&dir)
+            .expect_err("a non-UTF-8 entry name must fail the walk, not vanish from the listing");
+        let msg = format!("{err:#}");
+        assert!(
+            msg.contains("not valid UTF-8"),
+            "error should name the problem, got: {msg}"
+        );
+        assert!(
+            msg.contains("pkg"),
+            "error should name the directory, got: {msg}"
+        );
+    }
+
+    /// Two names that differ only in bytes `to_string_lossy` would both render
+    /// as `U+FFFD`. Silently dropping them (the old behavior) hid two real
+    /// paths; rendering them lossily would have fused them into one. Neither is
+    /// acceptable for something that ends up in a package name and a db key.
+    #[test]
+    fn read_dir_rejects_names_that_would_collide_under_lossy_rendering() {
+        let tmp = tempdir().unwrap();
+        let dir = tmp.path().join("pkg");
+        std::fs::create_dir(&dir).unwrap();
+        let Some(_a) = try_create_non_utf8_file(&dir, b"x\xffy") else {
+            return;
+        };
+        let Some(_b) = try_create_non_utf8_file(&dir, b"x\xfey") else {
+            return;
+        };
+        assert_eq!(
+            std::fs::read_dir(&dir).unwrap().count(),
+            2,
+            "the two names must be distinct on disk for this test to mean anything"
+        );
+
+        let w = walker(tmp.path());
+        let err = w
+            .read_dir(&dir)
+            .expect_err("names that render to the same lossy string must not reach a listing");
+        // The message must distinguish the two, or it sends the user to rename
+        // a file they cannot tell from its neighbour. `\u{FFFD}` in the text
+        // would mean the lossy render leaked into the one place precision is
+        // the whole point.
+        let msg = format!("{err:#}");
+        assert!(
+            msg.contains(r"\xFF") || msg.contains(r"\xFE"),
+            "error must name the offending bytes escaped, got: {msg}"
+        );
+        assert!(
+            !msg.contains('\u{FFFD}'),
+            "error must not render the name lossily, got: {msg}"
+        );
+    }
+
+    /// A `dirs` row is revalidated by directory mtime alone, so a listing
+    /// written under older filtering rules is byte-identical-valid to the mtime
+    /// guard. Only [`DIR_LISTING_VERSION`] stops it being served — without it
+    /// the entry-name fix is inert on every warm cache.
+    #[test]
+    fn a_listing_cached_under_an_older_version_is_not_reused() {
+        let tmp = tempdir().unwrap();
+        let root = tmp.path();
+        let pkg = root.join("pkg");
+        std::fs::create_dir(&pkg).unwrap();
+        std::fs::write(pkg.join("a.txt"), b"a").unwrap();
+
+        let w = walker(root);
+        assert_eq!(w.read_dir(&pkg).unwrap().entries.len(), 1);
+        drop(w);
+
+        // Rewrite the cached row the way a pre-fix binary would have left it:
+        // same path, same mtime, but a listing missing an entry.
+        let conn = Connection::open(root.join("fswalk.db")).unwrap();
+        let truncated = borsh::to_vec(&DirListing::default()).unwrap();
+        let updated = conn
+            .execute(
+                "UPDATE dirs SET entries = ?1, listing_version = 0 WHERE path = ?2",
+                rusqlite::params![truncated, pkg.to_str().unwrap()],
+            )
+            .unwrap();
+        assert_eq!(updated, 1, "the first walk should have cached one dirs row");
+        drop(conn);
+
+        let w2 = walker(root);
+        let listing = w2.read_dir(&pkg).unwrap();
+        assert_eq!(
+            listing.entries.len(),
+            1,
+            "a listing cached under an older listing version must be re-read, not served"
+        );
+    }
+
+    /// The `ALTER TABLE` path is never taken on a db this suite creates (the
+    /// `CREATE TABLE` already declares the column), so without this test the
+    /// migration every existing user's db actually takes is the one line no
+    /// test executes. Builds the pre-migration schema by hand and asserts the
+    /// walker both works on it and writes a current row.
+    #[test]
+    fn a_pre_migration_db_is_upgraded_in_place() {
+        let tmp = tempdir().unwrap();
+        let root = tmp.path();
+        let pkg = root.join("pkg");
+        std::fs::create_dir(&pkg).unwrap();
+        std::fs::write(pkg.join("a.txt"), b"a").unwrap();
+
+        let db = root.join("fswalk.db");
+        let conn = Connection::open(&db).unwrap();
+        conn.execute_batch(
+            "CREATE TABLE dirs (
+                 path        TEXT PRIMARY KEY,
+                 mtime_ns    INTEGER NOT NULL,
+                 entries     BLOB NOT NULL,
+                 accessed_ns INTEGER NOT NULL
+             );",
+        )
+        .unwrap();
+        drop(conn);
+
+        let w = CachedWalker::open(&db);
+        assert_eq!(w.read_dir(&pkg).unwrap().entries.len(), 1);
+        drop(w);
+
+        let conn = Connection::open(&db).unwrap();
+        let version: i64 = conn
+            .query_row(
+                "SELECT listing_version FROM dirs WHERE path = ?1",
+                [pkg.to_str().unwrap()],
+                |r| r.get(0),
+            )
+            .expect("the migrated db must hold a row for the walked dir");
+        assert_eq!(
+            version, DIR_LISTING_VERSION,
+            "the migrated column must be written with the current version"
+        );
+    }
+
+    /// The inverse of the test above, and the reason it is worth having: a
+    /// version predicate that never matches is *invisibly* correct — every
+    /// directory quietly falls back to disk and the durable cache stops
+    /// existing. Nothing else asserts a durable **hit** (equal content passes
+    /// whether the row was served or re-read), so a future
+    /// [`DIR_LISTING_VERSION`] written by `put_dir` and not accepted by
+    /// `get_dir` would cost the whole dir cache with nothing going red.
+    #[test]
+    fn a_current_listing_is_served_from_the_durable_cache() {
+        let tmp = tempdir().unwrap();
+        let root = tmp.path();
+        let pkg = root.join("pkg");
+        std::fs::create_dir(&pkg).unwrap();
+        std::fs::write(pkg.join("a.txt"), b"a").unwrap();
+        let stamped = std::fs::metadata(&pkg).unwrap().modified().unwrap();
+
+        let w = walker(root);
+        assert_eq!(w.read_dir(&pkg).unwrap().entries.len(), 1);
+        drop(w);
+
+        // Change the directory behind the cache's back and put its mtime back,
+        // so reuse is decided by the row alone. A walker that re-read from disk
+        // would see two entries.
+        std::fs::write(pkg.join("b.txt"), b"b").unwrap();
+        std::fs::File::open(&pkg)
+            .unwrap()
+            .set_modified(stamped)
+            .unwrap();
+
+        let w2 = walker(root);
+        assert_eq!(
+            w2.read_dir(&pkg).unwrap().entries.len(),
+            1,
+            "the durable listing was not reused — the dirs cache is not being hit at all"
+        );
     }
 
     #[test]

--- a/crates/walk/src/lib.rs
+++ b/crates/walk/src/lib.rs
@@ -64,7 +64,24 @@ impl Default for Ignore {
     }
 }
 
+/// The `.git` exclusion the engine always prepends to `fs.skip`. A `.git` dir is
+/// never a build input, and it is the one directory that reliably contains names
+/// no build tool chose — a ref file is whatever bytes the branch name was, so
+/// `git checkout -b $'\xe9'` puts a non-UTF-8 name in the tree that
+/// [`CachedWalker::read_dir`] refuses to walk past.
+pub const GIT_SKIP_GLOB: &str = "**/.git/**";
+
 impl Ignore {
+    /// An ignore set for a walker with no user skip configuration: prunes
+    /// [`GIT_SKIP_GLOB`] and nothing else.
+    ///
+    /// `Ignore::default()` prunes *nothing*, which is wrong for any real tree —
+    /// it descends into `.git`. Callers that genuinely have no config (the LSP)
+    /// want this instead.
+    pub fn git_only() -> Self {
+        Self::new(&[], &[GIT_SKIP_GLOB.to_string()]).expect("the .git ignore set is valid")
+    }
+
     /// Builds an ignore set from absolute `dirs` (exact-path prune) and
     /// workspace-relative `globs`.
     pub fn new(dirs: &[PathBuf], globs: &[String]) -> anyhow::Result<Self> {


### PR DESCRIPTION
Package names come from directory names, and since #218 the package list is **sorted** and feeds the def hash — so byte-level differences in those names now change cache keys. A `hermeticity` consult on that PR flagged two hazards here. Only one turned out to be real.

## What actually reproduces, and where

Measured on `aarch64-apple-darwin` (APFS) and in a Linux container, rather than assumed:

| | Linux (ext4/btrfs) | macOS (APFS) |
|---|---|---|
| Non-UTF-8 entry name | **reachable** — `mkdir` succeeds | unconstructible: `EILSEQ` at create |
| Unicode normalization | bytes preserved | bytes preserved (normalization-*preserving*) |
| Normalization-insensitive *lookup* | no | **yes** |

**Hazard 2 (silent skip) is real, and Linux-only.** `read_dir_uncached` dropped any entry whose name was not valid UTF-8. `*.BUILD` is a default pattern, so a `caf\xe9.BUILD` file made its package — and every ancestor the walk would have inserted — vanish from the def-hash-bearing list: add it or edit it, and no hash anywhere changed. The same drop cost the `fs` glob driver a file's content hash inside its parent's `hashin`, so editing that file served the previous artifact.

**Hazard 1 (normalization) does not reproduce on any supported configuration.** APFS is normalization-*preserving* — an NFD directory name reads back as NFD — so for one commit checked out onto a local ext4/btrfs/APFS volume, `readdir` returns identical bytes on all three supported targets and the def hash is already identical. HFS+ and some network / container-VM mounts do normalize; those produce a *different* def hash, which is a cache miss and never a wrong artifact, because every file input is content-hashed independently.

**The U+FFFD collision is not reachable through the provider**: every path component below the root comes from the walker, which now refuses those names.

## What this does

- **Fail, don't drop.** A non-UTF-8 entry name is now an error naming the path. Rendered with `{:?}`, not lossily — `caf\xe9` and `caf\xea` both *display* as `caf\u{FFFD}`, and the one message that must identify a name cannot use the rendering this change exists to reject. The adjacent `file_type()` drop goes with it: only a vanished entry (`NotFound`, a concurrent delete) is skippable.
- **`DIR_LISTING_VERSION`.** A `dirs` row is revalidated by directory mtime alone, and a filtering change bumps no mtime — so a pre-fix row would be served verbatim, leaving the fix inert on every warm cache and making the same tree build on a machine with a stale db while failing on a freshly-cloned one. Compared per row (not stamped db-wide) so a mixed fleet is safe both ways: an older binary's `INSERT` omits the column and lands on `DEFAULT 0`, which no current version accepts. The migration probes `table_info` rather than attempting the `ALTER` and ignoring the error.
- **`to_str`, not `to_string_lossy`**, where a path becomes a package name (buildfile + go providers).
- **The LSP gets `Ignore::git_only()`.** It built its `PackageList` with `Ignore::default()`, which prunes nothing — so it descends into `.git`, where a ref file's name is the branch name's raw bytes and one `git checkout -b $'\xe9'` would fail the whole package list and silently empty every completion.
- **No normalization**, with the exemption documented on `PackageList` and pinned by a test.

## Why not normalize

Normalizing to NFC would trade an unreachable cross-OS divergence for a reachable in-tree collision: a byte-preserving filesystem can legitimately hold the NFC and NFD spellings as two *distinct* package directories, and folding them would silently merge two packages. It would also re-key every target in a workspace with a non-ASCII package name, and add a Unicode dependency on the discovery hot path. Rejecting non-ASCII names is a hard break for those same users for no demonstrated benefit.

## Blast radius, chosen deliberately

The check lives in the walker and covers every entry kind, so one such name anywhere under a walked tree fails the package walk and every glob target, not just the targets that would have consumed it. Scoping it to directories does not work (a non-UTF-8 *file* name is package-defining via `*.BUILD`); pushing it to consumers cannot work at all, because a consumer never sees an entry the listing already dropped. Escape hatch: rename the file, or `fs.skip` its directory.

**No target is re-keyed.** For a valid-UTF-8 tree `to_str` and `to_string_lossy` are byte-identical, so every currently-well-formed package name hashes exactly as before. The only behavior that changes is an error where there used to be silence.

## Open decision for the user — not resolved here

**APFS lookup is normalization- and case-insensitive.** `//café:t` written NFC resolves on macOS against an NFD-stored directory and is `TargetNotFound` on Linux; the same holds on the case axis (`//Foo:t` → package `foo`). Within one macOS run the same physical package can then exist under two names, which `key_segment` hashes as two distinct remote revisions of the same work. It cannot serve a wrong artifact (file inputs are content-hashed; the exec def hash folds dep `Addr`s), so it is build-fails-on-one-OS plus duplicated work.

This is **pre-existing and untouched** — a per-platform behavioral divergence is the user's decision, and this PR was asked to remove a divergence, not choose a new one. Options if it is taken up: (i) accept and document; (ii) reject non-NFC / non-ASCII package names at discovery; (iii) canonicalize the resolved directory and compare bytes to the requested name, erroring on mismatch — one `canonicalize` per package `get`, and it makes macOS behave like Linux.

## Known follow-up, now sharper

`build_files_in_dir` reads `std::fs` directly and pattern-matches a **lossy** name, so a `caf\xe9.BUILD` matches `*.BUILD` there (as `caf\u{FFFD}.BUILD`). The engine now hard-errors on that name while the formatter (`src/commands/tool/build_fmt.rs:120`) and the LSP (`lsp/context.rs:185`) still match it and act on it. Editor-side only, so a diagnosability trap rather than a hash route — flagged at the site; it should be routed through the walker.

Also not swept here: the remaining `to_string_lossy` package identifiers in plugin-go and the LSP that do not feed a hash.

## Review

- `hermeticity` (design + review): **HERMETIC WITH EXEMPTIONS**, no blocker. Both design BLOCKERs — the warm-`dirs`-row hole and the silent drop — fixed; the migration verified sound across all four upgrade paths; every consumer fails closed; nothing re-keys.
- `compatibility` (design): **COMPATIBLE AFTER BUMP** — required the `dirs` version discriminator, which is `DIR_LISTING_VERSION`. `DirListing`/`DirEntry` borsh layout unchanged; no ABI, CLI, `--json` or exit-code contract touched.
- `code-quality` (review): two MAJORs, both fixed (the `.git`/LSP failure path; the swallowed `ALTER TABLE`). MINORs on error rendering, test discrimination, and the skip guard also taken.

## Verification

Every new test was confirmed red without the fix, on Linux (`podman`, aarch64), against a tree restored from `origin/master` with only the tests grafted on:

- `read_dir_rejects_a_non_utf8_entry_name` — red: the listing contained only `ok.txt`, the bad entry silently absent.
- `read_dir_rejects_names_that_would_collide_under_lossy_rendering` — red.
- `list_packages_rejects_a_non_utf8_package_dir` — red: `Ok`, with the package simply missing.
- `list_packages_rejects_package_dirs_that_would_fuse_under_lossy_rendering` — red.
- `a_listing_cached_under_an_older_version_is_not_reused` — red twice: against pristine `master` (no column), and against a variant that keeps the column but drops the version predicate, where the stale 0-entry listing was served.
- `a_current_listing_is_served_from_the_durable_cache` — the durable-**hit** guard; verified red by mutating `get_dir` to require a version `put_dir` never writes, and it is the only test that catches that.
- `a_pre_migration_db_is_upgraded_in_place` — exercises the `ALTER TABLE` path, which no test on a suite-created db would otherwise take.
- `package_names_are_the_directory_bytes_not_a_normalized_form` — a pinning test for the documented exemption; it cannot go red without the fix by construction, since the fix *is* the decision not to normalize.

The non-UTF-8 fixtures cannot be constructed on APFS, so they skip with a `SKIP:` message on macOS — and assert the refusal is macOS, so a Linux `$TMPDIR` that cannot host the fixture fails loudly instead of turning the only real coverage into a silent green. Green on both platforms: 13/13 `walk`, 30/30 `plugin-buildfile` provider tests. `cargo clippy --all-targets --locked -- -D warnings` clean from the workspace root.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01A76DChMohieGMbRbnV1E7x
