### PR TITLE
fix(engine): probe the sandboxfuse lock instead of kill(pid,0); dedupe LocalCache test doubles

### DIFF
--- a/crates/engine/src/engine/engine.rs
+++ b/crates/engine/src/engine/engine.rs
@@ -11,6 +11,7 @@ use crate::engine::request_state::RequestState;
 use crate::engine::result_lock::ResultLock;
 use crate::engine::{driver, provider};
 use anyhow::Context;
+use hlock::hlock::{FLock, FWriteGuard, Lock};
 use hsandboxfuse as sandboxfuse;
 use std::collections::HashMap;
 use std::path::{Path, PathBuf};
@@ -126,6 +127,11 @@ pub struct EngineFuse {
     pub(crate) lower: PathBuf,
     pub(crate) upper: PathBuf,
     pub(crate) mount: Option<EngineMount>,
+    /// Held for the process's entire lifetime once `root` exists, so a later
+    /// process's `sweep_stale_sandboxfuse_dirs` can tell this directory is
+    /// still owned. `None` when `root` was never created (FUSE off or
+    /// unsupported).
+    _lock: Option<FWriteGuard>,
 }
 
 pub struct EngineMount {
@@ -148,6 +154,7 @@ impl EngineFuse {
                 lower,
                 upper,
                 mount: None,
+                _lock: None,
             });
         }
 
@@ -161,6 +168,7 @@ impl EngineFuse {
                 lower,
                 upper,
                 mount: None,
+                _lock: None,
             });
         }
 
@@ -168,6 +176,16 @@ impl EngineFuse {
             .with_context(|| format!("create FUSE lower dir {:?}", lower))?;
         std::fs::create_dir_all(&upper)
             .with_context(|| format!("create FUSE upper dir {:?}", upper))?;
+        // Ownership marker for `sweep_stale_sandboxfuse_dirs` in a future
+        // process: held for as long as this `EngineFuse` lives. `root` is
+        // freshly named after our own pid and any stale same-named leftover
+        // was already reclaimed by the sweep that ran before this call, so
+        // contention here means a real invariant violation, not a race to
+        // retry.
+        let lock = FLock::new(root.join("lock"))
+            .try_lock()
+            .with_context(|| format!("locking sandboxfuse dir {:?}", root))?
+            .with_context(|| format!("sandboxfuse dir {:?} already owned", root))?;
         let fs = Arc::new(sandboxfuse::LayeredFs::new_empty(upper.clone()));
         match sandboxfuse::Mount::mount(&lower, fs.clone()) {
             Ok(m) => {
@@ -180,6 +198,7 @@ impl EngineFuse {
                     lower,
                     upper,
                     mount: Some(EngineMount { _mount: m, fs }),
+                    _lock: Some(lock),
                 })
             }
             Err(e) => {
@@ -192,6 +211,7 @@ impl EngineFuse {
                     lower,
                     upper,
                     mount: None,
+                    _lock: Some(lock),
                 })
             }
         }
@@ -258,10 +278,21 @@ pub(crate) fn force_umount(path: &Path) {
     }
 }
 
