### PR TITLE
ci(lint): lint macOS and the `fuse-sandbox`-off arm, as a per-platform matrix

### DIFF
--- a/.github/workflows/heph.yml
+++ b/.github/workflows/heph.yml
@@ -427,10 +427,14 @@ jobs:
     name: Lint
     runs-on: ubuntu-latest
     # The gate now check-builds every workspace member's libs *and* test targets,
-    # twice (default features, then --all-features), where it used to build the
-    # root package alone in ~1m35s. A fork PR gets no R2 sccache credentials and
-    # runs both passes stone cold. A timeout renders as a red `Lint`
-    # indistinguishable from a real lint failure, so the headroom is deliberate.
+    # three times (default features, --all-features, --no-default-features),
+    # where it used to build the root package alone in ~1m35s. A fork PR gets no
+    # R2 sccache credentials and runs every pass stone cold — and clippy's work
+    # is not sccache-cacheable at all (`sccache` does not cache `clippy-driver`,
+    # which is why the Lint job's own stats report ~200 "non-cacheable calls"),
+    # so a warm cache only saves the dependency compiles. A timeout renders as a
+    # red `Lint` indistinguishable from a real lint failure, so the headroom is
+    # deliberate.
     timeout-minutes: 30
     needs: gen
     steps:
@@ -447,6 +451,64 @@ jobs:
           # Distinct from the linux/amd64 build job, which uses the same target
           # triple: sharing a cargo cache key means whichever job saves first
           # freezes the entry and the other's crate downloads never persist.
+          cache-suffix: "-lint"
+          r2-secret: ${{ secrets.CF_SSCACHE }}
+
+      - name: Lint
+        shell: devenv shell bash -- -e {0}
+        run: lint
+
+      - name: sccache stats
+        if: always()
+        shell: devenv shell bash -- -e {0}
+        run: sccache --show-stats
+
+  # macOS-only code was clippy-linted nowhere. `Test darwin/arm64` compiles it,
+  # but nothing there passes `-D warnings`, so the Mach `sweep_threads` block in
+  # `src/diag.rs` — the largest unsafe region in the tree — plus
+  # `crates/proc/src/proc_exec/imp_macos.rs` and `process_watcher/kqueue_macos.rs`
+  # had never been through `undocumented_unsafe_blocks`,
+  # `multiple_unsafe_ops_per_block`, `indexing_slicing` or `unwrap_used`.
+  #
+  # It runs the *same* `lint` script as the Linux leg rather than a trimmed one.
+  # The failure this closes is a Mac developer's local `lint` disagreeing with
+  # CI in either direction — `#[expect]` is fulfilled-or-error, so a lint that
+  # fires on one OS and not the other is a hard error on the other — and that
+  # only stays closed if both run the same command. A darwin-only variant would
+  # recreate the divergence it exists to remove.
+  #
+  # A separate job, deliberately not a `matrix` on `lint`: the branch ruleset
+  # requires a status context named literally `Lint`. A matrix would publish
+  # `Lint linux/amd64` / `Lint darwin/arm64` and never `Lint` again, so every
+  # open PR would block on a required check that can no longer report, and the
+  # workflow edit and the ruleset edit cannot land atomically.
+  #
+  # Cost, measured rather than assumed — see the PR body. It is a fourth
+  # concurrent `macos-latest` job in the `needs: gen` wave, which is the real
+  # price: the darwin build chain has been observed on the critical path, and
+  # macOS jobs in this repo have queued for up to ~2m30s waiting for a slot.
+  lint_darwin:
+    name: Lint darwin/arm64
+    runs-on: macos-latest
+    # Same reasoning as `lint` above, and macOS starts colder: the Nix setup
+    # alone is measured at 3m44s-4m42s on this runner.
+    timeout-minutes: 30
+    needs: gen
+    steps:
+      - name: Download repo
+        uses: actions/download-artifact@v7
+        with:
+          name: repo
+          path: .
+
+      - name: Setup Nix + devenv
+        uses: ./.github/actions/setup-nix
+        with:
+          cargo-target: aarch64-apple-darwin
+          # Distinct from `Test darwin/arm64`, which uses the same target
+          # triple: actions/cache skips the save when the key already exists, so
+          # two jobs sharing a key means whichever saves first freezes the entry
+          # and the other's crate downloads never persist.
           cache-suffix: "-lint"
           r2-secret: ${{ secrets.CF_SSCACHE }}
 
@@ -653,7 +715,7 @@ jobs:
 
   release:
     name: Release
-    needs: [gen, upload_artifacts, lint, test, bin_e2e]
+    needs: [gen, upload_artifacts, lint, lint_darwin, test, bin_e2e]
     if: github.ref == 'refs/heads/master'
     runs-on: ubuntu-latest
     timeout-minutes: 10
@@ -705,7 +767,7 @@ jobs:
 
   cleanup:
     name: Cleanup
-    needs: [gen, build, lint, test, bin_e2e, upload_artifacts]
+    needs: [gen, build, lint, lint_darwin, test, bin_e2e, upload_artifacts]
     runs-on: ubuntu-latest
     timeout-minutes: 5
     steps:

--- a/.github/workflows/heph.yml
+++ b/.github/workflows/heph.yml
@@ -423,20 +423,56 @@ jobs:
       - name: Check plugin ABI version
         run: scripts/abi-check.sh "origin/${{ github.base_ref }}"
 
-  lint:
-    name: Lint
-    runs-on: ubuntu-latest
-    # The gate now check-builds every workspace member's libs *and* test targets,
-    # three times (default features, --all-features, --no-default-features),
-    # where it used to build the root package alone in ~1m35s. A fork PR gets no
-    # R2 sccache credentials and runs every pass stone cold — and clippy's work
-    # is not sccache-cacheable at all (`sccache` does not cache `clippy-driver`,
-    # which is why the Lint job's own stats report ~200 "non-cacheable calls"),
-    # so a warm cache only saves the dependency compiles. A timeout renders as a
-    # red `Lint` indistinguishable from a real lint failure, so the headroom is
-    # deliberate.
+  # The gate check-builds every workspace member's libs *and* test targets,
+  # three times (default features, --all-features, --no-default-features),
+  # where it used to build the root package alone in ~1m35s. A fork PR gets no
+  # R2 sccache credentials and runs every pass stone cold — and clippy's work is
+  # not sccache-cacheable at all (`sccache` does not cache `clippy-driver`,
+  # which is why these jobs' own stats report ~200 "non-cacheable calls"), so a
+  # warm cache only saves the dependency compiles. A timeout renders as a red
+  # lint leg indistinguishable from a real lint failure, so the 30min headroom
+  # is deliberate.
+  #
+  # Both platforms, because macOS-only code was clippy-linted nowhere.
+  # `Test darwin/arm64` compiles it, but nothing there passes `-D warnings`, so
+  # the Mach `sweep_threads` block in `src/diag.rs` — the largest unsafe region
+  # in the tree — plus `crates/proc/src/proc_exec/imp_macos.rs` and
+  # `process_watcher/kqueue_macos.rs` had never been through
+  # `undocumented_unsafe_blocks`, `multiple_unsafe_ops_per_block`,
+  # `indexing_slicing` or `unwrap_used`.
+  #
+  # Every leg runs the *same* `lint` script — no per-OS variant. The failure
+  # being closed is a Mac developer's local `lint` disagreeing with CI in either
+  # direction (`#[expect]` is fulfilled-or-error, so a lint that fires on one OS
+  # and not the other is a hard error on the other), and that only stays closed
+  # if every leg runs the same command as the developer does.
+  lint_matrix:
+    name: Lint ${{ matrix.os }}/${{ matrix.arch }}
+    runs-on: ${{ matrix.runs-on }}
     timeout-minutes: 30
     needs: gen
+    strategy:
+      # Both legs always report. With fail-fast the second is cancelled the
+      # moment the first goes red, and `cancelled` is exactly the state that
+      # tells you nothing about the platform you did not see.
+      fail-fast: false
+      matrix:
+        include:
+          - os: linux
+            arch: amd64
+            runs-on: ubuntu-latest
+            target: x86_64-unknown-linux-gnu
+
+          # macos-latest is Apple Silicon. There is no `Lint linux/arm64` leg:
+          # aarch64 is covered here on the OS axis, and an `#[expect]` that is
+          # unfulfilled only on aarch64-linux would be invisible anyway — plain
+          # rustc silently ignores an unfulfilled expectation on a *tool* lint
+          # it does not know, so `Test linux/arm64` cannot stand in for one.
+          # See the note in devenv.nix.
+          - os: darwin
+            arch: arm64
+            runs-on: macos-latest
+            target: aarch64-apple-darwin
     steps:
       - name: Download repo
         uses: actions/download-artifact@v7
@@ -447,9 +483,10 @@ jobs:
       - name: Setup Nix + devenv
         uses: ./.github/actions/setup-nix
         with:
-          cargo-target: x86_64-unknown-linux-gnu
-          # Distinct from the linux/amd64 build job, which uses the same target
-          # triple: sharing a cargo cache key means whichever job saves first
+          cargo-target: ${{ matrix.target }}
+          # Distinct from the build and test jobs, which use the same target
+          # triples: actions/cache skips the save when the exact key already
+          # exists, so two jobs sharing a key means whichever saves first
           # freezes the entry and the other's crate downloads never persist.
           cache-suffix: "-lint"
           r2-secret: ${{ secrets.CF_SSCACHE }}
@@ -463,63 +500,48 @@ jobs:
         shell: devenv shell bash -- -e {0}
         run: sccache --show-stats
 
-  # macOS-only code was clippy-linted nowhere. `Test darwin/arm64` compiles it,
-  # but nothing there passes `-D warnings`, so the Mach `sweep_threads` block in
-  # `src/diag.rs` — the largest unsafe region in the tree — plus
-  # `crates/proc/src/proc_exec/imp_macos.rs` and `process_watcher/kqueue_macos.rs`
-  # had never been through `undocumented_unsafe_blocks`,
-  # `multiple_unsafe_ops_per_block`, `indexing_slicing` or `unwrap_used`.
+  # Aggregator. Does no work; it exists so the status context stays named
+  # exactly `Lint`.
   #
