### PR TITLE
fix(validate): give each concurrent check its own RequestState

### DIFF
--- a/src/commands/validate.rs
+++ b/src/commands/validate.rs
@@ -9,6 +9,8 @@ use futures::TryStreamExt;
 use crate::commands::GlobalOptions;
 use crate::commands::bootstrap;
 use crate::engine::error::{MultiError, TargetNotFoundError};
+use crate::engine::event::EventSender;
+use crate::engine::request_state::RequestState;
 use crate::engine::{Engine, get_cwp, get_root, gitignore};
 use crate::hmemoizer::downcast_chain_ref;
 use crate::htaddr::Addr;
@@ -56,7 +58,8 @@ impl App for ValidateApp {
             root,
             fail_fast,
         } = self;
-        let rs = engine.new_state_with_events(fail_fast, ctx.event_sender());
+        let (rs, overlap_rs, gitignore_rs) =
+            independent_check_states(&engine, fail_fast, ctx.event_sender());
 
         // Overlap detection scopes to the user matcher when scoped, else uses the
         // codegen-tree selector (same one the gitignore enumeration uses).
@@ -106,14 +109,14 @@ impl App for ValidateApp {
             });
 
             // 2. Detect overlapping `codegen = copy` outputs.
-            let overlap_fut = enclose!((engine, rs) async move {
+            let overlap_fut = enclose!((engine, overlap_rs => rs) async move {
                 Arc::clone(&engine)
                     .codegen_copy_overlaps(rs.clone(), &overlap_matcher)
                     .await
             });
 
             // 3. Verify `.gitignore` is up to date (whole-workspace runs only).
-            let gitignore_fut = enclose!((engine, rs) async move {
+            let gitignore_fut = enclose!((engine, gitignore_rs => rs) async move {
                 if scoped {
                     return Ok::<bool, anyhow::Error>(false);
                 }
@@ -180,6 +183,33 @@ impl App for ValidateApp {
     }
 }
 
+/// One `RequestState` per concurrent check, never shared.
+///
+/// `link_fut`, `overlap_fut` and `gitignore_fut` run concurrently via
+/// `tokio::join!`, and `overlap_fut`/`gitignore_fut` walk with
+/// `Matcher::TreeOutputTo`, which hits the `MatchShrug` arm for every
+/// candidate. `mem_spec`/`mem_def` live on `RequestState::data`, so two
+/// concurrent walks sharing one `RequestState` race the same addr's `mem_spec`
+/// cell. Speculative cycle detection is a per-chain breadcrumb, not the shared
+/// `DepDag` (see `Engine::query`'s doc comment), so a losing chain's spurious
+/// `CycleError` can make the *other* chain's provider resolution win the
+/// memoized cell — and `def.driver` folds into `hashin`. Giving each
+/// concurrent walk its own `RequestState` restores the "one chain per walk"
+/// guarantee the speculative check already assumes, at the cost of
+/// re-resolving spec/def independently per check instead of sharing memoized
+/// work across them.
+fn independent_check_states(
+    engine: &Arc<Engine>,
+    fail_fast: bool,
+    events: Option<EventSender>,
+) -> (Arc<RequestState>, Arc<RequestState>, Arc<RequestState>) {
+    (
+        engine.new_state_with_events(fail_fast, events.clone()),
+        engine.new_state_with_events(fail_fast, events.clone()),
+        engine.new_state_with_events(fail_fast, events),
+    )
+}
+
 /// Fold the outcome of every validate check into a single result. Each check
 /// contributes either a list of human-readable problem strings (`Ok`) or a hard
 /// error (`Err`); a check's `Err` that is itself a [`MultiError`] is flattened
@@ -232,12 +262,55 @@ async fn execute_async(
 
 #[cfg(test)]
 mod tests {
-    use super::finish;
+    use super::{finish, independent_check_states};
     use crate::engine::error::MultiError;
+    use crate::engine::{Config, Engine};
 
     #[test]
     fn all_checks_ok_is_ok() {
         assert!(finish(vec![Ok(vec![]), Ok(vec![]), Ok(vec![])]).is_ok());
+    }
+
+    /// Regression guard for the concurrent-chain race documented on
+    /// `independent_check_states`: `link_fut`, `overlap_fut` and
+    /// `gitignore_fut` must never share a `RequestState`, or their concurrent
+    /// `Matcher::TreeOutputTo` walks can race the same addr's `mem_spec` cell
+    /// and let scheduling decide which provider's `driver` feeds `hashin`.
+    /// Each `RequestState` carries a fresh, unique `request_id` (see
+    /// `Engine::new_state_inner`), which is exactly the identity `mem_spec`/
+    /// `mem_def` are keyed under — so distinct ids here is what proves the
+    /// three checks cannot share that memoization.
+    #[test]
+    fn check_states_are_never_shared() {
+        let root = tempfile::tempdir().expect("tempdir");
+        let engine = Engine::new(Config {
+            root: root.path().to_path_buf(),
+            home_dir: root.path().join(".heph3"),
+            parallelism: None,
+            ..Default::default()
+        })
+        .expect("engine");
+        let engine = std::sync::Arc::new(engine);
+
+        let (rs, overlap_rs, gitignore_rs) = independent_check_states(&engine, true, None);
+
+        let ids = [
+            rs.request_id(),
+            overlap_rs.request_id(),
+            gitignore_rs.request_id(),
+        ];
+        assert_ne!(
+            ids[0], ids[1],
+            "link and overlap checks share a RequestState"
+        );
+        assert_ne!(
+            ids[0], ids[2],
+            "link and gitignore checks share a RequestState"
+        );
+        assert_ne!(
+            ids[1], ids[2],
+            "overlap and gitignore checks share a RequestState"
+        );
     }
 
     #[test]


### PR DESCRIPTION
## Summary

Investigated as part of a 4-item concurrency-remediation risk review (W7). Full write-up in the review's report; this PR is item 3.

`heph validate` runs `link`/`overlap`/`gitignore` concurrently via `tokio::join!` on one shared `RequestState`. The overlap and gitignore checks walk with `Matcher::TreeOutputTo("")`, hitting the `MatchShrug` arm, which resolves candidates on a *speculative* `RequestState` whose cycle detection is a per-chain breadcrumb walk, not the shared `DepDag`. `mem_spec`/`mem_def`, however, live on the shared `RequestState::data` — so two concurrent chains sharing one `RequestState` can race the same addr's `mem_spec` cell. `get_spec_inner` skips a provider whose `get()` spuriously cycles and falls through to the next one (named in-code example: the go provider over-claiming a buildfile codegen target), so whichever chain wins the `mem_spec` race decides which provider resolves an ambiguous addr — and `def.driver` folds into `hashin`.

Pre-existing (predates #247, whose own comment in `query.rs` correctly scopes its "one chain per walk" guarantee to a single walk and explicitly names this validate case as an exposure it does not close). `validate` never calls `execute()`/writes the cache, so nothing is poisoned today — the directly observable effect is validate's own overlap/gitignore checks potentially flapping run-to-run for such addrs. Consulted the hermeticity reviewer: verdict MAJOR (not BLOCKER, for the reason above), recommended the smallest correct fix.

- Give each of the three concurrent checks its own `RequestState` instead of sharing one — restores "one chain per walk" structurally (separate `RequestStateData` ⇒ separate memoizers ⇒ nothing left to race), rather than serializing away validate's concurrency.
- Cost: the three checks no longer share spec/def memoization, so validate does somewhat more resolution work than before.
- Command-layer only; no engine-core change.

## Test plan

- [x] `cargo test -p heph --lib check_states_are_never_shared` — new regression test pinning the exact property the fix relies on (three distinct `request_id`s from the extracted `independent_check_states` helper `run()` calls)
- [x] `cargo check -p heph --tests` clean
- [x] `cargo fmt --check` clean for touched file
- [x] `cargo clippy -p heph -- -D warnings` clean (full-workspace `lint` currently fails on unrelated pre-existing code in `crates/proc`/`crates/plugin` under `--all-targets`, confirmed independent of this change)

A full race-repro test (two ambiguous-provider addrs, forced-ordering barrier) was considered but not built: the fix removes the shared state the race needs by construction, so there's no longer a race to reproduce at the validate.rs level.

🤖 Generated with [Claude Code](https://claude.com/claude-code)