### PR TITLE
fix(lock): make the holder pid mean something, and actually test the stale-inode guard

### DIFF
--- a/crates/core/src/events.rs
+++ b/crates/core/src/events.rs
@@ -70,8 +70,10 @@ pub enum BuildEventKind {
         error: Option<String>,
     },
     /// Acquiring the per-addr result lock has been blocked past the notice
-    /// threshold. `holder_pid` is the process believed to hold the lock
-    /// (best-effort; `None` if unknown). Paired one-to-one with
+    /// threshold. `holder_pid` is a process that stamped the lock and still held
+    /// it when it was probed — a snapshot, and `None` whenever the holder cannot
+    /// be named (including the common case of waiting on readers to drain, which
+    /// nothing stamps). Paired one-to-one with
     /// `ResultLockWaitEnd` (which fires on acquire **or** cancellation), so a
     /// consumer can show the notice for exactly the duration of the wait.
     ResultLockWaitStart {

--- a/crates/engine/src/engine/result_lock.rs
+++ b/crates/engine/src/engine/result_lock.rs
@@ -21,11 +21,12 @@
 //! the in-memory backend serializes only within this process.
 
 use anyhow::Result;
+use async_trait::async_trait;
 use hcore::hasync::Cancellable;
 use hlock::hlock::{
-    FLock, FRWLock, FWriteGuard, KeyedGuard, KeyedTLock, MemLock, MemRWLock, TBridge,
+    Ctoken, FLock, FRWLock, FWriteGuard, KeyedGuard, KeyedTLock, Lock, MemLock, MemRWLock, TBridge,
     TBridgeReadGuard, TBridgeUpgradableGuard, TBridgeWriteGuard, TUpgradableReadGuard, TWriteGuard,
-    fs_tlock, mem_tlock,
+    mem_tlock,
 };
 use hmodel::htaddr::Addr;
 use std::io::Read as _;
@@ -42,14 +43,80 @@ pub enum LockBackend {
     Mem,
 }
 
-type FsBridge = TBridge<FLock, FRWLock>;
+type FsBridge = TBridge<GatewayLock, FRWLock>;
 type MemBridge = TBridge<MemLock, MemRWLock>;
+
+/// The per-addr gateway lock: an [`FLock`] plus one policy — **acquiring it
+/// empties the lock file.**
+///
+/// The gateway file's contents are the holder's pid stamp, and they describe
+/// *the current holder*. They only ever outlive their writer when a holder is
+/// killed without running `Drop`: nothing unlinks the gateway file then, and
+/// nothing sweeps `<home>/lock/`. The next exclusive acquire is the first moment
+/// anyone can clear that, so it is where the clearing belongs.
+///
+/// This is what closes the *wide* window. [`TBridge`] takes the gateway first
+/// and only then parks on the inner lock — a wait bounded by a whole build —
+/// and [`stamp_pid`] runs after both. A waiter in another process reading the
+/// file in between now sees an empty one ("holder unknown") rather than the name
+/// of the previous, dead holder.
+///
+/// It also means the common cross-process shape — we hold the gateway and are
+/// waiting for *other* processes' read guards on the inner lock to drain —
+/// reports "holder unknown". That is the point: stamping at outer-acquire
+/// instead would make it report this very process as the holder, which is worse
+/// than admitting we do not know who is in the way.
+///
+/// Deliberately here and not in [`FLock`]: `FLock` is also `driver-support`'s
+/// staging lock, which keeps nothing in its file and should not pay a syscall
+/// per acquire for a stamp it never writes.
+#[derive(Clone, Debug)]
+pub struct GatewayLock(FLock);
+
+impl GatewayLock {
+    fn new(path: PathBuf) -> Self {
+        Self(FLock::new(path))
+    }
+}
+
+/// Empty a freshly-acquired gateway file. Best-effort for the same reason
+/// [`stamp_pid`] is: the contents are a diagnostic, and failing a build lock
+/// because a pid could not be *erased* would trade a stale pid for a dead build.
+/// A failure leaves exactly the behaviour that shipped before this existed.
+///
+/// One `ftruncate` — `write_all_at` on an empty slice issues no syscall — on the
+/// gateway acquire, which is the cold path (a warm cache hit takes only the
+/// inner read lock and never reaches here).
+fn blank_stamp(gateway: &FWriteGuard) {
+    if let Err(err) = gateway.write_contents(b"") {
+        tracing::debug!(error = %err, "blanking the gateway pid stamp on acquire");
+    }
+}
+
+#[async_trait]
+impl Lock for GatewayLock {
+    type Guard = FWriteGuard;
+
+    async fn lock(&self, ctoken: Ctoken<'_>) -> Result<FWriteGuard> {
+        let guard = self.0.lock(ctoken).await?;
+        blank_stamp(&guard);
+        Ok(guard)
+    }
+
+    fn try_lock(&self) -> Result<Option<FWriteGuard>> {
+        let guard = self.0.try_lock()?;
+        if let Some(guard) = &guard {
+            blank_stamp(guard);
+        }
+        Ok(guard)
+    }
+}
 
 type FsReadGuard = KeyedGuard<Addr, FsBridge, TBridgeReadGuard<FRWLock>>;
 type MemReadGuard = KeyedGuard<Addr, MemBridge, TBridgeReadGuard<MemRWLock>>;
-type FsUpgradableGuard = KeyedGuard<Addr, FsBridge, TBridgeUpgradableGuard<FLock, FRWLock>>;
+type FsUpgradableGuard = KeyedGuard<Addr, FsBridge, TBridgeUpgradableGuard<GatewayLock, FRWLock>>;
 type MemUpgradableGuard = KeyedGuard<Addr, MemBridge, TBridgeUpgradableGuard<MemLock, MemRWLock>>;
-type FsWriteGuard = KeyedGuard<Addr, FsBridge, TBridgeWriteGuard<FLock, FRWLock>>;
+type FsWriteGuard = KeyedGuard<Addr, FsBridge, TBridgeWriteGuard<GatewayLock, FRWLock>>;
 type MemWriteGuard = KeyedGuard<Addr, MemBridge, TBridgeWriteGuard<MemLock, MemRWLock>>;
 
 /// Plain shared read guard on a target's cache entry. Held for as long as the
@@ -131,7 +198,10 @@ impl ResultLock {
             LockBackend::Fs => ResultLock::Fs {
                 dir: dir.clone(),
                 lock: KeyedTLock::new(move |addr: &Addr| {
-                    fs_tlock(outer_lock_path(&dir, addr), inner_lock_path(&dir, addr))
+                    TBridge::new(
+                        GatewayLock::new(outer_lock_path(&dir, addr)),
+                        FRWLock::new(inner_lock_path(&dir, addr)),
+                    )
                 }),
             },
             LockBackend::Mem => ResultLock::Mem(KeyedTLock::new(|_| mem_tlock())),
@@ -212,13 +282,66 @@ impl ResultLock {
         }
     }
 
-    /// Best-effort pid of the process currently holding (or last to hold) the
-    /// gateway for `addr`. For the filesystem backend this reads the pid the
-    /// holder stamped into the gateway lock file; for the in-memory backend the
-    /// holder is always this process. `None` when the holder is unknown.
+    /// Best-effort pid of the process **currently holding** the gateway for
+    /// `addr`, or `None` when the holder is unknown. For the in-memory backend
+    /// the holder is always this process.
+    ///
+    /// For the filesystem backend this is two questions, asked **in this order**:
+    ///
+    /// 1. *Is the gateway held at all?* — [`FLock::is_path_held`] probes the
+    ///    `flock` itself. A stamp with nobody holding the lock is a stamp its
+    ///    writer left behind when it was killed; the kernel dropped that
+    ///    process's lock at exit, but nothing unlinked the file and nothing
+    ///    sweeps `<home>/lock/`, so the pid would otherwise be readable forever.
+    /// 2. *Who stamped it?* — [`read_pid`] on the gateway file, which
+    ///    [`GatewayLock`] empties at acquire, so a holder that has not stamped
+    ///    yet reads as unknown rather than as its predecessor.
+    ///
+    /// **Probe first, then read.** Reading first leaves a window: the pid is
+    /// captured, the holder releases (and unlinks), a new holder takes the
+    /// gateway, and the probe then reports "held" — naming a process that holds
+    /// nothing and whose pid may already have been recycled. That is the exact
+    /// failure this function exists to prevent, so the order is load-bearing
+    /// rather than incidental. Probe-first has no such window: after a
+    /// confirmed "held", the read yields the confirmed holder's stamp, a newer
+    /// holder's stamp, or nothing — never a released holder's.
+    ///
+    /// For the same reason the read is *not* fused into the probe by reusing
+    /// its fd, which would save an `open`: that fd names the inode that was
+    /// held, and if the holder releases in between, reading it returns the
+    /// stamp of a lock nobody holds. Re-resolving the path is what makes the
+    /// stale answer unreachable.
+    ///
+    /// Probing the lock is the liveness check, deliberately in place of
+    /// `kill(pid, 0)` on the stamped pid: `kill` answers for a *pid*, which is a
+    /// recycled name — a reused pid, or a zombie whose pid still answers,
+    /// reports a live process that never held anything. The lock is the thing we
+    /// actually want to know about, and it costs one `open` + one `flock` on a
+    /// path that has already spent `RESULT_LOCK_NOTICE` waiting.
+    ///
+    /// It stays best-effort by nature. The probe is a snapshot — the holder may
+    /// release the instant after — and a pid is only a hint for the user, never
+    /// something the engine acts on.
+    ///
+    /// What this still cannot report: a wait on the *inner* lock, which is the
+    /// common cross-process shape. Plain read guards are not stamped at all, so
+    /// "who is holding the artifacts I want to rebuild" reads as unknown. See
+    /// [`GatewayLock`].
     pub fn holder_pid(&self, addr: &Addr) -> Option<u32> {
         match self {
-            ResultLock::Fs { dir, .. } => read_pid(&outer_lock_path(dir, addr)),
+            ResultLock::Fs { dir, .. } => {
+                let path = outer_lock_path(dir, addr);
+                match FLock::is_path_held(&path) {
+                    Ok(true) => read_pid(&path),
+                    Ok(false) => None,
+                    Err(err) => {
+                        // The probe is the only caller of those contexts; without
+                        // this the diagnostic path is itself undiagnosable.
+                        tracing::debug!(error = %err, "probing gateway lock liveness");
+                        None
+                    }
+                }
+            }
             ResultLock::Mem(_) => Some(std::process::id()),
         }
     }
@@ -255,13 +378,18 @@ fn inner_lock_path(dir: &Path, addr: &Addr) -> PathBuf {
 /// belongs to nobody; without the truncate-first order, a partially visible
 /// write could still land inside the old frame. See [`read_pid`].
 ///
-/// This bounds what a *torn* read can report. It does not make the pid fresh: a
-/// stamp outlives the process that wrote it whenever the holder is killed
-/// without running `Drop` (nothing unlinks the gateway file then), and the stamp
-/// lands only after the acquire completes, so a waiter can also read the
-/// previous holder's pid while the current one is still parked on the inner
-/// lock. Both are pre-existing and unaddressed here; a liveness check on the
-/// pid, or blanking the stamp at acquire, would be the fix.
+/// That bounds what a *torn* read can report. Freshness is a separate question,
+/// and neither half of it is answered here: this runs only after the whole
+/// bridge acquire completes, so between the gateway acquire and this line the
+/// file holds whatever the last holder left; and a stamp outlives its writer
+/// whenever that writer is killed without running `Drop`. Both are handled at
+/// the other end — [`GatewayLock`] empties the file the moment the gateway is
+/// acquired, and [`holder_pid`] reports a pid only while the lock is genuinely
+/// held. Both of those are best-effort too: a blank that fails re-opens the
+/// window for this addr until the next acquire, which is why the liveness probe
+/// is a second, independent check rather than a belt on the first.
+///
+/// [`holder_pid`]: ResultLock::holder_pid
 fn stamp_pid(gateway: Option<&FWriteGuard>) {
     debug_assert!(
         gateway.is_some(),
@@ -333,6 +461,18 @@ mod tests {
 
     fn fs(dir: &tempfile::TempDir) -> ResultLock {
         ResultLock::new(LockBackend::Fs, dir.path().to_path_buf())
+    }
+
+    /// Hold the gateway for `addr` the way another *process* would: a raw
+    /// [`FLock`] on the outer path, bypassing both [`GatewayLock`]'s blank and
+    /// [`stamp_pid`]. That lets a test plant exact bytes in the gateway file and
+    /// still have [`ResultLock::holder_pid`]'s liveness probe see a held lock, so
+    /// the assertion is about the *parsing* and nothing else.
+    async fn hold_raw_gateway(dir: &tempfile::TempDir, a: &Addr) -> FWriteGuard {
+        FLock::new(outer_lock_path(dir.path(), a))
+            .lock(&ct())
+            .await
+            .expect("raw gateway")
     }
 
     // ResultReadGuard must be Send + Sync — it lives inside Arc<dyn Content>
@@ -548,18 +688,22 @@ mod tests {
         assert_eq!(lock.holder_pid(&addr("a")), None, "unknown after release");
     }
 
-    // `write_contents` writes positionally and truncates second, so a reader in
-    // another process can catch the gateway file mid-stamp. A killed holder
-    // leaves a 7-digit pid behind (Linux `pid_max` defaults to 4194304); the
-    // next holder stamps a 3-digit one over it, and this is what a third process
-    // sees before the truncate lands. Unframed, `4214304` parses cleanly and the
-    // TUI names a pid the user might kill.
-    #[test]
-    fn holder_pid_ignores_a_torn_stamp_rather_than_reporting_a_wrong_pid() {
+    // `write_contents` writes positionally, so a reader in another process can
+    // catch the gateway file mid-stamp. A killed holder leaves a 7-digit pid
+    // behind (Linux `pid_max` defaults to 4194304); the next holder stamps a
+    // 3-digit one over it, and this is what a third process sees before the
+    // truncate lands. Unframed, `4214304` parses cleanly and the TUI names a pid
+    // the user might kill.
+    //
+    // The gateway is genuinely held throughout, so the liveness probe passes and
+    // the framing is the only thing that can decide the answer.
+    #[tokio::test]
+    async fn holder_pid_ignores_a_torn_stamp_rather_than_reporting_a_wrong_pid() {
         let dir = tempfile::tempdir().expect("tempdir");
         let lock = fs(&dir);
         let a = addr("a");
 
+        let held = hold_raw_gateway(&dir, &a).await;
         std::fs::write(outer_lock_path(dir.path(), &a), b"421\n304\n").expect("torn stamp");
 
         assert_eq!(
@@ -567,23 +711,172 @@ mod tests {
             Some(421),
             "the framed pid, never the concatenation with the stale tail"
         );
+        drop(held);
     }
 
-    #[test]
-    fn holder_pid_is_unknown_for_an_unterminated_stamp() {
+    #[tokio::test]
+    async fn holder_pid_is_unknown_for_an_unterminated_stamp() {
         // A write only half visible has no terminator. Naming `42` while the
         // holder is really `4211592` is worse than naming nobody.
+        //
+        // The planted pid is this process's own and the gateway is held, so
+        // neither the liveness probe nor a dead pid can account for the `None` —
+        // only the missing frame can.
         let dir = tempfile::tempdir().expect("tempdir");
         let lock = fs(&dir);
         let a = addr("a");
 
-        std::fs::write(outer_lock_path(dir.path(), &a), b"42").expect("partial stamp");
+        let held = hold_raw_gateway(&dir, &a).await;
+        std::fs::write(
+            outer_lock_path(dir.path(), &a),
+            std::process::id().to_string(),
+        )
+        .expect("partial stamp");
 
         assert_eq!(
             lock.holder_pid(&a),
             None,
             "an unframed payload is not a pid"
         );
+        drop(held);
+    }
+
+    #[test]
+    fn holder_pid_is_unknown_when_the_stamp_outlives_its_holder() {
+        // A holder killed mid-build leaves the gateway file behind: no `Drop`
+        // runs, so nothing unlinks it, and nothing sweeps `<home>/lock/`. The
+        // kernel does drop its `flock` at exit — so the lock is free while the
+        // stamp is not, and without a liveness check that pid stays readable
+        // forever.
+        //
+        // The stamp planted here is *this* process's pid: live, well-framed, and
+        // exactly what a `kill(pid, 0)` check would happily report. Only probing
+        // the lock itself gets this right.
+        let dir = tempfile::tempdir().expect("tempdir");
+        let lock = fs(&dir);
+        let a = addr("a");
+
+        std::fs::write(
+            outer_lock_path(dir.path(), &a),
+            format!("{}\n", std::process::id()),
+        )
+        .expect("stamp from a holder that is gone");
+
+        assert_eq!(
+            lock.holder_pid(&a),
+            None,
+            "a stamp nobody holds names nobody"
+        );
+    }
+
+    // The gateway's contents describe its *current* holder. `TBridge` acquires
+    // the gateway, then parks on the inner lock for as long as a build takes,
+    // and only then stamps — so whatever the previous holder left must be gone
+    // at the *first* of those three, not the last.
+    //
+    // The seeded pid is this process's own, and the lock is held once we
+    // acquire, so nothing but the blank itself can make it unreadable.
+    #[tokio::test]
+    async fn gateway_lock_blanks_a_stale_stamp_at_acquire() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let path = dir.path().join("gateway.lock");
+        std::fs::write(&path, format!("{}\n", std::process::id())).expect("stale stamp");
+
+        let gw = GatewayLock::new(path.clone());
+        let held = gw.lock(&ct()).await.expect("gateway");
+
+        assert_eq!(
+            std::fs::read(&path).expect("gateway readable"),
+            b"",
+            "acquiring the gateway must empty the stamp"
+        );
+        assert_eq!(read_pid(&path), None, "leaving no pid to report");
+        drop(held);
+    }
+
+    // The wide window, end to end through the *shipped* `ResultLock` rather than
+    // through `GatewayLock` directly.
+    //
+    // Two `ResultLock`s on one directory model two processes. A killed
+    // predecessor's stamp is still in the gateway file; the builder takes the
+    // gateway (blanking it) and then parks on the inner lock behind the
+    // watcher's read guard — a wait bounded by a whole build. For that entire
+    // wait, `holder_pid` used to name the predecessor.
+    //
+    // This is also the only test that pins `GatewayLock` into the bridge: the
+    // two tests above construct one themselves, so reverting `FsBridge` to
+    // `TBridge<FLock, FRWLock>` leaves them green. Here the planted pid is this
+    // process's own — live, framed, and sitting under a gateway that genuinely
+    // is held — so nothing but the blank can produce the `None`.
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn holder_pid_is_unknown_while_the_gateway_holder_waits_on_the_inner_lock() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let a = addr("a");
+        let watcher = fs(&dir);
+        let builder = Arc::new(fs(&dir));
+
+        std::fs::write(
+            outer_lock_path(dir.path(), &a),
+            format!("{}\n", std::process::id()),
+        )
+        .expect("stamp from a holder that is gone");
+
+        // Another process still has the artifacts open, so the inner write
+        // cannot be taken yet.
+        let reading = watcher.read(&a, &ct()).await.expect("plain read");
+
+        let b = Arc::clone(&builder);
+        let handle = tokio::spawn(async move {
+            let tok = StdCancellationToken::new();
+            b.write(&addr("a"), &tok).await
+        });
+
+        tokio::time::sleep(Duration::from_millis(50)).await;
+        assert!(
+            !handle.is_finished(),
+            "the builder must still be parked on the inner lock"
+        );
+        assert_eq!(
+            watcher.holder_pid(&a),
+            None,
+            "gateway held, but its new holder has not stamped yet"
+        );
+
+        drop(reading);
+        let held = tokio::time::timeout(Duration::from_secs(5), handle)
+            .await
+            .expect("did not hang")
+            .expect("join")
+            .expect("acquires once the read drains");
+        assert_eq!(
+            builder.holder_pid(&a),
+            Some(std::process::id()),
+            "and the stamp lands once the acquire completes"
+        );
+        drop(held);
+    }
+
+    // `try_write` is a live production stamp site (the GC trim), and it reaches
+    // the gateway through `try_lock`, not `lock`. Without this the blank could
+    // be dropped from that arm and ship green.
+    #[test]
+    fn gateway_try_lock_blanks_a_stale_stamp_at_acquire() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let path = dir.path().join("gateway.lock");
+        std::fs::write(&path, format!("{}\n", std::process::id())).expect("stale stamp");
+
+        let gw = GatewayLock::new(path.clone());
+        let held = gw
+            .try_lock()
+            .expect("try_lock ok")
+            .expect("free gateway acquires");
+
+        assert_eq!(
+            std::fs::read(&path).expect("gateway readable"),
+            b"",
+            "try_lock must empty the stamp too"
+        );
+        drop(held);
     }
 
     // Everything `read_pid` documents as `None`, in one place. The interesting
@@ -623,7 +916,6 @@ mod tests {
     // decoy was untouched — so a `stamp_pid` that wrote nothing cannot pass.
     #[tokio::test]
     async fn stamp_pid_writes_through_the_held_fd_not_the_path() {
-        use hlock::hlock::Lock;
         use std::os::unix::fs::FileExt as _;
 
         let dir = tempfile::tempdir().expect("tempdir");

--- a/crates/lock/src/hlock/bridge.rs
+++ b/crates/lock/src/hlock/bridge.rs
@@ -43,6 +43,12 @@ pub fn mem_tlock() -> TBridge<MemLock, MemRWLock> {
 
 /// Filesystem transformable reader/writer lock. `outer_path` and `inner_path`
 /// must be different files.
+///
+/// Used by this crate's own bridge tests. The engine deliberately does *not*
+/// build its result lock through here: it wraps the outer `FLock` in a
+/// `GatewayLock` decorator that empties the lock file at acquire, because it
+/// keeps the holder's pid stamp there and a stamp must not outlive its writer.
+/// Reach for `TBridge::new` directly when the outer lock needs a policy.
 pub fn fs_tlock(
     outer_path: impl AsRef<Path>,
     inner_path: impl AsRef<Path>,

--- a/crates/lock/src/hlock/flock.rs
+++ b/crates/lock/src/hlock/flock.rs
@@ -338,6 +338,15 @@ impl FLockState {
         self.fd.lock().force_stale = n;
     }
 
+    /// Whether the exhaustion warning is currently latched. The latch decides
+    /// `warn!` vs `debug!` only, so a test cannot observe it through behaviour
+    /// without installing a subscriber; asserting the state machine directly
+    /// keeps the reset-on-success arm from being dead code nobody would notice.
+    #[cfg(test)]
+    fn stale_warned(&self) -> bool {
+        self.fd.lock().stale_warned
+    }
+
     /// Injections not yet consumed — how many of the forced-stale iterations the
     /// acquire actually performed.
     #[cfg(test)]
@@ -863,6 +872,10 @@ mod tests {
             .unwrap()
             .expect("one fewer than the budget still acquires");
         assert_eq!(survives.state.pending_stale(), 0, "all retries consumed");
+        assert!(
+            !survives.state.stale_warned(),
+            "an acquire that succeeded never exhausted anything"
+        );
         drop(g);
 
         let exhausts = FLock::new(&path);
@@ -872,6 +885,10 @@ mod tests {
             "the full budget gives up"
         );
         assert_eq!(exhausts.state.pending_stale(), 0, "all retries consumed");
+        assert!(
+            exhausts.state.stale_warned(),
+            "exhaustion latches, so the next round logs at debug instead of warn"
+        );
         let (readers, writer, fd_open) = exhausts.state.counts();
         assert_eq!(
             (readers, writer, fd_open),
@@ -880,11 +897,18 @@ mod tests {
         );
 
         // Would-block, not failure: once the condition clears the same instance
-        // acquires.
-        exhausts
+        // acquires — and that clears the latch, so a *later* bout of staleness
+        // is reported afresh rather than silently downgraded for the rest of the
+        // process's life.
+        let g = exhausts
             .try_lock()
             .unwrap()
             .expect("acquires once it clears");
+        assert!(
+            !exhausts.state.stale_warned(),
+            "a successful acquire re-arms the warning"
+        );
+        drop(g);
     }
 
     #[tokio::test(flavor = "multi_thread", worker_threads = 2)]

--- a/crates/lock/src/hlock/flock.rs
+++ b/crates/lock/src/hlock/flock.rs
@@ -63,6 +63,22 @@ struct FdState {
     file: Option<File>,
     readers: usize,
     writer: bool,
+    /// Whether the stale-retry budget has already been reported exhausted since
+    /// the last successful acquire. `try_lock_fresh` is the `poll_acquire`
+    /// attempt closure, so a permanently stale path re-exhausts every backoff
+    /// round — ten times a second once the backoff saturates. Latching keeps the
+    /// first occurrence at `warn!` and drops the repeats to `debug!`.
+    stale_warned: bool,
+    /// Test-only: number of remaining [`FLockState::fd_matches_path`] calls that
+    /// must report "stale" regardless of the real inodes.
+    ///
+    /// A genuine stale inode needs a releaser to `unlink` in the window between
+    /// our `open` and our `flock` — nothing in-process can schedule that, and
+    /// racing for it would make the test flake green. Lives in `FdState` rather
+    /// than beside it so "only touched under the `fd` mutex" is structural
+    /// instead of a comment (and there is no atomic ordering to get wrong).
+    #[cfg(test)]
+    force_stale: usize,
 }
 
 #[derive(Debug)]
@@ -79,6 +95,9 @@ impl FLockState {
                 file: None,
                 readers: 0,
                 writer: false,
+                stale_warned: false,
+                #[cfg(test)]
+                force_stale: 0,
             }),
         })
     }
@@ -120,7 +139,15 @@ impl FLockState {
     /// Whether the currently open fd still names the inode at `path`. A `false`
     /// means a releaser unlinked the file out from under us between our open and
     /// our lock, so we hold a lock on a dead inode and must re-open.
-    fn fd_matches_path(&self, st: &FdState) -> Result<bool> {
+    fn fd_matches_path(&self, st: &mut FdState) -> Result<bool> {
+        // Test injection deliberately sits *inside* this function, ahead of the
+        // real comparison: hardwiring the body to `Ok(true)` — the mutation that
+        // used to pass the whole suite — then kills the retry tests too.
+        #[cfg(test)]
+        if st.force_stale > 0 {
+            st.force_stale -= 1;
+            return Ok(false);
+        }
         let f = st.file.as_ref().context("fd must be open to validate")?;
         let fd_meta = f.metadata().context("fstat-ing held lock fd")?;
         match std::fs::metadata(&self.path) {
@@ -150,11 +177,36 @@ impl FLockState {
                 return Ok(false);
             }
             if self.fd_matches_path(st)? {
+                st.stale_warned = false;
                 return Ok(true);
             }
             // Locked a file that a releaser already unlinked; drop it and retry
             // a fresh open (which re-creates the path).
             self.discard_fd(st);
+        }
+        // Giving up is reported as would-block, which the blocking callers
+        // retry forever and the `try_*` callers surface as "busy". That is the
+        // intended behaviour — the condition is transient by construction — but
+        // a path that is *permanently* stale would otherwise spin with nothing
+        // in the log.
+        //
+        // Latched, because this function is `poll_acquire`'s attempt closure:
+        // unlatched, a permanently stale path emits a warn per backoff round,
+        // ~10/s per addr, for the life of the run. The first one is the signal;
+        // the rest are the same fact again.
+        if st.stale_warned {
+            tracing::debug!(
+                path = %self.path.display(),
+                retries = STALE_RETRIES,
+                "lock file still being unlinked under us"
+            );
+        } else {
+            st.stale_warned = true;
+            tracing::warn!(
+                path = %self.path.display(),
+                retries = STALE_RETRIES,
+                "lock file kept being unlinked under us; reporting it busy"
+            );
         }
         Ok(false)
     }
@@ -241,6 +293,11 @@ impl FLockState {
         // waiter that grabbed this inode fails its post-lock inode check and
         // re-opens, and any fresh acquire creates a new file. Best-effort: a
         // missing file (someone raced us, or it was never created) is fine.
+        //
+        // The *order* here is the invariant, and no test can pin it: unlink after
+        // `LOCK_UN` reintroduces the two-holders race the module doc describes,
+        // yet leaves the same end state, so every assertion still passes. Only
+        // this comment stands between the two.
         if st.file.is_some() {
             match std::fs::remove_file(&self.path) {
                 Ok(()) => {}
@@ -257,6 +314,35 @@ impl FLockState {
     fn counts(&self) -> (usize, bool, bool) {
         let st = self.fd.lock();
         (st.readers, st.writer, st.file.is_some())
+    }
+
+    /// `(dev, ino)` of the currently held fd, or `None` when none is open.
+    /// Tests assert against this rather than calling
+    /// [`fd_matches_path`](Self::fd_matches_path) — asserting a guard with the
+    /// guard is circular, and would survive hardwiring it to `Ok(true)`.
+    #[cfg(test)]
+    fn held_ids(&self) -> Option<(u64, u64)> {
+        let st = self.fd.lock();
+        let meta = st
+            .file
+            .as_ref()?
+            .metadata()
+            .expect("fstat-ing held lock fd");
+        Some((meta.dev(), meta.ino()))
+    }
+
+    /// Make the next `n` inode checks report "stale". See
+    /// [`FdState::force_stale`].
+    #[cfg(test)]
+    fn inject_stale(&self, n: usize) {
+        self.fd.lock().force_stale = n;
+    }
+
+    /// Injections not yet consumed — how many of the forced-stale iterations the
+    /// acquire actually performed.
+    #[cfg(test)]
+    fn pending_stale(&self) -> usize {
+        self.fd.lock().force_stale
     }
 
     /// Current offset of the shared open file description. Exists so tests can
@@ -327,6 +413,59 @@ impl FLock {
         Self {
             state: FLockState::new(path.as_ref().to_path_buf()),
         }
+    }
+
+    /// Whether *some* open file description currently holds an exclusive lock on
+    /// `path`. Probe-only: it never creates the file, never waits, and leaves no
+    /// lock behind.
+    ///
+    /// The probe is a shared `flock(LOCK_SH | LOCK_NB)` on a fresh fd —
+    /// `EWOULDBLOCK` means an exclusive holder exists, success means none did at
+    /// that instant. It answers for the *lock*, not for a process: it is immune
+    /// to pid reuse, to a zombie whose pid still answers `kill(pid, 0)`, and to a
+    /// holder owned by another user.
+    ///
+    /// A missing file is "not held". Not because an unlinked inode cannot carry
+    /// a lock — this module is built on the fact that it can, which is what
+    /// [`fd_matches_path`](FLockState::fd_matches_path) exists to catch — but
+    /// because [`release_write`](FLockState::release_write) unlinks *before*
+    /// `LOCK_UN`: no path means any holder is already mid-release, or never
+    /// created the file. Either way there is nobody worth naming.
+    ///
+    /// On a local filesystem `flock` locks belong to the open file description,
+    /// not the process, so a lock this same process holds through some other fd
+    /// correctly reads as held. (Over NFS, Linux emulates `flock` with
+    /// per-process `fcntl` locks and a self-probe would read as unheld; macOS
+    /// does not emulate. Cross-process exclusion on NFS is already outside what
+    /// this module promises — this only notes that the probe inherits that.)
+    ///
+    /// Inherently a snapshot: the holder may release the moment after the probe.
+    /// It is a diagnostic, never an admission decision — use [`try_lock`] for
+    /// that, which acquires or does not.
+    ///
+    /// [`try_lock`]: Lock::try_lock
+    pub fn is_path_held(path: impl AsRef<Path>) -> Result<bool> {
+        let path = path.as_ref();
+        let f = match OpenOptions::new().read(true).open(path) {
+            Ok(f) => f,
+            Err(e) if e.kind() == std::io::ErrorKind::NotFound => return Ok(false),
+            Err(e) => {
+                return Err(anyhow::Error::new(e))
+                    .with_context(|| format!("opening lock file {} to probe", path.display()));
+            }
+        };
+        let held = !flock_nb(f.as_raw_fd(), libc::LOCK_SH)
+            .with_context(|| format!("probing lock file {}", path.display()))?;
+        if !held {
+            // We took the shared lock to learn nobody held it; release it
+            // explicitly rather than leaning on the `close` below, matching
+            // `discard_fd`'s idiom. A transient `LOCK_SH` here can make a
+            // concurrent `LOCK_EX|LOCK_NB` spuriously report busy, which costs
+            // the caller one backoff round — bounded, and once per wait.
+            // SAFETY: `f` owns a valid open fd for the duration of this call.
+            unsafe { libc::flock(f.as_raw_fd(), libc::LOCK_UN) };
+        }
+        Ok(held)
     }
 }
 
@@ -491,6 +630,31 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn cross_instance_shared_read_is_blocked_by_a_writer() {
+        // The mirror of `cross_instance_contention`, which only ever contends
+        // EX-against-SH. This is the SH-against-EX direction: it is the only
+        // thing that drives `try_lock_fresh`'s would-block early return down the
+        // *read* path, where leaving the failed fd open would keep a phantom
+        // reader alive for the lifetime of the instance.
+        let dir = tempfile::tempdir().expect("tempdir");
+        let path = dir.path().join("lock");
+        let a = FRWLock::new(&path);
+        let b = FRWLock::new(&path);
+
+        let held = a.try_write().unwrap().expect("free lock acquires");
+        assert!(b.try_read().unwrap().is_none(), "SH blocked by other EX");
+        let (readers, writer, fd_open) = b.state.counts();
+        assert_eq!(
+            (readers, writer, fd_open),
+            (0, false, false),
+            "a refused read must leave no fd behind"
+        );
+
+        drop(held);
+        assert!(b.try_read().unwrap().is_some(), "SH ok after EX released");
+    }
+
+    #[tokio::test]
     async fn write_contents_persists_and_truncates_through_held_fd() {
         let dir = tempfile::tempdir().expect("tempdir");
         let path = dir.path().join("lock");
@@ -637,23 +801,176 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn stale_inode_is_rejected_and_reopened() {
-        // Simulate the race tail: a lock file is unlinked and a *different*
-        // inode now sits at the path. A fresh acquire must not be fooled by the
-        // post-lock inode check — it re-opens the live file and succeeds.
+    async fn stale_locked_inode_is_discarded_and_the_live_file_reacquired() {
+        // The tail of the delete-on-unlock race: a releaser unlinked the file
+        // between our `open` and our `flock`, so the lock we just took is on a
+        // dead inode while a different one sits at the path.
+        //
+        // The window is between `ensure_open` and `flock_nb` and nothing
+        // in-process can schedule it — but `ensure_open` hands back an
+        // already-open `st.file` untouched, so seeding one reaches the same
+        // state. This is the *real* check: no injection, actual inode
+        // comparison. (Its predecessor swapped the inode before `lock()`, so the
+        // fd was opened after the swap, the first iteration matched, and the
+        // retry arm never ran.)
         let dir = tempfile::tempdir().expect("tempdir");
         let path = dir.path().join("lock");
         let l = FLock::new(&path);
 
-        // Create then remove the original file, leaving a new inode behind.
-        std::fs::write(&path, b"stale").unwrap();
+        let dead = OpenOptions::new()
+            .read(true)
+            .write(true)
+            .create(true)
+            .truncate(false)
+            .open(&path)
+            .unwrap();
+        let dead_ids = {
+            let m = dead.metadata().unwrap();
+            (m.dev(), m.ino())
+        };
         std::fs::remove_file(&path).unwrap();
-        std::fs::write(&path, b"fresh").unwrap();
+        std::fs::write(&path, b"live").unwrap();
+        l.state.fd.lock().file = Some(dead);
 
         let g = l.lock(&ct()).await.unwrap();
-        let (_, writer, fd_open) = l.state.counts();
-        assert!(writer && fd_open, "acquired the live file");
+
+        let live = std::fs::metadata(&path).unwrap();
+        assert_ne!(
+            l.state.held_ids(),
+            Some(dead_ids),
+            "the dead inode must not survive the acquire"
+        );
+        assert_eq!(
+            l.state.held_ids(),
+            Some((live.dev(), live.ino())),
+            "the retry must end up holding the file at the path"
+        );
         drop(g);
+    }
+
+    #[tokio::test]
+    async fn stale_retries_are_exhausted_rather_than_looping_forever() {
+        // Pins `STALE_RETRIES` from both sides. One fewer stale iteration than
+        // the budget still acquires; the full budget gives up — and gives up as
+        // *would-block*, so the caller's backoff retries rather than erroring.
+        let dir = tempfile::tempdir().expect("tempdir");
+        let path = dir.path().join("lock");
+
+        let survives = FLock::new(&path);
+        survives.state.inject_stale(STALE_RETRIES - 1);
+        let g = survives
+            .try_lock()
+            .unwrap()
+            .expect("one fewer than the budget still acquires");
+        assert_eq!(survives.state.pending_stale(), 0, "all retries consumed");
+        drop(g);
+
+        let exhausts = FLock::new(&path);
+        exhausts.state.inject_stale(STALE_RETRIES);
+        assert!(
+            exhausts.try_lock().unwrap().is_none(),
+            "the full budget gives up"
+        );
+        assert_eq!(exhausts.state.pending_stale(), 0, "all retries consumed");
+        let (readers, writer, fd_open) = exhausts.state.counts();
+        assert_eq!(
+            (readers, writer, fd_open),
+            (0, false, false),
+            "giving up must leave no lock and no fd behind"
+        );
+
+        // Would-block, not failure: once the condition clears the same instance
+        // acquires.
+        exhausts
+            .try_lock()
+            .unwrap()
+            .expect("acquires once it clears");
+    }
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn permanent_staleness_spins_cancellably_without_stranding_the_fd() {
+        // Exhaustion reports would-block, and `poll_acquire` retries would-block
+        // forever. That is the decision, not an oversight — but it must stay
+        // interruptible, and each of the STALE_RETRIES fds per round must be
+        // closed rather than accumulated.
+        let dir = tempfile::tempdir().expect("tempdir");
+        let l = FLock::new(dir.path().join("lock"));
+        l.state.inject_stale(usize::MAX);
+
+        let token = ct();
+        let token2 = token.clone();
+        tokio::spawn(async move {
+            tokio::time::sleep(Duration::from_millis(20)).await;
+            token2.cancel();
+        });
+
+        let err = tokio::time::timeout(Duration::from_secs(5), l.lock(&token))
+            .await
+            .expect("a permanently stale path must not hang")
+            .expect_err("cancellation is the only way out");
+        assert!(hplugin::error::is_cancelled(&err));
+
+        let (readers, writer, fd_open) = l.state.counts();
+        assert_eq!(
+            (readers, writer, fd_open),
+            (0, false, false),
+            "clean after cancel"
+        );
+    }
+
+    #[tokio::test]
+    async fn is_path_held_answers_for_the_lock_not_for_a_process() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let path = dir.path().join("lock");
+        let l = FLock::new(&path);
+
+        assert!(
+            !FLock::is_path_held(&path).unwrap(),
+            "no file yet: nothing can hold it"
+        );
+
+        // A file left behind by a holder that died: present, but its flock went
+        // with the process. This is the case a pid stamped in the file cannot
+        // answer — the pid may since have been reused by a live process.
+        std::fs::write(&path, b"stamp\n").unwrap();
+        assert!(
+            !FLock::is_path_held(&path).unwrap(),
+            "an unheld file is not held, whatever it contains"
+        );
+
+        // `flock` is per open file description, so our own guard is visible
+        // through the probe's separate fd.
+        let g = l.lock(&ct()).await.unwrap();
+        assert!(
+            FLock::is_path_held(&path).unwrap(),
+            "held while a guard lives"
+        );
+
+        // The probe must not have taken a lock of its own, or the guard below
+        // could not be re-acquired after release.
+        drop(g);
+        assert!(
+            !FLock::is_path_held(&path).unwrap(),
+            "released (and unlinked) on drop"
+        );
+        l.try_lock()
+            .unwrap()
+            .expect("probing must leave no lock behind");
+    }
+
+    #[tokio::test]
+    async fn is_path_held_sees_a_shared_reader_as_unheld() {
+        // The probe asks "is an exclusive holder present", which is what the
+        // gateway lock is. A shared reader coexists with the probe's own
+        // LOCK_SH, so it reads as unheld — correct for the gateway, and the
+        // reason this is on `FLock` rather than shared with `FRWLock`.
+        let dir = tempfile::tempdir().expect("tempdir");
+        let path = dir.path().join("lock");
+        let rw = FRWLock::new(&path);
+
+        let r = rw.read(&ct()).await.unwrap();
+        assert!(!FLock::is_path_held(&path).unwrap());
+        drop(r);
     }
 
     #[tokio::test(flavor = "multi_thread", worker_threads = 2)]


### PR DESCRIPTION
Follow-up to #227, which shipped with two MAJORs recorded as "pre-existing, out of scope" — one raised by both reviewers, one by `feature-quality`. Both are about `crates/lock/src/hlock/flock.rs` and the pid stamp above it. #227 has since merged, so this branches off `master`.

## 1. `fd_matches_path` had zero coverage — and it is the guard against two holders

`feature-quality` proved that hardwiring `fd_matches_path` to `Ok(true)` **passes the entire suite**. It is the check that catches an fd whose inode a releaser unlinked in the window between our `open` and our `flock`; without it, the delete-on-unlock design lets two processes hold the same lock.

`stale_inode_is_rejected_and_reopened` named the behaviour and never reached it: it swapped the inode *before* `lock()`, so the fd was opened after the swap, the first loop iteration matched, and neither `discard_fd` nor the retry arm ever ran. **Replaced**, not added alongside — a test whose name lies about its coverage is worse than none.

The real window cannot be scheduled in-process. But `ensure_open` hands back an already-open `st.file` untouched, so **seeding one that names an unlinked inode reaches the same state with no production hook and a real inode comparison**. `STALE_RETRIES` exhaustion has no such route (it needs sixteen consecutive mismatches), so that one gets a `#[cfg(test)]` counter — placed at the *top of `fd_matches_path`* on purpose, so the `Ok(true)` mutation kills those tests too rather than routing around them.

Exhaustion also stops being silent. It reports would-block, which `poll_acquire` retries forever — right for a transient condition, but a permanently stale path spun with nothing in the log. Now warns, **latched**: `try_lock_fresh` *is* the attempt closure, so an unlatched warn emitted ~10 lines/second per addr for the life of the run. The latch's reset-on-success arm turned out to be dead as far as the suite was concerned (deleting it left everything green), so it is now asserted through the state machine rather than through a log level — see the third commit.

## 2. The pid stamp was not a liveness check

`holder_pid` reported "the last pid to stamp". Two things made that worse than a stale value:

- A killed holder's stamp **persists indefinitely** — release runs from `Drop`, which a kill skips, and nothing sweeps `<home>/lock/`. The kernel dropped that process's `flock` at exit, so the lock was free while the name was not.
- The stamp lands **after the whole bridge acquire**. `TBridge` takes the gateway first, then parks on the inner lock — a wait bounded by a *build* — and `stamp_pid` runs after both. A waiter read the *previous* holder's pid for that entire window, not for the two syscalls #227 addressed.

Same user-visible symptom #227 exists to fix (naming a pid the user might `kill`), over a far wider window.

**Liveness probes the lock, not the pid.** `FLock::is_path_held` is a probe-only `open(O_RDONLY)` + `flock(LOCK_SH | LOCK_NB)`: `EWOULDBLOCK` ⇒ an exclusive holder exists, success ⇒ unlock immediately and report not-held.

`kill(pid, 0)` was the other candidate and is the wrong question — it answers for a *pid*, which is a recycled name. A reused pid, or a zombie whose pid still answers, reports a live process that never held anything; `EPERM`-means-alive is easy to invert; and `u32 → pid_t` wraps negative past `i32::MAX`, where `kill` addresses a process *group*. Probing the lock is immune to all of that, and costs one `open` + one `flock` on a path that has already spent `RESULT_LOCK_NOTICE` waiting. **This closes pid reuse rather than narrowing it** — no pid is ever trusted on its own.

(Noted, not fixed here: `engine.rs`'s `sweep_stale_sandboxfuse_dirs` has a `kill(pid, 0)` probe that treats `EPERM` as *dead*. Wrong direction, separate change.)

**Blanking closes the acquire→stamp window.** A `GatewayLock` decorator wraps `FLock` and empties the file the moment the gateway is acquired, so the contents can only ever describe the current holder. A decorator in the engine rather than behaviour on `FLock`, because `FLock` is also `driver-support`'s staging lock — it stores nothing in its file and should not pay a syscall per acquire for a stamp it never writes. Best-effort like `stamp_pid`: a build lock must not fail because a *diagnostic* could not be erased.

**Probe before read.** Reading the pid first leaves a window — capture the pid, the holder releases and unlinks, a new holder acquires, and the probe then says "held", naming a process that holds nothing. Probe-first has no such window: after a confirmed "held", the read yields the confirmed holder's stamp, a newer holder's stamp, or nothing. For the same reason the read is *not* fused into the probe's fd (which would save an `open`): that fd names the inode that *was* held, so if the holder releases in between, reading it returns the stamp of a lock nobody holds. Re-resolving the path is what makes the stale answer unreachable.

### Contract change

`holder_pid` meant "the last pid to stamp"; it now means "a pid that stamped the gateway and still held it when probed". The doc comments say so, and `stamp_pid`'s limitation note from #227 is **rewritten rather than duplicated**.

It also now returns `None` in the common cross-process shape — we hold the gateway and are waiting for *other* processes' read guards to drain — because plain readers are not stamped at all. Deliberate: stamping at outer-acquire instead would report *this very process* as the holder, which is worse than admitting we do not know who is in the way.

## Tests, each verified red against the stated mutation

| Test | Red against |
|---|---|
| `stale_locked_inode_is_discarded_and_the_live_file_reacquired` | `fd_matches_path -> Ok(true)` |
| `stale_retries_are_exhausted_rather_than_looping_forever` | same — and pins the retry budget from both sides |
| `permanent_staleness_spins_cancellably_without_stranding_the_fd` | same |
| `cross_instance_shared_read_is_blocked_by_a_writer` | dropping `st.file = None` on the would-block return |
| `is_path_held_answers_for_the_lock_not_for_a_process` | `is_path_held -> Ok(false)` |
| `holder_pid_is_unknown_when_the_stamp_outlives_its_holder` | dropping the probe from `holder_pid` |
| `gateway_lock_blanks_a_stale_stamp_at_acquire` | dropping the blank from `lock` |
| `gateway_try_lock_blanks_a_stale_stamp_at_acquire` | dropping the blank from `try_lock` |
| `holder_pid_is_unknown_while_the_gateway_holder_waits_on_the_inner_lock` | reverting `FsBridge` to `TBridge<FLock, FRWLock>` + `fs_tlock` |
| `stale_retries_are_exhausted_rather_than_looping_forever` (latch arm) | deleting `stale_warned = false` on a successful acquire |

Under the `fd_matches_path -> Ok(true)` mutation the other **34 tests still pass**, reproducing the original finding exactly — those three are the only thing catching it.

Every liveness test plants **this process's own live pid**, so a `kill`-style check would report it and only the mechanism under test can produce the `None`. The two framing tests from #227 now hold a real gateway while planting their bytes, so the new probe cannot account for their result either.

The last row was `feature-quality`'s BLOCKER: both gateway tests construct a `GatewayLock` themselves, so a consistent four-line revert of the *wiring* compiled and left the suite green. It is also the only test that drives the wide window end to end through the shipped `ResultLock` — two instances on one directory, one holding a read guard while the other takes the gateway and parks on the inner lock.

## Cost

Nothing on the warm path. A cache hit takes only the inner read lock (`TBridge::read` never instantiates the outer type), so `ResultLock::read` costs exactly what it did.

- Per **gateway** acquire — cold path only (cache miss, force/shell, GC trim): one `ftruncate`. `write_all_at` on an empty slice issues no syscall.
- Per `holder_pid` call — once per addr per lock *notice*, i.e. after 5s of waiting, not per 5s: one `open` + one `flock` + one `close`.
- The stale counter is a plain `usize` inside the existing `FdState`, under the existing mutex: zero release footprint, and no atomic ordering to get wrong on aarch64.

## Verification

- `cargo test -p lock` — 37 passed. `cargo test -p engine result_lock` — 21 passed.
- Rebased onto `dfc4e5cc`; no conflicts. None of the commits that landed in between (`#232`/`#234`/`#235` `hcore::blocking`, `#236`/`#241` memoizer, `#238`, `#240`, `#242`) touch `crates/lock`, `result_lock.rs` or `events.rs`, and neither changed file references `hcore::blocking`. Confirmed by path-filtered log, not assumed.
- `cargo clippy --all-targets --locked -- -D warnings` from the workspace root — clean. `cargo fmt --all -- --check` — clean.
- Ten mutations, each confirmed red and restored from the committed ref — all re-run after the rebase onto `dfc4e5cc`.
- No `cfg(target_os)` / `cfg(target_arch)` in the diff. `flock`, `ftruncate` and `open` behave identically on all three supported targets, and `EWOULDBLOCK == EAGAIN` on both OSes. The `kill(2)` permission-semantics question that would have forced a portability decision is moot — `kill` is not used.

## Review

| Agent | Design | Review |
|---|---|---|
| `code-quality` | PASS WITH NITS — 4 MAJORs, all taken (drop `kill`; best-effort blank; decorator not `FLock`; record the inner-wait consequence) | PASS WITH NITS |
| `feature-quality` | BLOCKED — both test-discrimination gaps taken | BLOCKED → fixed (wiring test + probe ordering) |

## Known, not fixed here

**`fs_tlock` now has no production caller.** The engine builds its bridge through `TBridge::new` with the `GatewayLock` decorator, so `fs_tlock` is used only by `crates/lock`'s own bridge tests. Documented rather than deleted — removing a `pub` helper is a public-API change, and this PR should not carry one. Its doc now says why the engine does not use it, so the next reader does not wire a gateway through it and silently lose the blanking.

**`sweep_stale_sandboxfuse_dirs` has the `EPERM` inversion this PR was built to avoid.** `engine.rs` probes with `kill(pid, 0)` and treats `EPERM` as *dead* — but `EPERM` means the process exists and is owned by someone else, i.e. alive. It can therefore sweep a live process's sandbox directory. Untouched here: it is different code with a different blast radius, and folding it in would mix a cleanup-correctness fix into a diagnostics change. Flagged, not fixed.

`<home>/lock/*.inner.lock` grows without bound: `release_read` deliberately never unlinks (a cross-process shared reader would be left on a removed inode), and the warm-hit path takes only the inner read lock. A warm run over N targets leaves N zero-byte inodes behind, permanently. Wants its own issue and a GC sweep.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01A76DChMohieGMbRbnV1E7x
