### PR TITLE
ci(lint): drop the lint aggregator; the matrix itself is the `lint` job

### DIFF
--- a/.github/workflows/heph.yml
+++ b/.github/workflows/heph.yml
@@ -466,7 +466,35 @@ jobs:
   # direction (`#[expect]` is fulfilled-or-error, so a lint that fires on one OS
   # and not the other is a hard error on the other), and that only stays closed
   # if every leg runs the same command as the developer does.
-  lint_matrix:
+  #
+  # This is a matrix, so the published status contexts are the *rendered* names,
+  # one per leg — `Lint linux/amd64` and `Lint darwin/arm64`. There is no longer
+  # any context named plain `Lint`. Branch protection must require the two new
+  # names; until it does, a red lint does not block a merge. (Verified from a
+  # real run of this matrix, not inferred: GitHub publishes the rendered name,
+  # with no parenthesised matrix suffix.)
+  #
+  # `needs: lint` elsewhere in this file waits for *every* leg and is skipped if
+  # any of them fails — the same fan-in the `build` matrix already relies on via
+  # `bin_e2e`'s `needs: [gen, build, …]`. Downstream gating therefore needs no
+  # aggregator job.
+  #
+  # No `continue-on-error:` and no `if:` on the Lint step, ever. Either one lets
+  # a leg conclude `success` with clippy never having run, which makes the leg's
+  # own check green — and, because `needs` treats a successful job as satisfied,
+  # lets `release` proceed over a platform that was not linted. It is the one
+  # remaining way to reach a silent pass here, and it is invisible in the check
+  # list. `tests/lint_gate.rs` asserts their absence.
+  #
+  # Cost, measured rather than assumed — see the PR body. The darwin leg is a
+  # fourth concurrent `macos-latest` job in the `needs: gen` wave, which is the
+  # real price rather than the minutes: the darwin build chain has been observed
+  # on the critical path, and macOS jobs in this repo have queued up to ~2m30s
+  # waiting for a slot. macOS also starts colder — the Nix setup alone measures
+  # 3m15s-4m42s there, and the cargo registry cache is restore-only on PRs
+  # (only master saves), so the darwin leg stays near its cold ~10min until this
+  # key is populated from master.
+  lint:
     name: Lint ${{ matrix.os }}/${{ matrix.arch }}
     runs-on: ${{ matrix.runs-on }}
     timeout-minutes: 30
@@ -519,49 +547,6 @@ jobs:
         if: always()
         shell: devenv shell bash -- -e {0}
         run: sccache --show-stats
-
-  # Aggregator. Does no work; it exists so the status context stays named
-  # exactly `Lint`.
-  #
-  # The branch ruleset requires a context named literally `Lint`. A bare matrix
-  # publishes one context per leg and never that name again, so every open PR
-  # would block forever on a required check that can no longer appear — a worse
-  # failure than the one being fixed, and the workflow edit and the ruleset edit
-  # cannot land atomically. Matrixing the work and keeping this fan-in gives
-  # per-platform legs with their own logs *and* an unchanged required context,
-  # so this lands with **no branch-protection change at all**.
-  #
-  # `if: always()` is what makes it able to report when a leg fails — without it
-  # a failed leg would *skip* this job, and a skipped required check is not a
-  # red one. That inverts the danger: `always()` alone would let it succeed on a
-  # failed leg, since a job whose steps all pass is green regardless of why its
-  # dependencies ended. Hence the explicit `result` check below. `needs` alone
-  # decides *ordering* here, not outcome.
-  #
-  # `needs.lint_matrix.result` is the aggregate over every leg: `success` only
-  # when all of them succeeded, otherwise `failure` / `cancelled` / `skipped`.
-  # Comparing against `success` therefore fails closed for a new leg too — add a
-  # third platform and it is covered without touching this job.
-  lint:
-    name: Lint
-    runs-on: ubuntu-latest
-    timeout-minutes: 5
-    needs: lint_matrix
-    if: always()
-    steps:
-      - name: Require every lint leg to have succeeded
-        env:
-          # Read through env rather than interpolated into the script body, so
-          # the value can never be parsed as shell.
-          LINT_MATRIX_RESULT: ${{ needs.lint_matrix.result }}
-        run: |
-          set -euo pipefail
-          echo "lint_matrix: $LINT_MATRIX_RESULT"
-          if [ "$LINT_MATRIX_RESULT" != "success" ]; then
-            echo "::error title=Lint::lint_matrix did not succeed (result: $LINT_MATRIX_RESULT). Open the 'Lint linux/amd64' and 'Lint darwin/arm64' jobs for the failing leg. A 'skipped' or 'cancelled' result counts as a failure here on purpose: it means a platform was never linted."
-            exit 1
-          fi
-          echo "every lint leg succeeded"
 
   test:
     name: Test ${{ matrix.os }}/${{ matrix.arch }}

