### PR TITLE
perf(engine): overlap package enumeration during discovery

### DIFF
--- a/crates/e2e/tests/query.rs
+++ b/crates/e2e/tests/query.rs
@@ -328,3 +328,70 @@ target(
     );
     Ok(())
 }
+
+/// Discovery now overlaps package evaluation, so which BUILD file finishes first
+/// is a race. The order the matched addrs come back in must not be: it becomes
+/// `plugingroup`'s `deps`, folded in order into the group's def hash. A
+/// `buffer_unordered` fan-out would make that hash a function of scheduling.
+///
+/// Built as several independent workspaces from byte-identical sources, with
+/// deliberately uneven per-package evaluation cost so the completion order does
+/// differ between runs. The emitted sequence must still be identical every time.
+#[tokio::test]
+async fn test_query_dep_order_is_stable_across_runs() -> anyhow::Result<()> {
+    // Uneven Starlark work per package: every third package spins a loop before
+    // declaring its target, so packages finish out of listing order.
+    fn build_src(i: usize) -> String {
+        let spin = if i % 3 == 0 { 20000 } else { 10 };
+        format!(
+            r#"
+_acc = 0
+for _i in range({spin}):
+    _acc = _acc + _i
+
+target(
+    name = "t",
+    driver = "bash",
+    run = "echo {i} > $OUT",
+    out = "o.txt",
+    labels = ["scan"],
+)
+"#
+        )
+    }
+
+    const PKGS: usize = 24;
+    let mut runs: Vec<Vec<String>> = Vec::new();
+
+    for _ in 0..3 {
+        let ws = Workspace::new();
+        for i in 0..PKGS {
+            ws.write_build_file(&format!("scan/p{i:02}"), &build_src(i));
+        }
+
+        let spec = ws
+            .get_spec(&format!("//{PACKAGE}:q@expr=\"//scan/... && label(scan)\""))
+            .await?;
+        let deps = match spec.config.get("deps") {
+            Some(TargetSpecValue::List(l)) => l,
+            _ => panic!("expected deps list, got: {:?}", spec.config.get("deps")),
+        };
+        let dep_strs: Vec<String> = deps
+            .iter()
+            .map(|v| match v {
+                TargetSpecValue::String(s) => s.clone(),
+                _ => panic!("expected string dep"),
+            })
+            .collect();
+        assert_eq!(dep_strs.len(), PKGS, "got: {dep_strs:?}");
+        runs.push(dep_strs);
+    }
+
+    // Sorted package listing order, verbatim — not "the same set", the same
+    // sequence, because the sequence is what is hashed.
+    let expected: Vec<String> = (0..PKGS).map(|i| format!("//scan/p{i:02}:t")).collect();
+    for (n, got) in runs.iter().enumerate() {
+        assert_eq!(got, &expected, "run {n} emitted a different dep order");
+    }
+    Ok(())
+}

--- a/crates/engine/src/engine/fanout.rs
+++ b/crates/engine/src/engine/fanout.rs
@@ -1,6 +1,38 @@
 use crate::engine::error::MultiError;
 use std::future::Future;
 
+/// In-flight cap for the discovery walks (`Engine::query`,
+/// `EngineProviderExecutor::query`, `states_under`).
+///
+/// Sized to [`hcore::blocking`]'s pool (`2 * cores`), because that pool is what
+/// the discovery work actually lands on: a package's `list` is a whole-package
+/// Starlark evaluation submitted there. This is an *orchestration* bound — the
+/// real admission control lives further down (`PKG_EVAL_SLOTS` caps concurrent
+/// package evaluations at the core count, in async-land, before queueing) — so
+/// its only job is to keep the set of live per-package futures, and the memory
+/// they pin, proportional to the machine rather than to the package count.
+///
+/// **The bound is per walk, and walks nest.** `Engine::query` buffers K
+/// packages; a package's `list` may call back through `ListRequest::executor`
+/// into `states_under` (plugin-go does, per module root) or
+/// `EngineProviderExecutor::query`, each opening its own `buffered(K)`. Live
+/// orchestration state is therefore K x depth, not K — on a 16-core machine the
+/// reachable two-level case is ~1024 concurrent probe futures rather than 32.
+/// What that does *not* multiply is the work: `PKG_EVAL_SLOTS` is a single
+/// global semaphore, so concurrent package evaluations stay capped at the core
+/// count no matter how deep the nesting. The cost of depth is pinned memory and
+/// scheduler pressure, not CPU oversubscription. Bounding the product would
+/// need this to become a process-wide semaphore rather than a per-stream cap.
+///
+/// Deliberately the same expression the engine's other stream-consuming walks
+/// use (`labels.rs`, `revdeps.rs`, `deppath.rs`).
+pub fn discovery_concurrency() -> usize {
+    std::thread::available_parallelism()
+        .map(|n| n.get())
+        .unwrap_or(1)
+        .saturating_mul(2)
+}
+
 /// `try_join_all` equivalent that honors `fail_fast`.
 ///
 /// - `fail_fast = true`: identical to `futures::future::try_join_all` —

--- a/crates/engine/src/engine/packages.rs
+++ b/crates/engine/src/engine/packages.rs
@@ -70,59 +70,96 @@ impl Engine {
     ) -> anyhow::Result<Box<dyn Iterator<Item = anyhow::Result<String>> + Send>> {
         let prefix = narrowing_prefix(m);
 
+        // Each provider's `list_packages` is an independent workspace walk — the
+        // buildfile provider's recursive BUILD-file scan and the go provider's
+        // `collect_go_packages` cover the same tree and never touched the same
+        // state, yet ran one after the other. Overlap them: the walks are the
+        // producer for the whole pipeline, so their latency is on the critical
+        // path of every `query` / `validate` / `labels` / `revdeps`.
+        //
+        // `join_all`, not `try_join_all`: the walks are few (one per registered
+        // provider) and already running, so short-circuiting saves nothing — and
+        // `try_join_all` would return whichever walk failed *first in time*,
+        // making "which provider does heph blame" a race on a flaky mount. The
+        // serial loop always blamed the earliest-registered failing provider;
+        // taking the lowest-index error below keeps that.
+        let results: Vec<anyhow::Result<Arc<Vec<String>>>> =
+            futures::future::join_all(self.providers.iter().map(|provider| {
+                let req = ListPackagesRequest {
+                    prefix: prefix.clone(),
+                };
+                let key = format!("{}:{}", provider.name, prefix);
+
+                async move {
+                    rs.data
+                        .mem_packages
+                        .once(
+                            key,
+                            enclose!((provider, rs) move || async move {
+                                let it = provider
+                                    .provider
+                                    .list_packages(req, rs.ctoken())
+                                    .await?;
+                                let mut pkgs = Vec::new();
+                                for res in it {
+                                    pkgs.push(res?.pkg.to_string());
+                                }
+                                // Canonicalize the provider's block rather than
+                                // trusting it to be ordered — see this method's
+                                // docs for why the order matters and why the
+                                // sort is per provider. Inside the memoizer, so
+                                // it is paid once per (provider, prefix) per
+                                // request, not once per call.
+                                //
+                                // This is the canonical package ordering for the
+                                // whole engine, and it must stay a
+                                // byte-lexicographic `String` compare. A
+                                // collation-aware or case-folding comparator
+                                // would make `LC_COLLATE` an undeclared hash
+                                // input: two machines would order the same tree
+                                // differently and could never share a
+                                // remote-cache entry for a query-backed target.
+                                //
+                                // `dedup` is free once sorted (adjacent, no
+                                // hashing) and shrinks the `Arc<Vec<String>>`
+                                // shared for the rest of the request. The
+                                // cross-provider dedup below still needs its own
+                                // set: `Vec::dedup` only collapses adjacent
+                                // equals, and the blocks are memoized apart.
+                                //
+                                // The sort lives inside the per-provider
+                                // memoizer cell, which is also why overlapping
+                                // the walks cannot disturb it: each block is
+                                // canonicalized by its own future, and the merge
+                                // below re-imposes registration order.
+                                pkgs.sort_unstable();
+                                pkgs.dedup();
+                                Ok(Arc::new(pkgs))
+                            }),
+                        )
+                        .await
+                        .map_err(unwrap_arc_err)
+                }
+            }))
+            .await;
+
+        let mut per_provider: Vec<Arc<Vec<String>>> = Vec::with_capacity(results.len());
+        for res in results {
+            per_provider.push(res?);
+        }
+
         let mut all_packages = Vec::new();
         // Different providers can list the same package; dedup so callers
         // (e.g. `query`) don't scan a package more than once. A package listed
         // by two providers keeps the position of the first one that listed it.
+        //
+        // Overlapping the walks above must not be allowed to reorder this
+        // merge: the fold runs over `per_provider` in provider-registration
+        // order, exactly as the serial loop did, regardless of which walk
+        // finished first.
         let mut seen: FxHashSet<String> = FxHashSet::default();
 
-        for provider in &self.providers {
-            let req = ListPackagesRequest {
-                prefix: prefix.clone(),
-            };
-            let key = format!("{}:{}", provider.name, prefix);
-
-            let pkgs = rs
-                .data
-                .mem_packages
-                .once(
-                    key,
-                    enclose!((provider, rs) move || async move {
-                        let it = provider
-                            .provider
-                            .list_packages(req, rs.ctoken())
-                            .await?;
-                        let mut pkgs = Vec::new();
-                        for res in it {
-                            pkgs.push(res?.pkg.to_string());
-                        }
-                        // Canonicalize the provider's block rather than trusting
-                        // it to be ordered — see this method's docs for why the
-                        // order matters and why the sort is per provider.
-                        // Inside the memoizer, so it is paid once per
-                        // (provider, prefix) per request, not once per call.
-                        //
-                        // This is the canonical package ordering for the whole
-                        // engine, and it must stay a byte-lexicographic
-                        // `String` compare. A collation-aware or case-folding
-                        // comparator would make `LC_COLLATE` an undeclared hash
-                        // input: two machines would order the same tree
-                        // differently and could never share a remote-cache
-                        // entry for a query-backed target.
-                        //
-                        // `dedup` is free once sorted (adjacent, no hashing) and
-                        // shrinks the `Arc<Vec<String>>` shared for the rest of
-                        // the request. The cross-provider dedup below still
-                        // needs its own set: `Vec::dedup` only collapses
-                        // adjacent equals, and the blocks are memoized apart.
-                        pkgs.sort_unstable();
-                        pkgs.dedup();
-                        Ok(Arc::new(pkgs))
-                    }),
-                )
-                .await
-                .map_err(unwrap_arc_err)?;
-
+        for pkgs in &per_provider {
             for p in pkgs.iter() {
                 if seen.insert(p.clone()) {
                     all_packages.push(p.clone());
@@ -416,6 +453,165 @@ mod tests {
             5,
             "provider was not re-asked"
         );
+        Ok(())
+    }
+
+    /// A provider whose `list_packages` is a slow workspace walk. Records how
+    /// many walks were in flight at once, so a test can tell an overlapped fan-out
+    /// from a serial loop without relying on wall-clock alone.
+    struct SlowWalk {
+        name: &'static str,
+        pkgs: &'static [&'static str],
+        delay: std::time::Duration,
+        inflight: Arc<std::sync::atomic::AtomicUsize>,
+        peak: Arc<std::sync::atomic::AtomicUsize>,
+    }
+
+    impl crate::engine::provider::Provider for SlowWalk {
+        fn config(&self, _req: ConfigRequest) -> anyhow::Result<ConfigResponse> {
+            Ok(ConfigResponse {
+                name: self.name.to_string(),
+            })
+        }
+        fn list<'a>(
+            &'a self,
+            _req: ListRequest,
+            _ctoken: &'a (dyn Cancellable + Send + Sync),
+        ) -> BoxFuture<
+            'a,
+            anyhow::Result<Box<dyn Iterator<Item = anyhow::Result<ListResponse>> + Send>>,
+        > {
+            Box::pin(async {
+                Ok(Box::new(std::iter::empty())
+                    as Box<
+                        dyn Iterator<Item = anyhow::Result<ListResponse>> + Send,
+                    >)
+            })
+        }
+        fn list_packages<'a>(
+            &'a self,
+            _req: ListPackagesRequest,
+            _ctoken: &'a (dyn Cancellable + Send + Sync),
+        ) -> BoxFuture<
+            'a,
+            anyhow::Result<Box<dyn Iterator<Item = anyhow::Result<ListPackageResponse>> + Send>>,
+        > {
+            use std::sync::atomic::Ordering::SeqCst;
+            let items: Vec<anyhow::Result<ListPackageResponse>> = self
+                .pkgs
+                .iter()
+                .map(|p| {
+                    Ok(ListPackageResponse {
+                        pkg: PkgBuf::from(*p),
+                    })
+                })
+                .collect();
+            let (delay, inflight, peak) = (
+                self.delay,
+                Arc::clone(&self.inflight),
+                Arc::clone(&self.peak),
+            );
+            Box::pin(async move {
+                let now = inflight.fetch_add(1, SeqCst) + 1;
+                peak.fetch_max(now, SeqCst);
+                tokio::time::sleep(delay).await;
+                inflight.fetch_sub(1, SeqCst);
+                Ok(Box::new(items.into_iter())
+                    as Box<
+                        dyn Iterator<Item = anyhow::Result<ListPackageResponse>> + Send,
+                    >)
+            })
+        }
+        fn get<'a>(
+            &'a self,
+            _req: GetRequest,
+            _ctoken: &'a (dyn Cancellable + Send + Sync),
+        ) -> BoxFuture<'a, Result<GetResponse, GetError>> {
+            Box::pin(async { Err(GetError::NotFound) })
+        }
+        fn probe<'a>(
+            &'a self,
+            req: ProbeRequest,
+            _ctoken: &'a (dyn Cancellable + Send + Sync),
+        ) -> BoxFuture<'a, anyhow::Result<ProbeResponse>> {
+            let pkg = req.package.clone();
+            let name = self.name.to_string();
+            Box::pin(async move {
+                Ok(ProbeResponse {
+                    states: vec![crate::engine::provider::State {
+                        package: pkg,
+                        provider: name,
+                        state: Default::default(),
+                    }],
+                })
+            })
+        }
+    }
+
+    /// Each provider's `list_packages` is an independent workspace walk (the
+    /// buildfile BUILD-file scan and the go `collect_go_packages` scan cover the
+    /// same tree). They used to run strictly one after another, so their
+    /// latencies added; now they overlap.
+    ///
+    /// Asserted on observed concurrency rather than only wall-clock: a serial
+    /// loop can never put two walks in flight at once, whatever the machine.
+    ///
+    /// The blocks are deliberately unsorted, so this also pins the composition
+    /// with #230's per-provider sort: the sort lives inside the memoizer cell
+    /// and must survive the fan-out, while the merge across blocks must stay in
+    /// registration order rather than becoming one global sort.
+    #[tokio::test]
+    async fn packages_overlaps_the_provider_walks() -> anyhow::Result<()> {
+        use std::sync::atomic::{AtomicUsize, Ordering::SeqCst};
+
+        let root = tempfile::tempdir()?;
+        let inflight = Arc::new(AtomicUsize::new(0));
+        let peak = Arc::new(AtomicUsize::new(0));
+        let delay = std::time::Duration::from_millis(120);
+
+        let mut engine = Engine::new(Config {
+            root: root.path().to_path_buf(),
+            home_dir: std::path::PathBuf::new(),
+            parallelism: None,
+            ..Default::default()
+        })?;
+        for (name, pkgs) in [
+            ("w1", &["zeta", "alpha"][..]),
+            ("w2", &["mid"][..]),
+            ("w3", &["beta"][..]),
+        ] {
+            engine.register_provider(enclose!((inflight, peak) move |_| Box::new(SlowWalk {
+                name,
+                pkgs,
+                delay,
+                inflight: Arc::clone(&inflight),
+                peak: Arc::clone(&peak),
+            })))?;
+        }
+        let engine = Arc::new(engine);
+        let rs = engine.new_state();
+
+        let start = std::time::Instant::now();
+        let pkgs: Vec<String> = engine
+            .packages(&Matcher::PackagePrefix(pkg("")), &rs)
+            .await?
+            .collect::<anyhow::Result<Vec<_>>>()?;
+        let elapsed = start.elapsed();
+
+        assert_eq!(
+            peak.load(SeqCst),
+            3,
+            "all three walks must be in flight at once; serial discovery peaks at 1"
+        );
+        assert!(
+            elapsed < delay * 3,
+            "three overlapped {delay:?} walks must beat three serial ones, took {elapsed:?}"
+        );
+        // Each block sorted (`alpha` before `zeta`, whichever walk finished
+        // first), blocks concatenated in registration order (`mid` and `beta`
+        // land *after* `zeta`, so this is not one global sort). That composite
+        // is the order that reaches a def hash.
+        assert_eq!(pkgs, vec!["@heph/fs", "alpha", "zeta", "mid", "beta"]);
         Ok(())
     }
 

