### PR TITLE
test(pprof): assert on a frame the blocklist must keep, not on sample count

### DIFF
--- a/src/pprof_dump.rs
+++ b/src/pprof_dump.rs
@@ -251,14 +251,57 @@ mod tests {
     use pprof::protos::Message;
     use std::time::Instant;
 
-    /// Keep `threads` threads busy for `at_least` **inside libc** — allocator
-    /// churn, syscalls, and thread create/join.
+    /// CPU burned entirely inside this binary's own text: an integer mix that
+    /// calls nothing, allocates nothing, and enters no shared object, so a sample
+    /// that interrupts it has a leaf PC no [`UNWIND_BLOCKLIST`] entry can match.
     ///
-    /// A pure integer loop is the wrong workload: every sample's leaf PC lands in
-    /// this binary's own text with a shallow stack, which is precisely the case
-    /// that never crashed. The unwinder faults when it interrupts a thread that
-    /// is already inside `malloc`, the dynamic loader, or a syscall stub, so the
-    /// workload has to live there for the sampler to be tested at all.
+    /// `black_box` on the accumulator and the loop variable keeps the whole thing
+    /// from being folded to a constant; `#[inline(never)]` gives it a frame of its
+    /// own, so `burn`'s caller can assert on it by name rather than on a count.
+    #[inline(never)]
+    fn cpu_only(rounds: u64) -> u64 {
+        let mut acc = std::hint::black_box(0x9E37_79B9_7F4A_7C15_u64);
+        for i in 0..rounds {
+            acc = acc
+                .wrapping_mul(6_364_136_223_846_793_005)
+                .wrapping_add(std::hint::black_box(i) | 1);
+            acc ^= acc >> 29;
+        }
+        std::hint::black_box(acc)
+    }
+
+    /// Rounds of [`cpu_only`] per `burn` iteration — enough that the in-binary
+    /// half is comparable to the libc half rather than a rounding error on it.
+    /// Sized by measurement, not by feel: see the sample counts in `burn`'s docs.
+    const CPU_ROUNDS: u64 = 50_000;
+
+    /// Keep `threads` threads busy for `at_least`, in two deliberately different
+    /// places: **inside libc** (allocator churn, syscalls, thread create/join) and
+    /// **inside this binary's own text** ([`cpu_only`]).
+    ///
+    /// Both halves are load-bearing, and for opposite assertions:
+    ///
+    /// - The libc churn is what the *crash* regression needs. The unwinder faults
+    ///   when it interrupts a thread already inside `malloc`, the dynamic loader
+    ///   or a syscall stub, so a pure integer loop — shallow stack, leaf PC in
+    ///   this binary — exercises precisely the case that never crashed.
+    /// - [`cpu_only`] is what the *profile has heph frames in it* assertion needs,
+    ///   and it is not decoration. `pprof` drops a sample whose leaf PC is
+    ///   blocklisted **by design**, so a workload built only from the first half
+    ///   is one the sampler is meant to record almost nothing from. Measured on
+    ///   darwin/arm64: a libc-only burn produced 0-6 distinct stacks, against
+    ///   25-57 for the same burn with the blocklist switched off — the blocklist
+    ///   was legitimately dropping 95-99% of the samples, and whether the profile
+    ///   came out empty was decided by which straggler happened to land. It came
+    ///   out empty on 4 of 50 runs, and 8 of 30 under load, which is what turned
+    ///   this test red on master's own CI. The fix is not a longer burn or a
+    ///   retry: it is giving the sampler a leaf it is *supposed* to keep, present
+    ///   for the whole window, on every thread.
+    ///
+    /// Interleaved rather than run on a thread of its own, so it does not matter
+    /// which thread the kernel picks to deliver `SIGPROF` to — a process-directed
+    /// timer signal is delivered to *some* eligible thread, and on Darwin that is
+    /// routinely not the one burning the most CPU.
     fn burn(threads: usize, at_least: Duration) {
         let handles: Vec<_> = (0..threads)
             .map(|_| {
@@ -283,6 +326,9 @@ mod tests {
                         // it deepens the stack the sampler has to walk.
                         let inner = std::thread::spawn(|| format!("{:?}", Instant::now()));
                         drop(inner.join());
+                        // The in-binary half — the only leaves the blocklist is
+                        // not meant to drop. See this function's docs.
+                        std::hint::black_box(cpu_only(CPU_ROUNDS));
                     }
                 })
             })
