### PR TITLE
fix(plugin-stabby): install log sink/supervisor before calling plugin create()

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3931,6 +3931,7 @@ dependencies = [
  "plugin-go",
  "plugin-sdk",
  "stabby",
+ "tracing",
  "walk",
 ]
 

--- a/crates/bin-e2e/tests/plugin_dylib.rs
+++ b/crates/bin-e2e/tests/plugin_dylib.rs
@@ -80,6 +80,50 @@ fn shipped_gha_cdylib_loads() {
     );
 }
 
+/// Regression test for the log-sink-before-`create` ordering bug: if the host
+/// installs its log sink *after* calling the plugin's `create`, a
+/// `tracing::error!` logged during construction failure has no subscriber to
+/// go to and is silently dropped — right before the ABI seam turns the
+/// failure into a non-unwinding abort with zero diagnostic output. Nothing
+/// about this is observable in a linked test: it needs a real dlopen'd cdylib
+/// whose own statically-linked `tracing` has no subscriber until the host
+/// installs one.
+///
+/// The shipped go plugin already fails construction deterministically given a
+/// malformed `walk_db` option (it decodes as a `PathBuf`; a YAML sequence
+/// can't deserialize into one) — no purpose-built test hook needed.
+#[test]
+fn plugin_construction_failure_logs_before_the_abort() {
+    let dist = Dist::locate();
+    let ws = Workspace::new().expect("workspace");
+    let dylib = dist.plugin("go");
+    assert!(dylib.is_file(), "missing {}", dylib.display());
+
+    let manifest = ws.root().join("heph-go-plugin.json");
+    let sum = sha256_file(&dylib).expect("hash go cdylib");
+    write_manifest(&manifest, "go", &dylib, Some(&sum)).expect("write manifest");
+
+    ws.config(&format!(
+        "{BASE_CONFIG}  - path: {}\n    options:\n      walk_db: [1, 2, 3]\n",
+        manifest.display()
+    ))
+    .expect("write config");
+
+    let out = ws.run(&dist, &["inspect", "functions"]).expect("run");
+    assert!(
+        !out.status.success(),
+        "plugin construction should have failed and aborted: {}",
+        describe(&out)
+    );
+    let stderr = String::from_utf8_lossy(&out.stderr);
+    assert!(
+        stderr.contains("plugin construction failed") && stderr.contains("walk_db"),
+        "construction-failure log was dropped — the log sink must be installed \
+         before `create` is called: {}",
+        describe(&out)
+    );
+}
+
 /// The checksum in the manifest is the supply-chain guard on a dylib that is
 /// about to be mapped into the process with full privileges. It must reject,
 /// loudly, before loading. Nothing about this path exists in a linked test —

--- a/crates/plugin-abi/src/lib.rs
+++ b/crates/plugin-abi/src/lib.rs
@@ -15,8 +15,11 @@
 /// The prost-generated wire message types (`heph.plugin.v1`).
 pub use hproto_gen::heph::plugin::v1 as pb;
 
-/// ABI semantic version. Major must match exactly between host and plugin;
-/// minor is negotiated to `min(host, plugin)` at handshake.
+/// ABI semantic version. Not read at runtime — no handshake or negotiation
+/// happens; a mismatched host/plugin pair just mismatches at `dlopen` load via
+/// stabby's structural `get_stabbied` check and aborts. This constant is
+/// bookkeeping: `scripts/abi-check.sh` fails CI if the ABI surface changed
+/// without a bump, so the version history documents *why* a break happened.
 ///
 /// 0.5.0: `StableExecutor` gained a `states` method (fetch a package's provider
 /// states for cross-subtree config resolution — the go variant `vp` lookup). A

--- a/crates/plugin-go-cdylib/Cargo.toml
+++ b/crates/plugin-go-cdylib/Cargo.toml
@@ -20,3 +20,4 @@ hwalk = { package = "walk", path = "../walk" }
 hdriver-support = { package = "driver-support", path = "../driver-support" }
 stabby = "72.1.8"
 anyhow = "1.0.102"
+tracing = "0.1"

--- a/crates/plugin-go-cdylib/src/lib.rs
+++ b/crates/plugin-go-cdylib/src/lib.rs
@@ -33,7 +33,7 @@ pub extern "C" fn heph_plugin_create(cfg: stabby::vec::Vec<u8>) -> PluginCompone
             // No safe way to surface an error through the stable bundle (it must
             // carry a valid provider handle), and unwinding across the FFI
             // boundary is UB — so fail loudly and abort.
-            eprintln!("heph-plugin-go: plugin construction failed: {e:#}");
+            tracing::error!("heph-plugin-go: plugin construction failed: {e:#}");
             std::process::abort();
         }
     }

