### PR TITLE
fix(bootstrap): restore terminal before the second-Ctrl-C hard exit

### DIFF
--- a/crates/core/src/shutdown.rs
+++ b/crates/core/src/shutdown.rs
@@ -2,8 +2,8 @@
 //! TUI's Ctrl+C handler. Lives here (the lowest crate) so the TUI can hold a
 //! `ShutdownTrigger` without depending on the bin's bootstrap module.
 
-use std::sync::Arc;
 use std::sync::atomic::{AtomicBool, Ordering};
+use std::sync::{Arc, Mutex};
 use tokio::sync::mpsc;
 
 /// Producer-side handle for the in-process shutdown signal. Both the SIGINT
@@ -53,5 +53,94 @@ pub struct SuppressionHandle {
 impl SuppressionHandle {
     pub fn set(&self, suppressed: bool) {
         self.flag.store(suppressed, Ordering::Release);
+    }
+}
+
+type RestoreFn = Arc<dyn Fn() + Send + Sync>;
+
+/// Closure that puts the terminal back into cooked mode, registered by
+/// whichever raw-mode session (the TUI) is currently active. The second
+/// Ctrl-C hard-exits via `process::exit`, which runs no destructors — the
+/// registered closure is the only thing that still runs on that path, so it
+/// must be self-contained: no crossterm (whose own raw-mode mutex it may
+/// already be holding), no writes when nothing was ever recorded (a
+/// redirected/non-tty run never registers one).
+static TERMINAL_RESTORE: Mutex<Option<RestoreFn>> = Mutex::new(None);
+
+/// Register the closure the hard-abort path calls to restore the terminal.
+/// Call once raw mode is entered, with a closure that already captured
+/// whatever state (e.g. the pre-raw-mode `termios`) it needs to restore.
+pub fn set_terminal_restore(f: impl Fn() + Send + Sync + 'static) {
+    *TERMINAL_RESTORE.lock().unwrap_or_else(|e| e.into_inner()) = Some(Arc::new(f));
+}
+
+/// Forget the registered closure — call once the session has torn itself
+/// down normally, so a later abort in some other (non-interactive) run
+/// doesn't fire a stale restore.
+pub fn clear_terminal_restore() {
+    *TERMINAL_RESTORE.lock().unwrap_or_else(|e| e.into_inner()) = None;
+}
+
+/// Invoke the registered restore closure, if any. A no-op when no raw-mode
+/// session is active — safe to call unconditionally right before a hard
+/// `process::exit`.
+///
+/// Clones the `Arc` and drops the lock before calling `f()`: `Mutex` is
+/// non-reentrant, so invoking the closure while still holding the guard
+/// would deadlock this same thread if `f` ever touched `TERMINAL_RESTORE`
+/// itself (e.g. a future closure that re-arms the restore after running).
+pub fn restore_terminal() {
+    let f = TERMINAL_RESTORE
+        .lock()
+        .unwrap_or_else(|e| e.into_inner())
+        .clone();
+    if let Some(f) = f {
+        f();
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::sync::atomic::AtomicUsize;
+
+    // Serialized: TERMINAL_RESTORE is a process-global static, so concurrent
+    // test runs on the same binary would stomp each other's registration.
+    static TEST_LOCK: Mutex<()> = Mutex::new(());
+
+    #[test]
+    fn restore_terminal_is_noop_when_nothing_registered() {
+        let _guard = TEST_LOCK.lock().unwrap_or_else(|e| e.into_inner());
+        clear_terminal_restore();
+        // Must not panic and must not call anything — there is nothing to
+        // observe here beyond "returns", which is the point: a
+        // non-interactive run that never registered a closure pays nothing.
+        restore_terminal();
+    }
+
+    #[test]
+    fn restore_terminal_invokes_registered_closure() {
+        let _guard = TEST_LOCK.lock().unwrap_or_else(|e| e.into_inner());
+        let calls = Arc::new(AtomicUsize::new(0));
+        let calls_clone = Arc::clone(&calls);
+        set_terminal_restore(move || {
+            calls_clone.fetch_add(1, Ordering::SeqCst);
+        });
+
+        restore_terminal();
+        assert_eq!(calls.load(Ordering::SeqCst), 1);
+
+        // Idempotent: the hard-abort path only ever calls this once, but a
+        // second call (e.g. a future caller) must not panic or double-free.
+        restore_terminal();
+        assert_eq!(calls.load(Ordering::SeqCst), 2);
+
+        clear_terminal_restore();
+        restore_terminal();
+        assert_eq!(
+            calls.load(Ordering::SeqCst),
+            2,
+            "cleared closure must not fire"
+        );
     }
 }

--- a/crates/tui/src/tui/backend/interactive.rs
+++ b/crates/tui/src/tui/backend/interactive.rs
@@ -1,4 +1,5 @@
 use std::io::{self, Write};
+use std::os::fd::AsRawFd;
 use std::time::Duration;
 
 use ansi_to_tui::IntoText;
@@ -53,6 +54,7 @@ pub async fn run<A: App + 'static>(
     let (event_tx, event_rx) = mpsc::unbounded_channel();
     let mut build_events: Option<EventReceiver> = Some(event_rx);
 
+    record_raw_mode_restore();
     enable_raw_mode().context("enabling raw mode")?;
     // StderrBackend wraps CrosstermBackend<Stderr> and overrides
     // get_cursor_position so the DSR query goes to stderr instead of
@@ -416,6 +418,7 @@ pub async fn run<A: App + 'static>(
         drop(Backend::flush(backend));
     }
     drop(disable_raw_mode());
+    hcore::shutdown::clear_terminal_restore();
     sink.switch_to_direct();
     drain_logs_to_stderr(&mut rx);
 
@@ -434,6 +437,52 @@ pub async fn run<A: App + 'static>(
     view.last_render();
 
     result
+}
+
+/// Capture stderr's pre-raw-mode `termios` and register a restore closure
+/// with `hcore::shutdown` before raw mode mutates it. The closure is the
+/// only thing that still runs if the run ends via `bootstrap`'s hard abort
+/// on the second Ctrl-C (`std::process::exit`, which skips destructors) — it
+/// restores cooked mode and re-shows the cursor with direct syscalls only,
+/// never crossterm: the abort path must not risk contending crossterm's own
+/// raw-mode mutex, which a concurrently-aborting thread could already hold.
+///
+/// A failed `tcgetattr` (stderr is not a tty — output redirected) records
+/// nothing, so a non-interactive run's hard abort stays a no-op: no stray
+/// escape bytes land in redirected output.
+fn record_raw_mode_restore() {
+    let fd = io::stderr().as_raw_fd();
+    let mut termios = std::mem::MaybeUninit::<libc::termios>::uninit();
+    // SAFETY: `fd` is stderr's descriptor, valid for the process lifetime;
+    // `termios.as_mut_ptr()` points at valid, correctly-sized storage for
+    // `tcgetattr` to write into.
+    let rc = unsafe { libc::tcgetattr(fd, termios.as_mut_ptr()) };
+    if rc != 0 {
+        return;
+    }
+    // SAFETY: `tcgetattr` returned success above, so `termios` is initialized.
+    let termios = unsafe { termios.assume_init() };
+    hcore::shutdown::set_terminal_restore(move || {
+        // SAFETY: `fd` was a valid, open tty when captured above; `tcsetattr`
+        // on an already-closed fd fails harmlessly (EBADF), not UB.
+        unsafe {
+            libc::tcsetattr(fd, libc::TCSANOW, &termios);
+        }
+        // Cursor-show escape, then a plain notice on its own line: the TUI
+        // buffers `tracing` output through its log sink and only drains it
+        // to the terminal on the next render tick — a tick the hard abort
+        // never reaches — so without this direct write the process just
+        // vanishes with no visible sign it force-killed itself rather than
+        // finishing normally.
+        let notice = b"\r\n\x1b[?25hheph: aborted (second Ctrl-C)\r\n";
+        // SAFETY: `notice` is a valid pointer for exactly its own length;
+        // the return value is intentionally ignored — this runs right
+        // before `process::exit`, so there is nothing left to do with a
+        // short write.
+        unsafe {
+            libc::write(fd, notice.as_ptr().cast(), notice.len());
+        }
+    });
 }
 
 fn terminal_cols(terminal: &StderrTerminal) -> u16 {

--- a/src/commands/bootstrap.rs
+++ b/src/commands/bootstrap.rs
@@ -230,8 +230,24 @@ fn spawn_shutdown_handler(engine: Weak<engine::Engine>, mut rx: mpsc::UnboundedR
             return;
         }
         tracing::error!("second ctrl-c, aborting");
-        std::process::exit(130);
+        hard_abort(|code| std::process::exit(code));
     });
