### PR TITLE
fix(model): bound addr/query package `..` traversal, cap query nesting depth

### DIFF
--- a/crates/model/src/htaddr/parse.rs
+++ b/crates/model/src/htaddr/parse.rs
@@ -1,5 +1,5 @@
 use crate::htaddr::addr::Addr;
-use crate::htpkg::PkgBuf;
+use crate::htpkg::{PkgBuf, join_rel_checked_pkg};
 use anyhow::Context;
 use nom::IResult;
 use nom::Parser;
@@ -75,20 +75,7 @@ fn addr_parser(i: &str) -> R<'_, (&str, &str, Vec<(&str, &str)>)> {
 }
 
 fn resolve_relative_pkg(base: &PkgBuf, rel: &str) -> anyhow::Result<String> {
-    let mut components: Vec<&str> = base.as_str().split('/').filter(|s| !s.is_empty()).collect();
-    let rel = rel.strip_prefix("./").unwrap_or(rel);
-    for component in rel.split('/') {
-        match component {
-            "" | "." => {}
-            ".." => {
-                if components.pop().is_none() {
-                    return Err(anyhow::anyhow!("relative path '{}' escapes root", rel));
-                }
-            }
-            c => components.push(c),
-        }
-    }
-    Ok(components.join("/"))
+    join_rel_checked_pkg(base.as_str(), rel)
 }
 
 pub fn parse_addr_with_base(input: &str, base: &PkgBuf) -> anyhow::Result<Addr> {
@@ -144,12 +131,21 @@ pub fn parse_addr(input: &str) -> anyhow::Result<Addr> {
         .parse(input)
         .map_err(|e| anyhow::anyhow!("invalid address {:?}: {}", input, e))?;
 
+    // The absolute `//pkg:name` form has no base to resolve against, but a
+    // `..` segment in `pkg` must still be bound to the workspace root — same
+    // rule `resolve_relative_pkg` enforces for relative references, and the
+    // same mechanism `fs.file`/`fs.glob` use (`join_rel_checked`). Without
+    // this, `//../../etc:passwd` parses cleanly and escapes into filesystem
+    // joins downstream (BUILD discovery, cache dir, sandbox dir).
+    let package =
+        join_rel_checked_pkg("", p).with_context(|| format!("invalid address {input:?}"))?;
+
     let mut args = BTreeMap::new();
     for (k, v) in kvs {
         args.insert(k.to_string(), v.to_string());
     }
 
-    Ok(Addr::new(PkgBuf::from(p), n.to_string(), args))
+    Ok(Addr::new(PkgBuf::from(package), n.to_string(), args))
 }
 
 #[cfg(test)]
@@ -276,6 +272,32 @@ mod tests {
         assert_eq!(res.name, "build_lib");
         assert_eq!(res.args.get("goos").unwrap(), "linux");
         assert_eq!(res.args.get("goarch").unwrap(), "amd64");
+    }
+
+    #[test]
+    fn test_parse_addr_absolute_dotdot_escapes_root_fails() {
+        // //../../etc:passwd must not parse into a package that walks above
+        // the workspace root — it used to (path-traversal into BUILD
+        // discovery / cache / sandbox dirs downstream).
+        let res = parse_addr("//../../etc:passwd");
+        assert!(res.is_err(), "expected error, got {res:?}");
+    }
+
+    #[test]
+    fn test_parse_addr_absolute_dotdot_within_bounds_normalizes() {
+        // A `..` that stays within the package tree is fine and normalizes
+        // like `join_rel_checked` does elsewhere.
+        let res = parse_addr("//a/b/../c:name").unwrap();
+        assert_eq!(res.package.as_str(), "a/c");
+    }
+
+    #[test]
+    fn test_parse_addr_with_base_absolute_dotdot_escapes_root_fails() {
+        // The absolute form bypasses `resolve_relative_pkg`'s guard by going
+        // straight through `parse_addr` — must still be rejected.
+        let base = PkgBuf::from("base/pkg");
+        let res = parse_addr_with_base("//../../etc:passwd", &base);
+        assert!(res.is_err(), "expected error, got {res:?}");
     }
 
     #[test]

--- a/crates/model/src/htpkg/mod.rs
+++ b/crates/model/src/htpkg/mod.rs
@@ -2,4 +2,4 @@ mod parse;
 mod pkg;
 
 pub use parse::parse;
-pub use pkg::{PkgBuf, join_rel_checked};
+pub use pkg::{PkgBuf, join_rel_checked, join_rel_checked_pkg};

--- a/crates/model/src/htpkg/parse.rs
+++ b/crates/model/src/htpkg/parse.rs
@@ -1,21 +1,8 @@
 use crate::htmatcher::Matcher;
-use crate::htpkg::PkgBuf;
+use crate::htpkg::{PkgBuf, join_rel_checked_pkg};
 
 fn resolve_relative_pkg(base: &PkgBuf, rel: &str) -> anyhow::Result<String> {
-    let mut components: Vec<&str> = base.as_str().split('/').filter(|s| !s.is_empty()).collect();
-    let rel = rel.strip_prefix("./").unwrap_or(rel);
-    for component in rel.split('/') {
-        match component {
-            "" | "." => {}
-            ".." => {
-                if components.pop().is_none() {
-                    return Err(anyhow::anyhow!("relative path '{}' escapes root", rel));
-                }
-            }
-            c => components.push(c),
-        }
-    }
-    Ok(components.join("/"))
+    join_rel_checked_pkg(base.as_str(), rel)
 }
 
 pub fn parse(input: &str, base: &PkgBuf) -> anyhow::Result<Matcher> {
@@ -26,9 +13,13 @@ pub fn parse(input: &str, base: &PkgBuf) -> anyhow::Result<Matcher> {
             return Ok(Matcher::PackagePrefix(PkgBuf::from("")));
         }
         if let Some(prefix) = abs.strip_suffix("/...") {
-            return Ok(Matcher::PackagePrefix(PkgBuf::from(prefix)));
+            return Ok(Matcher::PackagePrefix(PkgBuf::from(join_rel_checked_pkg(
+                "", prefix,
+            )?)));
         }
-        return Ok(Matcher::Package(PkgBuf::from(abs)));
+        return Ok(Matcher::Package(PkgBuf::from(join_rel_checked_pkg(
+            "", abs,
+        )?)));
     }
 
     // Relative package reference
@@ -162,5 +153,28 @@ mod tests {
         let base = PkgBuf::from("a/b");
         let m = parse("./...", &base).unwrap();
         assert_eq!(m, Matcher::PackagePrefix(PkgBuf::from("a/b")));
+    }
+
+    #[test]
+    fn test_absolute_package_dotdot_escapes_root_fails() {
+        // The bare package pattern (`//pkg`, reachable via `heph query -e`)
+        // must not accept `..` past the workspace root either.
+        let base = PkgBuf::from("anywhere");
+        let res = parse("//../../etc", &base);
+        assert!(res.is_err(), "expected error, got {res:?}");
+    }
+
+    #[test]
+    fn test_absolute_package_prefix_dotdot_escapes_root_fails() {
+        let base = PkgBuf::from("anywhere");
+        let res = parse("//../../etc/...", &base);
+        assert!(res.is_err(), "expected error, got {res:?}");
+    }
+
+    #[test]
+    fn test_absolute_package_dotdot_within_bounds_normalizes() {
+        let base = PkgBuf::from("anywhere");
+        let m = parse("//a/b/../c", &base).unwrap();
+        assert_eq!(m, Matcher::Package(PkgBuf::from("a/c")));
     }
 }

