### PR TITLE
fix(plugin-exec): log drain errors instead of swallowing them silently

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3859,6 +3859,8 @@ dependencies = [
  "tar",
  "tempfile",
  "tokio",
+ "tracing",
+ "tracing-subscriber",
  "xxhash-rust",
 ]
 

--- a/crates/plugin-exec/Cargo.toml
+++ b/crates/plugin-exec/Cargo.toml
@@ -23,8 +23,10 @@ xxhash-rust = { version = "0.8.15", features = ["xxh3", "std"] }
 minijinja = "2"
 crossterm = { version = "0.29", features = ["event-stream"] }
 tokio = { version = "1.52.3", features = ["rt", "rt-multi-thread", "io-util", "io-std", "process", "macros", "sync", "signal", "fs", "net"] }
+tracing = "0.1"
 
 [dev-dependencies]
 enclose = "1"
 serde_yaml = "0.9"
 tempfile = "3"
+tracing-subscriber = "0.3"

--- a/crates/plugin-exec/src/pluginexec/mod.rs
+++ b/crates/plugin-exec/src/pluginexec/mod.rs
@@ -377,14 +377,28 @@ async fn tee_stream(
     source: Option<impl tokio::io::AsyncRead + Unpin>,
     log: Arc<std::sync::Mutex<std::fs::File>>,
     mut sink: Option<&mut (dyn tokio::io::AsyncWrite + Send + Sync + Unpin)>,
+    addr: &str,
+    stream: &str,
+    bytes_read: &std::sync::atomic::AtomicUsize,
 ) {
     use tokio::io::{AsyncReadExt, AsyncWriteExt};
     let Some(mut source) = source else { return };
     let mut buf = vec![0u8; 8192];
     loop {
         match source.read(&mut buf).await {
-            Ok(0) | Err(_) => break,
+            Ok(0) => break,
+            Err(error) => {
+                tracing::warn!(
+                    addr,
+                    stream,
+                    %error,
+                    bytes_read = bytes_read.load(std::sync::atomic::Ordering::Relaxed),
+                    "pluginexec: error draining child output; log tail may be truncated"
+                );
+                break;
+            }
             Ok(n) => {
+                bytes_read.fetch_add(n, std::sync::atomic::Ordering::Relaxed);
                 #[expect(
                     clippy::indexing_slicing,
                     reason = "n guaranteed <= buf.len() by AsyncRead contract"
@@ -405,24 +419,52 @@ async fn tee_stream(
     }
 }
 
-/// Tee chunks from a [`proc_exec::ChunkReader`] into the log file and the
-/// optional TUI sink. Used in non-PTY mode where the child stdout/stderr
-/// pipes are drained on a dedicated `std::thread` (inside `proc_exec`) and
-/// surfaced to async-land via `std::sync::mpsc` — `ChunkReader::recv`
-/// internally uses `block_in_place` on a kernel condvar, bypassing tokio's
-/// macOS-flaky cross-thread waker.
+/// Source of chunks for [`tee_chunks`]. Exists so tests can exercise the
+/// error-diagnostic path with a fake that fails on demand — `ChunkReader`
+/// itself wraps a real pipe/PTY fd with no public constructor for injecting
+/// a synthetic IO error.
+trait ChunkSource {
+    async fn recv_chunk(&mut self) -> std::io::Result<Option<Vec<u8>>>;
+}
+
+impl ChunkSource for proc_exec::ChunkReader {
+    async fn recv_chunk(&mut self) -> std::io::Result<Option<Vec<u8>>> {
+        self.recv().await
+    }
+}
+
+/// Tee chunks from a [`proc_exec::ChunkReader`] (or a test [`ChunkSource`])
+/// into the log file and the optional TUI sink. Used in non-PTY mode where
+/// the child stdout/stderr pipes are drained on a dedicated `std::thread`
+/// (inside `proc_exec`) and surfaced to async-land via `std::sync::mpsc` —
+/// `ChunkReader::recv` internally uses `block_in_place` on a kernel condvar,
+/// bypassing tokio's macOS-flaky cross-thread waker.
 async fn tee_chunks(
-    reader: Option<proc_exec::ChunkReader>,
+    reader: Option<impl ChunkSource>,
     log: Arc<std::sync::Mutex<std::fs::File>>,
     mut sink: Option<&mut (dyn tokio::io::AsyncWrite + Send + Sync + Unpin)>,
+    addr: &str,
+    stream: &str,
+    bytes_read: &std::sync::atomic::AtomicUsize,
 ) {
     use tokio::io::AsyncWriteExt;
     let Some(mut reader) = reader else { return };
     loop {
-        let chunk = match reader.recv().await {
+        let chunk = match reader.recv_chunk().await {
             Ok(Some(c)) => c,
-            _ => break,
+            Ok(None) => break,
+            Err(error) => {
+                tracing::warn!(
+                    addr,
+                    stream,
+                    %error,
+                    bytes_read = bytes_read.load(std::sync::atomic::Ordering::Relaxed),
+                    "pluginexec: error draining child output; log tail may be truncated"
+                );
+                break;
+            }
         };
+        bytes_read.fetch_add(chunk.len(), std::sync::atomic::Ordering::Relaxed);
         if let Ok(mut g) = log.lock() {
             drop(g.write_all(&chunk));
         }
@@ -448,6 +490,23 @@ async fn pump_stdin_pty(
         _ = io::copy(&mut src, &mut sink) => {}
     }
     drop(sink.shutdown().await);
+}
+
+/// Await `io` for up to `deadline`. By the time this runs the child has
+/// already exited, so anything it wrote is already read or sitting in the
+/// pipe — `io` arriving late means something else (typically a surviving
+/// descendant sharing the same stdout/stderr fd) still holds the write end
+/// open. Runs `on_timeout` in that case rather than silently discarding the
+/// timeout, so a truncated log.txt tail is diagnosable instead of vanishing
+/// unremarked — mirrors `proc_exec`'s own `DRAIN_DEADLINE` abandonment log.
+async fn drain_or_warn(
+    io: impl std::future::Future<Output = ()>,
+    deadline: std::time::Duration,
+    on_timeout: impl FnOnce(),
+) {
+    if tokio::time::timeout(deadline, io).await.is_err() {
+        on_timeout();
+    }
 }
 
 /// Pump bytes from an async source into a [`proc_exec::StdinPump`]. Mirrors
@@ -1237,13 +1296,27 @@ impl Driver {
             },
         }
 
+        // Target addr for the drain diagnostics below, and per-stream byte
+        // counters so a post-wait drain timeout can report how much of the
+        // tail it actually got before giving up.
+        let addr_str = rreq.target.addr.format();
+        let stdout_bytes = std::sync::atomic::AtomicUsize::new(0);
+        let stderr_bytes = std::sync::atomic::AtomicUsize::new(0);
+
         let io_futures: IoFutures<'_> = if let Some(master) = pty_master {
             let read_fd = master.try_clone().context("dup pty master for read")?;
             let reader = pty::AsyncPty::new(read_fd).context("async pty reader")?;
             let writer = pty::AsyncPty::new(master).context("async pty writer")?;
 
             let log_for_out = Arc::clone(&output_log_file);
-            let stdout_fut = Box::pin(tee_stream(Some(reader), log_for_out, rreq.stdout));
+            let stdout_fut = Box::pin(tee_stream(
+                Some(reader),
+                log_for_out,
+                rreq.stdout,
+                &addr_str,
+                "pty",
+                &stdout_bytes,
+            ));
 
             let stdin_fut: std::pin::Pin<Box<dyn std::future::Future<Output = ()> + Send + '_>> =
                 if let Some(src) = rreq.stdin {
@@ -1262,8 +1335,22 @@ impl Driver {
             let stderr_reader = handle.take_stderr();
             let log_for_out = Arc::clone(&output_log_file);
             let log_for_err = Arc::clone(&output_log_file);
-            let stdout_fut = Box::pin(tee_chunks(stdout_reader, log_for_out, rreq.stdout));
-            let stderr_fut = Box::pin(tee_chunks(stderr_reader, log_for_err, rreq.stderr));
+            let stdout_fut = Box::pin(tee_chunks(
+                stdout_reader,
+                log_for_out,
+                rreq.stdout,
+                &addr_str,
+                "stdout",
+                &stdout_bytes,
+            ));
+            let stderr_fut = Box::pin(tee_chunks(
+                stderr_reader,
+                log_for_err,
+                rreq.stderr,
+                &addr_str,
+                "stderr",
+                &stderr_bytes,
+            ));
             let stdin_fut: std::pin::Pin<Box<dyn std::future::Future<Output = ()> + Send + '_>> =
                 match (rreq.stdin, stdin_pump) {
                     (Some(src), Some(pump)) => Box::pin(pump_stdin(src, pump, stdin_cancel_rx)),
@@ -1309,16 +1396,21 @@ impl Driver {
         // (the runtime may be tearing down) and surface `cancelled` below.
         let wait_res = match io_futures {
             IoFutures::Pty { stdin, stdout } => {
-                let io = async { tokio::join!(stdin, stdout) };
+                let io = async {
+                    tokio::join!(stdin, stdout);
+                };
                 tokio::pin!(io);
                 tokio::select! {
                     wait_res = &mut wait_handle => {
                         if !ctoken.is_cancelled() {
                             hcore::hmemoizer::set_phase("pluginexec:post_wait_io_drain");
-                            _ = tokio::time::timeout(
-                                std::time::Duration::from_millis(50),
-                                &mut io,
-                            ).await;
+                            drain_or_warn(&mut io, std::time::Duration::from_millis(50), || {
+                                tracing::warn!(
+                                    addr = addr_str.as_str(),
+                                    pty_bytes = stdout_bytes.load(std::sync::atomic::Ordering::Relaxed),
+                                    "pluginexec: post-wait output drain timed out; log tail may be truncated"
+                                );
+                            }).await;
                         }
                         wait_res
                     }
@@ -1333,16 +1425,22 @@ impl Driver {
                 stdout,
                 stderr,
             } => {
-                let io = async { tokio::join!(stdin, stdout, stderr) };
+                let io = async {
+                    tokio::join!(stdin, stdout, stderr);
+                };
                 tokio::pin!(io);
                 tokio::select! {
                     wait_res = &mut wait_handle => {
                         if !ctoken.is_cancelled() {
                             hcore::hmemoizer::set_phase("pluginexec:post_wait_io_drain");
-                            _ = tokio::time::timeout(
-                                std::time::Duration::from_millis(50),
-                                &mut io,
-                            ).await;
+                            drain_or_warn(&mut io, std::time::Duration::from_millis(50), || {
+                                tracing::warn!(
+                                    addr = addr_str.as_str(),
+                                    stdout_bytes = stdout_bytes.load(std::sync::atomic::Ordering::Relaxed),
+                                    stderr_bytes = stderr_bytes.load(std::sync::atomic::Ordering::Relaxed),
+                                    "pluginexec: post-wait output drain timed out; log tail may be truncated"
+                                );
+                            }).await;
                         }
                         wait_res
                     }
@@ -1411,6 +1509,173 @@ mod tests {
     use hmodel::htaddr::Addr;
     use hplugin::driver::RunRequest;
     use hplugin::driver::targetdef::CacheConfig;
+
+    /// Captures `tracing` events emitted on the calling OS thread while the
+    /// returned guard is alive. `#[tokio::test]`'s default `current_thread`
+    /// flavor keeps every task (including ones `tokio::spawn`ed by the code
+    /// under test) on this one thread, so the thread-local default this
+    /// installs covers the whole drive, not just the top-level future.
+    #[derive(Clone, Default)]
+    struct CapturedLog(Arc<std::sync::Mutex<Vec<u8>>>);
+
+    impl std::io::Write for CapturedLog {
+        fn write(&mut self, buf: &[u8]) -> std::io::Result<usize> {
+            let mut guard = self
+                .0
+                .lock()
+                .map_err(|_e| std::io::Error::other("captured log mutex poisoned"))?;
+            guard.extend_from_slice(buf);
+            Ok(buf.len())
+        }
+        fn flush(&mut self) -> std::io::Result<()> {
+            Ok(())
+        }
+    }
+
+    impl CapturedLog {
+        fn text(&self) -> String {
+            String::from_utf8(self.0.lock().expect("captured log mutex").clone())
+                .expect("captured log is utf8")
+        }
+    }
+
+    fn capture_tracing() -> (tracing::subscriber::DefaultGuard, CapturedLog) {
+        let captured = CapturedLog::default();
+        let writer = captured.clone();
+        let subscriber = tracing_subscriber::fmt()
+            .with_writer(move || writer.clone())
+            .with_ansi(false)
+            .finish();
+        (tracing::subscriber::set_default(subscriber), captured)
+    }
+
+    /// `AsyncRead` double that always fails — `tee_stream`'s real IO error
+    /// path (as opposed to clean `Ok(0)` EOF) has no other way to reach it,
+    /// since a real pipe/PTY essentially never produces a read error in a
+    /// controlled test.
+    struct FailingReader;
+
+    impl tokio::io::AsyncRead for FailingReader {
+        fn poll_read(
+            self: std::pin::Pin<&mut Self>,
+            _cx: &mut std::task::Context<'_>,
+            _buf: &mut tokio::io::ReadBuf<'_>,
+        ) -> std::task::Poll<std::io::Result<()>> {
+            std::task::Poll::Ready(Err(std::io::Error::other("synthetic read failure")))
+        }
+    }
+
+    /// [`ChunkSource`] double that fails once then reports EOF, mirroring
+    /// `FailingReader` for `tee_chunks`.
+    struct FailOnceSource {
+        failed: bool,
+    }
+
+    impl ChunkSource for FailOnceSource {
+        async fn recv_chunk(&mut self) -> std::io::Result<Option<Vec<u8>>> {
+            if self.failed {
+                return Ok(None);
+            }
+            self.failed = true;
+            Err(std::io::Error::other("synthetic chunk failure"))
+        }
+    }
+
+    fn log_file(dir: &tempfile::TempDir) -> Arc<std::sync::Mutex<std::fs::File>> {
+        let file = std::fs::File::create(dir.path().join("log.txt")).expect("create log file");
+        Arc::new(std::sync::Mutex::new(file))
+    }
+
+    #[tokio::test]
+    async fn tee_stream_logs_real_io_errors() {
+        let (guard, log) = capture_tracing();
+        let tmp = tempfile::tempdir().expect("tempdir");
+        let bytes_read = std::sync::atomic::AtomicUsize::new(0);
+
+        tee_stream(
+            Some(FailingReader),
+            log_file(&tmp),
+            None,
+            "//pkg:target",
+            "stdout",
+            &bytes_read,
+        )
+        .await;
+        drop(guard);
+
+        let text = log.text();
+        assert!(
+            text.contains("error draining child output"),
+            "missing diagnostic: {text}"
+        );
+        assert!(text.contains("//pkg:target"), "missing addr field: {text}");
+        assert!(text.contains("stdout"), "missing stream field: {text}");
+        assert!(
+            text.contains("synthetic read failure"),
+            "missing underlying error: {text}"
+        );
+    }
+
+    #[tokio::test]
+    async fn tee_chunks_logs_real_io_errors() {
+        let (guard, log) = capture_tracing();
+        let tmp = tempfile::tempdir().expect("tempdir");
+        let bytes_read = std::sync::atomic::AtomicUsize::new(0);
+
+        tee_chunks(
+            Some(FailOnceSource { failed: false }),
+            log_file(&tmp),
+            None,
+            "//pkg:other",
+            "stderr",
+            &bytes_read,
+        )
+        .await;
+        drop(guard);
+
+        let text = log.text();
+        assert!(
+            text.contains("error draining child output"),
+            "missing diagnostic: {text}"
+        );
+        assert!(text.contains("//pkg:other"), "missing addr field: {text}");
+        assert!(text.contains("stderr"), "missing stream field: {text}");
+        assert!(
+            text.contains("synthetic chunk failure"),
+            "missing underlying error: {text}"
+        );
+    }
+
+    /// Regression for the post-wait drain: before the fix, whether
+    /// `tokio::time::timeout` elapsed was discarded (`_ = timeout(...).await`)
+    /// so a truncated tail vanished silently. `drain_or_warn` is the
+    /// extracted decision — this proves it actually invokes the diagnostic
+    /// when time runs out on stalled IO (a stand-in for a stray descendant
+    /// still holding the pipe open), the shape `run_inner` wires to
+    /// `tracing::warn!` on both the PTY and pipes branches.
+    #[tokio::test]
+    async fn drain_or_warn_fires_when_deadline_elapses() {
+        let fired = std::sync::atomic::AtomicBool::new(false);
+        drain_or_warn(
+            std::future::pending::<()>(),
+            std::time::Duration::from_millis(1),
+            || {
+                fired.store(true, std::sync::atomic::Ordering::SeqCst);
+            },
+        )
+        .await;
+        assert!(fired.load(std::sync::atomic::Ordering::SeqCst));
+    }
+
+    #[tokio::test]
+    async fn drain_or_warn_stays_quiet_when_io_finishes_in_time() {
+        let fired = std::sync::atomic::AtomicBool::new(false);
+        drain_or_warn(async {}, std::time::Duration::from_millis(50), || {
+            fired.store(true, std::sync::atomic::Ordering::SeqCst);
+        })
+        .await;
+        assert!(!fired.load(std::sync::atomic::Ordering::SeqCst));
+    }
 
     #[test]
     fn env_key_segment_sanitizes_invalid_chars() {


### PR DESCRIPTION
## Summary
- `tee_stream`/`tee_chunks` discarded genuine IO errors while draining child stdout/stderr/PTY with no diagnostic at all — violated the "all diagnostics go through tracing" rule. Now they emit `tracing::warn!` with structured fields (`addr`, `stream`, `error`, `bytes_read`) before breaking out of the loop; control flow (still stop draining that stream on error) is unchanged.
- The post-wait 50ms drain timeout's result was discarded (`_ = timeout(...).await`), so undrained log tail bytes could vanish from `log.txt` with no trace. Extracted a `drain_or_warn` helper so the timeout decision is unit-testable, and both `run_inner` branches (PTY, pipes) now log `tracing::warn!` with the addr and bytes-read-so-far when the deadline elapses — mirroring `proc_exec`'s own `DRAIN_DEADLINE` abandonment log.
- Added a small `ChunkSource` trait so `tee_chunks` (previously hardcoded to `proc_exec::ChunkReader`, which has no public constructor for injecting a synthetic error) is generic and testable with a fake failing source, symmetric with `tee_stream`'s existing genericity over `AsyncRead`.

Reviewed by `product-vision` (diagnosability) and `code-quality` (Rust idiom/soundness) per this repo's Review Board; both findings were addressed (byte count added to the mid-stream error log; a clippy `unwrap_in_result` + fmt issue in test helpers was fixed).

## Test plan
- [x] New unit tests: `tee_stream_logs_real_io_errors`, `tee_chunks_logs_real_io_errors` — assert the previously-missing `tracing::warn!` now fires with addr/stream/error fields, using synthetic failing sources (`ChunkReader` has no way to inject a real IO error).
- [x] New unit tests: `drain_or_warn_fires_when_deadline_elapses`, `drain_or_warn_stays_quiet_when_io_finishes_in_time` — prove the previously-discarded timeout result now drives a diagnostic (deterministic, no real subprocess timing — an earlier real-subprocess version of this test was flaky across the proc_exec macOS/Linux backend split).
- [x] `cargo test -p plugin-exec --lib pluginexec::` — 84 passed, 0 failed.
- [x] `lint` (workspace root) — clean.
- [ ] Full `tst`/`e2e`/`heph-bench` — left to CI per project convention.