+}
+
+/// The second-Ctrl-C abort sequence, with the actual exit call taken as a
+/// parameter so tests can observe the ordering without killing the test
+/// process. `std::process::exit` runs no destructors — a raw-mode terminal
+/// left as-is would stay raw (and its cursor hidden) after heph exits — so
+/// the restore must happen here, before `exit`, rather than relying on a
+/// `Drop` impl the exit call would skip.
+///
+/// `restore_terminal` is a no-op unless a raw-mode session (the TUI)
+/// registered a restore closure, so a non-interactive run's second Ctrl-C
+/// still exits with no extra work and no stray writes to a redirected
+/// stdout/stderr.
+fn hard_abort(exit: impl FnOnce(i32)) {
+    hcore::shutdown::restore_terminal();
+    exit(130);
 }
 
 #[cfg(test)]
@@ -423,5 +439,60 @@ fs:
             await_cancelled(rs.ctoken()).await,
             "trigger after resume must cancel"
         );
+    }
+
+    // Serialized: `hcore::shutdown`'s restore-closure slot is a process-global
+    // static, so these must not run concurrently with each other (or with
+    // `crates/core`'s own tests of the same static, which live in a separate
+    // binary and can't collide with this one).
+    static TERMINAL_RESTORE_TEST_LOCK: std::sync::Mutex<()> = std::sync::Mutex::new(());
+
+    /// Regression for the bug this module used to have: the second Ctrl-C
+    /// called `std::process::exit(130)` directly, which runs no destructors —
+    /// a raw-mode terminal stayed raw and its cursor stayed hidden after heph
+    /// exited. `hard_abort` must restore the terminal *before* exiting rather
+    /// than relying on a `Drop` impl the exit call would skip.
+    ///
+    /// Pre-fix (`std::process::exit(130)` called directly, no
+    /// `restore_terminal()`), this test goes red: the registered closure
+    /// never fires. Exit is injected so the test can observe the ordering
+    /// without killing the test process.
+    #[test]
+    fn hard_abort_restores_terminal_before_exiting() {
+        let _guard = TERMINAL_RESTORE_TEST_LOCK
+            .lock()
+            .unwrap_or_else(|e| e.into_inner());
+
+        let restored = std::sync::Arc::new(std::sync::atomic::AtomicBool::new(false));
+        let restored_in_closure = std::sync::Arc::clone(&restored);
+        hcore::shutdown::set_terminal_restore(move || {
+            restored_in_closure.store(true, std::sync::atomic::Ordering::SeqCst);
+        });
+
+        let mut exit_code = None;
+        hard_abort(|code| exit_code = Some(code));
+
+        assert!(
+            restored.load(std::sync::atomic::Ordering::SeqCst),
+            "hard_abort must restore the terminal before exiting"
+        );
+        assert_eq!(exit_code, Some(130), "must exit with code 130");
+
+        hcore::shutdown::clear_terminal_restore();
+    }
+
+    /// A non-interactive run never registers a restore closure — `hard_abort`
+    /// must still exit cleanly and must not panic reaching for one.
+    #[test]
+    fn hard_abort_is_a_plain_exit_when_nothing_was_registered() {
+        let _guard = TERMINAL_RESTORE_TEST_LOCK
+            .lock()
+            .unwrap_or_else(|e| e.into_inner());
+        hcore::shutdown::clear_terminal_restore();
+
+        let mut exit_code = None;
+        hard_abort(|code| exit_code = Some(code));
+
+        assert_eq!(exit_code, Some(130));
     }
 }