-  # It runs the *same* `lint` script as the Linux leg rather than a trimmed one.
-  # The failure this closes is a Mac developer's local `lint` disagreeing with
-  # CI in either direction — `#[expect]` is fulfilled-or-error, so a lint that
-  # fires on one OS and not the other is a hard error on the other — and that
-  # only stays closed if both run the same command. A darwin-only variant would
-  # recreate the divergence it exists to remove.
+  # The branch ruleset requires a context named literally `Lint`. A bare matrix
+  # publishes one context per leg and never that name again, so every open PR
+  # would block forever on a required check that can no longer appear — a worse
+  # failure than the one being fixed, and the workflow edit and the ruleset edit
+  # cannot land atomically. Matrixing the work and keeping this fan-in gives
+  # per-platform legs with their own logs *and* an unchanged required context,
+  # so this lands with **no branch-protection change at all**.
   #
-  # A separate job, deliberately not a `matrix` on `lint`: the branch ruleset
-  # requires a status context named literally `Lint`. A matrix would publish
-  # `Lint linux/amd64` / `Lint darwin/arm64` and never `Lint` again, so every
-  # open PR would block on a required check that can no longer report, and the
-  # workflow edit and the ruleset edit cannot land atomically.
+  # `if: always()` is what makes it able to report when a leg fails — without it
+  # a failed leg would *skip* this job, and a skipped required check is not a
+  # red one. That inverts the danger: `always()` alone would let it succeed on a
+  # failed leg, since a job whose steps all pass is green regardless of why its
+  # dependencies ended. Hence the explicit `result` check below. `needs` alone
+  # decides *ordering* here, not outcome.
   #
-  # Cost, measured rather than assumed — see the PR body. It is a fourth
-  # concurrent `macos-latest` job in the `needs: gen` wave, which is the real
-  # price: the darwin build chain has been observed on the critical path, and
-  # macOS jobs in this repo have queued for up to ~2m30s waiting for a slot.
-  lint_darwin:
-    name: Lint darwin/arm64
-    runs-on: macos-latest
-    # Same reasoning as `lint` above, and macOS starts colder: the Nix setup
-    # alone is measured at 3m44s-4m42s on this runner.
-    timeout-minutes: 30
-    needs: gen
+  # `needs.lint_matrix.result` is the aggregate over every leg: `success` only
+  # when all of them succeeded, otherwise `failure` / `cancelled` / `skipped`.
+  # Comparing against `success` therefore fails closed for a new leg too — add a
+  # third platform and it is covered without touching this job.
+  lint:
+    name: Lint
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    needs: lint_matrix
+    if: always()
     steps:
-      - name: Download repo
-        uses: actions/download-artifact@v7
-        with:
-          name: repo
-          path: .
-
-      - name: Setup Nix + devenv
-        uses: ./.github/actions/setup-nix
-        with:
-          cargo-target: aarch64-apple-darwin
-          # Distinct from `Test darwin/arm64`, which uses the same target
-          # triple: actions/cache skips the save when the key already exists, so
-          # two jobs sharing a key means whichever saves first freezes the entry
-          # and the other's crate downloads never persist.
-          cache-suffix: "-lint"
-          r2-secret: ${{ secrets.CF_SSCACHE }}
-
-      - name: Lint
-        shell: devenv shell bash -- -e {0}
-        run: lint
-
-      - name: sccache stats
-        if: always()
-        shell: devenv shell bash -- -e {0}
-        run: sccache --show-stats
+      - name: Require every lint leg to have succeeded
+        env:
+          # Read through env rather than interpolated into the script body, so
+          # the value can never be parsed as shell.
+          LINT_MATRIX_RESULT: ${{ needs.lint_matrix.result }}
+        run: |
+          set -euo pipefail
+          echo "lint_matrix: $LINT_MATRIX_RESULT"
+          if [ "$LINT_MATRIX_RESULT" != "success" ]; then
+            echo "::error title=Lint::lint_matrix did not succeed (result: $LINT_MATRIX_RESULT). Open the 'Lint linux/amd64' and 'Lint darwin/arm64' jobs for the failing leg. A 'skipped' or 'cancelled' result counts as a failure here on purpose: it means a platform was never linted."
+            exit 1
+          fi
+          echo "every lint leg succeeded"
 
   test:
     name: Test ${{ matrix.os }}/${{ matrix.arch }}
@@ -715,7 +737,7 @@ jobs:
 
   release:
     name: Release
-    needs: [gen, upload_artifacts, lint, lint_darwin, test, bin_e2e]
+    needs: [gen, upload_artifacts, lint, test, bin_e2e]
     if: github.ref == 'refs/heads/master'
     runs-on: ubuntu-latest
     timeout-minutes: 10
@@ -767,7 +789,7 @@ jobs:
 
   cleanup:
     name: Cleanup
-    needs: [gen, build, lint, lint_darwin, test, bin_e2e, upload_artifacts]
+    needs: [gen, build, lint, test, bin_e2e, upload_artifacts]
     runs-on: ubuntu-latest
     timeout-minutes: 5
     steps:

--- a/crates/engine/src/engine/request_state.rs
+++ b/crates/engine/src/engine/request_state.rs
@@ -1060,7 +1060,7 @@ mod tests {
     #[tokio::test]
     #[expect(
         clippy::await_holding_lock,
-        reason = "`backstop_exclusive()` serializes whole tests against each other, so its guard is meant to outlive the awaits below; `#[tokio::test]` drives this body via `block_on` on the calling thread, so the `!Send` guard cannot migrate"
+        reason = "`backstop_exclusive()` serializes whole tests against each other, so its guard is meant to outlive the awaits below. No deadlock: nothing on the awaited path takes this mutex — `wait_drained` polls an `AtomicUsize` and sleeps, and neither the cleaner thread nor `flush_backstop` touches it; the only other holders are the three plain `#[test]` fns in `gc.rs`. And `#[tokio::test]` drives this body via `block_on` on the calling thread, so the `!Send` guard cannot migrate"
     )]
     async fn the_exit_gate_is_held_across_the_trim_retry() -> anyhow::Result<()> {
         let _exclusive = crate::engine::gc::backstop_exclusive();

--- a/devenv.nix
+++ b/devenv.nix
@@ -92,10 +92,17 @@ in
   #   - Without `--all-targets`: `#[cfg(test)]` modules, `tests/`, `benches/`
   #     and `examples/` are skipped. Most of this repo's test code lives in
   #     `#[cfg(test)] mod tests` inside member crates.
-  #   - The `--all-features` pass is only meaningful *with* `--workspace`: the
-  #     root package's sole feature (`fuse-sandbox`) is already default, so on
-  #     the root package alone that second invocation was a 0.30s no-op that
-  #     never once compiled the feature-gated code its name promises.
+  #   - Without `--workspace` the `--all-features` pass was a 0.30s no-op: the
+  #     root package's sole feature (`fuse-sandbox`) is already default, and the
+  #     feature-gated code it promises to cover lives in members that were not
+  #     selected. Measured honestly, it is *still* close to a no-op with
+  #     `--workspace` (2.31s, zero units recompiled after the default pass):
+  #     only four members declare features, and `--workspace` already unifies
+  #     every one of them on — the cdylibs pull `plugin-sdk/stabby` →
+  #     `plugin-stabby/host` → `plugin-abi`, and the root's default pulls
+  #     `sandboxfuse/fuse-sandbox`. It is kept as cheap insurance against a
+  #     future feature nothing else references, not because it covers anything
+  #     today. The pass that does add coverage is `--no-default-features`.
   #
   # Together those hid 323 clippy errors, and let the gate pass on a tree that
   # did not compile: a trait impl missing a method inside `crates/engine`'s
@@ -106,26 +113,60 @@ in
   # want a faster local loop, narrow with `-p <crate>` — never by dropping
   # `--workspace`.
   #
-  # `tests/lint_gate.rs` asserts both flags are still here, and that every
+  # `tests/lint_gate.rs` asserts these flags are still here, and that every
   # workspace member inherits `[workspace.lints]` — a member that does not is
   # linted with stock clippy only, which is the same silent hole one level down.
   #
-  # Known gaps, so nobody has to rediscover them:
-  #   - The CI `Lint` job runs on `ubuntu-latest` only, so macOS-only code
-  #     (`proc/src/proc_exec/imp_macos.rs`, the Mach `sweep_threads` in
-  #     `src/diag.rs`, …) is compiled by `Test darwin/arm64` but never linted.
-  #     Running `lint` on a Mac can therefore disagree with CI in either
-  #     direction — `#[expect]` is fulfilled-or-error, and the crate-root test
-  #     exemptions are pinned to the lint set that fires on Linux.
-  #   - `--all-targets` does not include doctests.
-  #   - `--no-default-features` (i.e. `fuse-sandbox` off) is linted nowhere,
-  #     and built nowhere either.
+  # The third pass covers `fuse-sandbox` **off**, and its selection is the
+  # subtle one. `--workspace --no-default-features` looks like it turns the
+  # feature off and does not: `crates/e2e`, `crates/plugingo-e2e` and
+  # `crates/testkit` depend on the root `heph` package with default features on,
+  # and cargo unifies features across the whole selection, so that edge switches
+  # `fuse-sandbox` straight back on. Verified, not reasoned: with an
+  # `indexing_slicing` error injected into `crates/sandboxfuse/src/stub.rs` — the
+  # file that is compiled *only* when the feature is off — the naive invocation
+  # exits 0 and the excluded one exits 101.
+  #
+  # Because that is invisible when it regresses (a new member with
+  # `heph = { path = ".." }` silently re-enables it, and the pass keeps
+  # reporting green while linting the wrong arm), the script *asserts* the
+  # feature is off before linting rather than trusting the flag. `cargo tree -i`
+  # exits non-zero when the package is absent from the resolved graph, which is
+  # the state we want.
+  #
+  # Remaining gaps, so nobody has to rediscover them:
+  #   - `--all-targets` does not include doctests (10 blocks).
+  #   - `cargo test --no-default-features` is not run — the feature-off arm is
+  #     compiled and linted, never executed. `crates/sandboxfuse`'s
+  #     `fuse_sandbox_is_a_default_feature` asserts the feature *is* on, so a
+  #     test leg would need that test `#[cfg]`-split first.
+  #   - CI lints `linux/amd64` and `darwin/arm64`, so the OS axis is covered but
+  #     the arch axis is confounded: `aarch64` is only ever linted together with
+  #     macOS, and there is no `Lint linux/arm64`. An `#[expect(clippy::…)]`
+  #     that is unfulfilled only on `aarch64-unknown-linux-gnu` would be
+  #     invisible — plain rustc reports `unfulfilled_lint_expectations` for its
+  #     own lints, but silently ignores an unfulfilled expectation on a *tool*
+  #     lint it does not know, so `Test linux/arm64` cannot stand in for a lint
+  #     job. Either keep lint exemptions free of `target_arch` conditions, or
+  #     add the third leg.
+  #
+  # The flags are written out literally in both scripts rather than factored
+  # into a shared Nix variable on purpose: `tests/lint_gate.rs` guards them by
+  # reading this file, and a guard that reads back an interpolation hole rather
+  # than the flags guards nothing.
   scripts.lint.exec = ''
     set -euo pipefail
     echo '> clippy'
     cargo clippy --workspace --all-targets --locked -- -D warnings
     echo '> clippy --all-features'
     cargo clippy --workspace --all-targets --all-features --locked -- -D warnings
+    echo '> clippy --no-default-features'
+    if cargo tree --workspace --exclude e2e --exclude plugingo-e2e --exclude testkit --no-default-features -i fuser >/dev/null 2>&1; then
+      echo "error: --no-default-features left 'fuser' in the dependency graph, so this pass is linting the fuse-sandbox=on arm and the feature-off code is still covered by nothing." >&2
+      echo "       Some selected package pulls the root 'heph' package (or 'sandboxfuse') with default features on; exclude it here and in 'fix'." >&2
+      exit 1
+    fi
+    cargo clippy --workspace --exclude e2e --exclude plugingo-e2e --exclude testkit --all-targets --no-default-features --locked -- -D warnings
     echo '> fmt'
     cargo fmt --check ${qualityCrates}
   '';
@@ -133,9 +174,16 @@ in
   # only reaches the root package leaves the member lints `lint` reports with
   # no automated fix at all. `clippy --fix` rather than `cargo fix`: it applies
   # clippy's machine-applicable suggestions as well as rustc's, and clippy's are
-  # what `lint` fails on. `tests/lint_gate.rs` guards the `lint` invocation;
-  # keep this one in step with it by hand.
-  scripts.fix.exec = "cargo clippy --fix --workspace --all-targets --allow-dirty --allow-staged && cargo fmt ${qualityCrates}";
+  # what `lint` fails on. The `--no-default-features` line carries the same
+  # exclusions for the same reason as in `lint`; without it CI reports a lint in
+  # `stub.rs` that `fix` cannot reach. `tests/lint_gate.rs` asserts the two
+  # scripts select the same code.
+  scripts.fix.exec = ''
+    set -euo pipefail
+    cargo clippy --fix --workspace --all-targets --allow-dirty --allow-staged
+    cargo clippy --fix --workspace --exclude e2e --exclude plugingo-e2e --exclude testkit --all-targets --no-default-features --allow-dirty --allow-staged
+    cargo fmt ${qualityCrates}
+  '';
   # Test everything. The default pass covers all crates with default features; the
   # targeted passes exercise the feature-gated transport code, off by default:
   # the stabby host loader/adapters (plugin-stabby `host`) and the stabby guest

--- a/devenv.nix
+++ b/devenv.nix
@@ -70,10 +70,12 @@ in
     gen-go-large
     install-go-plugin
   '';
-  # Lint default-feature code, then again with every feature enabled (so
-  # feature-gated code — the stabby host loader, the stabby guest serving — is
-  # covered too), then fmt-check all hand-written crates (qualityCrates;
-  # generated gen/proto is excluded).
+  # Three clippy passes — default features, `--all-features`, and
+  # `--no-default-features` — then fmt-check all hand-written crates
+  # (qualityCrates; generated gen/proto is excluded). What each pass is actually
+  # worth is measured below rather than assumed from its name: the
+  # `--all-features` one covers almost nothing here, and the
+  # `--no-default-features` one only works with the exclusions it carries.
   #
   # `--workspace --all-targets` is load-bearing. Do NOT shorten it. Both flags
   # were verified by injecting a deliberate error and re-running, not assumed
@@ -160,12 +162,34 @@ in
     cargo clippy --workspace --all-targets --locked -- -D warnings
     echo '> clippy --all-features'
     cargo clippy --workspace --all-targets --all-features --locked -- -D warnings
-    echo '> clippy --no-default-features'
-    if cargo tree --workspace --exclude e2e --exclude plugingo-e2e --exclude testkit --no-default-features -i fuser >/dev/null 2>&1; then
-      echo "error: --no-default-features left 'fuser' in the dependency graph, so this pass is linting the fuse-sandbox=on arm and the feature-off code is still covered by nothing." >&2
+    # Assert the feature is genuinely off before linting it. A *successful*
+    # `cargo tree -i fuser` means `fuser` is still in the resolved graph, i.e.
+    # the pass below would lint the fuse-sandbox=on arm while announcing the
+    # opposite. Absence is specifically "did not match any packages" — matching
+    # on the exit code alone would read *any* cargo failure (an ambiguous
+    # `fuser` after a transitive version bump, a resolver error) as "feature
+    # off" and wave the wrong arm through, which is the silent-green failure
+    # this whole gate exists to remove.
+    echo '> checking --no-default-features really disables fuse-sandbox'
+    if fuser_tree=$(cargo tree --workspace --exclude e2e --exclude plugingo-e2e --exclude testkit --no-default-features --locked -i fuser 2>&1); then
+      echo "error: --no-default-features left 'fuser' in the dependency graph, so the pass below would lint the fuse-sandbox=on arm and the feature-off code is still covered by nothing." >&2
       echo "       Some selected package pulls the root 'heph' package (or 'sandboxfuse') with default features on; exclude it here and in 'fix'." >&2
+      printf '%s\n' "$fuser_tree" >&2
+      exit 1
+    elif ! printf '%s' "$fuser_tree" | grep -q 'did not match any packages'; then
+      echo "error: cargo tree failed for a reason other than 'fuser' being absent, so this check proved nothing:" >&2
+      printf '%s\n' "$fuser_tree" >&2
       exit 1
     fi
+    # Positive control. Without it, `fuser` leaving the graph for an unrelated
+    # reason — renamed, or the FUSE backend swapped — makes the check above pass
+    # forever while proving nothing, because "absent when off" and "absent
+    # always" look identical from one direction.
+    if ! cargo tree --workspace --locked -i fuser >/dev/null 2>&1; then
+      echo "error: 'fuser' is not in the graph even with fuse-sandbox on, so the check above cannot tell 'feature off' from 'package gone'. Point this probe at whatever the feature now pulls in." >&2
+      exit 1
+    fi
+    echo '> clippy --no-default-features'
     cargo clippy --workspace --exclude e2e --exclude plugingo-e2e --exclude testkit --all-targets --no-default-features --locked -- -D warnings
     echo '> fmt'
     cargo fmt --check ${qualityCrates}

--- a/src/diag.rs
+++ b/src/diag.rs
@@ -240,11 +240,6 @@ fn sweep_threads() -> usize {
     n
 }
 
-/// Our own Mach task port.
-///
-/// `libc::mach_task_self()` is deprecated in favour of the `mach2` crate; this
-/// reads the same underlying static rather than pulling in a dependency for one
-/// port lookup.
 /// macOS has no `tgkill`; the Mach layer is the way in.
 ///
 /// `task_threads` hands back a port for every thread in the task,
@@ -257,8 +252,6 @@ fn sweep_threads() -> usize {
     let mut ports: mach2::mach_types::thread_act_array_t = std::ptr::null_mut();
     let mut count: mach2::message::mach_msg_type_number_t = 0;
 
-    // SAFETY: `task_threads` fills `ports`/`count` on success; both are valid
-    // out-params, and `mach_task_self()` names our own task.
     // SAFETY: names our own task.
     let task = unsafe { mach2::traps::mach_task_self() };
     // SAFETY: `ports`/`count` are valid out-params; `task_threads` fills them.

--- a/tests/lint_gate.rs
+++ b/tests/lint_gate.rs
@@ -7,11 +7,15 @@
 //! behind it, and on 2026-07-29 the `Lint` job reported pass on a master commit
 //! whose `engine (lib test)` did not compile.
 //!
-//! Both tests below assert a *selection* invariant — which code the gate is
+//! Every test below asserts a *selection* invariant — which code the gate is
 //! pointed at — because that is the class of failure that is silent. A lint the
-//! gate can see fails loudly; a crate the gate cannot see fails never.
+//! gate can see fails loudly; a crate the gate cannot see fails never. The
+//! selection has four axes and each one has already gone wrong or been left
+//! open: which packages (`--workspace`), which targets (`--all-targets`), which
+//! feature set (`--no-default-features`, whose obvious spelling is a no-op
+//! here), and which platform (macOS was linted nowhere).
 //!
-//! Cheap on purpose: two file reads and some string work, no build.
+//! Cheap on purpose: a few file reads and some string work, no build.
 
 use std::path::{Path, PathBuf};
 
@@ -105,6 +109,50 @@ fn every_workspace_member_inherits_the_workspace_lints() {
     );
 }
 
+/// The body of a `scripts.<name>.exec = ''…'';` block in `devenv.nix`.
+///
+/// Split per script rather than scanning the whole file: `lint` and `fix` both
+/// contain `cargo clippy` lines, and the invariant below is that they *agree* —
+/// which cannot be checked if the two are read as one pile.
+///
+/// `expect`, not `panic!`: `clippy.toml`'s `allow-panic-in-tests` only covers
+/// `#[test]` bodies, and this is a free function.
+#[track_caller]
+fn devenv_script(devenv: &str, name: &str) -> String {
+    let marker = format!("scripts.{name}.exec = ''");
+    // Built up front rather than inside `expect`, which would be
+    // `expect_fun_call`.
+    let opened = format!("devenv.nix defines `scripts.{name}.exec` as a '' block");
+    let closed = format!("`scripts.{name}.exec` block is closed");
+    let (_, rest) = devenv.split_once(&marker).expect(&opened);
+    let (body, _) = rest.split_once("'';").expect(&closed);
+    body.to_string()
+}
+
+/// The `cargo clippy` invocations inside one script body, trimmed.
+fn clippy_lines(script: &str) -> Vec<&str> {
+    script
+        .lines()
+        .map(str::trim)
+        .filter(|line| line.starts_with("cargo clippy"))
+        .collect()
+}
+
+/// The `--exclude <name>` arguments on a single invocation.
+fn excludes(line: &str) -> Vec<&str> {
+    let mut out = Vec::new();
+    let mut words = line.split_whitespace();
+    while let Some(word) = words.next() {
+        if word == "--exclude"
+            && let Some(name) = words.next()
+        {
+            out.push(name);
+        }
+    }
+    out.sort_unstable();
+    out
+}
+
 /// The `lint` script must point clippy at the whole workspace, every target.
 ///
 /// This restates the implementation on purpose: the literal regression was
@@ -113,19 +161,15 @@ fn every_workspace_member_inherits_the_workspace_lints() {
 #[test]
 fn the_lint_script_selects_the_whole_workspace() {
     let devenv = std::fs::read_to_string(repo_root().join("devenv.nix")).expect("read devenv.nix");
-    let clippy_lines: Vec<&str> = devenv
-        .lines()
-        .map(str::trim)
-        .filter(|line| line.starts_with("cargo clippy"))
-        .collect();
+    let lint = devenv_script(&devenv, "lint");
+    let lines = clippy_lines(&lint);
 
-    assert_eq!(
-        clippy_lines.len(),
-        2,
-        "expected exactly two clippy invocations in devenv.nix (default features \
-         and --all-features); found {clippy_lines:?}"
+    assert!(
+        lines.len() >= 3,
+        "expected at least three clippy invocations in `lint` (default features, \
+         --all-features, --no-default-features); found {lines:?}"
     );
-    for line in clippy_lines {
+    for line in &lines {
         assert!(
             line.contains("--workspace"),
             "`{line}` omits --workspace. The repo root is itself a package, so \
@@ -138,4 +182,181 @@ fn the_lint_script_selects_the_whole_workspace() {
              `tests/` are skipped — where most of this repo's test code lives."
         );
     }
+
+    let feature_off: Vec<&&str> = lines
+        .iter()
+        .filter(|line| line.contains("--no-default-features"))
+        .collect();
+    assert_eq!(
+        feature_off.len(),
+        1,
+        "`lint` must carry exactly one --no-default-features pass. With \
+         `fuse-sandbox` on — the default — `crates/sandboxfuse/src/stub.rs` is \
+         compiled by nothing at all, on any platform, and must still satisfy \
+         its callers in `crates/engine` and `crates/driver-bridge`. Found \
+         {feature_off:?}"
+    );
+}
+
+/// The `--no-default-features` pass must exclude every member that switches
+/// `fuse-sandbox` back on, or it silently lints the wrong arm.
+///
+/// Cargo unifies features across the whole selected set. `crates/e2e`,
+/// `crates/plugingo-e2e` and `crates/testkit` depend on the root `heph` package
+/// with default features on, so a plain `--workspace --no-default-features`
+/// re-enables `fuse-sandbox` through that edge and the pass becomes a no-op
+/// that still reports green — the same silent-selection failure the rest of
+/// this file exists to catch, one axis over.
+///
+/// Derived from the manifests, never copied: a *new* member with a default-
+/// featured `heph` edge is exactly the case a hardcoded list would miss.
+/// `lint` also asserts this at run time with `cargo tree -i fuser`; this test
+/// is the version that costs no build.
+#[test]
+fn the_feature_off_pass_excludes_every_member_that_re_enables_fuse_sandbox() {
+    let root = repo_root();
+    let manifest = std::fs::read_to_string(root.join("Cargo.toml")).expect("read root Cargo.toml");
+    let members = workspace_members(&manifest);
+
+    let mut re_enablers: Vec<String> = members
+        .iter()
+        .filter(|member| {
+            let path = root.join(member).join("Cargo.toml");
+            let member_manifest = std::fs::read_to_string(&path)
+                .unwrap_or_else(|e| panic!("read {}: {e}", path.display()));
+            member_manifest.lines().any(|line| {
+                let line = line.trim();
+                line.starts_with("heph = ") && !line.contains("default-features = false")
+            })
+        })
+        // The package name is the last path component for every member here.
+        .map(|member| {
+            member
+                .rsplit('/')
+                .next()
+                .unwrap_or(member.as_str())
+                .to_string()
+        })
+        .collect();
+    re_enablers.sort();
+    assert!(
+        !re_enablers.is_empty(),
+        "no member was found depending on the root `heph` package — this test \
+         is no longer reading the manifests it thinks it is"
+    );
+
+    let devenv = std::fs::read_to_string(root.join("devenv.nix")).expect("read devenv.nix");
+    for script in ["lint", "fix"] {
+        let body = devenv_script(&devenv, script);
+        let line = clippy_lines(&body)
+            .into_iter()
+            .find(|line| line.contains("--no-default-features"))
+            .unwrap_or_else(|| panic!("`{script}` has a --no-default-features clippy invocation"));
+        let excluded = excludes(line);
+        let missing: Vec<&String> = re_enablers
+            .iter()
+            .filter(|name| !excluded.contains(&name.as_str()))
+            .collect();
+        assert!(
+            missing.is_empty(),
+            "`{script}`'s --no-default-features pass does not exclude {missing:?}. \
+             Those members depend on the root `heph` package with default \
+             features on, and cargo unifies features across the selection, so \
+             `fuse-sandbox` is switched back on and the pass lints the feature-\
+             *on* arm while reporting that it covered the off one.\n\
+             Add `--exclude <name>` for each, or give the member's `heph` \
+             dependency `default-features = false`."
+        );
+    }
+}
+
+/// `fix` must select the same code as `lint`.
+///
+/// A `fix` that reaches less than `lint` leaves CI reporting lints with no
+/// automated fix — and the person who hits it has to work out which of three
+/// invocations produced the error before they can reproduce it.
+#[test]
+fn fix_selects_the_same_code_as_lint() {
+    let devenv = std::fs::read_to_string(repo_root().join("devenv.nix")).expect("read devenv.nix");
+    let fix = devenv_script(&devenv, "fix");
+    let fix_lines = clippy_lines(&fix);
+
+    for line in &fix_lines {
+        assert!(
+            line.contains("--fix"),
+            "`{line}` is a bare clippy invocation inside `fix`; it must be \
+             `cargo clippy --fix`"
+        );
+        assert!(
+            line.contains("--workspace") && line.contains("--all-targets"),
+            "`{line}` does not select the whole workspace and every target, so \
+             `fix` cannot reach the code `lint` fails on"
+        );
+    }
+
+    // Every feature selection `lint` checks must have a `fix` counterpart, or
+    // CI reports a lint in code `fix` cannot reach. `--all-features` is the one
+    // exemption: it selects no code that the default pass does not already
+    // select in this workspace (every member feature is unified on by
+    // `--workspace`), so a fourth rewriting pass would buy nothing.
+    let lint = devenv_script(&devenv, "lint");
+    for selection in clippy_lines(&lint)
+        .iter()
+        .filter(|line| line.contains("--no-default-features"))
+        .map(|_| "--no-default-features")
+    {
+        assert!(
+            fix_lines.iter().any(|line| line.contains(selection)),
+            "`lint` has a `{selection}` pass but `fix` does not, so CI reports \
+             lints in that arm with no automated fix at all. Found {fix_lines:?}"
+        );
+    }
+}
+
+/// The gate must run on macOS as well as Linux.
+///
+/// macOS-only code — the Mach `sweep_threads` block in `src/diag.rs`,
+/// `crates/proc/src/proc_exec/imp_macos.rs`, `kqueue_macos.rs` — is compiled by
+/// `Test darwin/arm64`, but nothing there passes `-D warnings`, so before the
+/// `Lint darwin/arm64` job it was clippy-linted nowhere.
+///
+/// It is also the half that cannot fail loudly on its own: `#[expect]` is
+/// fulfilled-or-error, so the crate-root test exemptions are pinned to whatever
+/// lint set the gate actually runs. Delete the darwin job and nothing goes red —
+/// the macOS half of every `#[expect]` simply stops being checked. Hence a test.
+#[test]
+fn the_lint_gate_runs_on_macos_as_well_as_linux() {
+    let workflow = std::fs::read_to_string(repo_root().join(".github/workflows/heph.yml"))
+        .expect("read .github/workflows/heph.yml");
+
+    // A job id is a two-space-indented `<name>:` at the end of its line; a job's
+    // body runs until the next one. Walk the file once and keep the `runs-on:`
+    // of every job whose id starts with `lint`.
+    let mut runners: Vec<&str> = Vec::new();
+    let mut in_lint_job = false;
+    for line in workflow.lines() {
+        if let Some(rest) = line.strip_prefix("  ")
+            && !rest.starts_with([' ', '#', '-'])
+            && let Some(id) = rest.strip_suffix(':')
+        {
+            in_lint_job = id.starts_with("lint");
+            continue;
+        }
+        if in_lint_job && let Some(runner) = line.trim().strip_prefix("runs-on:") {
+            runners.push(runner.trim());
+        }
+    }
+
+    assert!(
+        runners.iter().any(|r| r.contains("ubuntu")),
+        "no lint job runs on a Linux runner; found {runners:?}"
+    );
+    assert!(
+        runners.iter().any(|r| r.contains("macos")),
+        "no lint job runs on a macOS runner, so macOS-only code — including the \
+         Mach `sweep_threads` block in `src/diag.rs`, the largest unsafe region \
+         in the tree — is clippy-linted nowhere, and the crate-root `#[expect]` \
+         headers are only ever checked against the lints that fire on Linux. \
+         Found {runners:?}"
+    );
 }

--- a/tests/lint_gate.rs
+++ b/tests/lint_gate.rs
@@ -8,12 +8,19 @@
 //! whose `engine (lib test)` did not compile.
 //!
 //! Every test below asserts a *selection* invariant — which code the gate is
-//! pointed at — because that is the class of failure that is silent. A lint the
-//! gate can see fails loudly; a crate the gate cannot see fails never. The
-//! selection has four axes and each one has already gone wrong or been left
-//! open: which packages (`--workspace`), which targets (`--all-targets`), which
-//! feature set (`--no-default-features`, whose obvious spelling is a no-op
-//! here), and which platform (macOS was linted nowhere).
+//! pointed at, and whether what it finds can actually turn a check red —
+//! because that is the class of failure that is silent. A lint the gate can see
+//! fails loudly; a crate the gate cannot see fails never. Five axes, each of
+//! which has already gone wrong or been left open:
+//!
+//!   - which packages — `--workspace`;
+//!   - which targets — `--all-targets`;
+//!   - which feature set — `--no-default-features`, whose obvious spelling is a
+//!     silent no-op in this workspace;
+//!   - which platform — macOS was linted nowhere;
+//!   - whether a red leg reaches the required status context at all — the
+//!     `Lint` aggregator, which can be wired to report green over a failed
+//!     matrix leg.
 //!
 //! Cheap on purpose: a few file reads and some string work, no build.
 
@@ -451,118 +458,279 @@ fn the_fmt_pass_covers_every_workspace_member() {
     );
 }
 
+/// A job id and the text of its body, for every job in the workflow.
+///
+/// A job id is a two-space-indented `<id>:` alone on its line, below the
+/// top-level `jobs:` key. Anchored on `jobs:` rather than matched everywhere,
+/// because `on:` has `push:` and `pull_request:` at the same indent and they
+/// are not jobs.
+fn workflow_jobs(workflow: &str) -> Vec<(&str, String)> {
+    let (_, body) = workflow
+        .split_once("\njobs:\n")
+        .expect("the workflow has a top-level `jobs:` key");
+
+    let mut jobs: Vec<(&str, Vec<&str>)> = Vec::new();
+    for line in body.lines() {
+        let header = line
+            .strip_prefix("  ")
+            .filter(|rest| !rest.starts_with([' ', '#', '-']))
+            .and_then(|rest| rest.strip_suffix(':'))
+            .filter(|id| {
+                !id.is_empty()
+                    && id
+                        .chars()
+                        .all(|c| c.is_ascii_lowercase() || c.is_ascii_digit() || c == '_')
+            });
+        match header {
+            Some(id) => jobs.push((id, Vec::new())),
+            None => {
+                if let Some((_, lines)) = jobs.last_mut() {
+                    lines.push(line);
+                }
+            }
+        }
+    }
+    jobs.into_iter()
+        .map(|(id, lines)| (id, lines.join("\n")))
+        .collect()
+}
+
+/// The `needs:` of a job body, tokenised.
+///
+/// Tokenised rather than substring-matched: `lint` is a prefix of
+/// `lint_matrix`, so a `contains` check reports `lint` present when only
+/// `lint_matrix` is.
+fn job_needs(body: &str) -> Vec<&str> {
+    body.lines()
+        .map(str::trim)
+        .find(|line| line.starts_with("needs:"))
+        .map(|line| {
+            line.trim_start_matches("needs:")
+                .trim()
+                .trim_matches(['[', ']'])
+                .split(',')
+                .map(str::trim)
+                .filter(|entry| !entry.is_empty())
+                .collect()
+        })
+        .unwrap_or_default()
+}
+
+/// The `run:` step commands in a job body.
+fn job_run_steps(body: &str) -> Vec<&str> {
+    body.lines()
+        .map(str::trim)
+        .filter_map(|line| line.strip_prefix("run:"))
+        .map(str::trim)
+        .collect()
+}
+
+/// The concrete `runs-on:` labels in a job body.
+///
+/// Skips `${{ matrix.runs-on }}` and friends: on a matrix job the job-level
+/// `runs-on` is an expression and the real labels live in `matrix.include`.
+fn job_runners(body: &str) -> Vec<&str> {
+    body.lines()
+        .map(str::trim)
+        .filter_map(|line| line.trim_start_matches("- ").strip_prefix("runs-on:"))
+        .map(str::trim)
+        .filter(|label| !label.contains("${{"))
+        .collect()
+}
+
+/// Job ids that actually run the `lint` script.
+///
+/// Derived from the `run:` steps rather than from the job name: a job that
+/// keeps the name and the runner while running something narrower is the
+/// regression, not the thing to trust.
+fn lint_legs<'a>(jobs: &[(&'a str, String)]) -> Vec<&'a str> {
+    jobs.iter()
+        .filter(|(_, body)| job_run_steps(body).contains(&"lint"))
+        .map(|(id, _)| *id)
+        .collect()
+}
+
+/// The job named exactly `Lint` — the required status context.
+fn lint_aggregator<'a>(jobs: &'a [(&'a str, String)]) -> Option<(&'a str, &'a String)> {
+    jobs.iter()
+        .find(|(_, body)| body.lines().map(str::trim).any(|line| line == "name: Lint"))
+        .map(|(id, body)| (*id, body))
+}
+
 /// The gate must run on macOS as well as Linux.
 ///
 /// macOS-only code — the Mach `sweep_threads` block in `src/diag.rs`,
 /// `crates/proc/src/proc_exec/imp_macos.rs`, `kqueue_macos.rs` — is compiled by
 /// `Test darwin/arm64`, but nothing there passes `-D warnings`, so before the
-/// `Lint darwin/arm64` job it was clippy-linted nowhere.
+/// darwin lint leg it was clippy-linted nowhere.
 ///
 /// It is also the half that cannot fail loudly on its own: `#[expect]` is
 /// fulfilled-or-error, so the crate-root test exemptions are pinned to whatever
-/// lint set the gate actually runs. Delete the darwin job and nothing goes red —
+/// lint set the gate actually runs. Drop the darwin leg and nothing goes red —
 /// the macOS half of every `#[expect]` simply stops being checked. Hence a test.
 #[test]
 fn the_lint_gate_runs_on_macos_as_well_as_linux() {
     let workflow = std::fs::read_to_string(repo_root().join(".github/workflows/heph.yml"))
         .expect("read .github/workflows/heph.yml");
-
-    // A job id is a two-space-indented `<name>:` at the end of its line; a job's
-    // body runs until the next one. Walk the file once and collect, for every
-    // job whose id starts with `lint`, its `runs-on:` and its `run:` steps.
-    //
-    // The `run:` half matters as much as the runner: asserting only the label
-    // lets someone point the darwin job at `cargo fmt --check`, or drop its
-    // Lint step, and stay green while macOS clippy coverage disappears — which
-    // is the whole reason the job exists.
-    let mut runners: Vec<&str> = Vec::new();
-    let mut commands: Vec<&str> = Vec::new();
-    let mut in_lint_job = false;
-    for line in workflow.lines() {
-        if let Some(rest) = line.strip_prefix("  ")
-            && !rest.starts_with([' ', '#', '-'])
-            && let Some(id) = rest.strip_suffix(':')
-        {
-            in_lint_job = id.starts_with("lint");
-            continue;
-        }
-        if !in_lint_job {
-            continue;
-        }
-        if let Some(runner) = line.trim().strip_prefix("runs-on:") {
-            runners.push(runner.trim());
-        }
-        if let Some(cmd) = line.trim().strip_prefix("run:") {
-            commands.push(cmd.trim());
-        }
-    }
+    let jobs = workflow_jobs(&workflow);
+    let legs = lint_legs(&jobs);
 
     assert!(
-        runners.iter().any(|r| r.contains("ubuntu")),
-        "no lint job runs on a Linux runner; found {runners:?}"
+        !legs.is_empty(),
+        "no job in the workflow runs the `lint` script at all"
+    );
+
+    let runners: Vec<&str> = jobs
+        .iter()
+        .filter(|(id, _)| legs.contains(id))
+        .flat_map(|(_, body)| job_runners(body))
+        .collect();
+
+    assert!(
+        runners.iter().any(|label| label.contains("ubuntu")),
+        "no lint leg runs on a Linux runner; found {runners:?}"
     );
     assert!(
-        runners.iter().any(|r| r.contains("macos")),
-        "no lint job runs on a macOS runner, so macOS-only code — including the \
+        runners.iter().any(|label| label.contains("macos")),
+        "no lint leg runs on a macOS runner, so macOS-only code — including the \
          Mach `sweep_threads` block in `src/diag.rs`, the largest unsafe region \
          in the tree — is clippy-linted nowhere, and the crate-root `#[expect]` \
          headers are only ever checked against the lints that fire on Linux. \
          Found {runners:?}"
     );
+}
+
+/// The required status context must survive, and it must be able to go red.
+///
+/// The branch ruleset requires a context named literally `Lint`. A bare matrix
+/// publishes one context per leg (`Lint (ubuntu-latest)`, …) and never that
+/// name again, so every open PR would block forever on a required check that
+/// can no longer appear — strictly worse than the gap being closed, and the
+/// workflow edit and the ruleset edit cannot land atomically. The fix is to
+/// matrix the work and fan back in to an aggregator still named `Lint`.
+///
+/// That aggregator is load-bearing *and* silent when wrong, which is this
+/// file's whole subject. Two ways to get it backwards, both of which look fine
+/// in review:
+///
+///   - no `if: always()` — a failed leg *skips* the aggregator, and a skipped
+///     required check is not a red one, so the PR is merely un-mergeable rather
+///     than reported as failing;
+///   - `if: always()` with no result check — the aggregator's own steps all
+///     pass, so it reports **green on a failed leg**. That is the silent-pass
+///     class this entire branch exists to eliminate, reintroduced at the top
+///     of it.
+#[test]
+fn the_lint_aggregator_keeps_the_required_context_and_can_fail() {
+    let workflow = std::fs::read_to_string(repo_root().join(".github/workflows/heph.yml"))
+        .expect("read .github/workflows/heph.yml");
+    let jobs = workflow_jobs(&workflow);
+    let legs = lint_legs(&jobs);
+
+    let named_lint: Vec<&str> = jobs
+        .iter()
+        .filter(|(_, body)| body.lines().map(str::trim).any(|line| line == "name: Lint"))
+        .map(|(id, _)| *id)
+        .collect();
     assert_eq!(
-        commands.iter().filter(|c| **c == "lint").count(),
-        runners.len(),
-        "every lint job must actually run the `lint` script — one per runner. A \
-         job that runs something narrower keeps the check name and the runner \
-         while quietly covering less. runners: {runners:?}, run steps: \
-         {commands:?}"
+        named_lint.len(),
+        1,
+        "exactly one job must be named `Lint` — that string is the required \
+         status context in the branch ruleset, and it is what lets this land \
+         with no branch-protection change. Found {named_lint:?}"
     );
+    let (aggregator_id, aggregator) = lint_aggregator(&jobs).expect("a job is named `Lint`");
 
-    // Every lint job must gate something. `Lint darwin/arm64` is not in the
-    // branch ruleset, so its entries in `release.needs` / `cleanup.needs` are
-    // its only teeth: drop them and it can go red on every run forever with
-    // nothing blocked and nothing red downstream.
-    let mut lint_job_ids: Vec<&str> = Vec::new();
-    for line in workflow.lines() {
-        if let Some(rest) = line.strip_prefix("  ")
-            && !rest.starts_with([' ', '#', '-'])
-            && let Some(id) = rest.strip_suffix(':')
-            && id.starts_with("lint")
-        {
-            lint_job_ids.push(id);
-        }
-    }
+    // A matrix job's check name gets the matrix values appended, so the context
+    // would become `Lint (…)` and `Lint` would never report again. This is the
+    // literal regression the aggregator exists to prevent.
     assert!(
-        lint_job_ids.len() >= 2,
-        "expected at least two lint jobs (one per OS); found {lint_job_ids:?}"
+        !aggregator.lines().any(|line| line.trim() == "strategy:"),
+        "the job named `Lint` (`{aggregator_id}`) has a `strategy:` — a matrix \
+         job publishes one context per leg and never the bare name, so the \
+         required `Lint` context would stop appearing and every open PR would \
+         block on a check that can no longer report. Matrix the work in a \
+         separate job and keep this one as the fan-in."
     );
 
-    for gate in ["release", "cleanup"] {
-        let marker = format!("\n  {gate}:\n");
-        let (_, body) = workflow
-            .split_once(&marker)
-            .unwrap_or_else(|| panic!("the workflow defines a `{gate}` job"));
-        let needs = body
+    // It must do no work itself: the aggregator cannot be the thing whose
+    // failure it exists to report.
+    assert!(
+        !legs.contains(&aggregator_id),
+        "`{aggregator_id}` is named `Lint` and also runs the lint script; the \
+         aggregator must be a separate fan-in job"
+    );
+
+    let needs = job_needs(aggregator);
+    for leg in &legs {
+        assert!(
+            needs.contains(leg),
+            "the `Lint` aggregator does not `needs:` the `{leg}` lint leg, so \
+             that leg gates nothing and `Lint` can report green while it is \
+             red. needs: {needs:?}, legs: {legs:?}"
+        );
+    }
+
+    assert!(
+        aggregator
             .lines()
             .map(str::trim)
-            .find(|line| line.starts_with("needs:"))
-            .unwrap_or_else(|| panic!("`{gate}` declares `needs:`"));
-        // Tokenised, not substring-matched: `lint` is a prefix of `lint_darwin`,
-        // so a `contains` check would report `lint` present when only
-        // `lint_darwin` is.
-        let listed: Vec<&str> = needs
-            .trim_start_matches("needs:")
-            .trim()
-            .trim_matches(['[', ']'])
-            .split(',')
-            .map(str::trim)
-            .collect();
-        for id in &lint_job_ids {
-            assert!(
-                listed.contains(id),
-                "`{gate}` does not depend on the `{id}` job, so a red `{id}` \
-                 blocks nothing at all. Found `{needs}`."
-            );
-        }
+            .any(|line| line.starts_with("if:") && line.contains("always()")),
+        "the `Lint` aggregator has no `if: always()`, so a failed leg *skips* \
+         it rather than failing it — and a skipped required check is not a red \
+         one. needs: {needs:?}"
+    );
+
+    // `if: always()` alone is the dangerous half: the job then runs, its own
+    // steps pass, and it reports success no matter how its dependencies ended.
+    // Something must actually inspect each dependency's result and exit
+    // non-zero. Checked per dependency, so adding a leg without extending the
+    // check fails here rather than in production.
+    for dep in &needs {
+        assert!(
+            aggregator.contains(&format!("needs.{dep}.result")),
+            "the `Lint` aggregator runs with `if: always()` but never reads \
+             `needs.{dep}.result`, so it reports green when `{dep}` fails, is \
+             cancelled, or is skipped. `needs` decides ordering here, not \
+             outcome."
+        );
+    }
+    assert!(
+        aggregator.contains("exit 1"),
+        "the `Lint` aggregator reads its dependencies' results but never exits \
+         non-zero, so nothing it discovers can turn the check red"
+    );
+}
+
+/// Whatever represents "lint passed" must gate `release` and `cleanup`.
+///
+/// Only the `Lint` aggregator is in the branch ruleset, so for the legs these
+/// two `needs:` entries are their only other teeth. Drop them and a red lint
+/// blocks nothing downstream at all.
+#[test]
+fn lint_gates_release_and_cleanup() {
+    let workflow = std::fs::read_to_string(repo_root().join(".github/workflows/heph.yml"))
+        .expect("read .github/workflows/heph.yml");
+    let jobs = workflow_jobs(&workflow);
+    let legs = lint_legs(&jobs);
+    let (aggregator_id, _) = lint_aggregator(&jobs).expect("a job is named `Lint`");
+
+    for gate in ["release", "cleanup"] {
+        let (_, body) = jobs
+            .iter()
+            .find(|(id, _)| *id == gate)
+            .unwrap_or_else(|| panic!("the workflow defines a `{gate}` job"));
+        let needs = job_needs(body);
+
+        // Either the aggregator — which transitively requires every leg — or
+        // each leg directly. Accepting both spellings keeps this from
+        // dictating the wiring while still refusing the one that gates nothing.
+        let covered = needs.contains(&aggregator_id) || legs.iter().all(|leg| needs.contains(leg));
+        assert!(
+            covered,
+            "`{gate}` depends on neither the `{aggregator_id}` aggregator nor \
+             every lint leg ({legs:?}), so a red lint blocks nothing \
+             downstream. Found needs: {needs:?}"
+        );
     }
 }

--- a/tests/lint_gate.rs
+++ b/tests/lint_gate.rs
@@ -139,17 +139,22 @@ fn clippy_lines(script: &str) -> Vec<&str> {
 }
 
 /// The `--exclude <name>` arguments on a single invocation.
+///
+/// Both spellings cargo accepts, `--exclude name` and `--exclude=name`: reading
+/// only the first would turn a legal rewrite of the script into a spurious
+/// failure.
 fn excludes(line: &str) -> Vec<&str> {
     let mut out = Vec::new();
     let mut words = line.split_whitespace();
     while let Some(word) = words.next() {
-        if word == "--exclude"
+        if let Some(name) = word.strip_prefix("--exclude=") {
+            out.push(name);
+        } else if word == "--exclude"
             && let Some(name) = words.next()
         {
             out.push(name);
         }
     }
-    out.sort_unstable();
     out
 }
 
@@ -196,6 +201,34 @@ fn the_lint_script_selects_the_whole_workspace() {
          its callers in `crates/engine` and `crates/driver-bridge`. Found \
          {feature_off:?}"
     );
+
+    // The guard that proves the pass above is pointed at the feature-*off* arm
+    // must itself exist, and must select the same packages. Without this, the
+    // guard can be deleted the first time it is inconvenient and the third pass
+    // silently reverts to re-linting the arm pass 1 already covered — with the
+    // script still printing `> clippy --no-default-features`.
+    let probe = lint
+        .lines()
+        .map(str::trim)
+        // `!starts_with('#')`: the block is commented, and a comment mentioning
+        // the probe is not the probe.
+        .find(|line| {
+            !line.starts_with('#') && line.contains("cargo tree") && line.contains("-i fuser")
+        })
+        .expect(
+            "`lint` must assert `fuse-sandbox` is actually off before linting it, \
+             with a `cargo tree … -i fuser` probe. `--no-default-features` alone \
+             does not disable it: e2e/plugingo-e2e/testkit pull the root `heph` \
+             package with default features and cargo unifies across the selection.",
+        );
+    assert_eq!(
+        excludes(probe),
+        excludes(feature_off[0]),
+        "the `cargo tree -i fuser` probe and the --no-default-features clippy \
+         pass select different packages, so the probe is not checking the \
+         selection that gets linted.\nprobe: {probe}\npass:  {}",
+        feature_off[0]
+    );
 }
 
 /// The `--no-default-features` pass must exclude every member that switches
@@ -210,8 +243,15 @@ fn the_lint_script_selects_the_whole_workspace() {
 ///
 /// Derived from the manifests, never copied: a *new* member with a default-
 /// featured `heph` edge is exactly the case a hardcoded list would miss.
-/// `lint` also asserts this at run time with `cargo tree -i fuser`; this test
-/// is the version that costs no build.
+///
+/// **Scope, stated so it is not over-trusted.** This reads one line per
+/// manifest, so it sees a *direct*, single-line `heph = { … }` edge and nothing
+/// else — not a `[dependencies.heph]` table, not a multi-line inline table, and
+/// not a transitive re-enable (a new member dev-depending on `htestkit`, which
+/// itself pulls `heph` with default features, gets the feature back without
+/// appearing here). The authority is the `cargo tree -i fuser` assertion inside
+/// `lint`, which sees the fully resolved graph; this test is the cheap early
+/// warning that costs no build, not a replacement for it.
 #[test]
 fn the_feature_off_pass_excludes_every_member_that_re_enables_fuse_sandbox() {
     let root = repo_root();
@@ -252,7 +292,9 @@ fn the_feature_off_pass_excludes_every_member_that_re_enables_fuse_sandbox() {
             .into_iter()
             .find(|line| line.contains("--no-default-features"))
             .unwrap_or_else(|| panic!("`{script}` has a --no-default-features clippy invocation"));
-        let excluded = excludes(line);
+        let mut excluded = excludes(line);
+        excluded.sort_unstable();
+
         let missing: Vec<&String> = re_enablers
             .iter()
             .filter(|name| !excluded.contains(&name.as_str()))
@@ -266,6 +308,28 @@ fn the_feature_off_pass_excludes_every_member_that_re_enables_fuse_sandbox() {
              *on* arm while reporting that it covered the off one.\n\
              Add `--exclude <name>` for each, or give the member's `heph` \
              dependency `default-features = false`."
+        );
+
+        // Equality, not just containment. An *extra* exclusion is the more
+        // dangerous direction and a subset check waves it through: `--exclude
+        // engine` or `--exclude driver-bridge` drops the two callers `stub.rs`
+        // has to satisfy, and `--exclude sandboxfuse` drops the only package
+        // the feature changes at all. Each turns the pass into a no-op that
+        // still reports green, and none of them puts `fuser` back in the graph,
+        // so the `cargo tree` guard in `lint` cannot see it either.
+        let extra: Vec<&&str> = excluded
+            .iter()
+            .filter(|name| !re_enablers.iter().any(|r| r == *name))
+            .collect();
+        assert!(
+            extra.is_empty(),
+            "`{script}`'s --no-default-features pass excludes {extra:?}, which \
+             do not re-enable `fuse-sandbox`. Excluding a package that is not a \
+             re-enabler only shrinks what the pass lints — `engine` and \
+             `driver-bridge` are the callers `crates/sandboxfuse/src/stub.rs` \
+             must satisfy, and `sandboxfuse` is the only package the feature \
+             changes — and neither the `cargo tree` guard nor the check above \
+             can see the loss. Expected exactly {re_enablers:?}."
         );
     }
 }
@@ -299,18 +363,92 @@ fn fix_selects_the_same_code_as_lint() {
     // exemption: it selects no code that the default pass does not already
     // select in this workspace (every member feature is unified on by
     // `--workspace`), so a fourth rewriting pass would buy nothing.
+    //
+    // Both halves are asserted, not just the feature-off one. Checking only the
+    // `--no-default-features` axis let `fix` lose its *default* pass entirely
+    // and still pass every assertion above — the remaining feature-off line
+    // carries `--fix`, `--workspace` and `--all-targets`, so nothing went red
+    // while `fix` could no longer touch anything the first `lint` pass reports.
     let lint = devenv_script(&devenv, "lint");
-    for selection in clippy_lines(&lint)
+    let lint_lines = clippy_lines(&lint);
+
+    assert!(
+        fix_lines
+            .iter()
+            .any(|line| !line.contains("--all-features")
+                && !line.contains("--no-default-features")),
+        "`fix` has no default-feature pass, so it cannot fix anything `lint`'s \
+         first and largest pass reports. Found {fix_lines:?}"
+    );
+
+    if lint_lines
         .iter()
-        .filter(|line| line.contains("--no-default-features"))
-        .map(|_| "--no-default-features")
+        .any(|line| line.contains("--no-default-features"))
     {
         assert!(
-            fix_lines.iter().any(|line| line.contains(selection)),
-            "`lint` has a `{selection}` pass but `fix` does not, so CI reports \
-             lints in that arm with no automated fix at all. Found {fix_lines:?}"
+            fix_lines
+                .iter()
+                .any(|line| line.contains("--no-default-features")),
+            "`lint` has a --no-default-features pass but `fix` does not, so CI \
+             reports lints in that arm with no automated fix at all. Found \
+             {fix_lines:?}"
         );
     }
+
+    // One `fix` pass per `lint` pass, less the `--all-features` exemption.
+    assert!(
+        fix_lines.len() >= lint_lines.len().saturating_sub(1),
+        "`lint` runs {} clippy passes and `fix` only {}. At most one (\
+         --all-features) may be skipped; anything more leaves a selection \
+         `lint` fails on that `fix` cannot reach.\nlint: {lint_lines:?}\nfix: \
+         {fix_lines:?}",
+        lint_lines.len(),
+        fix_lines.len(),
+    );
+}
+
+/// `cargo fmt --check` must cover every member too.
+///
+/// The fourth selection axis, and the last one still hand-maintained: the fmt
+/// pass takes an explicit 34-entry `-p` list (`qualityCrates` in `devenv.nix`)
+/// rather than `--all`. Add a member and forget the `-p`, and `lint` reports
+/// green on an unformatted crate forever — the same silent hole as a member
+/// that never gets clippy'd, one tool over.
+#[test]
+fn the_fmt_pass_covers_every_workspace_member() {
+    let root = repo_root();
+    let manifest = std::fs::read_to_string(root.join("Cargo.toml")).expect("read root Cargo.toml");
+    let members = workspace_members(&manifest);
+    let devenv = std::fs::read_to_string(root.join("devenv.nix")).expect("read devenv.nix");
+
+    // Scoped to the `qualityCrates = "…"` value, not searched across the whole
+    // file: `scripts.tst.exec` also carries `-p plugin-stabby` and `-p
+    // plugin-sdk`, so a whole-file search stays green when either is deleted
+    // from `qualityCrates` — satisfied by the `tst` line while `cargo fmt
+    // --check` quietly stops looking at the crate.
+    let (_, after) = devenv
+        .split_once("qualityCrates = \"")
+        .expect("devenv.nix defines qualityCrates");
+    let (quality_crates, _) = after
+        .split_once('"')
+        .expect("the qualityCrates string is closed");
+    let selected: Vec<&str> = quality_crates.split_whitespace().collect();
+
+    // The package name is the last path component for every member here; the
+    // root package (`heph`) is not in `members` and is listed separately.
+    let missing: Vec<&str> = members
+        .iter()
+        .filter(|member| !LINTS_EXEMPT.contains(&member.as_str()))
+        .map(|member| member.rsplit('/').next().unwrap_or(member.as_str()))
+        .filter(|name| !selected.contains(name))
+        .collect();
+
+    assert!(
+        missing.is_empty(),
+        "these workspace members are not in `qualityCrates`, so `cargo fmt \
+         --check` never looks at them and `lint` reports green on unformatted \
+         code: {missing:?}"
+    );
 }
 
 /// The gate must run on macOS as well as Linux.
@@ -330,9 +468,15 @@ fn the_lint_gate_runs_on_macos_as_well_as_linux() {
         .expect("read .github/workflows/heph.yml");
 
     // A job id is a two-space-indented `<name>:` at the end of its line; a job's
-    // body runs until the next one. Walk the file once and keep the `runs-on:`
-    // of every job whose id starts with `lint`.
+    // body runs until the next one. Walk the file once and collect, for every
+    // job whose id starts with `lint`, its `runs-on:` and its `run:` steps.
+    //
+    // The `run:` half matters as much as the runner: asserting only the label
+    // lets someone point the darwin job at `cargo fmt --check`, or drop its
+    // Lint step, and stay green while macOS clippy coverage disappears — which
+    // is the whole reason the job exists.
     let mut runners: Vec<&str> = Vec::new();
+    let mut commands: Vec<&str> = Vec::new();
     let mut in_lint_job = false;
     for line in workflow.lines() {
         if let Some(rest) = line.strip_prefix("  ")
@@ -342,8 +486,14 @@ fn the_lint_gate_runs_on_macos_as_well_as_linux() {
             in_lint_job = id.starts_with("lint");
             continue;
         }
-        if in_lint_job && let Some(runner) = line.trim().strip_prefix("runs-on:") {
+        if !in_lint_job {
+            continue;
+        }
+        if let Some(runner) = line.trim().strip_prefix("runs-on:") {
             runners.push(runner.trim());
+        }
+        if let Some(cmd) = line.trim().strip_prefix("run:") {
+            commands.push(cmd.trim());
         }
     }
 
@@ -359,4 +509,60 @@ fn the_lint_gate_runs_on_macos_as_well_as_linux() {
          headers are only ever checked against the lints that fire on Linux. \
          Found {runners:?}"
     );
+    assert_eq!(
+        commands.iter().filter(|c| **c == "lint").count(),
+        runners.len(),
+        "every lint job must actually run the `lint` script — one per runner. A \
+         job that runs something narrower keeps the check name and the runner \
+         while quietly covering less. runners: {runners:?}, run steps: \
+         {commands:?}"
+    );
+
+    // Every lint job must gate something. `Lint darwin/arm64` is not in the
+    // branch ruleset, so its entries in `release.needs` / `cleanup.needs` are
+    // its only teeth: drop them and it can go red on every run forever with
+    // nothing blocked and nothing red downstream.
+    let mut lint_job_ids: Vec<&str> = Vec::new();
+    for line in workflow.lines() {
+        if let Some(rest) = line.strip_prefix("  ")
+            && !rest.starts_with([' ', '#', '-'])
+            && let Some(id) = rest.strip_suffix(':')
+            && id.starts_with("lint")
+        {
+            lint_job_ids.push(id);
+        }
+    }
+    assert!(
+        lint_job_ids.len() >= 2,
+        "expected at least two lint jobs (one per OS); found {lint_job_ids:?}"
+    );
+
+    for gate in ["release", "cleanup"] {
+        let marker = format!("\n  {gate}:\n");
+        let (_, body) = workflow
+            .split_once(&marker)
+            .unwrap_or_else(|| panic!("the workflow defines a `{gate}` job"));
+        let needs = body
+            .lines()
+            .map(str::trim)
+            .find(|line| line.starts_with("needs:"))
+            .unwrap_or_else(|| panic!("`{gate}` declares `needs:`"));
+        // Tokenised, not substring-matched: `lint` is a prefix of `lint_darwin`,
+        // so a `contains` check would report `lint` present when only
+        // `lint_darwin` is.
+        let listed: Vec<&str> = needs
+            .trim_start_matches("needs:")
+            .trim()
+            .trim_matches(['[', ']'])
+            .split(',')
+            .map(str::trim)
+            .collect();
+        for id in &lint_job_ids {
+            assert!(
+                listed.contains(id),
+                "`{gate}` does not depend on the `{id}` job, so a red `{id}` \
+                 blocks nothing at all. Found `{needs}`."
+            );
+        }
+    }
 }


### PR DESCRIPTION
> ## ⚠️ Read this first: you must change branch protection when this merges
>
> The lint job is a **matrix**, so its status contexts are the per-leg names. **No check named plain `Lint` will ever report again.** The ruleset currently requires exactly that string.
>
> **Required status checks — remove:**
> ```
> Lint
> ```
> **Required status checks — add:**
> ```
> Lint linux/amd64
> Lint darwin/arm64
> ```
>
> Those two strings are taken from a **real run of this matrix** ([30485344790](https://github.com/hephbuild/heph/actions/runs/30485344790)), not inferred: GitHub publishes the rendered `name:` with no parenthesised matrix suffix.  A wrong string here blocks every PR just as badly as a missing one.
>
> Consequences until you make that change:
> - a required `Lint` can no longer report, so **every open PR stays blocked**;
> - a **red lint will not block a merge**, because neither new context is required yet.
>
> Inside the repo, `release` and `cleanup` still `needs: lint`, so a red lint does stop a release on master regardless. That is the only enforcement the tree itself owns.

---

Closes the two coverage gaps #259 left open as decisions for you, and reshapes the lint job into a per-platform matrix.

## (a) macOS code was clippy-linted nowhere

`Test darwin/arm64` compiles it, but nothing there passes `-D warnings`. So the Mach `sweep_threads` block in `src/diag.rs` — the largest unsafe region in the tree — plus `crates/proc/src/proc_exec/imp_macos.rs` (609 lines) and `process_watcher/kqueue_macos.rs` (286 lines) had never been through `undocumented_unsafe_blocks`, `multiple_unsafe_ops_per_block`, `indexing_slicing` or `unwrap_used`.

The `lint` job is now a matrix over `linux/amd64` + `darwin/arm64`, both running the **same** `lint` script — no per-OS variant. The failure being closed is a Mac developer's local `lint` disagreeing with CI in either direction (`#[expect]` is fulfilled-or-error, so a lint that fires on one OS and not the other is a hard error on the other), and that only stays closed if every leg runs the same command the developer does.

`fail-fast: false` is load-bearing, not boilerplate: with fail-fast on, the first red leg cancels the other, so the platform you did not see reports `cancelled` rather than a result — hiding exactly the half you need on the one case that matters.

**It found nothing.** All three clippy passes exit 0 on `aarch64-apple-darwin`. Every unsafe block in the Mach path already carried a SAFETY comment, each holds one unsafe op, and the port array is consumed via `.iter().take(MAX_THREADS)` rather than indexed. The `#[expect]` headers #259 pruned against the Linux lint set are fulfilled on macOS too. Finding nothing is the outcome the leg exists to *keep* true.

Two stale comments in that newly-covered region are fixed here, because **no lint can catch either**: a doc block on `sweep_threads` describing a helper that no longer exists and asserting `mach2` had *not* been pulled in (it has — `Cargo.toml` adds it and line 263 calls it), and a duplicated `// SAFETY:` whose first copy documented the *next* block's invariant. `undocumented_unsafe_blocks` is satisfied by any preceding SAFETY line, so it stayed green while the text pointed at the wrong operation.

## (b) `--no-default-features` — and the obvious spelling of it is a no-op

`crates/sandboxfuse/src/stub.rs`, the whole feature-off arm, is compiled by nothing today on any platform, and must still satisfy its callers in `crates/engine` and `crates/driver-bridge`. A signature drift in `imp.rs` that `stub.rs` did not follow is green right now.

**The substance of this half: `cargo clippy --workspace --no-default-features` does not turn `fuse-sandbox` off.** `crates/e2e`, `crates/plugingo-e2e` and `crates/testkit` depend on the root `heph` package with default features on, and cargo unifies features across the whole selected set, so that edge switches it straight back on.

Verified rather than reasoned — an `indexing_slicing` error injected into `stub.rs`, the file compiled *only* when the feature is off:

| Invocation | Exit |
|---|---|
| `cargo clippy --workspace --all-targets --no-default-features` | **0** |
| `… --exclude e2e --exclude plugingo-e2e --exclude testkit …` | **101** |
| `cargo clippy -p sandboxfuse --all-targets --no-default-features` | 101 |
| `cargo clippy -p heph --all-targets --no-default-features` | 101 |

Landing the naive form would have shipped a third pass that reports green while re-linting the arm pass 1 already covered — the same silent-selection failure #259 exists to fix, one axis over.

Because that regresses invisibly (a new member with `heph = { path = "../.." }` re-enables it and the pass keeps reporting green), **`lint` asserts the feature is off before linting it**, with `cargo tree -i fuser`, rather than trusting the flag:

```
$ cargo tree --workspace --exclude e2e --exclude plugingo-e2e --exclude testkit --no-default-features -i fuser
exit 101   # fuser absent — feature genuinely off
$ cargo tree --workspace --no-default-features -i fuser
exit 0     # fuser still in the graph — the flag is a no-op
```

Absence is matched on `did not match any packages`, not on the exit code alone: reading *any* cargo failure as "feature off" would wave the wrong arm through. A positive control asserts `fuser` **is** present with the feature on, so "absent because off" cannot be confused with "absent because gone". `fix` carries the matching pass with the matching exclusions.

The feature-off arm compiles and lints clean. No code changes were needed.

## Guards: `tests/lint_gate.rs` goes 2 tests → 9

The selection has five axes and each has already gone wrong or been left open: which packages (`--workspace`), which targets (`--all-targets`), which feature set, which platform, and **whether a red leg has any consequence at all**.

That last one is the new silent-pass class, and it is the one worth reading: a leg can be made to conclude `success` with clippy never running. `continue-on-error: true` converts a failure into a success; an `if:` on the Lint step skips it entirely. Either turns the leg's own check green over an unlinted platform, and `needs:` treats it as satisfied. Both are now asserted absent (the `if:` check scoped to the Lint step, since `sccache stats` legitimately has `if: always()`).

**23 breaks injected across the round, each caught.** The 10 for the current shape:

| Break | Caught by |
|---|---|
| matrix loses its darwin leg | `the_lint_gate_runs_on_macos_as_well_as_linux` |
| matrix loses its linux leg | same |
| leg runs something narrower than `lint` | same |
| `strategy:` removed (silently one platform) | same |
| `fail-fast: true` | `the_lint_job_is_a_matrix_over_both_supported_oses` |
| duplicated os/arch coordinate | same |
| `continue-on-error:` on the leg | `a_lint_leg_cannot_report_success_without_running_the_lint` |
| `if:` on the Lint step | same |
| `release` stops depending on lint | `lint_gates_release_and_cleanup` |
| `cleanup` stops depending on lint | same |

plus, from the `--no-default-features` and fmt axes: drop `--workspace` · delete the ndf pass · delete the `cargo tree` probe · drift the probe from the pass · drop an `--exclude` · add an extra `--exclude engine` · `fix` loses its default pass · `fix` loses its ndf pass · drop a crate from `qualityCrates` · swap a member's `[lints]` for `[lints.clippy]`.

The exclusion list is **derived from the member manifests, never copied**, and checked for **equality** rather than containment — an *extra* `--exclude engine` or `--exclude sandboxfuse` guts the pass just as thoroughly and does not put `fuser` back in the graph, so neither the probe nor a subset check can see it.

`assert_eq!(clippy_lines.len(), 2)` is relaxed to `>= 3`: it asserted an exact count, so it failed when coverage was *added* — the wrong direction for a coverage guard.

Two negative tests initially proved nothing and were redone, recorded because a negative test that silently edits the wrong thing is indistinguishable from a guard that works: the first `- os: darwin` block in the workflow belongs to `build:`, so an unscoped rewrite deleted the wrong job's leg. Every workflow break is now applied inside the `lint` job only, via a helper that asserts the pattern was found there.

## What `needs: lint` actually guarantees

`needs:` on a matrix job waits for **every** leg and is satisfied only if all succeeded. Confirmed against run 30485344790 rather than trusting the docs: `bin_e2e` (`needs: [gen, build, …]`) started at 20:24:50 — four seconds after the *last* `build` leg finished (20:24:46), not after the first (19:55:52). So `release`/`cleanup` gate on the whole matrix with no aggregator, and their `needs` entries required no edit after the rename.

## Cost

Measured on the linux leg (run 30477623663, warm):

| Pass | Time |
|---|---|
| `clippy --workspace --all-targets` | 2m02s |
| `… --all-features` | **0.26s** |
| `… --no-default-features` | **13.70s** |
| **`Lint` step total** | **2m18s** (was 2m07s) |

**+11s** for the feature-off coverage; it rebuilds exactly the four packages the feature reaches (`sandboxfuse`, `driver-bridge`, `engine`, `heph`). The 0.26s on `--all-features` is the measurement behind a correction to #259's claim: that pass is ~a no-op even *with* `--workspace`, because `--workspace` already unifies every member feature on. It is kept as cheap insurance and the comment now says so.

The darwin leg measured **9m49s / 10m24s** job total (Nix setup ~3m15s, clippy ~6m). That is the **cold** number and should not be read as steady state: sccache does not cache `clippy-driver` at all (~230 non-cacheable calls, 0 non-cacheable compilations), and `setup-nix` saves the cargo registry cache only on `master` — PRs are restore-only by design, so `cargo-aarch64-apple-darwin-lint-*` will not exist until this lands.

**The real price is macOS runner contention, not minutes.** The repo has a hard 5-concurrent-macOS cap and this adds a fourth macOS job to the `needs: gen` wave. Measured against baseline run 30466726477: `Build darwin/arm64` — the darwin critical path — was **not** delayed, and the workflow critical path (`Test linux/amd64`) did not move. But `Warm Binary E2E darwin/arm64` took the queue instead, and its margin over `Binary E2E darwin/arm64` collapsed from **803s to 4s**. It is normally not the binding constraint, so the delay is largely absorbed today — but that is a property of the current numbers, not a guarantee. Two attempts to re-measure this precisely under the matrix shape were abandoned when the runner pool saturated with eight sibling branches in flight (all four macOS jobs still queued 7.5 min in); CI on this head is the evidence rather than a synthetic campaign.

## Still open — recorded in `devenv.nix` rather than left to be rediscovered

- Doctests: `--all-targets` excludes them (10 blocks).
- `cargo test --no-default-features` is not run — the arm is compiled and linted, never *executed*. `sandboxfuse`'s `fuse_sandbox_is_a_default_feature` asserts the feature **is** on, so a test leg needs that `#[cfg]`-split first.
- **The arch axis is confounded.** `aarch64` is only ever linted together with macOS, and there is no `Lint linux/arm64`. `Test linux/arm64` cannot stand in: plain rustc reports `unfulfilled_lint_expectations` for its *own* lints but silently ignores an unfulfilled expectation on a **tool** lint it does not know, so a `target_arch`-conditional `#[expect(clippy::…)]` would be invisible in every job that exists. Per-platform behaviour is your call, so it is written down, not decided here. (Cross-clippy from Linux is not an option: `ring`/`aws-lc-sys` compile C for the target, `macfuse-stubs` is Darwin-only in `devenv.nix`, and `--all-targets` needs a real Darwin linker.)
- `expect` vs `allow` for crate-root test exemptions is left alone — the tree genuinely contradicts itself (`config`/`selfupdate` use `allow`, `src/lib.rs` argues for `expect`) and picking a side is a convention call.

## Review

`code-quality` and `feature-quality` were consulted at design and on each finished shape. Findings implemented rather than noted, including two that were genuine defects in my own new tests: a fmt-coverage guard that was **red as written** (`-p xstarlark-fmt ` with a trailing space, and it is the last entry in `qualityCrates`), and a probe-existence guard that matched its own explanatory comment. One `feature-quality` design recommendation was **overruled with evidence** — it proposed `cargo clippy --workspace --all-targets --no-default-features` as clean; the injection test above shows that invocation exits 0 on a deliberate error in the feature-off arm.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01A76DChMohieGMbRbnV1E7x