-/// Walk `<home>/` for `sandboxfuse<pid>` directories whose pid is no
-/// longer alive (via `kill(pid, 0)` returning ESRCH). For each: best-
-/// effort umount of `<dir>/lower` (idempotent — works whether stale or
-/// not), then `remove_dir_all(<dir>)`. Silent on any error.
+/// Walk `<home>/` for `sandboxfuse<pid>` directories no longer owned by a
+/// live process. For each: best-effort umount of `<dir>/lower` (idempotent —
+/// works whether stale or not), then `remove_dir_all(<dir>)`. Silent on any
+/// error.
+///
+/// Ownership is decided by probing `<dir>/lock` with [`FLock::is_path_held`],
+/// not by `kill(pid, 0)` on the directory's pid suffix. `kill` cannot tell a
+/// live process owned by another uid from a dead one: both report `EPERM` or
+/// `ESRCH` indistinguishably to a caller that only checks the return code, and
+/// treating `EPERM` (process exists, just not ours) as "dead" reclaims a live
+/// process's sandbox out from under it. The `flock` probe answers for the
+/// lock itself, so it is immune to that inversion, to pid reuse, and to a
+/// zombie whose pid still answers `kill`. `EngineFuse::new` takes the lock for
+/// the directory's whole lifetime, so "held" and "owned by a live process" are
+/// the same fact.
 fn sweep_stale_sandboxfuse_dirs(home: &Path) {
     let Ok(entries) = std::fs::read_dir(home) else {
         return;
@@ -272,15 +303,15 @@ fn sweep_stale_sandboxfuse_dirs(home: &Path) {
         let Some(pid_str) = name.strip_prefix("sandboxfuse") else {
             continue;
         };
-        let Ok(pid) = pid_str.parse::<libc::pid_t>() else {
-            continue;
-        };
-        // SAFETY: kill(pid, 0) is a probe-only syscall; sig=0 doesn't deliver.
-        let alive = unsafe { libc::kill(pid, 0) } == 0;
-        if alive {
+        if pid_str.is_empty() || !pid_str.bytes().all(|b| b.is_ascii_digit()) {
             continue;
         }
         let dir = entry.path();
+        match FLock::is_path_held(dir.join("lock")) {
+            Ok(true) => continue,
+            Ok(false) => {}
+            Err(_) => continue,
+        }
         let lower = dir.join("lower");
         // Best-effort force umount. The previous process crashed; any
         // mount it left is unowned and may have dangling kernel state.
@@ -812,5 +843,74 @@ impl hplugin::lsp::LspEngine for Engine {
                     .map(|p| p.options)
             })
             .unwrap_or_default()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    // Names the dir after pid 1 (init/launchd): always alive, always owned by
+    // another user, so a non-root caller's `kill(1, 0)` always answers
+    // `EPERM`. That is precisely the case the old `kill(pid, 0) == 0` check
+    // got backwards — `EPERM` means the process exists and isn't ours, not
+    // that it's dead — and it is what let the sweep reclaim a live process's
+    // sandbox out from under it. The fix doesn't probe the pid at all: it
+    // probes whether `<dir>/lock` is held, which this test pins by holding it
+    // itself for the sweep's whole duration.
+    #[test]
+    fn sweep_preserves_a_dir_whose_lock_is_held() {
+        let home = tempfile::tempdir().expect("tempdir");
+        let dir = home.path().join("sandboxfuse1");
+        std::fs::create_dir_all(&dir).expect("create sandboxfuse dir");
+        let guard = FLock::new(dir.join("lock"))
+            .try_lock()
+            .expect("try_lock")
+            .expect("lock free");
+
+        sweep_stale_sandboxfuse_dirs(home.path());
+
+        assert!(
+            dir.exists(),
+            "a dir whose lock is held must survive the sweep"
+        );
+        drop(guard);
+    }
+
+    #[test]
+    fn sweep_removes_a_dir_whose_lock_is_not_held() {
+        let home = tempfile::tempdir().expect("tempdir");
+        let dir = home.path().join("sandboxfuse2");
+        std::fs::create_dir_all(&dir).expect("create sandboxfuse dir");
+        // A lock file can exist without being held (its owner exited without
+        // unlinking it, or it was never acquired): `try_lock` then drop
+        // leaves exactly that on disk.
+        drop(
+            FLock::new(dir.join("lock"))
+                .try_lock()
+                .expect("try_lock")
+                .expect("lock free"),
+        );
+
+        sweep_stale_sandboxfuse_dirs(home.path());
+
+        assert!(
+            !dir.exists(),
+            "a dir whose lock is not held must be reclaimed"
+        );
+    }
+
+    #[test]
+    fn sweep_ignores_entries_that_do_not_match_the_naming_scheme() {
+        let home = tempfile::tempdir().expect("tempdir");
+        let unrelated = home.path().join("sandboxfuse-not-a-pid");
+        std::fs::create_dir_all(&unrelated).expect("create dir");
+
+        sweep_stale_sandboxfuse_dirs(home.path());
+
+        assert!(
+            unrelated.exists(),
+            "a dir whose suffix isn't a pid must be left alone"
+        );
     }
 }

--- a/crates/engine/src/engine/gc.rs
+++ b/crates/engine/src/engine/gc.rs
@@ -944,6 +944,7 @@ mod tests {
         ManifestArtifactContentType, ManifestArtifactEncoding, ManifestArtifactType, PendingWrite,
         SizedReader, TargetStream,
     };
+    use crate::engine::local_cache_test_double::ForwardingCache;
     use hcore::hasync::StdCancellationToken;
     use hmodel::htpkg::PkgBuf;
     use std::collections::BTreeMap;
@@ -976,72 +977,6 @@ mod tests {
         })
         .expect("engine");
         (Arc::new(engine), dir)
-    }
-
-    /// Counts the two cache round-trips the post-write trim must not make when
-    /// the target is already inside its history budget: the write barrier
-    /// (`exists` on the manifest key) and the per-revision recency reads
-    /// (`reader` on the manifest key, one per revision). Everything else is
-    /// forwarded verbatim to the real backend, so the target under test is a
-    /// genuine sqlite cache rather than a stub.
-    struct CountingCache {
-        inner: Arc<dyn LocalCache>,
-        barrier_reads: Arc<AtomicUsize>,
-        manifest_reads: Arc<AtomicUsize>,
-    }
-
-    impl LocalCache for CountingCache {
-        fn reader(&self, addr: &Addr, hashin: &str, name: &str) -> anyhow::Result<SizedReader> {
-            if name == MANIFEST_V1 {
-                self.manifest_reads.fetch_add(1, Ordering::SeqCst);
-            }
-            self.inner.reader(addr, hashin, name)
-        }
-        fn writer(
-            &self,
-            addr: &Addr,
-            hashin: &str,
-            name: &str,
-        ) -> anyhow::Result<Box<dyn std::io::Write>> {
-            self.inner.writer(addr, hashin, name)
-        }
-        fn exists(&self, addr: &Addr, hashin: &str, name: &str) -> anyhow::Result<bool> {
-            if name == MANIFEST_V1 {
-                self.barrier_reads.fetch_add(1, Ordering::SeqCst);
-            }
-            self.inner.exists(addr, hashin, name)
-        }
-        fn existence(&self, addr: &Addr, hashin: &str, name: &str) -> anyhow::Result<Existence> {
-            // Forwarded to the layer that owns the write-behind queue, per the
-            // trait's contract — never re-derived from `exists`.
-            self.inner.existence(addr, hashin, name)
-        }
-        fn exists_committed(&self, addr: &Addr, hashin: &str, name: &str) -> anyhow::Result<bool> {
-            // Likewise forwarded: only the queue's owner knows what is committed.
-            // Not counted — `barrier_reads` tracks the manifest barrier probe,
-            // which goes through `exists`.
-            self.inner.exists_committed(addr, hashin, name)
-        }
-        fn delete(&self, addr: &Addr, hashin: &str, name: &str) -> anyhow::Result<()> {
-            self.inner.delete(addr, hashin, name)
-        }
-        fn list_targets(&self) -> anyhow::Result<TargetStream> {
-            self.inner.list_targets()
-        }
-        fn list_target_entries(&self, addr: &Addr) -> anyhow::Result<Vec<String>> {
-            self.inner.list_target_entries(addr)
-        }
-        fn seekable_reader(
-            &self,
-            addr: &Addr,
-            hashin: &str,
-            name: &str,
-        ) -> anyhow::Result<Option<Box<dyn hcore::hartifactcontent::ReadSeek + Send>>> {
-            self.inner.seekable_reader(addr, hashin, name)
-        }
-        fn file_path(&self, addr: &Addr, hashin: &str, name: &str) -> Option<std::path::PathBuf> {
-            self.inner.file_path(addr, hashin, name)
-        }
     }
 
     /// A cache that reproduces the one asymmetry the post-write trim depends on,