### PR DESCRIPTION
## Summary
- `spawn_shutdown_handler`'s second-Ctrl-C path called `std::process::exit(130)` directly, skipping all destructors — a raw-mode TUI session left the terminal raw with the cursor hidden after heph exited.
- `hcore::shutdown` now holds a process-global restore-closure slot (`set_terminal_restore`/`clear_terminal_restore`/`restore_terminal`); the TUI registers one on entering raw mode that restores the pre-raw `termios` (captured via `libc::tcgetattr`) plus the cursor-show escape and an "aborted" notice, using raw syscalls only — no crossterm, so the hard-abort path can't contend crossterm's own raw-mode mutex, and no writes at all for a redirected/non-tty run.
- `bootstrap::hard_abort(exit)` extracts the abort sequence (`restore_terminal()` then `exit(130)`) with the exit call injected, so a test can assert restore-before-exit ordering without killing the test process.

## Test plan
- [x] Test written first and confirmed red pre-fix (`hard_abort` calling `exit` directly, no restore call), then green after wiring in `restore_terminal()`.
- [x] `cargo clippy --all-targets --locked -- -D warnings` clean.
- [x] `cargo fmt --check` clean.
- [x] `cargo test --workspace --no-run --exclude plugingo-e2e` compiles.
- [x] `cargo test -p heph commands::bootstrap`, `cargo test -p tui -p core` — all pass (225 tests).
- [x] Reviewed by code-quality (PASS WITH NITS, fixed: closure no longer invoked while holding the mutex guard) and product-vision (SHIP WITH CHANGES, addressed: added a direct unbuffered "aborted" notice so the hard abort isn't silent to a user/agent watching the TUI).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014dxys12m9FYcvmJUJkUvec