### PR TITLE
perf(engine): revive the artifact direct-open fast path

### DIFF
--- a/crates/core/src/hartifactcontent/file.rs
+++ b/crates/core/src/hartifactcontent/file.rs
@@ -57,8 +57,13 @@ impl Content for FileContent {
         Ok(Some(Box::new(self.open()?)))
     }
 
+    /// Gated on the file being there, per [`Content::file_path`]'s contract: a
+    /// caller opens what it is handed with no fallback to the stream, and this
+    /// content's file is a sandbox process log, which the sandbox cleaner deletes
+    /// on the target's next run — so `Some` to a vanished path is constructible,
+    /// not hypothetical.
     fn file_path(&self) -> Option<PathBuf> {
-        Some(self.path.clone())
+        self.path.is_file().then(|| self.path.clone())
     }
 }
 

--- a/crates/core/src/hartifactcontent/mod.rs
+++ b/crates/core/src/hartifactcontent/mod.rs
@@ -72,18 +72,23 @@ pub trait Content: Send + Sync {
     /// the stable-ABI seam, where a guest can read the file rather than pulling
     /// it chunk-by-chunk across the vtable.
     ///
-    /// **The path is only valid while this `Content` is alive.** Unlike
-    /// [`reader`](Self::reader) and [`seekable_reader`](Self::seekable_reader),
-    /// which hand back an open handle that pins its inode, a `PathBuf` is
-    /// detached: whatever keeps the bytes from being reclaimed — for a cache
-    /// artifact, the read guard riding on the `Content` (see `GuardedArtifact`
-    /// in the engine) — is released when the `Content` drops, and cache GC may
-    /// then delete the file the path names. Open it (or copy from it) before
-    /// dropping the handle you called this on; do not store it for later.
+    /// Two rules, both load-bearing:
     ///
-    /// An implementation must answer `None` rather than a path that does not
-    /// exist: callers treat `Some` as "open this", with no fallback to the byte
-    /// stream, so a stale path turns a working read into a hard error.
+    /// 1. **Open it before dropping the `Content` it came from; never store
+    ///    it.** Unlike [`reader`](Self::reader) and
+    ///    [`seekable_reader`](Self::seekable_reader), which hand back an open
+    ///    handle that pins its inode, a `PathBuf` is detached — whatever keeps
+    ///    the bytes from being reclaimed is tied to the `Content`, not to the
+    ///    path, so the file may be gone once the handle drops. The path is also
+    ///    host- and revision-specific (an absolute path under a particular
+    ///    user's cache), so it must never be embedded in a target's output: that
+    ///    would make a content-addressed artifact machine-specific.
+    /// 2. **Answer `None` rather than a path that does not exist.** Callers treat
+    ///    `Some` as "open this", with no fallback to the byte stream, so a stale
+    ///    path turns a working read into a hard error rather than a slow one.
+    ///
+    /// What backs rule 1 is per-implementation; the engine's cache artifacts
+    /// document their own guarantee, and it is not the same for every `Content`.
     fn file_path(&self) -> Option<std::path::PathBuf> {
         None
     }

--- a/crates/core/src/hartifactcontent/mod.rs
+++ b/crates/core/src/hartifactcontent/mod.rs
@@ -71,6 +71,19 @@ pub trait Content: Send + Sync {
     /// consumer open the file directly instead of streaming its bytes — notably
     /// the stable-ABI seam, where a guest can read the file rather than pulling
     /// it chunk-by-chunk across the vtable.
+    ///
+    /// **The path is only valid while this `Content` is alive.** Unlike
+    /// [`reader`](Self::reader) and [`seekable_reader`](Self::seekable_reader),
+    /// which hand back an open handle that pins its inode, a `PathBuf` is
+    /// detached: whatever keeps the bytes from being reclaimed — for a cache
+    /// artifact, the read guard riding on the `Content` (see `GuardedArtifact`
+    /// in the engine) — is released when the `Content` drops, and cache GC may
+    /// then delete the file the path names. Open it (or copy from it) before
+    /// dropping the handle you called this on; do not store it for later.
+    ///
+    /// An implementation must answer `None` rather than a path that does not
+    /// exist: callers treat `Some` as "open this", with no fallback to the byte
+    /// stream, so a stale path turns a working read into a hard error.
     fn file_path(&self) -> Option<std::path::PathBuf> {
         None
     }

--- a/crates/core/src/hartifactcontent/tar_index.rs
+++ b/crates/core/src/hartifactcontent/tar_index.rs
@@ -175,6 +175,86 @@ mod tests {
         );
     }
 
+    /// The header scan and the walk must enumerate the same set.
+    ///
+    /// `Content::entry_paths` has two implementations — the trait default, which
+    /// drives [`TarWalker`](crate::hartifactcontent::tar::TarWalker) and reads
+    /// every byte to advance, and the tar-backed override, which seeks past file
+    /// data. Cache artifacts use the override; anything reaching the default gets
+    /// the walk. They are only interchangeable if they agree, and nothing checked
+    /// that — which is how the engine's `GuardedArtifact` silently served the
+    /// walk for every cached artifact while its callers documented a header scan.
+    ///
+    /// They agree as *sets*, not as sequences: the index is a `BTreeMap`, so it
+    /// is sorted and collapses a repeated path, where the walk preserves tar
+    /// order and repeats. Both consumers key by path (`detect_output_collisions`
+    /// compares producers, `build_source_map` builds a map), so set equality is
+    /// the property that matters — asserted here rather than assumed.
+    #[cfg(unix)]
+    #[test]
+    fn header_scan_and_walk_enumerate_the_same_paths() {
+        use crate::hartifactcontent::WalkEntryKind;
+        use crate::hartifactcontent::tar::TarWalker;
+        use std::collections::BTreeSet;
+        use std::os::unix::fs::symlink;
+
+        let dir = tempfile::tempdir().expect("tempdir");
+        let target = dir.path().join("target.txt");
+        std::fs::write(&target, b"data").unwrap();
+        let link = dir.path().join("link.txt");
+        symlink("target.txt", &link).unwrap();
+
+        // A nested file, an explicit dir entry, a symlink, and a duplicate path.
+        let mut buf = Vec::new();
+        {
+            let mut b = tar::Builder::new(&mut buf);
+            let mut dh = tar::Header::new_gnu();
+            dh.set_entry_type(tar::EntryType::Directory);
+            dh.set_size(0);
+            dh.set_mode(0o755);
+            b.append_data(&mut dh, "d/", std::io::empty()).expect("dir");
+            for (path, data) in [
+                ("d/f.txt", &b"abc"[..]),
+                ("g.txt", b"z"),
+                ("d/f.txt", b"abc"),
+            ] {
+                let mut fh = tar::Header::new_gnu();
+                fh.set_entry_type(tar::EntryType::Regular);
+                fh.set_size(data.len() as u64);
+                fh.set_mode(0o644);
+                b.append_data(&mut fh, path, data).expect("file");
+            }
+            let mut lh = tar::Header::new_gnu();
+            lh.set_entry_type(tar::EntryType::Symlink);
+            lh.set_size(0);
+            lh.set_mode(0o777);
+            b.append_link(&mut lh, "link.txt", "target.txt")
+                .expect("symlink");
+            b.finish().expect("finish");
+        }
+
+        let from_index: BTreeSet<PathBuf> = TarIndex::build(Cursor::new(buf.clone()))
+            .expect("build")
+            .entry_paths()
+            .into_iter()
+            .collect();
+        let from_walk: BTreeSet<PathBuf> = TarWalker::new(Box::new(Cursor::new(buf)))
+            .expect("walker")
+            .map(|e| e.expect("entry").path)
+            .collect();
+
+        assert_eq!(
+            from_index, from_walk,
+            "the header scan and the walk must enumerate the same paths"
+        );
+        assert!(from_index.contains(std::path::Path::new("d/f.txt")));
+        assert!(from_index.contains(std::path::Path::new("link.txt")));
+        assert!(
+            !from_index.contains(std::path::Path::new("d/")),
+            "neither enumeration includes directory entries"
+        );
+    }
+
     #[cfg(unix)]
     #[test]
     fn build_indexes_symlinks() {

--- a/crates/engine/src/engine/local_cache_fs.rs
+++ b/crates/engine/src/engine/local_cache_fs.rs
@@ -231,7 +231,20 @@ impl LocalCache for LocalCacheFS {
     /// [`LocalCacheSpill`]: crate::engine::local_cache_spill::LocalCacheSpill
     fn file_path(&self, addr: &Addr, hashin: &str, name: &str) -> Option<PathBuf> {
         let path = self.get_path(addr, hashin, name);
-        path.is_file().then_some(path)
+        match fs::metadata(&path) {
+            Ok(m) if m.is_file() => Some(path),
+            Ok(_) => None,
+            Err(e) if e.kind() == io::ErrorKind::NotFound => None,
+            // Not-found is the ordinary answer (every sub-threshold key); anything
+            // else — EACCES on the blobs dir, EIO — means the fast path is off for
+            // *every* artifact while the build merely looks slow. `Path::is_file`
+            // would fold that into the same silent `false`, which is the
+            // invisible-degradation failure this whole path exists to undo.
+            Err(e) => {
+                tracing::debug!(?path, error = %e, "stat cache blob for direct-open path");
+                None
+            }
+        }
     }
 }
 

--- a/crates/engine/src/engine/local_cache_fs.rs
+++ b/crates/engine/src/engine/local_cache_fs.rs
@@ -219,8 +219,19 @@ impl LocalCache for LocalCacheFS {
         }
     }
 
+    /// Only for a blob that actually lives here. This backend is normally the
+    /// *blob* half of [`LocalCacheSpill`], holding only entries over the spill
+    /// threshold — everything smaller is a sqlite row and has no file at this
+    /// path. Answering `Some` unconditionally would hand every small artifact a
+    /// path to nothing, and `Content::file_path`'s callers open what they are
+    /// given without falling back to the stream, so that is a hard read error
+    /// rather than a missed optimization. One `stat(2)`, on the seam hand-off
+    /// path only.
+    ///
+    /// [`LocalCacheSpill`]: crate::engine::local_cache_spill::LocalCacheSpill
     fn file_path(&self, addr: &Addr, hashin: &str, name: &str) -> Option<PathBuf> {
-        Some(self.get_path(addr, hashin, name))
+        let path = self.get_path(addr, hashin, name);
+        path.is_file().then_some(path)
     }
 }
 