@@ -290,6 +336,42 @@ mod tests {
         for h in handles {
             h.join().expect("burn thread must not panic");
         }
+    }
+
+    /// How many of `profile`'s samples name a function containing `needle`
+    /// anywhere in their stack.
+    ///
+    /// Walks pprof's id indirection (sample → location → line → function → string
+    /// table) rather than indexing by position: ids are not promised to be their
+    /// index plus one, and a profile that renumbered them would otherwise make
+    /// this silently answer zero.
+    fn samples_naming(profile: &pprof::protos::Profile, needle: &str) -> usize {
+        use std::collections::{HashMap, HashSet};
+        let names: HashMap<u64, &str> = profile
+            .function
+            .iter()
+            .filter_map(|f| {
+                let idx = usize::try_from(f.name).ok()?;
+                Some((f.id, profile.string_table.get(idx)?.as_str()))
+            })
+            .collect();
+        let hits: HashSet<u64> = profile
+            .location
+            .iter()
+            .filter(|loc| {
+                loc.line.iter().any(|l| {
+                    names
+                        .get(&l.function_id)
+                        .is_some_and(|n| n.contains(needle))
+                })
+            })
+            .map(|loc| loc.id)
+            .collect();
+        profile
+            .sample
+            .iter()
+            .filter(|s| s.location_id.iter().any(|id| hits.contains(id)))
+            .count()
     }
 
     /// Resolve the shared object owning `sym`, as the dynamic loader sees it —