--- a/tests/lint_gate.rs
+++ b/tests/lint_gate.rs
@@ -18,9 +18,16 @@
 //!   - which feature set — `--no-default-features`, whose obvious spelling is a
 //!     silent no-op in this workspace;
 //!   - which platform — macOS was linted nowhere;
-//!   - whether a red leg reaches the required status context at all — the
-//!     `Lint` aggregator, which can be wired to report green over a failed
-//!     matrix leg.
+//!   - whether a red leg has any consequence at all — a leg can be made to
+//!     conclude `success` without clippy ever running, and the `needs:` wiring
+//!     that makes a red lint stop a release can simply be deleted.
+//!
+//! What these tests **cannot** cover: the lint job is a matrix, so its status
+//! contexts are the rendered per-leg names (`Lint linux/amd64`,
+//! `Lint darwin/arm64`). Whether those are *required* lives in the repo's
+//! branch protection, outside this tree — so nothing here can assert that a red
+//! lint blocks a merge. `lint_gates_release_and_cleanup` guards the only part
+//! the workflow owns.
 //!
 //! Cheap on purpose: a few file reads and some string work, no build.
 
@@ -505,7 +512,8 @@ fn job_needs(body: &str) -> Vec<&str> {
         .map(str::trim)
         .find(|line| line.starts_with("needs:"))
         .map(|line| {
-            line.trim_start_matches("needs:")
+            line.strip_prefix("needs:")
+                .unwrap_or(line)
                 .trim()
                 .trim_matches(['[', ']'])
                 .split(',')
@@ -532,7 +540,11 @@ fn job_run_steps(body: &str) -> Vec<&str> {
 fn job_runners(body: &str) -> Vec<&str> {
     body.lines()
         .map(str::trim)
-        .filter_map(|line| line.trim_start_matches("- ").strip_prefix("runs-on:"))
+        .filter_map(|line| {
+            line.strip_prefix("- ")
+                .unwrap_or(line)
+                .strip_prefix("runs-on:")
+        })
         .map(str::trim)
         .filter(|label| !label.contains("${{"))
         .collect()
@@ -550,11 +562,82 @@ fn lint_legs<'a>(jobs: &[(&'a str, String)]) -> Vec<&'a str> {
         .collect()
 }
 
-/// The job named exactly `Lint` — the required status context.
-fn lint_aggregator<'a>(jobs: &'a [(&'a str, String)]) -> Option<(&'a str, &'a String)> {
-    jobs.iter()
-        .find(|(_, body)| body.lines().map(str::trim).any(|line| line == "name: Lint"))
-        .map(|(id, body)| (*id, body))
+/// The `matrix.include` entries of a job body, as `<key>: <value>` maps.
+///
+/// Parsed rather than pattern-matched on `os:`/`arch:` so the platform
+/// assertions read the same coordinates the workflow does.
+fn matrix_include(body: &str) -> Vec<Vec<(String, String)>> {
+    let mut entries: Vec<Vec<(String, String)>> = Vec::new();
+    let mut in_include = false;
+    for line in body.lines() {
+        if line.trim() == "include:" {
+            in_include = true;
+            continue;
+        }
+        if !in_include {
+            continue;
+        }
+        let trimmed = line.trim();
+        if trimmed.is_empty() || trimmed.starts_with('#') {
+            continue;
+        }
+        // A new entry starts at `- key: value`; `steps:` ends the block.
+        let (starts_entry, pair) = match trimmed.strip_prefix("- ") {
+            Some(rest) => (true, rest),
+            None => (false, trimmed),
+        };
+        if starts_entry {
+            entries.push(Vec::new());
+        } else if entries.is_empty() || !line.starts_with("            ") {
+            break;
+        }
+        if let Some((key, value)) = pair.split_once(':')
+            && let Some(last) = entries.last_mut()
+        {
+            last.push((key.trim().to_string(), value.trim().to_string()));
+        }
+    }
+    entries
+}
+
+/// The step blocks of a job body, each starting at a `      - ` line.
+///
+/// Some invariants are per *step*, not per job: the `sccache stats` step
+/// legitimately carries `if: always()`, so "the Lint step has no `if:`" cannot
+/// be checked by scanning the whole job.
+fn job_steps(body: &str) -> Vec<String> {
+    let mut steps: Vec<Vec<&str>> = Vec::new();
+    let mut in_steps = false;
+    for line in body.lines() {
+        if line.trim() == "steps:" {
+            in_steps = true;
+            continue;
+        }
+        if !in_steps {
+            continue;
+        }
+        if line.starts_with("      - ") {
+            steps.push(vec![line]);
+        } else if let Some(last) = steps.last_mut() {
+            last.push(line);
+        }
+    }
+    steps.into_iter().map(|lines| lines.join("\n")).collect()
+}
+
+/// `text` with whole-line YAML comments removed.
+///
+/// A content assertion must not be satisfiable by prose. `workflow_jobs`
+/// attributes a job's *leading* comment block to the job above it, so a
+/// comment that merely mentions `needs.<dep>.result` would otherwise satisfy
+/// the assertion that the aggregator checks it — reordering the two jobs is
+/// enough to hand the aggregator that block and let it pass with its script
+/// gutted.
+fn without_comments(text: &str) -> String {
+    text.lines()
+        .filter(|line| !line.trim_start().starts_with('#'))
+        .collect::<Vec<_>>()
+        .join("\n")
 }
 
 /// The gate must run on macOS as well as Linux.
@@ -600,120 +683,164 @@ fn the_lint_gate_runs_on_macos_as_well_as_linux() {
     );
 }
 
-/// The required status context must survive, and it must be able to go red.
+/// A lint leg must not be able to conclude `success` without linting.
 ///
-/// The branch ruleset requires a context named literally `Lint`. A bare matrix
-/// publishes one context per leg (`Lint (ubuntu-latest)`, …) and never that
-/// name again, so every open PR would block forever on a required check that
-/// can no longer appear — strictly worse than the gap being closed, and the
-/// workflow edit and the ruleset edit cannot land atomically. The fix is to
-/// matrix the work and fan back in to an aggregator still named `Lint`.
-///
-/// That aggregator is load-bearing *and* silent when wrong, which is this
-/// file's whole subject. Two ways to get it backwards, both of which look fine
-/// in review:
-///
-///   - no `if: always()` — a failed leg *skips* the aggregator, and a skipped
-///     required check is not a red one, so the PR is merely un-mergeable rather
-///     than reported as failing;
-///   - `if: always()` with no result check — the aggregator's own steps all
-///     pass, so it reports **green on a failed leg**. That is the silent-pass
-///     class this entire branch exists to eliminate, reintroduced at the top
-///     of it.
+/// The aggregator can only be as good as the legs' own conclusions, and there
+/// are two one-line ways to make a leg green while clippy never ran:
+/// `continue-on-error: true`, which converts a failure into a success, and an
+/// `if:` on the Lint step, which can skip it entirely. Either makes
+/// `needs.lint_matrix.result` `success` and the required `Lint` check green
+/// over a platform that was not linted — the last remaining route to a silent
+/// pass here, and invisible to every other test in this file.
 #[test]
-fn the_lint_aggregator_keeps_the_required_context_and_can_fail() {
+fn a_lint_leg_cannot_report_success_without_running_the_lint() {
     let workflow = std::fs::read_to_string(repo_root().join(".github/workflows/heph.yml"))
         .expect("read .github/workflows/heph.yml");
     let jobs = workflow_jobs(&workflow);
     let legs = lint_legs(&jobs);
+    assert!(
+        !legs.is_empty(),
+        "no job in the workflow runs the `lint` script at all"
+    );
 
-    let named_lint: Vec<&str> = jobs
-        .iter()
-        .filter(|(_, body)| body.lines().map(str::trim).any(|line| line == "name: Lint"))
-        .map(|(id, _)| *id)
-        .collect();
+    for (id, body) in jobs.iter().filter(|(id, _)| legs.contains(id)) {
+        let body = without_comments(body);
+
+        assert!(
+            !body
+                .lines()
+                .any(|line| line.trim().starts_with("continue-on-error:")),
+            "the `{id}` lint leg has a `continue-on-error:`. That turns a \
+             clippy failure into a job that concludes `success`, so the leg's \
+             own check goes green and `release` proceeds over a platform whose \
+             lint failed."
+        );
+
+        let lint_step = job_steps(&body)
+            .into_iter()
+            .find(|step| job_run_steps(step).contains(&"lint"))
+            .unwrap_or_else(|| panic!("`{id}` has a step running the `lint` script"));
+
+        // Scoped to this step: `sccache stats` legitimately has `if: always()`.
+        assert!(
+            !lint_step.lines().any(|line| line.trim().starts_with("if:")),
+            "the Lint step of the `{id}` leg carries an `if:`. A skipped step \
+             does not fail its job, so the leg would conclude `success` with \
+             clippy never having run, and its check would go green over an \
+             unlinted platform.\n{lint_step}"
+        );
+    }
+}
+
+/// The lint job must be a matrix, and it must carry both supported OSes.
+///
+/// The legs *are* the status contexts now — there is no aggregator and no
+/// context named plain `Lint` — so the matrix's shape is the gate's shape.
+/// Three things are asserted because each fails silently:
+///
+///   - both platforms present, or a whole OS goes unlinted while the remaining
+///     leg reports green (the macOS half is the one that was missing);
+///   - `fail-fast: false`, or the first red leg *cancels* the other and the
+///     platform you did not see reports `cancelled` rather than a result. On
+///     the pass that matters — a lint that fires on one OS only — fail-fast
+///     hides exactly the half you need;
+///   - one leg per platform, so a duplicated coordinate cannot masquerade as
+///     coverage of a second OS.
+#[test]
+fn the_lint_job_is_a_matrix_over_both_supported_oses() {
+    let workflow = std::fs::read_to_string(repo_root().join(".github/workflows/heph.yml"))
+        .expect("read .github/workflows/heph.yml");
+    let jobs = workflow_jobs(&workflow);
+    let legs = lint_legs(&jobs);
     assert_eq!(
-        named_lint.len(),
+        legs.len(),
         1,
-        "exactly one job must be named `Lint` — that string is the required \
-         status context in the branch ruleset, and it is what lets this land \
-         with no branch-protection change. Found {named_lint:?}"
-    );
-    let (aggregator_id, aggregator) = lint_aggregator(&jobs).expect("a job is named `Lint`");
-
-    // A matrix job's check name gets the matrix values appended, so the context
-    // would become `Lint (…)` and `Lint` would never report again. This is the
-    // literal regression the aggregator exists to prevent.
-    assert!(
-        !aggregator.lines().any(|line| line.trim() == "strategy:"),
-        "the job named `Lint` (`{aggregator_id}`) has a `strategy:` — a matrix \
-         job publishes one context per leg and never the bare name, so the \
-         required `Lint` context would stop appearing and every open PR would \
-         block on a check that can no longer report. Matrix the work in a \
-         separate job and keep this one as the fan-in."
+        "expected exactly one job to run the `lint` script — the matrix. Found \
+         {legs:?}"
     );
 
-    // It must do no work itself: the aggregator cannot be the thing whose
-    // failure it exists to report.
+    let (id, body) = jobs
+        .iter()
+        .find(|(id, _)| legs.contains(id))
+        .expect("the lint leg is a job");
+    let body = without_comments(body);
+
     assert!(
-        !legs.contains(&aggregator_id),
-        "`{aggregator_id}` is named `Lint` and also runs the lint script; the \
-         aggregator must be a separate fan-in job"
+        body.lines()
+            .any(|line| line.trim().starts_with("strategy:")),
+        "the `{id}` job has no `strategy:`, so it is not a matrix and cannot \
+         cover more than one platform"
+    );
+    assert!(
+        body.lines()
+            .any(|line| line.replace(' ', "") == "fail-fast:false"),
+        "the `{id}` matrix does not set `fail-fast: false`. With fail-fast on, \
+         the first red leg cancels the other, so the platform you did not see \
+         reports `cancelled` instead of a result — and a lint that fires on one \
+         OS only is exactly the case that hides."
     );
 
-    let needs = job_needs(aggregator);
-    for leg in &legs {
-        assert!(
-            needs.contains(leg),
-            "the `Lint` aggregator does not `needs:` the `{leg}` lint leg, so \
-             that leg gates nothing and `Lint` can report green while it is \
-             red. needs: {needs:?}, legs: {legs:?}"
-        );
-    }
+    let coords: Vec<String> = matrix_include(&body)
+        .iter()
+        .filter_map(|entry| {
+            let get = |k: &str| {
+                entry
+                    .iter()
+                    .find(|(key, _)| key == k)
+                    .map(|(_, value)| value.clone())
+            };
+            Some(format!("{}/{}", get("os")?, get("arch")?))
+        })
+        .collect();
 
     assert!(
-        aggregator
-            .lines()
-            .map(str::trim)
-            .any(|line| line.starts_with("if:") && line.contains("always()")),
-        "the `Lint` aggregator has no `if: always()`, so a failed leg *skips* \
-         it rather than failing it — and a skipped required check is not a red \
-         one. needs: {needs:?}"
+        coords.iter().any(|c| c.starts_with("linux/")),
+        "the `{id}` matrix has no linux leg; found {coords:?}"
+    );
+    assert!(
+        coords.iter().any(|c| c.starts_with("darwin/")),
+        "the `{id}` matrix has no darwin leg, so macOS-only code — including \
+         the Mach `sweep_threads` block in `src/diag.rs`, the largest unsafe \
+         region in the tree — is clippy-linted nowhere, and the crate-root \
+         `#[expect]` headers are only ever checked against the lints that fire \
+         on Linux. Found {coords:?}"
     );
 
-    // `if: always()` alone is the dangerous half: the job then runs, its own
-    // steps pass, and it reports success no matter how its dependencies ended.
-    // Something must actually inspect each dependency's result and exit
-    // non-zero. Checked per dependency, so adding a leg without extending the
-    // check fails here rather than in production.
-    for dep in &needs {
-        assert!(
-            aggregator.contains(&format!("needs.{dep}.result")),
-            "the `Lint` aggregator runs with `if: always()` but never reads \
-             `needs.{dep}.result`, so it reports green when `{dep}` fails, is \
-             cancelled, or is skipped. `needs` decides ordering here, not \
-             outcome."
-        );
-    }
-    assert!(
-        aggregator.contains("exit 1"),
-        "the `Lint` aggregator reads its dependencies' results but never exits \
-         non-zero, so nothing it discovers can turn the check red"
+    let mut unique = coords.clone();
+    unique.sort();
+    unique.dedup();
+    assert_eq!(
+        unique.len(),
+        coords.len(),
+        "the `{id}` matrix has a duplicated os/arch coordinate, so it looks \
+         like it covers more platforms than it does: {coords:?}"
     );
 }
 
-/// Whatever represents "lint passed" must gate `release` and `cleanup`.
+/// The lint job must gate `release` and `cleanup`.
 ///
-/// Only the `Lint` aggregator is in the branch ruleset, so for the legs these
-/// two `needs:` entries are their only other teeth. Drop them and a red lint
-/// blocks nothing downstream at all.
+/// This is the *only* automatic consequence of a red lint that lives in the
+/// repo. The status contexts are named per leg (`Lint linux/amd64`,
+/// `Lint darwin/arm64`) and branch protection is configured outside the tree,
+/// so nothing here can assert that a red lint blocks a merge — these two
+/// `needs:` entries are the whole of what the workflow itself enforces. Drop
+/// them and a red lint blocks nothing at all.
+///
+/// `needs:` on a matrix job waits for every leg and is satisfied only if all of
+/// them succeeded — verified against a real run rather than assumed:
+/// `bin_e2e` (`needs: [gen, build, …]`) started 4s after the *last* `build` leg
+/// finished, not the first.
 #[test]
 fn lint_gates_release_and_cleanup() {
     let workflow = std::fs::read_to_string(repo_root().join(".github/workflows/heph.yml"))
         .expect("read .github/workflows/heph.yml");
     let jobs = workflow_jobs(&workflow);
     let legs = lint_legs(&jobs);
-    let (aggregator_id, _) = lint_aggregator(&jobs).expect("a job is named `Lint`");
+    assert!(
+        !legs.is_empty(),
+        "no job in the workflow runs the `lint` script at all, so the check \
+         below would pass over an empty set"
+    );
 
     for gate in ["release", "cleanup"] {
         let (_, body) = jobs
@@ -722,15 +849,11 @@ fn lint_gates_release_and_cleanup() {
             .unwrap_or_else(|| panic!("the workflow defines a `{gate}` job"));
         let needs = job_needs(body);
 
-        // Either the aggregator — which transitively requires every leg — or
-        // each leg directly. Accepting both spellings keeps this from
-        // dictating the wiring while still refusing the one that gates nothing.
-        let covered = needs.contains(&aggregator_id) || legs.iter().all(|leg| needs.contains(leg));
+        let missing: Vec<&&str> = legs.iter().filter(|leg| !needs.contains(leg)).collect();
         assert!(
-            covered,
-            "`{gate}` depends on neither the `{aggregator_id}` aggregator nor \
-             every lint leg ({legs:?}), so a red lint blocks nothing \
-             downstream. Found needs: {needs:?}"
+            missing.is_empty(),
+            "`{gate}` does not depend on the lint job(s) {missing:?}, so a red \
+             lint blocks nothing downstream. Found needs: {needs:?}"
         );
     }
 }


### PR DESCRIPTION
Follow-up to #262, which merged while this was in flight. Implements your decision: **drop the aggregator, rename `lint_matrix` to `lint`.**

> ## ⚠️ You must change branch protection when this merges
>
> `lint` is now a matrix, so its status contexts are the per-leg names. **No check named plain `Lint` will report again.** The ruleset requires exactly that string today.
>
> **Required status checks — remove:**
> ```
> Lint
> ```
> **Required status checks — add:**
> ```
> Lint linux/amd64
> Lint darwin/arm64
> ```
>
> Those strings are copied from a **real run of this exact matrix** — run [30485344790](https://github.com/hephbuild/heph/actions/runs/30485344790) published `Lint linux/amd64` and `Lint darwin/arm64`. GitHub uses the rendered `name:`, with **no** parenthesised matrix suffix, so it is not `Lint (linux/amd64)`. Verified rather than guessed, because a wrong string blocks every PR exactly as badly as a missing one.
>
> Until you make that change:
> - the required `Lint` context can no longer report, so **every open PR stays blocked**;
> - a **red lint will not block a merge**, because neither new context is required yet.
>
> Both effects start the moment this merges, so it is worth doing in the same sitting.

## What changed

#262 landed with a matrix (`lint_matrix`) plus a do-nothing aggregator job named `Lint`, which existed purely to keep that required context reporting. You asked for the aggregator gone, so:

- job id `lint_matrix` → `lint`, keeping `name: Lint ${{ matrix.os }}/${{ matrix.arch }}`;
- the aggregator job and its `needs: lint_matrix` / `if: always()` / `needs.lint_matrix.result` machinery deleted, along with the comment block arguing for it.

Net **−15 lines** of workflow.

## `release` / `cleanup` still gate on a red lint

`release.needs` and `cleanup.needs` already said `lint`; after the rename they point at the matrix, so **no edit was required**. Confirmed rather than assumed.

`needs:` on a matrix job waits for **every** leg and is satisfied only if all succeeded. Checked against a real run instead of trusting the docs — in run 30485344790, `bin_e2e` (`needs: [gen, build, …]`, where `build` is a 3-leg matrix) started at `20:24:50`, four seconds after the **last** build leg finished (`20:24:46`), not after the first (`19:55:52`).

That `needs:` wiring is now the **only** consequence of a red lint that lives in the tree. Everything else is branch protection, which no test here can see — the module doc in `tests/lint_gate.rs` says so plainly rather than implying more coverage than exists.

## Guards: replaced, not dropped

`the_lint_aggregator_keeps_the_required_context_and_can_fail` asserted three things that are now false *by intent* — exactly one job named `Lint`, that it has no `strategy:`, and that it does not run the lint script. Deleted, with the `lint_aggregator` and `step_script` helpers, and replaced by `the_lint_job_is_a_matrix_over_both_supported_oses`, which asserts what the new shape must hold:

- it **is** a matrix — no `strategy:` means one platform, silently;
- both `linux/*` and `darwin/*` legs are present, parsed out of `matrix.include` as os/arch coordinates rather than pattern-matched on runner labels;
- **`fail-fast: false`** — with fail-fast on, the first red leg *cancels* the other, so the platform you did not see reports `cancelled` instead of a result. On the case that matters, a lint that fires on one OS only, that hides precisely the half you need;
- no duplicated coordinate, so a copy-pasted leg cannot masquerade as a second OS while both run the same one.

`a_lint_leg_cannot_report_success_without_running_the_lint` now covers the silent-pass class the aggregator check used to: `continue-on-error: true` turns a clippy failure into a `success` conclusion, and an `if:` on the Lint step skips clippy while the job still concludes `success`. Either makes the leg's own check green over an unlinted platform, and `needs:` treats it as satisfied. The `if:` check is scoped to the Lint step, because `sccache stats` legitimately carries `if: always()`.

**10 breaks injected, each caught:**

| Break | Caught by |
|---|---|
| matrix loses its darwin leg | `the_lint_gate_runs_on_macos_as_well_as_linux` |
| matrix loses its linux leg | same |
| leg runs something narrower than `lint` | same |
| `strategy:` removed entirely | same |
| `fail-fast: true` | `the_lint_job_is_a_matrix_over_both_supported_oses` |
| duplicated os/arch coordinate | same |
| `continue-on-error:` on the leg | `a_lint_leg_cannot_report_success_without_running_the_lint` |
| `if:` on the Lint step | same |
| `release` stops depending on lint | `lint_gates_release_and_cleanup` |
| `cleanup` stops depending on lint | same |

Each rewrite is applied **inside the `lint` job only**, via a helper that asserts the pattern was found there. An earlier round's negative test edited an identically-shaped block in `build:` instead and proved nothing — a negative test that silently edits the wrong thing is indistinguishable from a guard that works, so the mechanism is now scoped by construction.

Re-ran after rebasing onto current master (which gained #268 and #270): all 9 tests pass, all 10 breaks still caught. #270's new `bench`/`bench-corpus` members are in `qualityCrates`, which `the_fmt_pass_covers_every_workspace_member` independently confirms.

## Unchanged from #262

The `--no-default-features` pass and its `cargo tree -i fuser` probe plus positive control, the exclusion-list equality guard, `fix` keeping its default pass, and the measured cost notes in the workflow comment.

## Cost

No new cost: same two legs, one fewer job. The aggregator was a few seconds on an ubuntu runner and is gone.

Carried forward from #262, unchanged: the linux `Lint` step is 2m18s (the `--no-default-features` pass adds ~11s; `--all-features` is a measured 0.26s no-op). The darwin leg was 9m49s-10m24s cold and will stay near that on PRs until the `cargo-aarch64-apple-darwin-lint-*` key is populated from master — `setup-nix` is restore-only on PRs by design, and sccache never caches `clippy-driver` regardless.

**macOS runner contention remains the real price, and I did not re-measure it here.** The repo has a hard 5-concurrent-macOS cap; the darwin lint leg is a fourth macOS job in the `needs: gen` wave. From #262's measurements: `Build darwin/arm64` was not delayed and the workflow critical path (`Test linux/amd64`) did not move, but `Warm Binary E2E darwin/arm64` absorbed the queue and its margin over `Binary E2E darwin/arm64` fell from **803s to 4s**. Two attempts to re-measure under the matrix shape were abandoned when the pool saturated with eight sibling branches in flight (all four macOS jobs still queued 7.5 min in), so CI on this head is the evidence rather than a synthetic campaign. The shape is unchanged from what merged in #262 — this PR removes an ubuntu job, not a macOS one — so the contention should be identical.

## Verification

`cargo clippy --workspace --all-targets --locked -- -D warnings` exit 0 and `cargo fmt --check` exit 0 on `aarch64-apple-darwin` with `RUSTC_WRAPPER=""`; `nix-instantiate --parse devenv.nix` and a YAML parse of the workflow both clean; the workflow diff against master is exactly the rename plus the aggregator deletion, with nothing from #270's additions lost.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01A76DChMohieGMbRbnV1E7x
