### PR TITLE
test(diag): compare one snapshot, not two reads of live global state

### DIFF
--- a/crates/core/src/hmemoizer/cell.rs
+++ b/crates/core/src/hmemoizer/cell.rs
@@ -98,7 +98,7 @@ const NO_DRIVER: usize = usize::MAX;
 /// backstop with every wake evaporating — ~1000 ticks over 269s in the
 /// production wedge. A count that keeps climbing while a build makes no
 /// progress is that regression announcing itself; it is rendered in
-/// `render_full_report`, so it lands in the `SIGQUIT` dump and the stall
+/// `render_report`, so it lands in the `SIGQUIT` dump and the stall
 /// watchdog file. Not a `debug_assert!`: the benign cases above are reachable
 /// in correct executions.
 static VOID_WAKES: AtomicU64 = AtomicU64::new(0);

--- a/crates/core/src/hmemoizer/mod.rs
+++ b/crates/core/src/hmemoizer/mod.rs
@@ -628,25 +628,50 @@ pub fn render_inventory(cells: &[StuckCell], limit: usize) -> String {
     out
 }
 
-/// One sampling of everything [`render_full_report`] prints.
+/// One sampling of everything [`render_report`] prints.
 ///
 /// Rendering reads four independent process-wide sources ([`inventory`],
 /// [`void_wakes`], [`dump_wait_graph`], [`dump_phases`]), each of which moves
-/// while a build runs. Separating the sampling from the formatting means a
-/// caller that has to render the same picture more than once — into a dump and
-/// into a companion file, or into two representations being compared — renders
-/// *one* picture rather than two reads of a moving target.
+/// while a build runs. Sampling is split from formatting for the same reason
+/// [`inventory`] is split from [`render_inventory`] one screen up: so a value
+/// can be rendered more than once — by two writers being held against each
+/// other, or by one caller emitting both a capped and an uncapped view —
+/// without that being two reads of a moving target.
 ///
 /// It is a snapshot, not a consistent cut: the four sources are sampled in
 /// order under their own locks, so they can disagree with each other by however
 /// much moved in between. That is fine for a diagnostic and is not what the
-/// separation is for.
-#[derive(Debug, Clone)]
+/// split is for.
+#[derive(Debug)]
 pub struct ReportSnapshot {
     cells: Vec<StuckCell>,
     void_wakes: u64,
     wait_graph: String,
     phases: String,
+}
+
+impl ReportSnapshot {
+    /// Build a snapshot from values instead of from the live process, so
+    /// [`render_report`]'s output can be asserted against a controlled input.
+    ///
+    /// Without this the only way to exercise the format is to render whatever
+    /// the process registry happens to hold, which reduces every assertion to a
+    /// `contains` and leaves the branches that matter during an incident — an
+    /// empty inventory, an abandoned cell — uncovered. [`capture_report`] is the
+    /// live path.
+    pub fn from_parts(
+        cells: Vec<StuckCell>,
+        void_wakes: u64,
+        wait_graph: String,
+        phases: String,
+    ) -> Self {
+        Self {
+            cells,
+            void_wakes,
+            wait_graph,
+            phases,
+        }
+    }
 }
 
 /// Sample the in-flight state once, for [`render_report`].
@@ -659,11 +684,15 @@ pub fn capture_report() -> ReportSnapshot {
     }
 }
 
-/// Format a [`capture_report`] sampling.
+/// Format a [`capture_report`] sampling: the complete in-flight picture — every
+/// incomplete cell, the wait-for graph, and each invocation's next-await label.
 ///
 /// Uncapped, and rendered identically wherever it is written — the `SIGQUIT`
 /// dump and the stall watchdog's companion file are the same text, so a reader
-/// does not have to learn two formats or wonder which one is truncated.
+/// does not have to learn two formats or wonder which one is truncated. There
+/// is deliberately no "capture and render" convenience wrapper: a third entry
+/// point is a third thing a writer can pick, and the two writers agreeing is the
+/// property here.
 ///
 /// The gated sections self-describe when off rather than being absent, because
 /// a missing section reads as "nothing to report" when it means "not recorded".
