### PR TITLE
fix(diag,cli): stall-watchdog double-sample, poisoned diag locks, typed --shell error

### DIFF
--- a/crates/core/src/hmemoizer/mod.rs
+++ b/crates/core/src/hmemoizer/mod.rs
@@ -8,7 +8,7 @@ use std::future::Future;
 use std::hash::{Hash, Hasher};
 use std::sync::Arc;
 use std::sync::atomic::{AtomicU64, Ordering};
-use std::sync::{Mutex, OnceLock};
+use std::sync::{Mutex, OnceLock, PoisonError};
 use std::time::Duration;
 use xxhash_rust::xxh3::Xxh3Default;
 
@@ -232,7 +232,19 @@ pub fn dump_phases() -> String {
     if !phase_trace_enabled() {
         return format!("  (phase trace disabled — set {PHASE_TRACE_VAR}=1)");
     }
-    let map = phases().lock().expect("phases mutex poisoned");
+    format_phases()
+}
+
+/// The lock-and-format half of [`dump_phases`], split out so a poisoned-lock
+/// recovery can be exercised directly — `phase_trace_enabled` caches its
+/// answer for the process, so a test cannot reliably force this past the gate
+/// above once any other test in the binary has read the flag first.
+fn format_phases() -> String {
+    // A panic while some other caller held this lock (mid `set_phase` or
+    // `clear_phase`) must not turn this diagnostic dump into a second panic —
+    // recover the guard rather than propagating the poison, same as
+    // `ApprovalCenter::lock`.
+    let map = phases().lock().unwrap_or_else(PoisonError::into_inner);
     if map.is_empty() {
         return "  (none)".to_string();
     }
@@ -672,6 +684,13 @@ impl ReportSnapshot {
             phases,
         }
     }
+
+    /// The sampled cells, for a caller that needs to hand the *same* sample to
+    /// more than one renderer (see the stall watchdog's `sample_once`) instead
+    /// of taking a second, independent live read.
+    pub fn cells(&self) -> &[StuckCell] {
+        &self.cells
+    }
 }
 
 /// Sample the in-flight state once, for [`render_report`].