@@ -327,6 +338,46 @@ mod tests {
         cache.delete(&addr, hashin, name)?;
         assert!(!cache.exists(&addr, hashin, name)?);
 
+        Ok(())
+    }
+
+    /// `file_path` describes what is on disk, not what could be. Under
+    /// [`LocalCacheSpill`] this backend is asked about every key, including the
+    /// small ones that live in sqlite and have no file here — and a consumer
+    /// handed a path opens it with no fallback to the byte stream, so a path to
+    /// a missing file is a read error, not a slower read.
+    ///
+    /// [`LocalCacheSpill`]: crate::engine::local_cache_spill::LocalCacheSpill
+    #[test]
+    fn file_path_is_none_until_the_blob_is_on_disk() -> Result<()> {
+        let dir = tempdir()?;
+        let cache = LocalCacheFS::new(PathBuf::from(dir.path()))?;
+        let addr = Addr::new(
+            hmodel::htpkg::PkgBuf::from("pkg"),
+            "t".to_string(),
+            Default::default(),
+        );
+
+        assert!(
+            cache.file_path(&addr, "h", "out.tar").is_none(),
+            "no blob written: must not name a path that does not exist"
+        );
+
+        let mut w = cache.writer(&addr, "h", "out.tar")?;
+        w.write_all(b"bytes")?;
+        drop(w);
+
+        let path = cache
+            .file_path(&addr, "h", "out.tar")
+            .expect("written blob has a path");
+        assert_eq!(std::fs::read(&path)?, b"bytes", "path names the blob");
+
+        // Reclaimed by GC: the path goes away with the bytes.
+        cache.delete(&addr, "h", "out.tar")?;
+        assert!(
+            cache.file_path(&addr, "h", "out.tar").is_none(),
+            "deleted blob must not keep answering with a path"
+        );
         Ok(())
     }
 

--- a/crates/engine/src/engine/local_cache_mem.rs
+++ b/crates/engine/src/engine/local_cache_mem.rs
@@ -162,14 +162,25 @@ impl LocalCache for LocalCacheMem {
         self.inner.seekable_reader(addr, hashin, name)
     }
 
-    /// Delegated unconditionally: this tier only *fronts* reads — `writer`
-    /// forwards to the durable backend — so a resident entry is a copy of one
-    /// that is (or was) durable, never the only copy. Residency therefore says
-    /// nothing about whether a file exists, and the durable backend is the one
-    /// that can answer. In practice the two are disjoint anyway: entries here
-    /// are capped at `per_entry_bytes` (16 KiB by default) and only blobs over
-    /// the spill threshold (8 MiB) get a file, so a mem hit delegates to sqlite
-    /// and gets `None` without touching the disk.
+    /// Delegated unconditionally, unlike every other read path here: this tier
+    /// only *fronts* reads — `writer` forwards to the durable backend — so a
+    /// resident entry is a copy of a durable one, never the only copy. Residency
+    /// therefore cannot answer "is there a file?", and delegating is not an
+    /// optimization to skip but the only way to get the answer.
+    ///
+    /// It is not free. Under the production stack `inner` is [`LocalCacheSpill`],
+    /// which goes straight to the FS blob store, so this costs one `stat` that
+    /// misses for anything under the spill threshold — i.e. for every entry this
+    /// tier can hold. Paid on the seam hand-off path only, and worth it against
+    /// naming a file that is not there.
+    ///
+    /// The two tiers are disjoint *while* `per_entry_bytes` ≤ the spill
+    /// threshold (16 KiB vs 8 MiB by default) — both user-tunable, with nothing
+    /// enforcing the ordering. Above that an entry is both mem-resident and an FS
+    /// file, and `reader` (the mem copy) and `file_path` (the file) become two
+    /// sources for one key.
+    ///
+    /// [`LocalCacheSpill`]: crate::engine::local_cache_spill::LocalCacheSpill
     fn file_path(&self, addr: &Addr, hashin: &str, name: &str) -> Option<std::path::PathBuf> {
         self.inner.file_path(addr, hashin, name)
     }

--- a/crates/engine/src/engine/local_cache_mem.rs
+++ b/crates/engine/src/engine/local_cache_mem.rs
@@ -161,6 +161,18 @@ impl LocalCache for LocalCacheMem {
         // streaming consumers.
         self.inner.seekable_reader(addr, hashin, name)
     }
+
+    /// Delegated unconditionally: this tier only *fronts* reads — `writer`
+    /// forwards to the durable backend — so a resident entry is a copy of one
+    /// that is (or was) durable, never the only copy. Residency therefore says
+    /// nothing about whether a file exists, and the durable backend is the one
+    /// that can answer. In practice the two are disjoint anyway: entries here
+    /// are capped at `per_entry_bytes` (16 KiB by default) and only blobs over
+    /// the spill threshold (8 MiB) get a file, so a mem hit delegates to sqlite
+    /// and gets `None` without touching the disk.
+    fn file_path(&self, addr: &Addr, hashin: &str, name: &str) -> Option<std::path::PathBuf> {
+        self.inner.file_path(addr, hashin, name)
+    }
 }
 
 #[cfg(test)]
@@ -299,6 +311,33 @@ mod tests {
         let mut w = cache.writer(addr, "h1", name).expect("writer");
         w.write_all(data).expect("write");
         drop(w);
+    }
+
+    /// This tier sits at the top of the cacheable stack, so a method left to the
+    /// trait default here is that method switched off for every cached artifact
+    /// in the product. It only *fronts* reads — writes go straight through — so
+    /// whether a durable file exists is the durable backend's question, and
+    /// residency must not change the answer.
+    #[test]
+    fn file_path_delegates_to_the_durable_backend() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let inner = Arc::new(
+            crate::engine::local_cache_fs::LocalCacheFS::new(dir.path().join("blobs")).expect("fs"),
+        );
+        let dec = LocalCacheMem::new(inner, 1024, 64 * 1024);
+        let addr = make_addr();
+
+        write_blob(&dec, &addr, "out.tar", b"blob bytes");
+        // Read once so the entry is mem-resident; the answer must not change.
+        assert_eq!(
+            drain(dec.reader(&addr, "h1", "out.tar").expect("read").reader),
+            b"blob bytes"
+        );
+
+        let path = dec
+            .file_path(&addr, "h1", "out.tar")
+            .expect("durable backend has a file for this blob");
+        assert_eq!(std::fs::read(&path).expect("read"), b"blob bytes");
     }
 
     #[test]

--- a/crates/engine/src/engine/local_cache_spill.rs
+++ b/crates/engine/src/engine/local_cache_spill.rs
@@ -166,6 +166,15 @@ impl LocalCache for LocalCacheSpill {
             other => other,
         }
     }
+
+    /// Only spilled blobs have a file. The primary is sqlite — its blobs live in
+    /// rows, so it answers `None` — and asking it first would cost a query to
+    /// learn that; go straight to the FS store, which answers `Some` only for a
+    /// path that exists. A `(addr, hashin, name)` lives in exactly one backend,
+    /// so a hit here is unambiguous.
+    fn file_path(&self, addr: &Addr, hashin: &str, name: &str) -> Option<std::path::PathBuf> {
+        self.blobs.file_path(addr, hashin, name)
+    }
 }
 
 /// Streams a blob to the primary, promoting it to the FS store the moment its
@@ -351,6 +360,38 @@ mod tests {
         assert_eq!(read(&cache, &a, "large"), large);
         assert!(cache.exists(&a, "h", "small").expect("ex"));
         assert!(cache.exists(&a, "h", "large").expect("ex"));
+    }
+
+    /// The direct-open fast path tracks the routing: a spilled blob is a real
+    /// file and names it, a primary-resident one is a sqlite row and has no
+    /// path. Getting the second case wrong is worse than having no fast path at
+    /// all — a consumer opens what it is handed and never falls back to the
+    /// stream.
+    #[test]
+    fn file_path_answers_for_spilled_blobs_only() {
+        let dir = tempdir().expect("tempdir");
+        let (cache, _sqlite, _fs) = spill(dir.path(), 64);
+        let a = addr();
+
+        let large = vec![2u8; 256];
+        write(&cache, &a, "small", &vec![1u8; 32]);
+        write(&cache, &a, "large", &large);
+
+        assert!(
+            cache.file_path(&a, "h", "small").is_none(),
+            "sqlite-resident blob has no file"
+        );
+        let path = cache
+            .file_path(&a, "h", "large")
+            .expect("spilled blob is a real file");
+        assert_eq!(std::fs::read(&path).expect("read"), large);
+
+        // The manifest always stays in the primary, however big.
+        write(&cache, &a, MANIFEST_V1, &vec![9u8; 256]);
+        assert!(
+            cache.file_path(&a, "h", MANIFEST_V1).is_none(),
+            "manifest never spills, so it never has a path"
+        );
     }
 
     /// A blob written across many small chunks that *cumulatively* exceed the