@@ -420,10 +502,18 @@ mod tests {
     /// that is the first half of the assertion, and it cannot be written any
     /// other way.
     ///
-    /// The non-empty sample set is the second half, and it guards the fix rather
-    /// than the bug: an over-broad [`UNWIND_BLOCKLIST`] (one matching the main
-    /// binary) would drop every sample and leave `--pprof-cpu` writing empty
-    /// profiles forever, crashing nothing and telling no one.
+    /// The second half guards the fix rather than the bug: an over-broad
+    /// [`UNWIND_BLOCKLIST`] (one matching the main binary) would drop every sample
+    /// and leave `--pprof-cpu` writing empty profiles forever, crashing nothing
+    /// and telling no one.
+    ///
+    /// It asserts on [`cpu_only`] by name, not on "the profile is non-empty".
+    /// Non-empty was the weaker *and* the flakier statement: with the whole burn
+    /// living inside libc, nearly every sample was one the sampler is *designed*
+    /// to drop, so the profile came back empty on 4 of 50 darwin/arm64 runs — and
+    /// on master's own CI. Naming a frame the blocklist must never match turns a
+    /// statistical claim into a structural one, and says the thing the count was
+    /// only standing in for: heph's own frames survive the blocklist.
     ///
     /// **Only one test in this binary may call [`start`].** pprof's `PROFILER` is
     /// a process singleton: a concurrent second `start` fails with
@@ -462,9 +552,15 @@ mod tests {
         let snapshot = snapshot.unwrap_or_else(|| panic!("no profile at {}", path.display()));
         let profile = pprof::protos::Profile::decode(snapshot.as_slice())
             .expect("on-demand dump must be a decodable pprof profile — never a partial write");
+        let in_binary = samples_naming(&profile, "cpu_only");
         assert!(
-            !profile.sample.is_empty(),
-            "profiler collected no samples: UNWIND_BLOCKLIST is dropping everything"
+            in_binary > 0,
+            "no sample reached `cpu_only`, which burned a large share of this \
+             process's CPU inside the main binary for the whole sampling window: \
+             either UNWIND_BLOCKLIST now matches the main binary and every heph \
+             frame is being dropped, or the sampler collected nothing at all \
+             ({} sample(s) in total)",
+            profile.sample.len()
         );
 
         // `shutdown` writes the filtered exit-time report — the profile the flag

--- a/src/pprof_dump.rs
+++ b/src/pprof_dump.rs
@@ -256,24 +256,59 @@ mod tests {
     /// that interrupts it has a leaf PC no [`UNWIND_BLOCKLIST`] entry can match.
     ///
     /// `black_box` on the accumulator and the loop variable keeps the whole thing
-    /// from being folded to a constant; `#[inline(never)]` gives it a frame of its
-    /// own, so `burn`'s caller can assert on it by name rather than on a count.
+    /// from being folded to a constant, so `burn`'s caller can assert on it by
+    /// name rather than on a count.
+    ///
+    /// Split into a loop and a per-round callee, both `#[inline(never)]`, on
+    /// purpose. One `#[inline(never)]` leaf is not enough: optimized, the
+    /// interrupted leaf can be frameless and the unwinder attributes the sample
+    /// to whatever called it — measured, an `opt-level=3` build of this very test
+    /// binary named `cpu_only` in **zero** samples and failed 10/10. With the
+    /// round in a callee, `cpu_only` is a *caller* — recovered from a return
+    /// address on the stack, not from leaf attribution — and either name
+    /// satisfies [`CPU_NEEDLE`]. The call is what makes the frame observable, so
+    /// it is not an inlining hint to be removed.
+    #[inline(never)]
+    fn cpu_only_round(acc: u64, i: u64) -> u64 {
+        let acc = acc
+            .wrapping_mul(6_364_136_223_846_793_005)
+            .wrapping_add(std::hint::black_box(i) | 1);
+        std::hint::black_box(acc ^ (acc >> 29))
+    }
+
     #[inline(never)]
     fn cpu_only(rounds: u64) -> u64 {
         let mut acc = std::hint::black_box(0x9E37_79B9_7F4A_7C15_u64);
         for i in 0..rounds {
-            acc = acc
-                .wrapping_mul(6_364_136_223_846_793_005)
-                .wrapping_add(std::hint::black_box(i) | 1);
-            acc ^= acc >> 29;
+            acc = cpu_only_round(acc, i);
         }
         std::hint::black_box(acc)
     }
 
-    /// Rounds of [`cpu_only`] per `burn` iteration — enough that the in-binary
-    /// half is comparable to the libc half rather than a rounding error on it.
-    /// Sized by measurement, not by feel: see the sample counts in `burn`'s docs.
-    const CPU_ROUNDS: u64 = 50_000;
+    /// Rounds of [`cpu_only`] per `burn` iteration.
+    ///
+    /// A trade, and both sides were measured rather than guessed — 8 runs per
+    /// cell, darwin/arm64, `burn(4, 500ms)`, counting stacks naming
+    /// [`CPU_NEEDLE`] and `cpu_only`'s share of the ~2.0s burn window:
+    ///
+    /// | rounds | opt0 hits | opt0 cpu share | opt3 hits |
+    /// |---|---|---|---|
+    /// | 10_000 | 17-34 | 22-36% | 2-4 |
+    /// | **25_000** | **21-45** | **39-60%** | **4** |
+    /// | 50_000 | 35-42 | 50-72% | 4 |
+    ///
+    /// Up buys margin on the assertion; down leaves more of the window inside
+    /// libc, which is the only part that exposes the sampler to the frames
+    /// `UNWIND_BLOCKLIST` exists for. 25_000 keeps a ~20x margin on an assertion
+    /// that needs 1, at a roughly even split, with 2000-5000 full libc-churn
+    /// iterations still running per run. Re-measure before moving it; the split
+    /// depends on the allocator, so it will not be the same on the Linux targets.
+    const CPU_ROUNDS: u64 = 25_000;
+
+    /// Substring identifying an in-binary frame: matches both [`cpu_only`] and
+    /// [`cpu_only_round`], because which of the two a given build surfaces
+    /// depends on the optimization level (see [`cpu_only`]).
+    const CPU_NEEDLE: &str = "cpu_only";
 
     /// Keep `threads` threads busy for `at_least`, in two deliberately different
     /// places: **inside libc** (allocator churn, syscalls, thread create/join) and
@@ -281,10 +316,16 @@ mod tests {
     ///
     /// Both halves are load-bearing, and for opposite assertions:
     ///
-    /// - The libc churn is what the *crash* regression needs. The unwinder faults
-    ///   when it interrupts a thread already inside `malloc`, the dynamic loader
-    ///   or a syscall stub, so a pure integer loop — shallow stack, leaf PC in
-    ///   this binary — exercises precisely the case that never crashed.
+    /// - The libc churn is the half that puts the sampler in front of the frames
+    ///   the blocklist exists for. The unwinder faults when it interrupts a thread
+    ///   already inside `malloc`, the dynamic loader or a syscall stub, so a pure
+    ///   integer loop — shallow stack, leaf PC in this binary — exercises
+    ///   precisely the case that never crashed. Note what this does *not* claim:
+    ///   the original segfault has not been shown to reproduce here on any
+    ///   supported target (blocklist off, it does not fire on darwin/arm64), so
+    ///   the first half of this test is "the process survives being profiled",
+    ///   not a reproduction of the fault. That is why the churn is kept large
+    ///   rather than trimmed to whatever the second assertion needs.
     /// - [`cpu_only`] is what the *profile has heph frames in it* assertion needs,
     ///   and it is not decoration. `pprof` drops a sample whose leaf PC is
     ///   blocklisted **by design**, so a workload built only from the first half
@@ -338,14 +379,18 @@ mod tests {
         }
     }
 
-    /// How many of `profile`'s samples name a function containing `needle`
-    /// anywhere in their stack.
+    /// How many of `profile`'s **sample entries** name a function containing
+    /// `needle` anywhere in their stack.
+    ///
+    /// Entries, not sampling events: pprof collapses identical stacks into one
+    /// `Sample` carrying a count, so this is a count of *distinct stacks* and the
+    /// number of `SIGPROF` deliveries behind it is larger.
     ///
     /// Walks pprof's id indirection (sample → location → line → function → string
     /// table) rather than indexing by position: ids are not promised to be their
     /// index plus one, and a profile that renumbered them would otherwise make
     /// this silently answer zero.
-    fn samples_naming(profile: &pprof::protos::Profile, needle: &str) -> usize {
+    fn stacks_naming(profile: &pprof::protos::Profile, needle: &str) -> usize {
         use std::collections::{HashMap, HashSet};
         let names: HashMap<u64, &str> = profile
             .function
@@ -513,7 +558,9 @@ mod tests {
     /// to drop, so the profile came back empty on 4 of 50 darwin/arm64 runs — and
     /// on master's own CI. Naming a frame the blocklist must never match turns a
     /// statistical claim into a structural one, and says the thing the count was
-    /// only standing in for: heph's own frames survive the blocklist.
+    /// only standing in for: heph's own frames survive the blocklist. It is also
+    /// strictly stronger — a lone libc straggler satisfies "non-empty" while every
+    /// heph frame is being dropped, which is the failure it claimed to guard.
     ///
     /// **Only one test in this binary may call [`start`].** pprof's `PROFILER` is
     /// a process singleton: a concurrent second `start` fails with
@@ -552,15 +599,29 @@ mod tests {
         let snapshot = snapshot.unwrap_or_else(|| panic!("no profile at {}", path.display()));
         let profile = pprof::protos::Profile::decode(snapshot.as_slice())
             .expect("on-demand dump must be a decodable pprof profile — never a partial write");
-        let in_binary = samples_naming(&profile, "cpu_only");
+        // Diagnosis is branched on whether *anything* was sampled, because the two
+        // states have disjoint causes and a message naming the wrong one sends the
+        // reader after a bug that is not there.
+        let in_binary = stacks_naming(&profile, CPU_NEEDLE);
         assert!(
             in_binary > 0,
-            "no sample reached `cpu_only`, which burned a large share of this \
-             process's CPU inside the main binary for the whole sampling window: \
-             either UNWIND_BLOCKLIST now matches the main binary and every heph \
-             frame is being dropped, or the sampler collected nothing at all \
-             ({} sample(s) in total)",
-            profile.sample.len()
+            "no stack named `{}`, though it burned a large share of this process's \
+             CPU inside the main binary for the whole sampling window. {}",
+            CPU_NEEDLE,
+            if profile.sample.is_empty() {
+                "The profile is empty: either UNWIND_BLOCKLIST now matches the main \
+                 binary and every heph frame is being dropped, or the sampler \
+                 collected nothing at all."
+                    .to_string()
+            } else {
+                format!(
+                    "The profile has {} distinct stack(s), so the sampler is \
+                     working — the frames did not symbolize (a stripped build), or \
+                     `cpu_only`/`cpu_only_round` was renamed without updating \
+                     CPU_NEEDLE, or this build folded both frames away.",
+                    profile.sample.len()
+                )
+            }
         );
 
         // `shutdown` writes the filtered exit-time report — the profile the flag


### PR DESCRIPTION
`pprof_dump::tests::sampling_a_busy_process_yields_a_profile_without_crashing` is the failure that made **master's own CI red** ([run 30429168613](https://github.com/hephbuild/heph/actions/runs/30429168613), darwin/arm64):

```
profiler collected no samples: UNWIND_BLOCKLIST is dropping everything
```

## Classification: the test asserted a property the code never guaranteed

Not a product race, and not the environment. The sampler was doing exactly what it is designed to do.

`UNWIND_BLOCKLIST` makes `pprof` **drop a sample whose leaf PC is inside libc** — that is the whole fix for the `--pprof-cpu` segfault, and it is deliberate. `burn` was then written, just as deliberately, to spend its entire time *inside libc*: allocator churn across size classes, 16 `stat` syscalls per iteration, and a nested thread create/join. Its own doc said so — "a pure integer loop is the wrong workload […] the workload has to live there for the sampler to be tested at all".

Both halves are individually right. Together they mean the test generated almost nothing but samples the sampler is *supposed* to discard, and then asserted the profile was non-empty. Whether it passed came down to which straggler happened to land.

## Measured, on darwin/arm64

| burn workload | distinct stacks in the on-demand dump |
|---|---|
| libc-only, blocklist **on** (master) | **0**–6 |
| libc-only, blocklist **off** | 25–57 |

The blocklist was legitimately discarding 95–99% of the samples. Failure rate of the test itself, looping the real test binary:

| | failures |
|---|---|
| master | **4 / 50** (and 8 / 30 with the box under load) |
| this branch | **0 / 50** at opt-level 0, **0 / 20** at opt-level 3 |

## What changed

`burn` now interleaves `cpu_only` — an integer mix that calls nothing, allocates nothing and enters no shared object — into **every** burn thread. So a leaf PC no blocklist entry can match is present for the whole sampling window, on every thread; it does not matter which one the kernel picks for a process-directed `SIGPROF`, and on Darwin that is routinely not the thread burning the most CPU.

It is split into a loop and a per-round callee, both `#[inline(never)]`, and that is load-bearing rather than stylistic. A single `#[inline(never)]` leaf is only observable unoptimized: at `opt-level=3` the interrupted leaf is frameless and the unwinder attributes the sample to its caller, so an optimized build of this test binary named `cpu_only` in **zero** stacks and failed 10/10. With the round in a callee, `cpu_only` is a *caller* frame — recovered from a return address, not from leaf attribution — and the assertion holds at both optimization levels.

The libc churn is untouched in kind and still runs 2000–5000 full iterations per run.

The assertion is now **"some stack names `cpu_only`"**, not "the profile is non-empty". That is structural rather than statistical, and strictly stronger: a lone libc straggler satisfies "non-empty" while every heph frame is being dropped, which is the exact failure the old assertion claimed to guard. `stacks_naming` walks pprof's id indirection (sample → location → line → function → string table) by id rather than by position, so a profile that renumbered ids cannot make it silently answer zero.

## `CPU_ROUNDS = 25_000`

Sized against a measured sweep rather than feel — 8 runs per cell, darwin/arm64, `burn(4, 500ms)`:

| rounds | opt0 hits | opt0 cpu share | opt3 hits |
|---|---|---|---|
| 10_000 | 17–34 | 22–36% | 2–4 |
| **25_000** | **21–45** | **39–60%** | **4** |
| 50_000 | 35–42 | 50–72% | 4 |

Up buys margin on the assertion; down leaves more of the window inside libc. 25_000 keeps a ~20x margin on an assertion that needs one hit, at a roughly even split. The table is in the constant's doc comment so the next person has something to re-tune against.

## Verification

- **0 / 50** at opt-level 0 and **0 / 20** at opt-level 3, versus 4 / 50 on master.
- Red-checked twice, on the committed tree, restored from the commit each time:
  - adding `"heph"` to `UNWIND_BLOCKLIST` (an over-broad entry matching the main binary — precisely the bug this assertion exists to catch) fails it, with the *empty-profile* branch of the message;
  - pointing `CPU_NEEDLE` at a function that does not exist fails it with the *other* branch — "19 distinct stack(s), so the sampler is working — the frames did not symbolize, or … was renamed without updating CPU_NEEDLE".
- `cargo fmt --all --check` and `cargo clippy -p heph --all-targets -- -D warnings` clean.

## Review board

`code-quality`: PASS with nits — all four taken (`CPU_ROUNDS` sized against a real measurement, the doc's dangling evidence pointer replaced, the failure message branched, `samples_naming` → `stacks_naming` because pprof collapses identical stacks).

`feature-quality`: PASS with follow-ups — both closed. The optimized-build failure is fixed rather than papered over (measured 10/10 red before, 0/20 after). The unverified claim that the libc churn reproduces the original segfault is **removed**: it does not fire here with the blocklist off, and it has not been measured on the Linux targets. The churn is kept large because it is the only half that puts the sampler in front of the frames the blocklist exists for — which the docs now say instead.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01A76DChMohieGMbRbnV1E7x
