### PR TITLE
fix(engine): implement `exists_committed` on the trim-lane test double

### DIFF
--- a/crates/engine/src/engine/result.rs
+++ b/crates/engine/src/engine/result.rs
@@ -6991,6 +6991,18 @@ mod tests {
             ) -> anyhow::Result<Existence> {
                 self.inner.existence(addr, hashin, name)
             }
+            /// Mirrors this decorator's own `exists`: that one forwards, so the
+            /// committed-only answer forwards too. Required by the trait
+            /// precisely so a decorator cannot inherit a default that re-parks
+            /// the runtime on the backend's write-behind queue.
+            fn exists_committed(
+                &self,
+                addr: &Addr,
+                hashin: &str,
+                name: &str,
+            ) -> anyhow::Result<bool> {
+                self.inner.exists_committed(addr, hashin, name)
+            }
             fn delete(&self, addr: &Addr, hashin: &str, name: &str) -> anyhow::Result<()> {
                 self.inner.delete(addr, hashin, name)
             }


### PR DESCRIPTION
`master` does not compile — every `Test` job is red at the `engine` lib-test compile, so **the suite has not run on master since `e3585c4e`**.

## What broke

Two PRs landed close together. One made `LocalCache::exists_committed` a required trait method; the other added the `TrimThreadCache` decorator inside `engine::result`'s test module. Neither diff touched the other's file, so both merged green and their union does not build:

```
error[E0046]: not all trait items implemented, missing: `exists_committed`
    --> crates/engine/src/engine/result.rs:6971:9
     |
6971 |         impl LocalCache for TrimThreadCache {
     |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ missing `exists_committed` in implementation
```

Run [30439973587](https://github.com/hephbuild/heph/actions/runs/30439973587), `Test linux/amd64` and `Test linux/arm64`.

## The fix

The decorator forwards `exists`, so it forwards `exists_committed` — exactly the mirror the trait doc asks a decorator for. No behaviour change: the double exists only to record which thread `list_target_entries` lands on.

## Verification

`cargo test -p engine --lib --no-run` builds clean on this branch; it fails with the error above on `master`. That *is* the red-check — the missing method is a compile error, so the check is the compiler, not a test.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01A76DChMohieGMbRbnV1E7x