--- a/crates/plugin-stabby/src/load_stable.rs
+++ b/crates/plugin-stabby/src/load_stable.rs
@@ -81,32 +81,34 @@ pub fn load(
 
     // Scope the symbol borrow so the library can be leaked after the call.
     let comps: PluginComponents = {
-        // SAFETY: get_stabbied verifies the symbol's stabby type report matches
-        // `CreateFn` before returning it; calling it is then ABI-sound.
-        let create = unsafe { lib.get_stabbied::<CreateFn>(CREATE_SYMBOL) }
-            .map_err(|e| anyhow::anyhow!("stabby ABI check failed for {}: {e}", path.display()))?;
-        let comps = create(sv(&cfg));
-        // Optional: hand the plugin a host log sink so its `tracing` events (which
-        // its statically-linked `tracing` would otherwise drop — no subscriber is
-        // set in the dylib) are re-emitted on the host. A plugin built against an
-        // older SDK simply won't export the symbol; that is not an error.
+        // Install the host log sink and supervisor *before* `create` runs: `create`
+        // is exactly where plugin construction can fail, and a `tracing::error!`
+        // logged during that failure needs a subscriber already installed or it is
+        // silently dropped — right before the ABI seam turns any panic into a
+        // non-unwinding abort with no diagnostic at all. Optional: a plugin built
+        // against an older SDK simply won't export these symbols; that is not an
+        // error.
         // SAFETY: get_stabbied checks the symbol's stabby type report against
         // `SetLogSinkFn` before returning it.
         if let Ok(set_sink) = unsafe { lib.get_stabbied::<SetLogSinkFn>(SET_LOG_SINK_SYMBOL) } {
             set_sink(crate::host::HostLogSink::wrap());
         }
-        // Optional: hand the plugin the host's supervisor client. The plugin's own
-        // copy of the `proc` crate has an uninitialised tracker (statics are not
-        // shared across the dylib boundary), so without this every child it spawns
-        // goes unregistered — no reaping on a hard kill of the host, and a warning
-        // per spawn. Same older-SDK tolerance as the log sink.
+        // Hand the plugin the host's supervisor client. The plugin's own copy of
+        // the `proc` crate has an uninitialised tracker (statics are not shared
+        // across the dylib boundary), so without this every child it spawns goes
+        // unregistered — no reaping on a hard kill of the host, and a warning per
+        // spawn. Same older-SDK tolerance as the log sink.
         // SAFETY: get_stabbied checks the symbol's stabby type report against
         // `SetSupervisorFn` before returning it.
         let set_supervisor = unsafe { lib.get_stabbied::<SetSupervisorFn>(SET_SUPERVISOR_SYMBOL) };
         if let Ok(set_supervisor) = set_supervisor {
             set_supervisor(crate::host::HostSupervisor::wrap());
         }
-        comps
+        // SAFETY: get_stabbied verifies the symbol's stabby type report matches
+        // `CreateFn` before returning it; calling it is then ABI-sound.
+        let create = unsafe { lib.get_stabbied::<CreateFn>(CREATE_SYMBOL) }
+            .map_err(|e| anyhow::anyhow!("stabby ABI check failed for {}: {e}", path.display()))?;
+        create(sv(&cfg))
     };
     // Keep the dylib mapped for the process lifetime (the returned trait objects'
     // vtables point into its code); leaking the handle is intentional.


### PR DESCRIPTION
## Summary
- `load_stable.rs`'s `load()` called a plugin cdylib's `create()` entry before installing the host log sink / supervisor. If `create()` fails, its `tracing::error!` has no subscriber yet, so the diagnostic is silently dropped — right before the ABI seam turns the failure into a non-unwinding abort with zero output. Reordered so `set_log_sink`/`set_supervisor` run first.
- `plugin-go-cdylib`'s construction-failure fallback used `eprintln!`, which happened to survive this bug but violates the project's no-`eprintln!`-in-plugin-code rule — swapped for `tracing::error!`, matching `plugin-gha-cdylib`'s existing pattern (also added the missing `tracing` dependency it needed).
- Fixed a stale `ABI_SEMVER` doc comment claiming runtime version negotiation that doesn't exist — the real gate is CI's `abi-check.sh` plus stabby's structural `get_stabbied` check.

## Test plan
- [x] New `crates/bin-e2e` regression test `plugin_construction_failure_logs_before_the_abort`: dlopens the real shipped go cdylib via the CLI binary, forces a deterministic construction failure (malformed `walk_db` option), and asserts the subprocess's stderr contains the construction-failure log — proving the sink is installed before `create()` runs.
- [x] `cargo test -p plugin-stabby --all-features` (existing suite, all passing)
- [x] `lint` clean (clippy default/all-features/no-default-features + fmt)
- [ ] CI: `bin_e2e` job (release build + the new test)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013j42Hr6B6PVYnbrwwmNtE9