--- a/crates/engine/src/engine/local_cache_spill.rs
+++ b/crates/engine/src/engine/local_cache_spill.rs
@@ -181,19 +181,48 @@ impl LocalCache for LocalCacheSpill {
         }
     }
 
-    /// Only spilled blobs have a file. The primary is sqlite — its blobs live in
-    /// rows, so it answers `None` — and asking it first would cost a query per
-    /// call to learn that; go straight to the FS store, which answers `Some` only
-    /// for a path that exists.
+    /// Only spilled blobs have a file: the primary is sqlite, whose blobs live in
+    /// rows. Ask the FS store first — it answers `Some` only for a path that
+    /// exists, and for anything under the threshold (nearly every artifact) that
+    /// single `stat` ends it.
     ///
-    /// Note this resolves against one backend where [`reader`](Self::reader)
-    /// tries the primary first. The two agree only because a key lives in exactly
-    /// one backend, so this rests on that invariant rather than re-deriving it —
-    /// which is why [`writer`](Self::writer) now enforces it instead of assuming
-    /// it. If the invariant ever breaks again, this method is where it shows up
-    /// as two answers for one key.
+    /// **Then confirm the primary does not also hold the key**, so this agrees
+    /// with [`reader`](Self::reader), which tries the primary *first*. The two
+    /// would otherwise resolve to different bytes for one key whenever both
+    /// backends hold it, and this method has no error to report it with — the
+    /// caller would just silently open the wrong blob.
+    ///
+    /// [`writer`](Self::writer) stops that state being *created*, but cannot
+    /// repair a cache that already has it: `spillThresholdBytes` is user-tunable
+    /// and nothing swept a still-live revision, so a directory written before
+    /// that fix can carry a superseded FS blob indefinitely — and GC only
+    /// reclaims trimmed or orphaned revisions, never audits a live one. Deferring
+    /// to the primary here makes the read side correct on those caches too,
+    /// without a migration.
+    ///
+    /// The probe costs nothing in the common case: it runs *only* when an FS blob
+    /// exists, which for a healthy cache means a genuinely spilled (large)
+    /// artifact, not the per-call sqlite query that asking primary-first would be.
     fn file_path(&self, addr: &Addr, hashin: &str, name: &str) -> Option<std::path::PathBuf> {
-        self.blobs.file_path(addr, hashin, name)
+        let path = self.blobs.file_path(addr, hashin, name)?;
+        match self.primary.exists_committed(addr, hashin, name) {
+            // Sole resident: the ordinary spilled-blob case.
+            Ok(false) => Some(path),
+            // Both hold it. `reader` serves the primary, so this must not offer
+            // the FS copy; no direct-open beats a fast route to the wrong bytes.
+            Ok(true) => {
+                tracing::debug!(
+                    %addr, hashin, name,
+                    "cache key in both spill backends; superseded blob left for the next write"
+                );
+                None
+            }
+            // Cannot establish it is the only copy — decline rather than guess.
+            Err(e) => {
+                tracing::debug!(%addr, hashin, name, error = %e, "probe primary for spilled blob");
+                None
+            }
+        }
     }
 }
 
@@ -411,6 +440,41 @@ mod tests {
         assert!(
             cache.file_path(&a, "h", MANIFEST_V1).is_none(),
             "manifest never spills, so it never has a path"
+        );
+    }
+
+    /// A cache that *already* carries a superseded spilled blob must not serve it
+    /// through the direct-open path.
+    ///
+    /// `writer` stops this state being created, but cannot repair a directory
+    /// written before that fix, and GC never audits a still-live revision — so
+    /// the read side has to be correct on its own or those caches silently hand
+    /// out the wrong bytes. Both backends are written directly here, bypassing
+    /// `writer`, because that is exactly the state an older heph could leave.
+    ///
+    /// `reader` resolves primary-first, so the primary is the answer and
+    /// `file_path` must decline rather than offer a faster route to the stale
+    /// copy.
+    #[test]
+    fn file_path_declines_when_the_primary_also_holds_the_key() {
+        let dir = tempdir().expect("tempdir");
+        let (cache, sqlite, fs) = spill(dir.path(), 64);
+        let a = addr();
+
+        // Pre-existing dual residency: superseded blob on disk, live row in sqlite.
+        write(&*fs, &a, "out", &[9u8; 256]);
+        write(&*sqlite, &a, "out", &[4u8; 32]);
+        assert!(fs.exists(&a, "h", "out").expect("ex"));
+        assert!(sqlite.exists(&a, "h", "out").expect("ex"));
+
+        assert_eq!(
+            read(&cache, &a, "out"),
+            vec![4u8; 32],
+            "reader resolves primary-first"
+        );
+        assert!(
+            cache.file_path(&a, "h", "out").is_none(),
+            "direct open must not disagree with reader"
         );
     }
 

