### PR TITLE
fix(pluginbuildfile): close BUILD-file load() workspace-root escapes

### DIFF
--- a/crates/plugin-buildfile/src/pluginbuildfile/provider.rs
+++ b/crates/plugin-buildfile/src/pluginbuildfile/provider.rs
@@ -417,11 +417,16 @@ fn find_packages_sync(
     let mut has_build_file = false;
     for entry in &listing.entries {
         match entry.kind {
-            hwalk::EntryKind::File | hwalk::EntryKind::Symlink => {
+            // A symlinked BUILD file is not evidence of a package: `find_build_files`
+            // (run_file.rs) deliberately excludes symlinks when it later reads this
+            // package's build files, so counting one here would list a package that
+            // resolves zero targets when actually loaded.
+            hwalk::EntryKind::File => {
                 if patterns.iter().any(|p| p.matches(&entry.name)) {
                     has_build_file = true;
                 }
             }
+            hwalk::EntryKind::Symlink => {}
             hwalk::EntryKind::Dir => {
                 let entry_path = path.join(&entry.name);
                 let rel = entry_path.strip_prefix(root).unwrap_or(&entry_path);
@@ -773,6 +778,47 @@ mod tests {
             vec!["".to_string(), "a".to_string(), "b".to_string()],
             "a newly-added package is re-discovered"
         );
+    }
+
+    /// A symlinked BUILD file is not a build file to `find_build_files` (run_file.rs
+    /// deliberately mirrors the prior `file_type().is_file()`), so `list_packages`
+    /// must not count it as package evidence either — otherwise a symlinked-BUILD
+    /// package appears in `heph query` but resolves zero targets when loaded.
+    #[tokio::test]
+    async fn test_list_packages_excludes_symlink_only_build_file() {
+        let tmp = tempdir().expect("tempdir");
+        let root = tmp.path();
+        fs::write(root.join("real.BUILD"), "").unwrap();
+
+        let pkg_dir = root.join("linked");
+        fs::create_dir_all(&pkg_dir).unwrap();
+        std::os::unix::fs::symlink(root.join("real.BUILD"), pkg_dir.join("BUILD")).unwrap();
+
+        let provider = Provider {
+            root: root.to_path_buf(),
+            ..Provider::default()
+        };
+        let ctoken = StdCancellationToken::new();
+        let listed: Vec<String> = provider
+            .list_packages(
+                ListPackagesRequest {
+                    prefix: PkgBuf::from(""),
+                },
+                &ctoken,
+            )
+            .await
+            .unwrap()
+            .map(|r| r.unwrap().pkg.to_string())
+            .collect();
+        assert!(
+            !listed.contains(&"linked".to_string()),
+            "symlinked-BUILD package must not be listed: {listed:?}"
+        );
+
+        // Consistent with the listing: actually loading the package (as
+        // `find_build_files` would for evaluation) finds no build files either.
+        let result = provider.run_pkg("linked").await.expect("eval package");
+        assert!(result.targets.is_empty(), "{:?}", result.targets);
     }
 
     #[test]

--- a/crates/plugin-buildfile/src/pluginbuildfile/run_file.rs
+++ b/crates/plugin-buildfile/src/pluginbuildfile/run_file.rs
@@ -1194,11 +1194,20 @@ impl BuildFileLoader {
 
     /// Top-level entry: evaluate every BUILD file in `pkg`'s directory matching the
     /// configured patterns and merge their targets/states/symbols. Returns an empty
-    /// result if the directory is missing or has no matching file — this is the path
-    /// used by `Provider::list`/`get`/`probe`, where unknown packages should surface
-    /// as empty/`NotFound` rather than hard errors. Use `load_dir` directly (via the
-    /// `FileLoader` impl) for the `load(...)` path, which is strict.
+    /// result if the directory is missing, escapes the workspace root, or has no
+    /// matching file — this is the path used by `Provider::list`/`get`/`probe`,
+    /// where unknown packages should surface as empty/`NotFound` rather than hard
+    /// errors. Use `load_dir` directly (via the `FileLoader` impl) for the
+    /// `load(...)` path, which is strict.
+    ///
+    /// `pkg` reaches here from an `Addr`/`PkgBuf` that the address parser does not
+    /// itself bound to the workspace (a package segment may contain `..`), so this
+    /// is the chokepoint that keeps `root.join(pkg)` from walking outside the
+    /// workspace for a crafted address like `//../../etc:x`.
     fn load_pkg(&self, pkg: &str) -> anyhow::Result<Arc<RunResult>> {
+        if hmodel::htpkg::join_rel_checked("", pkg).is_err() {
+            return Ok(Arc::new(empty_run_result()?));
+        }
         let dir = self.root.join(pkg);
         if !dir.is_dir() {
             return Ok(Arc::new(empty_run_result()?));
@@ -1498,51 +1507,37 @@ impl BuildFileLoader {
     }
 }
 
-/// Resolve a `load()` path argument to an absolute (logically normalized) filesystem path.
+/// Resolve a `load()` path argument to an absolute filesystem path, rejecting
+/// any path that would resolve outside the workspace root.
 ///
 /// Accepts:
 ///   `//pkg/...`     absolute, relative to workspace root
 ///   `./rel/...`     relative to `current_pkg`'s directory
 ///   `../rel/...`    relative to `current_pkg`'s directory (walks up via `..`)
+///
+/// Uses [`hmodel::htpkg::join_rel_checked`] — the same boundary check `fs.file`/
+/// `fs.glob` apply — so a `..`-laden path (e.g. `load("../../../../etc/hosts")`)
+/// errors instead of escaping the workspace and being parsed as Starlark.
 pub(crate) fn resolve_load_target(
     root: &Path,
     current_pkg: &str,
     path: &str,
 ) -> anyhow::Result<PathBuf> {
-    let raw = if let Some(rel) = path.strip_prefix("//") {
+    let rel_from_root = if let Some(rel) = path.strip_prefix("//") {
         if rel.is_empty() {
             anyhow::bail!("load() path must not be empty after `//`");
         }
-        root.join(rel)
+        hmodel::htpkg::join_rel_checked("", rel)
     } else if path.starts_with("./") || path.starts_with("../") {
-        root.join(current_pkg).join(path)
+        hmodel::htpkg::join_rel_checked(current_pkg, path)
     } else {
         anyhow::bail!("load() path must start with `//`, `./`, or `../`, got `{path}`");
-    };
-    Ok(normalize_path(&raw))
-}
-
-/// Logically collapse `.` and `..` components in an absolute path without touching the
-/// filesystem. Used so cache keys for `//a/sub` and `./sub` (from `a/BUILD`) match.
-fn normalize_path(path: &Path) -> PathBuf {
-    let mut out: Vec<std::path::Component> = Vec::with_capacity(path.components().count());
-    for comp in path.components() {
-        match comp {
-            std::path::Component::CurDir => {}
-            std::path::Component::ParentDir => {
-                if matches!(
-                    out.last(),
-                    Some(std::path::Component::Normal(_)) | Some(std::path::Component::CurDir)
-                ) {
-                    out.pop();
-                } else {
-                    out.push(comp);
-                }
-            }
-            other => out.push(other),
-        }
     }
-    out.iter().map(|c| c.as_os_str()).collect()
+    .with_context(|| format!("resolving load() path `{path}`"))?;
+    // `join_rel_checked` preserves a trailing slash so `fs.glob` can tell a directory
+    // path from a file path; `load()` has no such distinction, and a trailing slash on
+    // a path that names a real file makes `std::fs::metadata` reject it as not-a-directory.
+    Ok(root.join(rel_from_root.trim_end_matches('/')))
 }
 
 /// Enumerate every file in `dir` whose name matches any of `patterns`.
@@ -2745,6 +2740,33 @@ target(name = "t", driver = FOO + BAR)
         assert!(r.states.is_empty());
     }
 
+    /// `pkg` comes from an `Addr`'s package segment, which the address parser does
+    /// not itself bound to the workspace root — a package like `"../secret"` reaches
+    /// `Provider::get`/`list`/`probe` (and therefore `load_pkg`) unchecked. Without a
+    /// boundary check here, `root.join(pkg)` would walk outside the workspace and
+    /// parse whatever BUILD file lives there, the same class of escape `load()`
+    /// resolution is guarded against elsewhere in this file.
+    #[test]
+    fn test_run_pkg_escaping_package_addr_returns_empty() {
+        let tmp_dir = tempdir().unwrap();
+        let root = tmp_dir.path().join("root");
+        fs::create_dir_all(&root).unwrap();
+        let secret = tmp_dir.path().join("secret");
+        fs::create_dir_all(&secret).unwrap();
+        fs::write(
+            secret.join("BUILD"),
+            r#"target(name = "t", driver = "leaked")"#,
+        )
+        .unwrap();
+
+        let provider = Provider {
+            root,
+            ..Provider::default()
+        };
+        let r = run_pkg_blocking(&provider, "../secret").unwrap();
+        assert!(r.targets.is_empty(), "{:?}", r.targets);
+    }
+
     #[test]
     fn test_run_pkg_dir_without_match_returns_empty() {
         let tmp_dir = tempdir().unwrap();
@@ -3156,6 +3178,103 @@ target(name = "t", driver = FOO)
         let result = run_pkg_blocking(&provider, "app").unwrap();
         assert_eq!(result.targets.len(), 1);
         assert_eq!(result.targets[0].driver, "shared");
+    }
+
+    #[test]
+    fn test_load_relative_parent_dir_escaping_root_is_rejected() {
+        // A workspace root at `tmp/root`, with a secret file just outside it at
+        // `tmp/secret.BUILD`. `../secret.BUILD` from the root package's directory
+        // resolves (on disk) to that outside file — load() must refuse to follow
+        // it rather than parsing whatever lives outside the workspace.
+        let tmp_dir = tempdir().unwrap();
+        let root = tmp_dir.path().join("root");
+        fs::create_dir_all(&root).unwrap();
+        fs::write(tmp_dir.path().join("secret.BUILD"), "SECRET = \"leaked\"\n").unwrap();
+        fs::write(
+            root.join("BUILD"),
+            r#"
+load("../secret.BUILD", "SECRET")
+target(name = "t", driver = SECRET)
+"#,
+        )
+        .unwrap();
+
+        let provider = Provider {
+            root: root.clone(),
+            ..Provider::default()
+        };
+        let err = run_pkg_blocking(&provider, "").unwrap_err();
+        let chain = err
+            .chain()
+            .map(|c| c.to_string())
+            .collect::<Vec<_>>()
+            .join(" | ");
+        assert!(chain.contains("escapes workspace root"), "{chain}");
+    }
+
+    #[test]
+    fn test_load_absolute_path_escaping_root_is_rejected() {
+        let tmp_dir = tempdir().unwrap();
+        let root = tmp_dir.path().join("root");
+        fs::create_dir_all(&root).unwrap();
+        fs::write(
+            root.join("BUILD"),
+            r#"load("//../../../../etc/hosts", "X")"#,
+        )
+        .unwrap();
+
+        let provider = Provider {
+            root,
+            ..Provider::default()
+        };
+        let err = run_pkg_blocking(&provider, "").unwrap_err();
+        let chain = err
+            .chain()
+            .map(|c| c.to_string())
+            .collect::<Vec<_>>()
+            .join(" | ");
+        assert!(chain.contains("escapes workspace root"), "{chain}");
+    }
+
+    #[test]
+    fn resolve_load_target_rejects_escape_from_nested_package() {
+        let root = Path::new("/workspace");
+        let err = resolve_load_target(root, "a/b", "../../../etc/hosts").unwrap_err();
+        assert!(
+            format!("{err:#}").contains("escapes workspace root"),
+            "{err:#}"
+        );
+    }
+
+    #[test]
+    fn resolve_load_target_allows_in_bounds_paths() {
+        let root = Path::new("/workspace");
+        assert_eq!(
+            resolve_load_target(root, "a/b", "../c/d.BUILD").unwrap(),
+            root.join("a/c/d.BUILD")
+        );
+        assert_eq!(
+            resolve_load_target(root, "a", "//lib/shared.BUILD").unwrap(),
+            root.join("lib/shared.BUILD")
+        );
+        // A trailing slash is meaningless for load() (unlike fs.glob's dir-vs-file
+        // distinction) and must not survive into the filesystem path, or `stat` on a
+        // path naming a real file fails with "not a directory".
+        assert_eq!(
+            resolve_load_target(root, "a", "./sub/").unwrap(),
+            root.join("a/sub")
+        );
+    }
+
+    #[test]
+    fn resolve_load_target_contains_leading_slash_smuggling() {
+        // `//` + a leading `/` in the remainder (e.g. `load("///etc/passwd")`) must not
+        // let `Path::join` treat the joined path as absolute and discard the root.
+        let root = Path::new("/workspace");
+        assert_eq!(
+            resolve_load_target(root, "", "///etc/passwd").unwrap(),
+            root.join("etc/passwd")
+        );
     }
 
     #[test]


### PR DESCRIPTION
## Summary

- `load()` path resolution (`resolve_load_target`) had no workspace-root boundary check — `load(\"../../../../etc/hosts\")` (or an equivalent `//`-absolute path) escaped the repo and was parsed as Starlark. Fixed by routing both the `//pkg` and `./`/`../` forms through `hmodel::htpkg::join_rel_checked`, the same boundary-checked join `fs.file`/`fs.glob` already use.
- Hermeticity/code-quality review of that fix independently found a second, more directly reachable instance of the same escape: package addresses (`Provider::get`/`list`/`probe`/`run_pkg`) reached `load_pkg`'s `root.join(pkg)` with **no** boundary check, since the address parser doesn't bound `..` in an absolute `//pkg:name`'s package segment (`run_pkg("../secret")` loaded a BUILD file outside the workspace). Fixed at the same chokepoint (`load_pkg`), returning empty/not-found to match this path's existing "unknown package" semantics. The deeper fix at the address-parser level (`crates/model/src/htaddr`, shared across providers incl. plugin-go) is pre-existing on master and out of scope for this PR — flagging it here rather than leaving it silently unmentioned, worth a tracked follow-up.
- `list_packages`/`heph query` counted symlinked BUILD files as package evidence while the actual package loader (`find_build_files`) deliberately excludes symlinks, so a symlinked-BUILD package showed up in query output but resolved zero targets. Made `find_packages_sync` agree with the existing `find_build_files` exclusion.
- Minor hardening surfaced in review: a trailing slash on a `load()` path no longer reaches `std::fs::metadata` (which would reject a file as not-a-directory), and a `///`-leading path can no longer make `Path::join` discard the workspace root.

## Test plan

- [x] New unit + integration tests for each fix, each verified red on the pre-fix code (reverted the source change locally, confirmed failure, restored)
- [x] `cargo test -p plugin-buildfile` — 145 passed, 0 failed
- [x] `lint` (fmt + clippy, workspace + `--no-default-features`) — clean
- [x] Consulted `hermeticity` and `code-quality` agents; all BLOCKER/MINOR findings addressed (package-address escape fixed, duplicate comment removed, trailing/leading-slash edge cases fixed and tested)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019cajZxQ78Agzw6D2TaQCWh