### PR TITLE
fix: give every hand-written executable the ETXTBSY barrier

### DIFF
--- a/crates/core/src/fsutil.rs
+++ b/crates/core/src/fsutil.rs
@@ -1,8 +1,104 @@
 //! Small filesystem helpers shared across crates.
 
+use anyhow::Context;
 use std::fs;
 use std::io;
 use std::path::Path;
+
+/// Close `file` (a freshly-written, writable handle to `path`) in a way that
+/// guarantees no writable descriptor for the file survives anywhere, then
+/// return. Call this on any file that is about to be `exec`'d.
+///
+/// Works around <https://github.com/rust-lang/rust/issues/114554>. `File` sets
+/// `O_CLOEXEC`, but that only closes the descriptor at `execve` — so if another
+/// thread `fork`s between our `File::create` and a later `exec` of this file,
+/// the child holds an inherited writable fd for the whole `fork`→`execve`
+/// window, and any `exec` of the file during it fails with `ETXTBSY`. Closing
+/// our own handle is therefore not enough: the racing child's copy is the one
+/// that blocks the exec, and we cannot see it.
+///
+/// `flock` locks are held by the *open file description*, which a forked child
+/// shares rather than copies, so a lock is the one handle we do have on that
+/// invisible fd:
+///
+/// 1. take an exclusive lock on the writable fd — any forked child's copy of
+///    the description now holds it too,
+/// 2. close our fd (the lock lives on in every inherited copy),
+/// 3. reopen read-only and take a shared lock — this blocks until the last
+///    writable description is gone, i.e. until every racing child has reached
+///    `execve` and dropped its `O_CLOEXEC` copy.
+///
+/// On return no writable description *derived from `file`* survives, and since
+/// ours is closed no later `fork` can create one, so a subsequent `exec` cannot
+/// see `ETXTBSY`.
+///
+/// Limits, in decreasing likelihood of mattering:
+///
+/// - **An independent writer is not covered.** Another thread or process that
+///   opened the same path itself holds none of our lock and is invisible to the
+///   shared acquire. Callers must not race their own writes against a path they
+///   are about to exec.
+/// - **`file` and `path` must name the same inode.** The reopen is by path, so
+///   if anything renames over `path` in the window the barrier drains a
+///   different inode and passes vacuously.
+/// - **On NFS the barrier can silently degrade to a no-op.** Since Linux
+///   2.6.37 an NFS client emulates `flock` as a whole-file POSIX record lock
+///   unless mounted `-o local_lock=flock`, and record locks are process-owned:
+///   closing our fd drops the exclusive lock, so the shared acquire returns
+///   immediately even while a racing child holds a writable fd. Local
+///   filesystems — where heph puts its cache, sandboxes and stage — are
+///   unaffected.
+///
+/// Ports the Go tree's `xfs.CloseEnsureROFD`. Costs two `flock`s and one
+/// `open` per executable file, so callers gate it on `+x` rather than paying
+/// it for every write. Prefer [`write_executable`] over calling this directly:
+/// it is the forgettable last step of a four-step sequence, and the flake this
+/// exists to prevent came from a caller that did the first three.
+pub fn close_ensure_ro_fd(file: fs::File, path: &Path) -> anyhow::Result<()> {
+    // `File::lock`/`lock_shared` do not retry on `EINTR`. Unreachable today —
+    // `flock` is restartable and the tree's only handler (signal-hook, via
+    // `tokio::signal::ctrl_c`) installs `SA_RESTART` — but a hand-rolled
+    // `sigaction` without it would turn this into a spurious failure.
+    file.lock()
+        .with_context(|| format!("flock(exclusive) writable fd {:?}", path))?;
+    drop(file);
+
+    let ro = fs::File::open(path).with_context(|| format!("reopen {:?} read-only", path))?;
+    // Blocking, with no timeout and no cancellation. The wait is bounded by a
+    // racing child's fork→execve — microseconds — because every heph child is
+    // spawned with `Command` (fork+exec) and a grandchild spawned by the exec'd
+    // program never inherits the fd. Keep it that way: a caller that hands this
+    // an fd some long-lived child holds open turns it into a silent hang.
+    ro.lock_shared()
+        .with_context(|| format!("flock(shared) read-only fd {:?}", path))?;
+    drop(ro);
+    Ok(())
+}
+
+/// Write `bytes` to `path` as an executable (`0o755`) file that is safe to
+/// `exec` the moment this returns.
+///
+/// Exists so the ordering cannot be got wrong. The sequence is create, write,
+/// chmod, then drain writable descriptors via [`close_ensure_ro_fd`] — and the
+/// last step is the one that gets forgotten, which is exactly how the `ETXTBSY`
+/// flake this guards against was introduced. Callers that stream rather than
+/// buffer (`unpack`) call the barrier directly; everyone else should use this.
+pub fn write_executable(path: &Path, bytes: &[u8]) -> anyhow::Result<()> {
+    use std::io::Write as _;
+
+    let mut file = fs::File::create(path).with_context(|| format!("create {:?}", path))?;
+    file.write_all(bytes)
+        .with_context(|| format!("write {} bytes to {:?}", bytes.len(), path))?;
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::PermissionsExt as _;
+        // fchmod on the handle we hold, so no window where the path is
+        // executable but still open for writing by someone we cannot see.
+        file.set_permissions(fs::Permissions::from_mode(0o755))
+            .with_context(|| format!("chmod +x {:?}", path))?;
+    }
+    close_ensure_ro_fd(file, path)
+}
 
 /// `remove_dir_all` that recovers from `PermissionDenied`. Read-only dirs
 /// (e.g. a 0555 codegen output tree) make the kernel refuse to unlink their
