### PR TITLE
ci: rename lint_matrix job to lint, drop aggregator

### DIFF
--- a/.github/workflows/heph.yml
+++ b/.github/workflows/heph.yml
@@ -446,7 +446,7 @@ jobs:
   # direction (`#[expect]` is fulfilled-or-error, so a lint that fires on one OS
   # and not the other is a hard error on the other), and that only stays closed
   # if every leg runs the same command as the developer does.
-  lint_matrix:
+  lint:
     name: Lint ${{ matrix.os }}/${{ matrix.arch }}
     runs-on: ${{ matrix.runs-on }}
     timeout-minutes: 30
@@ -499,49 +499,6 @@ jobs:
         if: always()
         shell: devenv shell bash -- -e {0}
         run: sccache --show-stats
-
-  # Aggregator. Does no work; it exists so the status context stays named
-  # exactly `Lint`.
-  #
-  # The branch ruleset requires a context named literally `Lint`. A bare matrix
-  # publishes one context per leg and never that name again, so every open PR
-  # would block forever on a required check that can no longer appear — a worse
-  # failure than the one being fixed, and the workflow edit and the ruleset edit
-  # cannot land atomically. Matrixing the work and keeping this fan-in gives
-  # per-platform legs with their own logs *and* an unchanged required context,
-  # so this lands with **no branch-protection change at all**.
-  #
-  # `if: always()` is what makes it able to report when a leg fails — without it
-  # a failed leg would *skip* this job, and a skipped required check is not a
-  # red one. That inverts the danger: `always()` alone would let it succeed on a
-  # failed leg, since a job whose steps all pass is green regardless of why its
-  # dependencies ended. Hence the explicit `result` check below. `needs` alone
-  # decides *ordering* here, not outcome.
-  #
-  # `needs.lint_matrix.result` is the aggregate over every leg: `success` only
-  # when all of them succeeded, otherwise `failure` / `cancelled` / `skipped`.
-  # Comparing against `success` therefore fails closed for a new leg too — add a
-  # third platform and it is covered without touching this job.
-  lint:
-    name: Lint
-    runs-on: ubuntu-latest
-    timeout-minutes: 5
-    needs: lint_matrix
-    if: always()
-    steps:
-      - name: Require every lint leg to have succeeded
-        env:
-          # Read through env rather than interpolated into the script body, so
-          # the value can never be parsed as shell.
-          LINT_MATRIX_RESULT: ${{ needs.lint_matrix.result }}
-        run: |
-          set -euo pipefail
-          echo "lint_matrix: $LINT_MATRIX_RESULT"
-          if [ "$LINT_MATRIX_RESULT" != "success" ]; then
-            echo "::error title=Lint::lint_matrix did not succeed (result: $LINT_MATRIX_RESULT). Open the 'Lint linux/amd64' and 'Lint darwin/arm64' jobs for the failing leg. A 'skipped' or 'cancelled' result counts as a failure here on purpose: it means a platform was never linted."
-            exit 1
-          fi
-          echo "every lint leg succeeded"
 
   test:
     name: Test ${{ matrix.os }}/${{ matrix.arch }}


### PR DESCRIPTION
## Summary
- Rename the `lint_matrix` job to `lint`; downstream `needs: [..., lint, ...]` (release, cleanup) now points at the matrix job directly, which already fails closed when any leg fails.
- Remove the `lint` aggregator job that existed only to keep the required-status context named `Lint`.

**Branch ruleset needs updating**: the required context `Lint` no longer exists — replace it with the per-leg contexts `Lint linux/amd64` and `Lint darwin/arm64`.

## Test plan
- [ ] CI green on this PR (both `Lint linux/amd64` and `Lint darwin/arm64` legs report)
- [ ] Update branch ruleset required checks before/after merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)