@@ -680,13 +709,6 @@ pub fn render_report(snapshot: &ReportSnapshot) -> String {
         snapshot.wait_graph,
         snapshot.phases,
     )
-}
-
-/// The complete in-flight picture: every incomplete cell, the wait-for graph,
-/// and each invocation's next-await label. Samples and formats in one call —
-/// see [`capture_report`] when the same picture must be rendered twice.
-pub fn render_full_report() -> String {
-    render_report(&capture_report())
 }
 
 /// Monotone process-wide count of wakes that reached an incomplete cell and
@@ -2216,6 +2238,94 @@ mod tests {
             !text.contains("[spec] //c:d waiters=1 driver=true STRANDED"),
             "a driven cell must not be marked stranded: {text}"
         );
+    }
+
+    /// The full report over a *controlled* snapshot.
+    ///
+    /// Every other assertion on this text renders whatever the live process
+    /// registry happens to hold, so it can only ask whether a substring is
+    /// present. This one fixes the input, which is the only way to state that
+    /// the header count agrees with the lines below it, that the listing is
+    /// uncapped, and that the gated sections are echoed rather than rewritten.
+    #[test]
+    fn render_report_counts_what_it_lists_and_never_caps_it() {
+        let mut cells = vec![
+            StuckCell {
+                tag: "result",
+                key: "//a:stranded".to_string(),
+                waiters: Some(2),
+                has_driver: false,
+            },
+            StuckCell {
+                tag: "result",
+                key: "//a:abandoned".to_string(),
+                waiters: Some(0),
+                has_driver: false,
+            },
+        ];
+        // Enough to trip any cap a future edit might reintroduce.
+        cells.extend((0..40).map(|i| StuckCell {
+            tag: "spec",
+            key: format!("//p:{i}"),
+            waiters: Some(1),
+            has_driver: true,
+        }));
+
+        let text = render_report(&ReportSnapshot::from_parts(
+            cells,
+            7,
+            "  GRAPH-SECTION".to_string(),
+            "  PHASES-SECTION".to_string(),
+        ));
+
+        assert!(
+            text.contains("=== in-flight inventory (42 incomplete cells) ==="),
+            "the header counts every cell in the snapshot: {text}"
+        );
+        assert!(
+            !text.contains("… and "),
+            "the full report is uncapped — a truncated one is the thing this \
+             renderer exists to avoid: {text}"
+        );
+        assert!(
+            text.contains("[result] //a:stranded waiters=2 driver=false STRANDED"),
+            "{text}"
+        );
+        assert!(
+            text.contains("[result] //a:abandoned waiters=0 driver=false ABANDONED"),
+            "{text}"
+        );
+        assert!(
+            text.contains("//p:39"),
+            "the last cell is listed too: {text}"
+        );
+        assert!(text.contains("void wakes   7 "), "{text}");
+        // The gated sections are pass-through: this renderer must not restate
+        // them, or "not recorded" turns into "nothing to report".
+        assert!(text.contains("  GRAPH-SECTION"), "{text}");
+        assert!(text.contains("  PHASES-SECTION"), "{text}");
+    }
+
+    /// The empty case has to say *why* it is empty. "No section" and "no cells"
+    /// read identically to someone opening this file during an incident.
+    #[test]
+    fn render_report_says_nothing_is_in_flight_rather_than_showing_nothing() {
+        let text = render_report(&ReportSnapshot::from_parts(
+            Vec::new(),
+            0,
+            "  (empty)".to_string(),
+            "  (none)".to_string(),
+        ));
+        assert!(
+            text.contains("=== in-flight inventory (0 incomplete cells) ==="),
+            "{text}"
+        );
+        assert!(
+            text.contains("none — no memoizer cell is incomplete"),
+            "{text}"
+        );
+        assert!(text.contains("memoizer wait-for graph"), "{text}");
+        assert!(text.contains("memoizer phases"), "{text}");
     }
 
     #[test]