@@ -94,4 +190,200 @@ pub fn make_readonly_tree(root: &Path) -> io::Result<()> {
 #[cfg(not(unix))]
 pub fn make_readonly_tree(_root: &Path) -> io::Result<()> {
     Ok(())
+}
+
+#[cfg(all(test, unix))]
+mod tests {
+    use super::*;
+    use std::io::Write as _;
+    use std::os::unix::fs::PermissionsExt as _;
+    use std::os::unix::io::AsRawFd as _;
+    use std::os::unix::process::CommandExt as _;
+    use std::process::{Child, ChildStdin, Command, Stdio};
+    use std::sync::mpsc;
+    use std::time::Duration;
+
+    /// Long enough that a barrier which never blocks cannot accidentally exceed
+    /// it (the pre-fix `drop` returns in microseconds), short enough to be free.
+    const STILL_BLOCKED: Duration = Duration::from_millis(200);
+    /// Ceiling for the barrier to notice the fd is gone. Only a hang trips it.
+    const RELEASE: Duration = Duration::from_secs(10);
+
+    fn write_script(path: &Path) -> fs::File {
+        let mut file = fs::File::create(path).expect("create");
+        file.write_all(b"#!/bin/sh\necho ok\n").expect("write");
+        fs::set_permissions(path, fs::Permissions::from_mode(0o755)).expect("chmod +x");
+        file
+    }
+
+    /// Spawn a child holding a *duplicate* of `file`'s descriptor — which is
+    /// precisely what a `fork` racing our write leaves behind: `dup` clears
+    /// `O_CLOEXEC` and shares the open file description, so the child keeps a
+    /// writable fd on the file across its own `execve`.
+    ///
+    /// The child blocks on `read`, a shell builtin, so nothing is looked up on
+    /// `$PATH`; dropping the returned stdin closes the pipe and lets it exit.
+    /// That makes the release causal rather than a wall-clock race.
+    fn spawn_fd_holder(file: &fs::File) -> (Child, ChildStdin) {
+        let raw = file.as_raw_fd();
+        // SAFETY: pre_exec runs between fork and exec; only async-signal-safe
+        // syscalls (`dup`) are invoked, and the error path uses
+        // `Error::last_os_error` (`from_raw_os_error`), which does not allocate.
+        let mut child = unsafe {
+            Command::new("/bin/sh")
+                .arg("-c")
+                .arg("read x")
+                .stdin(Stdio::piped())
+                .stdout(Stdio::null())
+                .stderr(Stdio::null())
+                .pre_exec(move || {
+                    if libc::dup(raw) < 0 {
+                        return Err(io::Error::last_os_error());
+                    }
+                    Ok(())
+                })
+                .spawn()
+        }
+        .expect("spawn fd holder");
+        let stdin = child.stdin.take().expect("holder stdin");
+        (child, stdin)
+    }
+
+    /// The `fork`/`exec` race, made deterministic. While a child holds an
+    /// inherited writable fd the barrier must not return; once the fd is gone
+    /// it must, and the file must then be exec'able.
+    ///
+    /// The assertion is the platform-independent half of the contract ("no
+    /// writable description survives the barrier") rather than `ETXTBSY`, which
+    /// only Linux enforces — so this one test discriminates on all three
+    /// supported targets. Replacing the barrier with a plain `drop(file)`
+    /// returns immediately, the first `recv_timeout` succeeds, and it fails.
+    #[test]
+    fn close_ensure_ro_fd_waits_for_a_forked_childs_writable_fd() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let script = dir.path().join("prog.sh");
+        let file = write_script(&script);
+        let (mut holder, holder_stdin) = spawn_fd_holder(&file);
+
+        let (tx, rx) = mpsc::channel();
+        let barrier = {
+            let script = script.clone();
+            std::thread::spawn(move || {
+                let r = close_ensure_ro_fd(file, &script);
+                let _ = tx.send(());
+                r
+            })
+        };
+
+        assert!(
+            matches!(
+                rx.recv_timeout(STILL_BLOCKED),
+                Err(mpsc::RecvTimeoutError::Timeout)
+            ),
+            "close_ensure_ro_fd returned while a forked child still held a writable \
+             fd for the file; an exec of it can still fail with ETXTBSY"
+        );
+
+        // Causal release: closing the pipe ends the holder, dropping the last
+        // writable descriptor. The barrier must now — and only now — complete.
+        drop(holder_stdin);
+        holder.wait().expect("reap fd holder");
+        rx.recv_timeout(RELEASE)
+            .expect("barrier must return once the last writable fd is gone");
+        barrier
+            .join()
+            .expect("barrier thread")
+            .expect("barrier failed");
+
+        let out = Command::new(&script).output().expect("exec");
+        assert!(out.status.success(), "exec after barrier failed: {out:?}");
+        assert_eq!(String::from_utf8_lossy(&out.stdout), "ok\n");
+    }
+
+    /// The symptom the barrier exists to prevent, asserted where the kernel
+    /// actually produces it: heph behaves identically on all three targets, but
+    /// Linux alone enforces `ETXTBSY`, so only there can the untreated failure
+    /// be observed at all.
+    ///
+    /// Scope, precisely: this pins that a live writable fd really does make
+    /// `execve` fail and that draining it really does fix that. It does *not*
+    /// isolate the forked child's contribution — this process still holds its
+    /// own writable `file` during the first exec, and either fd alone is enough
+    /// for `ETXTBSY`. Nor does it exercise the barrier's *wait*, since the
+    /// holder is already reaped before it is called. Both of those are the
+    /// preceding test's job; this one is about the errno.
+    #[cfg(target_os = "linux")]
+    #[test]
+    fn a_live_writable_fd_makes_exec_fail_until_the_barrier_clears_it() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let script = dir.path().join("prog.sh");
+        let file = write_script(&script);
+        let (mut holder, holder_stdin) = spawn_fd_holder(&file);
+
+        let err = Command::new(&script)
+            .output()
+            .expect_err("exec must fail while a writable fd for the file is open");
+        assert_eq!(
+            err.raw_os_error(),
+            Some(libc::ETXTBSY),
+            "expected ETXTBSY, got: {err}"
+        );
+
+        drop(holder_stdin);
+        holder.wait().expect("reap fd holder");
+        close_ensure_ro_fd(file, &script).expect("barrier");
+
+        let out = Command::new(&script).output().expect("exec after barrier");
+        assert!(out.status.success(), "exec after barrier failed: {out:?}");
+    }
+
+    /// `write_executable`'s own contract: the bytes land, the exec bit is set,
+    /// and the result runs. Its barrier step is covered by the tests above —
+    /// it cannot be re-asserted from out here, because the only descriptor the
+    /// barrier drains is the one `write_executable` creates internally, and an
+    /// independently-opened fd is (documented as) outside the guarantee.
+    #[test]
+    fn write_executable_writes_a_runnable_file() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let script = dir.path().join("tool");
+
+        write_executable(&script, b"#!/bin/sh\necho ok\n").expect("write_executable");
+
+        let mode = fs::metadata(&script).expect("stat").permissions().mode();
+        assert_eq!(mode & 0o111, 0o111, "must be executable, mode={mode:o}");
+        let out = Command::new(&script).output().expect("exec");
+        assert!(out.status.success(), "exec failed: {out:?}");
+        assert_eq!(String::from_utf8_lossy(&out.stdout), "ok\n");
+    }
+
+    /// Overwriting an existing file must truncate, not leave a tail behind.
+    #[test]
+    fn write_executable_truncates_a_longer_previous_file() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let script = dir.path().join("tool");
+
+        write_executable(&script, b"#!/bin/sh\necho aaaaaaaaaaaaaaaaaaaa\n").expect("first");
+        write_executable(&script, b"#!/bin/sh\necho ok\n").expect("second");
+
+        let out = Command::new(&script).output().expect("exec");
+        assert_eq!(String::from_utf8_lossy(&out.stdout), "ok\n");
+    }
+
+    /// The barrier must fail loudly, naming the step, if the file it is asked to
+    /// drain is gone. Silently tolerating this would turn it into a no-op and
+    /// bring the ETXTBSY flake back with nothing going red.
+    #[test]
+    fn close_ensure_ro_fd_errors_when_the_file_vanishes_before_the_reopen() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let script = dir.path().join("prog.sh");
+        let file = write_script(&script);
+        fs::remove_file(&script).expect("unlink");
+
+        let err = close_ensure_ro_fd(file, &script).expect_err("must not succeed");
+        let msg = format!("{err:#}");
+        assert!(
+            msg.contains("reopen"),
+            "error must name the step, got: {msg}"
+        );
+    }
 }