@@ -1095,7 +1114,16 @@ pub fn dump_wait_graph() -> String {
     if !cycle_detection_enabled() {
         return "  (cycle detection disabled — set HEPH_DEBUG_MEMOIZER_CYCLE=1)".to_string();
     }
-    let wg = wait_graph().lock().expect("wait_graph poisoned");
+    format_wait_graph()
+}
+
+/// The lock-and-format half of [`dump_wait_graph`], split out for the same
+/// reason as [`format_phases`]: `cycle_detection_enabled` is a process-cached
+/// flag, so a test cannot force this past the gate above on demand.
+fn format_wait_graph() -> String {
+    // Recover a poisoned guard instead of panicking a second time — see
+    // `format_phases`.
+    let wg = wait_graph().lock().unwrap_or_else(PoisonError::into_inner);
     let mut out = String::new();
     if wg.cells.is_empty() && wg.waiting.is_empty() {
         out.push_str("  (empty)");
@@ -2326,6 +2354,49 @@ mod tests {
         );
         assert!(text.contains("memoizer wait-for graph"), "{text}");
         assert!(text.contains("memoizer phases"), "{text}");
+    }
+
+    /// A panic while some other caller held the `phases` lock must not turn
+    /// `dump_phases`'s dump into a second panic — it should recover the
+    /// poisoned guard and still render, same as `ApprovalCenter::lock`.
+    ///
+    /// Goes through `format_phases` directly rather than `dump_phases`:
+    /// `phase_trace_enabled` caches its answer for the whole process the
+    /// first time anything reads it, so a test cannot reliably force
+    /// `dump_phases` past its disabled-gate once some other test in this
+    /// binary has already read the flag as `false`.
+    #[test]
+    fn format_phases_recovers_from_a_poisoned_lock() {
+        drop(
+            std::thread::spawn(|| {
+                let _guard = phases().lock().expect("lock for poisoning");
+                panic!("intentional poison for format_phases_recovers_from_a_poisoned_lock");
+            })
+            .join(),
+        );
+
+        // Before the fix, this line panics with "phases mutex poisoned"
+        // instead of returning.
+        let text = format_phases();
+        assert!(text.contains("(none)") || text.contains("inv "), "{text}");
+    }
+
+    /// Same as `format_phases_recovers_from_a_poisoned_lock`, for the
+    /// wait-for-graph lock.
+    #[test]
+    fn format_wait_graph_recovers_from_a_poisoned_lock() {
+        drop(
+            std::thread::spawn(|| {
+                let _guard = wait_graph().lock().expect("lock for poisoning");
+                panic!("intentional poison for format_wait_graph_recovers_from_a_poisoned_lock");
+            })
+            .join(),
+        );
+
+        // Before the fix, this line panics with "wait_graph poisoned" instead
+        // of returning.
+        let text = format_wait_graph();
+        assert!(text.contains("(empty)") || text.contains("cells (owned)"), "{text}");
     }
 
     #[test]

--- a/crates/core/src/hmemoizer/mod.rs
+++ b/crates/core/src/hmemoizer/mod.rs
@@ -2387,16 +2387,14 @@ mod tests {
     #[test]
     fn format_phases_recovers_from_a_poisoned_lock() {
         let m: Mutex<HashMap<u64, &'static str>> = Mutex::new(HashMap::new());
-        drop(
-            std::thread::scope(|scope| {
-                scope
-                    .spawn(|| {
-                        let _guard = m.lock().expect("lock for poisoning");
-                        panic!("intentional poison for format_phases_recovers_from_a_poisoned_lock");
-                    })
-                    .join()
-            }),
-        );
+        drop(std::thread::scope(|scope| {
+            scope
+                .spawn(|| {
+                    let _guard = m.lock().expect("lock for poisoning");
+                    panic!("intentional poison for format_phases_recovers_from_a_poisoned_lock");
+                })
+                .join()
+        }));
 
         // Before the fix, this line panics with "phases mutex poisoned"
         // instead of returning.
@@ -2409,23 +2407,24 @@ mod tests {
     #[test]
     fn format_wait_graph_recovers_from_a_poisoned_lock() {
         let m: Mutex<WaitGraph> = Mutex::new(WaitGraph::new());
-        drop(
-            std::thread::scope(|scope| {
-                scope
-                    .spawn(|| {
-                        let _guard = m.lock().expect("lock for poisoning");
-                        panic!(
-                            "intentional poison for format_wait_graph_recovers_from_a_poisoned_lock"
-                        );
-                    })
-                    .join()
-            }),
-        );
+        drop(std::thread::scope(|scope| {
+            scope
+                .spawn(|| {
+                    let _guard = m.lock().expect("lock for poisoning");
+                    panic!(
+                        "intentional poison for format_wait_graph_recovers_from_a_poisoned_lock"
+                    );
+                })
+                .join()
+        }));
 
         // Before the fix, this line panics with "wait_graph poisoned" instead
         // of returning.
         let text = format_wait_graph_from(&m);
-        assert!(text.contains("(empty)") || text.contains("cells (owned)"), "{text}");
+        assert!(
+            text.contains("(empty)") || text.contains("cells (owned)"),
+            "{text}"
+        );
     }
 
     #[test]

--- a/crates/core/src/hmemoizer/mod.rs
+++ b/crates/core/src/hmemoizer/mod.rs
@@ -240,11 +240,20 @@ pub fn dump_phases() -> String {
 /// answer for the process, so a test cannot reliably force this past the gate
 /// above once any other test in the binary has read the flag first.
 fn format_phases() -> String {
+    format_phases_from(phases())
+}
+
+/// Takes the mutex as a parameter (rather than reading the `phases()` static
+/// directly) so a test can poison a private `Mutex` of its own to exercise
+/// the recovery below, instead of poisoning the process-wide static — which
+/// every other test in the binary also locks, permanently, for the rest of
+/// the process.
+fn format_phases_from(m: &Mutex<HashMap<u64, &'static str>>) -> String {
     // A panic while some other caller held this lock (mid `set_phase` or
     // `clear_phase`) must not turn this diagnostic dump into a second panic —
     // recover the guard rather than propagating the poison, same as
     // `ApprovalCenter::lock`.
-    let map = phases().lock().unwrap_or_else(PoisonError::into_inner);
+    let map = m.lock().unwrap_or_else(PoisonError::into_inner);
     if map.is_empty() {
         return "  (none)".to_string();
     }
@@ -1121,9 +1130,16 @@ pub fn dump_wait_graph() -> String {
 /// reason as [`format_phases`]: `cycle_detection_enabled` is a process-cached
 /// flag, so a test cannot force this past the gate above on demand.
 fn format_wait_graph() -> String {
+    format_wait_graph_from(wait_graph())
+}
+
+/// Takes the mutex as a parameter for the same reason as
+/// [`format_phases_from`]: so a test can poison a private `Mutex` instead of
+/// the process-wide static.
+fn format_wait_graph_from(m: &Mutex<WaitGraph>) -> String {
     // Recover a poisoned guard instead of panicking a second time — see
     // `format_phases`.
-    let wg = wait_graph().lock().unwrap_or_else(PoisonError::into_inner);
+    let wg = m.lock().unwrap_or_else(PoisonError::into_inner);
     let mut out = String::new();
     if wg.cells.is_empty() && wg.waiting.is_empty() {
         out.push_str("  (empty)");
@@ -2360,24 +2376,31 @@ mod tests {
     /// `dump_phases`'s dump into a second panic — it should recover the
     /// poisoned guard and still render, same as `ApprovalCenter::lock`.
     ///
-    /// Goes through `format_phases` directly rather than `dump_phases`:
-    /// `phase_trace_enabled` caches its answer for the whole process the
-    /// first time anything reads it, so a test cannot reliably force
-    /// `dump_phases` past its disabled-gate once some other test in this
-    /// binary has already read the flag as `false`.
+    /// Goes through `format_phases_from` on a private `Mutex`, for two
+    /// reasons: `phase_trace_enabled` caches its answer for the whole
+    /// process the first time anything reads it, so a test cannot reliably
+    /// force `dump_phases` past its disabled-gate once some other test in
+    /// this binary has already read the flag as `false`; and poisoning the
+    /// real `phases()` static would poison it for every other test in this
+    /// binary for the rest of the process (a `Mutex`'s poison never clears),
+    /// not just this one.
     #[test]
     fn format_phases_recovers_from_a_poisoned_lock() {
+        let m: Mutex<HashMap<u64, &'static str>> = Mutex::new(HashMap::new());
         drop(
-            std::thread::spawn(|| {
-                let _guard = phases().lock().expect("lock for poisoning");
-                panic!("intentional poison for format_phases_recovers_from_a_poisoned_lock");
-            })
-            .join(),
+            std::thread::scope(|scope| {
+                scope
+                    .spawn(|| {
+                        let _guard = m.lock().expect("lock for poisoning");
+                        panic!("intentional poison for format_phases_recovers_from_a_poisoned_lock");
+                    })
+                    .join()
+            }),
         );
 
         // Before the fix, this line panics with "phases mutex poisoned"
         // instead of returning.
-        let text = format_phases();
+        let text = format_phases_from(&m);
         assert!(text.contains("(none)") || text.contains("inv "), "{text}");
     }
 
@@ -2385,17 +2408,23 @@ mod tests {
     /// wait-for-graph lock.
     #[test]
     fn format_wait_graph_recovers_from_a_poisoned_lock() {
+        let m: Mutex<WaitGraph> = Mutex::new(WaitGraph::new());
         drop(
-            std::thread::spawn(|| {
-                let _guard = wait_graph().lock().expect("lock for poisoning");
-                panic!("intentional poison for format_wait_graph_recovers_from_a_poisoned_lock");
-            })
-            .join(),
+            std::thread::scope(|scope| {
+                scope
+                    .spawn(|| {
+                        let _guard = m.lock().expect("lock for poisoning");
+                        panic!(
+                            "intentional poison for format_wait_graph_recovers_from_a_poisoned_lock"
+                        );
+                    })
+                    .join()
+            }),
         );
 
         // Before the fix, this line panics with "wait_graph poisoned" instead
         // of returning.
-        let text = format_wait_graph();
+        let text = format_wait_graph_from(&m);
         assert!(text.contains("(empty)") || text.contains("cells (owned)"), "{text}");
     }
 

--- a/crates/engine/src/engine/diag.rs
+++ b/crates/engine/src/engine/diag.rs
@@ -1198,11 +1198,33 @@ pub struct Watchdog {
     stop: std::sync::Arc<std::sync::atomic::AtomicBool>,
 }
 
+/// Sample the in-flight state exactly once for a firing `report`, via
+/// `capture`, and stamp `report.stuck` from that same sample.
+///
+/// The capped paragraph (`report.stuck`, rendered by [`render_stall`]) and the
+/// uncapped companion file (the returned snapshot, rendered by
+/// [`InflightLog::render`]) used to each call the live global registry on
+/// their own — one via `hcore::hmemoizer::inventory()` here, the other via
+/// `hcore::hmemoizer::capture_report()` at the call site in `heph run`. Two
+/// reads of state that moves while a build runs can disagree, so a reader
+/// diffing the two files for a hang could see the paragraph name a cell the
+/// companion file's listing does not contain. Splitting the sample from the
+/// two renders — same shape as `capture_report`/`render_report` — makes
+/// "one sample feeds both" a property `emit`'s caller cannot opt out of.
+fn sample_once(
+    mut report: StallReport,
+    capture: impl FnOnce() -> hcore::hmemoizer::ReportSnapshot,
+) -> (StallReport, hcore::hmemoizer::ReportSnapshot) {
+    let snapshot = capture();
+    report.stuck = snapshot.cells().to_vec();
+    (report, snapshot)
+}
+
 impl Watchdog {
     pub fn spawn(
         state: std::sync::Arc<DiagState>,
         threshold: Duration,
-        emit: impl Fn(&StallReport) + Send + 'static,
+        emit: impl Fn(&StallReport, &hcore::hmemoizer::ReportSnapshot) + Send + 'static,
     ) -> Self {
         let stop = std::sync::Arc::new(std::sync::atomic::AtomicBool::new(false));
         let stop_thread = std::sync::Arc::clone(&stop);
@@ -1248,8 +1270,9 @@ impl Watchdog {
                         // pure and testable by passing a time: this walks live
                         // maps and formats keys, which is affordable once a stall
                         // is already confirmed and not on every tick.
-                        report.stuck = hcore::hmemoizer::inventory();
-                        emit(&report);
+                        let (report, snapshot) =
+                            sample_once(report, hcore::hmemoizer::capture_report);
+                        emit(&report, &snapshot);
                         last_fired = Some(now);
                         last_seen = Some((done, open, now));
                     }
@@ -1289,6 +1312,60 @@ mod tests {
             kind,
             at_unix_ms: 0,
         }
+    }
+
+    /// `sample_once` must call `capture` exactly once per fire and stamp
+    /// `report.stuck` from that same call's cells — not from a second,
+    /// independent read.
+    ///
+    /// Before the fix, the watchdog filled `report.stuck` from a live
+    /// `hcore::hmemoizer::inventory()` call, and the `heph run` call site
+    /// separately called `hcore::hmemoizer::capture_report()` for the
+    /// companion file. Two live reads of state that moves while a build runs
+    /// can disagree, but a test that just calls the real global registry
+    /// twice would not reliably catch that (a quiet test process usually
+    /// returns the same thing both times). So this fakes the capture with a
+    /// closure that returns a *different* sample per call — mirroring what a
+    /// live registry does under concurrent mutation — and asserts both the
+    /// call count and that the paragraph and the snapshot agree.
+    #[test]
+    fn sample_once_captures_the_live_state_exactly_once() {
+        let s = state();
+        s.op_start(Op::Result, "//a:b", 0);
+        let report = s.evaluate(61_000, T).expect("stalled");
+
+        let calls = std::cell::Cell::new(0);
+        let (report, snapshot) = sample_once(report, || {
+            calls.set(calls.get() + 1);
+            hcore::hmemoizer::ReportSnapshot::from_parts(
+                vec![hcore::hmemoizer::StuckCell {
+                    tag: "result",
+                    key: format!("//call:{}", calls.get()),
+                    waiters: Some(1),
+                    has_driver: false,
+                }],
+                0,
+                String::new(),
+                String::new(),
+            )
+        });
+
+        assert_eq!(
+            calls.get(),
+            1,
+            "the live state must be sampled exactly once per fire, or the \
+             paragraph and the companion file can read it at two different \
+             instants and disagree"
+        );
+        assert_eq!(
+            report.stuck.len(),
+            snapshot.cells().len(),
+            "the paragraph's cell list must be the snapshot's cell list"
+        );
+        assert_eq!(
+            report.stuck[0].key, snapshot.cells()[0].key,
+            "…not just the same length by coincidence — the same cells"
+        );
     }
 
     /// A lone quiet subprocess is not a stall at the ordinary threshold.

--- a/crates/engine/src/engine/diag.rs
+++ b/crates/engine/src/engine/diag.rs
@@ -1363,7 +1363,8 @@ mod tests {
             "the paragraph's cell list must be the snapshot's cell list"
         );
         assert_eq!(
-            report.stuck[0].key, snapshot.cells()[0].key,
+            report.stuck[0].key,
+            snapshot.cells()[0].key,
             "…not just the same length by coincidence — the same cells"
         );
     }

--- a/crates/engine/src/engine/result.rs
+++ b/crates/engine/src/engine/result.rs
@@ -1185,7 +1185,7 @@ impl Engine {
         opts: &ResultOptions,
     ) -> anyhow::Result<Arc<EResult>> {
         if opts.shell && opts.interactive.is_none() {
-            anyhow::bail!("cannot use --shell in non-interactive mode");
+            return Err(ShellNeedsSingleTarget::NotInteractive { addr: addr.clone() }.into());
         }
 
         // Stop the moment the request is cancelled (Ctrl-C). Every queued
@@ -10353,6 +10353,46 @@ mod tests {
         assert!(
             !msg.contains("non-interactive mode"),
             "the user is on a terminal; do not claim otherwise: {msg}",
+        );
+        assert_eq!(
+            h.runs.load(Ordering::SeqCst),
+            0,
+            "nothing may run once --shell is refused",
+        );
+        Ok(())
+    }
+
+    /// `--shell` on a single target with no terminal attached is refused with
+    /// a typed error naming the addr and the next action — not a bare
+    /// `anyhow::bail!` string with neither.
+    #[tokio::test]
+    async fn shell_without_a_terminal_names_the_addr_and_the_next_step() -> anyhow::Result<()> {
+        let h = terminal_harness(vec![leaf_spec("//pkg:a", false)?])?;
+        let rs = h.engine.new_state();
+        let addr = hmodel::htaddr::parse_addr("//pkg:a")?;
+        let opts = ResultOptions {
+            shell: true,
+            interactive: None,
+            ..Default::default()
+        };
+
+        let err = Arc::clone(&h.engine)
+            .result_addr(rs, &addr, OutputMatcher::All, &opts)
+            .await
+            .err()
+            .expect("--shell with no terminal must fail");
+
+        let typed = downcast_chain_ref::<ShellNeedsSingleTarget>(&err)
+            .expect("must be the typed shell error, not a bare anyhow string");
+        assert!(
+            matches!(typed, ShellNeedsSingleTarget::NotInteractive { addr } if addr.format() == "//pkg:a"),
+            "the error must carry the addr that was refused: {err:#}"
+        );
+        let msg = format!("{err:#}");
+        assert!(msg.contains("//pkg:a"), "msg: {msg}");
+        assert!(
+            msg.contains("try: run `heph run --shell //pkg:a`"),
+            "an actionable message must name the next command: {msg}"
         );
         assert_eq!(
             h.runs.load(Ordering::SeqCst),

--- a/crates/plugin/src/error.rs
+++ b/crates/plugin/src/error.rs
@@ -68,9 +68,10 @@ impl std::error::Error for HashUnknownError {}
 /// How many group members the `--shell` diagnostic lists before eliding.
 const SHELL_MEMBERS_SHOWN: usize = 5;
 
-/// `--shell` was asked for on something that does not resolve to a single
-/// executing target — a multi-target selection, or a transparent group that is
-/// not an alias for one target.
+/// `--shell` was refused: either the request does not resolve to a single
+/// executing target (a multi-target selection, or a transparent group that is
+/// not an alias for one target), or it does, but there is no terminal to hand
+/// it to.
 ///
 /// A property of the *request*, not a failure of any target: nothing ran, and
 /// nothing was going to. So `classify_failure` propagates it unchanged rather
@@ -94,20 +95,24 @@ pub enum ShellNeedsSingleTarget {
         /// The group's distinct members, in declaration order.
         members: Vec<Addr>,
     },
+    /// `addr` is a single target — the shape is fine — but this run has
+    /// nothing to attach a shell to: no tty (CI, a redirected stdin/stdout),
+    /// or a client that never offered one.
+    NotInteractive { addr: Addr },
 }
 
 impl fmt::Display for ShellNeedsSingleTarget {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        f.write_str("--shell needs exactly one target; ")?;
         match self {
             Self::Selection { query } => write!(
                 f,
-                "{query} selects many\n  try: heph run --shell //pkg:name with one address"
+                "--shell needs exactly one target; {query} selects many\n  \
+                 try: heph run --shell //pkg:name with one address"
             ),
             Self::Group { addr, members } => {
                 write!(
                     f,
-                    "{} is a group with {} members",
+                    "--shell needs exactly one target; {} is a group with {} members",
                     addr.format(),
                     members.len()
                 )?;
@@ -130,6 +135,14 @@ impl fmt::Display for ShellNeedsSingleTarget {
                 }
                 write!(f, "\n  try: heph run --shell {}", first.format())
             }
+            Self::NotInteractive { addr } => write!(
+                f,
+                "--shell needs a terminal to attach to; {} would run in a \
+                 non-interactive session (CI, a redirected stdin/stdout, or --no-tui)\n  \
+                 try: run `heph run --shell {}` from an interactive terminal",
+                addr.format(),
+                addr.format(),
+            ),
         }
     }
 }

--- a/src/commands/run.rs
+++ b/src/commands/run.rs
@@ -306,14 +306,13 @@ async fn execute_async(args: RunArgs, sink: LogSink, global: GlobalOptions) -> a
         hengine::engine::diag::Watchdog::spawn(
             std::sync::Arc::clone(hengine::engine::diag::global()),
             threshold,
-            move |report| {
+            move |report, snapshot| {
                 // Best-effort and first: the paragraph points at this file, and
                 // a hang that ends with the process being killed takes every
                 // byte of in-flight state with it unless it was already on disk.
                 // A failure here must not cost us the paragraph itself.
-                let snapshot = hcore::hmemoizer::capture_report();
                 if let Err(e) =
-                    inflight.write(&hengine::engine::diag::InflightLog::render(&snapshot))
+                    inflight.write(&hengine::engine::diag::InflightLog::render(snapshot))
                 {
                     tracing::warn!(
                         path = %inflight.path().display(),


### PR DESCRIPTION
## Summary

Three independent defects in the diag/CLI surface (W3):

- **Stall watchdog double-samples `hcore::hmemoizer` state.** The watchdog filled `report.stuck` (the capped paragraph) via a live `inventory()` call, then `heph run`'s emit callback separately called `capture_report()` (uncapped companion file) — two independent reads of state that moves while a build runs, so the two files could disagree on the same fire. Fixed by sampling once via `capture_report()` inside the watchdog and handing that one `ReportSnapshot` to both renderers, following the same split (`capture_report`/`render_report`, no third entry point) already used for the `SIGQUIT` dump path.
- **`dump_phases`/`dump_wait_graph` panicked on a poisoned lock.** A panic while either lock was held turned every later diagnostic dump into a second panic instead of surfacing anything useful. Recovers the guard via `PoisonError::into_inner`, matching `ApprovalCenter::lock`.
- **`--shell` in a non-interactive session was an untyped `anyhow::bail!`** with no addr and no next action, unlike its siblings (`ShellNeedsSingleTarget::Selection`/`Group`). Added a `NotInteractive` variant carrying the addr and naming the retry command.

## Test plan

- [x] Each fix ships a test; each was verified to fail (red) against the pre-fix production code before being restored via `git checkout HEAD -- <file>` (never a plain `git checkout --`, which would discard the uncommitted work rather than prove the test).
- [x] `cargo test -p core --lib` (112 passed), `cargo test -p engine --lib` (474 passed), `cargo test -p heph --lib` (105 passed).
- [x] `cargo test --no-run -p heph -p engine -p core -p plugin` — compiles clean.
- [x] `cargo fmt --check` clean on touched files.
- [x] `cargo clippy --workspace --all-targets -- -D warnings` — pre-existing, unrelated `plugin-go` failures reproduced identically on a disposable `origin/master` worktree (17 errors, none in any file this PR touches); no clippy findings in the changed files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019zjZdkZzJLmxoG4FEBCjcp