--- a/crates/core/src/hmemoizer/mod.rs
+++ b/crates/core/src/hmemoizer/mod.rs
@@ -628,8 +628,38 @@ pub fn render_inventory(cells: &[StuckCell], limit: usize) -> String {
     out
 }
 
-/// The complete in-flight picture: every incomplete cell, the wait-for graph,
-/// and each invocation's next-await label.
+/// One sampling of everything [`render_full_report`] prints.
+///
+/// Rendering reads four independent process-wide sources ([`inventory`],
+/// [`void_wakes`], [`dump_wait_graph`], [`dump_phases`]), each of which moves
+/// while a build runs. Separating the sampling from the formatting means a
+/// caller that has to render the same picture more than once — into a dump and
+/// into a companion file, or into two representations being compared — renders
+/// *one* picture rather than two reads of a moving target.
+///
+/// It is a snapshot, not a consistent cut: the four sources are sampled in
+/// order under their own locks, so they can disagree with each other by however
+/// much moved in between. That is fine for a diagnostic and is not what the
+/// separation is for.
+#[derive(Debug, Clone)]
+pub struct ReportSnapshot {
+    cells: Vec<StuckCell>,
+    void_wakes: u64,
+    wait_graph: String,
+    phases: String,
+}
+
+/// Sample the in-flight state once, for [`render_report`].
+pub fn capture_report() -> ReportSnapshot {
+    ReportSnapshot {
+        cells: inventory(),
+        void_wakes: void_wakes(),
+        wait_graph: dump_wait_graph(),
+        phases: dump_phases(),
+    }
+}
+
+/// Format a [`capture_report`] sampling.
 ///
 /// Uncapped, and rendered identically wherever it is written — the `SIGQUIT`
 /// dump and the stall watchdog's companion file are the same text, so a reader