--- a/crates/core/src/hartifactcontent/unpack.rs
+++ b/crates/core/src/hartifactcontent/unpack.rs
@@ -9,33 +9,8 @@ use std::path::Path;
 #[cfg(unix)]
 use std::os::unix::fs::PermissionsExt;
 
-/// Close `file` (a freshly-written, writable handle to `path`) in a way that
-/// guarantees no writable descriptor for the file survives, then return.
-///
-/// Works around <https://github.com/rust-lang/rust/issues/114554>: if another
-/// thread `fork`s between our `File::create` and a later `exec` of the unpacked
-/// binary, the child inherits our writable fd and the `exec` fails with
-/// `ETXTBSY`. `flock` locks are tied to the open file description and shared
-/// with any forked child, so:
-///
-/// 1. take an exclusive lock on the writable fd,
-/// 2. close it (the lock lives on in any inherited copy),
-/// 3. reopen read-only and take a shared lock — this blocks until every
-///    writable fd (ours and any forked child's) is gone.
-///
-/// Only meaningful for files that will be executed, so callers gate on `+x`.
 #[cfg(unix)]
-fn close_ensure_ro_fd(file: fs::File, path: &Path) -> anyhow::Result<()> {
-    file.lock()
-        .with_context(|| format!("flock(exclusive) writable fd {:?}", path))?;
-    drop(file);
-
-    let ro = fs::File::open(path).with_context(|| format!("reopen {:?} read-only", path))?;
-    ro.lock_shared()
-        .with_context(|| format!("flock(shared) read-only fd {:?}", path))?;
-    drop(ro);
-    Ok(())
-}
+use crate::fsutil::close_ensure_ro_fd;
 
 /// Describe what currently exists at `path` for error messages. Returns a
 /// short tag like "file", "dir", "symlink->/foo", or "<none>". Never errors.