@@ -1213,11 +1148,31 @@ mod tests {
         .expect("engine");
         let barrier_reads = Arc::new(AtomicUsize::new(0));
         let manifest_reads = Arc::new(AtomicUsize::new(0));
-        engine.local_cache = Arc::new(CountingCache {
-            inner: Arc::clone(&engine.local_cache),
-            barrier_reads: Arc::clone(&barrier_reads),
-            manifest_reads: Arc::clone(&manifest_reads),
-        });
+        // Counts the two cache round-trips the post-write trim must not make
+        // when the target is already inside its history budget: the write
+        // barrier (`exists` on the manifest key) and the per-revision recency
+        // reads (`reader` on the manifest key, one per revision). Everything
+        // else is forwarded verbatim to the real backend, so the target under
+        // test is a genuine sqlite cache rather than a stub.
+        engine.local_cache = Arc::new(
+            ForwardingCache::new(Arc::clone(&engine.local_cache))
+                .on_reader({
+                    let manifest_reads = Arc::clone(&manifest_reads);
+                    move |_, _, name| {
+                        if name == MANIFEST_V1 {
+                            manifest_reads.fetch_add(1, Ordering::SeqCst);
+                        }
+                    }
+                })
+                .on_exists({
+                    let barrier_reads = Arc::clone(&barrier_reads);
+                    move |_, _, name| {
+                        if name == MANIFEST_V1 {
+                            barrier_reads.fetch_add(1, Ordering::SeqCst);
+                        }
+                    }
+                }),
+        );
         (Arc::new(engine), barrier_reads, manifest_reads, dir)
     }
 