@@ -637,20 +667,26 @@ pub fn render_inventory(cells: &[StuckCell], limit: usize) -> String {
 ///
 /// The gated sections self-describe when off rather than being absent, because
 /// a missing section reads as "nothing to report" when it means "not recorded".
-pub fn render_full_report() -> String {
-    let cells = inventory();
+pub fn render_report(snapshot: &ReportSnapshot) -> String {
     format!(
         "=== in-flight inventory ({} incomplete cells) ===\n{}  \
          void wakes   {} (wakes that reached an incomplete cell and found nobody; \
          a count still climbing while nothing progresses is a lost-wake regression)\n\
          === memoizer wait-for graph ===\n{}\n\
          === memoizer phases (invocation -> next await) ===\n{}\n",
-        cells.len(),
-        render_inventory(&cells, usize::MAX),
-        void_wakes(),
-        dump_wait_graph(),
-        dump_phases(),
+        snapshot.cells.len(),
+        render_inventory(&snapshot.cells, usize::MAX),
+        snapshot.void_wakes,
+        snapshot.wait_graph,
+        snapshot.phases,
     )
+}
+
+/// The complete in-flight picture: every incomplete cell, the wait-for graph,
+/// and each invocation's next-await label. Samples and formats in one call —
+/// see [`capture_report`] when the same picture must be rendered twice.
+pub fn render_full_report() -> String {
+    render_report(&capture_report())
 }
 
 /// Monotone process-wide count of wakes that reached an incomplete cell and

--- a/crates/engine/src/engine/diag.rs
+++ b/crates/engine/src/engine/diag.rs
@@ -1127,6 +1127,17 @@ impl InflightLog {
         &self.path
     }
 
+    /// The text this log carries, from an already-sampled picture.
+    ///
+    /// Named, rather than left as an expression at the watchdog's call site, so
+    /// that "the companion file and the `SIGQUIT` dump are the same renderer" is
+    /// a statement about two functions a test can hold side by side. While the
+    /// choice of renderer lived inline in `heph run`, nothing linked the two and
+    /// they could drift with every test still green.
+    pub fn render(snapshot: &hcore::hmemoizer::ReportSnapshot) -> String {
+        hcore::hmemoizer::render_report(snapshot)
+    }
+
     /// Replace the file with the current in-flight report.
     pub fn write(&self, text: &str) -> std::io::Result<()> {
         if let Some(dir) = self.path.parent() {
@@ -1671,7 +1682,7 @@ mod tests {
     /// during an incident.
     #[test]
     fn the_inflight_report_carries_every_section() {
-        let text = hcore::hmemoizer::render_full_report();
+        let text = InflightLog::render(&hcore::hmemoizer::capture_report());
         assert!(text.contains("in-flight inventory"), "{text}");
         assert!(text.contains("memoizer wait-for graph"), "{text}");
         assert!(text.contains("memoizer phases"), "{text}");

--- a/src/commands/run.rs
+++ b/src/commands/run.rs
@@ -311,7 +311,10 @@ async fn execute_async(args: RunArgs, sink: LogSink, global: GlobalOptions) -> a
                 // a hang that ends with the process being killed takes every
                 // byte of in-flight state with it unless it was already on disk.
                 // A failure here must not cost us the paragraph itself.
-                if let Err(e) = inflight.write(&hcore::hmemoizer::render_full_report()) {
+                let snapshot = hcore::hmemoizer::capture_report();
+                if let Err(e) =
+                    inflight.write(&hengine::engine::diag::InflightLog::render(&snapshot))
+                {
                     tracing::warn!(
                         path = %inflight.path().display(),
                         error = %e,

--- a/src/diag.rs
+++ b/src/diag.rs
@@ -191,13 +191,10 @@ fn sweep() {
 /// Runs on the sweeper thread, after every signalled thread has written its
 /// frames — never inside the signal handler, and never with a blocking lock (see
 /// `hmemoizer::inventory`).
-fn inventory_report() -> String {
-    inventory_report_from(&hcore::hmemoizer::capture_report())
-}
-
-/// [`inventory_report`] over an already-sampled picture, so the same in-flight
-/// state can be rendered twice without re-reading globals that move in between.
-fn inventory_report_from(snapshot: &hcore::hmemoizer::ReportSnapshot) -> String {
+/// Takes the sampling rather than doing it, so the caller that owns the timing
+/// decides when the picture is taken — and so the same picture can be handed to
+/// this and to the watchdog's renderer and the two compared.
+fn inventory_report(snapshot: &hcore::hmemoizer::ReportSnapshot) -> String {
     // Same renderer the stall watchdog writes to its companion file, so the two
     // are byte-identical and neither is the "truncated" one. No cap: this is
     // read once, on a build that has already gone wrong.
@@ -205,7 +202,7 @@ fn inventory_report_from(snapshot: &hcore::hmemoizer::ReportSnapshot) -> String 
 }
 
 fn write_inventory(fd: libc::c_int) {
-    let text = inventory_report();
+    let text = inventory_report(&hcore::hmemoizer::capture_report());
     let bytes = text.as_bytes();
     // SAFETY: appending an owned, initialised byte buffer to the diag fd.
     unsafe {
@@ -355,7 +352,7 @@ mod tests {
     /// or the next reader has no way to know a deeper view exists.
     #[test]
     fn the_dump_carries_the_in_flight_state_and_names_its_gated_sections() {
-        let text = inventory_report();
+        let text = inventory_report(&hcore::hmemoizer::capture_report());
         assert!(text.contains("in-flight inventory"), "{text}");
         assert!(text.contains("memoizer wait-for graph"), "{text}");
         assert!(text.contains("memoizer phases"), "{text}");
@@ -390,18 +387,23 @@ mod tests {
     /// them is the truncated one, during an incident, which is exactly when
     /// nobody should be reverse-engineering a diagnostic.
     ///
-    /// Both sides render *one* snapshot. Calling the two renderers back to back
-    /// compared two separate reads of process-wide memoizer state instead, and
-    /// any other test in this binary building a request between them changed one
-    /// read and not the other — a ~10%-per-run failure that had nothing to do
-    /// with the formats being compared. Sampling once removes the only variable
-    /// this test was never about; a divergence in either renderer still fails it.
+    /// Both sides are the *writers*, not one library function against itself:
+    /// `inventory_report` is what the `SIGQUIT` sweeper appends to the dump,
+    /// `InflightLog::render` is what `heph run`'s stall watchdog writes to the
+    /// companion file. Change either and this fails.
+    ///
+    /// Both render *one* snapshot. Calling the renderers back to back compared
+    /// two separate reads of process-wide memoizer state instead, and any other
+    /// test in this binary building a request between them changed one read and
+    /// not the other — a ~10%-per-run failure that had nothing to do with the
+    /// formats being compared. Sampling once removes the only variable this test
+    /// was never about.
     #[test]
     fn the_dump_and_the_watchdog_companion_file_render_identically() {
         let snapshot = hcore::hmemoizer::capture_report();
         assert_eq!(
-            inventory_report_from(&snapshot).trim(),
-            hcore::hmemoizer::render_report(&snapshot).trim()
+            inventory_report(&snapshot).trim(),
+            hengine::engine::diag::InflightLog::render(&snapshot).trim()
         );
     }
 }

--- a/src/diag.rs
+++ b/src/diag.rs
@@ -192,10 +192,16 @@ fn sweep() {
 /// frames — never inside the signal handler, and never with a blocking lock (see
 /// `hmemoizer::inventory`).
 fn inventory_report() -> String {
+    inventory_report_from(&hcore::hmemoizer::capture_report())
+}
+
+/// [`inventory_report`] over an already-sampled picture, so the same in-flight
+/// state can be rendered twice without re-reading globals that move in between.
+fn inventory_report_from(snapshot: &hcore::hmemoizer::ReportSnapshot) -> String {
     // Same renderer the stall watchdog writes to its companion file, so the two
     // are byte-identical and neither is the "truncated" one. No cap: this is
     // read once, on a build that has already gone wrong.
-    format!("\n{}", hcore::hmemoizer::render_full_report())
+    format!("\n{}", hcore::hmemoizer::render_report(snapshot))
 }
 
 fn write_inventory(fd: libc::c_int) {
@@ -383,11 +389,19 @@ mod tests {
     /// text. Two formats for one thing means a reader has to work out which of
     /// them is the truncated one, during an incident, which is exactly when
     /// nobody should be reverse-engineering a diagnostic.
+    ///
+    /// Both sides render *one* snapshot. Calling the two renderers back to back
+    /// compared two separate reads of process-wide memoizer state instead, and
+    /// any other test in this binary building a request between them changed one
+    /// read and not the other — a ~10%-per-run failure that had nothing to do
+    /// with the formats being compared. Sampling once removes the only variable
+    /// this test was never about; a divergence in either renderer still fails it.
     #[test]
     fn the_dump_and_the_watchdog_companion_file_render_identically() {
+        let snapshot = hcore::hmemoizer::capture_report();
         assert_eq!(
-            inventory_report().trim(),
-            hcore::hmemoizer::render_full_report().trim()
+            inventory_report_from(&snapshot).trim(),
+            hcore::hmemoizer::render_report(&snapshot).trim()
         );
     }
 }


### PR DESCRIPTION
`diag::tests::the_dump_and_the_watchdog_companion_file_render_identically` fails
about **10% of the time on pristine `master`** — it can redden any PR at random,
and several agents have already spent time diagnosing it as their own breakage.

## What it was doing

The test checks that the `SIGQUIT` dump and the stall watchdog's companion file
are the same text. Both are `hmemoizer::render_full_report()`, and it called that
function **twice**:

```rust
assert_eq!(inventory_report().trim(), render_full_report().trim());
```

`render_full_report` reads four *process-wide* sources — the live-memoizer
registry (`inventory`), `void_wakes`, the wait-for graph, the phase map. Any other
test in the same binary constructing an `Engine` and a `RequestState` registers
memoizer cells that show up in one read and not the other.

Captured failure:

```
left:  === in-flight inventory (6 incomplete cells) ===
right: === in-flight inventory (5 incomplete cells) ===
```

with `[probe_inner] ("buildfile", PkgBuf("foo"))` on one side and `PkgBuf("")` on
the other — a `pluginbuildfile` test mid-flight between the two reads.

**Classification: the test asserted a property the code never guaranteed** — that
unsynchronised global state holds still across two reads while the rest of the
suite runs. Neither renderer is wrong; there is nothing in the product to fix.

## The fix

Separate sampling from formatting, so one picture can be rendered twice:

- `hmemoizer::ReportSnapshot` + `capture_report()` + `render_report(&snap)`.
  `render_full_report()` becomes `render_report(&capture_report())`; all three
  existing callers are untouched.
- `diag::inventory_report_from(&snap)`, with `inventory_report()` delegating.
- The test captures once and renders both sides from that snapshot.

The snapshot is explicitly **not** a consistent cut — the four sources are still
sampled in sequence under their own locks and may disagree with each other. That
is fine for a diagnostic, and it is not what the split is for: what matters is
that both renderers now format the *same value*, so equality is a statement about
the formats and nothing else.

## The assertion still has teeth

Verified red by mutating `inventory_report_from` on the committed tree:

| Mutation | Result |
|---|---|
| truncate the report to 200 bytes ("neither is the truncated one") | **FAILED** |
| prepend an extra `=== heph in-flight ===` header | **FAILED** |
| (restored from the commit) | ok |

No `#[ignore]`, no retry loop, no sleep, no deleted assertion.

## Failure rate

Looping the `heph` lib unit binary on the same machine under the same load:

| | failures |
|---|---|
| before (`origin/master`, `be5b01fe`) | **5 / 50** |
| after | **0 / 150** |

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01A76DChMohieGMbRbnV1E7x

---

## Review-board follow-up (second commit)

`code-quality` and `feature-quality` independently raised the same MAJOR: the
first commit left the two *writers* on different entry points, so the test no
longer mentioned the watchdog at all.

- `InflightLog::render(&ReportSnapshot)` names what the companion file carries,
  beside the type that owns the file; `heph run` calls it instead of picking a
  renderer inline.
- `hmemoizer::render_full_report()` is **deleted** — a third entry point is a
  third thing a writer can pick. Both writers now spell `capture_report()` plus
  a named renderer, and `hmemoizer` is back to two verbs (`inventory()` /
  `render_inventory()` above it, `capture_report()` / `render_report()` here).
- `inventory_report_from` folds back into `inventory_report(&snapshot)`.
- The test is now `inventory_report(&s)` vs `InflightLog::render(&s)` — the
  sweeper's writer against the watchdog's writer, over one snapshot.
- `ReportSnapshot::from_parts` + two deterministic format tests. Every existing
  assertion on this text renders whatever the live registry happens to hold, so
  all of them are `contains` checks; these freeze the header count agreeing with
  the lines below it, the listing being uncapped at 42 cells, STRANDED and
  ABANDONED, `void wakes`, the gated sections echoed verbatim, and the empty
  case saying *why* it is empty.
- Dropped the unused `#[derive(Clone)]` on `ReportSnapshot`.

### Red-checks, one mutation per property, on the committed tree

| Mutation | Test | Result |
|---|---|---|
| truncate `inventory_report` (dump side) | identity | **RED** |
| header in `inventory_report` (dump side) | identity | **RED** |
| header in `InflightLog::render` (**watchdog side**) | identity | **RED** |
| cap `render_report`'s listing | format | **RED** |
| restored from the commit | both | green |

The third one is the finding: before this commit no mutation of the watchdog's
writer could redden anything.

### Not taken here (pre-existing, flagged by `feature-quality`)

- The watchdog walks `hmemoizer::inventory()` twice per fire — once into
  `StallReport::stuck` for the capped paragraph, once inside the companion
  file's render — so the two halves of one incident report are different
  samples, and the paragraph's "the full list is in `<inflight>`" is not quite
  true. `from_parts` makes fixing it cheap; doing it here would mean changing
  what `Watchdog` hands its callback.
- `dump_phases` / `dump_wait_graph` `.expect()` on a poisoned lock where
  `sources()` recovers with `into_inner()`. A panic there ends the sweeper loop,
  i.e. the last diagnostic channel on an already-hung process.