--- a/crates/model/src/htpkg/pkg.rs
+++ b/crates/model/src/htpkg/pkg.rs
@@ -76,6 +76,16 @@ pub fn join_rel_checked(pkg: &str, rel: &str) -> anyhow::Result<String> {
     Ok(finish(&out, &joined))
 }
 
+/// Like [`join_rel_checked`], but for building a [`PkgBuf`] rather than a
+/// file/glob path: a package never carries a trailing slash (there is no
+/// directory-vs-file distinction to preserve), so it is trimmed after the
+/// same `..`-bounded join.
+pub fn join_rel_checked_pkg(pkg: &str, rel: &str) -> anyhow::Result<String> {
+    Ok(join_rel_checked(pkg, rel)?
+        .trim_end_matches('/')
+        .to_string())
+}
+
 /// Concatenate `pkg` and `rel` with a single separator, skipping the separator
 /// when either side is empty (root package, or a bare package reference).
 fn join_raw(pkg: &str, rel: &str) -> String {

--- a/crates/model/src/htquery/mod.rs
+++ b/crates/model/src/htquery/mod.rs
@@ -18,7 +18,7 @@
 
 use crate::htaddr::parse_addr_with_base;
 use crate::htmatcher::Matcher;
-use crate::htpkg::{self, PkgBuf};
+use crate::htpkg::{self, PkgBuf, join_rel_checked_pkg};
 use anyhow::{Context, Result, bail};
 
 /// Render a [`Matcher`] back into query-language syntax — the inverse of
@@ -100,6 +100,7 @@ pub fn parse(input: &str, base: &PkgBuf) -> Result<Matcher> {
         tokens: &tokens,
         pos: 0,
         base,
+        depth: 0,
     };
     let m = p.parse_or()?;
     if let Some(tok) = p.peek() {
@@ -201,10 +202,17 @@ fn tokenize(input: &str) -> Result<Vec<Tok>> {
     Ok(tokens)
 }
 
+/// Cap on `!`/`(…)` nesting depth. Each level of nesting descends through
+/// `parse_not`, so this bounds native stack usage — a deeply nested or
+/// parenthesized expression must fail cleanly instead of overflowing the
+/// stack (reachable from `heph query -e '<expr>'` on user-controlled input).
+const MAX_NESTING_DEPTH: usize = 256;
+
 struct Parser<'a> {
     tokens: &'a [Tok],
     pos: usize,
     base: &'a PkgBuf,
+    depth: usize,
 }
 
 impl<'a> Parser<'a> {
@@ -249,10 +257,24 @@ impl<'a> Parser<'a> {
     }
 
     /// `not := "!" not | atom`
+    ///
+    /// Every level of `!`/`(…)` nesting passes through here exactly once
+    /// (directly for `!`, via `parse_atom` -> `parse_or` -> `parse_and` for
+    /// `(…)`), so guarding depth here bounds both recursion paths.
     fn parse_not(&mut self) -> Result<Matcher> {
+        self.depth += 1;
+        let result = self.parse_not_inner();
+        self.depth -= 1;
+        result
+    }
+
+    fn parse_not_inner(&mut self) -> Result<Matcher> {
+        if self.depth > MAX_NESTING_DEPTH {
+            bail!("query expression nested too deeply (limit: {MAX_NESTING_DEPTH})");
+        }
         if matches!(self.peek(), Some(Tok::Not)) {
             self.bump();
-            return Ok(Matcher::Not(Box::new(self.parse_not()?)));
+            return self.parse_not().map(|inner| Matcher::Not(Box::new(inner)));
         }
         self.parse_atom()
     }
@@ -308,13 +330,21 @@ impl<'a> Parser<'a> {
     fn func_to_matcher(&self, name: &str, arg: &str) -> Result<Matcher> {
         match name {
             "label" => Ok(Matcher::Label(arg.to_string())),
-            "tree_output" | "tree_output_to" => Ok(Matcher::TreeOutputTo(to_pkg(arg))),
+            "tree_output" | "tree_output_to" => Ok(Matcher::TreeOutputTo(
+                to_pkg(arg).with_context(|| format!("parsing {name}({arg})"))?,
+            )),
             "addr" => Ok(Matcher::Addr(
                 parse_addr_with_base(arg, self.base)
                     .with_context(|| format!("parsing addr({arg})"))?,
             )),
-            "package" | "pkg" => Ok(Matcher::Package(to_pkg(arg))),
-            "package_prefix" => Ok(Matcher::PackagePrefix(to_pkg(arg))),
+            "package" | "pkg" => Ok(Matcher::Package(
+                to_pkg(arg).with_context(|| format!("parsing {name}({arg})"))?,
+            )),
+            "package_prefix" => {
+                Ok(Matcher::PackagePrefix(to_pkg(arg).with_context(|| {
+                    format!("parsing package_prefix({arg})")
+                })?))
+            }
             other => bail!(
                 "unknown query function `{other}` (expected one of: label, tree_output, addr, package, package_prefix)"
             ),
@@ -336,10 +366,11 @@ impl<'a> Parser<'a> {
 }
 
 /// Normalise a package argument: strip a leading `//` so both `//pkg` and `pkg`
-/// are accepted, and drop any trailing `/`.
-fn to_pkg(arg: &str) -> PkgBuf {
+/// are accepted, and bound `..` segments to the workspace root (same rule
+/// `parse_addr` enforces for `//pkg:name`).
+fn to_pkg(arg: &str) -> Result<PkgBuf> {
     let arg = arg.strip_prefix("//").unwrap_or(arg);
-    PkgBuf::from(arg.trim_end_matches('/'))
+    Ok(PkgBuf::from(join_rel_checked_pkg("", arg)?))
 }
 
 #[cfg(test)]
@@ -625,5 +656,36 @@ mod tests {
     fn err_empty_addr_func_arg() {
         // `addr()` still needs a real address.
         assert!(parse("addr()", &base()).is_err());
+    }
+
+    #[test]
+    fn err_deeply_nested_not_returns_clean_error() {
+        // Reachable via `heph query -e '<expr>'` on user-controlled input;
+        // must fail cleanly instead of stack-overflowing the process.
+        let input = format!("{}//a:b", "!".repeat(10_000));
+        assert!(parse(&input, &base()).is_err());
+    }
+
+    #[test]
+    fn err_deeply_nested_parens_returns_clean_error() {
+        let input = format!("{}//a:b{}", "(".repeat(10_000), ")".repeat(10_000));
+        assert!(parse(&input, &base()).is_err());
+    }
+
+    #[test]
+    fn err_package_func_dotdot_escapes_root_fails() {
+        // package()/package_prefix()/tree_output() args funnel through the
+        // same PkgBuf construction as bare patterns — must reject `..` past
+        // the workspace root too.
+        assert!(parse("package(../../etc)", &base()).is_err());
+        assert!(parse("package_prefix(../../etc)", &base()).is_err());
+        assert!(parse("tree_output(../../etc)", &base()).is_err());
+    }
+
+    #[test]
+    fn moderately_nested_not_still_parses() {
+        // The depth cap must not reject ordinary, non-adversarial input.
+        let input = format!("{}//a:b", "!".repeat(10));
+        assert!(parse(&input, &base()).is_ok());
     }
 }


### PR DESCRIPTION
## Summary
- Absolute `//pkg:name` addresses (and bare `//pkg` query patterns, and `package()`/`package_prefix()`/`tree_output()` query-function args) accepted unvalidated `..` segments, e.g. `//../../etc:passwd` — a path-traversal bug reachable from `heph run`/`heph query` and BUILD-file `deps = [...]` strings, feeding filesystem joins in BUILD discovery, the cache dir, and the sandbox dir downstream.
- `heph query -e '<expr>'`'s recursive-descent parser had no bound on `!`/`(...)` nesting depth — a deeply nested or heavily parenthesized expression stack-overflows and aborts the process (verified locally: 10,000 nested parens SIGABRTs pre-fix).

## Fix
- Route every `PkgBuf`-constructing entry point (`parse_addr`, the relative-address resolver, bare package patterns, and the query-language functions) through the existing `join_rel_checked` mechanism — the same one `fs.file`/`fs.glob` already use to bound relative paths to the workspace root — via a new `join_rel_checked_pkg` helper (adds the trailing-slash trim `PkgBuf` needs but file/glob paths don't). This also collapsed two duplicated hand-rolled `..`-walking loops (`resolve_relative_pkg` existed separately in both `htaddr::parse` and `htpkg::parse`) into one-line delegations.
- Added a `depth` counter to the query parser's `Parser`, incremented/decremented around `parse_not` (every level of `!` or paren nesting passes through it exactly once), returning a clean error past 256 levels instead of crashing.

Both fixes were consulted with the `code-quality` and `product-vision` review agents before commit; findings from that pass (the bare-pattern/function-arg gap, an unconditional-decrement cleanup, and error-wording unification) are folded into this diff.

## Test plan
- [x] New tests for `parse_addr("//../../etc:passwd")`, the `parse_addr_with_base` bypass, in-bounds `..` normalization, bare package pattern (`htpkg::parse`) escape, and `package()`/`package_prefix()`/`tree_output()` escape — all confirmed red without the fix (manually reverted the guard, observed failures) and green with it.
- [x] New tests for deep `!`-chain and deep-paren nesting — confirmed the pre-fix parser SIGABRTs (stack overflow) on 10,000 nested parens; post-fix both return a clean `Err` and a moderate (10-level) nesting case still parses successfully.
- [x] `cargo test -p model` — 111/111 passing.
- [x] `cargo build --workspace` — clean, no downstream breakage from the signature/behavior changes.
- [x] `lint` (clippy + fmt) from workspace root — clean.
- [ ] CI (`tst`, full matrix) — not run locally per project convention; CI covers it on push.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XwSrR7ghWM7kLbpvTQMurq