--- a/crates/engine/src/engine/local_cache_test_double.rs
+++ b/crates/engine/src/engine/local_cache_test_double.rs
@@ -1,0 +1,189 @@
+//! Shared `LocalCache` test double.
+//!
+//! `ForwardingCache` forwards every call to a wrapped `inner` cache, with
+//! optional hooks on the handful of calls existing tests observe (`reader`,
+//! `exists`, `list_target_entries`). Before this module, three call sites each
+//! hand-copied the full ten-method `LocalCache` forwarding impl to instrument
+//! one or two of those calls — the exact shape that let #252 happen: a method
+//! added to the trait gets forwarded correctly on the copies a PR's author
+//! remembers to touch, compiles green because the others still satisfy the
+//! trait via whatever the last edit left them at, and only reddens whichever
+//! unrelated test exercises the copy that fell behind. Consolidating the
+//! forwarding into one place means there is only one copy to keep in sync.
+//!
+//! Add another `on_*` hook here, not another struct, if a test needs to watch
+//! a different call.
+
+use crate::engine::local_cache::{Existence, LocalCache, SizedReader, TargetStream};
+use hmodel::htaddr::Addr;
+use std::io;
+use std::path::PathBuf;
+use std::sync::Arc;
+
+type ReaderHook = Box<dyn Fn(&Addr, &str, &str) + Send + Sync>;
+type ExistsHook = Box<dyn Fn(&Addr, &str, &str) + Send + Sync>;
+type ListTargetEntriesHook = Box<dyn Fn(&Addr) + Send + Sync>;
+
+pub(crate) struct ForwardingCache {
+    inner: Arc<dyn LocalCache>,
+    on_reader: ReaderHook,
+    on_exists: ExistsHook,
+    on_list_target_entries: ListTargetEntriesHook,
+}
+
+impl ForwardingCache {
+    pub(crate) fn new(inner: Arc<dyn LocalCache>) -> Self {
+        Self {
+            inner,
+            on_reader: Box::new(|_, _, _| {}),
+            on_exists: Box::new(|_, _, _| {}),
+            on_list_target_entries: Box::new(|_| {}),
+        }
+    }
+
+    /// Run `f` before every `reader` call, then forward regardless of what it
+    /// does.
+    pub(crate) fn on_reader(mut self, f: impl Fn(&Addr, &str, &str) + Send + Sync + 'static) -> Self {
+        self.on_reader = Box::new(f);
+        self
+    }
+
+    /// Run `f` before every `exists` call, then forward regardless of what it
+    /// does.
+    pub(crate) fn on_exists(mut self, f: impl Fn(&Addr, &str, &str) + Send + Sync + 'static) -> Self {
+        self.on_exists = Box::new(f);
+        self
+    }
+
+    /// Run `f` before every `list_target_entries` call, then forward
+    /// regardless of what it does.
+    pub(crate) fn on_list_target_entries(mut self, f: impl Fn(&Addr) + Send + Sync + 'static) -> Self {
+        self.on_list_target_entries = Box::new(f);
+        self
+    }
+}
+
+impl LocalCache for ForwardingCache {
+    fn reader(&self, addr: &Addr, hashin: &str, name: &str) -> anyhow::Result<SizedReader> {
+        (self.on_reader)(addr, hashin, name);
+        self.inner.reader(addr, hashin, name)
+    }
+
+    fn writer(&self, addr: &Addr, hashin: &str, name: &str) -> anyhow::Result<Box<dyn io::Write>> {
+        self.inner.writer(addr, hashin, name)
+    }
+
+    fn exists(&self, addr: &Addr, hashin: &str, name: &str) -> anyhow::Result<bool> {
+        (self.on_exists)(addr, hashin, name);
+        self.inner.exists(addr, hashin, name)
+    }
+
+    fn existence(&self, addr: &Addr, hashin: &str, name: &str) -> anyhow::Result<Existence> {
+        self.inner.existence(addr, hashin, name)
+    }
+
+    fn exists_committed(&self, addr: &Addr, hashin: &str, name: &str) -> anyhow::Result<bool> {
+        self.inner.exists_committed(addr, hashin, name)
+    }
+
+    fn delete(&self, addr: &Addr, hashin: &str, name: &str) -> anyhow::Result<()> {
+        self.inner.delete(addr, hashin, name)
+    }
+
+    fn list_targets(&self) -> anyhow::Result<TargetStream> {
+        self.inner.list_targets()
+    }
+
+    fn list_target_entries(&self, addr: &Addr) -> anyhow::Result<Vec<String>> {
+        (self.on_list_target_entries)(addr);
+        self.inner.list_target_entries(addr)
+    }
+
+    fn seekable_reader(
+        &self,
+        addr: &Addr,
+        hashin: &str,
+        name: &str,
+    ) -> anyhow::Result<Option<Box<dyn hcore::hartifactcontent::ReadSeek + Send>>> {
+        self.inner.seekable_reader(addr, hashin, name)
+    }
+
+    fn file_path(&self, addr: &Addr, hashin: &str, name: &str) -> Option<PathBuf> {
+        self.inner.file_path(addr, hashin, name)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::engine::{Config, Engine};
+    use hmodel::htpkg::PkgBuf;
+    use std::collections::BTreeMap;
+    use std::io::Write as _;
+    use std::sync::atomic::{AtomicUsize, Ordering};
+
+    fn addr() -> Addr {
+        Addr::new(PkgBuf::from("pkg"), "t".to_string(), BTreeMap::new())
+    }
+
+    fn real_cache(dir: &std::path::Path) -> Arc<dyn LocalCache> {
+        let engine = Engine::new(Config {
+            root: dir.to_path_buf(),
+            home_dir: std::path::PathBuf::new(),
+            parallelism: None,
+            ..Default::default()
+        })
+        .expect("engine");
+        engine.local_cache.clone()
+    }
+
+    // A hook that is never installed must not fire — otherwise `on_exists`
+    // firing on a `reader` call (or vice versa) would silently miscount every
+    // caller that only wires up one hook, exactly the kind of cross-wiring
+    // bug this double exists to keep out of every call site that reaches for
+    // it.
+    #[test]
+    fn unset_hooks_are_silent_and_set_hooks_fire_only_their_own_call() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let a = addr();
+
+        let reader_calls = Arc::new(AtomicUsize::new(0));
+        let exists_calls = Arc::new(AtomicUsize::new(0));
+
+        let cache = ForwardingCache::new(real_cache(dir.path()))
+            .on_reader({
+                let c = Arc::clone(&reader_calls);
+                move |_, _, _| {
+                    c.fetch_add(1, Ordering::SeqCst);
+                }
+            })
+            .on_exists({
+                let c = Arc::clone(&exists_calls);
+                move |_, _, _| {
+                    c.fetch_add(1, Ordering::SeqCst);
+                }
+            });
+        // `on_list_target_entries` deliberately left unset.
+
+        let mut w = cache.writer(&a, "h", "out").expect("writer");
+        w.write_all(b"data").expect("write");
+        drop(w);
+
+        assert_eq!(reader_calls.load(Ordering::SeqCst), 0, "writer must not fire the reader hook");
+        assert_eq!(exists_calls.load(Ordering::SeqCst), 0, "writer must not fire the exists hook");
+
+        assert!(cache.exists(&a, "h", "out").expect("exists"));
+        assert_eq!(exists_calls.load(Ordering::SeqCst), 1, "exists hook must fire on exists");
+        assert_eq!(reader_calls.load(Ordering::SeqCst), 0, "exists must not fire the reader hook");
+
+        let sized = cache.reader(&a, "h", "out").expect("reader");
+        drop(sized);
+        assert_eq!(reader_calls.load(Ordering::SeqCst), 1, "reader hook must fire on reader");
+        assert_eq!(exists_calls.load(Ordering::SeqCst), 1, "reader must not re-fire the exists hook");
+
+        // Unset hook: call must still forward correctly and must not panic on
+        // the no-op default.
+        let entries = cache.list_target_entries(&a).expect("list_target_entries");
+        assert_eq!(entries, vec!["h".to_string()], "call still forwards with no hook installed");
+    }
+}