--- a/crates/plugin-exec/src/pluginexec/mod.rs
+++ b/crates/plugin-exec/src/pluginexec/mod.rs
@@ -2622,12 +2622,12 @@ mod tests {
         name: &str,
         body: &str,
     ) -> anyhow::Result<std::path::PathBuf> {
-        use std::os::unix::fs::PermissionsExt;
         let path = dir.join(name);
-        std::fs::write(&path, format!("#!/bin/sh\n{body}"))?;
-        let mut perms = std::fs::metadata(&path)?.permissions();
-        perms.set_mode(0o755);
-        std::fs::set_permissions(&path, perms)?;
+        // These tools are exec'd by the driver while sibling tests spawn their own
+        // subprocesses; a fork racing the write inherits the writable fd and the
+        // exec fails with ETXTBSY. `write_executable` takes the barrier that
+        // writing by hand would skip.
+        hcore::fsutil::write_executable(&path, format!("#!/bin/sh\n{body}").as_bytes())?;
         Ok(path)
     }
 

--- a/crates/plugingo-e2e/tests/codegen.rs
+++ b/crates/plugingo-e2e/tests/codegen.rs
@@ -78,10 +78,16 @@ async fn test_codegen_build_binary_outputs_hello() -> anyhow::Result<()> {
                 heph::hartifactcontent::WalkEntryKind::File { mut data, x } => {
                     let mut buf = Vec::new();
                     data.read_to_end(&mut buf)?;
-                    std::fs::write(&dest, &buf)?;
                     if x {
-                        std::fs::set_permissions(&dest, std::fs::Permissions::from_mode(0o755))?;
+                        // Writing the binary by hand skips `unpack`, which is where
+                        // the rest of the tree gets the writable-fd barrier. This
+                        // suite runs many Go builds concurrently, each forking
+                        // subprocesses, so a fork racing the write inherits the
+                        // writable fd and the exec below fails with ETXTBSY.
+                        hcore::fsutil::write_executable(&dest, &buf)?;
                         binary_path = Some(dest);
+                    } else {
+                        std::fs::write(&dest, &buf)?;
                     }
                 }
                 heph::hartifactcontent::WalkEntryKind::Symlink { .. } => {}

--- a/crates/selfupdate/src/lib.rs
+++ b/crates/selfupdate/src/lib.rs
@@ -210,7 +210,6 @@ mod imp {
     use super::{UPGRADED_ENV, binary_name, download_url, host_os_arch};
     use anyhow::{Context, anyhow};
     use std::io::{IsTerminal, Read, Write};
-    use std::os::unix::fs::PermissionsExt;
     use std::os::unix::io::AsRawFd;
     use std::os::unix::process::CommandExt;
     use std::path::{Path, PathBuf};
@@ -381,16 +380,12 @@ mod imp {
     /// Write `bytes` to a temp file, mark it executable, then rename into place so
     /// a partial download is never seen as a usable binary by a concurrent run.
     fn install_atomic(dir: &Path, dest: &Path, bytes: &[u8]) -> anyhow::Result<()> {
-        use std::io::Write;
         let tmp = dir.join(".heph.download");
-        {
-            let mut f =
-                std::fs::File::create(&tmp).with_context(|| format!("create {}", tmp.display()))?;
-            f.write_all(bytes)?;
-            f.flush()?;
-        }
-        std::fs::set_permissions(&tmp, std::fs::Permissions::from_mode(0o755))
-            .with_context(|| format!("chmod {}", tmp.display()))?;
+        // `exec_into` execve's this binary moments later, so it must be written
+        // with the writable-fd barrier: a thread forking during the write leaves
+        // an inherited writable fd in the child until it reaches its own execve,
+        // and an exec of a binary with a live writable fd fails with ETXTBSY.
+        hcore::fsutil::write_executable(&tmp, bytes)?;
         std::fs::rename(&tmp, dest)
             .with_context(|| format!("install heph to {}", dest.display()))?;
         Ok(())
@@ -442,7 +437,57 @@ mod imp {
 
     #[cfg(test)]
     mod tests {
-        use super::{fmt_bytes, progress_line};
+        use super::{fmt_bytes, install_atomic, progress_line};
+
+        /// `install_atomic` is the last step before `exec_into` replaces the
+        /// process image, and its errors are fatal (`main` turns them into
+        /// `ExitCode::FAILURE`), so every command in a pinned workspace depends
+        /// on it. Pin the contract end to end: the bytes land, the exec bit is
+        /// set, the installed file actually runs, and no partial download is
+        /// left behind for a concurrent run to mistake for a usable binary.
+        #[test]
+        fn install_atomic_writes_a_runnable_binary_and_leaves_no_partial() {
+            let dir = tempfile::tempdir().expect("tempdir");
+            let dest = dir.path().join("heph");
+
+            install_atomic(dir.path(), &dest, b"#!/bin/sh\necho ok\n").expect("install");
+
+            use std::os::unix::fs::PermissionsExt as _;
+            let mode = std::fs::metadata(&dest).expect("stat").permissions().mode();
+            assert_eq!(mode & 0o111, 0o111, "installed binary must be executable");
+
+            let out = std::process::Command::new(&dest).output().expect("exec");
+            assert!(out.status.success(), "installed binary failed: {out:?}");
+            assert_eq!(String::from_utf8_lossy(&out.stdout), "ok\n");
+
+            assert!(
+                !dir.path().join(".heph.download").exists(),
+                "the temp download must be renamed away, not left beside the binary"
+            );
+        }
+
+        /// A failed install must say which step failed and must not leave a
+        /// half-installed binary at `dest` — the next run would exec it.
+        #[test]
+        fn install_atomic_reports_the_failing_step_and_installs_nothing() {
+            let dir = tempfile::tempdir().expect("tempdir");
+            // `dest` is a non-empty directory: the rename cannot succeed.
+            let dest = dir.path().join("occupied");
+            std::fs::create_dir(&dest).expect("mkdir dest");
+            std::fs::write(dest.join("child"), b"x").expect("occupy");
+
+            let err = install_atomic(dir.path(), &dest, b"#!/bin/sh\necho ok\n")
+                .expect_err("rename over a non-empty dir must fail");
+            let msg = format!("{err:#}");
+            assert!(
+                msg.contains("install heph to"),
+                "error must name the step that failed, got: {msg}"
+            );
+            assert!(
+                dest.is_dir(),
+                "a failed install must not replace what was there"
+            );
+        }
 
         #[test]
         fn fmt_bytes_scales_by_unit() {


### PR DESCRIPTION
## The failure

```
crates/plugingo-e2e/tests/codegen.rs:95
---- test_codegen_build_binary_outputs_hello stdout ----
Error: run binary /home/runner/work/_temp/.tmp6H2pRk/codegen
Caused by: Text file busy (os error 26)
```

## Does the Rust tree already have the Go tree's handling? Yes — but not everywhere it is needed

`utils/xfs/fs.go:82-111` is `CloseEnsureROFD`: **not** a retry, a flock drain barrier. The Rust equivalent already exists as `close_ensure_ro_fd` in `crates/core/src/hartifactcontent/unpack.rs`, applied to every `+x` entry unpacked — which covers every *product* materialization path (stage, driver-managed unpack, cache reads).

It was **private to `unpack.rs`**, so the three sites that write an executable by hand could not reach it, and all three then exec the result.

## Why `O_CLOEXEC` doesn't save us

`std::fs::File` does set `O_CLOEXEC` on Linux — but that only closes the descriptor **at** `execve`. A thread that forks during our write leaves a child holding an inherited writable fd for the whole fork→execve window, and any exec of that file during the window gets `ETXTBSY`. The racing child's copy is the one blocking the exec and we cannot see it — but `flock` locks are held by the *open file description*, which a forked child **shares rather than copies**. That lock is the one handle we have on the invisible fd.

## Product bug or test bug?

**The observed CI failure is a test bug** — `codegen.rs` bypasses `unpack` and writes the binary itself. The forks come from the product (ten concurrent Go builds), but the leaked writable fd is the harness's own.

Surveying for the same shape turned up **one genuine product bug**: `selfupdate::install_atomic` writes the upgraded binary and `exec_into` `execve`s it moments later in the same process.

| Site | Kind |
|---|---|
| `plugingo-e2e/tests/codegen.rs` | test — the observed failure |
| `selfupdate::install_atomic` | **product** |
| `pluginexec::make_tool_binary` (9 tests) | test — same latent shape |

Checked and clear: `plugin_load.rs` `dlopen`s a cdylib but `ETXTBSY` comes from `deny_write_access()` in `open_exec()`, which only `execve` reaches (`MAP_DENYWRITE` is gone from modern Linux); `plugin-http::fetch` and the `plugin-nix` wrapper are safe because consumers re-materialize through `unpack`, so the exec'd inode is always the barriered one; `stage.rs` is `unpack` + `hard_link`.

## Which fix shape

**Eliminate the race, not retry it.** A bounded retry still loses when the leaked fd lands in a long-lived child; the barrier returns only once no writable description survives — and ours is closed, so no later fork can create one.

Rather than just exporting the barrier and leaving four sites to remember a four-step sequence, this adds `hcore::fsutil::write_executable` (create → write → chmod → drain) and routes all three hand-rolled sites through it. **That duplication is precisely what caused the bug**: the e2e site had the first three steps and forgot the fourth. `unpack` keeps calling the barrier directly since it streams rather than buffers.

## Red/green verification

The fd-leak shape is deterministically testable, so this is not a timing test. A child holds a `dup` of the writable fd (`dup` clears `O_CLOEXEC` and shares the open file description — exactly what a racing fork leaves behind) and is released **causally**, by closing a pipe, not by a clock:

| | barrier | plain `drop(file)` (pre-fix) |
|---|---|---|
| `recv_timeout(200ms)` | `Err(Timeout)` — still blocked ✅ | `Ok(())` — returned in ~14µs ❌ |

Verified by mutation in an isolated standalone build of the identical mechanism, and independently reproduced by the `feature-quality` reviewer (11µs vs 1.05s). The first revision used `sleep` on `$PATH` and a wall-clock floor; that was replaced on review.

Asserting *the block* rather than `ETXTBSY` keeps **one** test discriminating on all three supported targets — measured, macOS does not enforce `ETXTBSY`. A `#[cfg(target_os = "linux")]` companion asserts the real errno where the kernel produces it. Also adds the first-ever tests for `install_atomic`, whose errors are fatal at startup (`main` turns them into `ExitCode::FAILURE`).

## Platform

No behavioural split: heph does the identical thing on all three targets. Documented limits on the barrier — an independently-opened writable fd is not covered; `file` and `path` must name the same inode; and **on NFS** mounted without `-o local_lock=flock`, Linux emulates `flock` as a process-owned POSIX record lock, which silently degrades the barrier to a no-op. heph's cache, sandboxes and stage are local, so this is documented rather than handled — flagging it as a call that is yours, not mine.

## Review

`code-quality` and `feature-quality` both consulted on the committed ref. Their blocking findings are fixed: the `fmt` gate, the `$PATH`-dependent test signal, the `install_atomic` coverage gap, the doc overclaim, a missing `// SAFETY:` on `pre_exec`, and the three-way duplication.

**Deliberately deferred:** a `tracing` warn on a slow barrier acquire. `crates/core` has no `tracing` dependency today and adding one is a layering decision I did not want to take unilaterally; both reviewers independently concluded there is no real hang risk at the current call sites.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01A76DChMohieGMbRbnV1E7x