### PR TITLE
fix(sandbox): keep synchronous cache reads off the runtime workers

### DIFF
--- a/crates/driver-bridge/src/driver_managed_fuse.rs
+++ b/crates/driver-bridge/src/driver_managed_fuse.rs
@@ -1,10 +1,10 @@
 use anyhow::Context;
-use hcore::hartifactcontent;
 use hcore::hartifactcontent::tar_index::TarIndex;
 use hcore::hasync::Cancellable;
 use hdriver_support::driver_managed::{
-    ManagedDriver, ManagedRunInput, ShellFallback, collect_outputs, detect_output_collisions,
-    invoke_inner, list_path_for, resolve_unpack_root, write_source_map,
+    ManagedDriver, ManagedRunInput, ShellFallback, collect_outputs,
+    detect_output_collisions_blocking, invoke_inner, list_path_for, resolve_unpack_root,
+    unpack_blocking, write_source_map_blocking,
 };
 use hplugin::driver::{RunInput, RunRequest, RunResponse, SandboxGuard};
 use hsandboxfuse as sandboxfuse;
@@ -68,8 +68,11 @@ impl ManagedDriverFuse {
 
         // Reject two distinct targets producing the same sandbox file before we
         // register any slot — overlapping layer paths would otherwise silently
-        // shadow by registration order.
-        detect_output_collisions(&groups)
+        // shadow by registration order. Off the worker: the check enumerates
+        // every input's entry paths, which for a cache-backed input is a header
+        // scan over a sqlite blob and can park on that key's queued write.
+        let groups = detect_output_collisions_blocking(groups)
+            .await
             .with_context(|| format!("output-collision check for {}", req.target.addr.format()))?;
 
         let mut slot_guards: Vec<sandboxfuse::SlotGuard> = Vec::new();
@@ -78,7 +81,15 @@ impl ManagedDriverFuse {
         for (unpack_root, group) in groups {
             fs::create_dir_all(&unpack_root)
                 .with_context(|| format!("create unpack root {:?}", unpack_root))?;
-            match try_register_slot(&self.fs, &self.fuse_lower, &unpack_root, &list_dir, &group)? {
+            let (slot, group) = try_register_slot_blocking(
+                Arc::clone(&self.fs),
+                self.fuse_lower.clone(),
+                unpack_root.clone(),
+                list_dir.clone(),
+                group,
+            )
+            .await?;
+            match slot {
                 Some(guard) => {
                     slot_guards.push(guard);
                     // Slot registered; inputs served via layers — no per-input unpack.
@@ -96,18 +107,15 @@ impl ManagedDriverFuse {
                     // into the FUSE upper layer just like OS mode.
                     for input in group {
                         let list_path = list_path_for(&input, &list_dir);
-                        let filters = input.filters.clone();
-                        let predicate: Option<&dyn Fn(&Path) -> bool> = if filters.is_empty() {
-                            None
-                        } else {
-                            Some(&|rel: &Path| filters.iter().any(|f| Path::new(f) == rel))
-                        };
-                        hartifactcontent::unpack::unpack(
-                            input.artifact.content.as_ref(),
-                            unpack_root.as_path(),
-                            list_path.as_deref(),
-                            predicate,
+                        // Off the worker, through the same shared helper the OS
+                        // runner uses — see `unpack_blocking`.
+                        unpack_blocking(
+                            Arc::clone(&input.artifact.content),
+                            unpack_root.clone(),
+                            list_path.clone(),
+                            input.filters.clone(),
                         )
+                        .await
                         .with_context(|| {
                             format!(
                                 "unpack input origin_id={} source_addr={} into {:?}",
@@ -130,7 +138,10 @@ impl ManagedDriverFuse {
         fs::create_dir_all(&sandbox_pkg_dir)
             .with_context(|| format!("create pkg dir: {:?}", sandbox_pkg_dir))?;
 
-        write_source_map(&inputs, &ws_dir, &sandbox_pkg_dir)?;
+        // Off the worker, as the OS runner already does it: an input that opts in
+        // costs an `entry_paths()` per artifact, a header scan over a sqlite blob
+        // that can park on that key's queued write.
+        let inputs = write_source_map_blocking(inputs, &ws_dir, &sandbox_pkg_dir).await?;
 
         let target = req.target;
         let hashin = req.hashin;
@@ -177,17 +188,75 @@ impl ManagedDriverFuse {
     }
 }
 
-/// Build per-input `TarIndex`es and register a slot on the shared FUSE
-/// filesystem. Returns `None` if any input lacks a seekable reader (the
-/// FUSE path requires random-access bytes) — caller falls back to
-/// unpack-into-upper for that group.
-fn try_register_slot(
-    fs: &Arc<sandboxfuse::LayeredFs>,
-    fuse_lower: &Path,
+/// Layers plus the list files a group's inputs want written.
+type SlotLayers = (Vec<sandboxfuse::Layer>, Vec<(PathBuf, Vec<PathBuf>)>);
+
+/// Build a group's FUSE layers off the runtime workers, then register the slot
+/// here on the caller's frame.
+///
+/// [`build_slot_layers`] is the expensive half — a `par_iter` that opens a
+/// seekable reader and builds a `TarIndex` per input, i.e. cache reads that park
+/// on any queued sqlite write to those keys. The rayon workers parking is their
+/// contract; the tokio worker pinned on the join for the whole group is the
+/// runtime stall `hcore::blocking` exists to remove.
+///
+/// **The registration deliberately stays out of the job.** `register_slot` is a
+/// map insert keyed by the sandbox prefix, and that prefix is stable per addr
+/// rather than per attempt — while an `hcore::blocking` job runs to completion
+/// even when its caller's future is dropped. Registering inside the job would
+/// let an abandoned attempt insert its layers over a *successor's* live slot,
+/// and then, when its unwanted `SlotGuard` was dropped on the pool thread,
+/// remove the prefix outright — the successor's sandbox would lose its inputs
+/// mid-run. Done here, a slot is only ever registered by a frame that is alive
+/// to own its guard. The insert itself is one `RwLock` write; there is nothing
+/// to offload.
+async fn try_register_slot_blocking(
+    fs: Arc<sandboxfuse::LayeredFs>,
+    fuse_lower: PathBuf,
+    unpack_root: PathBuf,
+    list_dir: PathBuf,
+    group: Vec<RunInput>,
+) -> anyhow::Result<(Option<sandboxfuse::SlotGuard>, Vec<RunInput>)> {
+    let prefix = unpack_root
+        .strip_prefix(&fuse_lower)
+        .map_err(|_e| {
+            anyhow::anyhow!(
+                "unpack_root {:?} not under FUSE mount {:?}",
+                unpack_root,
+                fuse_lower
+            )
+        })?
+        .to_path_buf();
+
+    let (built, group) = hcore::blocking::run(move || {
+        let built = build_slot_layers(&unpack_root, &list_dir, &group)?;
+        anyhow::Ok((built, group))
+    })
+    .await?;
+
+    let Some((layers, list_writes)) = built else {
+        return Ok((None, group));
+    };
+    let guard = fs.register_slot(prefix, layers);
+    for (list_path, abs_paths) in list_writes {
+        write_list_file(&list_path, &abs_paths)
+            .with_context(|| format!("write list file {:?} for fuse-slot group", list_path))?;
+    }
+    Ok((Some(guard), group))
+}
+
+/// Build one `TarIndex`-backed [`sandboxfuse::Layer`] per input, plus the list
+/// files the group's inputs want written. `None` if any input lacks a seekable
+/// reader (the FUSE path requires random-access bytes) — the caller falls back
+/// to unpack-into-upper for that group.
+///
+/// Synchronous and I/O-bound: reached from `run_inner` only through
+/// [`try_register_slot_blocking`].
+fn build_slot_layers(
     unpack_root: &Path,
     list_dir: &Path,
     group: &[RunInput],
-) -> anyhow::Result<Option<sandboxfuse::SlotGuard>> {
+) -> anyhow::Result<Option<SlotLayers>> {
     use rayon::prelude::*;
     type Built = (sandboxfuse::Layer, Option<(PathBuf, Vec<PathBuf>)>);
     let results: Vec<anyhow::Result<Option<Built>>> = group
@@ -242,20 +311,7 @@ fn try_register_slot(
         }
     }
 
-    let prefix = unpack_root.strip_prefix(fuse_lower).map_err(|_e| {
-        anyhow::anyhow!(
-            "unpack_root {:?} not under FUSE mount {:?}",
-            unpack_root,
-            fuse_lower
-        )
-    })?;
-    let guard = fs.register_slot(prefix.to_path_buf(), layers);
-
-    for (list_path, abs_paths) in list_writes {
-        write_list_file(&list_path, &abs_paths)
-            .with_context(|| format!("write list file {:?} for fuse-slot group", list_path))?;
-    }
-    Ok(Some(guard))
+    Ok(Some((layers, list_writes)))
 }
 
 fn write_list_file(list_path: &Path, paths: &[PathBuf]) -> std::io::Result<()> {
@@ -270,4 +326,102 @@ fn write_list_file(list_path: &Path, paths: &[PathBuf]) -> std::io::Result<()> {
         writeln!(f, "{}", p.display())?;
     }
     f.flush()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use hcore::hartifactcontent::tar::TarPacker;
+    use hcore::hartifactcontent::{Content, ReadSeek, WalkEntry};
+    use hplugin::driver::inputartifact::{InputArtifact, Type};
+    use std::collections::BTreeMap;
+
+    /// A tar-backed input whose `seekable_reader` records the thread it was
+    /// opened on. Both the reader open and the `TarIndex` build happen inside
+    /// `try_register_slot`'s `par_iter`, so this witnesses the whole fan-out.
+    struct ThreadRecordingTar {
+        bytes: Vec<u8>,
+        thread: Arc<std::sync::Mutex<Option<String>>>,
+    }
+
+    impl Content for ThreadRecordingTar {
+        fn reader(&self) -> anyhow::Result<Box<dyn std::io::Read>> {
+            Ok(Box::new(std::io::Cursor::new(self.bytes.clone())))
+        }
+        fn walk(&self) -> anyhow::Result<Box<dyn Iterator<Item = anyhow::Result<WalkEntry>> + '_>> {
+            Ok(Box::new(hcore::hartifactcontent::tar::TarWalker::new(
+                std::io::Cursor::new(self.bytes.clone()),
+            )?))
+        }
+        fn hashout(&self) -> anyhow::Result<String> {
+            Ok("HO".to_string())
+        }
+        fn seekable_reader(&self) -> anyhow::Result<Option<Box<dyn ReadSeek + Send>>> {
+            // Not an `expect`: this returns a `Result`, and a poisoned slot would
+            // only hide the assertion rather than signal anything.
+            let mut slot = self.thread.lock().unwrap_or_else(|e| e.into_inner());
+            *slot = std::thread::current()
+                .name()
+                .map(std::borrow::ToOwned::to_owned);
+            drop(slot);
+            Ok(Some(Box::new(std::io::Cursor::new(self.bytes.clone()))))
+        }
+    }
+
+    /// Registering a FUSE slot must not run on a tokio worker.
+    ///
+    /// It is the heaviest of the moved sites: a `par_iter` that opens a seekable
+    /// reader and builds a `TarIndex` per input. The rayon workers parking on
+    /// those cache reads is their contract — the tokio worker pinned on the join
+    /// for the whole group is not.
+    ///
+    /// Needs no FUSE mount: `LayeredFs::new_empty` + `register_slot` are a map
+    /// insert in both the real backend and the stub, so this runs on every
+    /// supported target and under either `fuse-sandbox` setting.
+    #[tokio::test]
+    async fn slot_registration_runs_off_the_runtime_workers() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let fuse_lower = dir.path().join("lower");
+        let unpack_root = fuse_lower.join("sandbox/ws");
+        let list_dir = dir.path().join("list");
+        fs::create_dir_all(&unpack_root).expect("mkdir unpack root");
+        fs::create_dir_all(&list_dir).expect("mkdir list dir");
+
+        let mut packer = TarPacker::new();
+        packer.create_raw(b"payload".to_vec(), "pkg/x.txt", false);
+        let mut bytes = Vec::new();
+        packer.pack(&mut bytes).expect("pack");
+        let thread = Arc::new(std::sync::Mutex::new(None));
+
+        let input = RunInput {
+            artifact: InputArtifact {
+                r#type: Type::Dep,
+                origin_id: "dep|a|0".to_string(),
+                content: Arc::new(ThreadRecordingTar {
+                    bytes,
+                    thread: Arc::clone(&thread),
+                }),
+            },
+            origin_id: "dep|a|0".to_string(),
+            source_addr: hmodel::htaddr::parse_addr("//pkg:_a").expect("addr"),
+            filters: vec![],
+            annotations: BTreeMap::new(),
+        };
+
+        let fs_handle = Arc::new(sandboxfuse::LayeredFs::new_empty(dir.path().join("upper")));
+        let (slot, group) =
+            try_register_slot_blocking(fs_handle, fuse_lower, unpack_root, list_dir, vec![input])
+                .await
+                .expect("register slot");
+
+        assert!(slot.is_some(), "a seekable input must register a slot");
+        assert_eq!(group.len(), 1, "the group must come back to the caller");
+        let ran_on = thread.lock().unwrap_or_else(|e| e.into_inner()).clone();
+        assert!(
+            ran_on
+                .as_deref()
+                .is_some_and(|n| n.starts_with("heph-blocking")),
+            "slot registration must run on the blocking pool, ran on {ran_on:?}"
+        );
+    }
 }

--- a/crates/driver-support/src/driver_managed.rs
+++ b/crates/driver-support/src/driver_managed.rs
@@ -442,6 +442,9 @@ pub fn list_path_for(input: &RunInput, list_dir: &Path) -> Option<PathBuf> {
 /// a collision fails fast with both producers named rather than silently
 /// last-write-wins in the sandbox (regular deps `File::create`-truncate; FUSE
 /// layers shadow by registration order — neither surfaces the conflict).
+///
+/// Synchronous and I/O-bound: call it from
+/// [`detect_output_collisions_blocking`] rather than directly from an `async fn`.
 pub fn detect_output_collisions(groups: &BTreeMap<PathBuf, Vec<RunInput>>) -> anyhow::Result<()> {
     // Absolute sandbox path -> the target that claimed it.
     let mut owners: HashMap<PathBuf, Addr> = HashMap::new();
@@ -494,6 +497,58 @@ pub fn detect_output_collisions(groups: &BTreeMap<PathBuf, Vec<RunInput>>) -> an
         }
     }
     Ok(())
+}
+
+/// [`hartifactcontent::unpack::unpack`] on the blocking pool.
+///
+/// Unpacking reads every byte of the artifact out of the cache and writes the
+/// whole tree to disk. Inline in an `async fn` it holds a runtime worker for the
+/// entire materialization — and the cache read underneath it additionally parks
+/// that thread on any queued sqlite write to the same key
+/// (`LocalCacheSQLite::reader`). With `2 * ncpu` execute permits against `ncpu`
+/// workers, enough targets in this window park every one of them and the
+/// reactor, the timer wheel and the TUI stop with them.
+///
+/// The captures are an `Arc` bump, two paths and the (usually empty) filter
+/// list. Shared by both sandbox runners and by [`crate::stage`] so the discipline
+/// has one definition — and one test — rather than three copies, only some of
+/// which run on a host with a FUSE mount.
+pub async fn unpack_blocking(
+    content: Arc<dyn hartifactcontent::Content>,
+    dst: PathBuf,
+    list_path: Option<PathBuf>,
+    filters: Vec<String>,
+) -> anyhow::Result<()> {
+    hcore::blocking::run(move || {
+        let pred = |rel: &Path| filters.iter().any(|f| Path::new(f) == rel);
+        let predicate: Option<&dyn Fn(&Path) -> bool> = if filters.is_empty() {
+            None
+        } else {
+            Some(&pred)
+        };
+        hartifactcontent::unpack::unpack(content.as_ref(), &dst, list_path.as_deref(), predicate)
+    })
+    .await
+}
+
+/// [`detect_output_collisions`] on the blocking pool, taking and returning the
+/// groups so the job can own them.
+///
+/// The check is not the cheap map walk it looks like: `entry_paths()` on a
+/// cache-backed input is a header scan over a sqlite blob, and it goes through
+/// `LocalCacheSQLite::seekable_reader`, which parks the calling thread until any
+/// queued write to that key has been committed by the single writer thread.
+/// Inline in an `async fn` that is exactly the runtime-worker stall
+/// `hcore::blocking` exists to remove; on a pool thread the park is the
+/// backend's documented contract.
+pub async fn detect_output_collisions_blocking(
+    groups: BTreeMap<PathBuf, Vec<RunInput>>,
+) -> anyhow::Result<BTreeMap<PathBuf, Vec<RunInput>>> {
+    hcore::blocking::run(move || {
+        detect_output_collisions(&groups)?;
+        anyhow::Ok(groups)
+    })
+    .await
 }
 
 /// The fs provider's package. Its `file`/`glob` targets only expose existing
@@ -944,6 +999,71 @@ mod source_map_tests {
         detect_output_collisions(&groups).expect("filtered-out path must not collide");
     }
 
+    /// Records the thread its bytes were read on, then behaves like `TarBytes`.
+    ///
+    /// The witness for every "runs off the runtime workers" test in this module:
+    /// `entry_paths` (the default) and `unpack` both go through `walk`, so one
+    /// recorder covers path enumeration and full materialization alike.
+    struct ThreadRecordingTar {
+        inner: TarBytes,
+        thread: Arc<std::sync::Mutex<Option<String>>>,
+    }
+
+    impl Content for ThreadRecordingTar {
+        fn reader(&self) -> anyhow::Result<Box<dyn Read>> {
+            self.inner.reader()
+        }
+        fn walk(&self) -> anyhow::Result<Box<dyn Iterator<Item = anyhow::Result<WalkEntry>> + '_>> {
+            record_current_thread(&self.thread);
+            self.inner.walk()
+        }
+        fn hashout(&self) -> anyhow::Result<String> {
+            self.inner.hashout()
+        }
+    }
+
+    /// Record the name of the thread this runs on into `slot`.
+    ///
+    /// A free function returning `()` rather than a lock inside `walk`: `walk`
+    /// returns a `Result`, and `clippy::unwrap_in_result` (denied in this crate)
+    /// rejects an `expect` there. Poisoning is ignored — the `Option` is still
+    /// consistent, and a poisoned slot would only hide the assertion.
+    fn record_current_thread(slot: &std::sync::Mutex<Option<String>>) {
+        let mut g = slot.lock().unwrap_or_else(|e| e.into_inner());
+        *g = std::thread::current()
+            .name()
+            .map(std::borrow::ToOwned::to_owned);
+    }
+
+    /// A `ThreadRecordingTar` over `files`, plus the slot it reports into.
+    fn recording_content(
+        files: &[(&str, &str)],
+    ) -> (Arc<dyn Content>, Arc<std::sync::Mutex<Option<String>>>) {
+        let thread = Arc::new(std::sync::Mutex::new(None));
+        let content = Arc::new(ThreadRecordingTar {
+            inner: TarBytes(pack_files(files)),
+            thread: Arc::clone(&thread),
+        });
+        (content, thread)
+    }
+
+    /// The witness itself: `hcore::blocking`'s pool threads are the only ones
+    /// named `heph-blocking-*`, so the name separates them from a runtime worker
+    /// (`tokio-runtime-worker`) and from the test thread.
+    ///
+    /// Positive rather than negative on purpose — asserting `!= "tokio-runtime-
+    /// worker"` passes vacuously under `#[tokio::test]`, whose current-thread
+    /// flavor runs the body on the test thread.
+    fn assert_ran_on_blocking_pool(thread: &Arc<std::sync::Mutex<Option<String>>>, what: &str) {
+        let ran_on = thread.lock().unwrap_or_else(|e| e.into_inner()).clone();
+        assert!(
+            ran_on
+                .as_deref()
+                .is_some_and(|n| n.starts_with("heph-blocking")),
+            "{what} must run on the blocking pool, ran on {ran_on:?}"
+        );
+    }
+
     /// Sandbox materialization must not run on a tokio worker.
     ///
     /// `build_source_map` calls `entry_paths()` per opted-in input, which for
@@ -956,42 +1076,14 @@ mod source_map_tests {
     /// only ones named `heph-blocking-*`, so the name is the witness.
     #[tokio::test]
     async fn source_map_generation_runs_off_the_runtime_workers() {
-        /// Records the thread its enumeration ran on, then behaves like `TarBytes`.
-        struct ThreadRecordingTar {
-            inner: TarBytes,
-            thread: Arc<std::sync::Mutex<Option<String>>>,
-        }
-
-        impl Content for ThreadRecordingTar {
-            fn reader(&self) -> anyhow::Result<Box<dyn Read>> {
-                self.inner.reader()
-            }
-            fn walk(
-                &self,
-            ) -> anyhow::Result<Box<dyn Iterator<Item = anyhow::Result<WalkEntry>> + '_>>
-            {
-                *self.thread.lock().expect("thread slot") = std::thread::current()
-                    .name()
-                    .map(std::borrow::ToOwned::to_owned);
-                self.inner.walk()
-            }
-            fn hashout(&self) -> anyhow::Result<String> {
-                self.inner.hashout()
-            }
-        }
-
         let dir = tempfile::tempdir().expect("tempdir");
         let ws_dir = dir.path().join("ws");
         let pkg_dir = dir.path().join("ws/pkg");
         fs::create_dir_all(&pkg_dir).expect("mkdir");
 
-        let thread = Arc::new(std::sync::Mutex::new(None));
+        let (content, thread) = recording_content(&[("pkg/x.txt", "1")]);
         let mut input = make_input("dep|a|0", "//pkg:_a", &[("pkg/x.txt", "1")]);
-        let tar = pack_files(&[("pkg/x.txt", "1")]);
-        input.input.artifact.content = Arc::new(ThreadRecordingTar {
-            inner: TarBytes(tar),
-            thread: Arc::clone(&thread),
-        });
+        input.input.artifact.content = content;
         input.unpack_root = ws_dir.clone();
 
         let inputs = write_source_map_blocking(vec![input], &ws_dir, &pkg_dir)
@@ -1003,12 +1095,52 @@ mod source_map_tests {
             pkg_dir.join("source_map.json").exists(),
             "the map itself must still be written"
         );
-        let ran_on = thread.lock().expect("thread slot").clone();
-        assert!(
-            ran_on
-                .as_deref()
-                .is_some_and(|n| n.starts_with("heph-blocking")),
-            "source map generation must run on the blocking pool, ran on {ran_on:?}"
+        assert_ran_on_blocking_pool(&thread, "source map generation");
+    }
+
+    /// The output-collision check must not run on a tokio worker either.
+    ///
+    /// It looks like a map walk, but `entry_paths()` per input is a header scan
+    /// over the artifact's bytes — for a cache-backed input, over a sqlite blob,
+    /// through `seekable_reader`, which additionally parks the calling thread
+    /// until any queued write to that key has been committed. Both sandbox
+    /// runners call it before materializing anything, on every cache miss.
+    #[tokio::test]
+    async fn output_collision_check_runs_off_the_runtime_workers() {
+        let (content, thread) = recording_content(&[("pkg/x.txt", "1")]);
+        let mut input = make_input("dep|a|0", "//pkg:_a", &[("pkg/x.txt", "1")]);
+        input.input.artifact.content = content;
+
+        let groups = detect_output_collisions_blocking(group(vec![input]))
+            .await
+            .expect("no collision");
+
+        assert_eq!(groups.len(), 1, "the groups must come back to the caller");
+        assert_ran_on_blocking_pool(&thread, "the output-collision check");
+    }
+
+    /// Unpacking an input must not run on a tokio worker.
+    ///
+    /// This is the heaviest of the three: every byte of the artifact is read out
+    /// of the cache and written to disk. Both sandbox runners and
+    /// [`crate::stage`] route through this one helper so the discipline has a
+    /// single definition — and this single test.
+    #[tokio::test]
+    async fn unpacking_an_input_runs_off_the_runtime_workers() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let dst = dir.path().join("ws");
+        fs::create_dir_all(&dst).expect("mkdir");
+        let (content, thread) = recording_content(&[("pkg/x.txt", "hello")]);
+
+        unpack_blocking(content, dst.clone(), None, Vec::new())
+            .await
+            .expect("unpack");
+
+        assert_eq!(
+            fs::read_to_string(dst.join("pkg/x.txt")).expect("unpacked file"),
+            "hello",
+            "the tree must still be materialized"
         );
+        assert_ran_on_blocking_pool(&thread, "unpacking an input");
     }
 }

--- a/crates/driver-support/src/driver_managed_os.rs
+++ b/crates/driver-support/src/driver_managed_os.rs
@@ -1,14 +1,14 @@
 use crate::driver_managed::{
-    ManagedDriver, ManagedRunInput, ShellFallback, collect_outputs, detect_output_collisions,
-    invoke_inner, list_path_for, resolve_unpack_root, write_source_map_blocking,
+    ManagedDriver, ManagedRunInput, ShellFallback, collect_outputs,
+    detect_output_collisions_blocking, invoke_inner, list_path_for, resolve_unpack_root,
+    unpack_blocking, write_source_map_blocking,
 };
 use anyhow::Context;
-use hcore::hartifactcontent;
 use hcore::hasync::Cancellable;
 use hplugin::driver::{RunInput, RunRequest, RunResponse};
 use std::collections::BTreeMap;
 use std::fs;
-use std::path::{Path, PathBuf};
+use std::path::PathBuf;
 use std::sync::Arc;
 
 /// OS-backed managed driver: materializes every input artifact to disk via
@@ -65,8 +65,11 @@ impl ManagedDriverOs {
 
         // Reject two distinct targets producing the same sandbox file before we
         // materialize anything — the copy path would otherwise silently
-        // last-write-wins.
-        detect_output_collisions(&groups)
+        // last-write-wins. Off the worker: the check enumerates every input's
+        // entry paths, which for a cache-backed input is a header scan over a
+        // sqlite blob and can park on that key's queued write.
+        let groups = detect_output_collisions_blocking(groups)
+            .await
             .with_context(|| format!("output-collision check for {}", req.target.addr.format()))?;
 
         let mut inputs: Vec<ManagedRunInput> = Vec::new();
@@ -78,7 +81,7 @@ impl ManagedDriverOs {
                 match self.stage_dir.as_deref() {
                     Some(stage_dir) if crate::stage::is_read_only(&input.annotations) => {
                         crate::stage::stage_and_link(
-                            input.artifact.content.as_ref(),
+                            &input.artifact.content,
                             stage_dir,
                             &input.source_addr.format(),
                             unpack_root.as_path(),
@@ -98,29 +101,14 @@ impl ManagedDriverOs {
                         })?;
                     }
                     _ => {
-                        // Writes the input's entire tree to disk. Inline in this
-                        // `async fn` that is a tokio worker held for the whole
-                        // materialization, and with `2 * ncpu` execute permits
-                        // against `ncpu` workers, enough targets in this window
-                        // park every one of them. The captures are an `Arc`
-                        // bump and the (usually empty) filter list.
-                        let content = Arc::clone(&input.artifact.content);
-                        let filters = input.filters.clone();
-                        let (root, lp) = (unpack_root.clone(), list_path.clone());
-                        hcore::blocking::run(move || {
-                            let pred = |rel: &Path| filters.iter().any(|f| Path::new(f) == rel);
-                            let predicate: Option<&dyn Fn(&Path) -> bool> = if filters.is_empty() {
-                                None
-                            } else {
-                                Some(&pred)
-                            };
-                            hartifactcontent::unpack::unpack(
-                                content.as_ref(),
-                                root.as_path(),
-                                lp.as_deref(),
-                                predicate,
-                            )
-                        })
+                        // Writes the input's entire tree to disk — off the
+                        // worker, see `unpack_blocking`.
+                        unpack_blocking(
+                            Arc::clone(&input.artifact.content),
+                            unpack_root.clone(),
+                            list_path.clone(),
+                            input.filters.clone(),
+                        )
                         .await
                         .with_context(|| {
                             format!(

--- a/crates/driver-support/src/stage.rs
+++ b/crates/driver-support/src/stage.rs
@@ -22,6 +22,7 @@ use hcore::hartifactcontent::{Content, unpack};
 use hcore::hasync::Cancellable;
 use hlock::hlock::{FLock, Lock};
 use std::path::{Path, PathBuf};
+use std::sync::Arc;
 
 /// Input annotation opting a dep into read-only staging. Value must be the
 /// string `"true"`. Set by producers for artifacts the consuming target only
@@ -69,7 +70,7 @@ fn sanitize_component(key: &str) -> String {
               only move the noise"
 )]
 pub async fn stage_and_link(
-    content: &dyn Content,
+    content: &Arc<dyn Content>,
     stage_root: &Path,
     key_prefix: &str,
     link_root: &Path,
@@ -82,17 +83,15 @@ pub async fn stage_and_link(
         .hashout()
         .with_context(|| format!("hashout for staging ({key_prefix})"))?;
     if hashout.is_empty() {
-        // No stable key → nothing to dedup on; behave like the copy path. The
-        // predicate is built and consumed entirely before the first await, so
-        // it never crosses a suspension point.
-        let pred = |rel: &Path| filters.iter().any(|f| Path::new(f) == rel);
-        let predicate: Option<&dyn Fn(&Path) -> bool> = if filters.is_empty() {
-            None
-        } else {
-            Some(&pred)
-        };
-        return unpack::unpack(content, link_root, list_path, predicate)
-            .with_context(|| format!("unshared unpack into {:?} (no content hash)", link_root));
+        // No stable key → nothing to dedup on; behave like the copy path.
+        return crate::driver_managed::unpack_blocking(
+            Arc::clone(content),
+            link_root.to_path_buf(),
+            list_path.map(Path::to_path_buf),
+            filters.to_vec(),
+        )
+        .await
+        .with_context(|| format!("unshared unpack into {:?} (no content hash)", link_root));
     }
 
     let group_dir = stage_root.join(sanitize_component(key_prefix));
@@ -105,18 +104,44 @@ pub async fn stage_and_link(
         std::fs::create_dir_all(&group_dir)
             .with_context(|| format!("create stage group dir {:?}", group_dir))?;
         let lock = FLock::new(&lock_path);
-        let _guard = lock
+        let guard = lock
             .lock(ctoken)
             .await
             .with_context(|| format!("acquire stage lock {:?}", lock_path))?;
-        // Re-check under the lock: another writer may have finished while we
-        // waited. The `.ready` marker is the witness, written last.
-        if !ready.exists() {
-            materialize(content, &entry)
-                .with_context(|| format!("materialize stage entry {:?}", entry))?;
-            std::fs::write(&ready, b"")
-                .with_context(|| format!("write stage ready marker {:?}", ready))?;
-        }
+
+        // Materialization reads the artifact's every byte out of the cache and
+        // writes the whole tree to disk, and the cache read parks the calling
+        // thread on any queued sqlite write to that key. Both belong off a
+        // runtime worker.
+        //
+        // The **guard moves into the job**, so the lock spans exactly the
+        // critical section it always did. Leaving it on this side would be a
+        // cancellation hole rather than a style choice: a pool job runs to
+        // completion even when its caller's future is dropped, so a cancelled
+        // consumer would release the lock while its orphaned job kept unpacking
+        // — and the next consumer, seeing no `.ready`, would take the lock and
+        // `remove_dir_all` the tree out from under it. Owning the guard keeps
+        // the whole "re-check, materialize, publish" sequence atomic against a
+        // dropped caller, exactly as it was when it ran inline.
+        //
+        // `.ready` is written inside too: it is the witness that the entry is
+        // complete, and publishing it from a future that may never be polled
+        // again would leave a materialized entry nobody can use.
+        let (content, entry_owned, ready_owned) =
+            (Arc::clone(content), entry.clone(), ready.clone());
+        hcore::blocking::run(move || {
+            let _guard = guard;
+            // Re-check under the lock: another writer may have finished while we
+            // waited. The `.ready` marker is the witness, written last.
+            if ready_owned.exists() {
+                return Ok(());
+            }
+            materialize(content.as_ref(), &entry_owned)
+                .with_context(|| format!("materialize stage entry {:?}", entry_owned))?;
+            std::fs::write(&ready_owned, b"")
+                .with_context(|| format!("write stage ready marker {:?}", ready_owned))
+        })
+        .await?;
     }
 
     // Unfiltered inputs (the common case: a whole self-contained read-only tree
@@ -132,6 +157,12 @@ pub async fn stage_and_link(
     // `tools` flatten each file into a `bin/` dir by basename — a subtree symlink
     // would list only the directory root, which they cannot use). `link_tree`
     // with empty filters links the whole tree.
+    //
+    // Both link paths stay on the calling worker, unlike the materialize above:
+    // they touch no cache and cannot park on the write queue, they hold no lock,
+    // and the common one (`link_symlinked`) is O(depth) syscalls. `link_tree` is
+    // O(files) and would be worth offloading if a filtered input ever got large
+    // — the exec `tools` shape it serves is a handful of files.
     if !filters.is_empty() || per_file {
         link_tree(&entry, link_root, list_path, filters)
             .with_context(|| format!("link staged {:?} into {:?}", entry, link_root))
@@ -394,6 +425,9 @@ fn link_symlinked(
 /// whole tree. Any partial leftover from a crashed prior attempt is removed
 /// first — `.ready` is absent here (checked under the lock), so whatever sits
 /// at `entry` is untrustworthy.
+///
+/// Synchronous and byte-moving: reached from [`stage_and_link`] only through
+/// `hcore::blocking::run`.
 fn materialize(content: &dyn Content, entry: &Path) -> anyhow::Result<()> {
     match hcore::fsutil::remove_dir_all(entry) {
         Ok(()) => {}
@@ -644,7 +678,7 @@ mod tests {
         }
     }
 
-    fn content(hash: &str, files: &[(&str, &str, bool)]) -> TarBytes {
+    fn content(hash: &str, files: &[(&str, &str, bool)]) -> Arc<dyn Content> {
         let dir = tempfile::tempdir().expect("tempdir");
         let mut packer = TarPacker::new();
         for (rel, body, x) in files {
@@ -664,10 +698,10 @@ mod tests {
         }
         let mut bytes = Vec::new();
         packer.pack(&mut bytes).expect("pack");
-        TarBytes {
+        Arc::new(TarBytes {
             bytes,
             hash: hash.to_string(),
-        }
+        })
     }
 
     fn ct() -> StdCancellationToken {
@@ -803,10 +837,10 @@ mod tests {
         );
         let mut bytes = Vec::new();
         packer.pack(&mut bytes).expect("pack");
-        let c = TarBytes {
+        let c: Arc<dyn Content> = Arc::new(TarBytes {
             bytes,
             hash: "sym1".to_string(),
-        };
+        });
 
         let tmp = tempfile::tempdir().expect("tempdir");
         let stage = tmp.path().join("stage");
@@ -1330,5 +1364,99 @@ mod tests {
             "no-hash fallback must copy a real file, not symlink"
         );
         assert!(!stage.exists(), "fallback must not create a stage entry");
+    }
+
+    /// Materializing a stage entry must not run on a tokio worker.
+    ///
+    /// It reads the artifact's every byte out of the cache and writes the whole
+    /// tree to disk — for a read-only Go SDK input, ~11k files — and the cache
+    /// read underneath parks the calling thread on any queued sqlite write to
+    /// that key. It also runs under the stage `FLock`, so a parked worker holds
+    /// the lock every other consumer of that artifact is waiting on.
+    ///
+    /// The content records the thread it was walked on;
+    /// `hcore::blocking`'s pool threads are the only ones named
+    /// `heph-blocking-*`. Asserted positively — `!= "tokio-runtime-worker"`
+    /// would pass vacuously, since `#[tokio::test]` runs the body on the test
+    /// thread.
+    #[tokio::test]
+    async fn stage_materialization_runs_off_the_runtime_workers() {
+        struct ThreadRecordingTar {
+            inner: TarBytes,
+            thread: Arc<std::sync::Mutex<Option<String>>>,
+        }
+
+        impl Content for ThreadRecordingTar {
+            fn reader(&self) -> anyhow::Result<Box<dyn Read>> {
+                self.inner.reader()
+            }
+            fn walk(
+                &self,
+            ) -> anyhow::Result<Box<dyn Iterator<Item = anyhow::Result<WalkEntry>> + '_>>
+            {
+                record_current_thread(&self.thread);
+                self.inner.walk()
+            }
+            fn hashout(&self) -> anyhow::Result<String> {
+                self.inner.hashout()
+            }
+        }
+
+        /// Record the name of the thread this runs on into `slot`.
+        ///
+        /// A free function returning `()` rather than a lock inside `walk`:
+        /// `walk` returns a `Result`, and `clippy::unwrap_in_result` (denied in
+        /// this crate) rejects an `expect` there. Poisoning is ignored — the
+        /// `Option` is still consistent, and a poisoned slot would only hide the
+        /// assertion.
+        fn record_current_thread(slot: &std::sync::Mutex<Option<String>>) {
+            let mut g = slot.lock().unwrap_or_else(|e| e.into_inner());
+            *g = std::thread::current()
+                .name()
+                .map(std::borrow::ToOwned::to_owned);
+        }
+
+        let tmp = tempfile::tempdir().expect("tempdir");
+        let stage = tmp.path().join("stage");
+        let link = tmp.path().join("ws");
+        let thread = Arc::new(std::sync::Mutex::new(None));
+        // A real hashout, so this takes the staged path and not the
+        // `unpack_blocking` fallback `no_content_hash_falls_back_to_copy` covers.
+        let inner = content("stagethread", &[("pkg/x.txt", "hello", false)]);
+        let c: Arc<dyn Content> = Arc::new(ThreadRecordingTar {
+            inner: TarBytes {
+                bytes: drain_tar(&inner),
+                hash: "stagethread".to_string(),
+            },
+            thread: Arc::clone(&thread),
+        });
+
+        stage_and_link(&c, &stage, "k", &link, None, &[], false, &ct())
+            .await
+            .expect("stage");
+
+        assert_eq!(
+            std::fs::read_to_string(link.join("pkg/x.txt")).expect("linked file"),
+            "hello",
+            "the tree must still be staged and linked"
+        );
+        let ran_on = thread.lock().unwrap_or_else(|e| e.into_inner()).clone();
+        assert!(
+            ran_on
+                .as_deref()
+                .is_some_and(|n| n.starts_with("heph-blocking")),
+            "stage materialization must run on the blocking pool, ran on {ran_on:?}"
+        );
+    }
+
+    /// The packed tar bytes behind a `content(..)` fixture, so a decorator can
+    /// wrap them.
+    fn drain_tar(c: &Arc<dyn Content>) -> Vec<u8> {
+        let mut buf = Vec::new();
+        c.reader()
+            .expect("reader")
+            .read_to_end(&mut buf)
+            .expect("read");
+        buf
     }
 }

--- a/crates/engine/src/engine/approval.rs
+++ b/crates/engine/src/engine/approval.rs
@@ -56,6 +56,45 @@ pub trait ApprovalHandler: Send + Sync {
     ) -> anyhow::Result<bool>;
 }
 
+/// [`read_notice_text`] on the blocking pool.
+///
+/// Rendering a notice walks every file of every matched artifact and pulls its
+/// bytes out of the cache, which additionally parks the calling thread on any
+/// queued sqlite write to those keys. The artifacts are `Arc`s, so the job owns
+/// them outright and survives a dropped caller future.
+///
+/// A named wrapper rather than an inline `hcore::blocking::run`, so the
+/// "off the worker" property has something a test can hold — see
+/// `notice_rendering_runs_off_the_runtime_workers`.
+async fn read_notice_text_blocking(
+    artifacts: Vec<Arc<dyn hcore::hartifactcontent::Content>>,
+) -> anyhow::Result<String> {
+    hcore::blocking::run(move || read_notice_text(&artifacts)).await
+}
+
+/// Concatenate the UTF-8 text of every file in `artifacts`. Binary bytes are
+/// rendered lossily — a notice is shown to a human, not parsed.
+///
+/// Synchronous and byte-moving: called only through
+/// [`read_notice_text_blocking`].
+fn read_notice_text(
+    artifacts: &[Arc<dyn hcore::hartifactcontent::Content>],
+) -> anyhow::Result<String> {
+    let mut out = String::new();
+    for art in artifacts {
+        for entry in art.walk().context("walk notice artifact")? {
+            let entry = entry.context("read notice artifact entry")?;
+            if let WalkEntryKind::File { mut data, .. } = entry.kind {
+                let mut bytes = Vec::new();
+                data.read_to_end(&mut bytes)
+                    .context("reading notice file")?;
+                out.push_str(&String::from_utf8_lossy(&bytes));
+            }
+        }
+    }
+    Ok(out)
+}
+
 /// Whether an input belongs to the notice group `name`. An input's `origin_id`
 /// is driver-encoded as `|`-delimited tokens with the declared group name as one
 /// segment (e.g. `dep|plan|0` for the `plan` dep group), so a notice can name the
@@ -196,17 +235,11 @@ impl Engine {
                 .with_context(|| {
                     format!("resolving notice input {}", input.target.addr.format())
                 })?;
-            for art in &res.artifacts {
-                for entry in art.walk()? {
-                    let entry = entry?;
-                    if let WalkEntryKind::File { mut data, .. } = entry.kind {
-                        let mut bytes = Vec::new();
-                        data.read_to_end(&mut bytes)
-                            .with_context(|| "reading notice file")?;
-                        out.push_str(&String::from_utf8_lossy(&bytes));
-                    }
-                }
-            }
+            let addr = input.target.addr.format();
+            let text = read_notice_text_blocking(res.artifacts.clone())
+                .await
+                .with_context(|| format!("reading notice input {addr}"))?;
+            out.push_str(&text);
         }
         Ok(out)
     }
@@ -236,7 +269,113 @@ impl Engine {
 
 #[cfg(test)]
 mod tests {
-    use super::input_in_group;
+    use super::{input_in_group, read_notice_text, read_notice_text_blocking};
+    use hcore::hartifactcontent::{Content, WalkEntry};
+    use std::sync::Arc;
+
+    /// A tar of `(path, bytes)` pairs, as a `Content`.
+    struct TarBytes(Vec<u8>);
+
+    impl Content for TarBytes {
+        fn reader(&self) -> anyhow::Result<Box<dyn std::io::Read>> {
+            Ok(Box::new(std::io::Cursor::new(self.0.clone())))
+        }
+        fn walk(&self) -> anyhow::Result<Box<dyn Iterator<Item = anyhow::Result<WalkEntry>> + '_>> {
+            Ok(Box::new(hcore::hartifactcontent::tar::TarWalker::new(
+                std::io::Cursor::new(self.0.clone()),
+            )?))
+        }
+        fn hashout(&self) -> anyhow::Result<String> {
+            Ok(String::new())
+        }
+    }
+
+    fn tar_of(files: &[(&str, &[u8])]) -> Arc<dyn Content> {
+        let mut packer = hcore::hartifactcontent::tar::TarPacker::new();
+        for (rel, body) in files {
+            packer.create_raw(body.to_vec(), *rel, false);
+        }
+        let mut bytes = Vec::new();
+        packer.pack(&mut bytes).expect("pack");
+        Arc::new(TarBytes(bytes))
+    }
+
+    /// The notice is the text a human reads before approving a target, so it
+    /// concatenates every file of every matched artifact in order, and never
+    /// fails on bytes that are not UTF-8 — a notice that errored out would block
+    /// the approval rather than merely look odd.
+    /// Rendering a notice must not run on a tokio worker: it walks every file of
+    /// every matched artifact and reads its bytes out of the cache, and that read
+    /// parks the calling thread on any queued sqlite write to those keys.
+    ///
+    /// The content records the thread it was walked on; `hcore::blocking`'s pool
+    /// threads are the only ones named `heph-blocking-*`. Asserted positively —
+    /// `!= "tokio-runtime-worker"` would pass vacuously, since `#[tokio::test]`
+    /// runs the body on the test thread.
+    #[tokio::test]
+    async fn notice_rendering_runs_off_the_runtime_workers() {
+        struct ThreadRecordingTar {
+            inner: TarBytes,
+            thread: Arc<std::sync::Mutex<Option<String>>>,
+        }
+
+        impl Content for ThreadRecordingTar {
+            fn reader(&self) -> anyhow::Result<Box<dyn std::io::Read>> {
+                self.inner.reader()
+            }
+            fn walk(
+                &self,
+            ) -> anyhow::Result<Box<dyn Iterator<Item = anyhow::Result<WalkEntry>> + '_>>
+            {
+                let mut slot = self.thread.lock().unwrap_or_else(|e| e.into_inner());
+                *slot = std::thread::current()
+                    .name()
+                    .map(std::borrow::ToOwned::to_owned);
+                drop(slot);
+                self.inner.walk()
+            }
+            fn hashout(&self) -> anyhow::Result<String> {
+                self.inner.hashout()
+            }
+        }
+
+        let mut packer = hcore::hartifactcontent::tar::TarPacker::new();
+        packer.create_raw(b"notice body\n".to_vec(), "NOTICE.txt", false);
+        let mut bytes = Vec::new();
+        packer.pack(&mut bytes).expect("pack");
+        let thread = Arc::new(std::sync::Mutex::new(None));
+        let artifacts: Vec<Arc<dyn Content>> = vec![Arc::new(ThreadRecordingTar {
+            inner: TarBytes(bytes),
+            thread: Arc::clone(&thread),
+        })];
+
+        let out = read_notice_text_blocking(artifacts).await.expect("render");
+
+        assert_eq!(out, "notice body\n", "the notice must still be rendered");
+        let ran_on = thread.lock().unwrap_or_else(|e| e.into_inner()).clone();
+        assert!(
+            ran_on
+                .as_deref()
+                .is_some_and(|n| n.starts_with("heph-blocking")),
+            "notice rendering must run on the blocking pool, ran on {ran_on:?}"
+        );
+    }
+
+    #[test]
+    fn notice_text_concatenates_every_file_and_survives_binary_bytes() {
+        let artifacts = vec![
+            tar_of(&[("a.txt", b"first\n"), ("b.txt", b"second\n")]),
+            tar_of(&[("c.bin", &[0xff, 0xfe])]),
+        ];
+
+        let out = read_notice_text(&artifacts).expect("render");
+
+        assert!(out.starts_with("first\nsecond\n"), "got {out:?}");
+        assert!(
+            out.contains('\u{fffd}'),
+            "non-UTF-8 bytes must render lossily rather than fail: {out:?}"
+        );
+    }
 
     #[test]
     fn group_matches_origin_id_segment() {

--- a/crates/engine/src/engine/gc.rs
+++ b/crates/engine/src/engine/gc.rs
@@ -640,6 +640,12 @@ mod tests {
             // trait's contract — never re-derived from `exists`.
             self.inner.existence(addr, hashin, name)
         }
+        fn exists_committed(&self, addr: &Addr, hashin: &str, name: &str) -> anyhow::Result<bool> {
+            // Likewise forwarded: only the queue's owner knows what is committed.
+            // Not counted — `barrier_reads` tracks the manifest barrier probe,
+            // which goes through `exists`.
+            self.inner.exists_committed(addr, hashin, name)
+        }
         fn delete(&self, addr: &Addr, hashin: &str, name: &str) -> anyhow::Result<()> {
             self.inner.delete(addr, hashin, name)
         }

--- a/crates/engine/src/engine/local_cache.rs
+++ b/crates/engine/src/engine/local_cache.rs
@@ -200,6 +200,24 @@ pub trait LocalCache: Send + Sync {
     /// An inline backend answers `Ok(Existence::Committed(self.exists(..)?))`
     /// explicitly; a decorator forwards to the layer that owns the queue.
     fn existence(&self, addr: &Addr, hashin: &str, name: &str) -> anyhow::Result<Existence>;
+    /// [`exists`](Self::exists) answered from the *committed* state alone, with
+    /// no regard for the write-behind queue and no wait on it.
+    ///
+    /// The answer [`existence`](Self::existence) gives as
+    /// `Existence::Committed`, available on its own. [`Engine::exists_local`]
+    /// needs it for the one case `existence` cannot serve: having spent its
+    /// retry budget on a key that keeps reporting `Queued`, it has to answer
+    /// *something*, and the only non-waiting answer is the committed one.
+    /// Falling back to `exists` there re-parked the caller on the very condvar
+    /// the loop exists to avoid.
+    ///
+    /// **Required, for the same reason as `existence`.** A default of
+    /// `self.exists(..)` is right for a backend that commits inline and silently
+    /// reinstates the park for one that queues. A decorator must mirror its own
+    /// `exists` — including any tier-local short-circuit, since an entry this
+    /// layer can serve is committed as far as any caller is concerned — rather
+    /// than delegate blind.
+    fn exists_committed(&self, addr: &Addr, hashin: &str, name: &str) -> anyhow::Result<bool>;
     fn delete(&self, addr: &Addr, hashin: &str, name: &str) -> anyhow::Result<()>;
     /// Stream the distinct target address keys (`Addr::format()`, parseable via
     /// `htaddr::parse_addr`) present in the cache. Streamed rather than collected
@@ -787,6 +805,14 @@ impl Engine {
     /// exhaustion the committed answer is the right one to return — a reader has no
     /// happens-before against a write still in flight, so "absent" was always a
     /// legitimate answer, and the `warn!` says the backend is behaving oddly.
+    ///
+    /// That exhaustion answer comes from [`LocalCache::exists_committed`], not
+    /// from `exists`. `exists` waits out the queue, so using it here re-parked
+    /// the worker in precisely the case the cap exists to prevent, while the
+    /// `warn!` claimed the opposite. The case is reachable rather than
+    /// hypothetical: `SpillWriter::spill` re-arms the pending map twice for one
+    /// key (a write, then a `delete`) every time a blob crosses the spill
+    /// threshold.
     pub(crate) async fn exists_local(
         &self,
         addr: &Addr,
@@ -806,7 +832,7 @@ impl Engine {
             waits = MAX_QUEUE_WAITS,
             "local cache kept reporting a queued write for one key; answering from committed state"
         );
-        self.local_cache.exists(addr, hashin, name)
+        self.local_cache.exists_committed(addr, hashin, name)
     }
 
     /// Build this caller's artifact set from an already-parsed `manifest`, gating
@@ -1413,11 +1439,16 @@ mod tests {
     /// A backend that reports the write queue a fixed number of times before
     /// settling — a key rewritten while it is being probed, or a backend that has
     /// gone wrong and keeps claiming a queue forever.
+    ///
+    /// `exists` **blocks**, standing in for the real backend's
+    /// `wait_if_pending`: `exists_local` must never reach it, and a double that
+    /// answered instantly would let a regression through unnoticed.
     struct QueuedTimes {
         queued_answers: std::sync::Mutex<usize>,
         committed: bool,
         existence_calls: Arc<std::sync::atomic::AtomicUsize>,
         exists_calls: Arc<std::sync::atomic::AtomicUsize>,
+        exists_committed_calls: Arc<std::sync::atomic::AtomicUsize>,
     }
 
     impl LocalCache for QueuedTimes {
@@ -1429,6 +1460,18 @@ mod tests {
         }
         fn exists(&self, _: &Addr, _: &str, _: &str) -> anyhow::Result<bool> {
             self.exists_calls
+                .fetch_add(1, std::sync::atomic::Ordering::SeqCst);
+            // The waiting variant: `LocalCacheSQLite::exists` parks on the
+            // pending slot's untimed condvar. Sleeping rather than blocking
+            // forever so a regression ends with the counters intact instead of
+            // hanging the suite — comfortably past the caller's 5s timeout, but
+            // not so long that a failing run is painful. Never reached while the
+            // fallback goes through `exists_committed`, so it costs nothing.
+            std::thread::sleep(std::time::Duration::from_secs(10));
+            Ok(self.committed)
+        }
+        fn exists_committed(&self, _: &Addr, _: &str, _: &str) -> anyhow::Result<bool> {
+            self.exists_committed_calls
                 .fetch_add(1, std::sync::atomic::Ordering::SeqCst);
             Ok(self.committed)
         }
@@ -1468,6 +1511,7 @@ mod tests {
             committed: true,
             existence_calls: calls.clone(),
             exists_calls: Arc::new(std::sync::atomic::AtomicUsize::new(0)),
+            exists_committed_calls: Arc::new(std::sync::atomic::AtomicUsize::new(0)),
         }));
 
         assert!(
@@ -1487,15 +1531,28 @@ mod tests {
     /// A backend that never settles must not spin a worker. The loop gives up
     /// after a bounded number of waits and answers from committed state, which is
     /// a legitimate answer for a reader with no happens-before against the write.
+    ///
+    /// And it must reach that answer **without waiting**. `exists` is the
+    /// backend's waiting probe — on sqlite it parks on `PendingSlot`'s untimed
+    /// condvar — so falling back to it here re-parks the worker in exactly the
+    /// case the cap exists to prevent, while the `warn!` claims the opposite.
+    /// The double's `exists` therefore blocks: swap `exists_committed` back to
+    /// `exists` in `exists_local` and this test fails on the call counters
+    /// below. Not on the `timeout` — `#[tokio::test]` is current-thread, so the
+    /// double's `sleep` blocks the runtime and the timer never fires; the sleep
+    /// is there to make the park *real* rather than to trip a deadline, and the
+    /// counters are what catch it.
     #[tokio::test]
-    async fn exists_local_gives_up_after_a_bounded_number_of_waits() {
+    async fn exists_local_gives_up_without_ever_waiting_on_the_queue() {
         let existence_calls = Arc::new(std::sync::atomic::AtomicUsize::new(0));
         let exists_calls = Arc::new(std::sync::atomic::AtomicUsize::new(0));
+        let exists_committed_calls = Arc::new(std::sync::atomic::AtomicUsize::new(0));
         let (engine, _dir) = engine_with_cache(Arc::new(QueuedTimes {
             queued_answers: std::sync::Mutex::new(usize::MAX),
             committed: false,
             existence_calls: existence_calls.clone(),
             exists_calls: exists_calls.clone(),
+            exists_committed_calls: exists_committed_calls.clone(),
         }));
 
         let found = tokio::time::timeout(
@@ -1513,9 +1570,14 @@ mod tests {
             "the retries must be capped"
         );
         assert_eq!(
-            exists_calls.load(std::sync::atomic::Ordering::SeqCst),
+            exists_committed_calls.load(std::sync::atomic::Ordering::SeqCst),
             1,
             "the capped-out answer comes from one committed-state probe"
+        );
+        assert_eq!(
+            exists_calls.load(std::sync::atomic::Ordering::SeqCst),
+            0,
+            "the capped-out path must never call the queue-waiting probe"
         );
     }
 }

--- a/crates/engine/src/engine/local_cache_fs.rs
+++ b/crates/engine/src/engine/local_cache_fs.rs
@@ -150,6 +150,11 @@ impl LocalCache for LocalCacheFS {
         Ok(Existence::Committed(self.exists(addr, hashin, name)?))
     }
 
+    fn exists_committed(&self, addr: &Addr, hashin: &str, name: &str) -> Result<bool> {
+        // No queue, so every answer this backend can give is committed.
+        self.exists(addr, hashin, name)
+    }
+
     fn delete(&self, addr: &Addr, hashin: &str, name: &str) -> Result<()> {
         let path = self.get_path(addr, hashin, name);
         if path.exists() {

--- a/crates/engine/src/engine/local_cache_mem.rs
+++ b/crates/engine/src/engine/local_cache_mem.rs
@@ -115,6 +115,17 @@ impl LocalCache for LocalCacheMem {
         self.inner.existence(addr, hashin, name)
     }
 
+    fn exists_committed(&self, addr: &Addr, hashin: &str, name: &str) -> Result<bool> {
+        let key = Self::key(addr, hashin, name);
+        // Mirrors `exists`/`existence`, peek included: a resident entry is
+        // served by `reader` from this tier alone, so it is committed as far as
+        // any caller is concerned, whatever the durable backend's queue says.
+        if self.cache.peek(&key).is_some() {
+            return Ok(true);
+        }
+        self.inner.exists_committed(addr, hashin, name)
+    }
+
     fn delete(&self, addr: &Addr, hashin: &str, name: &str) -> Result<()> {
         let key = Self::key(addr, hashin, name);
         self.cache.remove(&key);
@@ -240,6 +251,12 @@ mod tests {
         // In-memory map, committed the instant the writer drops.
         fn existence(&self, addr: &Addr, hashin: &str, name: &str) -> Result<Existence> {
             Ok(Existence::Committed(self.exists(addr, hashin, name)?))
+        }
+
+        fn exists_committed(&self, addr: &Addr, hashin: &str, name: &str) -> Result<bool> {
+            // Commits inline, so the committed answer is just `exists`. Counted
+            // the same way, so a probe through either name is visible.
+            self.exists(addr, hashin, name)
         }
 
         fn delete(&self, addr: &Addr, hashin: &str, name: &str) -> Result<()> {
@@ -406,6 +423,9 @@ mod tests {
         }
         fn existence(&self, _: &Addr, _: &str, _: &str) -> Result<Existence> {
             Ok(Existence::Committed(true))
+        }
+        fn exists_committed(&self, _: &Addr, _: &str, _: &str) -> Result<bool> {
+            Ok(true)
         }
         fn delete(&self, _: &Addr, _: &str, _: &str) -> Result<()> {
             Ok(())

--- a/crates/engine/src/engine/local_cache_spill.rs
+++ b/crates/engine/src/engine/local_cache_spill.rs
@@ -130,6 +130,13 @@ impl LocalCache for LocalCacheSpill {
         }
     }
 
+    fn exists_committed(&self, addr: &Addr, hashin: &str, name: &str) -> Result<bool> {
+        // Mirrors `exists`: a blob lives in exactly one backend and the caller
+        // does not know which, so both are asked. Neither wait on a queue.
+        Ok(self.primary.exists_committed(addr, hashin, name)?
+            || self.blobs.exists_committed(addr, hashin, name)?)
+    }
+
     fn delete(&self, addr: &Addr, hashin: &str, name: &str) -> Result<()> {
         // A blob lives in exactly one backend, but the deleter (GC) doesn't know
         // which — both deletes are no-ops on the absent side. The FS delete also

--- a/crates/engine/src/engine/local_cache_sqlite.rs
+++ b/crates/engine/src/engine/local_cache_sqlite.rs
@@ -832,6 +832,12 @@ impl LocalCache for LocalCacheSQLite {
         ))
     }
 
+    fn exists_committed(&self, addr: &Addr, hashin: &str, name: &str) -> Result<bool> {
+        // The inherent `exists_committed` is exactly this method's contract: one
+        // indexed point lookup, no `wait_if_pending`.
+        Self::exists_committed(self, &Self::key(addr), hashin, name)
+    }
+
     fn list_targets(&self) -> Result<TargetStream> {
         // Stream distinct addrs over a bounded channel: the producer holds one
         // pooled connection and a `SELECT DISTINCT addr` cursor on a dedicated

--- a/crates/engine/src/engine/local_cache_tmp.rs
+++ b/crates/engine/src/engine/local_cache_tmp.rs
@@ -145,6 +145,16 @@ impl LocalCache for LocalCacheTmp {
         self.durable.existence(addr, hashin, name)
     }
 
+    fn exists_committed(&self, addr: &Addr, hashin: &str, name: &str) -> Result<bool> {
+        let key = Self::key(addr, hashin, name);
+        // Mirrors `exists`. Unlike the mem tier this map has no eviction, so an
+        // admitted entry stays readable from here for the process's life.
+        if self.store.map.read().contains_key(&key) {
+            return Ok(true);
+        }
+        self.durable.exists_committed(addr, hashin, name)
+    }
+
     fn delete(&self, addr: &Addr, hashin: &str, name: &str) -> Result<()> {
         let key = Self::key(addr, hashin, name);
         if let Some(v) = self.store.map.write().remove(&key) {
@@ -308,6 +318,10 @@ mod tests {
         // In-memory map, committed the instant the writer drops.
         fn existence(&self, addr: &Addr, hashin: &str, name: &str) -> Result<Existence> {
             Ok(Existence::Committed(self.exists(addr, hashin, name)?))
+        }
+        fn exists_committed(&self, addr: &Addr, hashin: &str, name: &str) -> Result<bool> {
+            // Commits inline: nothing to distinguish from `exists`.
+            self.exists(addr, hashin, name)
         }
         fn delete(&self, addr: &Addr, hashin: &str, name: &str) -> Result<()> {
             let key = (addr.format(), hashin.to_string(), name.to_string());

--- a/crates/engine/src/engine/result.rs
+++ b/crates/engine/src/engine/result.rs
@@ -2346,6 +2346,9 @@ impl Engine {
     ///   semantics). `Copy` (net-new) groups additionally stamp every written
     ///   file with the codegen xattr so a later fs glob excludes them; `InPlace`
     ///   groups are not stamped (they overwrite tracked source files).
+    ///
+    /// The gates are cheap and stay here; everything past them runs on
+    /// `hcore::blocking` (see [`Self::materialize_codegen_tree`]).
     async fn materialize_codegen(
         &self,
         is_top: bool,
@@ -2369,13 +2372,48 @@ impl Engine {
             return Ok(false);
         }
 
+        // Past the gates this walks every generated file, reads its bytes out of
+        // the cache, reads the tree file back and (when frozen) diffs the two —
+        // the heaviest synchronous read on the result path, and one that parks
+        // on any queued sqlite write to the artifact it is walking. It does not
+        // belong on a runtime worker. Cloned rather than borrowed because a pool
+        // job outlives a dropped caller future: an `Arc<TargetDef>` bump and a
+        // `Vec` of `ResultArtifact` (an `Arc` plus two short strings each).
+        //
+        // Outliving the caller is the accepted cost here. A run cancelled mid
+        // write-back reports cancelled while the job finishes rewriting the
+        // tree, where before it could only be interrupted by a signal. Stopping
+        // half way would be worse: the write-back is per-file and the tree is
+        // the user's source, so an abandoned job leaves a *partial* codegen tree
+        // either way, and letting it finish at least leaves a consistent one.
+        let (target, cached, root) = (
+            Arc::clone(&def.target),
+            cached.to_vec(),
+            self.cfg.root.clone(),
+        );
+        hcore::blocking::run(move || {
+            Self::materialize_codegen_tree(&target, &cached, &root, frozen)
+        })
+        .await
+    }
+
+    /// The body of [`Self::materialize_codegen`], past its gates.
+    ///
+    /// Synchronous and byte-moving: called only through `hcore::blocking::run`.
+    fn materialize_codegen_tree(
+        target: &crate::engine::driver::targetdef::TargetDef,
+        cached: &[ResultArtifact],
+        root: &std::path::Path,
+        frozen: bool,
+    ) -> anyhow::Result<bool> {
+        use crate::engine::driver::targetdef::path::CodegenMode;
+
         // Whether anything about the tree actually moved. Content writes, exec-bit
         // reconciles and symlink recreates all count; the codegen xattr does not
         // (it is metadata, outside the `@heph/fs` content+exec-bit hash). `false`
         // therefore means the tree still hashes exactly as it did before this
         // call — which is what lets the caller skip the fixpoint recompute.
         let mut wrote = false;
-        let root = &self.cfg.root;
         let mut frozen_diff = String::new();
 
         // Map each codegen output group to its declared mode (first non-None
@@ -2385,7 +2423,7 @@ impl Engine {
         // artifact, and exactly once.
         let mut group_mode: std::collections::HashMap<&str, &CodegenMode> =
             std::collections::HashMap::new();
-        for output in &def.target.outputs {
+        for output in &target.outputs {
             if let Some(mode) = output
                 .paths
                 .iter()
@@ -2495,7 +2533,7 @@ impl Engine {
                 // target hits the fixpoint cache instead of re-executing.
                 // Skipping identical writes also avoids needless source-control
                 // churn and pointless mtime bumps.
-                let stamp = def.target.addr.format();
+                let stamp = target.addr.format();
                 let walker = artifact
                     .content
                     .walk()
@@ -2610,7 +2648,7 @@ impl Engine {
 
         if frozen && !frozen_diff.is_empty() {
             return Err(anyhow::Error::new(crate::engine::error::FrozenCheckError {
-                addr: def.target.addr.clone(),
+                addr: target.addr.clone(),
                 diff: frozen_diff,
             }));
         }
@@ -7110,6 +7148,16 @@ mod tests {
             ) -> anyhow::Result<Existence> {
                 self.inner.existence(addr, hashin, name)
             }
+            // Forwarded for the same reason: only the layer that owns the write
+            // queue can answer "committed" without waiting on it.
+            fn exists_committed(
+                &self,
+                addr: &Addr,
+                hashin: &str,
+                name: &str,
+            ) -> anyhow::Result<bool> {
+                self.inner.exists_committed(addr, hashin, name)
+            }
             fn delete(&self, addr: &Addr, hashin: &str, name: &str) -> anyhow::Result<()> {
                 self.inner.delete(addr, hashin, name)
             }
@@ -8858,6 +8906,113 @@ mod tests {
             "--shell on a cached alias still shells into the member",
         );
         assert_eq!(h.probe.calls.load(Ordering::SeqCst), 2);
+        Ok(())
+    }
+
+    /// The codegen write-back must not run on a tokio worker.
+    ///
+    /// It is the heaviest synchronous read on the result path: it walks every
+    /// generated file, pulls its bytes out of the cache, reads the tree file back
+    /// and (when frozen) diffs the two. The cache read underneath additionally
+    /// parks the calling thread until any queued sqlite write to that artifact
+    /// has been committed — and the artifacts it walks come straight from
+    /// `cache_locally`, which queues them.
+    ///
+    /// The content records the thread it was walked on. `hcore::blocking`'s pool
+    /// threads are the only ones named `heph-blocking-*`, so the name is the
+    /// witness. Asserted positively: `!= "tokio-runtime-worker"` would pass
+    /// vacuously, since `#[tokio::test]` runs the body on the test thread.
+    #[tokio::test]
+    async fn codegen_write_back_runs_off_the_runtime_workers() -> anyhow::Result<()> {
+        use crate::engine::driver::targetdef::path;
+
+        /// A one-file tar that records the thread its walk ran on.
+        struct ThreadRecordingTar {
+            bytes: Vec<u8>,
+            thread: Arc<std::sync::Mutex<Option<String>>>,
+        }
+
+        impl Content for ThreadRecordingTar {
+            fn reader(&self) -> anyhow::Result<Box<dyn std::io::Read>> {
+                Ok(Box::new(std::io::Cursor::new(self.bytes.clone())))
+            }
+            fn walk(
+                &self,
+            ) -> anyhow::Result<Box<dyn Iterator<Item = anyhow::Result<WalkEntry>> + '_>>
+            {
+                *self.thread.lock().expect("thread slot") = std::thread::current()
+                    .name()
+                    .map(std::borrow::ToOwned::to_owned);
+                Ok(Box::new(hcore::hartifactcontent::tar::TarWalker::new(
+                    std::io::Cursor::new(self.bytes.clone()),
+                )?))
+            }
+            fn hashout(&self) -> anyhow::Result<String> {
+                Ok("HO".to_string())
+            }
+        }
+
+        let root = tempdir()?;
+        let engine = Engine::new(Config {
+            root: root.path().to_path_buf(),
+            home_dir: std::path::PathBuf::new(),
+            parallelism: None,
+            ..Default::default()
+        })?;
+
+        let mut packer = hcore::hartifactcontent::tar::TarPacker::new();
+        packer.create_raw(b"generated\n".to_vec(), "gen.txt", false);
+        let mut bytes = Vec::new();
+        packer.pack(&mut bytes)?;
+        let thread = Arc::new(std::sync::Mutex::new(None));
+
+        let def = LinkedTargetDef {
+            target: Arc::new(TargetDef {
+                addr: hmodel::htaddr::parse_addr("//pkg:gen")?,
+                labels: Vec::new(),
+                raw_def: Arc::new(()),
+                inputs: Vec::new(),
+                outputs: vec![crate::engine::driver::targetdef::Output {
+                    group: "out".to_string(),
+                    paths: vec![path::Path {
+                        content: path::Content::FilePath("gen.txt".to_string()),
+                        codegen_tree: path::CodegenMode::Copy,
+                        collect: false,
+                    }],
+                }],
+                support_files: Vec::new(),
+                cache: crate::engine::driver::targetdef::CacheConfig::on(false),
+                pty: false,
+                hash: Vec::new(),
+                transparent: false,
+            }),
+            inputs: Vec::new(),
+        };
+        let cached = vec![ResultArtifact {
+            content: Arc::new(ThreadRecordingTar {
+                bytes,
+                thread: Arc::clone(&thread),
+            }),
+            group: "out".to_string(),
+            r#type: ManifestArtifactType::Output,
+        }];
+
+        let wrote = engine
+            .materialize_codegen(true, &def, &cached, false)
+            .await?;
+
+        assert!(wrote, "the tree must actually be written back");
+        assert_eq!(
+            std::fs::read_to_string(root.path().join("gen.txt"))?,
+            "generated\n",
+        );
+        let ran_on = thread.lock().expect("thread slot").clone();
+        assert!(
+            ran_on
+                .as_deref()
+                .is_some_and(|n| n.starts_with("heph-blocking")),
+            "the codegen write-back must run on the blocking pool, ran on {ran_on:?}"
+        );
         Ok(())
     }
 }


### PR DESCRIPTION
**P2.3** of the threading/scale remediation — the half #201 left, reached by a different route than it advertised.

## Problem

`LocalCacheSQLite::reader` and `seekable_reader` both open with `self.pending.wait_if_pending(..)`, which parks the calling thread on an untimed condvar until the single sqlite writer thread commits its next batch. #201 made that wait *awaitable* for `exists` (`Existence::Queued(PendingWrite)`, driven by `Engine::exists_local`) and closed with: "`reader` and `seekable_reader` still park, and they have their own callers on tokio workers — the driver unpack/staging path, `materialize_codegen`, `render_notice`, `resolve_target_go`. Making those awaitable means a two-phase read API. Its own PR."

This is that PR, and tracing the callers changed the answer.

**No tokio worker calls `LocalCache::reader` or `seekable_reader` directly.** Every direct caller is already on `hcore::blocking` or a dedicated OS thread: `read_manifest_blocking`, `duplicate_cache_entry`, the remote-cache upload paths, `SpillWriter::spill`, `gc_entry`/`trim_addr_history`, `list_targets`' producer, the FUSE `LayerOpener` (a FUSE session thread).

Every genuine worker-side offender reaches the cache through the **synchronous** `hcore::hartifactcontent::Content` trait — `reader`/`walk`/`entry_paths`/`seekable_reader` on a `CacheArtifact`:

| where | what it does on the worker |
|---|---|
| `driver_managed_os.rs:69`, `driver_managed_fuse.rs:72` — `detect_output_collisions` | `entry_paths()` per input: a `TarIndex` header scan over a sqlite blob. ~11k preads for a Go SDK input. |
| `driver_managed_fuse.rs:105` — fallback `unpack` | every byte of the artifact, read and written |
| `driver_managed_fuse.rs:133` — `write_source_map` | `entry_paths()` per opted-in input |
| `stage.rs` — `stage_and_link`'s `materialize` | every byte, under the stage `FLock` |
| `result.rs` — `materialize_codegen` | walks every generated file, `read_to_end`s it, reads the tree file back, diffs when frozen |
| `approval.rs` — `render_notice` | walks and reads every notice file |
| `driver_managed_fuse.rs:196` — `try_register_slot` | parks rayon workers, pins the calling tokio worker on the join |

`Content` is sync, and it is implemented across the `extern "C"` plugin seam (`plugin-sdk`, `plugin-stabby`), so no `async fn` on `LocalCache` can be called from any of them. A two-phase `LocalCache` read API would have had **no consumer, and none obtainable** — the population that needs it does not hold the cache.

The queue-park is also the smaller half at every one of these sites. The same call moves the artifact's bytes synchronously on a runtime worker: with `2 * ncpu` execute permits against `ncpu` workers, enough targets in the materialization window park every worker, and the reactor, the timer wheel, in-flight remote transfers and the TUI stop with them. That is the failure `hcore::blocking` was written to remove, and it is already half-removed — `driver_managed_os.rs` moved its unpack and its source map onto the pool, with `source_map_generation_runs_off_the_runtime_workers` freezing the discipline. The FUSE twin of that exact call was still inline.

## Change

Move the synchronous artifact reads off the runtime workers, so that every remaining caller of `reader`/`seekable_reader` is on a thread where parking is the backend's documented contract — the same standard GC's `delete` and the FUSE session thread are already held to.

### 1. The offload lives in shared `driver-support` helpers

`unpack_blocking` and `detect_output_collisions_blocking` join the existing `write_source_map_blocking`. Both sandbox runners *and* `crate::stage` route through them, so the discipline has one definition rather than three copies.

Placement is deliberate, not tidiness: four of the seven sites are in the FUSE runner, and CI has no macFUSE (`heph.yml`: "No macFUSE on the runner… FUSE mount tests skip"). An assertion written inside `ManagedDriverFuse::run_inner` would run on two of three supported targets and be dead on `darwin/arm64`. Written against the helper, it runs everywhere and the runners only have to call it.

### 2. The seven sites

- **`detect_output_collisions`** (both runners) — take-and-return, the shape `write_source_map_blocking` already uses.
- **FUSE `write_source_map`** → `write_source_map_blocking`. The OS path has called it since it was written; this closes the divergence, and the existing test now covers both sides through the shared helper.
- **FUSE fallback `unpack`** → `unpack_blocking`, identical to the OS runner.
- **`try_register_slot`** → split into `build_slot_layers` (the `par_iter` — a seekable reader and a `TarIndex` per input) on the pool, and the `register_slot` insert on the caller's frame. The `par_iter` itself is left alone: rayon workers parking on cache reads is their contract, and what was wrong is the tokio worker pinned on the join. The registration is deliberately *outside* the job, because a pool job outlives a dropped caller: `register_slot` is keyed by a sandbox prefix that is stable per addr rather than per attempt, so an abandoned attempt registering inside the job could insert its layers over a successor's live slot and then — dropping its unwanted `SlotGuard` on the pool thread — remove that prefix outright, and the successor's sandbox would lose its inputs mid-run. Registered on the caller's frame, a slot is only ever created by a frame that is alive to own its guard.
- **`stage_and_link`** — `content: &dyn Content` becomes `&Arc<dyn Content>` so `materialize` can own a `'static` job. The **stage lock guard moves into the job**, along with the re-check and the `.ready` write. That is a correctness requirement, not a style choice: an `hcore::blocking` job runs to completion even when its caller's future is dropped, so leaving the guard on the caller's side would let a cancelled consumer release the lock while its orphaned job kept unpacking — and the next consumer, seeing no `.ready`, would take the lock and `remove_dir_all` the tree out from under it. Owning the guard keeps "re-check, materialize, publish" atomic against a dropped caller, exactly as it was when the whole sequence ran inline with no await point in it.
- **`materialize_codegen`** — the gates (`is_top`, declares a codegen path) are cheap and stay in the `async fn`; everything past them becomes `materialize_codegen_tree` on the pool. The body contained no `await` at all, so this is a move rather than a restructure.
- **`render_notice`** — the walk+read becomes `read_notice_text`, reached through a named `read_notice_text_blocking` wrapper (named rather than inline so the "off the worker" property has something a test can hold). Its two bare `?`s on I/O now carry `.context`.

### 3. `exists_local` no longer re-parks the worker it just protected

Not the headline, but the same bug and found while auditing it. `Engine::exists_local` caps its retries at `MAX_QUEUE_WAITS` and then falls back — to `LocalCache::exists`, which **waits on the queue**. So the loop whose entire purpose is to keep a worker off that condvar put it right back on, while the `warn!` said "answering from committed state".

The trait had no committed-only probe to fall back to, so this adds one:

```rust
fn exists_committed(&self, addr: &Addr, hashin: &str, name: &str) -> anyhow::Result<bool>;
```

**Required, no default**, for #201's reason: `self.exists(..)` is right for a backend that commits inline and silently reinstates the park for one that queues, and a decorator that forwarded `exists` and inherited the default would put it straight back. Required means the compiler asks all five tiers and all six test doubles which one they are — which is how `local_cache_mem`'s LRU `peek` and `local_cache_tmp`'s map check got mirrored rather than delegated blind.

The exhaustion case is reachable rather than theoretical: `SpillWriter::spill` re-arms the pending map twice for one key (the staged prefix's write, then the `delete`) every time a blob crosses the spill threshold.

## Semantic change

Every move is a thread change: the same function, the same order, the same errors, run on `hcore::blocking`'s pool instead of inline. The one behavioural fix is §3, where the exhaustion answer now comes from committed state — which is what its own doc comment already claimed.

There is one consequence worth stating plainly, because it is the whole hazard class of this change. **An `hcore::blocking` job runs to completion even when its caller's future is dropped**, so every side effect moved into a job can now outlive a cancelled caller. Three sites were audited for it:

- **`stage_and_link`** — a real bug if written the obvious way, and the reason the lock guard moved into the job (above).
- **`try_register_slot_blocking`** — a real bug if written the obvious way, and the reason the registration stayed out of the job (above).
- **`materialize_codegen`** — accepted. A run cancelled mid-write-back now reports cancelled while the job finishes rewriting the tree, where before only a signal could interrupt it. Stopping half way would be worse rather than better: the write-back is per-file over the user's own source, so an abandoned job leaves a partial tree either way, and letting it finish at least leaves a consistent one.

The remaining moved sites (`unpack_blocking`, `detect_output_collisions_blocking`, `write_source_map_blocking`, `read_notice_text_blocking`) write only into a sandbox the cancelled caller owns, or nothing at all.

## Callers deliberately left parking

Parking is correct on a thread that may block, and converting these would cost clarity for nothing:

- **`LocalCache::delete`** — waits by contract; GC counts freed bytes against it. Its callers (`gc_entry`, `SpillWriter::spill`) are on the pool or the sandbox-cleaner thread.
- **The FUSE `LayerOpener`** (`driver_managed_fuse.rs:223`) — invoked from `sandboxfuse`'s `read`/`copy_up_layer_entry`, on a FUSE session thread that exists to block.
- **`read_manifest_blocking`, `duplicate_cache_entry`, `upload_to_remote_inner`'s manifest read and its encode closures, `SpillWriter::spill`, `gc_entry`/`trim_addr_history`** — already on `hcore::blocking` or the sandbox-cleaner thread.
- **`list_targets`' producer** — its own named thread, holding a cursor for the whole GC stream by design.
- **`try_register_slot`'s `par_iter` bodies** — rayon workers. What was wrong was the tokio worker pinned on the join, and that is what moved.

## Tests

Six thread-name assertions, one per moved shape, each written against the content itself: a `Content` that records the thread it was walked on. `hcore::blocking`'s pool threads are the only ones named `heph-blocking-*`, so the name is the witness.

Asserted **positively** (`starts_with("heph-blocking")`), never as `!= "tokio-runtime-worker"` — the negative form passes vacuously, because `#[tokio::test]`'s current-thread flavor runs the body on the test thread, which is named after the test.

- `output_collision_check_runs_off_the_runtime_workers`
- `unpacking_an_input_runs_off_the_runtime_workers`
- `stage_materialization_runs_off_the_runtime_workers`
- `slot_registration_runs_off_the_runtime_workers` — and it needs no FUSE mount, which matters: `LayeredFs::new_empty` + `register_slot` are a map insert in the real backend *and* in the `fuse-sandbox`-off stub, so this runs on all three supported targets rather than only where macFUSE exists. `driver_managed_fuse.rs` had no test module at all before this.
- `codegen_write_back_runs_off_the_runtime_workers`
- `notice_rendering_runs_off_the_runtime_workers`
- `exists_local_gives_up_without_ever_waiting_on_the_queue` — replaces `exists_local_gives_up_after_a_bounded_number_of_waits`, which could not have caught §3: its double answered `exists` instantly, so the fallback's park was invisible. The double's `exists` now blocks, standing in for `wait_if_pending`, and the test asserts the queue-waiting probe is called **zero** times. (It fails on the call counters, not on the `timeout` — `#[tokio::test]` is current-thread, so a blocking double stops the timer too. The comment says so.)
- `notice_text_concatenates_every_file_and_survives_binary_bytes` — correctness of `read_notice_text`: every file of every artifact, in order, with non-UTF-8 bytes rendered lossily rather than failing the approval.

**Every one of them verified load-bearing** by breaking the fix and confirming the failure: the six thread assertions reverted to the inline call (each then reports the test's own thread), and `exists_local_gives_up_without_ever_waiting_on_the_queue` with the fallback reverted to `exists` (the run blocks and the committed-probe count is 0 instead of 1).

`lint` (both clippy passes and `fmt --check`) is clean; `cargo test -p engine -p driver-support -p driver-bridge` and `cargo test -p e2e --test codegen_in_place` pass.

## Not in this PR

**No two-phase `reader`/`seekable_reader` on `LocalCache`.** The API #201 pointed at was designed, reviewed and dropped: it has no reachable consumer, and none is obtainable without making `Content` async, which crosses the plugin ABI seam. If a settle primitive is ever wanted, the place for it is right after `pull_missing_blobs` — the one point where the queued keys are *known* rather than guessed — and not at `artifacts_from_manifest`, where the warm path already settled through `exists_local` and would pay a probe per blob to learn nothing.

**Two worker-side sites remain, both narrow.** `resolve_target_go` (`plugin-go/.../toolchain.rs:269`) calls `entry_paths()` on a worker, but only for `gotool = "//pkg:go"` and only when the go plugin runs in-process — as a cdylib, `plugin-sdk` substitutes `DiskInputContent` and it never reaches the cache. And `src/commands/run.rs`'s `--cat-out`/`--list-out`/`--copy-out` read on the runtime's `block_on` thread, after every worker has drained; lower severity, and it wants the CLI output path looked at as a whole.

**The plugin seam still parks.** `plugin-stabby`'s `HostArtifactContent::open` calls `CacheArtifact::reader()` inside an `extern "C"` call, on whichever host thread is polling the guest future. `plugin-sdk`'s `guest.rs` tries to avoid the seam via `handle.path()`, but only `LocalCacheFS` implements `file_path` — `Mem`, `Tmp` and `Spill` all inherit the `None` default, so in the production stack that fast path is dead for every key and every plugin artifact streams across the ABI. Worth its own issue; it is a wider bug than this one.

**Pool pressure is now slightly higher.** More cache readers run on `hcore::blocking`'s fixed `2*cores` threads. No deadlock is possible — the sqlite writer is a dedicated thread and drains regardless, and nothing inside a moved job needs the pool again — but two things are worth naming. `read_pool_headroom` is derived from `pipe_limit`, not from the blocking pool size, and its own doc calls it "a budget, not a proof"; bounding it against `hcore::blocking::pool_size()` is a reasonable follow-up. And `try_register_slot_blocking` holds a pool slot while it does nothing but wait on a rayon join, which is head-of-line blocking rather than work — fanning the per-input `TarIndex::build`s out as individual pool jobs would put the whole thing under one bound. Both noted, neither acted on here.

**`link_tree` stays on the worker.** The stage's link half touches no cache and holds no lock, and the common path (`link_symlinked`) is O(depth) syscalls. `link_tree` is O(files) and would be worth offloading if a filtered input ever got large; the exec `tools` shape it serves is a handful of files. Stated at the call site so the asymmetry is deliberate rather than an oversight.

**No test forces a decorator's `exists_committed` to agree with its own `exists`.** All five tiers do, and the doc says they must, but the sixth implementor gets it right only by reading. A shared test parameterised over the decorators would close it.

**Still untested, and pre-existing:** a dead sqlite writer thread degrading to a rebuild (`DrainOnExit` is the mechanism; nothing asserts the engine-level outcome), and `register_and_send` returning `None` dropping a write silently.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015fwgLLsXhwNN4wHNJQg9Qf
