### PR TITLE
feat(ci): enforce perfbench for real, monitor master, file issues

### DIFF
--- a/.github/workflows/heph.yml
+++ b/.github/workflows/heph.yml
@@ -996,6 +996,7 @@ jobs:
         run: |
           BENCH=./candidate-dist/heph-bench
           any_regression=false
+          mkdir -p verdicts
           report=$(
             echo "# Perf: ${{ matrix.os }}/${{ matrix.arch }}"
             if [ "${{ steps.baseline_fetch.outputs.ok }}" != "true" ]; then
@@ -1015,6 +1016,7 @@ jobs:
                   if [ -f "$base" ] && [ -f "$cand" ]; then
                     "$BENCH" compare --baseline "$base" --candidate "$cand" \
                       --thresholds "$GITHUB_WORKSPACE/.github/perfbench-thresholds.json" \
+                      --json "verdicts/${tier}_${scenario}.json" \
                       --allow-regression
                   else
                     echo "_${scenario}: no results (run step failed — see logs)_"
@@ -1033,6 +1035,52 @@ jobs:
             echo "regression detected — see the job summary for the table" >&2
             exit 1
           fi
+
+      # `always()`: the step above now genuinely exits non-zero on a real
+      # regression, and the numbers are worth having in PostHog regardless of
+      # whether this run passed or failed the gate. `event_type` (pull_request
+      # vs push) rides along as a property rather than gating which runs get
+      # sent — a trend chart can filter to `push` for the "master over time"
+      # view; nothing here decides that policy for it. Best-effort: PostHog
+      # being briefly unreachable must never fail this job over telemetry.
+      - name: Push metrics to PostHog
+        if: always() && steps.baseline_fetch.outputs.ok == 'true'
+        env:
+          POSTHOG_CI_KEY: ${{ secrets.POSTHOG_CI_KEY }}
+        run: |
+          events="[]"
+          for f in verdicts/*.json; do
+            [ -f "$f" ] || continue
+            base=$(basename "$f" .json)
+            tier="${base%_*}"
+            scenario="${base#*_}"
+            batch=$(jq --arg tier "$tier" --arg scenario "$scenario" \
+              --arg os "${{ matrix.os }}" --arg arch "${{ matrix.arch }}" \
+              --arg sha "${{ github.sha }}" --arg base_sha "${{ steps.base.outputs.sha }}" \
+              --arg event_type "${{ github.event_name }}" \
+              --arg run_id "${{ github.run_id }}" \
+              --arg run_url "${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}" \
+              '[.[] | {
+                event: "perf_benchmark",
+                distinct_id: "perfbench",
+                properties: (. + {
+                  tier: $tier, scenario: $scenario, os: $os, arch: $arch,
+                  sha: $sha, base_sha: $base_sha, event_type: $event_type,
+                  run_id: $run_id, run_url: $run_url
+                })
+              }]' "$f")
+            events=$(printf '%s' "$events" | jq --argjson add "$batch" '. + $add')
+          done
+          count=$(printf '%s' "$events" | jq 'length')
+          if [ "$count" -eq 0 ]; then
+            echo "no verdicts to push"
+            exit 0
+          fi
+          echo "pushing $count perf_benchmark event(s) to PostHog"
+          payload=$(jq -n --arg key "$POSTHOG_CI_KEY" --argjson batch "$events" '{api_key: $key, batch: $batch}')
+          curl -sS --max-time 15 -X POST "https://eu.i.posthog.com/batch/" \
+            -H "Content-Type: application/json" \
+            -d "$payload" || echo "PostHog push failed — not failing the job over telemetry"
 
       # Push-only: a PR failing this check already blocks the merge, so
       # there's nothing further to escalate there. On `master` the merge

--- a/.github/workflows/heph.yml
+++ b/.github/workflows/heph.yml
@@ -819,7 +819,12 @@ jobs:
       PERFBENCH_LAYERS: "10"
       PERFBENCH_FAN_OUT: "4"
       PERFBENCH_GO_PACKAGES: "60"
-      PERFBENCH_REPS: "3"
+      # 3 was too few to tell signal from CI-runner noise (the first live
+      # runs showed exactly that). Interleaving (see the run steps below)
+      # fixes systematic drift between candidate/baseline; more reps is what
+      # narrows the noise floor itself. Bumped for now — a real number should
+      # come from watching `noise_band_pct` in actual runs, not a guess.
+      PERFBENCH_REPS: "7"
     strategy:
       fail-fast: false
       matrix:
@@ -958,26 +963,54 @@ jobs:
             --go-packages "$PERFBENCH_GO_PACKAGES" \
             --out bench-corpus
 
+      # Candidate and baseline are interleaved rep-by-rep, not run to
+      # completion one side at a time: `run ... --reps N` in one shot would
+      # let a systematic drift on the runner (thermal state ramping up, a
+      # noisy neighbor arriving mid-job) land entirely on whichever side
+      # happened to run second, biasing the comparison rather than adding
+      # symmetric noise to both. `--warmup 1 --reps 0` primes the shared
+      # cache state once per side (a no-op for `cold`, which has none); each
+      # `--reps 1 --skip-prepare --append` round after that measures one more
+      # rep per side and merges it into the same output file, alternating.
       - name: Time Tier A (inprocess) scenarios
         if: steps.baseline_fetch.outputs.bench_ok == 'true'
         continue-on-error: true
         run: |
           for scenario in cold full-hit incremental; do
+            cand_out="candidate_inproc_${scenario}.json"
+            base_out="baseline_inproc_${scenario}.json"
             ./candidate-dist/heph-bench run inprocess --corpus bench-corpus --scenario "$scenario" \
-              --warmup 1 --reps "$PERFBENCH_REPS" --out "candidate_inproc_${scenario}.json"
+              --warmup 1 --reps 0 --out /dev/null
             ./baseline-dist/heph-bench run inprocess --corpus bench-corpus --scenario "$scenario" \
-              --warmup 1 --reps "$PERFBENCH_REPS" --out "baseline_inproc_${scenario}.json"
+              --warmup 1 --reps 0 --out /dev/null
+            rm -f "$cand_out" "$base_out"
+            for i in $(seq 0 $((PERFBENCH_REPS - 1))); do
+              ./candidate-dist/heph-bench run inprocess --corpus bench-corpus --scenario "$scenario" \
+                --warmup 0 --reps 1 --skip-prepare --rep-offset "$i" --append --out "$cand_out"
+              ./baseline-dist/heph-bench run inprocess --corpus bench-corpus --scenario "$scenario" \
+                --warmup 0 --reps 1 --skip-prepare --rep-offset "$i" --append --out "$base_out"
+            done
           done
 
       - name: Time Tier B (dist) scenarios
         if: steps.baseline_fetch.outputs.ok == 'true'
         continue-on-error: true
         run: |
+          BENCH=./candidate-dist/heph-bench
           for scenario in cold full-hit incremental; do
-            ./candidate-dist/heph-bench run dist --dist candidate-dist --corpus bench-corpus --scenario "$scenario" \
-              --warmup 1 --reps "$PERFBENCH_REPS" --out "candidate_dist_${scenario}.json"
-            ./candidate-dist/heph-bench run dist --dist baseline-dist --corpus bench-corpus --scenario "$scenario" \
-              --warmup 1 --reps "$PERFBENCH_REPS" --out "baseline_dist_${scenario}.json"
+            cand_out="candidate_dist_${scenario}.json"
+            base_out="baseline_dist_${scenario}.json"
+            "$BENCH" run dist --dist candidate-dist --corpus bench-corpus --scenario "$scenario" \
+              --warmup 1 --reps 0 --out /dev/null
+            "$BENCH" run dist --dist baseline-dist --corpus bench-corpus --scenario "$scenario" \
+              --warmup 1 --reps 0 --out /dev/null
+            rm -f "$cand_out" "$base_out"
+            for i in $(seq 0 $((PERFBENCH_REPS - 1))); do
+              "$BENCH" run dist --dist candidate-dist --corpus bench-corpus --scenario "$scenario" \
+                --warmup 0 --reps 1 --skip-prepare --rep-offset "$i" --append --out "$cand_out"
+              "$BENCH" run dist --dist baseline-dist --corpus bench-corpus --scenario "$scenario" \
+                --warmup 0 --reps 1 --skip-prepare --rep-offset "$i" --append --out "$base_out"
+            done
           done
 
       # Every scenario/tier combination is always attempted and reported —
@@ -987,6 +1020,12 @@ jobs:
       # rendered table for "REGRESSION" (the verdict `compare --allow-
       # regression` still prints even though it won't fail on it) and fails
       # for real if anything regressed, on both `pull_request` and `push`.
+      #
+      # One `compare` call per TIER, not per scenario: each `run` invocation
+      # writes a single-scenario RunResults, so the 3 scenario files per side
+      # are merged into one multi-scenario RunResults first (`jq -s`) — a
+      # `compare` call per scenario would render its own header each time,
+      # repeating the table 3x instead of one table with 3 rows.
       #
       # The assembled report is captured to `perf-report.md` as well as the
       # step summary — "File regression issue" reads that file back so the
@@ -1010,18 +1049,26 @@ jobs:
                   echo "_skipped: baseline release predates publishing \`heph-bench\`_"
                   continue
                 fi
+                base_files=()
+                cand_files=()
                 for scenario in cold full-hit incremental; do
-                  base="baseline_${tier}_${scenario}.json"
-                  cand="candidate_${tier}_${scenario}.json"
-                  if [ -f "$base" ] && [ -f "$cand" ]; then
-                    "$BENCH" compare --baseline "$base" --candidate "$cand" \
-                      --thresholds "$GITHUB_WORKSPACE/.github/perfbench-thresholds.json" \
-                      --json "verdicts/${tier}_${scenario}.json" \
-                      --allow-regression
-                  else
-                    echo "_${scenario}: no results (run step failed — see logs)_"
+                  b="baseline_${tier}_${scenario}.json"
+                  c="candidate_${tier}_${scenario}.json"
+                  if [ -f "$b" ] && [ -f "$c" ]; then
+                    base_files+=("$b")
+                    cand_files+=("$c")
                   fi
                 done
+                if [ ${#base_files[@]} -eq 0 ]; then
+                  echo "_no results (run step failed — see logs)_"
+                  continue
+                fi
+                jq -s '{tier: .[0].tier, scenarios: [.[].scenarios[0]]}' "${base_files[@]}" > "merged_baseline_${tier}.json"
+                jq -s '{tier: .[0].tier, scenarios: [.[].scenarios[0]]}' "${cand_files[@]}" > "merged_candidate_${tier}.json"
+                "$BENCH" compare --baseline "merged_baseline_${tier}.json" --candidate "merged_candidate_${tier}.json" \
+                  --thresholds "$GITHUB_WORKSPACE/.github/perfbench-thresholds.json" \
+                  --json "verdicts/${tier}.json" \
+                  --allow-regression
               done
             fi
           )
@@ -1051,10 +1098,10 @@ jobs:
           events="[]"
           for f in verdicts/*.json; do
             [ -f "$f" ] || continue
-            base=$(basename "$f" .json)
-            tier="${base%_*}"
-            scenario="${base#*_}"
-            batch=$(jq --arg tier "$tier" --arg scenario "$scenario" \
+            # One file per tier (inproc/dist), each an array of per-scenario
+            # verdicts — `scenario` already lives inside each entry.
+            tier=$(basename "$f" .json)
+            batch=$(jq --arg tier "$tier" \
               --arg os "${{ matrix.os }}" --arg arch "${{ matrix.arch }}" \
               --arg sha "${{ github.sha }}" --arg base_sha "${{ steps.base.outputs.sha }}" \
               --arg event_type "${{ github.event_name }}" \
@@ -1064,7 +1111,7 @@ jobs:
                 event: "perf_benchmark",
                 distinct_id: "perfbench",
                 properties: (. + {
-                  tier: $tier, scenario: $scenario, os: $os, arch: $arch,
+                  tier: $tier, os: $os, arch: $arch,
                   sha: $sha, base_sha: $base_sha, event_type: $event_type,
                   run_id: $run_id, run_url: $run_url
                 })

--- a/.github/workflows/heph.yml
+++ b/.github/workflows/heph.yml
@@ -740,11 +740,17 @@ jobs:
         shell: devenv shell bash -- -e {0}
         run: sccache --show-stats
 
-  # Perf-regression gate: generates one synthetic corpus, times a fixed
-  # scenario set against N (this PR's head, from the `build` job's own
-  # artifacts) and N-1 (a *published release* of the PR's merge-base), and
-  # reports a regression verdict. PR-only — there is nothing to compare a
-  # baseline against on a plain `push`.
+  # Perf-regression check: generates one synthetic corpus, times a fixed
+  # scenario set against N and N-1, and reports a regression verdict. Two
+  # triggers, two roles:
+  #   - `pull_request`: N is this PR's head, N-1 its merge-base with the
+  #     target branch. This is the GATE — a real regression fails the check
+  #     for real (see "Enforced for real" below).
+  #   - `push` to `master`: N is the commit that just landed, N-1 is the
+  #     commit immediately before it (`github.event.before`). Nothing is
+  #     blocked at this point (the merge already happened) — this is
+  #     continuous monitoring, so a regression instead files a GitHub issue
+  #     (see "File regression issue").
   #
   # Nothing in this job is built. `heph`, the go plugin cdylib, and
   # `heph-bench` itself are all release assets (the `build` job publishes
@@ -769,34 +775,40 @@ jobs:
   # prerelease to hephbuild/heph-artifacts-v1 (the `upload_artifacts` job).
   # The release tag isn't the commit SHA — it's `git describe` plus the CI
   # run_number that built it — so "resolve baseline release" re-derives that
-  # exact tag by finding the `master`-push CI run for the merge-base SHA via
+  # exact tag by finding the `master`-push CI run for the baseline SHA via
   # the GitHub API and feeding its run_number through the same `version.sh`
   # logic that originally produced it. If no such run is found (history
-  # pruned, merge-base predates this job, API hiccup), the job is skipped for
-  # that leg with a note — there is deliberately no "build it instead"
-  # fallback, since a slow silent fallback is exactly what turns into "why is
-  # this job suddenly slow" months from now.
+  # pruned, baseline predates this job, API hiccup, or — on `push` — this is
+  # the first commit on the ref), the job is skipped for that leg with a
+  # note — there is deliberately no "build it instead" fallback, since a slow
+  # silent fallback is exactly what turns into "why is this job suddenly
+  # slow" months from now.
   #
-  # Bootstrap note: this PR is what starts publishing `heph-bench`. Every
-  # merge-base predates that until this merges, so `baseline_fetch`'s
-  # `heph-bench` download will 404 on the very first runs — Tier A is skipped
-  # for those (Tier B still needs only `heph` + the go plugin, always
-  # present). Resolves itself permanently once this merges.
-  #
-  # Report-only for now: `continue-on-error` on the run/compare steps means a
-  # detected regression (or a harness bug) shows as a yellow warning, not a
-  # red required check. Once the thresholds in `.github/perfbench-thresholds.json`
-  # have been sanity-checked against a couple weeks of real PRs, drop
-  # `continue-on-error` and add "Perf" as a required status check in branch
-  # protection. That also gives the override this needs ("overridable by
-  # me"): a repo admin already bypasses required checks on merge — no extra
-  # plumbing to build.
+  # Enforced for real: the "Compare and report" step exits non-zero when any
+  # scenario regresses past its threshold, on both triggers. On a PR that
+  # fails the check; on `push` there is nothing left to block, but a red
+  # check on the commit is still useful signal, and it drives "File
+  # regression issue" below. The override this needs ("overridable by me")
+  # is a repo admin bypassing a required check on merge — no extra plumbing.
+  # Thresholds live in `.github/perfbench-thresholds.json`; they started
+  # deliberately loose (20%) and should tighten as real PR data comes in.
   perfbench:
     name: Perf ${{ matrix.os }}/${{ matrix.arch }}
-    if: github.event_name == 'pull_request'
+    if: github.event_name == 'pull_request' || (github.event_name == 'push' && github.ref == 'refs/heads/master')
     runs-on: ${{ matrix.runs-on }}
     timeout-minutes: 20
     needs: [build]
+    # Specifying `permissions:` at all makes it exhaustive — everything not
+    # listed drops to `none`. `contents: read` for the checkout, `actions:
+    # read` for the "Resolve baseline release" run-lookup, `issues: write`
+    # for "File regression issue" (list/create/label, all against this
+    # repo). The cross-repo `gh release download` against
+    # hephbuild/heph-artifacts-v1 uses HEPH_ARTIFACTS_PAT, not this token, so
+    # it is unaffected either way.
+    permissions:
+      contents: read
+      actions: read
+      issues: write
     env:
       # Tunable without touching the steps below. Sized for a few minutes'
       # wall time per leg; raise toward the thousands-of-targets scale heph
@@ -841,18 +853,34 @@ jobs:
           go-version: "1.25"
           cache: false
 
-      - name: Resolve merge-base
+      # PR: the merge-base with the target branch. Push (to master): the
+      # commit immediately before this one — `github.event.before`, the
+      # correct source for "previous commit on this ref" (robust to force-
+      # pushes in a way `HEAD~1` is not). `before` is all-zeros on the very
+      # first push to a ref; treated the same as "no baseline found" below.
+      - name: Resolve baseline SHA
         id: base
         run: |
-          git fetch origin "${{ github.base_ref }}"
-          echo "sha=$(git merge-base "origin/${{ github.base_ref }}" HEAD)" >> "$GITHUB_OUTPUT"
+          if [ "${{ github.event_name }}" = "pull_request" ]; then
+            git fetch origin "${{ github.base_ref }}"
+            echo "sha=$(git merge-base "origin/${{ github.base_ref }}" HEAD)" >> "$GITHUB_OUTPUT"
+          else
+            sha="${{ github.event.before }}"
+            if [ -z "$sha" ] || [ "$sha" = "0000000000000000000000000000000000000000" ]; then
+              echo "no previous commit on this ref (first push) — nothing to compare against"
+              echo "sha=" >> "$GITHUB_OUTPUT"
+            else
+              echo "sha=$sha" >> "$GITHUB_OUTPUT"
+            fi
+          fi
 
       # Re-derives the exact version tag `master`'s own CI run published the
-      # merge-base commit's release under — see the job comment. Only needs
+      # baseline commit's release under — see the job comment. Only needs
       # `gh api` (against this repo, default token) and `git describe`
       # against a commit already present from the full-history checkout
       # above; no build, no checkout of that commit.
       - name: Resolve baseline release
+        if: steps.base.outputs.sha != ''
         id: baseline_release
         env:
           GH_TOKEN: ${{ github.token }}
@@ -860,7 +888,7 @@ jobs:
           RUN_NUMBER=$(gh api "repos/${{ github.repository }}/actions/runs?head_sha=${{ steps.base.outputs.sha }}&status=success" \
             --jq '[.workflow_runs[] | select(.name=="CI" and .event=="push")] | first | .run_number // empty')
           if [ -z "$RUN_NUMBER" ]; then
-            echo "no successful master push run found for merge-base ${{ steps.base.outputs.sha }}"
+            echo "no successful master push run found for baseline ${{ steps.base.outputs.sha }}"
             echo "found=false" >> "$GITHUB_OUTPUT"
             exit 0
           fi
@@ -952,14 +980,23 @@ jobs:
               --warmup 1 --reps "$PERFBENCH_REPS" --out "baseline_dist_${scenario}.json"
           done
 
+      # Every scenario/tier combination is always attempted and reported —
+      # `--allow-regression` keeps an individual `compare` call from ever
+      # exiting non-zero, so one regression doesn't cut the table short. The
+      # step's OWN exit code is what actually enforces: it greps the
+      # rendered table for "REGRESSION" (the verdict `compare --allow-
+      # regression` still prints even though it won't fail on it) and fails
+      # for real if anything regressed, on both `pull_request` and `push`.
       - name: Compare and report
-        continue-on-error: true
+        id: compare
         run: |
+          BENCH=./candidate-dist/heph-bench
+          any_regression=false
           {
             echo "# Perf: ${{ matrix.os }}/${{ matrix.arch }}"
             if [ "${{ steps.baseline_fetch.outputs.ok }}" != "true" ]; then
               echo ""
-              echo "_skipped: no published release found for merge-base \`${{ steps.base.outputs.sha }}\`_"
+              echo "_skipped: no published release found for baseline \`${{ steps.base.outputs.sha }}\`_"
             else
               for tier in inproc dist; do
                 echo ""
@@ -972,9 +1009,13 @@ jobs:
                   base="baseline_${tier}_${scenario}.json"
                   cand="candidate_${tier}_${scenario}.json"
                   if [ -f "$base" ] && [ -f "$cand" ]; then
-                    ./candidate-dist/heph-bench compare --baseline "$base" --candidate "$cand" \
+                    table=$("$BENCH" compare --baseline "$base" --candidate "$cand" \
                       --thresholds "$GITHUB_WORKSPACE/.github/perfbench-thresholds.json" \
-                      --allow-regression || true
+                      --allow-regression)
+                    printf '%s\n' "$table"
+                    if printf '%s' "$table" | grep -q 'REGRESSION'; then
+                      any_regression=true
+                    fi
                   else
                     echo "_${scenario}: no results (run step failed — see logs)_"
                   fi
@@ -982,6 +1023,41 @@ jobs:
               done
             fi
           } >> "$GITHUB_STEP_SUMMARY"
+          echo "regressed=$any_regression" >> "$GITHUB_OUTPUT"
+          if [ "$any_regression" = "true" ]; then
+            echo "regression detected — see the job summary for the table" >&2
+            exit 1
+          fi
+
+      # Push-only: a PR failing this check already blocks the merge, so
+      # there's nothing further to escalate there. On `master` the merge
+      # already happened — a red check on the commit is easy to miss, so a
+      # regression instead becomes a durable, visible artifact. `always()`
+      # because the step above now genuinely exits non-zero on a real
+      # regression (outputs set before `exit 1` are still recorded); a dedup
+      # check against open issues keeps a re-run (or retry) from spamming.
+      - name: File regression issue
+        if: always() && steps.compare.outputs.regressed == 'true' && github.event_name == 'push'
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          TITLE="Perf regression: ${{ matrix.os }}/${{ matrix.arch }} at ${{ github.sha }}"
+          existing=$(gh issue list --repo "${{ github.repository }}" --state open \
+            --search "\"$TITLE\" in:title" --json number --jq '.[0].number // empty')
+          if [ -n "$existing" ]; then
+            echo "issue #$existing already covers this — not filing a duplicate"
+            exit 0
+          fi
+          gh label create perf-regression --repo "${{ github.repository }}" \
+            --color d73a4a --description "Automated performance regression report" --force
+          BODY=$(printf 'Perf regression on `master` for **%s/%s**, vs the previous commit `%s`.\n\nJob summary: %s/%s/actions/runs/%s\nCommit: %s/%s/commit/%s\n' \
+            "${{ matrix.os }}" "${{ matrix.arch }}" "${{ steps.base.outputs.sha }}" \
+            "${{ github.server_url }}" "${{ github.repository }}" "${{ github.run_id }}" \
+            "${{ github.server_url }}" "${{ github.repository }}" "${{ github.sha }}")
+          gh issue create --repo "${{ github.repository }}" \
+            --title "$TITLE" \
+            --label perf-regression \
+            --body "$BODY"
 
   release:
     name: Release

--- a/.github/workflows/heph.yml
+++ b/.github/workflows/heph.yml
@@ -987,12 +987,16 @@ jobs:
       # rendered table for "REGRESSION" (the verdict `compare --allow-
       # regression` still prints even though it won't fail on it) and fails
       # for real if anything regressed, on both `pull_request` and `push`.
+      #
+      # The assembled report is captured to `perf-report.md` as well as the
+      # step summary — "File regression issue" reads that file back so the
+      # issue carries the actual numbers, not just links to go find them.
       - name: Compare and report
         id: compare
         run: |
           BENCH=./candidate-dist/heph-bench
           any_regression=false
-          {
+          report=$(
             echo "# Perf: ${{ matrix.os }}/${{ matrix.arch }}"
             if [ "${{ steps.baseline_fetch.outputs.ok }}" != "true" ]; then
               echo ""
@@ -1009,20 +1013,21 @@ jobs:
                   base="baseline_${tier}_${scenario}.json"
                   cand="candidate_${tier}_${scenario}.json"
                   if [ -f "$base" ] && [ -f "$cand" ]; then
-                    table=$("$BENCH" compare --baseline "$base" --candidate "$cand" \
+                    "$BENCH" compare --baseline "$base" --candidate "$cand" \
                       --thresholds "$GITHUB_WORKSPACE/.github/perfbench-thresholds.json" \
-                      --allow-regression)
-                    printf '%s\n' "$table"
-                    if printf '%s' "$table" | grep -q 'REGRESSION'; then
-                      any_regression=true
-                    fi
+                      --allow-regression
                   else
                     echo "_${scenario}: no results (run step failed — see logs)_"
                   fi
                 done
               done
             fi
-          } >> "$GITHUB_STEP_SUMMARY"
+          )
+          printf '%s\n' "$report" >> "$GITHUB_STEP_SUMMARY"
+          printf '%s\n' "$report" > perf-report.md
+          if printf '%s' "$report" | grep -q 'REGRESSION'; then
+            any_regression=true
+          fi
           echo "regressed=$any_regression" >> "$GITHUB_OUTPUT"
           if [ "$any_regression" = "true" ]; then
             echo "regression detected — see the job summary for the table" >&2
@@ -1050,10 +1055,12 @@ jobs:
           fi
           gh label create perf-regression --repo "${{ github.repository }}" \
             --color d73a4a --description "Automated performance regression report" --force
-          BODY=$(printf 'Perf regression on `master` for **%s/%s**, vs the previous commit `%s`.\n\nJob summary: %s/%s/actions/runs/%s\nCommit: %s/%s/commit/%s\n' \
-            "${{ matrix.os }}" "${{ matrix.arch }}" "${{ steps.base.outputs.sha }}" \
+          LINKS=$(printf 'Job summary: %s/%s/actions/runs/%s\nCommit: %s/%s/commit/%s\n' \
             "${{ github.server_url }}" "${{ github.repository }}" "${{ github.run_id }}" \
             "${{ github.server_url }}" "${{ github.repository }}" "${{ github.sha }}")
+          BODY=$(printf 'Perf regression on `master` for **%s/%s**, vs the previous commit `%s`:\n\n%s\n%s' \
+            "${{ matrix.os }}" "${{ matrix.arch }}" "${{ steps.base.outputs.sha }}" \
+            "$(cat perf-report.md)" "$LINKS")
           gh issue create --repo "${{ github.repository }}" \
             --title "$TITLE" \
             --label perf-regression \

--- a/crates/bench/src/dist.rs
+++ b/crates/bench/src/dist.rs
@@ -6,7 +6,7 @@
 //! `crates/bin-e2e/tests/common/mod.rs`'s `Dist` does: a normalized
 //! directory (`heph`, `heph-<name>-plugin.<ext>`), never rebuilt here.
 
-use crate::timing::{RunResults, ScenarioResult};
+use crate::timing::{RunOptions, RunResults, ScenarioResult};
 use anyhow::{Context, Result, bail};
 use bench_corpus::CorpusManifest;
 use clap::ValueEnum;
@@ -26,11 +26,17 @@ pub struct Dist {
 
 impl Dist {
     pub fn locate(dir: &Path) -> Result<Self> {
-        let root = dir.to_path_buf();
-        let heph = root.join("heph");
+        let heph = dir.join("heph");
         if !heph.is_file() {
-            bail!("{} does not contain a `heph` binary", root.display());
+            bail!("{} does not contain a `heph` binary", dir.display());
         }
+        // Absolute: `build_go_tree` spawns `heph` with `current_dir(corpus)`,
+        // so a relative `--dist` path (the common case — CI passes plain
+        // `candidate-dist`) would silently resolve against the corpus dir
+        // instead of the caller's cwd once that happens.
+        let root = dir
+            .canonicalize()
+            .with_context(|| format!("canonicalize {}", dir.display()))?;
         Ok(Self { root })
     }
 
@@ -159,8 +165,7 @@ pub fn run(
     corpus: &Path,
     manifest: &CorpusManifest,
     scenario: Scenario,
-    warmup: usize,
-    reps: usize,
+    opts: &RunOptions,
 ) -> Result<RunResults> {
     if manifest.go_package_count == 0 {
         bail!(
@@ -171,7 +176,7 @@ pub fn run(
     write_go_config(corpus, &dist)?;
     let home = tempfile::tempdir().context("create HOME tempdir")?;
 
-    let mut wall_ms = Vec::with_capacity(reps);
+    let mut wall_ms = Vec::with_capacity(opts.reps);
     let timed_build = |home: &Path| -> Result<f64> {
         let start = Instant::now();
         build_go_tree(&dist, corpus, home)?;
@@ -180,35 +185,43 @@ pub fn run(
 
     match scenario {
         Scenario::Cold => {
-            for _ in 0..warmup {
+            for _ in 0..opts.warmup {
                 wipe_cache(corpus)?;
                 timed_build(home.path())?;
             }
-            for _ in 0..reps {
+            for _ in 0..opts.reps {
                 wipe_cache(corpus)?;
                 wall_ms.push(timed_build(home.path())?);
             }
         }
         Scenario::FullHit => {
-            wipe_cache(corpus)?;
-            for _ in 0..warmup {
-                timed_build(home.path())?;
+            if !opts.skip_prepare {
+                wipe_cache(corpus)?;
+                for _ in 0..opts.warmup {
+                    timed_build(home.path())?;
+                }
             }
-            for _ in 0..reps {
+            for _ in 0..opts.reps {
                 wall_ms.push(timed_build(home.path())?);
             }
         }
         Scenario::Incremental => {
-            wipe_cache(corpus)?;
-            for _ in 0..warmup {
-                timed_build(home.path())?;
+            if !opts.skip_prepare {
+                wipe_cache(corpus)?;
+                for _ in 0..opts.warmup {
+                    timed_build(home.path())?;
+                }
             }
-            for i in 0..reps {
+            for i in 0..opts.reps {
                 // Mutates the go/ subtree being built here, not the bash
                 // pkgN packages `bench_corpus::incrementalize` touches — Tier
                 // B only builds `//go/...`.
-                bench_corpus::incrementalize_go(&corpus.join("go"), 0.01, 0xDEC1 ^ i as u64)
-                    .context("mutate go corpus for incremental scenario")?;
+                bench_corpus::incrementalize_go(
+                    &corpus.join("go"),
+                    0.01,
+                    0xDEC1 ^ (opts.rep_offset + i) as u64,
+                )
+                .context("mutate go corpus for incremental scenario")?;
                 wall_ms.push(timed_build(home.path())?);
             }
         }

--- a/crates/bench/src/inprocess.rs
+++ b/crates/bench/src/inprocess.rs
@@ -7,7 +7,7 @@
 //! registered — real users' most common path, and the one that never
 //! crosses the plugin ABI seam.
 
-use crate::timing::{RunResults, ScenarioResult};
+use crate::timing::{RunOptions, RunResults, ScenarioResult};
 use anyhow::{Context, Result};
 use bench_corpus::CorpusManifest;
 use clap::ValueEnum;
@@ -95,18 +95,17 @@ pub async fn run(
     corpus: &Path,
     manifest: &CorpusManifest,
     scenario: Scenario,
-    warmup: usize,
-    reps: usize,
+    opts: &RunOptions,
 ) -> Result<RunResults> {
-    let mut wall_ms = Vec::with_capacity(reps);
+    let mut wall_ms = Vec::with_capacity(opts.reps);
 
     match scenario {
         Scenario::Cold => {
-            for _ in 0..warmup {
+            for _ in 0..opts.warmup {
                 wipe_cache(corpus)?;
                 resolve_all(corpus).await?;
             }
-            for _ in 0..reps {
+            for _ in 0..opts.reps {
                 wipe_cache(corpus)?;
                 let start = Instant::now();
                 resolve_all(corpus).await?;
@@ -114,27 +113,36 @@ pub async fn run(
             }
         }
         Scenario::FullHit => {
-            wipe_cache(corpus)?;
-            for _ in 0..warmup {
-                resolve_all(corpus).await?;
+            if !opts.skip_prepare {
+                wipe_cache(corpus)?;
+                for _ in 0..opts.warmup {
+                    resolve_all(corpus).await?;
+                }
             }
-            for _ in 0..reps {
+            for _ in 0..opts.reps {
                 let start = Instant::now();
                 resolve_all(corpus).await?;
                 wall_ms.push(start.elapsed().as_secs_f64() * 1000.0);
             }
         }
         Scenario::Incremental => {
-            wipe_cache(corpus)?;
-            for _ in 0..warmup {
-                resolve_all(corpus).await?;
+            if !opts.skip_prepare {
+                wipe_cache(corpus)?;
+                for _ in 0..opts.warmup {
+                    resolve_all(corpus).await?;
+                }
             }
             // Fresh mutation before every measured rep — otherwise only the
             // first rep is a genuine incremental rebuild and the rest are
             // full-hit repeats wearing the wrong label.
-            for i in 0..reps {
-                bench_corpus::incrementalize(manifest, corpus, 0.01, 0xDEC1 ^ i as u64)
-                    .context("mutate corpus for incremental scenario")?;
+            for i in 0..opts.reps {
+                bench_corpus::incrementalize(
+                    manifest,
+                    corpus,
+                    0.01,
+                    0xDEC1 ^ (opts.rep_offset + i) as u64,
+                )
+                .context("mutate corpus for incremental scenario")?;
                 let start = Instant::now();
                 resolve_all(corpus).await?;
                 wall_ms.push(start.elapsed().as_secs_f64() * 1000.0);

--- a/crates/bench/src/main.rs
+++ b/crates/bench/src/main.rs
@@ -7,6 +7,7 @@ use anyhow::{Context, Result};
 use bench_corpus::CorpusParams;
 use clap::{Args, Parser, Subcommand};
 use std::path::PathBuf;
+use timing::RunOptions;
 
 /// Perf-regression harness: generate a deterministic synthetic corpus, time
 /// `heph` scenarios against it (in-process or the real prebuilt binary +
@@ -68,6 +69,21 @@ struct InprocessArgs {
     warmup: usize,
     #[arg(long, default_value_t = 5)]
     reps: usize,
+    /// Skip the scenario's wipe/warm preamble — assumes a prior invocation
+    /// already did it. Lets a caller interleave candidate/baseline rep by
+    /// rep: one `--skip-prepare=false` call to prepare, then alternating
+    /// `--reps 1 --skip-prepare --append` calls per side per round.
+    #[arg(long)]
+    skip_prepare: bool,
+    /// Seed offset for `incremental`'s per-rep mutation. Required to be
+    /// distinct across separate `--reps 1` invocations of the same
+    /// scenario/corpus, or each call mutates the same files again.
+    #[arg(long, default_value_t = 0)]
+    rep_offset: usize,
+    /// Merge into an existing `--out` file's matching scenario instead of
+    /// overwriting it — the other half of interleaving one rep at a time.
+    #[arg(long)]
+    append: bool,
     #[arg(long)]
     out: PathBuf,
 }
@@ -86,6 +102,15 @@ struct DistArgs {
     warmup: usize,
     #[arg(long, default_value_t = 3)]
     reps: usize,
+    /// See `run inprocess --skip-prepare` — identical contract here.
+    #[arg(long)]
+    skip_prepare: bool,
+    /// See `run inprocess --rep-offset` — identical contract here.
+    #[arg(long, default_value_t = 0)]
+    rep_offset: usize,
+    /// See `run inprocess --append` — identical contract here.
+    #[arg(long)]
+    append: bool,
     #[arg(long)]
     out: PathBuf,
 }
@@ -164,38 +189,65 @@ async fn run_run(cmd: RunCmd) -> Result<()> {
         RunCmd::Inprocess(args) => {
             let manifest = bench_corpus::load_manifest(&args.corpus)
                 .context("load corpus manifest (run `corpus` first)")?;
-            let results = inprocess::run(
-                &args.corpus,
-                &manifest,
-                args.scenario,
-                args.warmup,
-                args.reps,
-            )
-            .await
-            .context("run inprocess scenario")?;
-            write_results(&args.out, &results)
+            let opts = RunOptions {
+                warmup: args.warmup,
+                reps: args.reps,
+                skip_prepare: args.skip_prepare,
+                rep_offset: args.rep_offset,
+            };
+            let results = inprocess::run(&args.corpus, &manifest, args.scenario, &opts)
+                .await
+                .context("run inprocess scenario")?;
+            write_results(&args.out, &results, args.append)
         }
         RunCmd::Dist(args) => {
             let manifest = bench_corpus::load_manifest(&args.corpus)
                 .context("load corpus manifest (run `corpus` first)")?;
-            let results = dist::run(
-                &args.dist,
-                &args.corpus,
-                &manifest,
-                args.scenario,
-                args.warmup,
-                args.reps,
-            )
-            .context("run dist scenario")?;
-            write_results(&args.out, &results)
+            let opts = RunOptions {
+                warmup: args.warmup,
+                reps: args.reps,
+                skip_prepare: args.skip_prepare,
+                rep_offset: args.rep_offset,
+            };
+            let results = dist::run(&args.dist, &args.corpus, &manifest, args.scenario, &opts)
+                .context("run dist scenario")?;
+            write_results(&args.out, &results, args.append)
         }
     }
 }
 
-fn write_results(out: &std::path::Path, results: &timing::RunResults) -> Result<()> {
-    let bytes = serde_json::to_vec_pretty(results).context("encode results")?;
+/// `append`: merge `results`' scenarios into whatever's already at `out`
+/// (extending a matching scenario's `wall_ms` rather than replacing it),
+/// instead of overwriting — how interleaved single-rep invocations
+/// accumulate into one file across separate process runs.
+fn write_results(out: &std::path::Path, results: &timing::RunResults, append: bool) -> Result<()> {
+    let merged = if append && out.exists() {
+        let existing_bytes =
+            std::fs::read(out).with_context(|| format!("read {}", out.display()))?;
+        let mut existing: timing::RunResults = serde_json::from_slice(&existing_bytes)
+            .with_context(|| format!("parse {}", out.display()))?;
+        for new_scenario in &results.scenarios {
+            match existing
+                .scenarios
+                .iter_mut()
+                .find(|s| s.scenario == new_scenario.scenario)
+            {
+                Some(existing_scenario) => {
+                    existing_scenario
+                        .wall_ms
+                        .extend(new_scenario.wall_ms.iter().copied());
+                }
+                None => existing.scenarios.push(new_scenario.clone()),
+            }
+        }
+        existing
+    } else {
+        results.clone()
+    };
+
+    let bytes = serde_json::to_vec_pretty(&merged).context("encode results")?;
     std::fs::write(out, bytes).with_context(|| format!("write {}", out.display()))?;
-    for s in &results.scenarios {
+    for s in &merged.scenarios {
         println!(
             "{}: {} reps, {:.1}ms mean",
             s.scenario,

--- a/crates/bench/src/main.rs
+++ b/crates/bench/src/main.rs
@@ -108,6 +108,12 @@ struct CompareArgs {
     noise_k: f64,
     #[arg(long)]
     out: Option<PathBuf>,
+    /// Write the per-scenario verdicts as JSON — machine-readable numbers
+    /// (mean_ms, delta_pct, threshold_pct, regression) for a caller that
+    /// wants to push them somewhere (a metrics backend, a dashboard) rather
+    /// than parse the markdown table.
+    #[arg(long)]
+    json: Option<PathBuf>,
     /// Print the verdict but always exit 0 — the local escape hatch. In CI
     /// the equivalent is the repo admin's existing bypass on required
     /// checks, not a flag baked into the job.
@@ -217,6 +223,10 @@ fn run_compare(args: CompareArgs) -> Result<()> {
     print!("{report}");
     if let Some(out) = &args.out {
         std::fs::write(out, &report).with_context(|| format!("write {}", out.display()))?;
+    }
+    if let Some(json) = &args.json {
+        let bytes = serde_json::to_vec_pretty(&verdicts).context("encode verdicts")?;
+        std::fs::write(json, bytes).with_context(|| format!("write {}", json.display()))?;
     }
 
     let any_regression = verdicts.iter().any(|v| v.regression);

--- a/crates/bench/src/timing.rs
+++ b/crates/bench/src/timing.rs
@@ -23,3 +23,22 @@ pub struct RunResults {
     pub tier: String,
     pub scenarios: Vec<ScenarioResult>,
 }
+
+/// How to run a scenario — shared by `inprocess::run` and `dist::run`.
+///
+/// `skip_prepare` lets a caller split "wipe + warm the shared cache state"
+/// from "measure one more rep" across *separate invocations* — needed to
+/// interleave candidate/baseline measurement rep-by-rep (alternating whole
+/// scenario runs confounds a regression with whatever drifted on the runner
+/// between the two, e.g. thermal state or a noisy neighbor). Cold has no
+/// shared state to prep (every rep is independently cold), so both tiers'
+/// Cold arm ignores this flag. `rep_offset` seeds `Incremental`'s per-rep
+/// mutation — callers doing exactly one rep per invocation must pass a
+/// distinct offset each time, or every call mutates the same files again.
+#[derive(Debug, Clone, Copy)]
+pub struct RunOptions {
+    pub warmup: usize,
+    pub reps: usize,
+    pub skip_prepare: bool,
+    pub rep_offset: usize,
+}


### PR DESCRIPTION
## Summary

Follow-up to #270, now that `heph-bench` is actually published (that PR's bootstrap gap — every merge-base predating the harness — is closed).

- **Enforced for real**: `Compare and report` now exits non-zero when any scenario regresses past its threshold. Each individual `compare` call still uses `--allow-regression` (so one regression doesn't cut the rendered table short — every scenario/tier is always attempted and reported), but the step greps that table for `REGRESSION` and fails for real if anything shows up. No more `continue-on-error` masking it as a yellow warning. The override is unchanged from the original design: a repo admin bypassing a required check on merge — no new plumbing needed for that.
- **Runs on `push` to `master` too**, not just `pull_request`. Baseline there is `github.event.before` (the commit immediately preceding this push) rather than a merge-base computation — robust to force-pushes in a way `HEAD~1` isn't, and treated the same as "no baseline found" when it's the all-zero SHA a ref's first push reports.
- **Auto-files a GitHub issue on regression**, but only on `push`: a PR failing the check already blocks the merge, so there's nothing further to escalate there. On `master` the merge already happened — a red commit check is easy to miss — so a regression instead opens an issue (labeled `perf-regression`, created idempotently via `gh label create --force`), deduped against any already-open issue with the same title so a re-run/retry doesn't spam.

## Fixed along the way

Giving the job a `permissions:` block (needed for `issues: write`) makes that block **exhaustive** — everything not listed drops to `none`. Added `contents: read` (checkout) and `actions: read` (the `gh api .../actions/runs` lookup in "Resolve baseline release") alongside `issues: write`, or both of those would have silently broken.

## What's still manual

Making "Perf" an actual **required** status check in branch protection is a repo-settings change outside this diff — I haven't touched branch protection. Happy to do it via `gh api` if you want, but flagging it as a separate, deliberate action rather than bundling it silently into this PR.

## Test plan

- [x] YAML parses; `actionlint` clean (no new findings — pre-existing findings are the unrelated `background`/`wait-all` govet-job steps this PR doesn't touch).
- [ ] Not yet validated by a live `push`-triggered run (the next merge to `master` is what exercises that path for the first time) or by an actual detected regression (nothing here has intentionally regressed to prove the fail-for-real / issue-filing path fires) — flagging both as real gaps in coverage rather than claiming more confidence than the testing supports.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01F9mbNMBQVSrsJojDYnQcDV