--- a/crates/engine/src/engine/local_cache_test_double.rs
+++ b/crates/engine/src/engine/local_cache_test_double.rs
@@ -43,21 +43,30 @@ impl ForwardingCache {
 
     /// Run `f` before every `reader` call, then forward regardless of what it
     /// does.
-    pub(crate) fn on_reader(mut self, f: impl Fn(&Addr, &str, &str) + Send + Sync + 'static) -> Self {
+    pub(crate) fn on_reader(
+        mut self,
+        f: impl Fn(&Addr, &str, &str) + Send + Sync + 'static,
+    ) -> Self {
         self.on_reader = Box::new(f);
         self
     }
 
     /// Run `f` before every `exists` call, then forward regardless of what it
     /// does.
-    pub(crate) fn on_exists(mut self, f: impl Fn(&Addr, &str, &str) + Send + Sync + 'static) -> Self {
+    pub(crate) fn on_exists(
+        mut self,
+        f: impl Fn(&Addr, &str, &str) + Send + Sync + 'static,
+    ) -> Self {
         self.on_exists = Box::new(f);
         self
     }
 
     /// Run `f` before every `list_target_entries` call, then forward
     /// regardless of what it does.
-    pub(crate) fn on_list_target_entries(mut self, f: impl Fn(&Addr) + Send + Sync + 'static) -> Self {
+    pub(crate) fn on_list_target_entries(
+        mut self,
+        f: impl Fn(&Addr) + Send + Sync + 'static,
+    ) -> Self {
         self.on_list_target_entries = Box::new(f);
         self
     }
@@ -169,21 +178,49 @@ mod tests {
         w.write_all(b"data").expect("write");
         drop(w);
 
-        assert_eq!(reader_calls.load(Ordering::SeqCst), 0, "writer must not fire the reader hook");
-        assert_eq!(exists_calls.load(Ordering::SeqCst), 0, "writer must not fire the exists hook");
+        assert_eq!(
+            reader_calls.load(Ordering::SeqCst),
+            0,
+            "writer must not fire the reader hook"
+        );
+        assert_eq!(
+            exists_calls.load(Ordering::SeqCst),
+            0,
+            "writer must not fire the exists hook"
+        );
 
         assert!(cache.exists(&a, "h", "out").expect("exists"));
-        assert_eq!(exists_calls.load(Ordering::SeqCst), 1, "exists hook must fire on exists");
-        assert_eq!(reader_calls.load(Ordering::SeqCst), 0, "exists must not fire the reader hook");
+        assert_eq!(
+            exists_calls.load(Ordering::SeqCst),
+            1,
+            "exists hook must fire on exists"
+        );
+        assert_eq!(
+            reader_calls.load(Ordering::SeqCst),
+            0,
+            "exists must not fire the reader hook"
+        );
 
         let sized = cache.reader(&a, "h", "out").expect("reader");
         drop(sized);
-        assert_eq!(reader_calls.load(Ordering::SeqCst), 1, "reader hook must fire on reader");
-        assert_eq!(exists_calls.load(Ordering::SeqCst), 1, "reader must not re-fire the exists hook");
+        assert_eq!(
+            reader_calls.load(Ordering::SeqCst),
+            1,
+            "reader hook must fire on reader"
+        );
+        assert_eq!(
+            exists_calls.load(Ordering::SeqCst),
+            1,
+            "reader must not re-fire the exists hook"
+        );
 
         // Unset hook: call must still forward correctly and must not panic on
         // the no-op default.
         let entries = cache.list_target_entries(&a).expect("list_target_entries");
-        assert_eq!(entries, vec!["h".to_string()], "call still forwards with no hook installed");
+        assert_eq!(
+            entries,
+            vec!["h".to_string()],
+            "call still forwards with no hook installed"
+        );
     }
 }

--- a/crates/engine/src/engine/mod.rs
+++ b/crates/engine/src/engine/mod.rs
@@ -39,6 +39,8 @@ mod local_cache_fs;
 mod local_cache_mem;
 mod local_cache_spill;
 mod local_cache_sqlite;
+#[cfg(test)]
+pub(crate) mod local_cache_test_double;
 mod local_cache_tmp;
 mod packages;
 mod remote_cache;

--- a/crates/engine/src/engine/result.rs
+++ b/crates/engine/src/engine/result.rs
@@ -8554,14 +8554,15 @@ mod tests {
         })
         .expect("engine");
         let manifest_reads = SArc::new(AtomicUsize::new(0));
-        engine.local_cache = SArc::new(ForwardingCache::new(engine.local_cache.clone()).on_reader({
-            let manifest_reads = SArc::clone(&manifest_reads);
-            move |_, _, name| {
-                if name == MANIFEST_V1 {
-                    manifest_reads.fetch_add(1, Ordering::SeqCst);
+        engine.local_cache =
+            SArc::new(ForwardingCache::new(engine.local_cache.clone()).on_reader({
+                let manifest_reads = SArc::clone(&manifest_reads);
+                move |_, _, name| {
+                    if name == MANIFEST_V1 {
+                        manifest_reads.fetch_add(1, Ordering::SeqCst);
+                    }
                 }
-            }
-        }));
+            }));
         let exec_count = SArc::new(AtomicUsize::new(0));
         engine
             .register_driver(enclose!(

--- a/crates/engine/src/engine/result.rs
+++ b/crates/engine/src/engine/result.rs
@@ -8254,89 +8254,7 @@ mod tests {
     /// (Linux's 16-byte `PR_SET_NAME` truncation affects `/proc`, not this).
     #[tokio::test(flavor = "multi_thread", worker_threads = 4)]
     async fn each_background_job_class_runs_on_its_own_lane() {
-        use crate::engine::local_cache::{Existence, LocalCache, SizedReader, TargetStream};
-
-        /// Records the thread of the first `list_target_entries` call. In this
-        /// test that call can only come from `try_trim_after_write`, which starts
-        /// with an unlocked revision count — so it is reached whether or not the
-        /// trim goes on to take the write lock.
-        struct TrimThreadCache {
-            inner: SArc<dyn LocalCache>,
-            thread: SArc<std::sync::OnceLock<String>>,
-        }
-        impl LocalCache for TrimThreadCache {
-            fn reader(&self, addr: &Addr, hashin: &str, name: &str) -> anyhow::Result<SizedReader> {
-                self.inner.reader(addr, hashin, name)
-            }
-            fn writer(
-                &self,
-                addr: &Addr,
-                hashin: &str,
-                name: &str,
-            ) -> anyhow::Result<Box<dyn std::io::Write>> {
-                self.inner.writer(addr, hashin, name)
-            }
-            fn exists(&self, addr: &Addr, hashin: &str, name: &str) -> anyhow::Result<bool> {
-                self.inner.exists(addr, hashin, name)
-            }
-            fn existence(
-                &self,
-                addr: &Addr,
-                hashin: &str,
-                name: &str,
-            ) -> anyhow::Result<Existence> {
-                self.inner.existence(addr, hashin, name)
-            }
-            /// Mirrors this decorator's own `exists`: that one forwards, so the
-            /// committed-only answer forwards too. Required by the trait
-            /// precisely so a decorator cannot inherit a default that re-parks
-            /// the runtime on the backend's write-behind queue.
-            fn exists_committed(
-                &self,
-                addr: &Addr,
-                hashin: &str,
-                name: &str,
-            ) -> anyhow::Result<bool> {
-                self.inner.exists_committed(addr, hashin, name)
-            }
-            fn delete(&self, addr: &Addr, hashin: &str, name: &str) -> anyhow::Result<()> {
-                self.inner.delete(addr, hashin, name)
-            }
-            fn list_targets(&self) -> anyhow::Result<TargetStream> {
-                self.inner.list_targets()
-            }
-            fn list_target_entries(&self, addr: &Addr) -> anyhow::Result<Vec<String>> {
-                drop(
-                    self.thread.set(
-                        std::thread::current()
-                            .name()
-                            .unwrap_or("<unnamed>")
-                            .to_string(),
-                    ),
-                );
-                self.inner.list_target_entries(addr)
-            }
-            fn seekable_reader(
-                &self,
-                addr: &Addr,
-                hashin: &str,
-                name: &str,
-            ) -> anyhow::Result<Option<Box<dyn hcore::hartifactcontent::ReadSeek + Send>>>
-            {
-                self.inner.seekable_reader(addr, hashin, name)
-            }
-            // Forwarded, not defaulted: a decorator that swallows this turns the
-            // direct-open path off for every artifact in the test that wraps the
-            // cache — the exact defect this file's `GuardedArtifact` doc warns of.
-            fn file_path(
-                &self,
-                addr: &Addr,
-                hashin: &str,
-                name: &str,
-            ) -> Option<std::path::PathBuf> {
-                self.inner.file_path(addr, hashin, name)
-            }
-        }
+        use crate::engine::local_cache_test_double::ForwardingCache;
 
         let exec_count = SArc::new(AtomicUsize::new(0));
         let rmdir_thread: SArc<std::sync::OnceLock<String>> = SArc::new(std::sync::OnceLock::new());
@@ -8348,10 +8266,24 @@ mod tests {
             "p62_lane_routing",
             Some(SArc::clone(&rmdir_thread)),
             Some(&|inner| {
-                SArc::new(TrimThreadCache {
-                    inner,
-                    thread: SArc::clone(&wrap_trim),
-                })
+                // Records the thread of the first `list_target_entries` call.
+                // In this test that call can only come from
+                // `try_trim_after_write`, which starts with an unlocked
+                // revision count — so it is reached whether or not the trim
+                // goes on to take the write lock.
+                SArc::new(ForwardingCache::new(inner).on_list_target_entries({
+                    let wrap_trim = SArc::clone(&wrap_trim);
+                    move |_| {
+                        drop(
+                            wrap_trim.set(
+                                std::thread::current()
+                                    .name()
+                                    .unwrap_or("<unnamed>")
+                                    .to_string(),
+                            ),
+                        );
+                    }
+                }))
             }),
         )
         .expect("engine");
@@ -8604,81 +8536,8 @@ mod tests {
         // presence-probe and the per-caller read each parsed the manifest (two
         // backend reads per hit); now the probe stashes the parsed manifest on
         // `LockedResolution` and the caller filters its outputs from it.
-        use crate::engine::local_cache::{
-            Existence, LocalCache, MANIFEST_V1, SizedReader, TargetStream,
-        };
-
-        struct CountingCache {
-            inner: SArc<dyn LocalCache>,
-            manifest_reads: SArc<AtomicUsize>,
-        }
-        impl LocalCache for CountingCache {
-            fn reader(&self, addr: &Addr, hashin: &str, name: &str) -> anyhow::Result<SizedReader> {
-                if name == MANIFEST_V1 {
-                    self.manifest_reads.fetch_add(1, Ordering::SeqCst);
-                }
-                self.inner.reader(addr, hashin, name)
-            }
-            fn writer(
-                &self,
-                addr: &Addr,
-                hashin: &str,
-                name: &str,
-            ) -> anyhow::Result<Box<dyn std::io::Write>> {
-                self.inner.writer(addr, hashin, name)
-            }
-            fn exists(&self, addr: &Addr, hashin: &str, name: &str) -> anyhow::Result<bool> {
-                self.inner.exists(addr, hashin, name)
-            }
-            // Forwarded, not defaulted: defaulting would route the probe through
-            // the blocking  and park the worker this test runs on.
-            fn existence(
-                &self,
-                addr: &Addr,
-                hashin: &str,
-                name: &str,
-            ) -> anyhow::Result<Existence> {
-                self.inner.existence(addr, hashin, name)
-            }
-            // Forwarded for the same reason: only the layer that owns the write
-            // queue can answer "committed" without waiting on it.
-            fn exists_committed(
-                &self,
-                addr: &Addr,
-                hashin: &str,
-                name: &str,
-            ) -> anyhow::Result<bool> {
-                self.inner.exists_committed(addr, hashin, name)
-            }
-            fn delete(&self, addr: &Addr, hashin: &str, name: &str) -> anyhow::Result<()> {
-                self.inner.delete(addr, hashin, name)
-            }
-            fn list_targets(&self) -> anyhow::Result<TargetStream> {
-                self.inner.list_targets()
-            }
-            fn list_target_entries(&self, addr: &Addr) -> anyhow::Result<Vec<String>> {
-                self.inner.list_target_entries(addr)
-            }
-            fn seekable_reader(
-                &self,
-                addr: &Addr,
-                hashin: &str,
-                name: &str,
-            ) -> anyhow::Result<Option<Box<dyn hcore::hartifactcontent::ReadSeek + Send>>>
-            {
-                self.inner.seekable_reader(addr, hashin, name)
-            }
-            // See the note on the other cache decorator in this file: defaulting
-            // this silently disables the direct-open path under the test.
-            fn file_path(
-                &self,
-                addr: &Addr,
-                hashin: &str,
-                name: &str,
-            ) -> Option<std::path::PathBuf> {
-                self.inner.file_path(addr, hashin, name)
-            }
-        }
+        use crate::engine::local_cache::MANIFEST_V1;
+        use crate::engine::local_cache_test_double::ForwardingCache;
 
         let dir = tempdir().expect("tempdir");
         let mut engine = Engine::new(Config {
@@ -8695,10 +8554,14 @@ mod tests {
         })
         .expect("engine");
         let manifest_reads = SArc::new(AtomicUsize::new(0));
-        engine.local_cache = SArc::new(CountingCache {
-            inner: engine.local_cache.clone(),
-            manifest_reads: SArc::clone(&manifest_reads),
-        });
+        engine.local_cache = SArc::new(ForwardingCache::new(engine.local_cache.clone()).on_reader({
+            let manifest_reads = SArc::clone(&manifest_reads);
+            move |_, _, name| {
+                if name == MANIFEST_V1 {
+                    manifest_reads.fetch_add(1, Ordering::SeqCst);
+                }
+            }
+        }));
         let exec_count = SArc::new(AtomicUsize::new(0));
         engine
             .register_driver(enclose!(

--- a/crates/lock/src/hlock/bridge.rs
+++ b/crates/lock/src/hlock/bridge.rs
@@ -10,14 +10,12 @@
 //! readers draining, and a downgrader's `inner.read()` cannot block on any
 //! writer (no other task can reach the write lock without the gateway it holds).
 
-use crate::hlock::flock::{FLock, FRWLock};
 use crate::hlock::mem::{MemLock, MemRWLock};
 use crate::hlock::traits::{
     Ctoken, Lock, RWLock, TLock, TRWLock, TReadGuard, TUpgradableReadGuard, TWriteGuard,
 };
 use anyhow::{Context, Result};
 use async_trait::async_trait;
-use std::path::Path;
 
 /// A transformable lock composed of an outer exclusive lock and an inner
 /// reader/writer lock.
@@ -39,21 +37,6 @@ impl<O, I> TBridge<O, I> {
 /// In-memory transformable reader/writer lock.
 pub fn mem_tlock() -> TBridge<MemLock, MemRWLock> {
     TBridge::new(MemLock::new(), MemRWLock::new())
-}
-
-/// Filesystem transformable reader/writer lock. `outer_path` and `inner_path`
-/// must be different files.
-///
-/// Used by this crate's own bridge tests. The engine deliberately does *not*
-/// build its result lock through here: it wraps the outer `FLock` in a
-/// `GatewayLock` decorator that empties the lock file at acquire, because it
-/// keeps the holder's pid stamp there and a stamp must not outlive its writer.
-/// Reach for `TBridge::new` directly when the outer lock needs a policy.
-pub fn fs_tlock(
-    outer_path: impl AsRef<Path>,
-    inner_path: impl AsRef<Path>,
-) -> TBridge<FLock, FRWLock> {
-    TBridge::new(FLock::new(outer_path), FRWLock::new(inner_path))
 }
 
 /// Plain shared read guard from a [`TBridge`]: holds only the inner read lock.

--- a/crates/lock/src/hlock/mod.rs
+++ b/crates/lock/src/hlock/mod.rs
@@ -18,9 +18,7 @@ pub mod traits;
 #[cfg(test)]
 mod tests;
 
-pub use bridge::{
-    TBridge, TBridgeReadGuard, TBridgeUpgradableGuard, TBridgeWriteGuard, fs_tlock, mem_tlock,
-};
+pub use bridge::{TBridge, TBridgeReadGuard, TBridgeUpgradableGuard, TBridgeWriteGuard, mem_tlock};
 pub use flock::{FLock, FRWLock, FReadGuard, FWriteGuard};
 pub use keyed::{KeyedGuard, KeyedLock, KeyedRWLock, KeyedTLock, KeyedTRWLock};
 pub use mem::{MemGuard, MemLock, MemRWLock, MemReadGuard, MemWriteGuard};

--- a/crates/lock/src/hlock/tests.rs
+++ b/crates/lock/src/hlock/tests.rs
@@ -2,8 +2,11 @@
 //! same trait surface as the in-memory one (the inline per-module tests cover
 //! the in-memory bridge in detail).
 
+use crate::hlock::bridge::TBridge;
+use crate::hlock::flock::{FLock, FRWLock};
 use crate::hlock::traits::{TLock, TUpgradableReadGuard, TWriteGuard};
 use hcore::hasync::StdCancellationToken;
+use std::path::Path;
 use std::sync::Arc;
 use std::time::Duration;
 
@@ -11,10 +14,16 @@ fn ct() -> StdCancellationToken {
     StdCancellationToken::new()
 }
 
+/// Filesystem-backed transformable lock, built directly from `TBridge` —
+/// used only by this module's own cross-backend tests.
+fn fs_tlock(outer_path: impl AsRef<Path>, inner_path: impl AsRef<Path>) -> TBridge<FLock, FRWLock> {
+    TBridge::new(FLock::new(outer_path), FRWLock::new(inner_path))
+}
+
 #[tokio::test]
 async fn fs_bridge_upgrade_then_downgrade() {
     let dir = tempfile::tempdir().expect("tempdir");
-    let l = crate::hlock::fs_tlock(dir.path().join("outer"), dir.path().join("inner"));
+    let l = fs_tlock(dir.path().join("outer"), dir.path().join("inner"));
 
     // upgradable read -> upgrade -> exclusive
     let r = l.upgradable_read(&ct()).await.unwrap();
@@ -50,7 +59,7 @@ async fn fs_two_upgraders_no_deadlock() {
         let outer = Arc::clone(&outer);
         let inner = Arc::clone(&inner);
         tokio::spawn(async move {
-            let l = crate::hlock::fs_tlock(&*outer, &*inner);
+            let l = fs_tlock(&*outer, &*inner);
             let u = l.upgradable_read(&ct()).await.unwrap();
             let w = u.upgrade(&ct()).await.unwrap();
             tokio::time::sleep(Duration::from_millis(20)).await;
@@ -74,8 +83,8 @@ async fn fs_bridge_writers_serialize_across_instances() {
     let dir = tempfile::tempdir().expect("tempdir");
     let outer = dir.path().join("outer");
     let inner = dir.path().join("inner");
-    let a = crate::hlock::fs_tlock(&outer, &inner);
-    let b = crate::hlock::fs_tlock(&outer, &inner);
+    let a = fs_tlock(&outer, &inner);
+    let b = fs_tlock(&outer, &inner);
 
     let _w = a.write(&ct()).await.unwrap();
     assert!(


### PR DESCRIPTION
## Summary
- **Real bug, fixed first**: `sweep_stale_sandboxfuse_dirs` probed liveness with `kill(pid, 0)` and treated `EPERM` as dead. `EPERM` means the process exists but isn't ours — that's *alive*. The inversion let the sweep reclaim a live process's sandbox dir. `EngineFuse` now holds an `flock` on `<dir>/lock` for its whole lifetime, and the sweep probes that lock via `FLock::is_path_held` instead of the pid — the same approach #246 used for the result-lock gateway, immune to the EPERM inversion, pid reuse, and zombies.
- **`fs_tlock` deleted**: it had no production caller (documented rather than deleted in #246 to keep a public-API change out of that PR). Its own bridge tests now build the equivalent `TBridge::new(FLock::new(..), FRWLock::new(..))` inline as a private test helper.
- **Consolidated three near-identical `LocalCache` test doubles** (`gc.rs::CountingCache`, `result.rs::CountingCache`, `result.rs::TrimThreadCache`) into one shared `ForwardingCache` (`local_cache_test_double.rs`) that forwards every call to `inner` with optional hooks on `reader`/`exists`/`list_target_entries`. Closes the gap that let #252 happen: a trait method forwarded correctly on the copies a PR's author remembers to touch, missed on the one they don't, compiling green until an unrelated PR reddens.

## Test plan
- [x] New tests for `sweep_stale_sandboxfuse_dirs`: a dir whose lock is held survives the sweep; a dir whose lock isn't held is reclaimed; non-matching dir names are left alone.
- [x] Verified red without the fix: temporarily restored the old `kill(pid, 0)`-based body (from `origin/master`) with the new tests in place — `sweep_preserves_a_dir_whose_lock_is_held` failed exactly as expected (dir naming pid 1, always alive, always EPERM for a non-root caller, got wrongly reclaimed). Restored via `git checkout HEAD --` after confirming.
- [x] New `ForwardingCache` test (`unset_hooks_are_silent_and_set_hooks_fire_only_their_own_call`), sanity-checked by deliberately cross-wiring `on_exists` to fire `on_reader` — the test caught it, then reverted.
- [x] All touched suites pass: `cargo test -p engine --lib` (sweep/local_cache_test_double/gc/result subsets) and `cargo test -p lock --lib` (full crate, including relocated `fs_bridge` tests).
- [x] `cargo test --no-run -p engine -p lock` (compiles cleanly, not just clippy-clean).
- [x] `lint` (clippy `-D warnings`, both feature sets, + fmt) from the workspace root — clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WUmnoqE8NnGm4SF8UyBEKs