### PR TITLE
fix(engine): reject a Provider::list() call that reenters query()

### DIFF
--- a/crates/engine/src/engine/query.rs
+++ b/crates/engine/src/engine/query.rs
@@ -151,7 +151,11 @@ impl Engine {
                     let states = Arc::clone(&engine).probe_segments(&rs, &pkg).await?;
 
                     for provider in &engine.providers {
-                        let it = provider.provider.list(ListRequest {
+                        // Scoped under `IN_PROVIDER_LIST` so a reentrant
+                        // `executor.query()` called from inside this `list()` is
+                        // caught rather than silently nested — see its doc
+                        // comment in `result.rs`.
+                        let it = crate::engine::result::IN_PROVIDER_LIST.scope((), provider.provider.list(ListRequest {
                             request_id: rs.request_id().to_string(),
                             package: pkg.clone(),
                             states: states
@@ -160,7 +164,7 @@ impl Engine {
                                 .cloned()
                                 .collect(),
                             executor: Arc::clone(&executor),
-                        }, rs.ctoken()).await?;
+                        }, rs.ctoken())).await?;
                         // The iterator is not `Send`; drain it before the next await.
                         let raw: Vec<_> = it.collect::<anyhow::Result<Vec<_>>>()?;
 

--- a/crates/engine/src/engine/result.rs
+++ b/crates/engine/src/engine/result.rs
@@ -44,6 +44,24 @@ const RESULT_LOCK_NOTICE: std::time::Duration = std::time::Duration::from_secs(5
 type BoxedResultFuture<'a> =
     Pin<Box<dyn Future<Output = anyhow::Result<Arc<EResult>>> + Send + 'a>>;
 
+tokio::task_local! {
+    /// Set for the duration of a `Provider::list` call dispatched by a
+    /// discovery walk's per-package fan-out — both `Engine::query`'s (in
+    /// `query.rs`) and `EngineProviderExecutor::query`'s own nested one (below)
+    /// scope this around their `.list(...)` call.
+    ///
+    /// `ListRequest::executor` hands `list()` implementations the same `query()`
+    /// capability `get()` gets (see the ABI note at the `query()` call site). A
+    /// provider that calls `executor.query()` back from inside its own `list()`
+    /// would nest another K-wide walk under an already-running one — degrading to
+    /// pinned memory and scheduler pressure rather than a hard deadlock (nesting
+    /// doesn't manufacture extra `PKG_EVAL_SLOTS` permits, see the long comment at
+    /// the fan-out), but with no in-tree caller and no diagnostic if a third-party
+    /// or out-of-process plugin ever does it by accident. `query()` checks this
+    /// flag first and fails loudly instead of silently nesting.
+    pub(crate) static IN_PROVIDER_LIST: ();
+}
+
 /// rs carries the parent addr (set by result_addr via with_parent) so the executor
 /// does not need to store it separately.
 pub(crate) struct EngineProviderExecutor {
@@ -234,6 +252,16 @@ impl ProviderExecutor for EngineProviderExecutor {
         extra_skip: &'a [String],
     ) -> futures::future::BoxFuture<'a, anyhow::Result<Vec<Addr>>> {
         Box::pin(async move {
+            // See `IN_PROVIDER_LIST`: a provider calling back into `query()` from
+            // its own `list()` would nest a K-wide walk under an already-running
+            // one. Fail loudly here rather than let it silently nest.
+            if IN_PROVIDER_LIST.try_with(|()| ()).is_ok() {
+                anyhow::bail!(
+                    "ListRequest::executor.query() was called from inside Provider::list() \
+                     — this would nest a K-wide package walk under an already-running one; \
+                     use ProviderExecutor::states_under instead"
+                );
+            }
             let engine = self
                 .engine
                 .upgrade()
@@ -277,7 +305,8 @@ impl ProviderExecutor for EngineProviderExecutor {
             // concurrent `list` calls, so a provider that calls back into it from
             // `list` gets K nested walks. No in-tree provider does (plugin-go's
             // `list` calls only `states_under`), but it is a constraint on the
-            // plugin surface, not an accident of the current callers.
+            // plugin surface, not an accident of the current callers — and it is
+            // enforced below (`IN_PROVIDER_LIST`), not just documented here.
             let per_pkg = futures::stream::iter(pkgs.into_iter()
                 // Ends the source when abandoning, so the drain joins only the
                 // <=K tasks already spawned instead of spawning one per remaining
@@ -316,21 +345,25 @@ impl ProviderExecutor for EngineProviderExecutor {
                             {
                                 continue;
                             }
-                            // Collect list results eagerly (non-Send iterator dropped before next await)
-                            let list_iter = provider
-                                .provider
-                                .list(
-                                    ListRequest {
-                                        request_id: rs.request_id().to_string(),
-                                        package: pkg.clone(),
-                                        states: states
-                                            .iter()
-                                            .filter(|s| s.provider == provider.name)
-                                            .cloned()
-                                            .collect(),
-                                        executor: Arc::clone(&executor),
-                                    },
-                                    rs.ctoken(),
+                            // Collect list results eagerly (non-Send iterator dropped before next await).
+                            // Scoped under `IN_PROVIDER_LIST` so a reentrant `executor.query()`
+                            // called from inside this `list()` is caught — see its doc comment.
+                            let list_iter = IN_PROVIDER_LIST
+                                .scope(
+                                    (),
+                                    provider.provider.list(
+                                        ListRequest {
+                                            request_id: rs.request_id().to_string(),
+                                            package: pkg.clone(),
+                                            states: states
+                                                .iter()
+                                                .filter(|s| s.provider == provider.name)
+                                                .cloned()
+                                                .collect(),
+                                            executor: Arc::clone(&executor),
+                                        },
+                                        rs.ctoken(),
+                                    ),
                                 )
                                 .await?;
                             let raw: Vec<_> = list_iter.collect::<anyhow::Result<Vec<_>>>()?;
@@ -6945,6 +6978,106 @@ mod tests {
                 )
             })??;
         assert!(addrs.is_empty(), "no target has this label, got {addrs:?}");
+        Ok(())
+    }
+
+    /// A `list()` implementation that calls back into `req.executor.query()` —
+    /// exactly the reentrant call `IN_PROVIDER_LIST` exists to catch (see its doc
+    /// comment). No in-tree provider does this, but nothing stopped a third-party
+    /// or out-of-process one from nesting a second K-wide walk under the one
+    /// already dispatching this `list()` call, silently, with no diagnostic.
+    /// Must fail loudly instead.
+    #[tokio::test]
+    async fn list_calling_back_into_query_is_rejected() -> anyhow::Result<()> {
+        struct ReentrantQueryProvider {
+            pkg: String,
+        }
+
+        impl crate::engine::provider::Provider for ReentrantQueryProvider {
+            fn config(&self, _req: ConfigRequest) -> anyhow::Result<ConfigResponse> {
+                Ok(ConfigResponse {
+                    name: "reentrant".to_string(),
+                })
+            }
+            fn list<'a>(
+                &'a self,
+                req: ListRequest,
+                _ctoken: &'a (dyn Cancellable + Send + Sync),
+            ) -> BoxFuture<
+                'a,
+                anyhow::Result<Box<dyn Iterator<Item = anyhow::Result<ListResponse>> + Send>>,
+            > {
+                Box::pin(async move {
+                    // Incorrect provider behaviour: calling back into `query()`
+                    // from inside `list()`. This must error, not nest.
+                    req.executor
+                        .query(&Matcher::PackagePrefix(PkgBuf::from("")), &[])
+                        .await?;
+                    Ok(Box::new(std::iter::empty()) as Box<dyn Iterator<Item = _> + Send>)
+                })
+            }
+            fn list_packages<'a>(
+                &'a self,
+                _req: ListPackagesRequest,
+                _ctoken: &'a (dyn Cancellable + Send + Sync),
+            ) -> BoxFuture<
+                'a,
+                anyhow::Result<
+                    Box<dyn Iterator<Item = anyhow::Result<ListPackageResponse>> + Send>,
+                >,
+            > {
+                let pkg = self.pkg.clone();
+                Box::pin(async move {
+                    let items: Vec<anyhow::Result<ListPackageResponse>> =
+                        vec![Ok(ListPackageResponse {
+                            pkg: PkgBuf::from(pkg.as_str()),
+                        })];
+                    Ok(Box::new(items.into_iter()) as Box<dyn Iterator<Item = _> + Send>)
+                })
+            }
+            fn get<'a>(
+                &'a self,
+                _req: GetRequest,
+                _ctoken: &'a (dyn Cancellable + Send + Sync),
+            ) -> BoxFuture<'a, Result<GetResponse, GetError>> {
+                Box::pin(async { Err(GetError::NotFound) })
+            }
+            fn probe<'a>(
+                &'a self,
+                _req: ProbeRequest,
+                _ctoken: &'a (dyn Cancellable + Send + Sync),
+            ) -> BoxFuture<'a, anyhow::Result<ProbeResponse>> {
+                Box::pin(async { Ok(ProbeResponse { states: vec![] }) })
+            }
+        }
+
+        let root = tempdir()?;
+        let mut engine = Engine::new(Config {
+            root: root.path().to_path_buf(),
+            home_dir: std::path::PathBuf::new(),
+            parallelism: None,
+            ..Default::default()
+        })?;
+        engine.register_provider(|_| {
+            Box::new(ReentrantQueryProvider {
+                pkg: "p".to_string(),
+            })
+        })?;
+        let engine = SArc::new(engine);
+        let rs = engine.new_state();
+
+        let matcher = Matcher::PackagePrefix(PkgBuf::from(""));
+        let err = SArc::clone(&engine)
+            .query(rs, &matcher)
+            .try_collect::<Vec<Addr>>()
+            .await
+            .expect_err(
+                "a list() that calls back into query() must be rejected, not silently nested",
+            );
+        assert!(
+            format!("{err:#}").contains("Provider::list"),
+            "expected the reentrancy error, got: {err:#}"
+        );
         Ok(())
     }
 

--- a/crates/plugin/src/provider.rs
+++ b/crates/plugin/src/provider.rs
@@ -109,6 +109,15 @@ pub trait ProviderExecutor: Send + Sync {
     /// `Engine::get_spec`, which registers `parent → addr` in the `DepDag`.
     /// Do not memoize this on the matcher in a provider — waiters would bypass
     /// the dep registration and a target-dep cycle would hide as a deadlock.
+    ///
+    /// **Do not call this from [`Provider::list`].** `ListRequest::executor`
+    /// hands `list()` this same `query()`, but `list()` itself runs inside one
+    /// of an already K-wide concurrent package fan-out; calling back into
+    /// `query()` from there nests another K-wide walk under it. The engine's
+    /// executor detects and rejects this reentrant call with an error rather
+    /// than nesting silently — use [`ProviderExecutor::states_under`] instead,
+    /// which is what `list()` implementations that need cross-package state
+    /// (e.g. a Go module's variant universe) are for.
     fn query<'a>(
         &'a self,
         m: &'a Matcher,
@@ -359,6 +368,10 @@ pub trait Provider: Send + Sync {
     /// come off a filesystem walk — therefore gives the same tree a different
     /// build definition, and a different list-file order, on every run. Sort, or
     /// preserve a stable walk order.
+    ///
+    /// `req.executor` must not have [`ProviderExecutor::query`] called on it from
+    /// here — see that method's doc for why. Use
+    /// [`ProviderExecutor::states_under`] for cross-package state instead.
     fn list<'a>(
         &'a self,
         req: ListRequest,


### PR DESCRIPTION
## Summary

Investigated as part of a 4-item concurrency-remediation risk review (W7). Full write-up in the review's report; this PR is item 4.

`ListRequest::executor` hands `list()` implementations the same `query()` capability `get()` gets, wired end-to-end including across the cdylib ABI — reachable by third-party/out-of-process plugin authors, not just reviewed in-tree code. #247 made the discovery fan-out K-wide (`discovery_concurrency()`), so a `list()` that calls back into `query()` nests another K-wide walk under the one already dispatching it: K x depth live orchestration state. Work stays capped by `PKG_EVAL_SLOTS` regardless, so this degrades to resource/scheduler pressure rather than a hard deadlock for the in-process path — but no in-tree provider does this (plugin-go's `list` uses only `states_under`; pluginquery calls `query()` only from `get()`), and nothing stopped a third-party one from doing it by accident with zero diagnostic beyond a silent, RAM-heavier walk.

The only prose warning about this lived in an internal comment inside `crates/engine`, a crate no plugin author (in-tree or third-party) has any code path to see — `plugin-sdk`, the actual author-facing contract, never depends on `engine`. A doc-only constraint wasn't enough given the reachability and the silent-hang failure mode.

- Add a `tokio::task_local!` guard (`IN_PROVIDER_LIST`) scoped around every `Provider::list()` dispatch site (both `Engine::query` in `query.rs` and `EngineProviderExecutor::query`'s own nested fan-out in `result.rs`).
- `EngineProviderExecutor::query()` checks it first and fails loudly with a clear message instead of nesting silently.
- Moved the warning onto the ABI-facing types plugin authors actually implement against (`ProviderExecutor::query` and `Provider::list` docs in `crates/plugin/src/provider.rs`).

## Test plan

- [x] `cargo test -p engine --lib list_calling_back_into_query_is_rejected` — new test, a mock provider whose `list()` calls back into `executor.query()`, asserting the walk now errors instead of nesting
- [x] `cargo test -p engine --lib` regression sweep on the touched paths: `discovery_fanout_does_not_starve_the_matcher_consumer`, `executor_query_fanout_does_not_starve_its_consumer`, and the full `query::` module (24 tests) all still pass — the guard doesn't disturb any legitimate (non-reentrant) `list()`/`query()` call
- [x] `cargo check -p engine --tests` clean
- [x] `cargo fmt --check` clean for touched files
- [x] `cargo clippy -p engine -p plugin -- -D warnings` clean (full-workspace `lint` currently fails on unrelated pre-existing code in `crates/proc`/`crates/plugin` under `--all-targets`, confirmed independent of this change)

🤖 Generated with [Claude Code](https://claude.com/claude-code)