--- a/crates/engine/src/engine/local_cache_spill.rs
+++ b/crates/engine/src/engine/local_cache_spill.rs
@@ -94,6 +94,20 @@ impl LocalCache for LocalCacheSpill {
         if Self::is_manifest(name) {
             return self.primary.writer(addr, hashin, name);
         }
+        // Drop any stale FS copy before writing, so this key ends up in exactly
+        // one backend — the invariant the module doc asserts and every read path
+        // relies on. It is not self-maintaining: `spill` deletes the primary's
+        // staged prefix when a blob is promoted, but nothing deleted the FS copy
+        // when a rewrite of the same key stays *under* the threshold, which
+        // `cache.spillThresholdBytes` being user-tunable makes reachable. Dual
+        // residency would make `reader` (primary first) and `file_path` (FS only)
+        // resolve to different bytes for one key. Cheap and on the cold path: one
+        // `stat` per blob write, and an unlink only in the rare stale case.
+        if self.blobs.file_path(addr, hashin, name).is_some() {
+            self.blobs
+                .delete(addr, hashin, name)
+                .with_context(|| format!("drop stale spilled blob for {addr} {name}"))?;
+        }
         // Stream to the primary by default; promote to FS on the first byte past
         // the threshold. Opening the primary writer up front means small blobs
         // (the common case) hit their final home with no buffering and no copy.
@@ -168,10 +182,16 @@ impl LocalCache for LocalCacheSpill {
     }
 
     /// Only spilled blobs have a file. The primary is sqlite — its blobs live in
-    /// rows, so it answers `None` — and asking it first would cost a query to
-    /// learn that; go straight to the FS store, which answers `Some` only for a
-    /// path that exists. A `(addr, hashin, name)` lives in exactly one backend,
-    /// so a hit here is unambiguous.
+    /// rows, so it answers `None` — and asking it first would cost a query per
+    /// call to learn that; go straight to the FS store, which answers `Some` only
+    /// for a path that exists.
+    ///
+    /// Note this resolves against one backend where [`reader`](Self::reader)
+    /// tries the primary first. The two agree only because a key lives in exactly
+    /// one backend, so this rests on that invariant rather than re-deriving it —
+    /// which is why [`writer`](Self::writer) now enforces it instead of assuming
+    /// it. If the invariant ever breaks again, this method is where it shows up
+    /// as two answers for one key.
     fn file_path(&self, addr: &Addr, hashin: &str, name: &str) -> Option<std::path::PathBuf> {
         self.blobs.file_path(addr, hashin, name)
     }
@@ -374,7 +394,7 @@ mod tests {
         let a = addr();
 
         let large = vec![2u8; 256];
-        write(&cache, &a, "small", &vec![1u8; 32]);
+        write(&cache, &a, "small", &[1u8; 32]);
         write(&cache, &a, "large", &large);
 
         assert!(
@@ -387,10 +407,51 @@ mod tests {
         assert_eq!(std::fs::read(&path).expect("read"), large);
 
         // The manifest always stays in the primary, however big.
-        write(&cache, &a, MANIFEST_V1, &vec![9u8; 256]);
+        write(&cache, &a, MANIFEST_V1, &[9u8; 256]);
         assert!(
             cache.file_path(&a, "h", MANIFEST_V1).is_none(),
             "manifest never spills, so it never has a path"
+        );
+    }
+
+    /// A rewrite that lands under the threshold must not leave the previous
+    /// spilled copy behind. `spill` deletes the primary's staged prefix when a
+    /// blob is promoted, but the reverse — a key that used to spill and no longer
+    /// does — had no cleanup, and `cache.spillThresholdBytes` is user-tunable, so
+    /// lowering it and raising it back is enough to create it. Dual residency
+    /// makes `reader` (primary first) and `file_path` (FS only) resolve to
+    /// *different bytes for one key*: the read path would serve the new blob
+    /// while a plugin opening the path got the old one.
+    #[test]
+    fn a_rewrite_below_the_threshold_drops_the_stale_spilled_copy() {
+        let dir = tempdir().expect("tempdir");
+        let a = addr();
+
+        // Threshold 64: the 256-byte blob spills to the FS store.
+        let (low, _sqlite, fs) = spill(dir.path(), 64);
+        write(&low, &a, "out", &[1u8; 256]);
+        assert!(
+            fs.exists(&a, "h", "out").expect("ex"),
+            "precondition: spilled"
+        );
+
+        // Threshold raised; the same key is rewritten and now stays in sqlite.
+        let (high, sqlite2, fs2) = spill(dir.path(), 4096);
+        write(&high, &a, "out", &[2u8; 256]);
+
+        assert!(
+            sqlite2.exists(&a, "h", "out").expect("ex"),
+            "the rewrite belongs in the primary now"
+        );
+        assert!(
+            !fs2.exists(&a, "h", "out").expect("ex"),
+            "the stale spilled copy must be gone, not shadowed"
+        );
+        // The two read routes must not disagree.
+        assert_eq!(read(&high, &a, "out"), vec![2u8; 256]);
+        assert!(
+            high.file_path(&a, "h", "out").is_none(),
+            "file_path must not hand out the superseded blob"
         );
     }
 

--- a/crates/engine/src/engine/local_cache_sqlite.rs
+++ b/crates/engine/src/engine/local_cache_sqlite.rs
@@ -940,12 +940,29 @@ impl LocalCache for LocalCacheSQLite {
 
 /// Owns both a pooled sqlite connection and a `Blob` opened against it.
 ///
-/// `rusqlite::blob::Blob<'conn>` borrows its connection; lifetime extension
-/// to `'static` is sound because the blob is dropped before `_conn` (Rust
-/// drops struct fields in declaration order).
+/// `rusqlite::blob::Blob<'conn>` borrows its connection, and we extend that
+/// borrow to `'static` to store the two together. Two things make it sound, and
+/// **both** are required:
+///
+/// 1. *Drop order* — `blob` is declared before `_conn`, and Rust drops fields in
+///    declaration order, so the blob is finalized while its connection is alive.
+/// 2. *A stable address* — the connection is behind a `Box`, so the
+///    `&Connection` the blob captured stays valid when this struct is moved.
+///
+/// The `Box` is the subtle one and is **not** an allocation to optimize away.
+/// [`r2d2::PooledConnection`] stores its `Connection` inline, so without the
+/// indirection the borrow would be taken from a local that is then *moved* into
+/// the returned struct (and moved again by every `Box::new`/return after it),
+/// leaving the blob pointing at a dead stack slot. Reads then go through a
+/// dangling pointer, which surfaces as sqlite's `RefCell` appearing already
+/// mutably borrowed — a panic inside `Blob::read`, followed by a second panic in
+/// this struct's own drop, i.e. a non-unwinding abort of the whole process.
+/// Boxing first is what makes the address the blob captured outlive the moves.
 struct OwnedBlob {
     blob: rusqlite::blob::Blob<'static>,
-    _conn: r2d2::PooledConnection<SqliteConnectionManager>,
+    /// Boxed for address stability — see the type doc. Never dereferenced here;
+    /// it exists to keep the connection alive and pinned for `blob`.
+    _conn: Box<r2d2::PooledConnection<SqliteConnectionManager>>,
 }
 
 // SAFETY: rusqlite::Connection is Send. The blob holds a raw sqlite3
@@ -956,13 +973,17 @@ unsafe impl Send for OwnedBlob {}
 
 impl OwnedBlob {
     fn new(conn: r2d2::PooledConnection<SqliteConnectionManager>, row_id: i64) -> Result<Self> {
+        // Box BEFORE borrowing: the blob captures an address that must survive
+        // this struct being moved out of `new`. See the type doc.
+        let conn = Box::new(conn);
         let conn_ref: &Connection = &conn;
         let blob = conn_ref
             .blob_open(rusqlite::MAIN_DB, "artifacts", "data", row_id, true)
             .context("opening seekable sqlite blob")?;
-        // SAFETY: `blob` borrows from `conn` which is owned alongside it in
-        // the returned struct; struct field drop order (blob before _conn)
-        // guarantees the borrow outlives no longer than the connection.
+        // SAFETY: `blob` borrows the `Connection` inside the heap allocation
+        // `conn` owns, which this struct keeps alive and never moves (moving the
+        // `Box` moves the pointer, not the pointee). Field order drops `blob`
+        // first, so the borrow never outlives the connection.
         let blob_static: rusqlite::blob::Blob<'static> = unsafe { std::mem::transmute(blob) };
         Ok(Self {
             blob: blob_static,
@@ -1600,6 +1621,80 @@ mod tests {
         queued_write(&cache, &addr, "blob", b"bytes");
         assert!(cache.exists(&addr, "h", "blob")?); // barrier: commit has landed
         assert!(committed(cache.existence(&addr, "h", "blob")?));
+        Ok(())
+    }
+
+    /// Scribble over a few KiB of stack below the current frame.
+    ///
+    /// Only meaningful for the test above: it turns "the blob may point at a
+    /// popped frame" from a platform-dependent maybe into a deterministic
+    /// corruption. `black_box` keeps the writes from being optimized out.
+    #[inline(never)]
+    fn clobber_stack() {
+        let mut scratch = [0xAAu8; 8192];
+        std::hint::black_box(&mut scratch);
+    }
+
+    /// A seekable blob reader must survive being returned, boxed and moved.
+    ///
+    /// `OwnedBlob` extends the blob's borrow of its connection to `'static`. That
+    /// is only sound while the `Connection` the blob captured stays put — and
+    /// `PooledConnection` stores it inline, so taking the borrow *before* moving
+    /// the connection into the struct leaves the blob pointing at a dead stack
+    /// slot. The reader still constructs fine; it is the reads afterwards that go
+    /// through a dangling pointer, which is why nothing catches it at the seam.
+    ///
+    /// This drives the shape `TarIndex::build` uses — interleaved seeks and short
+    /// reads, well past the first buffer — across the move boundary, and checks
+    /// the bytes rather than merely that it did not crash. Corrupt reads from a
+    /// reused stack slot fail the comparison even when they do not panic.
+    #[test]
+    fn a_seekable_blob_reads_correctly_after_the_reader_is_moved() -> Result<()> {
+        use std::io::Seek;
+
+        let dir = tempdir()?;
+        let cache = LocalCacheSQLite::with_pipe_limit(
+            dir.path().join("cache.db"),
+            16 * 1024,
+            DEFAULT_MAX_CONCURRENT_PIPES,
+        )?;
+        let addr = make_addr("pkg", "seekable");
+
+        // Distinctive, position-dependent bytes: a wrong offset or a garbage read
+        // cannot coincidentally match.
+        let payload: Vec<u8> = (0..64_000u32).map(|i| (i % 251) as u8).collect();
+        queued_write(&cache, &addr, "blob", &payload);
+        assert!(cache.exists(&addr, "h", "blob")?); // barrier
+
+        // Returned boxed from `seekable_reader`, then moved again into this local.
+        let mut reader = cache
+            .seekable_reader(&addr, "h", "blob")?
+            .expect("sqlite serves a seekable reader");
+
+        // Overwrite the stack region `OwnedBlob::new` and its callers used. If the
+        // blob captured an address in a frame that has since been popped, this is
+        // what a later caller doing ordinary work would do to it — made explicit
+        // and immediate so the failure is deterministic here instead of appearing
+        // as an abort somewhere downstream on one platform.
+        clobber_stack();
+
+        let mut whole = Vec::new();
+        reader.read_to_end(&mut whole)?;
+        assert_eq!(whole, payload, "sequential read must match");
+
+        // Seek back and re-read at several offsets, the way a tar header scan
+        // walks an archive.
+        for off in [0u64, 511, 1024, 40_000, 63_000] {
+            reader.seek(std::io::SeekFrom::Start(off))?;
+            let mut chunk = [0u8; 512];
+            let n = reader.read(&mut chunk)?;
+            let start = off as usize;
+            assert_eq!(
+                &chunk[..n],
+                &payload[start..start + n],
+                "read at offset {off} must match"
+            );
+        }
         Ok(())
     }
 

--- a/crates/engine/src/engine/local_cache_tmp.rs
+++ b/crates/engine/src/engine/local_cache_tmp.rs
@@ -187,10 +187,25 @@ impl LocalCache for LocalCacheTmp {
     }
 
     /// An admitted entry lives only in `map` — there is no file anywhere, so
-    /// `None` is the answer, not a gap. Anything else spilled, and the durable
-    /// cache decides. Unlike the other read paths this checks residency to
-    /// *avoid* delegating: the durable answer for a resident key would be a
-    /// wasted `stat` on a path that by construction does not exist.
+    /// `None` is the answer, not a gap to fill with an invented temp file.
+    /// Anything else spilled, and the durable cache decides. Residency is checked
+    /// for the same reason every read path here checks it, but to a different
+    /// end: the tier-local answer is negative, so a hit means "no file, and don't
+    /// ask" rather than "here it is" — saving a `stat` on a path that by
+    /// construction does not exist.
+    ///
+    /// **Lifetime exemption.** [`Content::file_path`]'s contract says the path
+    /// stays valid while the artifact is alive because a cache read guard rides
+    /// on it. That does not hold here: `build_eresult` attaches no
+    /// `GuardedArtifact` on the uncacheable path (`guard: None`), so a spilled
+    /// tmp entry hands out a durable path with *no lock held on its addr*. Its
+    /// revision is enumerable, so a concurrent `heph gc` can reclaim the blob
+    /// while the path is in flight. The consumer then gets `ENOENT` — a hard
+    /// error, not wrong bytes, and the same exposure `reader` already had. Do not
+    /// build a consumer that holds a tmp path across an await on the assumption
+    /// the guarded contract covers it.
+    ///
+    /// [`Content::file_path`]: hcore::hartifactcontent::Content::file_path
     fn file_path(&self, addr: &Addr, hashin: &str, name: &str) -> Option<std::path::PathBuf> {
         let key = Self::key(addr, hashin, name);
         if self.store.map.read().contains_key(&key) {
@@ -281,6 +296,9 @@ mod tests {
     #[derive(Default)]
     struct RecordingCache {
         store: Arc<RwLock<FxHashMap<Key, Arc<[u8]>>>>,
+        /// Counts `file_path` delegations, so a test can assert the tmp tier
+        /// answered from its own map instead of asking.
+        file_path_calls: Arc<std::sync::atomic::AtomicUsize>,
     }
 
     struct RecordingWriter {
@@ -341,6 +359,15 @@ mod tests {
             self.store.write().remove(&key);
             Ok(())
         }
+        /// Answers a path for *any* key, whether or not it holds it. Deliberately
+        /// unlike a real backend: it makes the tmp tier's residency
+        /// short-circuit observable, since delegating would visibly return
+        /// `Some` for a mem-resident entry.
+        fn file_path(&self, _a: &Addr, _h: &str, name: &str) -> Option<std::path::PathBuf> {
+            self.file_path_calls
+                .fetch_add(1, std::sync::atomic::Ordering::Relaxed);
+            Some(std::path::PathBuf::from("/durable").join(name))
+        }
     }
 
     fn addr() -> Addr {
@@ -390,12 +417,15 @@ mod tests {
     /// file. A spilled one is an ordinary durable blob and must expose the
     /// durable backend's path, or an uncacheable target's artifacts never take
     /// the direct-open path however large they are.
+    ///
+    /// The durable double answers `Some` for *every* key, including ones it does
+    /// not hold. That is what makes the mem-resident half discriminating: against
+    /// a real backend (which has no file for a mem-resident key either) the
+    /// assertion would hold whether or not the residency short-circuit existed.
     #[test]
     fn file_path_answers_only_for_spilled_entries() {
-        let dir = tempfile::tempdir().expect("tempdir");
-        let durable = Arc::new(
-            crate::engine::local_cache_fs::LocalCacheFS::new(dir.path().join("blobs")).expect("fs"),
-        );
+        let durable = Arc::new(RecordingCache::default());
+        let calls = Arc::clone(&durable.file_path_calls);
         // per-entry cap of 8 bytes: the short entry stays in mem, the 64-byte
         // one spills.
         let tmp = LocalCacheTmp::new(durable, 8, 1024 * 1024);
@@ -404,15 +434,22 @@ mod tests {
         write_all(&tmp, &a, "h_m", "out", b"hi");
         assert!(
             tmp.file_path(&a, "h_m", "out").is_none(),
-            "mem-resident tmp entry has no file on disk"
+            "mem-resident tmp entry has no file on disk, whatever durable would say"
+        );
+        assert_eq!(
+            calls.load(std::sync::atomic::Ordering::Relaxed),
+            0,
+            "a resident entry must be answered locally, not delegated"
         );
 
         let big = vec![7u8; 64];
         write_all(&tmp, &a, "h_s", "out", &big);
-        let path = tmp
-            .file_path(&a, "h_s", "out")
-            .expect("spilled tmp entry is a durable file");
-        assert_eq!(std::fs::read(&path).expect("read"), big);
+        assert_eq!(
+            tmp.file_path(&a, "h_s", "out"),
+            Some(std::path::PathBuf::from("/durable/out")),
+            "a spilled entry must expose the durable backend's path"
+        );
+        assert_eq!(calls.load(std::sync::atomic::Ordering::Relaxed), 1);
     }
 
     #[test]

--- a/crates/engine/src/engine/local_cache_tmp.rs
+++ b/crates/engine/src/engine/local_cache_tmp.rs
@@ -185,6 +185,19 @@ impl LocalCache for LocalCacheTmp {
     fn list_target_entries(&self, addr: &Addr) -> Result<Vec<String>> {
         self.durable.list_target_entries(addr)
     }
+
+    /// An admitted entry lives only in `map` — there is no file anywhere, so
+    /// `None` is the answer, not a gap. Anything else spilled, and the durable
+    /// cache decides. Unlike the other read paths this checks residency to
+    /// *avoid* delegating: the durable answer for a resident key would be a
+    /// wasted `stat` on a path that by construction does not exist.
+    fn file_path(&self, addr: &Addr, hashin: &str, name: &str) -> Option<std::path::PathBuf> {
+        let key = Self::key(addr, hashin, name);
+        if self.store.map.read().contains_key(&key) {
+            return None;
+        }
+        self.durable.file_path(addr, hashin, name)
+    }
 }
 
 /// Writer that buffers in memory and publishes on drop. It spills to the durable
@@ -370,6 +383,36 @@ mod tests {
         assert_eq!(read_all(&tmp, &a, "h_1", "out"), b"hello");
         assert!(tmp.exists(&a, "h_1", "out").unwrap());
         assert!(durable.store.read().is_empty());
+    }
+
+    /// An admitted entry lives only in the map — there is no file anywhere, so
+    /// `None` is its true answer, not a gap to be filled with an invented temp
+    /// file. A spilled one is an ordinary durable blob and must expose the
+    /// durable backend's path, or an uncacheable target's artifacts never take
+    /// the direct-open path however large they are.
+    #[test]
+    fn file_path_answers_only_for_spilled_entries() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let durable = Arc::new(
+            crate::engine::local_cache_fs::LocalCacheFS::new(dir.path().join("blobs")).expect("fs"),
+        );
+        // per-entry cap of 8 bytes: the short entry stays in mem, the 64-byte
+        // one spills.
+        let tmp = LocalCacheTmp::new(durable, 8, 1024 * 1024);
+        let a = addr();
+
+        write_all(&tmp, &a, "h_m", "out", b"hi");
+        assert!(
+            tmp.file_path(&a, "h_m", "out").is_none(),
+            "mem-resident tmp entry has no file on disk"
+        );
+
+        let big = vec![7u8; 64];
+        write_all(&tmp, &a, "h_s", "out", &big);
+        let path = tmp
+            .file_path(&a, "h_s", "out")
+            .expect("spilled tmp entry is a durable file");
+        assert_eq!(std::fs::read(&path).expect("read"), big);
     }
 
     #[test]

--- a/crates/engine/src/engine/result.rs
+++ b/crates/engine/src/engine/result.rs
@@ -313,6 +313,23 @@ pub use hplugin::eresult::{ArtifactMeta, EResult};
 /// purely for RAII, so the cache entry cannot be overwritten/deleted while any
 /// handle to it (here, or cloned into a dependent's sandbox input) is alive. The
 /// lock releases when the last `Arc<dyn Content>` for the entry drops.
+///
+/// **Every method must be forwarded**, including the ones with a working
+/// default. This wrapper sits on *every* cacheable result artifact, so a method
+/// left to its default is that method's fast path switched off product-wide,
+/// with the inner artifact's implementation dead and nothing to see: `file_path`
+/// silently answered `None` for on-disk cache blobs (the stable-ABI seam then
+/// streamed them chunk-by-chunk instead of opening the file) and `entry_paths`
+/// silently fell back to a byte-reading `walk` instead of the tar header scan.
+///
+/// [`file_path`](Content::file_path) is safe to forward for the same reason it
+/// needs the guard: cache GC deletes a revision only under the per-addr *write*
+/// lock (`Engine::gc_apply`, `Engine::try_trim_after_write`), which cannot be
+/// taken while this read guard is alive — so the path stays valid for exactly as
+/// long as this artifact does, which is the contract `Content::file_path`
+/// states. Handing the bare `PathBuf` further out than the artifact would break
+/// that; the one consumer (`HostArtifactContent::path`) opens it while still
+/// holding the `Arc<dyn Content>`, and the open fd pins the inode thereafter.
 struct GuardedArtifact {
     inner: Arc<dyn Content>,
     _lock: Arc<ResultReadGuard>,
@@ -328,11 +345,17 @@ impl Content for GuardedArtifact {
     fn hashout(&self) -> anyhow::Result<String> {
         self.inner.hashout()
     }
+    fn entry_paths(&self) -> anyhow::Result<Vec<std::path::PathBuf>> {
+        self.inner.entry_paths()
+    }
     fn seekable_reader(&self) -> anyhow::Result<Option<Box<dyn ReadSeek + Send>>> {
         self.inner.seekable_reader()
     }
     fn byte_size(&self) -> Option<u64> {
         self.inner.byte_size()
+    }
+    fn file_path(&self) -> Option<std::path::PathBuf> {
+        self.inner.file_path()
     }
 }
 
@@ -3662,6 +3685,82 @@ mod tests {
         }
     }
 
+    /// A [`Content`] whose fast paths are answerable and *differ* from what the
+    /// trait defaults would produce: `entry_paths` reports a name `walk` never
+    /// yields, and `file_path` names a real file whose bytes `reader` refuses to
+    /// serve. Standing in for a `CacheArtifact`, whose overrides are exactly
+    /// these two.
+    struct FastPathContent {
+        path: std::path::PathBuf,
+    }
+
+    impl Content for FastPathContent {
+        fn reader(&self) -> anyhow::Result<Box<dyn std::io::Read>> {
+            anyhow::bail!("must be read through file_path, not the stream")
+        }
+        fn walk(&self) -> anyhow::Result<Box<dyn Iterator<Item = anyhow::Result<WalkEntry>> + '_>> {
+            Ok(Box::new(std::iter::once(Ok(WalkEntry {
+                path: std::path::PathBuf::from("from-walk"),
+                kind: WalkEntryKind::Symlink {
+                    target: std::path::PathBuf::from("t"),
+                },
+            }))))
+        }
+        fn hashout(&self) -> anyhow::Result<String> {
+            Ok("fast".to_string())
+        }
+        fn entry_paths(&self) -> anyhow::Result<Vec<std::path::PathBuf>> {
+            Ok(vec![std::path::PathBuf::from("from-index")])
+        }
+        fn file_path(&self) -> Option<std::path::PathBuf> {
+            Some(self.path.clone())
+        }
+    }
+
+    /// `GuardedArtifact` wraps *every* cacheable result artifact, so a `Content`
+    /// method it leaves to the trait default is that method's fast path switched
+    /// off product-wide — the inner artifact's implementation unreachable, and
+    /// nothing failing to show it. Both defaults are silent: `file_path` reports
+    /// "not a file" for an on-disk cache blob (the stable-ABI seam then streams
+    /// it 64 KiB at a time instead of opening it), and `entry_paths` falls back
+    /// to a `walk` that reads every byte instead of the tar header scan.
+    ///
+    /// Asserted through `&dyn Content`, which is how every consumer sees it.
+    #[tokio::test]
+    async fn guarded_artifact_forwards_the_direct_open_fast_paths() {
+        let dir = tempdir().expect("tempdir");
+        let lock = SArc::new(ResultLock::new(LockBackend::Mem, dir.path().to_path_buf()));
+        let addr = Addr::new(PkgBuf::from("pkg"), "x".to_string(), BTreeMap::new());
+        let read = lock
+            .read(&addr, &StdCancellationToken::new())
+            .await
+            .expect("read");
+
+        let blob = dir.path().join("blob.tar");
+        std::fs::write(&blob, b"artifact bytes").expect("write blob");
+
+        let guarded: Arc<dyn Content> = Arc::new(GuardedArtifact {
+            inner: Arc::new(FastPathContent { path: blob.clone() }),
+            _lock: SArc::new(read),
+        });
+
+        // The direct-open path reaches the consumer: it gets the cache file, not
+        // `None`, and the bytes are readable without going near `reader()`.
+        let path = guarded
+            .file_path()
+            .expect("the wrapper must not hide the artifact's on-disk path");
+        assert_eq!(path, blob);
+        assert_eq!(std::fs::read(&path).expect("read"), b"artifact bytes");
+
+        // The header-scan enumeration reaches the consumer too — the walk-based
+        // default would answer `from-walk`.
+        assert_eq!(
+            guarded.entry_paths().expect("entry_paths"),
+            vec![std::path::PathBuf::from("from-index")],
+            "must use the inner artifact's index, not the byte-reading walk"
+        );
+    }
+
     /// The read lock travels with the artifact, not the `EResult`: it stays held
     /// as long as *any* handle to the artifact is alive — including a handle
     /// cloned into a dependent's sandbox input (or a group target's merged
@@ -6942,6 +7041,81 @@ mod tests {
         };
         engine.register_provider(move |_| Box::new(OneTargetProvider { spec }))?;
         Ok((Arc::new(engine), dir, addr))
+    }
+
+    /// The direct-open fast path, end to end through the real cache stack.
+    ///
+    /// Every tier has to answer for a consumer to get anything: the artifact is
+    /// a `GuardedArtifact` over a `CacheArtifact` over `Mem(Spill(SQLite, FS))`,
+    /// and a single tier defaulting to `None` — as all of them did — turns the
+    /// whole path off with nothing failing. The unit tests pin the tiers; this
+    /// pins that they compose, which is the property that was actually broken.
+    ///
+    /// The spill threshold is lowered to 64 bytes so the packed tar lands in the
+    /// FS blob store without the test writing megabytes. The mem tier is left at
+    /// its default — it is what production runs, and it is the tier sitting on
+    /// top of the answer.
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn a_cached_artifact_exposes_its_blob_file_for_direct_open() {
+        let dir = tempdir().expect("tempdir");
+        let mut engine = Engine::new(Config {
+            root: dir.path().to_path_buf(),
+            home_dir: std::path::PathBuf::new(),
+            parallelism: None,
+            spill_threshold_bytes: 64,
+            ..Default::default()
+        })
+        .expect("engine");
+        engine
+            .register_driver(|_| {
+                Box::new(BlockingDriver {
+                    exec_count: SArc::new(AtomicUsize::new(0)),
+                    outputs: SArc::new(vec![("main".to_string(), "out_main".to_string())]),
+                    cleanup_thread: None,
+                })
+            })
+            .expect("driver");
+        let addr = Addr::new(PkgBuf::from("pkg"), "a".to_string(), Default::default());
+        let spec = TargetSpec {
+            addr: addr.clone(),
+            driver: "blocking".to_string(),
+            ..Default::default()
+        };
+        engine
+            .register_provider(move |_| Box::new(OneTargetProvider { spec }))
+            .expect("provider");
+        let engine = Arc::new(engine);
+
+        let r = engine
+            .clone()
+            .result_addr(
+                engine.new_state(),
+                &addr,
+                OutputMatcher::All,
+                &ResultOptions::default(),
+            )
+            .await
+            .expect("resolves");
+        assert_eq!(r.artifacts.len(), 1, "the single output is surfaced");
+
+        let path = r.artifacts[0]
+            .file_path()
+            .expect("a spilled cache blob must reach the consumer as a path");
+        let via_path = std::fs::read(&path).expect("open the cache blob directly");
+        assert!(!via_path.is_empty(), "the path must name the real blob");
+
+        // Same bytes either way — the fast path is a different route to the
+        // artifact, not a different artifact.
+        let mut via_stream = Vec::new();
+        std::io::Read::read_to_end(
+            &mut r.artifacts[0].reader().expect("reader"),
+            &mut via_stream,
+        )
+        .expect("stream the artifact");
+        assert_eq!(
+            via_path, via_stream,
+            "direct open and the byte stream must serve the same artifact"
+        );
     }
 
     /// P6.2: each background job class must reach its own lane.

--- a/crates/engine/src/engine/result.rs
+++ b/crates/engine/src/engine/result.rs
@@ -321,6 +321,9 @@ pub use hplugin::eresult::{ArtifactMeta, EResult};
 /// silently answered `None` for on-disk cache blobs (the stable-ABI seam then
 /// streamed them chunk-by-chunk instead of opening the file) and `entry_paths`
 /// silently fell back to a byte-reading `walk` instead of the tar header scan.
+/// `missing_trait_methods` on the impl below makes that a compile error rather
+/// than a comment nobody reads — a doc cannot fail a build, and this exact
+/// omission survived two `Content` methods being added.
 ///
 /// [`file_path`](Content::file_path) is safe to forward for the same reason it
 /// needs the guard: cache GC deletes a revision only under the per-addr *write*
@@ -335,6 +338,11 @@ struct GuardedArtifact {
     _lock: Arc<ResultReadGuard>,
 }
 
+#[deny(
+    clippy::missing_trait_methods,
+    reason = "this wrapper must forward every Content method; a default here \
+              silently disables that method's fast path for every cached artifact"
+)]
 impl Content for GuardedArtifact {
     fn reader(&self) -> anyhow::Result<Box<dyn std::io::Read>> {
         self.inner.reader()
@@ -7043,26 +7051,19 @@ mod tests {
         Ok((Arc::new(engine), dir, addr))
     }
 
-    /// The direct-open fast path, end to end through the real cache stack.
-    ///
-    /// Every tier has to answer for a consumer to get anything: the artifact is
-    /// a `GuardedArtifact` over a `CacheArtifact` over `Mem(Spill(SQLite, FS))`,
-    /// and a single tier defaulting to `None` — as all of them did — turns the
-    /// whole path off with nothing failing. The unit tests pin the tiers; this
-    /// pins that they compose, which is the property that was actually broken.
-    ///
-    /// The spill threshold is lowered to 64 bytes so the packed tar lands in the
-    /// FS blob store without the test writing megabytes. The mem tier is left at
-    /// its default — it is what production runs, and it is the tier sitting on
-    /// top of the answer.
-    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
-    async fn a_cached_artifact_exposes_its_blob_file_for_direct_open() {
+    /// Resolve one cacheable target through the **real** production cache stack
+    /// (`Mem(Spill(SQLite, FS))`, mem tier at its default) at the given spill
+    /// threshold, and hand back its single result artifact. Held `TempDir` is
+    /// returned because the cache lives under it.
+    async fn resolve_one_artifact_at_spill(
+        spill_threshold_bytes: u64,
+    ) -> (Arc<dyn Content>, tempfile::TempDir) {
         let dir = tempdir().expect("tempdir");
         let mut engine = Engine::new(Config {
             root: dir.path().to_path_buf(),
             home_dir: std::path::PathBuf::new(),
             parallelism: None,
-            spill_threshold_bytes: 64,
+            spill_threshold_bytes,
             ..Default::default()
         })
         .expect("engine");
@@ -7097,8 +7098,26 @@ mod tests {
             .await
             .expect("resolves");
         assert_eq!(r.artifacts.len(), 1, "the single output is surfaced");
+        (Arc::clone(&r.artifacts[0]), dir)
+    }
 
-        let path = r.artifacts[0]
+    /// The direct-open fast path, end to end through the real cache stack.
+    ///
+    /// Every tier has to answer for a consumer to get anything: the artifact is
+    /// a `GuardedArtifact` over a `CacheArtifact` over `Mem(Spill(SQLite, FS))`,
+    /// and a single tier defaulting to `None` — as all of them did — turns the
+    /// whole path off with nothing failing. The unit tests pin the tiers; this
+    /// pins that they compose, which is the property that was actually broken.
+    ///
+    /// The spill threshold is lowered to 64 bytes so the packed tar lands in the
+    /// FS blob store without the test writing megabytes. The mem tier is left at
+    /// its default — it is what production runs, and it is the tier sitting on
+    /// top of the answer.
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn a_cached_artifact_exposes_its_blob_file_for_direct_open() {
+        let (artifact, _dir) = resolve_one_artifact_at_spill(64).await;
+
+        let path = artifact
             .file_path()
             .expect("a spilled cache blob must reach the consumer as a path");
         let via_path = std::fs::read(&path).expect("open the cache blob directly");
@@ -7107,14 +7126,78 @@ mod tests {
         // Same bytes either way — the fast path is a different route to the
         // artifact, not a different artifact.
         let mut via_stream = Vec::new();
-        std::io::Read::read_to_end(
-            &mut r.artifacts[0].reader().expect("reader"),
-            &mut via_stream,
-        )
-        .expect("stream the artifact");
+        std::io::Read::read_to_end(&mut artifact.reader().expect("reader"), &mut via_stream)
+            .expect("stream the artifact");
         assert_eq!(
             via_path, via_stream,
             "direct open and the byte stream must serve the same artifact"
+        );
+    }
+
+    /// The property that makes handing out a bare `PathBuf` safe at all: an fd
+    /// opened from it keeps serving the bytes it was opened on, even after the
+    /// same cache key is rewritten underneath it.
+    ///
+    /// This is the half of the safety argument that is not about locking.
+    /// `AtomicFileWriter` finishes by `rename`ing over the destination, so a
+    /// rewrite (a lazy remote-cache pull, a rebuild) swaps the *inode* the path
+    /// names while an already-open fd keeps the old one alive — POSIX unlink
+    /// semantics, identical on all three supported targets. Without that, a
+    /// consumer that opened the file could observe a torn mix of two revisions.
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn an_fd_opened_from_the_path_survives_the_blob_being_rewritten() {
+        let (artifact, _dir) = resolve_one_artifact_at_spill(64).await;
+        let path = artifact.file_path().expect("spilled blob has a path");
+
+        let mut fd = std::fs::File::open(&path).expect("open before the rewrite");
+        let original = std::fs::read(&path).expect("read blob");
+
+        // Replace the blob the way the cache does — write a sibling, rename over.
+        let tmp = path.with_extension("rewrite");
+        std::fs::write(&tmp, b"a completely different revision").expect("write");
+        std::fs::rename(&tmp, &path).expect("rename over the live blob");
+
+        let mut held = Vec::new();
+        std::io::Read::read_to_end(&mut fd, &mut held).expect("read through the held fd");
+        assert_eq!(
+            held, original,
+            "the open fd must still serve the revision it was opened on"
+        );
+        assert_ne!(
+            std::fs::read(&path).expect("read"),
+            original,
+            "precondition: the path itself now names different bytes"
+        );
+    }
+
+    /// The shape ~every production artifact actually has, which the test above
+    /// does not cover: at the **default** spill threshold a small artifact is a
+    /// sqlite row with no file anywhere, so the honest answer is `None` and the
+    /// consumer must fall back to the byte stream.
+    ///
+    /// This is the direction that turns a working read into a hard error if it
+    /// regresses — a consumer opens what it is handed and never falls back — and
+    /// it is exactly what a well-meaning "optimization" in the mem tier (answer
+    /// from residency!) would break, with every other test in this area still
+    /// green. `_golist`, the only artifact plugin-go reads across the seam, takes
+    /// this branch and never the one above.
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn a_small_cached_artifact_reports_no_file_and_still_streams() {
+        let (artifact, _dir) =
+            resolve_one_artifact_at_spill(crate::engine::config::DEFAULT_SPILL_THRESHOLD_BYTES)
+                .await;
+
+        assert!(
+            artifact.file_path().is_none(),
+            "a sub-threshold blob lives in sqlite; naming a path would be naming nothing"
+        );
+
+        let mut bytes = Vec::new();
+        std::io::Read::read_to_end(&mut artifact.reader().expect("reader"), &mut bytes)
+            .expect("stream the artifact");
+        assert!(
+            !bytes.is_empty(),
+            "the stream must still serve the artifact when there is no file"
         );
     }
 
@@ -7202,6 +7285,17 @@ mod tests {
             ) -> anyhow::Result<Option<Box<dyn hcore::hartifactcontent::ReadSeek + Send>>>
             {
                 self.inner.seekable_reader(addr, hashin, name)
+            }
+            // Forwarded, not defaulted: a decorator that swallows this turns the
+            // direct-open path off for every artifact in the test that wraps the
+            // cache — the exact defect this file's `GuardedArtifact` doc warns of.
+            fn file_path(
+                &self,
+                addr: &Addr,
+                hashin: &str,
+                name: &str,
+            ) -> Option<std::path::PathBuf> {
+                self.inner.file_path(addr, hashin, name)
             }
         }
 
@@ -7534,6 +7628,16 @@ mod tests {
             ) -> anyhow::Result<Option<Box<dyn hcore::hartifactcontent::ReadSeek + Send>>>
             {
                 self.inner.seekable_reader(addr, hashin, name)
+            }
+            // See the note on the other cache decorator in this file: defaulting
+            // this silently disables the direct-open path under the test.
+            fn file_path(
+                &self,
+                addr: &Addr,
+                hashin: &str,
+                name: &str,
+            ) -> Option<std::path::PathBuf> {
+                self.inner.file_path(addr, hashin, name)
             }
         }
 

--- a/crates/plugin-stabby/src/host.rs
+++ b/crates/plugin-stabby/src/host.rs
@@ -79,8 +79,17 @@ impl StableArtifactContent for HostArtifactContent {
     extern "C" fn path(&self) -> SString {
         // Non-empty only when the content is a real on-disk file (e.g. cache
         // artifact); the guest then reads it directly instead of streaming.
-        match self.content.file_path() {
-            Some(p) => SString::from(p.to_string_lossy().as_ref()),
+        //
+        // `to_str`, not `to_string_lossy`: the guest opens whatever it is handed
+        // and does NOT fall back to the stream on failure, so a path mangled by
+        // U+FFFD substitution is a hard read error where streaming would have
+        // worked. A non-UTF-8 cache path (reachable on Linux, where the cache
+        // root derives from an arbitrary `PathBuf`; APFS rejects invalid UTF-8)
+        // therefore reports "not file-backed" and takes the slower-but-correct
+        // route. `SString` is UTF-8, so carrying the raw bytes would mean an ABI
+        // change — not worth it for a case whose only cost is a stream.
+        match self.content.file_path().as_deref().and_then(Path::to_str) {
+            Some(p) => SString::from(p),
             None => SString::new(),
         }
     }
@@ -370,9 +379,64 @@ impl StableExecutor for HostExecutor {
 
 #[cfg(test)]
 mod tests {
-    use super::{HostLogSink, HostSupervisor};
-    use crate::abi::{DynRead, StableRead, StableReadDyn};
+    use super::{HostArtifactContent, HostLogSink, HostSupervisor};
+    use crate::abi::{DynRead, StableArtifactContent, StableRead, StableReadDyn};
     use stabby::vec::Vec as SVec;
+
+    /// `Content` naming a path the seam has to render as a `SString`.
+    struct PathContent(std::path::PathBuf);
+
+    impl hcore::hartifactcontent::Content for PathContent {
+        fn reader(&self) -> anyhow::Result<Box<dyn std::io::Read>> {
+            Ok(Box::new(std::io::empty()))
+        }
+        fn walk(
+            &self,
+        ) -> anyhow::Result<
+            Box<dyn Iterator<Item = anyhow::Result<hcore::hartifactcontent::WalkEntry>> + '_>,
+        > {
+            Ok(Box::new(std::iter::empty()))
+        }
+        fn hashout(&self) -> anyhow::Result<String> {
+            Ok("h".to_string())
+        }
+        fn file_path(&self) -> Option<std::path::PathBuf> {
+            Some(self.0.clone())
+        }
+    }
+
+    /// A UTF-8 cache path crosses intact — the ordinary case.
+    #[test]
+    fn path_carries_a_utf8_cache_path() {
+        let h = HostArtifactContent {
+            content: std::sync::Arc::new(PathContent("/cache/blobs/out.tar".into())),
+        };
+        assert_eq!(h.path().to_string(), "/cache/blobs/out.tar");
+    }
+
+    /// A non-UTF-8 cache path must report "not file-backed" (empty), so the guest
+    /// streams. `SString` is UTF-8, and the guest opens whatever it is handed
+    /// with no fallback — so lossy conversion would substitute U+FFFD and turn a
+    /// working read into `ENOENT`. Correct-and-slower beats wrong.
+    ///
+    /// Unix-only: the byte sequence has no `OsString` equivalent elsewhere. It is
+    /// reachable on Linux (ext4/xfs accept arbitrary bytes) and not on macOS
+    /// (APFS rejects invalid UTF-8), which is exactly why it needs a test rather
+    /// than a green CI run.
+    #[cfg(unix)]
+    #[test]
+    fn path_refuses_a_non_utf8_cache_path_instead_of_mangling_it() {
+        use std::os::unix::ffi::OsStrExt;
+        let raw = std::ffi::OsStr::from_bytes(b"/cache/blobs/\xff\xfe/out.tar");
+        let h = HostArtifactContent {
+            content: std::sync::Arc::new(PathContent(std::path::PathBuf::from(raw))),
+        };
+        assert_eq!(
+            h.path().to_string(),
+            "",
+            "a path that cannot round-trip must read as 'not file-backed'"
+        );
+    }
 
     /// A distinct `StableRead` implementor per `N`: each monomorphization is its
     /// own source type, so each construction is a FIRST-USE insert into stabby's


### PR DESCRIPTION
## The finding

`Content::file_path()` — the fast path that lets an in-process consumer `open(2)` an artifact's backing file instead of streaming it — has answered `None` for **every artifact in the production stack since the day it landed** (8a7575ba). Its only consumer is the stable-ABI seam: `HostArtifactContent::path` hands the path over and the guest opens the file, instead of pulling 64 KiB per vtable call through `GuestRead`. That never happened, because four layers each left the method at its trait default.

A review comment on #250 reported it missing on the Mem/Tmp/Spill backends. That is real, but it is the smaller half.

**The one that subsumes the rest:** `GuardedArtifact` (`result.rs`) wraps *every* cacheable result artifact and forwarded `reader`/`walk`/`hashout`/`seekable_reader`/`byte_size` — but not `file_path`. So even an FS-backed artifact whose `CacheArtifact::file_path` would have answered reported `None`. Fixing only the backends changes nothing observable. Its own doc claimed it "delegates every `Content` method"; it did not.

`entry_paths` was dead in that same impl for the same reason — and **that one is where the measurable win actually is.** Sandbox input staging (`driver_managed.rs`) documents it as a tar header scan that seeks past file data; through the wrapper it fell back to a `walk` that reads every byte of every opted-in input artifact, on every cache-miss execution. The comments claiming the header scan were false until this PR.

## Oversight, not a safety property

The obvious question was whether the omission was deliberate — a `PathBuf` is detached in a way a `Box<dyn Read>` is not, and the cache read guard rides on the `Content`. The evidence says oversight:

- 8a7575ba's own commit message says "the artifact is *usually* a real on-disk cache file — so the guest can just open it". `GuardedArtifact` and the whole Mem/Spill/Tmp stack already existed at that commit. The feature was born dead.
- `seekable_reader` **is** forwarded and hands back a detached owned `File`, so "no detached handles" was never the operating principle.
- `PassthroughContent` leaves `file_path` `None` deliberately, but its stated reason is forcing every consumer through the verifying reader — verification, not lifetime. It does not generalise, and it keeps its `None`.
- Two methods missing from the same impl, one of them a pure perf loss with no lifetime story at all.

**The lifetime concern is real and now holds explicitly.** GC deletes a revision only under the per-addr write lock (`gc_apply`, `try_trim_after_write` — `trim_addr_history` takes `_guard: &ResultWriteGuard` as proof), and the riding read guard blocks it. With the default `Fs` lock backend that read guard is a real `flock(2)`, so it excludes another *process*'s GC too. The sole consumer opens the file while still holding the `Arc<dyn Content>`, and the fd pins the inode thereafter — tested.

**One documented exemption:** the contract does *not* hold on the tmp/uncacheable path, where `build_eresult` attaches no guard at all. A spilled tmp entry hands out a durable path with no lock on its addr. That is now stated at both sites rather than left as a contract with a silent violator.

## What changed

| Layer | Before | After |
|---|---|---|
| `GuardedArtifact` | default `None` | forwards `file_path` **and** `entry_paths`; `#[deny(clippy::missing_trait_methods)]` makes a future omission a compile error |
| `LocalCacheMem` | default `None` | delegates (it only fronts reads; writes go through) |
| `LocalCacheSpill` | not implemented | the FS blob store answers, then defers to the primary if it holds the key too; `writer` drops a stale spilled copy so single-residency is enforced, not assumed |
| `LocalCacheTmp` | not implemented | `None` for map-resident entries, delegates for spilled |
| `LocalCacheFS` | `Some(path)` always | `Some` only if the file exists, via `fs::metadata` so EACCES/EIO is logged rather than silently disabling the path |
| `HostArtifactContent::path` | `to_string_lossy` | `to_str`; a non-UTF-8 path reports "not file-backed" and streams instead of failing to open |

The FS existence gate is load-bearing, not tidiness. Under `Spill` the FS backend is asked about *every* key including the sub-threshold ones living in sqlite, and a consumer opens what it is handed with no fallback — so an unconditional `Some` would turn every small artifact's read into a hard error.

**Mem and Spill can only ever answer for blobs over the spill threshold** (8 MiB by default); everything smaller is a sqlite row with no file, and `None` is correct, not a gap. An admitted `Tmp` entry has no file by construction — no temp file is invented for it. The guest side was already fully wired (`StableContent::reader`/`seekable_reader` both consume `path()`), so nothing was needed there.

## Honest cost/benefit

Worth stating plainly rather than claiming a perf win:

- **`entry_paths` is the real win.** It lands on `detect_output_collisions` and `build_source_map`, per input, on every cache-miss execution, and replaces reading every byte of every input artifact with a header scan.
- **`file_path` engages for no shipped artifact today.** The only cdylib consumer is plugin-go's `_golist`, whose artifacts are a few KB — always under the 8 MiB spill threshold, hence always `None`. It costs one `stat` per artifact read across the seam (~1–3 µs, single-digit ms over a large Go build).

So this restores latent capability rather than delivering a measured speedup on `file_path`, and it stops the SDK advertising a slot production never populates. I did **not** benchmark — the box was under load ~20–40 and a timing number would not have been honest. The load-immune measurement (counting `file_path` calls and the `Some`/`None` ratio on a warm plugingo run) is noted as the right follow-up if the `stat` is ever worth removing; the size predicate needed to do it without a syscall is available from the manifest but needs a signature change across six impls.

## Tests

Thirteen, each verified **red** when its production change is reverted:

| Test | Reverting… |
|---|---|
| `guarded_artifact_forwards_the_direct_open_fast_paths` | the `file_path` forward, and separately the `entry_paths` forward |
| `a_cached_artifact_exposes_its_blob_file_for_direct_open` | any of the four forwards |
| `a_small_cached_artifact_reports_no_file_and_still_streams` | the production shape — a mem-tier "optimize from residency" regression |
| `an_fd_opened_from_the_path_survives_the_blob_being_rewritten` | the non-locking half of the safety argument |
| `file_path_answers_for_spilled_blobs_only` | the Spill impl, and separately the FS existence gate |
| `a_rewrite_below_the_threshold_drops_the_stale_spilled_copy` | the single-residency enforcement |
| `file_path_declines_when_the_primary_also_holds_the_key` | the read-side deference (correctness on caches written before the fix) |
| `file_path_delegates_to_the_durable_backend` | the Mem impl |
| `file_path_answers_only_for_spilled_entries` | the Tmp impl (via a double answering `Some` for every key, so the short-circuit is observable) |
| `file_path_is_none_until_the_blob_is_on_disk` | the FS existence gate |
| `header_scan_and_walk_enumerate_the_same_paths` | the assumption `entry_paths` forwarding rests on |
| `path_refuses_a_non_utf8_cache_path_instead_of_mangling_it` | the `to_str` fix (fails with a visible U+FFFD path) |
| `a_seekable_blob_reads_correctly_after_the_reader_is_moved` | the `OwnedBlob` boxing (reproduces the CI abort deterministically) |

Green: `engine` (439), `core`, `driver-support`, `driver-bridge`, `e2e`, `plugin-sdk --features stabby`, `plugin-stabby --features host`. `cargo clippy --all-targets --locked -- -D warnings` clean.

## A latent soundness bug this surfaced

Forwarding `entry_paths` moved `detect_output_collisions` onto the tar header scan, which reads through `seekable_reader` — and that path had **pre-existing UB**. `OwnedBlob` (`local_cache_sqlite.rs`) extends a `rusqlite::Blob`'s borrow of its connection to `'static`; its doc reasoned about drop order, which is necessary but not sufficient. The borrow was taken from a local that is then *moved* into the returned struct, and `r2d2::PooledConnection` stores its `Connection` inline — so the blob was left pointing at a popped stack frame, and every read went through a dangling pointer.

It surfaces as sqlite's `RefCell` appearing already mutably borrowed: `Blob::read` panics decoding a result against garbage, then `OwnedBlob`'s own drop panics the same way — a panic in a destructor during unwinding, i.e. a **non-unwinding abort** with a backtrace pointing at rusqlite rather than at the cache.

The fix is to box the connection before borrowing it, so the captured address survives the moves. Boxing is load-bearing, not an allocation to optimize away, and the type doc now says so.

This is why the first CI run aborted `e2e --test deps` on `linux/amd64` while `linux/arm64` and `darwin/arm64` passed — whether the popped frame has been reused yet is a codegen and platform accident. The regression test removes that dependence: it clobbers the stack region between constructing the reader and reading it, then checks the bytes. **Verified red without the fix, reproducing the exact CI panic (`RefCell already mutably borrowed`, rusqlite `lib.rs:1024`) on a platform whose CI job had passed** — and green with it.

## Review

`hermeticity` (mandatory here — this touches artifact lifetime and cache reclamation): **HERMETIC WITH EXEMPTIONS**, cache key verifiably untouched; both exemptions it found are now documented at their sites, and the one it rated MAJOR (`file_path`/`reader` resolving against different backends) is fixed rather than documented.

`compatibility`: **COMPATIBLE** — no `ABI_SEMVER` bump (`StableArtifactContent` is byte-identical; the host-side `to_str` change stays inside the already-documented "empty = not file-backed" protocol, which the guest implements), no cache-format bump, nothing else crossing a versioned boundary. Its one MAJOR — that `writer` fixes dual residency going forward but leaves caches written *before* the fix serving a superseded blob — is fixed by the read-side deference in the last commit, so no migration is needed.

`code-quality` and `feature-quality` both returned BLOCKED on the first revision; every blocker is fixed above (the production-shape test, the two unforwarded decorators, the `useless_vec`), and the structural guard they asked for — `#[deny(clippy::missing_trait_methods)]` — is in and verified by deleting a forward.

## One thing for the maintainer

**`lint` does not cover workspace members' test targets.** `cargo clippy --all-targets` from the repo root lints the root package plus members' *libs*, not their unit-test targets. `cargo clippy -p engine --all-targets` surfaces 10 pre-existing errors and `-p core` another 14 — none of them mine, all invisible to CI. They only became reachable once the `engine` test target compiled again (#252). Left alone deliberately: deciding which stale `#[expect(...)]` entries to drop is a judgement call that does not belong in this PR, but the gate being narrower than it looks is worth knowing.

(An earlier revision of this branch carried its own fix for the `exists_committed` compile break; #252 landed the same fix first, so that commit was dropped on rebase.)