--- a/crates/engine/src/engine/query.rs
+++ b/crates/engine/src/engine/query.rs
@@ -1,8 +1,9 @@
 use crate::engine::Engine;
-use crate::engine::error::{CycleError, TargetNotFoundError};
+use crate::engine::error::{CancelledError, CycleError, TargetNotFoundError};
 use crate::engine::provider::ListRequest;
 use crate::engine::request_state::RequestState;
-use futures::Stream;
+use enclose::enclose;
+use futures::{Stream, StreamExt};
 use hcore::hmemoizer::downcast_chain_ref;
 use hmodel::htaddr::Addr;
 use hmodel::htmatcher;
@@ -34,8 +35,85 @@ impl Engine {
             let executor: Arc<dyn hplugin::provider::ProviderExecutor> = Arc::new(
                 crate::engine::result::EngineProviderExecutor::new(Arc::downgrade(&self), rs.clone()),
             );
-            for pkg_result in self.packages(m, &rs).await? {
-                let pkg = PkgBuf::from(pkg_result?);
+            let pkgs: Vec<String> = self.packages(m, &rs).await?.collect::<anyhow::Result<_>>()?;
+
+            // Set when the walk is abandoning. `Buffered` refills its queue from
+            // the underlying iterator on every poll, so a drain still *visits*
+            // all N packages — what this flag removes is the cost of each: a
+            // package that has not started falls straight through instead of
+            // paying a whole-package Starlark evaluation for a walk whose answer
+            // nobody wants. O(N) cheap poll-throughs, not O(N) evaluations.
+            let stop = Arc::new(std::sync::atomic::AtomicBool::new(false));
+
+            // Discovery splits in two, and the split is not cosmetic.
+            //
+            // **Enumeration** — `probe` + `list` per package — is overlapped, `K
+            // ≈ 2 * cores` packages in flight. `list` is a whole-package
+            // Starlark evaluation for the buildfile provider, the single
+            // heaviest synchronous unit in a build, and it was the producer for
+            // the entire pipeline running strictly one package at a time.
+            //
+            // **Matcher evaluation** stays strictly serial, below, and this is
+            // load-bearing rather than incidental. The `MatchShrug` arm
+            // resolves a candidate's spec/def on a *speculative*
+            // `RequestState`, and a speculative chain detects cycles by walking
+            // its own breadcrumb list rather than the shared `DepDag`
+            // (`RequestState::speculative`). That is only sound while one such
+            // chain exists at a time. Run two concurrently and they are
+            // mutually invisible, with two consequences, both of which reach a
+            // build definition:
+            //
+            //   1. `mem_spec`/`mem_def` are shared across chains and keyed by
+            //      addr alone, and the memoized closure captures whichever
+            //      chain created the cell. `get_spec_inner` skips a provider
+            //      whose `get` cycles and falls through to the next one, so a
+            //      chain-dependent cycle means the *winning* chain decides
+            //      which provider resolves the addr — and `hashin` folds
+            //      `def.driver`. Whoever wins the race would pick the cache key.
+            //   2. Two chains that resolve each other close a cycle neither can
+            //      see: the `DepDag` is bypassed, the breadcrumbs are
+            //      per-chain, and the memoizer's own cycle detection is off
+            //      unless `HEPH_DEBUG_MEMOIZER_CYCLE=1`. That is a hang where
+            //      the serial code reported an error.
+            //
+            // What guarantees one chain at a time is *structural*, not a claim
+            // about which matchers reach the arm: the arm lives in the consumer
+            // of the fan-out, inside this one linear generator body, so while it
+            // awaits `get_spec`/`get_def` the stream below is not polled at all.
+            // (Do not weaken this to "the shrug arm is rare". It is not —
+            // `Matcher::Label` shrugs from `matches_addr` unconditionally, and
+            // `Matcher::TreeOutputTo` shrugs at both the addr and the spec
+            // level, so `heph validate`, `heph tool gen-gitignore` and
+            // `heph query 'tree_output()'` drive `get_spec` *and* `get_def` for
+            // every target in the workspace through it.)
+            //
+            // The guarantee is per **walk**, not per engine: `heph validate`
+            // runs three `Engine::query` walks concurrently on one
+            // `RequestState` (`src/commands/validate.rs`), two of them with
+            // `TreeOutputTo`, so speculative chains from different walks can
+            // still overlap. That exposure predates this change — the loops here
+            // neither create nor close it — but it is the reason widening the
+            // arm needs the speculative cycle check to become shared state
+            // first, which is a separate change.
+            //
+            // `buffered`, never `buffer_unordered`: the emission order here is a
+            // build input. It carries through `pluginquery`'s `deps` into
+            // `plugingroup`, which folds `deps` in order into its def hash, so
+            // under `buffer_unordered` the def hash of a query group target
+            // would become a function of which BUILD file the OS scheduler
+            // finished first. `buffered` yields in submission order, so the
+            // sequence — and every candidate's position in it — is exactly the
+            // one the serial loop produced.
+            let per_pkg = futures::stream::iter(pkgs.into_iter()
+                // Ends the source once the walk is abandoning, rather than
+                // letting `Buffered` keep refilling from it. `Buffered` pulls a
+                // replacement on every poll, and each pull *spawns*, so a plain
+                // drain over a 20k-package workspace would spawn 20k tasks just
+                // to have each one bail. Ending the iterator makes the drain
+                // await only the <=K handles already spawned.
+                .take_while(enclose!((stop) move |_| !stop.load(std::sync::atomic::Ordering::Relaxed)))
+                .filter_map(|pkg_str| {
+                let pkg = PkgBuf::from(pkg_str);
 
                 // Prune before probing or listing. `list` is a whole-package
                 // Starlark evaluation for the buildfile provider, so without
@@ -43,72 +121,164 @@ impl Engine {
                 // a bare `//foo:bar`) still pays to evaluate every BUILD file
                 // in the repo and then throws the results away at the addr
                 // check below. Providers are free to ignore `ListPackagesRequest::prefix`
-                // — most do — so the narrowing has to happen here too.
+                // — most do — so the narrowing has to happen here too. Done
+                // before the stream so a pruned package never takes a slot.
                 if m.matches_pkg(&pkg) == MatchResult::MatchNo {
-                    continue;
+                    return None;
                 }
 
-                let states = Arc::clone(&self).probe_segments(&rs, &pkg).await?;
+                // Spawned here rather than through a later `.map()`: handing the
+                // async block to a generic fn through a combinator makes its
+                // captured lifetimes late-bound and trips "implementation of
+                // `FnOnce` is not general enough".
+                Some(hcore::hmemoizer::spawn_with_cycle_ctx(enclose!((self => engine, rs, executor, stop) async move {
+                    // An abandoned walk must not start evaluating packages it has
+                    // not reached yet — that is what keeps the drains below (and
+                    // in `Engine::result`) to a cheap poll per remaining package
+                    // instead of a package evaluation per remaining package.
+                    //
+                    // `Err`, never `Ok(vec![])`: this sequence becomes
+                    // `pluginquery`'s `deps` and is folded in order into a def
+                    // hash, so returning "no candidates here" would silently
+                    // hash a *truncated* graph whose length depends on when the
+                    // cancel landed. A short answer is not an answer.
+                    if rs.ctoken().is_cancelled()
+                        || stop.load(std::sync::atomic::Ordering::Relaxed)
+                    {
+                        return Err(anyhow::Error::new(CancelledError));
+                    }
+                    let mut candidates: Vec<Addr> = Vec::new();
+                    let states = Arc::clone(&engine).probe_segments(&rs, &pkg).await?;
 
-                for provider in &self.providers {
-                    let it = provider.provider.list(ListRequest {
-                        request_id: rs.request_id().to_string(),
-                        package: pkg.clone(),
-                        states: states
-                            .iter()
-                            .filter(|s| s.provider == provider.name)
-                            .cloned()
-                            .collect(),
-                        executor: Arc::clone(&executor),
-                    }, rs.ctoken()).await?;
+                    for provider in &engine.providers {
+                        let it = provider.provider.list(ListRequest {
+                            request_id: rs.request_id().to_string(),
+                            package: pkg.clone(),
+                            states: states
+                                .iter()
+                                .filter(|s| s.provider == provider.name)
+                                .cloned()
+                                .collect(),
+                            executor: Arc::clone(&executor),
+                        }, rs.ctoken()).await?;
+                        // The iterator is not `Send`; drain it before the next await.
+                        let raw: Vec<_> = it.collect::<anyhow::Result<Vec<_>>>()?;
 
-                    for item in it {
-                        let addr = item?.addr;
-
-                        if addr.package != pkg {
-                            continue;
-                        }
-
-                        match m.matches_addr(&addr) {
-                            MatchResult::MatchYes => {
-                                if seen.insert(addr.clone()) { yield addr; }
+                        for item in raw {
+                            if item.addr.package == pkg {
+                                candidates.push(item.addr);
                             }
-                            MatchResult::MatchNo => {}
-                            MatchResult::MatchShrug => {
-                                // Speculative inspection: resolve the candidate's spec/def only
-                                // to evaluate the matcher, on a speculative rs so a rejected
-                                // candidate records no edge in the shared dep DAG (which would
-                                // otherwise close a false cycle later).
-                                let spec_rs = rs.speculative();
-                                let spec = match Arc::clone(&self).get_spec(spec_rs.clone(), &addr).await {
-                                    Ok(spec) => Ok(spec),
-                                    Err(e) if downcast_chain_ref::<TargetNotFoundError>(&e).is_some() => continue,
-                                    Err(e) if downcast_chain_ref::<CycleError>(&e).is_some() => continue,
-                                    res => res,
-                                }?;
+                        }
+                    }
 
-                                match crate::engine::matcher_spec::match_spec(m, &spec) {
-                                    MatchResult::MatchYes => {
-                                        if seen.insert(addr.clone()) { yield addr; }
-                                    }
-                                    MatchResult::MatchNo => {}
-                                    MatchResult::MatchShrug => {
-                                        let def = match Arc::clone(&self).get_def(spec_rs.clone(), &addr).await {
-                                            Ok(def) => def,
-                                            // Cycle means this candidate transitively depends on the
-                                            // query caller — it cannot be a result. Skip it.
-                                            Err(e) if downcast_chain_ref::<CycleError>(&e).is_some() => continue,
-                                            Err(e) => Err(e)?,
-                                        };
+                    anyhow::Ok(candidates)
+                })))
+            }))
+            // Each package runs as its own task, not merely as a future inside
+            // `Buffered`. That is what makes the serial consumer below safe.
+            //
+            // Both `query` walks must be polled inside a tokio runtime because of
+            // it. Every caller today is (the commands, `Engine::result`'s walk
+            // task, `pluginquery::get`, and the stabby host's `DynFuture`, which
+            // host workers poll) — but the surrounding code is otherwise
+            // runtime-agnostic, and `HostExecutor::note_dep` already drives an
+            // engine future with `block_on` across the synchronous seam, so state
+            // the precondition rather than leave it to be rediscovered.
+            //
+            // `pluginbuildfile::probe`/`list` reach `run_pkg`, which holds a
+            // `PKG_EVAL_SLOTS` permit (a global semaphore sized `cores`) across
+            // its `blocking::run(..).await`. As plain futures, those permit
+            // holders advance only when the consumer polls this stream — and the
+            // consumer stops polling it the moment it awaits `get_spec`/`get_def`
+            // in the `MatchShrug` arm, which itself can need a permit for another
+            // package. The blocking jobs finish, but the permits are released
+            // only by a poll that never comes, and `Semaphore` is FIFO: the
+            // consumer queues behind `cores` futures that cannot advance.
+            // Deadlock, escaping only if some unrelated task happens to drive the
+            // same `pkg_cache` cell. Spawned, they are polled by the runtime
+            // regardless of what the consumer is doing, so permits always drain.
+            //
+            // `spawn_with_cycle_ctx`, not bare `tokio::spawn`, for the reason
+            // `Engine::result` uses it one level up: the body calls
+            // `Memoizer::once`, and without the inherited frame those calls get
+            // no wait-for edge, so a cycle through them hangs instead of
+            // reporting `MemoizerCycleError`.
+            //
+            // `buffered` over `JoinHandle`s still yields in submission order, so
+            // the emitted sequence is unchanged.
+            .buffered(crate::engine::fanout::discovery_concurrency())
+            .map(|joined| match joined {
+                Ok(res) => res,
+                Err(e) => Err(anyhow::Error::new(e).context("package discovery task panicked")),
+            });
+            futures::pin_mut!(per_pkg);
 
-                                        if crate::engine::matcher_target::match_target(
-                                            m,
-                                            &def.target_def,
-                                        ) == MatchResult::MatchYes
-                                            && seen.insert(addr.clone())
-                                        {
-                                            yield addr;
-                                        }
+            loop {
+                let candidates = match per_pkg.next().await {
+                    None => break,
+                    Some(Ok(candidates)) => candidates,
+                    // Never `?` straight out: inside `try_stream!` that yields the
+                    // error and *returns*, leaving up to K-1 package tasks running
+                    // with an `Arc<RequestState>` each. They would finish and
+                    // release it — spawning means they are no longer strandable —
+                    // but not before `Engine::result` has returned, so the request
+                    // would deregister late and `drain_bg`, which waits on
+                    // `bg_pending` rather than on detached tasks, would race it.
+                    // Flag the walk as abandoning (which ends the source, so
+                    // nothing further is spawned) and join what is already running
+                    // before propagating.
+                    Some(Err(e)) => {
+                        stop.store(true, std::sync::atomic::Ordering::Relaxed);
+                        while per_pkg.next().await.is_some() {}
+                        Err(e)?;
+                        // Not reached: `Err(e)?` in a `try_stream!` body yields
+                        // the error and returns. Present because the match arm
+                        // still has to produce a value.
+                        break;
+                    }
+                };
+                for addr in candidates {
+                    match m.matches_addr(&addr) {
+                        MatchResult::MatchYes => {
+                            if seen.insert(addr.clone()) { yield addr; }
+                        }
+                        MatchResult::MatchNo => {}
+                        MatchResult::MatchShrug => {
+                            // Speculative inspection: resolve the candidate's spec/def only
+                            // to evaluate the matcher, on a speculative rs so a rejected
+                            // candidate records no edge in the shared dep DAG (which would
+                            // otherwise close a false cycle later). One chain at a time
+                            // *within this walk* — see the note above the fan-out, which
+                            // also records the engine-level exposure across walks.
+                            let spec_rs = rs.speculative();
+                            let spec = match Arc::clone(&self).get_spec(spec_rs.clone(), &addr).await {
+                                Ok(spec) => Ok(spec),
+                                Err(e) if downcast_chain_ref::<TargetNotFoundError>(&e).is_some() => continue,
+                                Err(e) if downcast_chain_ref::<CycleError>(&e).is_some() => continue,
+                                res => res,
+                            }?;
+
+                            match crate::engine::matcher_spec::match_spec(m, &spec) {
+                                MatchResult::MatchYes => {
+                                    if seen.insert(addr.clone()) { yield addr; }
+                                }
+                                MatchResult::MatchNo => {}
+                                MatchResult::MatchShrug => {
+                                    let def = match Arc::clone(&self).get_def(spec_rs.clone(), &addr).await {
+                                        Ok(def) => def,
+                                        // Cycle means this candidate transitively depends on the
+                                        // query caller — it cannot be a result. Skip it.
+                                        Err(e) if downcast_chain_ref::<CycleError>(&e).is_some() => continue,
+                                        Err(e) => Err(e)?,
+                                    };
+
+                                    if crate::engine::matcher_target::match_target(
+                                        m,
+                                        &def.target_def,
+                                    ) == MatchResult::MatchYes
+                                        && seen.insert(addr.clone())
+                                    {
+                                        yield addr;
                                     }
                                 }
                             }
@@ -645,6 +815,282 @@ mod tests {
                 "foo/deep".to_string(),
                 "unrelated".to_string(),
             ]
+        );
+        Ok(())
+    }
+
+    /// A provider whose per-package `list` is slow, with a per-package delay the
+    /// test chooses. Tracks peak in-flight `list` calls so a test can distinguish
+    /// an overlapped walk from a serial one without trusting wall-clock alone.
+    struct SlowList {
+        pkgs: Vec<String>,
+        /// Sleep for the package at index `i` in `pkgs`.
+        delay: Box<dyn Fn(usize) -> std::time::Duration + Send + Sync>,
+        inflight: Arc<std::sync::atomic::AtomicUsize>,
+        peak: Arc<std::sync::atomic::AtomicUsize>,
+    }
+
+    impl crate::engine::provider::Provider for SlowList {
+        fn config(
+            &self,
+            _req: crate::engine::provider::ConfigRequest,
+        ) -> anyhow::Result<crate::engine::provider::ConfigResponse> {
+            Ok(crate::engine::provider::ConfigResponse {
+                name: "slow".to_string(),
+            })
+        }
+        fn list<'a>(
+            &'a self,
+            req: ListRequest,
+            _ctoken: &'a (dyn hcore::hasync::Cancellable + Send + Sync),
+        ) -> futures::future::BoxFuture<
+            'a,
+            anyhow::Result<
+                Box<
+                    dyn Iterator<Item = anyhow::Result<crate::engine::provider::ListResponse>>
+                        + Send,
+                >,
+            >,
+        > {
+            use std::sync::atomic::Ordering::SeqCst;
+            let pkg = req.package.clone();
+            let idx = self.pkgs.iter().position(|p| p == pkg.as_str());
+            // Packages this provider does not own (e.g. the built-in `@heph/fs`)
+            // cost nothing and list nothing.
+            let Some(idx) = idx else {
+                return Box::pin(async { Ok(Box::new(std::iter::empty()) as Box<_>) });
+            };
+            let d = (self.delay)(idx);
+            let (inflight, peak) = (Arc::clone(&self.inflight), Arc::clone(&self.peak));
+            Box::pin(async move {
+                let now = inflight.fetch_add(1, SeqCst) + 1;
+                peak.fetch_max(now, SeqCst);
+                tokio::time::sleep(d).await;
+                inflight.fetch_sub(1, SeqCst);
+                let items: Vec<anyhow::Result<crate::engine::provider::ListResponse>> =
+                    vec![Ok(crate::engine::provider::ListResponse {
+                        addr: Addr::new(pkg, "t".to_string(), Default::default()),
+                    })];
+                Ok(Box::new(items.into_iter()) as Box<dyn Iterator<Item = _> + Send>)
+            })
+        }
+        fn list_packages<'a>(
+            &'a self,
+            _req: crate::engine::provider::ListPackagesRequest,
+            _ctoken: &'a (dyn hcore::hasync::Cancellable + Send + Sync),
+        ) -> futures::future::BoxFuture<
+            'a,
+            anyhow::Result<
+                Box<
+                    dyn Iterator<
+                            Item = anyhow::Result<crate::engine::provider::ListPackageResponse>,
+                        > + Send,
+                >,
+            >,
+        > {
+            let items: Vec<anyhow::Result<crate::engine::provider::ListPackageResponse>> = self
+                .pkgs
+                .iter()
+                .map(|p| {
+                    Ok(crate::engine::provider::ListPackageResponse {
+                        pkg: PkgBuf::from(p.as_str()),
+                    })
+                })
+                .collect();
+            Box::pin(async move {
+                Ok(Box::new(items.into_iter()) as Box<dyn Iterator<Item = _> + Send>)
+            })
+        }
+        fn get<'a>(
+            &'a self,
+            _req: crate::engine::provider::GetRequest,
+            _ctoken: &'a (dyn hcore::hasync::Cancellable + Send + Sync),
+        ) -> futures::future::BoxFuture<
+            'a,
+            Result<crate::engine::provider::GetResponse, crate::engine::provider::GetError>,
+        > {
+            Box::pin(async { Err(crate::engine::provider::GetError::NotFound) })
+        }
+        fn probe<'a>(
+            &'a self,
+            req: crate::engine::provider::ProbeRequest,
+            _ctoken: &'a (dyn hcore::hasync::Cancellable + Send + Sync),
+        ) -> futures::future::BoxFuture<'a, anyhow::Result<crate::engine::provider::ProbeResponse>>
+        {
+            let pkg = req.package.clone();
+            Box::pin(async move {
+                Ok(crate::engine::provider::ProbeResponse {
+                    states: vec![crate::engine::provider::State {
+                        package: pkg,
+                        provider: "slow".to_string(),
+                        state: Default::default(),
+                    }],
+                })
+            })
+        }
+    }
+
+    fn slow_engine(
+        pkgs: Vec<String>,
+        delay: impl Fn(usize) -> std::time::Duration + Send + Sync + 'static,
+        inflight: Arc<std::sync::atomic::AtomicUsize>,
+        peak: Arc<std::sync::atomic::AtomicUsize>,
+    ) -> anyhow::Result<(Arc<Engine>, tempfile::TempDir)> {
+        let root = tempdir()?;
+        let mut engine = Engine::new(Config {
+            root: root.path().to_path_buf(),
+            home_dir: std::path::PathBuf::new(),
+            parallelism: None,
+            ..Default::default()
+        })?;
+        let delay = Arc::new(delay);
+        engine.register_provider(move |_| {
+            Box::new(SlowList {
+                pkgs: pkgs.clone(),
+                delay: {
+                    let d = Arc::clone(&delay);
+                    Box::new(move |i| d(i))
+                },
+                inflight: Arc::clone(&inflight),
+                peak: Arc::clone(&peak),
+            })
+        })?;
+        Ok((Arc::new(engine), root))
+    }
+
+    /// Discovery is the producer for the whole pipeline and used to be strictly
+    /// serial — `for pkg { probe; for provider { list } }` — so a workspace's
+    /// wall-clock discovery time was the *sum* of every package's evaluation.
+    ///
+    /// The assertion is on observed concurrency, not only elapsed time: a serial
+    /// loop peaks at one in-flight `list` on any machine, so this cannot pass
+    /// against it however fast or slow the host is.
+    #[tokio::test]
+    async fn query_overlaps_per_package_listing() -> anyhow::Result<()> {
+        use std::sync::atomic::{AtomicUsize, Ordering::SeqCst};
+
+        const N: usize = 12;
+        let delay = std::time::Duration::from_millis(60);
+        let pkgs: Vec<String> = (0..N).map(|i| format!("p{i:02}")).collect();
+        let inflight = Arc::new(AtomicUsize::new(0));
+        let peak = Arc::new(AtomicUsize::new(0));
+        let (engine, _root) = slow_engine(
+            pkgs,
+            move |_| delay,
+            Arc::clone(&inflight),
+            Arc::clone(&peak),
+        )?;
+
+        let rs = engine.new_state();
+        let start = std::time::Instant::now();
+        let addrs: Vec<Addr> = Arc::clone(&engine)
+            .query(rs, &Matcher::PackagePrefix(PkgBuf::from("")))
+            .try_collect()
+            .await?;
+        let elapsed = start.elapsed();
+
+        assert_eq!(addrs.len(), N);
+
+        let k = crate::engine::fanout::discovery_concurrency();
+        let peak = peak.load(SeqCst);
+        // A serial `for pkg { … list.await … }` peaks at exactly one in-flight
+        // `list`, on every machine — that is what this cannot pass against.
+        // Not asserted as an equality: `min(N, K)` only holds if the runtime
+        // polls all K before the first sleep expires, which a descheduled
+        // worker on a loaded runner can break. The exact cap is asserted in
+        // `query_keeps_at_most_k_packages_in_flight`, where it is the point.
+        assert!(peak > 1, "package listings must overlap; serial peaks at 1");
+        assert!(
+            peak <= k,
+            "in-flight listings must stay within K={k}, saw {peak}"
+        );
+        // Wall clock, derived from the actual K rather than a fixed fraction:
+        // the serial cost is `N * delay`, the overlapped cost about
+        // `ceil(N/K) * delay`. Allowing 2x that still fails against serial for
+        // every K >= 2, which is the floor `discovery_concurrency()` can return.
+        let waves = N.div_ceil(k.max(1)) as u32;
+        assert!(
+            elapsed < delay * waves * 2,
+            "overlapped discovery of {N} packages at K={k} must beat serial \
+             ({:?}), took {elapsed:?}",
+            delay * (N as u32)
+        );
+        Ok(())
+    }
+
+    /// The in-flight *cap* is the memory half of the change — what keeps a
+    /// 20k-package workspace from holding 20k live package futures. The test
+    /// above cannot see it, because `K >= N` on most dev machines. Here N is a
+    /// multiple of K, so the bound is the thing being measured.
+    #[tokio::test]
+    async fn query_keeps_at_most_k_packages_in_flight() -> anyhow::Result<()> {
+        use std::sync::atomic::{AtomicUsize, Ordering::SeqCst};
+
+        let k = crate::engine::fanout::discovery_concurrency();
+        let n = k * 4;
+        let pkgs: Vec<String> = (0..n).map(|i| format!("p{i:04}")).collect();
+        let inflight = Arc::new(AtomicUsize::new(0));
+        let peak = Arc::new(AtomicUsize::new(0));
+        let (engine, _root) = slow_engine(
+            pkgs,
+            |_| std::time::Duration::from_millis(5),
+            Arc::clone(&inflight),
+            Arc::clone(&peak),
+        )?;
+
+        let rs = engine.new_state();
+        let addrs: Vec<Addr> = Arc::clone(&engine)
+            .query(rs, &Matcher::PackagePrefix(PkgBuf::from("")))
+            .try_collect()
+            .await?;
+
+        assert_eq!(addrs.len(), n);
+        let peak = peak.load(SeqCst);
+        assert!(
+            peak <= k,
+            "at most K={k} packages may be in flight at once, saw {peak} with N={n}"
+        );
+        assert!(peak > 1, "package listings must still overlap, saw {peak}");
+        Ok(())
+    }
+
+    /// The addr sequence `query` emits is a build input: it carries through
+    /// `pluginquery`'s `deps` into `plugingroup`, which folds `deps` in order
+    /// into its def hash. Overlapping the packages must therefore keep the
+    /// *submission* order (`buffered`) and never adopt completion order
+    /// (`buffer_unordered`), or a query group's identity becomes a function of
+    /// which BUILD file the scheduler happened to finish first.
+    ///
+    /// The delays here invert completion order relative to package order, so a
+    /// `buffer_unordered` implementation returns the exact reverse.
+    #[tokio::test]
+    async fn query_emits_packages_in_listing_order_not_completion_order() -> anyhow::Result<()> {
+        use std::sync::atomic::AtomicUsize;
+
+        const N: usize = 8;
+        let pkgs: Vec<String> = (0..N).map(|i| format!("p{i:02}")).collect();
+        let (engine, _root) = slow_engine(
+            pkgs.clone(),
+            // First package listed sleeps longest, last sleeps least.
+            |i| std::time::Duration::from_millis(((N - i) * 15) as u64),
+            Arc::new(AtomicUsize::new(0)),
+            Arc::new(AtomicUsize::new(0)),
+        )?;
+
+        let rs = engine.new_state();
+        let addrs: Vec<Addr> = Arc::clone(&engine)
+            .query(rs, &Matcher::PackagePrefix(PkgBuf::from("")))
+            .try_collect()
+            .await?;
+
+        let got: Vec<String> = addrs
+            .iter()
+            .map(|a| a.package.as_str().to_string())
+            .collect();
+        assert_eq!(
+            got, pkgs,
+            "query must emit packages in listing order even though they complete \
+             in the reverse order"
         );
         Ok(())
     }

--- a/crates/engine/src/engine/result.rs
+++ b/crates/engine/src/engine/result.rs
@@ -115,12 +115,57 @@ impl ProviderExecutor for EngineProviderExecutor {
                         let pkg_iter = engine.packages(&matcher, &rs).await?;
                         let pkgs: Vec<String> = pkg_iter.collect::<anyhow::Result<_>>()?;
 
-                        let mut acc: Vec<State> = Vec::new();
-                        for pkg_str in pkgs {
+                        // One probe per `(package, provider)` pair, overlapped.
+                        //
+                        // `buffered`, never `buffer_unordered`: `acc` order is
+                        // the order plugin-go's `variant::build_universe` walks
+                        // the module universe in, which is the order its `list`
+                        // emits library addrs in, which reaches a def hash
+                        // through `pluginquery` → `plugingroup`. `buffered`
+                        // yields in submission order, so `acc` is byte-identical
+                        // to what the serial nested loop produced no matter
+                        // which probe lands first; `buffer_unordered` would put
+                        // completion order — i.e. probe latency — into a build
+                        // definition.
+                        //
+                        // The pair sequence is produced lazily and mapped to
+                        // futures one at a time, so the live set stays O(K) —
+                        // materializing `packages × providers` up front would be
+                        // ~80k `(PkgBuf, Arc)` pairs on a 20k-package workspace,
+                        // for no gain. Everything the iterator touches is owned
+                        // (the memoized closure's future must be `'static`), so
+                        // the registry is shared by `Arc` rather than borrowed.
+                        let providers: Arc<Vec<Arc<crate::engine::engine::Provider>>> =
+                            Arc::new(engine.providers.clone());
+                        let n_providers = providers.len();
+                        // Set when the walk is abandoning. A probe is *not* cheap
+                        // — `pluginbuildfile::probe` is `run_pkg`, the heaviest
+                        // synchronous unit in a build, and it takes a
+                        // `PKG_EVAL_SLOTS` permit — so without this the drain
+                        // below keeps topping the buffer from the underlying
+                        // iterator and Starlark-evaluates the whole workspace
+                        // *after* the walk has already failed.
+                        let stop = Arc::new(std::sync::atomic::AtomicBool::new(false));
+                        let probes = futures::stream::iter(pkgs.into_iter().flat_map(move |pkg_str| {
                             let pkg = PkgBuf::from(pkg_str.as_str());
-                            for provider in engine.providers.iter() {
-                                let inner = rs
-                                    .data
+                            let providers = Arc::clone(&providers);
+                            // `i < n_providers` holds by construction; `get`
+                            // rather than `[]` keeps this panic-free without an
+                            // unwrap, and without allocating a `Vec` per package.
+                            (0..n_providers).filter_map(move |i| {
+                                providers
+                                    .get(i)
+                                    .map(|provider| (pkg.clone(), Arc::clone(provider)))
+                            })
+                        }))
+                        .map(|(pkg, provider)| {
+                            enclose!((rs, stop) async move {
+                                if rs.ctoken().is_cancelled()
+                                    || stop.load(std::sync::atomic::Ordering::Relaxed)
+                                {
+                                    return Err(anyhow::Error::new(CancelledError));
+                                }
+                                rs.data
                                     .mem_probe_inner
                                     .once(
                                         (provider.name.clone(), pkg.clone()),
@@ -139,8 +184,39 @@ impl ProviderExecutor for EngineProviderExecutor {
                                         }),
                                     )
                                     .await
-                                    .map_err(unwrap_arc_err)?;
-                                acc.extend(inner.iter().cloned());
+                                    .map_err(unwrap_arc_err)
+                            })
+                        })
+                        .buffered(crate::engine::fanout::discovery_concurrency());
+                        tokio::pin!(probes);
+
+                        let mut acc: Vec<State> = Vec::new();
+                        loop {
+                            match probes.next().await {
+                                None => break,
+                                Some(Ok(inner)) => acc.extend(inner.iter().cloned()),
+                                // Same reason as the two `query` walks: returning
+                                // here would drop up to K in-flight probes, each
+                                // holding an `Arc<RequestState>`, while this
+                                // fan-out is itself running *inside* the
+                                // `mem_states_under` cell. Since #241 that is no
+                                // longer a leak — dropping a probe releases its
+                                // memoizer interest, and the last one out evicts
+                                // the `mem_probe_inner` cell and drops its future
+                                // — so what the drain buys now is ordering, not
+                                // liveness: the request's in-flight probes are
+                                // finished before the error escapes, rather than
+                                // torn down underneath a caller that may still
+                                // want them. `Buffered` refills from the
+                                // underlying iterator on every poll, so the drain
+                                // visits all N pairs, not just the K in flight;
+                                // `stop` is what keeps the tail from costing a
+                                // package evaluation each.
+                                Some(Err(e)) => {
+                                    stop.store(true, std::sync::atomic::Ordering::Relaxed);
+                                    while probes.next().await.is_some() {}
+                                    return Err(e);
+                                }
                             }
                         }
                         Ok(Arc::new(acc))
@@ -168,66 +244,150 @@ impl ProviderExecutor for EngineProviderExecutor {
             let pkg_iter = engine.packages(m, &rs).await?;
             let pkgs: Vec<String> = pkg_iter.collect::<anyhow::Result<_>>()?;
 
-            let mut result = Vec::new();
+            // One `list` callback surface for the whole walk, not one per
+            // (package, provider) pair — it is stateless apart from the engine
+            // handle and the request.
+            let executor: Arc<dyn ProviderExecutor> = Arc::new(EngineProviderExecutor::new(
+                Arc::downgrade(&engine),
+                rs.clone(),
+            ));
 
-            for pkg_str in pkgs {
+            // Set when the walk is abandoning; see `Engine::query`.
+            let stop = Arc::new(std::sync::atomic::AtomicBool::new(false));
+
+            // Owned copy: each package runs as its own `'static` task (see the
+            // spawn note below), so the borrowed `extra_skip` cannot cross into
+            // it. One `Arc` for the whole walk, cloned per package, not per
+            // (package, provider) pair.
+            let extra_skip: Arc<[String]> = extra_skip.into();
+
+            // Enumeration overlapped, matcher evaluation serial — the same split,
+            // for the same reasons, as `Engine::query`; see the long note there.
+            // The short version: the `MatchShrug` arm runs on a *speculative*
+            // `RequestState` whose cycle detection is a per-chain breadcrumb walk
+            // that bypasses the shared `DepDag`, so two concurrent chains are
+            // mutually invisible — which decides by race both which provider wins
+            // a shared `mem_spec` cell (and so `hashin`, which folds
+            // `def.driver`) and whether a two-chain cycle is reported or hangs.
+            // Serial *within this walk* is structural: the arm is in the consumer
+            // below, so the fan-out is not polled while it awaits. Across walks it
+            // is not guaranteed — see the note in `Engine::query`.
+            //
+            // ABI note: `ListRequest::executor` hands this `query()` to K
+            // concurrent `list` calls, so a provider that calls back into it from
+            // `list` gets K nested walks. No in-tree provider does (plugin-go's
+            // `list` calls only `states_under`), but it is a constraint on the
+            // plugin surface, not an accident of the current callers.
+            let per_pkg = futures::stream::iter(pkgs.into_iter()
+                // Ends the source when abandoning, so the drain joins only the
+                // <=K tasks already spawned instead of spawning one per remaining
+                // package — see `Engine::query`.
+                .take_while(enclose!((stop) move |_| !stop.load(std::sync::atomic::Ordering::Relaxed)))
+                .filter_map(|pkg_str| {
                 let pkg = PkgBuf::from(pkg_str.as_str());
 
                 // Same pruning as `Engine::query`: skip packages the matcher
-                // cannot select before paying for probe + list.
+                // cannot select before paying for probe + list. Done here, off
+                // the buffered stream, so a pruned package costs no slot.
                 if m.matches_pkg(&pkg) == hmodel::htmatcher::MatchResult::MatchNo {
-                    continue;
+                    return None;
                 }
 
-                let states = Arc::clone(&engine).probe_segments(&rs, &pkg).await?;
+                // Spawned here, not through a later `.map()` — see `Engine::query`.
+                Some(hcore::hmemoizer::spawn_with_cycle_ctx(
+                    enclose!((engine, rs, executor, stop, extra_skip) async move {
+                        // See `Engine::query`: an abandoning walk stops evaluating
+                        // packages it has not started, so the drain below costs a
+                        // cheap poll per remaining package rather than a package
+                        // evaluation each. `Err`, never `Ok(vec![])` — this sequence
+                        // is `pluginquery`'s `deps` and is folded in order into a def
+                        // hash, so a short answer would hash a truncated graph.
+                        if rs.ctoken().is_cancelled()
+                            || stop.load(std::sync::atomic::Ordering::Relaxed)
+                        {
+                            return Err(anyhow::Error::new(CancelledError));
+                        }
+                        let mut candidates: Vec<Addr> = Vec::new();
+                        let states = Arc::clone(&engine).probe_segments(&rs, &pkg).await?;
 
-                for provider in &engine.providers {
-                    if rs.skip_providers.contains(&provider.name)
-                        || extra_skip.iter().any(|n| n == &provider.name)
-                    {
-                        continue;
-                    }
-                    // Collect list results eagerly (non-Send iterator dropped before next await)
-                    let list_iter = provider
-                        .provider
-                        .list(
-                            ListRequest {
-                                request_id: rs.request_id().to_string(),
-                                package: pkg.clone(),
-                                states: states
-                                    .iter()
-                                    .filter(|s| s.provider == provider.name)
-                                    .cloned()
-                                    .collect(),
-                                executor: Arc::new(EngineProviderExecutor::new(
-                                    Arc::downgrade(&engine),
-                                    rs.clone(),
-                                )),
-                            },
-                            rs.ctoken(),
-                        )
-                        .await?;
-                    let raw: Vec<_> = list_iter.collect::<anyhow::Result<_>>()?;
+                        for provider in &engine.providers {
+                            if rs.skip_providers.contains(&provider.name)
+                                || extra_skip.iter().any(|n| n == &provider.name)
+                            {
+                                continue;
+                            }
+                            // Collect list results eagerly (non-Send iterator dropped before next await)
+                            let list_iter = provider
+                                .provider
+                                .list(
+                                    ListRequest {
+                                        request_id: rs.request_id().to_string(),
+                                        package: pkg.clone(),
+                                        states: states
+                                            .iter()
+                                            .filter(|s| s.provider == provider.name)
+                                            .cloned()
+                                            .collect(),
+                                        executor: Arc::clone(&executor),
+                                    },
+                                    rs.ctoken(),
+                                )
+                                .await?;
+                            let raw: Vec<_> = list_iter.collect::<anyhow::Result<Vec<_>>>()?;
 
-                    for item in raw {
-                        let addr = item.addr;
-                        if addr.package != pkg {
-                            continue;
+                            for item in raw {
+                                if item.addr.package == pkg {
+                                    candidates.push(item.addr);
+                                }
+                            }
                         }
 
-                        match m.matches_addr(&addr) {
-                            MatchResult::MatchYes => result.push(addr),
-                            MatchResult::MatchNo => {}
-                            MatchResult::MatchShrug => {
-                                // Resolve the candidate's spec/def only to evaluate the
-                                // matcher — a speculative inspection, not a dependency. Use a
-                                // speculative rs so a rejected candidate leaves no edge in the
-                                // shared dep DAG (an edge would close a false cycle later).
-                                let spec_rs = rs.speculative();
-                                let spec = match Arc::clone(&engine)
-                                    .get_spec(spec_rs.clone(), &addr)
-                                    .await
-                                {
+                        anyhow::Ok(candidates)
+                    }),
+                ))
+            }))
+            // One task per package — see the long note in `Engine::query`: as
+            // plain futures the `PKG_EVAL_SLOTS` permit holders would be
+            // unpollable while this walk's consumer awaits the `MatchShrug` arm,
+            // and the consumer would then queue behind them on the same
+            // semaphore.
+            .buffered(crate::engine::fanout::discovery_concurrency())
+            .map(|joined| match joined {
+                Ok(res) => res,
+                Err(e) => Err(anyhow::Error::new(e).context("package discovery task panicked")),
+            });
+            tokio::pin!(per_pkg);
+
+            let mut result = Vec::new();
+            loop {
+                let candidates = match per_pkg.next().await {
+                    None => break,
+                    Some(Ok(candidates)) => candidates,
+                    // Never `?` straight out — returning drops `per_pkg` with up
+                    // to K-1 package *tasks* still running, each holding an
+                    // `Arc<RequestState>` it releases only when it finishes. See
+                    // `Engine::query` for why late deregistration races
+                    // `drain_bg`.
+                    Some(Err(e)) => {
+                        stop.store(true, std::sync::atomic::Ordering::Relaxed);
+                        while per_pkg.next().await.is_some() {}
+                        return Err(e);
+                    }
+                };
+                for addr in candidates {
+                    match m.matches_addr(&addr) {
+                        MatchResult::MatchYes => result.push(addr),
+                        MatchResult::MatchNo => {}
+                        MatchResult::MatchShrug => {
+                            // Resolve the candidate's spec/def only to evaluate the
+                            // matcher — a speculative inspection, not a dependency. Use a
+                            // speculative rs so a rejected candidate leaves no edge in the
+                            // shared dep DAG (an edge would close a false cycle later).
+                            // One chain at a time *within this walk* — see the note
+                            // above the fan-out.
+                            let spec_rs = rs.speculative();
+                            let spec =
+                                match Arc::clone(&engine).get_spec(spec_rs.clone(), &addr).await {
                                     Ok(spec) => Ok(spec),
                                     Err(e)
                                         if downcast_chain_ref::<TargetNotFoundError>(&e)
@@ -244,33 +404,30 @@ impl ProviderExecutor for EngineProviderExecutor {
                                     res => res,
                                 }?;
 
-                                match crate::engine::matcher_spec::match_spec(m, &spec) {
-                                    MatchResult::MatchYes => result.push(addr),
-                                    MatchResult::MatchNo => {}
-                                    MatchResult::MatchShrug => {
-                                        let def_res = Arc::clone(&engine)
-                                            .get_def(spec_rs.clone(), &addr)
-                                            .await;
-                                        let def = match def_res {
-                                            Ok(def) => def,
-                                            // Same as the get_spec branch: cycle means this
-                                            // target transitively depends on the query caller —
-                                            // it can't be a dep of the caller. Skip it.
-                                            Err(e)
-                                                if downcast_chain_ref::<CycleError>(&e)
-                                                    .is_some() =>
-                                            {
-                                                continue;
-                                            }
-                                            Err(e) => return Err(e),
-                                        };
-                                        if crate::engine::matcher_target::match_target(
-                                            m,
-                                            &def.target_def,
-                                        ) == MatchResult::MatchYes
+                            match crate::engine::matcher_spec::match_spec(m, &spec) {
+                                MatchResult::MatchYes => result.push(addr),
+                                MatchResult::MatchNo => {}
+                                MatchResult::MatchShrug => {
+                                    let def_res =
+                                        Arc::clone(&engine).get_def(spec_rs.clone(), &addr).await;
+                                    let def = match def_res {
+                                        Ok(def) => def,
+                                        // Same as the get_spec branch: cycle means this
+                                        // target transitively depends on the query caller —
+                                        // it can't be a dep of the caller. Skip it.
+                                        Err(e)
+                                            if downcast_chain_ref::<CycleError>(&e).is_some() =>
                                         {
-                                            result.push(addr);
+                                            continue;
                                         }
+                                        Err(e) => return Err(e),
+                                    };
+                                    if crate::engine::matcher_target::match_target(
+                                        m,
+                                        &def.target_def,
+                                    ) == MatchResult::MatchYes
+                                    {
+                                        result.push(addr);
                                     }
                                 }
                             }
@@ -1521,11 +1678,38 @@ impl Engine {
             }
         } else {
             // Broke early (cancelled, or a fatal landed): its answer is no longer
-            // wanted, and it may be deep inside a whole-package Starlark
-            // evaluation. Abort rather than wait it out — the previous shape
-            // dropped the stream mid-poll and Ctrl-C must stay that responsive.
+            // wanted. Abort rather than wait it out, so the *enqueue* side of
+            // Ctrl-C stays immediate.
+            //
+            // Read this precisely: aborting stops the walk **task**, which is the
+            // consumer of the discovery fan-out. It does not stop the fan-out.
+            // `Engine::query` runs each package as its own task and a dropped
+            // `JoinHandle` detaches rather than cancels, so up to K
+            // whole-package Starlark evaluations that were already in flight run
+            // to completion after this returns. Ctrl-C therefore stops
+            // *scheduling* new package work, not the work already started.
+            //
+            // That is deliberate, and it is the cheaper side of the trade: a
+            // detached package task drives its `mem_probe` cell to completion, so
+            // the cell releases its future and the `Arc<RequestState>` inside it,
+            // and the ≤K whole-package evaluations already paid for land in the
+            // memoizer instead of being thrown away. The residue is bounded at K
+            // because `query`'s per-package futures short-circuit on a cancelled
+            // token before starting anything new.
+            //
+            // Detaching is no longer what *rescues* those cells, only what
+            // happens to them. Before #241 a cell nobody polled kept its future
+            // forever — an Arc cycle through the `RequestStateData` that owns the
+            // memoizer, so the request never deregistered — and running the tasks
+            // out was the only way to avoid it. `Memoizer::process` now registers
+            // an interest per frame, and the last one to go on an incomplete cell
+            // evicts it and drops its future (`hmemoizer::cancel_abandoned`). So
+            // aborting the package tasks would be *safe* today; detaching is kept
+            // because it is the better trade, not because the alternative leaks.
+            // The `JoinSet` drain below stands on its own reasoning, not on this.
             walk.abort();
         }
+
         // Matcher fully resolved: mark the matched set final (drops the `~`).
         // Not on a failed walk — the set never became final, so claiming it did
         // would paint a wrong denominator over an aborting run.
@@ -3877,6 +4061,352 @@ mod tests {
         Ok(())
     }
 
+    /// A provider over a fixed package set whose `probe` is slow, with a
+    /// per-package delay the test picks. Tracks peak in-flight probes.
+    struct SlowProbe {
+        pkgs: Vec<String>,
+        delay: SArc<dyn Fn(usize) -> Duration + Send + Sync>,
+        inflight: SArc<AtomicUsize>,
+        peak: SArc<AtomicUsize>,
+    }
+
+    impl crate::engine::provider::Provider for SlowProbe {
+        fn config(&self, _req: ConfigRequest) -> anyhow::Result<ConfigResponse> {
+            Ok(ConfigResponse {
+                name: "slowprobe".to_string(),
+            })
+        }
+        fn list<'a>(
+            &'a self,
+            _req: ListRequest,
+            _ctoken: &'a (dyn Cancellable + Send + Sync),
+        ) -> BoxFuture<
+            'a,
+            anyhow::Result<Box<dyn Iterator<Item = anyhow::Result<ListResponse>> + Send>>,
+        > {
+            Box::pin(async { Ok(Box::new(std::iter::empty()) as Box<_>) })
+        }
+        fn list_packages<'a>(
+            &'a self,
+            _req: ListPackagesRequest,
+            _ctoken: &'a (dyn Cancellable + Send + Sync),
+        ) -> BoxFuture<
+            'a,
+            anyhow::Result<Box<dyn Iterator<Item = anyhow::Result<ListPackageResponse>> + Send>>,
+        > {
+            let items: Vec<anyhow::Result<ListPackageResponse>> = self
+                .pkgs
+                .iter()
+                .map(|p| {
+                    Ok(ListPackageResponse {
+                        pkg: PkgBuf::from(p.as_str()),
+                    })
+                })
+                .collect();
+            Box::pin(async move { Ok(Box::new(items.into_iter()) as Box<_>) })
+        }
+        fn get<'a>(
+            &'a self,
+            _req: GetRequest,
+            _ctoken: &'a (dyn Cancellable + Send + Sync),
+        ) -> BoxFuture<'a, Result<GetResponse, GetError>> {
+            Box::pin(async { Err(GetError::NotFound) })
+        }
+        fn probe<'a>(
+            &'a self,
+            req: ProbeRequest,
+            _ctoken: &'a (dyn Cancellable + Send + Sync),
+        ) -> BoxFuture<'a, anyhow::Result<ProbeResponse>> {
+            let pkg = req.package.clone();
+            // Packages this provider does not own (the always-on built-in
+            // `@heph/fs`) cost nothing and declare nothing.
+            let Some(idx) = self.pkgs.iter().position(|p| p == pkg.as_str()) else {
+                return Box::pin(async { Ok(ProbeResponse { states: vec![] }) });
+            };
+            let d = (self.delay)(idx);
+            let (inflight, peak) = (SArc::clone(&self.inflight), SArc::clone(&self.peak));
+            Box::pin(async move {
+                let now = inflight.fetch_add(1, Ordering::SeqCst) + 1;
+                peak.fetch_max(now, Ordering::SeqCst);
+                tokio::time::sleep(d).await;
+                inflight.fetch_sub(1, Ordering::SeqCst);
+                Ok(ProbeResponse {
+                    states: vec![State {
+                        package: pkg,
+                        provider: "slowprobe".to_string(),
+                        state: Default::default(),
+                    }],
+                })
+            })
+        }
+    }
+
+    fn slow_probe_engine(
+        pkgs: Vec<String>,
+        delay: impl Fn(usize) -> Duration + Send + Sync + 'static,
+        inflight: SArc<AtomicUsize>,
+        peak: SArc<AtomicUsize>,
+    ) -> anyhow::Result<(SArc<Engine>, tempfile::TempDir)> {
+        let root = tempdir()?;
+        let mut engine = Engine::new(Config {
+            root: root.path().to_path_buf(),
+            home_dir: std::path::PathBuf::new(),
+            parallelism: None,
+            ..Default::default()
+        })?;
+        let delay: SArc<dyn Fn(usize) -> Duration + Send + Sync> = SArc::new(delay);
+        engine.register_provider(move |_| {
+            Box::new(SlowProbe {
+                pkgs: pkgs.clone(),
+                delay: SArc::clone(&delay),
+                inflight: SArc::clone(&inflight),
+                peak: SArc::clone(&peak),
+            })
+        })?;
+        Ok((SArc::new(engine), root))
+    }
+
+    fn states_under_of(engine: &SArc<Engine>, rs: &SArc<RequestState>) -> EngineProviderExecutor {
+        EngineProviderExecutor::new(SArc::downgrade(engine), SArc::clone(rs))
+    }
+
+    /// `states_under`'s output order is a build input, not a display detail:
+    /// plugin-go feeds it straight into `variant::build_universe`, which walks it
+    /// in order to build the module variant universe, which fixes the order its
+    /// `list` emits library addrs in — and that reaches a def hash.
+    ///
+    /// So the fan-out must be `buffered`, never `buffer_unordered`. The delays
+    /// here make the probes complete in the exact reverse of listing order, so a
+    /// `buffer_unordered` implementation returns the reverse sequence.
+    #[tokio::test]
+    async fn states_under_returns_states_in_package_order_not_completion_order()
+    -> anyhow::Result<()> {
+        const N: usize = 8;
+        let pkgs: Vec<String> = (0..N).map(|i| format!("p{i:02}")).collect();
+        let (engine, _root) = slow_probe_engine(
+            pkgs.clone(),
+            // First package probed sleeps longest, last sleeps least.
+            |i| Duration::from_millis(((N - i) * 15) as u64),
+            SArc::new(AtomicUsize::new(0)),
+            SArc::new(AtomicUsize::new(0)),
+        )?;
+        let rs = engine.new_state();
+
+        let states = states_under_of(&engine, &rs)
+            .states_under(&PkgBuf::from(""))
+            .await?;
+
+        let got: Vec<String> = states
+            .iter()
+            .filter(|s| s.provider == "slowprobe")
+            .map(|s| s.package.as_str().to_string())
+            .collect();
+        assert_eq!(
+            got, pkgs,
+            "states must accumulate in package-listing order even though the \
+             probes complete in the reverse order"
+        );
+        Ok(())
+    }
+
+    /// The same walk, overlapped: `for pkg { for provider { probe.await } }` paid
+    /// the sum of every probe. plugin-go calls this for a whole module root
+    /// before it can emit a single addr, so it sits on the critical path of a
+    /// Go workspace's discovery.
+    /// A failed `states_under` walk must stop probing.
+    ///
+    /// `Buffered` refills its queue from the underlying iterator on *every*
+    /// poll, so `while probes.next().await.is_some() {}` walks the entire
+    /// remaining `(package, provider)` sequence rather than the K in flight.
+    /// Without the `stop` flag each of those pulls runs a real probe — and
+    /// `pluginbuildfile::probe` is `run_pkg`, a whole-package Starlark
+    /// evaluation holding a `PKG_EVAL_SLOTS` permit. The observable difference
+    /// is stark: the whole workspace gets evaluated *after* the walk has
+    /// already failed.
+    ///
+    /// The drain itself stays — it finishes this request's in-flight probes
+    /// before the error escapes, rather than tearing them down from inside the
+    /// `mem_states_under` cell they run under. (Since #241 dropping them would
+    /// not *leak*: an abandoned cell now evicts itself and drops its future. The
+    /// drain is about ordering, not liveness.) What the flag buys is that the
+    /// drain costs a cheap poll per remaining pair instead of a package
+    /// evaluation per remaining pair.
+    #[tokio::test]
+    async fn failed_states_under_walk_stops_probing() -> anyhow::Result<()> {
+        /// Counts real probes; the first package it is asked about fails.
+        struct CountingFailProbe {
+            pkgs: Vec<String>,
+            probes: SArc<AtomicUsize>,
+        }
+
+        impl crate::engine::provider::Provider for CountingFailProbe {
+            fn config(&self, _req: ConfigRequest) -> anyhow::Result<ConfigResponse> {
+                Ok(ConfigResponse {
+                    name: "countingfail".to_string(),
+                })
+            }
+            fn list<'a>(
+                &'a self,
+                _req: ListRequest,
+                _ctoken: &'a (dyn Cancellable + Send + Sync),
+            ) -> BoxFuture<
+                'a,
+                anyhow::Result<Box<dyn Iterator<Item = anyhow::Result<ListResponse>> + Send>>,
+            > {
+                Box::pin(async { Ok(Box::new(std::iter::empty()) as Box<_>) })
+            }
+            fn list_packages<'a>(
+                &'a self,
+                _req: ListPackagesRequest,
+                _ctoken: &'a (dyn Cancellable + Send + Sync),
+            ) -> BoxFuture<
+                'a,
+                anyhow::Result<
+                    Box<dyn Iterator<Item = anyhow::Result<ListPackageResponse>> + Send>,
+                >,
+            > {
+                let items: Vec<anyhow::Result<ListPackageResponse>> = self
+                    .pkgs
+                    .iter()
+                    .map(|p| {
+                        Ok(ListPackageResponse {
+                            pkg: PkgBuf::from(p.as_str()),
+                        })
+                    })
+                    .collect();
+                Box::pin(async move { Ok(Box::new(items.into_iter()) as Box<_>) })
+            }
+            fn get<'a>(
+                &'a self,
+                _req: GetRequest,
+                _ctoken: &'a (dyn Cancellable + Send + Sync),
+            ) -> BoxFuture<'a, Result<GetResponse, GetError>> {
+                Box::pin(async { Err(GetError::NotFound) })
+            }
+            fn probe<'a>(
+                &'a self,
+                req: ProbeRequest,
+                _ctoken: &'a (dyn Cancellable + Send + Sync),
+            ) -> BoxFuture<'a, anyhow::Result<ProbeResponse>> {
+                let pkg = req.package.clone();
+                let Some(idx) = self.pkgs.iter().position(|p| p == pkg.as_str()) else {
+                    return Box::pin(async { Ok(ProbeResponse { states: vec![] }) });
+                };
+                let probes = SArc::clone(&self.probes);
+                Box::pin(async move {
+                    probes.fetch_add(1, Ordering::SeqCst);
+                    // Yield so the fan-out actually fills before the first
+                    // result is consumed — otherwise a single-threaded runtime
+                    // could complete pair 0 before any sibling starts and the
+                    // test would prove nothing about the drain.
+                    tokio::task::yield_now().await;
+                    if idx == 0 {
+                        anyhow::bail!("probe blew up on package 0");
+                    }
+                    Ok(ProbeResponse {
+                        states: vec![State {
+                            package: pkg,
+                            provider: "countingfail".to_string(),
+                            state: Default::default(),
+                        }],
+                    })
+                })
+            }
+        }
+
+        // Large enough that "bounded" and "the whole workspace" cannot be
+        // confused on any core count.
+        const N: usize = 400;
+        let pkgs: Vec<String> = (0..N).map(|i| format!("p{i:04}")).collect();
+        let probes = SArc::new(AtomicUsize::new(0));
+        let root = tempdir()?;
+        let mut engine = Engine::new(Config {
+            root: root.path().to_path_buf(),
+            home_dir: std::path::PathBuf::new(),
+            parallelism: None,
+            ..Default::default()
+        })?;
+        engine.register_provider(enclose!((probes) move |_| Box::new(CountingFailProbe {
+            pkgs: pkgs.clone(),
+            probes: SArc::clone(&probes),
+        })))?;
+        let engine = SArc::new(engine);
+        let rs = engine.new_state();
+
+        let err = states_under_of(&engine, &rs)
+            .states_under(&PkgBuf::from(""))
+            .await
+            .expect_err("package 0's probe fails, so the walk must fail");
+        assert!(
+            format!("{err:#}").contains("blew up"),
+            "expected the probe's error, got: {err:#}"
+        );
+
+        // Package 0 is the first pair submitted, so `buffered` surfaces its
+        // error before anything later. Everything already in flight when that
+        // lands still counts — the bound is K-ish, not 1 — but the ~N-K pairs
+        // behind it must cost nothing.
+        let ran = probes.load(Ordering::SeqCst);
+        let k = crate::engine::fanout::discovery_concurrency();
+        assert!(
+            ran <= k * 4,
+            "a failed walk must stop probing: ran {ran} probes over {N} packages \
+             (K={k}). Unbounded would be ~{N} — the whole workspace evaluated \
+             after the walk had already failed."
+        );
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn states_under_overlaps_probes() -> anyhow::Result<()> {
+        const N: usize = 8;
+        let delay = Duration::from_millis(40);
+        let pkgs: Vec<String> = (0..N).map(|i| format!("p{i:02}")).collect();
+        let inflight = SArc::new(AtomicUsize::new(0));
+        let peak = SArc::new(AtomicUsize::new(0));
+        let (engine, _root) = slow_probe_engine(
+            pkgs,
+            move |_| delay,
+            SArc::clone(&inflight),
+            SArc::clone(&peak),
+        )?;
+        let rs = engine.new_state();
+
+        let start = std::time::Instant::now();
+        let states = states_under_of(&engine, &rs)
+            .states_under(&PkgBuf::from(""))
+            .await?;
+        let elapsed = start.elapsed();
+
+        assert_eq!(
+            states.iter().filter(|s| s.provider == "slowprobe").count(),
+            N
+        );
+        // A serial `for pkg { for provider { probe.await } }` peaks at exactly
+        // one in-flight probe, on every machine.
+        assert!(
+            peak.load(Ordering::SeqCst) > 1,
+            "probes must overlap; serial discovery peaks at 1 in-flight probe"
+        );
+        // The buffer interleaves this provider's slow probes with the built-in
+        // `fs` provider's instant ones, so only about K/2 slow probes are live
+        // at once. At K=2 — a 1-CPU cgroup, where `available_parallelism`
+        // reports 1 — that is ~1, and no wall-clock bound can distinguish
+        // overlapped from serial. Rather than assert something vacuous there,
+        // the timing claim is made only where it means something; `peak > 1`
+        // above is the machine-independent half and carries the test either way.
+        let k = crate::engine::fanout::discovery_concurrency();
+        if k >= 4 {
+            assert!(
+                elapsed < delay * (N as u32) * 3 / 4,
+                "overlapped probing of {N} packages at K={k} must beat serial ({:?}), \
+                 took {elapsed:?}",
+                delay * (N as u32)
+            );
+        }
+        Ok(())
+    }
+
     #[test]
     fn provider_functions_lists_exposed_functions() {
         let root = tempdir().unwrap();
@@ -5938,6 +6468,395 @@ mod tests {
              un-polled futures in this request's memoizers, and those futures hold an \
              Arc back into the RequestStateData that owns them, so its Drop — which \
              cancels the token and deregisters the request — can never run"
+        );
+        Ok(())
+    }
+
+    /// The deep `MatchShrug` arm — the one that shrugs *again* at spec level and
+    /// so reaches `get_def` + `matcher_target::match_target`.
+    ///
+    /// This arm is the entire justification for the shape of this walk
+    /// (enumeration overlapped, matcher evaluation serial in the consumer), and
+    /// the change physically moved it: it used to run inside the per-provider
+    /// loop, interleaved with that provider's listing, and now runs after every
+    /// provider for a package has listed, while K other packages are mid-`list`.
+    /// `label(...)` does not reach it — that resolves at `match_spec` —
+    /// so without a `TreeOutputTo` case the deepest path has no coverage at all.
+    #[tokio::test]
+    async fn query_tree_output_matcher_resolves_through_get_def() -> anyhow::Result<()> {
+        // Both targets live in `gen`, so both survive the addr-level cheap
+        // reject (which needs the two packages to be prefix-related) and both
+        // shrug all the way down. Only `//gen:a`'s codegen tree actually lands
+        // in `gen/dst`, and deciding that needs the def, not the spec.
+        let engine = engine_with(vec![
+            codegen_target("//gen:a", &[], "dst", &[]),
+            codegen_target("//gen:b", &[], "other", &[]),
+        ])?;
+        let rs = engine.new_state();
+
+        let matcher = Matcher::TreeOutputTo(PkgBuf::from("gen/dst"));
+        let addrs: Vec<Addr> = SArc::clone(&engine)
+            .query(rs, &matcher)
+            .try_collect()
+            .await?;
+
+        let names: Vec<&str> = addrs.iter().map(|a| a.name.as_str()).collect();
+        assert_eq!(
+            names,
+            vec!["a"],
+            "only the target whose codegen tree lands in //gen/dst may match"
+        );
+        Ok(())
+    }
+
+    /// The same arm through `EngineProviderExecutor::query` — a second, separately
+    /// edited copy of the loop, and the one `pluginquery` actually drives.
+    #[tokio::test]
+    async fn executor_query_tree_output_matcher_resolves_through_get_def() -> anyhow::Result<()> {
+        let engine = engine_with(vec![
+            codegen_target("//gen:a", &[], "dst", &[]),
+            codegen_target("//gen:b", &[], "other", &[]),
+        ])?;
+        let rs = engine.new_state();
+        let executor = EngineProviderExecutor::new(SArc::downgrade(&engine), SArc::clone(&rs));
+
+        let matcher = Matcher::TreeOutputTo(PkgBuf::from("gen/dst"));
+        let addrs = executor.query(&matcher, &[]).await?;
+
+        let names: Vec<&str> = addrs.iter().map(|a| a.name.as_str()).collect();
+        assert_eq!(names, vec!["a"]);
+        Ok(())
+    }
+
+    /// Models the `PKG_EVAL_SLOTS` shape: `probe` takes a permit and holds it
+    /// across a yield, `get` (reached from the shrug arm) needs one too.
+    struct PermitProvider {
+        pkgs: Vec<String>,
+        slots: SArc<tokio::sync::Semaphore>,
+    }
+
+    impl crate::engine::provider::Provider for PermitProvider {
+        fn config(&self, _req: ConfigRequest) -> anyhow::Result<ConfigResponse> {
+            Ok(ConfigResponse {
+                name: "permit".to_string(),
+            })
+        }
+        fn list<'a>(
+            &'a self,
+            req: ListRequest,
+            _ctoken: &'a (dyn Cancellable + Send + Sync),
+        ) -> BoxFuture<
+            'a,
+            anyhow::Result<Box<dyn Iterator<Item = anyhow::Result<ListResponse>> + Send>>,
+        > {
+            let pkg = req.package.clone();
+            if !self.pkgs.iter().any(|p| p == pkg.as_str()) {
+                return Box::pin(async { Ok(Box::new(std::iter::empty()) as Box<_>) });
+            }
+            Box::pin(async move {
+                let items: Vec<anyhow::Result<ListResponse>> = vec![Ok(ListResponse {
+                    addr: Addr::new(pkg, "t".to_string(), Default::default()),
+                })];
+                Ok(Box::new(items.into_iter()) as Box<dyn Iterator<Item = _> + Send>)
+            })
+        }
+        fn list_packages<'a>(
+            &'a self,
+            _req: ListPackagesRequest,
+            _ctoken: &'a (dyn Cancellable + Send + Sync),
+        ) -> BoxFuture<
+            'a,
+            anyhow::Result<Box<dyn Iterator<Item = anyhow::Result<ListPackageResponse>> + Send>>,
+        > {
+            let items: Vec<anyhow::Result<ListPackageResponse>> = self
+                .pkgs
+                .iter()
+                .map(|p| {
+                    Ok(ListPackageResponse {
+                        pkg: PkgBuf::from(p.as_str()),
+                    })
+                })
+                .collect();
+            Box::pin(async move { Ok(Box::new(items.into_iter()) as Box<_>) })
+        }
+        fn get<'a>(
+            &'a self,
+            req: GetRequest,
+            _ctoken: &'a (dyn Cancellable + Send + Sync),
+        ) -> BoxFuture<'a, Result<GetResponse, GetError>> {
+            let slots = SArc::clone(&self.slots);
+            let addr = req.addr.clone();
+            Box::pin(async move {
+                // The consumer's shrug arm lands here and needs a permit —
+                // the ones the fan-out is holding.
+                let _permit = slots
+                    .acquire()
+                    .await
+                    .map_err(|e| GetError::Other(anyhow::Error::new(e)))?;
+                Ok(GetResponse {
+                    target_spec: TargetSpec {
+                        addr,
+                        driver: "exec".to_string(),
+                        config: Default::default(),
+                        ..Default::default()
+                    },
+                })
+            })
+        }
+        fn probe<'a>(
+            &'a self,
+            req: ProbeRequest,
+            _ctoken: &'a (dyn Cancellable + Send + Sync),
+        ) -> BoxFuture<'a, anyhow::Result<ProbeResponse>> {
+            let pkg = req.package.clone();
+            if !self.pkgs.iter().any(|p| p == pkg.as_str()) {
+                return Box::pin(async { Ok(ProbeResponse { states: vec![] }) });
+            }
+            let slots = SArc::clone(&self.slots);
+            Box::pin(async move {
+                // Mirrors `run_pkg`: permit acquired in async-land, then held
+                // across a yield point.
+                let _permit = slots.acquire().await.context("permit")?;
+                tokio::time::sleep(Duration::from_millis(20)).await;
+                Ok(ProbeResponse { states: vec![] })
+            })
+        }
+    }
+
+    /// The discovery fan-out must not be able to starve its own consumer.
+    ///
+    /// `pluginbuildfile`'s `probe`/`list` reach `run_pkg`, which holds a
+    /// `PKG_EVAL_SLOTS` permit — a global semaphore sized `cores` — across an
+    /// await. The consumer of the fan-out then awaits `get_spec`/`get_def` in the
+    /// `MatchShrug` arm, which can need a permit for a *different* package. If
+    /// the fan-out's futures are only advanced by the consumer polling them, the
+    /// permit holders are unpollable exactly while the consumer needs a permit,
+    /// and `Semaphore` is FIFO: deadlock.
+    ///
+    /// Modelled here with the provider's own semaphore rather than
+    /// `PKG_EVAL_SLOTS` (which is buildfile-internal): `probe` takes a permit and
+    /// holds it across a yield, `get` — reached from the shrug arm via a `Label`
+    /// matcher — needs one too, and there are more in-flight packages than
+    /// permits. Fails by timing out rather than by assertion, which is the only
+    /// honest way to test a deadlock.
+    #[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+    async fn discovery_fanout_does_not_starve_the_matcher_consumer() -> anyhow::Result<()> {
+        let k = crate::engine::fanout::discovery_concurrency();
+        // Fewer permits than the fan-out width, so the fan-out can hold them all.
+        let slots = SArc::new(tokio::sync::Semaphore::new((k / 2).max(1)));
+        let n = k * 2;
+        let root = tempdir()?;
+        let mut engine = Engine::new(Config {
+            root: root.path().to_path_buf(),
+            home_dir: std::path::PathBuf::new(),
+            parallelism: None,
+            ..Default::default()
+        })?;
+        let pkgs: Vec<String> = (0..n).map(|i| format!("p{i:04}")).collect();
+        engine.register_provider(enclose!((slots) move |_| Box::new(PermitProvider {
+            pkgs: pkgs.clone(),
+            slots: SArc::clone(&slots),
+        })))?;
+        let engine = SArc::new(engine);
+        let rs = engine.new_state();
+
+        // A `Label` matcher shrugs at `matches_addr` for every candidate, so the
+        // consumer awaits `get_spec` — and therefore a permit — between batches.
+        let matcher = Matcher::Label("nope".to_string());
+        let walk = SArc::clone(&engine)
+            .query(rs, &matcher)
+            .try_collect::<Vec<Addr>>();
+
+        let addrs = tokio::time::timeout(Duration::from_secs(20), walk)
+            .await
+            .map_err(|_| {
+                anyhow::anyhow!(
+                    "discovery deadlocked: the fan-out held every permit while the \
+                     consumer's MatchShrug arm waited for one, and the holders were \
+                     only pollable by the consumer"
+                )
+            })??;
+        // No target carries the label, so nothing matches — the point is that it
+        // terminated.
+        assert!(addrs.is_empty(), "no target has this label, got {addrs:?}");
+        Ok(())
+    }
+
+    /// The same starvation through `EngineProviderExecutor::query` — a separate
+    /// copy of the loop, and the one behind every BUILD-file `query(...)` and
+    /// every `//@heph/query:q@expr=` target. It is also the *nested* case: this
+    /// walk runs inside `pluginquery::get`, reachable from `Engine::query`'s own
+    /// shrug arm, so before the fix an outer walk could deadlock through it.
+    #[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+    async fn executor_query_fanout_does_not_starve_its_consumer() -> anyhow::Result<()> {
+        let k = crate::engine::fanout::discovery_concurrency();
+        let slots = SArc::new(tokio::sync::Semaphore::new((k / 2).max(1)));
+        let n = k * 2;
+        let root = tempdir()?;
+        let mut engine = Engine::new(Config {
+            root: root.path().to_path_buf(),
+            home_dir: std::path::PathBuf::new(),
+            parallelism: None,
+            ..Default::default()
+        })?;
+        let pkgs: Vec<String> = (0..n).map(|i| format!("p{i:04}")).collect();
+        engine.register_provider(enclose!((slots) move |_| Box::new(PermitProvider {
+            pkgs: pkgs.clone(),
+            slots: SArc::clone(&slots),
+        })))?;
+        let engine = SArc::new(engine);
+        let rs = engine.new_state();
+        let executor = EngineProviderExecutor::new(SArc::downgrade(&engine), rs);
+
+        let matcher = Matcher::Label("nope".to_string());
+        let addrs = tokio::time::timeout(Duration::from_secs(20), executor.query(&matcher, &[]))
+            .await
+            .map_err(|_e| {
+                anyhow::anyhow!(
+                    "executor discovery deadlocked: the fan-out held every permit \
+                     while the consumer's MatchShrug arm waited for one"
+                )
+            })??;
+        assert!(addrs.is_empty(), "no target has this label, got {addrs:?}");
+        Ok(())
+    }
+
+    /// Cancelling a walk must stop it *starting* packages it has not reached.
+    ///
+    /// Discovery is overlapped now, so an abandoned walk is abandoned with up to
+    /// K package futures in flight. Those cannot be un-started — but everything
+    /// behind them can, and must be: without the short-circuit the walk keeps
+    /// evaluating whole BUILD files, one per remaining package, for a request
+    /// whose answer nobody wants. On a 20k-package workspace that is the entire
+    /// workspace evaluated after Ctrl-C.
+    ///
+    /// The provider counts `list` calls. Slow, non-cancellation-aware packages
+    /// hold the fan-out open long enough for the cancel to land mid-walk.
+    #[tokio::test]
+    async fn cancelling_a_walk_stops_starting_new_packages() -> anyhow::Result<()> {
+        struct CountingSlowList {
+            pkgs: Vec<String>,
+            lists: SArc<AtomicUsize>,
+        }
+
+        impl crate::engine::provider::Provider for CountingSlowList {
+            fn config(&self, _req: ConfigRequest) -> anyhow::Result<ConfigResponse> {
+                Ok(ConfigResponse {
+                    name: "slowcount".to_string(),
+                })
+            }
+            fn list<'a>(
+                &'a self,
+                req: ListRequest,
+                _ctoken: &'a (dyn Cancellable + Send + Sync),
+            ) -> BoxFuture<
+                'a,
+                anyhow::Result<Box<dyn Iterator<Item = anyhow::Result<ListResponse>> + Send>>,
+            > {
+                if !self.pkgs.iter().any(|p| p == req.package.as_str()) {
+                    return Box::pin(async { Ok(Box::new(std::iter::empty()) as Box<_>) });
+                }
+                let lists = SArc::clone(&self.lists);
+                Box::pin(async move {
+                    lists.fetch_add(1, Ordering::SeqCst);
+                    // Deliberately not cancellation-aware: a whole-package
+                    // Starlark evaluation does not stop early either.
+                    tokio::time::sleep(Duration::from_millis(40)).await;
+                    Ok(Box::new(std::iter::empty()) as Box<_>)
+                })
+            }
+            fn list_packages<'a>(
+                &'a self,
+                _req: ListPackagesRequest,
+                _ctoken: &'a (dyn Cancellable + Send + Sync),
+            ) -> BoxFuture<
+                'a,
+                anyhow::Result<
+                    Box<dyn Iterator<Item = anyhow::Result<ListPackageResponse>> + Send>,
+                >,
+            > {
+                let items: Vec<anyhow::Result<ListPackageResponse>> = self
+                    .pkgs
+                    .iter()
+                    .map(|p| {
+                        Ok(ListPackageResponse {
+                            pkg: PkgBuf::from(p.as_str()),
+                        })
+                    })
+                    .collect();
+                Box::pin(async move { Ok(Box::new(items.into_iter()) as Box<_>) })
+            }
+            fn get<'a>(
+                &'a self,
+                _req: GetRequest,
+                _ctoken: &'a (dyn Cancellable + Send + Sync),
+            ) -> BoxFuture<'a, Result<GetResponse, GetError>> {
+                Box::pin(async { Err(GetError::NotFound) })
+            }
+            fn probe<'a>(
+                &'a self,
+                _req: ProbeRequest,
+                _ctoken: &'a (dyn Cancellable + Send + Sync),
+            ) -> BoxFuture<'a, anyhow::Result<ProbeResponse>> {
+                Box::pin(async { Ok(ProbeResponse { states: vec![] }) })
+            }
+        }
+
+        let k = crate::engine::fanout::discovery_concurrency();
+        // Far more packages than the buffer, so an un-short-circuited walk has
+        // plenty left to start after the cancel lands.
+        let n = k * 8;
+        let root = tempdir()?;
+        let lists = SArc::new(AtomicUsize::new(0));
+        let mut engine = Engine::new(Config {
+            root: root.path().to_path_buf(),
+            home_dir: std::path::PathBuf::new(),
+            parallelism: None,
+            ..Default::default()
+        })?;
+        let pkgs: Vec<String> = (0..n).map(|i| format!("p{i:04}")).collect();
+        engine.register_provider(enclose!((lists) move |_| Box::new(CountingSlowList {
+            pkgs: pkgs.clone(),
+            lists: SArc::clone(&lists),
+        })))?;
+        let engine = SArc::new(engine);
+
+        let rs = engine.new_state();
+        let matcher = Matcher::PackagePrefix(PkgBuf::from(""));
+        let stream = SArc::clone(&engine).query(rs.clone(), &matcher);
+        tokio::pin!(stream);
+
+        // Let one buffer-load get under way, then cancel and keep draining.
+        let drain = async {
+            tokio::time::sleep(Duration::from_millis(60)).await;
+            rs.ctoken().cancel();
+        };
+        let consume = async {
+            let mut last: Option<anyhow::Error> = None;
+            while let Some(item) = stream.next().await {
+                if let Err(e) = item {
+                    last = Some(e);
+                }
+            }
+            last
+        };
+        let (err, ()) = tokio::join!(consume, drain);
+
+        let started = lists.load(Ordering::SeqCst);
+        assert!(
+            started < n,
+            "a cancelled walk must stop starting packages: it listed {started} of {n}"
+        );
+        // And it must *say so*. Returning `Ok(vec![])` for the packages it
+        // skipped would let the walk complete normally with a short answer —
+        // and that answer becomes `pluginquery`'s `deps`, folded in order into
+        // `plugingroup`'s def hash. A Ctrl-C during discovery would then write a
+        // cache entry keyed on a graph whose size depends on when the cancel
+        // landed, and that entry outlives the run that was abandoned.
+        let err = err.expect("a cancelled walk must surface an error, not a short answer");
+        assert!(
+            downcast_chain_ref::<CancelledError>(&err).is_some(),
+            "expected CancelledError, got: {err:#}"
         );
         Ok(())
     }

