### PR TITLE
fix(engine): barrier the post-write trim's pre-count against its own write

### DIFF
--- a/crates/engine/src/engine/gc.rs
+++ b/crates/engine/src/engine/gc.rs
@@ -22,7 +22,7 @@
 
 use crate::engine::Engine;
 use crate::engine::error::TargetNotFoundError;
-use crate::engine::local_cache::MANIFEST_V1;
+use crate::engine::local_cache::{Existence, MANIFEST_V1};
 use crate::engine::request_state::RequestState;
 use crate::engine::result_lock::ResultWriteGuard;
 use anyhow::{Context, Result};
@@ -111,10 +111,11 @@ pub(crate) enum TrimOutcome {
     /// `try_write` reported the lock held by another request or process. The
     /// **only** outcome worth retrying — a holder exists, and it may let go.
     Contended,
-    /// Something else went wrong and was logged at the site: the unlocked
-    /// pre-count, an `Err` from `try_write` (a vanished or unwritable lock dir,
-    /// `EMFILE`, `ENOLCK`), or a failure with the lock held — the barrier, the
-    /// enumerate, or the trim itself.
+    /// Something else went wrong and was logged at the site: without the lock,
+    /// the pre-count or the `existence` probe that corrects it; an `Err` from
+    /// `try_write` itself (a vanished or unwritable lock dir, `EMFILE`,
+    /// `ENOLCK`); or, with the lock held, the barrier, the enumerate, or the
+    /// trim.
     ///
     /// Never retried. Not because these faults are permanent — `EMFILE` and
     /// `ENOLCK` are exactly the transient ones, and fd exhaustion at the end of a
@@ -298,6 +299,21 @@ impl Engine {
         Ok((removed, kept, bytes))
     }
 
+    /// The target's cached revisions, logged under `stage` when the read fails.
+    ///
+    /// `None` rather than the error: every caller here turns a failure into
+    /// [`TrimOutcome::Failed`] after logging, and threading an `anyhow::Error`
+    /// through only to drop it invites a caller to propagate one instead — this is
+    /// a fire-and-forget background lane.
+    fn revisions(&self, addr: &Addr, stage: &'static str) -> Option<Vec<String>> {
+        self.local_cache
+            .list_target_entries(addr)
+            .inspect_err(|e| {
+                tracing::debug!(error = %format!("{e:#}"), %addr, stage, "post-write gc enumerate");
+            })
+            .ok()
+    }
+
     /// Synchronous post-write trim: keep the target's `keep` newest revisions,
     /// always preserving `written_hashin`. Runs only if `addr`'s lock is free —
     /// returns immediately (trimming nothing) when contended, never blocking.
@@ -309,8 +325,9 @@ impl Engine {
     /// and only a target genuinely over budget pays for the write lock, the
     /// write barrier and the per-revision manifest reads. The steady state — a
     /// target rebuilt within its `cache.history` budget — is the common case on
-    /// every warm run, and it now costs one `list_target_entries` instead of a
-    /// lock acquire plus one manifest read per revision.
+    /// every warm run, and it costs one `list_target_entries`, plus at most one
+    /// non-blocking `existence` probe, instead of a lock acquire plus one
+    /// manifest read per revision.
     ///
     /// The unlocked count is safe precisely because it can only *skip*: it never
     /// deletes, so it needs no lock, and a revision that lands between the count
@@ -326,9 +343,22 @@ impl Engine {
     /// having *never asked for the lock*: not contention, not an error, nothing to
     /// retry, and indistinguishable in any log from a target that was legitimately
     /// within budget. That is a systematic, every-run undercount by exactly one —
-    /// self-inflicted, unlike another writer's revision landing late — so the
-    /// count is barriered against it before it is trusted. Any other revision
-    /// arriving late is somebody else's write, and the paragraph above covers it.
+    /// self-inflicted, unlike another writer's revision landing late. Any other
+    /// revision arriving late is somebody else's write, and the paragraph above
+    /// covers it.
+    ///
+    /// So the count is *corrected* for our own write before it is trusted — with
+    /// [`existence`](LocalCache::existence), which reports the write-behind queue
+    /// rather than blocking on it. A queued-or-committed manifest counts as a
+    /// revision, and that is all the budget decision needs. Deliberately not
+    /// `exists` here: `exists` parks the caller until the sqlite writer has
+    /// drained *everything queued ahead of our entry* — at the end of a large
+    /// build, the whole remaining write backlog — and this runs on the single FIFO
+    /// cleaner thread that also owes every sandbox rmdir and gates process exit.
+    /// Paying that before knowing whether there is anything to delete would charge
+    /// every within-budget target for a decision it does not need. The wait stays
+    /// where it has always been, inside the lock branch, where the enumeration
+    /// that actually chooses what to delete has to be ordered against our write.
     ///
     /// Deliberately `try_write` and not a blocking `write`: the lock is a
     /// cross-process `flock`, so a blocking acquire can wait on another `heph`
@@ -337,64 +367,73 @@ impl Engine {
     /// the async `ResultLock::write` on anyway. A skip is recoverable; an
     /// unbounded stall of all cleanup is not. [`Engine::run_trim_batch_with_delay`] hedges
     /// the skip instead, with one immediate re-probe and one delayed retry.
-    /// One unlocked revision enumeration, logged under `stage` when it fails.
-    ///
-    /// `Err(())` rather than the error itself: every caller here turns a failure
-    /// into [`TrimOutcome::Failed`] after logging, and threading an `anyhow::Error`
-    /// through only to drop it invites a caller to propagate one instead — this is
-    /// a fire-and-forget background lane.
-    fn enumerate(&self, addr: &Addr, stage: &'static str) -> std::result::Result<Vec<String>, ()> {
-        self.local_cache.list_target_entries(addr).map_err(|e| {
-            tracing::debug!(error = %format!("{e:#}"), %addr, stage, "post-write gc enumerate");
-        })
-    }
-
     pub(crate) fn try_trim_after_write(
         &self,
         addr: &Addr,
         keep: u32,
         written_hashin: &str,
     ) -> TrimOutcome {
-        let pre = match self.enumerate(addr, "pre-count") {
-            Ok(h) => h,
-            Err(()) => return TrimOutcome::Failed,
+        let Some(pre) = self.revisions(addr, "pre-count") else {
+            return TrimOutcome::Failed;
         };
-        // Barrier only when the count cannot see the revision it was handed —
-        // when it can, there is nothing to order against and a warm run pays a
-        // `Vec` scan instead of a cache round-trip. `exists` is the barrier
-        // because it is the read that waits: `LocalCacheSQLite::exists` calls
-        // `wait_if_pending` on this exact key, and neither tier above it can
-        // short-circuit that away — `LocalCacheMem::writer` *invalidates* the key
-        // rather than populating it, so a resident mem entry implies a landed
-        // write, and `LocalCacheSpill` asks its sqlite primary first.
-        let pre = if pre.iter().any(|h| h == written_hashin) {
-            pre
+        // Correct the count for our own write only when it cannot already see it.
+        // When it can, there is nothing to ask about and a warm run pays a `Vec`
+        // scan rather than a cache round-trip.
+        let count = if pre.iter().any(|h| h == written_hashin) {
+            pre.len()
         } else {
-            if let Err(e) = self.local_cache.exists(addr, written_hashin, MANIFEST_V1) {
-                tracing::debug!(error = %format!("{e:#}"), %addr, "post-write gc barrier");
-                return TrimOutcome::Failed;
-            }
-            match self.enumerate(addr, "re-count") {
-                Ok(h) => h,
-                Err(()) => return TrimOutcome::Failed,
+            match self
+                .local_cache
+                .existence(addr, written_hashin, MANIFEST_V1)
+            {
+                // Queued or committed, the revision exists as far as a budget
+                // decision is concerned. `Queued` is dropped without awaiting: it
+                // is the answer, not something to wait on.
+                Ok(Existence::Queued(_) | Existence::Committed(true)) => pre.len() + 1,
+                // Neither queued nor committed: the write we were handed never
+                // landed (the writer thread is gone, or it dropped an oversized
+                // entry). Say so rather than silently trimming to a count that is
+                // missing a revision — the silence is the bug this guards.
+                Ok(Existence::Committed(false)) => {
+                    tracing::debug!(
+                        %addr,
+                        hashin = %written_hashin,
+                        "post-write gc: the written revision is neither queued nor committed"
+                    );
+                    pre.len()
+                }
+                Err(e) => {
+                    tracing::debug!(error = %format!("{e:#}"), %addr, "post-write gc existence");
+                    return TrimOutcome::Failed;
+                }
             }
         };
         // Undercount by another writer is safe (see above): a target at exactly
         // `keep` has nothing to delete anyway. `Settled`, not `Contended` — the
         // lock was never asked for, so there is nothing for a retry to win.
-        if pre.len() as u32 <= keep {
+        if count as u32 <= keep {
             return TrimOutcome::SETTLED_NOTHING;
         }
 
         match self.result_lock().try_write(addr) {
             Ok(Some(guard)) => {
+                // Barrier, here and not above: the enumeration that decides *what
+                // to delete* must observe our write, and this is the one path that
+                // deletes. `exists` is the read that waits —
+                // `LocalCacheSQLite::exists` calls `wait_if_pending` on this key,
+                // `LocalCacheSpill::exists` evaluates its sqlite primary first, and
+                // `LocalCacheMem::writer` invalidates rather than populates, so the
+                // mem tier cannot answer from a stale resident entry. Each of those
+                // three is pinned by its own test; without them this is not a
+                // barrier at all, and the failure is silent.
+                if let Err(e) = self.local_cache.exists(addr, written_hashin, MANIFEST_V1) {
+                    tracing::debug!(error = %format!("{e:#}"), %addr, "post-write gc barrier");
+                    return TrimOutcome::Failed;
+                }
                 // Re-listed under the lock: authoritative, and it may have grown
-                // since the unlocked pre-count above. No second barrier — the
-                // count above is already ordered against our own write, and that
-                // is the only write this call knows about.
-                let hashins = match self.enumerate(addr, "locked") {
-                    Ok(h) => h,
-                    Err(()) => return TrimOutcome::Failed,
+                // since the unlocked pre-count above.
+                let Some(hashins) = self.revisions(addr, "locked") else {
+                    return TrimOutcome::Failed;
                 };
                 match self.trim_addr_history(&guard, addr, &hashins, keep, Some(written_hashin)) {
                     Ok((removed, _kept, bytes)) => TrimOutcome::Settled { removed, bytes },
@@ -902,8 +941,8 @@ mod tests {
     use crate::engine::Config;
     use crate::engine::local_cache::{
         Existence, LocalCache, MANIFEST_V1, Manifest, ManifestArtifact,
-        ManifestArtifactContentType, ManifestArtifactEncoding, ManifestArtifactType, SizedReader,
-        TargetStream,
+        ManifestArtifactContentType, ManifestArtifactEncoding, ManifestArtifactType, PendingWrite,
+        SizedReader, TargetStream,
     };
     use hcore::hasync::StdCancellationToken;
     use hmodel::htpkg::PkgBuf;
@@ -1015,20 +1054,57 @@ mod tests {
     /// nothing in a CI log distinguishes a trim that skipped because of that from
     /// a trim that skipped because the target really was within budget.
     ///
-    /// `queued` names such a revision: it is filtered out of every enumeration
+    /// `queued` names such revisions: each is filtered out of every enumeration
     /// until an `exists` on its manifest clears it, exactly as a real
-    /// `wait_if_pending` would. Everything else is forwarded to a genuine sqlite
-    /// cache, so the trim under test is running against the real backend.
+    /// `wait_if_pending` would, and is reported by `existence` as
+    /// [`Existence::Queued`] — the non-blocking answer the budget decision uses.
+    /// Everything else is forwarded to a genuine sqlite cache, so the trim under
+    /// test is running against the real backend.
+    ///
+    /// The *asymmetry itself* — that the real `exists` waits and the real
+    /// `list_target_entries` does not — is not taken on trust from this double.
+    /// It is pinned directly against `LocalCacheSQLite` by
+    /// `queued_write_is_invisible_to_list_target_entries_and_awaited_by_exists`,
+    /// and against the tiers above it by `LocalCacheMem` /  `LocalCacheSpill`'s
+    /// own delegation tests. Without those, a double like this one would be free
+    /// to assert a property the backend had stopped having.
     struct QueuedWriteCache {
         inner: Arc<dyn LocalCache>,
-        queued: std::sync::Mutex<Option<(String, String)>>,
+        /// `(addr, hashin)` of every revision whose write is "in flight".
+        queued: std::sync::Mutex<Vec<(String, String)>>,
         barrier_reads: Arc<AtomicUsize>,
     }
 
     impl QueuedWriteCache {
         /// Hide `hashin` from enumerations until it is barriered.
+        ///
+        /// Consumed by *any* `exists` on that manifest — including the one inside
+        /// `write_revision` and the one inside `present`. So setup writes must
+        /// happen before `queue`, and `present` probes after any `barrier_reads`
+        /// assertion, or the test silently stops testing anything.
         fn queue(&self, addr: &Addr, hashin: &str) {
-            *self.queued.lock().expect("queued") = Some((addr.format(), hashin.to_string()));
+            self.queued
+                .lock()
+                .expect("queued")
+                .push((addr.format(), hashin.to_string()));
+        }
+
+        /// Whether `(addr, hashin)` is still in flight. Observes; never clears.
+        fn is_queued(&self, addr: &Addr, hashin: &str) -> bool {
+            self.queued
+                .lock()
+                .expect("queued")
+                .iter()
+                .any(|(a, h)| *a == addr.format() && h == hashin)
+        }
+
+        /// Drop `(addr, hashin)` from the in-flight set, the way a completed
+        /// write does. Returns whether it was there.
+        fn land(&self, addr: &Addr, hashin: &str) -> bool {
+            let mut q = self.queued.lock().expect("queued");
+            let before = q.len();
+            q.retain(|(a, h)| !(*a == addr.format() && h == hashin));
+            q.len() != before
         }
     }
 
@@ -1049,17 +1125,30 @@ mod tests {
                 self.barrier_reads.fetch_add(1, Ordering::SeqCst);
                 // The wait: once this returns, the write has landed and every
                 // later enumeration sees it.
-                let mut q = self.queued.lock().expect("queued");
-                if q.as_ref()
-                    .is_some_and(|(a, h)| *a == addr.format() && h == hashin)
-                {
-                    *q = None;
-                }
+                self.land(addr, hashin);
             }
             self.inner.exists(addr, hashin, name)
         }
         fn existence(&self, addr: &Addr, hashin: &str, name: &str) -> anyhow::Result<Existence> {
+            // Reports the queue, never waits on it, and never clears it — the
+            // whole point of `existence` is that it settles nothing.
+            if name == MANIFEST_V1 && self.is_queued(addr, hashin) {
+                return Ok(Existence::Queued(PendingWrite::new(std::future::ready(()))));
+            }
             self.inner.existence(addr, hashin, name)
+        }
+        /// Mirrors *this* layer's `exists`, as the trait requires — not
+        /// `inner`'s. The bytes really are in the sqlite cache underneath (the
+        /// writes are forwarded), so a blind delegation would answer `true` for
+        /// a revision this double is pretending is still in flight, and the
+        /// asymmetry the double exists to model would only hold for `exists`
+        /// and `existence`. Committed-only, so no `land` and no
+        /// `barrier_reads`: this settles nothing and waits for nothing.
+        fn exists_committed(&self, addr: &Addr, hashin: &str, name: &str) -> anyhow::Result<bool> {
+            if name == MANIFEST_V1 && self.is_queued(addr, hashin) {
+                return Ok(false);
+            }
+            self.inner.exists_committed(addr, hashin, name)
         }
         fn delete(&self, addr: &Addr, hashin: &str, name: &str) -> anyhow::Result<()> {
             self.inner.delete(addr, hashin, name)
@@ -1069,11 +1158,8 @@ mod tests {
         }
         fn list_target_entries(&self, addr: &Addr) -> anyhow::Result<Vec<String>> {
             let mut entries = self.inner.list_target_entries(addr)?;
-            if let Some((a, h)) = self.queued.lock().expect("queued").as_ref()
-                && *a == addr.format()
-            {
-                entries.retain(|e| e != h);
-            }
+            let q = self.queued.lock().expect("queued");
+            entries.retain(|e| !q.iter().any(|(a, h)| *a == addr.format() && h == e));
             Ok(entries)
         }
         fn seekable_reader(
@@ -1089,13 +1175,9 @@ mod tests {
         }
     }
 
-    /// Engine whose cache can hide one just-written revision from enumerations.
-    fn test_engine_queued() -> (
-        Arc<Engine>,
-        Arc<QueuedWriteCache>,
-        Arc<AtomicUsize>,
-        tempfile::TempDir,
-    ) {
+    /// Engine whose cache can hide just-written revisions from enumerations.
+    /// `cache.barrier_reads` is the manifest-barrier counter.
+    fn test_engine_queued() -> (Arc<Engine>, Arc<QueuedWriteCache>, tempfile::TempDir) {
         let dir = tempfile::tempdir().expect("tempdir");
         let mut engine = Engine::new(Config {
             root: dir.path().to_path_buf(),
@@ -1104,14 +1186,13 @@ mod tests {
             ..Default::default()
         })
         .expect("engine");
-        let barrier_reads = Arc::new(AtomicUsize::new(0));
         let cache = Arc::new(QueuedWriteCache {
             inner: Arc::clone(&engine.local_cache),
-            queued: std::sync::Mutex::new(None),
-            barrier_reads: Arc::clone(&barrier_reads),
+            queued: std::sync::Mutex::new(Vec::new()),
+            barrier_reads: Arc::new(AtomicUsize::new(0)),
         });
         engine.local_cache = Arc::clone(&cache) as Arc<dyn LocalCache>;
-        (Arc::new(engine), cache, barrier_reads, dir)
+        (Arc::new(engine), cache, dir)
     }
 
     /// Engine whose cache counts manifest barrier/recency reads. Returns the two
@@ -1381,8 +1462,8 @@ mod tests {
 
         assert_eq!(
             barrier_reads.load(Ordering::SeqCst),
-            0,
-            "the pre-count could already see the written revision: no barrier"
+            1,
+            "over budget: the just-written manifest is barriered once, under the lock"
         );
         assert_eq!(
             manifest_reads.load(Ordering::SeqCst),
@@ -1408,20 +1489,21 @@ mod tests {
     ///
     /// Constructed, not raced: [`QueuedWriteCache`] hides `h2` from every
     /// enumeration until the manifest barrier runs, which is exactly what the real
-    /// backend does while a write sits in the queue. Delete the barrier and this
-    /// fails every time rather than one run in N.
+    /// backend does while a write sits in the queue. Drop the `existence`
+    /// correction and this fails every time rather than one run in N.
     #[tokio::test]
-    async fn try_trim_after_write_barriers_a_pre_count_that_cannot_see_its_own_revision() {
-        let (engine, cache, barrier_reads, _dir) = test_engine_queued();
+    async fn try_trim_after_write_counts_a_revision_its_pre_count_cannot_see() {
+        let (engine, cache, _dir) = test_engine_queued();
         let a = addr("t");
         write_revision(&engine, &a, "h1", 100, &["o.tar"]);
         write_revision(&engine, &a, "h2", 200, &["o.tar"]);
         // `h2` is this run's write and its commit is not yet observable to an
-        // unbarriered enumeration.
+        // unbarriered enumeration. Queued *after* the setup writes, whose own
+        // `exists` barriers would consume it.
         cache.queue(&a, "h2");
-        barrier_reads.store(0, Ordering::SeqCst);
+        cache.barrier_reads.store(0, Ordering::SeqCst);
 
-        // Unbarriered the count is `["h1"]`, `1 <= keep`, and the answer is
+        // Uncorrected the count is `["h1"]`, `1 <= keep`, and the answer is
         // SETTLED_NOTHING with `h1` still on disk.
         assert_eq!(
             engine.try_trim_after_write(&a, 1, "h2"),
@@ -1432,12 +1514,97 @@ mod tests {
             "a queued revision is still a revision: the target is over budget",
         );
         assert_eq!(
-            barrier_reads.load(Ordering::SeqCst),
+            cache.barrier_reads.load(Ordering::SeqCst),
             1,
-            "barriered exactly once, before the count is trusted"
+            "the budget decision used the non-blocking `existence`; the one \
+             barrier is the `exists` under the lock"
         );
         assert!(!present(&engine, &a, "h1"), "the stale revision is trimmed");
         assert!(present(&engine, &a, "h2"), "the just-written one is kept");
+    }
+
+    /// A revision that is queued but *within* budget must not be trimmed, and
+    /// must not park the cleaner thread finding that out.
+    ///
+    /// This is the case the earlier shape of this fix mispriced: barriering
+    /// before the budget decision made every within-budget target wait on the
+    /// sqlite writer's whole backlog, on the thread that gates process exit.
+    /// `existence` reports the queue instead of blocking on it.
+    #[tokio::test]
+    async fn try_trim_after_write_counts_a_queued_revision_without_barriering() {
+        let (engine, cache, _dir) = test_engine_queued();
+        let a = addr("t");
+        write_revision(&engine, &a, "h1", 100, &["o.tar"]);
+        write_revision(&engine, &a, "h2", 200, &["o.tar"]);
+        cache.queue(&a, "h2");
+        cache.barrier_reads.store(0, Ordering::SeqCst);
+
+        // 2 revisions (one of them invisible to the enumeration), history 2.
+        assert_eq!(
+            engine.try_trim_after_write(&a, 2, "h2"),
+            TrimOutcome::SETTLED_NOTHING,
+            "the queued revision counts, so the target is inside its budget",
+        );
+        assert_eq!(
+            cache.barrier_reads.load(Ordering::SeqCst),
+            0,
+            "within budget: nothing is deleted, so nothing waits on the writer"
+        );
+        assert!(present(&engine, &a, "h1"), "nothing trimmed");
+    }
+
+    /// Only *our* revision is corrected for. Another writer's in-flight write
+    /// stays uncounted — that undercount is the pre-existing, non-systematic one
+    /// the unlocked count has always tolerated, and correcting it would mean
+    /// waiting on a writer this call knows nothing about.
+    #[tokio::test]
+    async fn try_trim_after_write_corrects_only_for_its_own_write() {
+        let (engine, cache, _dir) = test_engine_queued();
+        let a = addr("t");
+        write_revision(&engine, &a, "h1", 100, &["o.tar"]);
+        write_revision(&engine, &a, "h2", 200, &["o.tar"]);
+        write_revision(&engine, &a, "h3", 300, &["o.tar"]);
+        // Ours, and a foreign writer's.
+        cache.queue(&a, "h3");
+        cache.queue(&a, "h1");
+        cache.barrier_reads.store(0, Ordering::SeqCst);
+
+        // Visible: ["h2"]. Ours (h3) is corrected in, h1 is not → count 2 > 1.
+        assert_eq!(
+            engine.try_trim_after_write(&a, 1, "h3"),
+            TrimOutcome::Settled {
+                removed: 1,
+                bytes: 4
+            },
+            "corrected for h3 only; h1 stays invisible and is not counted",
+        );
+        assert!(present(&engine, &a, "h3"), "the written revision is kept");
+    }
+
+    /// A write we were handed that never landed is *said out loud* in the count,
+    /// not silently trimmed around. `existence` answering `Committed(false)`
+    /// means the writer thread dropped it; the count then genuinely has one fewer
+    /// revision, and the trim must behave as though it does.
+    #[tokio::test]
+    async fn try_trim_after_write_does_not_invent_a_revision_that_never_landed() {
+        let (engine, cache, _dir) = test_engine_queued();
+        let a = addr("t");
+        write_revision(&engine, &a, "h1", 100, &["o.tar"]);
+        // "h2" was never written at all: not in the enumeration, not queued,
+        // not committed.
+        cache.barrier_reads.store(0, Ordering::SeqCst);
+
+        assert_eq!(
+            engine.try_trim_after_write(&a, 1, "h2"),
+            TrimOutcome::SETTLED_NOTHING,
+            "one real revision against keep=1: nothing to do",
+        );
+        assert_eq!(
+            cache.barrier_reads.load(Ordering::SeqCst),
+            0,
+            "no lock, so no barrier"
+        );
+        assert!(present(&engine, &a, "h1"));
     }
 
     /// Take `addr`'s write lock synchronously, the way the trim itself asks for
@@ -1529,6 +1696,54 @@ mod tests {
             report.removed, 2,
             "both stale revisions reclaimed: {report:?}"
         );
+    }
+
+    /// The batch lane, with a revision the enumeration cannot see — the shape
+    /// `e2e::cache_history_is_enforced_by_the_end_of_the_run` actually runs.
+    ///
+    /// Every other assertion about the invisible-revision case calls
+    /// `try_trim_after_write` directly. This one goes through
+    /// `run_trim_batch_with_delay`, which is what `DeferredTrims::drop` submits
+    /// and what the flaking test exercises: without the `existence` correction the
+    /// batch reports `removed: 0` and the run ends with `cache.history`
+    /// unenforced, exactly as CI sees it.
+    #[test]
+    fn trim_batch_reclaims_a_target_whose_revision_is_still_queued() {
+        let (engine, cache, _dir) = test_engine_queued();
+        let a = addr("t");
+        write_revision(&engine, &a, "h1", 100, &["o.tar"]);
+        write_revision(&engine, &a, "h2", 200, &["o.tar"]);
+        // Queued after the setup writes, whose `exists` barriers would consume it.
+        cache.queue(&a, "h2");
+        cache.barrier_reads.store(0, Ordering::SeqCst);
+
+        let report = engine.run_trim_batch_with_delay(
+            vec![(a.clone(), 1, "h2".to_string())],
+            Duration::from_millis(1),
+        );
+
+        assert_eq!(
+            (
+                report.batch,
+                report.removed,
+                report.still_contended,
+                report.failed
+            ),
+            (1, 1, 0, 0),
+            "the batch reclaimed the stale revision on its first pass: {report:?}",
+        );
+        assert_eq!(
+            report.retried, 0,
+            "an invisible revision is not contention and must not spend the \
+             batch's one delay: {report:?}",
+        );
+        assert_eq!(
+            cache.barrier_reads.load(Ordering::SeqCst),
+            1,
+            "barriered once, under the lock, on the single attempt that ran"
+        );
+        assert!(!present(&engine, &a, "h1"), "the stale revision is trimmed");
+        assert!(present(&engine, &a, "h2"), "the just-written one is kept");
     }
 
     /// The retry re-enumerates under the lock it newly acquired rather than

--- a/crates/engine/src/engine/gc.rs
+++ b/crates/engine/src/engine/gc.rs
@@ -317,6 +317,19 @@ impl Engine {
     /// and the lock is reclaimed by the next write's trim or by `heph gc`. The
     /// authoritative enumeration is re-taken under the write lock below.
     ///
+    /// **The one revision that must not be missing from that count is our own.**
+    /// `list_target_entries` is a plain `SELECT DISTINCT` with no
+    /// [`wait_if_pending`](crate::engine::local_cache_sqlite) — unlike `exists`,
+    /// which waits — so the revision this call was handed can still be sitting in
+    /// the sqlite writer's queue and be absent here. Then `pre.len() <= keep`
+    /// fires on a target that is genuinely over budget, and the trim returns
+    /// having *never asked for the lock*: not contention, not an error, nothing to
+    /// retry, and indistinguishable in any log from a target that was legitimately
+    /// within budget. That is a systematic, every-run undercount by exactly one —
+    /// self-inflicted, unlike another writer's revision landing late — so the
+    /// count is barriered against it before it is trusted. Any other revision
+    /// arriving late is somebody else's write, and the paragraph above covers it.
+    ///
     /// Deliberately `try_write` and not a blocking `write`: the lock is a
     /// cross-process `flock`, so a blocking acquire can wait on another `heph`
     /// arbitrarily long — on the single FIFO cleaner thread that also owes every
@@ -324,44 +337,64 @@ impl Engine {
     /// the async `ResultLock::write` on anyway. A skip is recoverable; an
     /// unbounded stall of all cleanup is not. [`Engine::run_trim_batch_with_delay`] hedges
     /// the skip instead, with one immediate re-probe and one delayed retry.
+    /// One unlocked revision enumeration, logged under `stage` when it fails.
+    ///
+    /// `Err(())` rather than the error itself: every caller here turns a failure
+    /// into [`TrimOutcome::Failed`] after logging, and threading an `anyhow::Error`
+    /// through only to drop it invites a caller to propagate one instead — this is
+    /// a fire-and-forget background lane.
+    fn enumerate(&self, addr: &Addr, stage: &'static str) -> std::result::Result<Vec<String>, ()> {
+        self.local_cache.list_target_entries(addr).map_err(|e| {
+            tracing::debug!(error = %format!("{e:#}"), %addr, stage, "post-write gc enumerate");
+        })
+    }
+
     pub(crate) fn try_trim_after_write(
         &self,
         addr: &Addr,
         keep: u32,
         written_hashin: &str,
     ) -> TrimOutcome {
-        let pre = match self.local_cache.list_target_entries(addr) {
+        let pre = match self.enumerate(addr, "pre-count") {
             Ok(h) => h,
-            Err(e) => {
-                tracing::debug!(error = %format!("{e:#}"), %addr, "post-write gc pre-count");
+            Err(()) => return TrimOutcome::Failed,
+        };
+        // Barrier only when the count cannot see the revision it was handed —
+        // when it can, there is nothing to order against and a warm run pays a
+        // `Vec` scan instead of a cache round-trip. `exists` is the barrier
+        // because it is the read that waits: `LocalCacheSQLite::exists` calls
+        // `wait_if_pending` on this exact key, and neither tier above it can
+        // short-circuit that away — `LocalCacheMem::writer` *invalidates* the key
+        // rather than populating it, so a resident mem entry implies a landed
+        // write, and `LocalCacheSpill` asks its sqlite primary first.
+        let pre = if pre.iter().any(|h| h == written_hashin) {
+            pre
+        } else {
+            if let Err(e) = self.local_cache.exists(addr, written_hashin, MANIFEST_V1) {
+                tracing::debug!(error = %format!("{e:#}"), %addr, "post-write gc barrier");
                 return TrimOutcome::Failed;
             }
+            match self.enumerate(addr, "re-count") {
+                Ok(h) => h,
+                Err(()) => return TrimOutcome::Failed,
+            }
         };
-        // Undercount is safe (see above): the just-written revision may not be
-        // visible to this read yet, and a target at exactly `keep` has nothing to
-        // delete anyway. `Settled`, not `Contended` — the lock was never asked
-        // for, so there is nothing for a retry to win.
+        // Undercount by another writer is safe (see above): a target at exactly
+        // `keep` has nothing to delete anyway. `Settled`, not `Contended` — the
+        // lock was never asked for, so there is nothing for a retry to win.
         if pre.len() as u32 <= keep {
             return TrimOutcome::SETTLED_NOTHING;
         }
 
         match self.result_lock().try_write(addr) {
             Ok(Some(guard)) => {
-                // Barrier on the just-written manifest so enumeration observes it
-                // (the sqlite write may still be in flight) and we don't leave the
-                // fresh revision uncounted.
-                if let Err(e) = self.local_cache.exists(addr, written_hashin, MANIFEST_V1) {
-                    tracing::debug!(error = %format!("{e:#}"), %addr, "post-write gc barrier");
-                    return TrimOutcome::Failed;
-                }
                 // Re-listed under the lock: authoritative, and it may have grown
-                // since the unlocked pre-count above.
-                let hashins = match self.local_cache.list_target_entries(addr) {
+                // since the unlocked pre-count above. No second barrier — the
+                // count above is already ordered against our own write, and that
+                // is the only write this call knows about.
+                let hashins = match self.enumerate(addr, "locked") {
                     Ok(h) => h,
-                    Err(e) => {
-                        tracing::debug!(error = %format!("{e:#}"), %addr, "post-write gc enumerate");
-                        return TrimOutcome::Failed;
-                    }
+                    Err(()) => return TrimOutcome::Failed,
                 };
                 match self.trim_addr_history(&guard, addr, &hashins, keep, Some(written_hashin)) {
                     Ok((removed, _kept, bytes)) => TrimOutcome::Settled { removed, bytes },
@@ -972,6 +1005,115 @@ mod tests {
         }
     }
 
+    /// A cache that reproduces the one asymmetry the post-write trim depends on,
+    /// deterministically.
+    ///
+    /// On the real sqlite backend `exists` waits for an in-flight write of its key
+    /// (`PendingTracker::wait_if_pending`) and `list_target_entries` — a plain
+    /// `SELECT DISTINCT hashin` — does not. So a revision whose manifest write is
+    /// still queued is *invisible to an enumeration and visible to a barrier*, and
+    /// nothing in a CI log distinguishes a trim that skipped because of that from
+    /// a trim that skipped because the target really was within budget.
+    ///
+    /// `queued` names such a revision: it is filtered out of every enumeration
+    /// until an `exists` on its manifest clears it, exactly as a real
+    /// `wait_if_pending` would. Everything else is forwarded to a genuine sqlite
+    /// cache, so the trim under test is running against the real backend.
+    struct QueuedWriteCache {
+        inner: Arc<dyn LocalCache>,
+        queued: std::sync::Mutex<Option<(String, String)>>,
+        barrier_reads: Arc<AtomicUsize>,
+    }
+
+    impl QueuedWriteCache {
+        /// Hide `hashin` from enumerations until it is barriered.
+        fn queue(&self, addr: &Addr, hashin: &str) {
+            *self.queued.lock().expect("queued") = Some((addr.format(), hashin.to_string()));
+        }
+    }
+
+    impl LocalCache for QueuedWriteCache {
+        fn reader(&self, addr: &Addr, hashin: &str, name: &str) -> anyhow::Result<SizedReader> {
+            self.inner.reader(addr, hashin, name)
+        }
+        fn writer(
+            &self,
+            addr: &Addr,
+            hashin: &str,
+            name: &str,
+        ) -> anyhow::Result<Box<dyn std::io::Write>> {
+            self.inner.writer(addr, hashin, name)
+        }
+        fn exists(&self, addr: &Addr, hashin: &str, name: &str) -> anyhow::Result<bool> {
+            if name == MANIFEST_V1 {
+                self.barrier_reads.fetch_add(1, Ordering::SeqCst);
+                // The wait: once this returns, the write has landed and every
+                // later enumeration sees it.
+                let mut q = self.queued.lock().expect("queued");
+                if q.as_ref()
+                    .is_some_and(|(a, h)| *a == addr.format() && h == hashin)
+                {
+                    *q = None;
+                }
+            }
+            self.inner.exists(addr, hashin, name)
+        }
+        fn existence(&self, addr: &Addr, hashin: &str, name: &str) -> anyhow::Result<Existence> {
+            self.inner.existence(addr, hashin, name)
+        }
+        fn delete(&self, addr: &Addr, hashin: &str, name: &str) -> anyhow::Result<()> {
+            self.inner.delete(addr, hashin, name)
+        }
+        fn list_targets(&self) -> anyhow::Result<TargetStream> {
+            self.inner.list_targets()
+        }
+        fn list_target_entries(&self, addr: &Addr) -> anyhow::Result<Vec<String>> {
+            let mut entries = self.inner.list_target_entries(addr)?;
+            if let Some((a, h)) = self.queued.lock().expect("queued").as_ref()
+                && *a == addr.format()
+            {
+                entries.retain(|e| e != h);
+            }
+            Ok(entries)
+        }
+        fn seekable_reader(
+            &self,
+            addr: &Addr,
+            hashin: &str,
+            name: &str,
+        ) -> anyhow::Result<Option<Box<dyn hcore::hartifactcontent::ReadSeek + Send>>> {
+            self.inner.seekable_reader(addr, hashin, name)
+        }
+        fn file_path(&self, addr: &Addr, hashin: &str, name: &str) -> Option<std::path::PathBuf> {
+            self.inner.file_path(addr, hashin, name)
+        }
+    }
+
+    /// Engine whose cache can hide one just-written revision from enumerations.
+    fn test_engine_queued() -> (
+        Arc<Engine>,
+        Arc<QueuedWriteCache>,
+        Arc<AtomicUsize>,
+        tempfile::TempDir,
+    ) {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let mut engine = Engine::new(Config {
+            root: dir.path().to_path_buf(),
+            home_dir: std::path::PathBuf::new(),
+            parallelism: None,
+            ..Default::default()
+        })
+        .expect("engine");
+        let barrier_reads = Arc::new(AtomicUsize::new(0));
+        let cache = Arc::new(QueuedWriteCache {
+            inner: Arc::clone(&engine.local_cache),
+            queued: std::sync::Mutex::new(None),
+            barrier_reads: Arc::clone(&barrier_reads),
+        });
+        engine.local_cache = Arc::clone(&cache) as Arc<dyn LocalCache>;
+        (Arc::new(engine), cache, barrier_reads, dir)
+    }
+
     /// Engine whose cache counts manifest barrier/recency reads. Returns the two
     /// counters alongside it.
     fn test_engine_counting() -> (
@@ -1219,9 +1361,13 @@ mod tests {
         assert!(present(&engine, &a, "h2"));
     }
 
-    /// The mirror of the above: over budget, the trim *does* pay for the barrier
-    /// and the recency reads. Without this the skip assertion could pass on a
+    /// The mirror of the above: over budget, the trim *does* pay for the
+    /// per-revision recency reads. Without this the skip assertion could pass on a
     /// trim that had stopped working entirely.
+    ///
+    /// Still no barrier read: setup barriered its own writes, so the pre-count
+    /// already contains `h2` and there is nothing to order against. The case that
+    /// *does* barrier is the test below.
     #[tokio::test]
     async fn try_trim_after_write_reads_manifests_when_over_budget() {
         let (engine, barrier_reads, manifest_reads, _dir) = test_engine_counting();
@@ -1235,8 +1381,8 @@ mod tests {
 
         assert_eq!(
             barrier_reads.load(Ordering::SeqCst),
-            1,
-            "over budget: the just-written manifest is barriered once"
+            0,
+            "the pre-count could already see the written revision: no barrier"
         );
         assert_eq!(
             manifest_reads.load(Ordering::SeqCst),
@@ -1245,6 +1391,53 @@ mod tests {
              of the one revision actually deleted"
         );
         assert!(!present(&engine, &a, "h1"), "stale revision trimmed");
+    }
+
+    /// **A pre-count that cannot see its own revision must not be believed.**
+    ///
+    /// `list_target_entries` is a plain `SELECT DISTINCT` with no
+    /// `wait_if_pending` — unlike `exists`, which waits — so the revision this
+    /// trim was handed can still be queued in the sqlite writer and absent from
+    /// the count. Then `pre.len() <= keep` fires on a target that is genuinely
+    /// over budget and the trim returns having never asked for the lock: not
+    /// `Contended`, so #222's retry deliberately never revisits it ("the lock was
+    /// never asked for, so there is nothing for a retry to win" — true for a
+    /// within-budget target, false for a stale count). `cache.history` silently
+    /// goes unenforced for the run, and the log is identical to the legitimate
+    /// case.
+    ///
+    /// Constructed, not raced: [`QueuedWriteCache`] hides `h2` from every
+    /// enumeration until the manifest barrier runs, which is exactly what the real
+    /// backend does while a write sits in the queue. Delete the barrier and this
+    /// fails every time rather than one run in N.
+    #[tokio::test]
+    async fn try_trim_after_write_barriers_a_pre_count_that_cannot_see_its_own_revision() {
+        let (engine, cache, barrier_reads, _dir) = test_engine_queued();
+        let a = addr("t");
+        write_revision(&engine, &a, "h1", 100, &["o.tar"]);
+        write_revision(&engine, &a, "h2", 200, &["o.tar"]);
+        // `h2` is this run's write and its commit is not yet observable to an
+        // unbarriered enumeration.
+        cache.queue(&a, "h2");
+        barrier_reads.store(0, Ordering::SeqCst);
+
+        // Unbarriered the count is `["h1"]`, `1 <= keep`, and the answer is
+        // SETTLED_NOTHING with `h1` still on disk.
+        assert_eq!(
+            engine.try_trim_after_write(&a, 1, "h2"),
+            TrimOutcome::Settled {
+                removed: 1,
+                bytes: 4
+            },
+            "a queued revision is still a revision: the target is over budget",
+        );
+        assert_eq!(
+            barrier_reads.load(Ordering::SeqCst),
+            1,
+            "barriered exactly once, before the count is trusted"
+        );
+        assert!(!present(&engine, &a, "h1"), "the stale revision is trimmed");
+        assert!(present(&engine, &a, "h2"), "the just-written one is kept");
     }
 
     /// Take `addr`'s write lock synchronously, the way the trim itself asks for

--- a/crates/engine/src/engine/local_cache_mem.rs
+++ b/crates/engine/src/engine/local_cache_mem.rs
@@ -467,6 +467,42 @@ mod tests {
         assert_eq!(inner.exists_calls.load(Ordering::Relaxed), before);
     }
 
+    /// **The mem tier must never answer `exists` for a key it has just written.**
+    ///
+    /// `exists` short-circuits on a resident entry, which is only safe because
+    /// `writer` *invalidates* the key instead of populating it — so the sole way
+    /// an entry becomes resident is through `reader`, which has already waited on
+    /// the inner backend's write queue. Populating the cache from `writer` with
+    /// the bytes it already holds is an obvious optimization, and it would quietly
+    /// turn `exists` into a non-barrier: `Engine::try_trim_after_write` would stop
+    /// being ordered against its own write, `cache.history` would go unenforced,
+    /// and every test of the trim itself would stay green.
+    ///
+    /// This is that invariant, pinned where it lives.
+    #[test]
+    fn exists_delegates_after_a_write_with_no_intervening_read() {
+        let inner = Arc::new(CountingCache::default());
+        let dec = LocalCacheMem::new(inner.clone(), 1024, 64 * 1024);
+        let addr = make_addr();
+
+        // A read first, to make the key resident and prove the short-circuit is
+        // otherwise live (see `exists_short_circuits_on_cache_hit`).
+        write_blob(&dec, &addr, "k", b"v");
+        let _ = drain(dec.reader(&addr, "h1", "k").expect("r").reader);
+
+        // Now rewrite it, with no read in between.
+        write_blob(&dec, &addr, "k", b"v2");
+
+        let before = inner.exists_calls.load(Ordering::Relaxed);
+        assert!(dec.exists(&addr, "h1", "k").expect("exists"));
+        assert_eq!(
+            inner.exists_calls.load(Ordering::Relaxed),
+            before + 1,
+            "the write invalidated the entry, so `exists` must reach the inner \
+             backend — that call is what makes it a write barrier"
+        );
+    }
+
     #[test]
     fn delete_invalidates_cache() {
         let inner = Arc::new(CountingCache::default());

--- a/crates/engine/src/engine/local_cache_sqlite.rs
+++ b/crates/engine/src/engine/local_cache_sqlite.rs
@@ -1632,6 +1632,118 @@ mod tests {
         Ok(())
     }
 
+    /// **The asymmetry the post-write cache trim is built on.**
+    ///
+    /// `exists` waits on this key's in-flight write (`wait_if_pending`);
+    /// `list_target_entries` is a plain `SELECT DISTINCT hashin` and does not.
+    /// So a revision whose every write is still queued is *invisible to an
+    /// enumeration and knowable to a probe*.
+    ///
+    /// `Engine::try_trim_after_write` depends on exactly this: it counts with
+    /// `list_target_entries`, corrects that count with `existence`, and orders the
+    /// enumeration that chooses what to delete with `exists`. Its own tests use a
+    /// double that *models* the asymmetry, so this is the test that says the
+    /// backend really has it — delete `wait_if_pending` from `exists` and this
+    /// fails here, where the property lives, instead of nowhere.
+    ///
+    /// Every observation is *captured* while the gate is shut and asserted only
+    /// after it reopens. A panic with the gate closed would leave the writer
+    /// thread parked in it, and `LocalCacheSQLite::drop` joins that thread — so
+    /// asserting in place turns any failure into a hung test process instead of a
+    /// red one. (Found exactly that way: the first version of this test deadlocked
+    /// under the mutation it exists to catch.)
+    #[tokio::test]
+    async fn a_queued_revision_is_invisible_to_list_target_entries_and_awaited_by_exists()
+    -> Result<()> {
+        let dir = tempdir()?;
+        let cache = Arc::new(LocalCacheSQLite::with_pipe_limit(
+            dir.path().join("cache.db"),
+            16 * 1024,
+            DEFAULT_MAX_CONCURRENT_PIPES,
+        )?);
+        let addr = make_addr("pkg", "trimmed");
+
+        cache.gate.close();
+        queued_write(&cache, &addr, "manifest-v1.borsh", b"manifest");
+
+        let listed_while_queued = cache.list_target_entries(&addr)?;
+        // The non-blocking probe knows better, and does not settle it either.
+        let existence_while_queued = cache.existence(&addr, "h", "manifest-v1.borsh")?;
+
+        // `exists` must *block* until the write lands, on another thread since
+        // this one has to open the gate.
+        let probe = std::thread::spawn({
+            let (cache, addr) = (cache.clone(), addr.clone());
+            move || cache.exists(&addr, "h", "manifest-v1.borsh")
+        });
+        tokio::time::sleep(std::time::Duration::from_millis(50)).await;
+        let probe_parked = !probe.is_finished();
+
+        cache.gate.open();
+
+        assert!(
+            listed_while_queued.is_empty(),
+            "an enumeration does not wait on the write queue — this is the \
+             undercount that makes a post-write trim skip a target that is over \
+             budget, and it is silent"
+        );
+        assert!(
+            probe_parked,
+            "`exists` must park on the queued write, not answer from the \
+             committed state — that wait is the barrier"
+        );
+        tokio::time::timeout(
+            std::time::Duration::from_secs(5),
+            queued(existence_while_queued),
+        )
+        .await
+        .expect("the queued write must land");
+        assert!(
+            probe.join().expect("probe thread")?,
+            "present once it lands"
+        );
+        assert_eq!(
+            cache.list_target_entries(&addr)?,
+            vec!["h".to_string()],
+            "and only then does the enumeration see it"
+        );
+        Ok(())
+    }
+
+    /// The other half of the same story, and the reason the trim's correction is
+    /// *conditional*: `cache_locally` writes artifacts before the manifest on one
+    /// FIFO writer, so a revision whose blob has committed is already in the
+    /// enumeration even while its manifest is queued. That is the common case on a
+    /// warm run, and it must cost no probe at all.
+    #[tokio::test]
+    async fn a_revision_with_one_committed_blob_is_listed_while_its_manifest_is_queued()
+    -> Result<()> {
+        let dir = tempdir()?;
+        let cache = LocalCacheSQLite::with_pipe_limit(
+            dir.path().join("cache.db"),
+            16 * 1024,
+            DEFAULT_MAX_CONCURRENT_PIPES,
+        )?;
+        let addr = make_addr("pkg", "partial");
+
+        queued_write(&cache, &addr, "out.tar", b"bytes");
+        assert!(cache.exists(&addr, "h", "out.tar")?); // barrier: the blob landed
+
+        cache.gate.close();
+        queued_write(&cache, &addr, "manifest-v1.borsh", b"manifest");
+
+        // Captured, not asserted, while the gate is shut — see the test above.
+        let listed = cache.list_target_entries(&addr)?;
+        cache.gate.open();
+
+        assert_eq!(
+            listed,
+            vec!["h".to_string()],
+            "the hashin is listed on the strength of the committed blob alone"
+        );
+        Ok(())
+    }
+
     /// The case a "queued means present" shortcut would get wrong: `delete`
     /// registers a slot too, so a key mid-GC reports `Queued` and then resolves to
     /// *absent*.


### PR DESCRIPTION
> **Stacked on #249** (`raphaelvigee/gc-trim-retry-contended`), which rewrites
> the function this touches and is open, not merged. Based on its head and
> targeted at its branch so the diff here is only this change; GitHub retargets
> to `master` when #249 merges. CI runs on every PR since #240, so the stacked
> base still gets full coverage.

`try_trim_after_write` has **two** silent no-trim paths. #249 fixes the first
(a contended `try_write`, retried with a flush). This is the second, and it is
why `e2e::cache_history_is_enforced_by_the_end_of_the_run` still flakes on
`linux/amd64`.

## The unlocked pre-count under-counts its own write

#219 made the trim decide cheaply: one *unlocked* `list_target_entries`, and
only a target genuinely over budget pays for the lock, the barrier and the
per-revision manifest reads. But on the sqlite backend `list_target_entries` is

```rust
// LocalCacheSQLite::list_target_entries
let conn = self.read_conn()?;
let mut stmt = conn.prepare_cached("SELECT DISTINCT hashin FROM artifacts WHERE addr=?1")
```

— a plain `SELECT`, with **no `wait_if_pending`**. `exists`, three methods up,
does have it:

```rust
fn exists(&self, addr: &Addr, hashin: &str, name: &str) -> Result<bool> {
    let addr_key = Self::key(addr);
    self.pending.wait_if_pending(&addr_key, hashin, name);   // <-- the barrier
    self.exists_committed(&addr_key, hashin, name)
}
```

So the revision the trim was just handed can still be in the writer thread's
queue and simply not be in the count. Then `pre.len() <= keep` fires on a target
that *is* over budget, and the call returns having **never asked for the lock**.

That is why it survived #249: the outcome is `SETTLED_NOTHING`, and the retry
deliberately never revisits it — *"the lock was never asked for, so there is
nothing for a retry to win."* True for a target that really is within budget.
False for a stale count, and the two are indistinguishable from a CI log: both
end the run at `revisions_removed: 1, revisions_kept: 1`.

#249's own soak hit this mechanism and "fixed" it by barriering the **test's**
sqlite write (`write_revision`) rather than the production pre-count. That is
why it is still here.

## The fix

The barrier already existed — one step too late, inside the lock branch, after
the decision that skips the lock branch. Move it above the pre-count, and make
it conditional:

```rust
let pre = if pre.iter().any(|h| h == written_hashin) {
    pre
} else {
    self.local_cache.exists(addr, written_hashin, MANIFEST_V1)?;  // the wait
    self.enumerate(addr, "re-count")?
};
```

**Conditional**, because the count only needs ordering against the one write
this call knows about:

- pre-count already contains it (the normal case — the write landed): a `Vec`
  scan of ~`keep` short strings, no cache round-trip. #219's steady-state cost
  claim is preserved.
- it does not: one `exists` plus one re-list — exactly the case that was broken.

Under-counting somebody *else's* concurrent write is unchanged and still fine;
#219's reasoning covers it and it is not systematic. Ours was: every run, every
target, by exactly one.

The **in-lock barrier is deleted**, not duplicated. After this the count is
ordered against our write before the lock is even requested, so a second
`exists` under the guard orders against nothing. Net cost on the over-budget
path is one `exists` *fewer*.

### `exists` really is a barrier through the whole stack

Checked each tier, because a barrier that silently isn't one is this exact bug
class:

| tier | behaviour |
|---|---|
| `LocalCacheSQLite::exists` | calls `wait_if_pending` on this key |
| `LocalCacheMem::exists` | short-circuits on a `peek` hit — but `writer` *invalidates* the key rather than populating it, and `reader` waits before caching, so a resident entry can only mean the write already landed |
| `LocalCacheSpill::exists` | asks its sqlite primary first |

It still parks the calling thread, as it did before — that is the sandbox
cleaner's dedicated OS thread, which `LocalCache::delete` already documents as a
thread-parking caller, never a runtime worker. The wait is bounded by the writer
thread draining one FIFO entry for one key.

Also folds four copies of `list_target_entries` + the same six log lines into
`Engine::enumerate`, which names the stage that failed.

## The test

`QueuedWriteCache` reproduces the asymmetry **deterministically**: a named
revision is filtered out of every enumeration until an `exists` on its manifest
clears it — precisely what the backend does while a write sits in the queue —
with everything else forwarded to a genuine sqlite cache.

Constructed rather than raced, on purpose: a test that *hopes* to catch this
race is a test that also flakes.

### Red-checks, on the committed tree

| Mutation | Test | Result |
|---|---|---|
| drop the pre-count barrier (i.e. the bug) | the new test | **RED** — `Settled { removed: 0 }`, `h1` still present |
| barrier unconditionally | `..._skips_reads_when_within_budget` | **RED** — `barrier_reads` 1 ≠ 0 |
| barrier unconditionally | `..._reads_manifests_when_over_budget` | **RED** — `barrier_reads` 1 ≠ 0 |
| restore the in-lock barrier | `..._reads_manifests_when_over_budget` | **RED** |
| restored from the commit | all 5 trim tests | green |

The first one reproduces the production signature exactly: `SETTLED_NOTHING`,
with the stale revision left on disk and the lock never requested.

## Reproduction: I could not, and that is expected

This is `linux/amd64`-only in practice. On this darwin/arm64 box:

- 150 runs of `cache_history_is_enforced_by_the_end_of_the_run` under 6-way
  parallel stress: **0 failures before the fix, 0 after**.
- an earlier instrumented probe comparing the unbarriered pre-count against a
  barriered re-count found them equal on 300/300 samples here.

So the argument for this change is **structural** — the missing
`wait_if_pending`, present on `exists` and absent on `list_target_entries` — and
the test forces the condition rather than waiting for it. A before/after failure
rate on this machine would be 0/150 → 0/150 and would prove nothing either way.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01A76DChMohieGMbRbnV1E7x

---

## Review-board follow-up (second commit)

`feature-quality` and `code-quality` both returned **BLOCKED**. Three real
problems, all fixed.

### 1. The barrier was in the wrong place (cost)

Moving `exists` above the pre-count fixed the undercount but mispriced it.
`exists` parks the caller until the sqlite writer has drained **everything
queued ahead of our entry** — and this runs on the single FIFO cleaner thread
that also owes every sandbox rmdir and gates process exit. The pre-image only
paid that for a target already known to be over budget.

`existence` is the right probe for a *decision*: it reports the write-behind
queue instead of blocking on it.

```rust
let count = if pre.iter().any(|h| h == written_hashin) {
    pre.len()                                    // warm run: a Vec scan
} else {
    match self.local_cache.existence(addr, written_hashin, MANIFEST_V1) {
        Ok(Queued(_) | Committed(true)) => pre.len() + 1,
        Ok(Committed(false)) => { debug!(…); pre.len() }   // never landed
        Err(e)               => { debug!(…); return TrimOutcome::Failed }
    }
};
```

The `exists` wait goes back **inside the lock branch**, where the enumeration
that chooses what to delete has to be ordered against our write. Net effect vs.
the pre-image: the undercount is fixed and **no target waits on the writer that
did not wait before**. `Committed(false)` is now logged rather than silently
trimmed around.

### 2. The premise was asserted nowhere against the backend

`QueuedWriteCache` *models* the asymmetry — so deleting `wait_if_pending` from
`LocalCacheSQLite::exists`, or letting `LocalCacheMem::writer` populate instead
of invalidate, would reintroduce this bug **with every test in the commit still
green**. For a fix justified structurally rather than by a reproduction, the
structure is what has to be pinned. This repo has shipped a broken trim-lane
double before (#252).

Three characterization tests, each where the property lives:

- `local_cache_sqlite`: with the writer gate shut, a fully-queued revision is
  absent from `list_target_entries`, `existence` reports `Queued`, and `exists`
  **blocks** — asserted on a spawned thread that must still be unfinished.
- `local_cache_sqlite`: a revision whose blob committed *is* listed while its
  manifest is queued — why the correction is conditional and a warm run pays
  nothing.
- `local_cache_mem`: after a write with no intervening read, `exists` must reach
  the inner backend.

### 3. `fn enumerate` stole `try_trim_after_write`'s doc comment

Inserted between the 39-line rationale block and the function it documents, so
rustdoc filed #219's cost argument, #222's retry rule and this fix's
justification under a four-line logging helper. Moved.

### Red-checks, on the committed tree

| Mutation | Test | Result |
|---|---|---|
| drop the `existence` correction (the bug) | new unit test | **RED** |
| drop it — batch lane | `trim_batch_reclaims_a_target_whose_revision_is_still_queued` | **RED** |
| correct unconditionally | `..._skips_reads_when_within_budget` | **RED** |
| use the **parking** probe for the decision | `..._counts_a_queued_revision_without_barriering` | **RED** |
| delete the in-lock barrier | `..._reads_manifests_when_over_budget` | **RED** |
| **remove `wait_if_pending` from sqlite `exists`** | sqlite characterization | **RED** |
| **make mem `writer` populate instead of invalidate** | mem delegation | **RED** |
| restored | 30 gc + 57 local_cache | green |

The last two are the point of the BLOCKER fix: before them, neither mutation
reddened anything.

### Also from the reviews

- `enumerate` → `revisions`, returning `Option` not `Result<_, ()>`.
- `TrimOutcome::Failed`'s doc split correctly across unlocked/locked stages.
- `QueuedWriteCache` holds a *set*, so "we correct only for our own write" is a
  test, not a sentence; `queue()` documents that any `exists` consumes it.
- New tests: queued-but-within-budget (counted, not barriered); correcting only
  for our own write; a written revision that never landed.
- **Found while red-checking:** the first version of the sqlite test asserted
  while the gate was shut, so a failure panicked with the writer parked and
  `Drop` then deadlocked joining it — a hang instead of a red. Both gate tests
  now capture observations and assert only after reopening.

### Deliberately not done

- **A `LocalCacheSpill::exists` delegation test.** The property is that the
  queue-aware primary is consulted first, spelled `primary.exists(…)? || …` —
  short-circuit order is a language guarantee, not a runtime lookup that can
  silently regress the way the mem tier's `peek` can.
- **Folding the three delegating `LocalCache` doubles into one.** Real
  duplication, but it spans `gc.rs` and `result.rs` and wants a shared
  test-support module — not in a flake fix.
- **`keep = 0`.** Unreachable from a BUILD file (`parse_cache_history` rejects
  `< 1`); reachable in principle from a driver. Traced: lock taken, nothing
  deleted, `written_hashin` protected. Benign.

### Note on this PR's own CI

The `Test linux/arm64` failure on the first push is **flake A** —
`the_dump_and_the_watchdog_companion_file_render_identically`, fixed by #257,
which is not in this branch's base (#249 branched before it). It reddening this
PR is the problem #257 exists to solve.