--- a/crates/plugin-buildfile/src/pluginbuildfile/run_file.rs
+++ b/crates/plugin-buildfile/src/pluginbuildfile/run_file.rs
@@ -1079,10 +1079,10 @@ impl Provider {
                 key.clone(),
                 enclose!((key) move || async move {
                     // Bound the fan-out before queueing: see `PKG_EVAL_SLOTS`.
-                    // Taken here rather than inside the closure so the wait
+                    // Waited for here rather than inside the closure so the wait
                     // happens in async-land, not on a pool thread — parking a
                     // pool thread to wait for a pool thread is the deadlock.
-                    let _slot = PKG_EVAL_SLOTS
+                    let slot = PKG_EVAL_SLOTS
                         .acquire()
                         .await
                         .context("acquiring a package-evaluation slot")?;
@@ -1091,6 +1091,27 @@ impl Provider {
                     // worker it stops that worker polling anything at all — see
                     // `hcore::blocking`.
                     hcore::blocking::run(move || -> anyhow::Result<Arc<RunResult>> {
+                        // The permit rides *into* the job rather than being held
+                        // across the await. `PKG_EVAL_SLOTS` is a static, so the
+                        // guard is already `'static`, and this costs nothing.
+                        //
+                        // It matters because a permit held across an await is
+                        // released only by a poll of this future — and callers
+                        // exist that stop polling. The discovery fan-out in
+                        // `Engine::query` buffers K of these and its consumer
+                        // parks in the `MatchShrug` arm awaiting a *different*
+                        // package's spec, which needs a permit of its own: the
+                        // holders go unpollable exactly when the consumer needs
+                        // what they hold, and the semaphore is FIFO. That walk
+                        // spawns each package as a task so the runtime keeps
+                        // polling them, which breaks the cycle — but that is the
+                        // caller's discipline, and `list` here is reachable from
+                        // arbitrary provider code. Submitted jobs run to
+                        // completion even when the receiver is gone
+                        // (`hcore::blocking::run`), so releasing on the pool
+                        // thread makes the class impossible rather than merely
+                        // unreached.
+                        let _slot = slot;
                         let loader =
                             BuildFileLoader::new(root, patterns, file_cache, dir_cache, registry, globals, walker, packages, loads);
                         loader


### PR DESCRIPTION
P5.4 of the threading plan. Discovery was serial by construction and is the producer for the whole pipeline — every `heph query` / `validate` / `labels` / `revdeps`, and the warm-cache part of every `heph run`, paid the *sum* of every package's evaluation.

Four loops now overlap at `K = 2 * available_parallelism()`:

| Site | Was | Now |
|---|---|---|
| `Engine::query` | `for pkg { probe.await; for provider { list.await } }` | one future per package, `buffered(K)` |
| `EngineProviderExecutor::query` | same shape | same |
| `states_under` | `for pkg { for provider { probe.await } }` | `buffered(K)` over `(pkg, provider)` |
| `Engine::packages` | `for provider { list_packages.await }` | `join_all` |

## Measured

Full-cache-hit `heph query -e '//...'`, PR head vs its merge-base, **14 interleaved rounds per binary**, on a quiet darwin/arm64 10-core box — background CPU verified 60-68% idle via `top`, not load average.

| fixture | baseline median | treatment median | speedup |
|---|---|---|---|
| 2000 pkg × 8 targets + `glob()` per package | 0.606 s (range 0.537-1.214) | 0.374 s (range 0.289-0.584) | **1.62×** |
| 2000 pkg × 2 trivial targets | ~0.45 s | ~0.30-0.35 s | ~1.3× |

14/14 rounds treatment-faster, consistent direction, outside the noise band — **regression-free**. The second fixture is noise-adjacent (same-binary spread ~29%), so the honest headline is a range: **1.3-1.6× on quiet darwin/arm64**.

### Superseding the original numbers

This PR previously claimed `~9.6×` (`Engine::query`) and `~7.9×` (`EngineProviderExecutor::query`), from 8.27 s → 0.86 s and 8.34 s → 1.05 s. Those are **not reproducible** and are superseded by the table above. They are not deleted here because the delta is the interesting part.

The probable explanation — the best the data supports, and **explicitly not proven**, since no loaded-box run was made to confirm the mechanism — is that the original numbers came from a heavily loaded shared machine, and load structurally inflates the ratio in the parallel version's favour: under contention a strictly serial loop stalls completely on preemption, while a `buffered(K)` fan-out still makes partial progress whenever any core frees. So "~8-10× observed once on a loaded box, mechanism not isolated" is as much as can be said.

### What the measurement could not establish

Both are real limits on the claim, not caveats:

- **No realistic fixture exists in-tree.** The only workspace is `example/`, 20 BUILD files — far too small to exercise discovery scaling, so every number above comes from a synthetic tree built for the occasion. A Starlark-macro-heavy fixture is needed if this path is to stay defensibly measured; an unmeasurable hot path regresses unnoticed.
- **The `PKG_EVAL_SLOTS`-vs-K ceiling was not tested.** No CLI flag exposes the parallelism override, and macOS has no cheap `taskset` equivalent, so core count could not be varied. The achieved 1.6× is far below both K (20) and the core count (10) — equally consistent with "`PKG_EVAL_SLOTS` is the true ceiling" and with "a large fraction of wall time is serial or fixed overhead". Those two cannot be separated without a heavier fixture or a variable core count.

The plan's `20k packages × 2 ms, ~40 s → ~3 s at 16-way` is a **pure Amdahl ceiling**: it assumes all wall time is parallelisable per-package evaluation with zero serial overhead. At the per-package cost actually measurable here, 10 cores bought 1.6×. It is an upper bound, not an expected number.

## Only enumeration is overlapped

The `MatchShrug` arm — resolving a candidate's spec/def to evaluate the matcher — stays strictly serial. It runs on a **speculative** `RequestState` whose cycle detection is a per-chain breadcrumb walk that bypasses the shared `DepDag`, so two concurrent chains are mutually invisible. That decides by race (a) which provider wins a shared `mem_spec` cell, and so `hashin`, which folds `def.driver`; and (b) whether a two-chain cycle is reported or hangs. Both reach a build definition. Widening this needs the speculative cycle check to become shared state first.

## `buffered`, never `buffer_unordered`

Emission order is a build input: `EngineProviderExecutor::query`'s result becomes `pluginquery`'s `deps` verbatim (no sort) and `plugingroup` folds `deps` in order into its def hash; `states_under`'s accumulator drives `variant::build_universe`. `buffered` yields in submission order, so every sequence is byte-identical to the serial result.

## Composition with #230 — resolved, not assumed

#230 has merged and this PR is rebased onto it. The two **do** compose semantically: #230 sorts and dedups each provider's block *inside* the per-`(provider, prefix)` memoizer, and sorting inside a cell is unaffected by running the cells concurrently, while the merge after the fan-out re-imposes provider-registration order.

But the earlier claim that they compose *textually* — that this PR "only replaced the loop around the memoizer calls, leaving the closure body #230 edits untouched" — **was wrong**, and the rebase produced a genuine conflict. This PR moves the whole `once(...)` call into a `join_all`, so it carries its own copy of that closure body. Taking this side of the conflict verbatim would have silently dropped #230's `sort_unstable()` / `dedup()`. The resolution keeps all three pieces: per-provider sort inside the memoizer closure, `join_all` around it, registration-order merge after it.

`packages_overlaps_the_provider_walks` now lists its providers' blocks **unsorted**, so it pins the composition rather than only the fan-out. It goes red if the sort is dropped, if the sort becomes global, or if the merge stops running in registration order.

## Tests

Each was verified red by mutating the thing it guards, re-run after the rebase:

| mutation | red |
|---|---|
| `buffered(1)` | `query_overlaps_per_package_listing`, `query_keeps_at_most_k_packages_in_flight`, `states_under_overlaps_probes` |
| `buffer_unordered` | `query_emits_packages_in_listing_order_not_completion_order`, `states_under_returns_states_in_package_order_not_completion_order`, and the e2e `test_query_dep_order_is_stable_across_runs` |
| serial provider loop in `Engine::packages` | `packages_overlaps_the_provider_walks` (peak 1, not 3) |
| cancellation short-circuit removed | `cancelling_a_walk_stops_starting_new_packages` ("listed 160 of 160") |
| `states_under`'s `stop` flag removed | `failed_states_under_walk_stops_probing` ("ran 400 probes over 400 packages") |
| #230's `sort_unstable()` / `dedup()` removed | `packages_sorts_each_providers_listing`, `packages_order_is_independent_of_how_a_provider_lists`, `packages_is_stable_across_requests_when_a_provider_reorders`, **and** `packages_overlaps_the_provider_walks` |

The two ordering tests are green against the *pre-change* code by construction, so the `buffer_unordered` mutation is what makes them meaningful. A first attempt at a leak test for the aborted fan-out was **deleted rather than shipped** — it passed under both `abort()` and `await`, so it proved nothing.

One gap, recorded rather than closed: neutering the `take_while(!stop)` source cutoff leaves every test green. That is by design — the cutoff is a *cost* optimization (it stops `Buffered` refilling and therefore spawning a task per remaining package), while the correctness guard is the `stop` check inside the spawned body, which is covered above. What is untested is the spawn count during a drain.

## Review board

`hermeticity` returned **NOT HERMETIC** and `feature-quality` **BLOCKED** on the first revision, both tracing to concurrent speculative chains — fixed by keeping matcher evaluation serial. `code-quality` then returned **BLOCKED** on the cancel path returning `Ok(vec![])` (a silently truncated sequence that reaches a def hash) — fixed by returning `CancelledError`. `perf-measurement` returned **REGRESSION-FREE BUT OVERSTATED**, which is what the Measured section above now reflects.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01A76DChMohieGMbRbnV1E7x
