### PR TITLE
fix(tui): keep the tick armed while the interactive TUI is paused

### DIFF
--- a/crates/tui/src/tui/backend/interactive.rs
+++ b/crates/tui/src/tui/backend/interactive.rs
@@ -363,7 +363,29 @@ pub async fn run<A: App + 'static>(
                     None => build_events = None,
                 }
             }
-            _ = ticker.tick(), if !paused => {
+            _ = ticker.tick() => {
+                // Deliberately NOT gated on `!paused`. While paused, the tick
+                // draws nothing — the terminal belongs to the interactive
+                // child — but it must keep firing as the loop's only
+                // self-wake: with the event stream torn down and the ticker
+                // off, the loop's sole remaining wake sources are the control
+                // channel and the app `JoinHandle`, and both of those wakes
+                // are issued from the app task, which by the end of a target
+                // has usually gone through `block_in_place` (pluginexec's
+                // macOS drain path) and lost its runtime core — so they ride
+                // tokio's cross-thread wake (`mio::Waker` → kqueue
+                // `EVFILT_USER`), observed to be droppable on macOS (see
+                // `hproc::proc_exec` and `hcore::blocking`). One dropped
+                // `Control::Resume` wake then left this loop parked forever
+                // in a runtime with no timers: frame frozen mid-pause, engine
+                // idle, process never exiting. A timer expiry is a kernel
+                // timeout on the parked driver, not an `EVFILT_USER` trigger,
+                // so the tick is the wake that cannot be lost; each one
+                // re-enters the loop and the next `select!` re-polls the
+                // control channel, observing any message whose wake vanished.
+                if paused {
+                    continue;
+                }
                 if needs_resize {
                     // Re-anchor the inline viewport at the new size before drawing.
                     // The tick is a synchronous draw-owning point, so the
@@ -716,6 +738,84 @@ mod tests {
         assert!(
             observed >= 3,
             "renderer must keep ticking while app is in block_in_place; got {observed} ticks during {BLOCK_MS} ms"
+        );
+    }
+
+    /// Regression for the darwin-only CI hang in `bin-e2e`'s
+    /// `tui_renders_the_run_and_restores_the_terminal`: the run finished
+    /// engine-side (stall watchdog reported `open=0`), the frame stayed frozen
+    /// at the pre-pause render, and the process never exited.
+    ///
+    /// While the TUI is paused for an interactive target, the event stream is
+    /// torn down and the ticker used to be gated off (`, if !paused`), so the
+    /// loop's only remaining wake sources were the control channel and the app
+    /// `JoinHandle`. Both of those wakes are issued by the app task, which by
+    /// the end of a target has typically passed through `block_in_place`
+    /// (pluginexec's macOS drain path) and lost its runtime core, so they ride
+    /// tokio's cross-thread wake — kqueue `EVFILT_USER`, observed to drop on
+    /// macOS (see `hproc::proc_exec`, `hcore::blocking`). One dropped
+    /// `Control::Resume` wake left the loop parked in a runtime with no timers
+    /// registered at all: nothing could ever poll it again. The fix keeps the
+    /// ticker armed while paused (drawing nothing) as a wake the kernel
+    /// timeout delivers, so a message whose wake vanished is still observed on
+    /// the next tick's re-poll of the select.
+    ///
+    /// A genuinely dropped tokio wake cannot be forced from a test, so — like
+    /// the other tests in this module — this mirrors the loop's shape rather
+    /// than driving `run` itself (which needs a real terminal). The dropped
+    /// wake is modelled precisely: state that is observable by polling but
+    /// whose change produces *no* wake (an atomic flipped from a plain OS
+    /// thread), next to a control arm that never wakes. With the pre-fix shape
+    /// (tick arm gated on `!paused`) this loop has no wake source left and
+    /// hangs until the timeout; with the ticker armed it converges within a
+    /// few frames. What it does not prove: that `run`'s real arm carries no
+    /// gate — that line is covered by review, not by this mirror.
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn paused_loop_keeps_ticking_so_a_wakeless_resume_is_still_observed() {
+        use std::sync::atomic::AtomicBool;
+
+        // "A Resume is queued, but the wake that should announce it was
+        // dropped": observable state, zero waker traffic.
+        let resume_queued = Arc::new(AtomicBool::new(false));
+        {
+            let resume_queued = Arc::clone(&resume_queued);
+            std::thread::spawn(move || {
+                std::thread::sleep(Duration::from_millis(150));
+                resume_queued.store(true, Ordering::Release);
+            });
+        }
+
+        let mut paused = true;
+        let mut interval = tokio::time::interval(TICK);
+        interval.set_missed_tick_behavior(tokio::time::MissedTickBehavior::Skip);
+
+        let outcome = tokio::time::timeout(Duration::from_secs(10), async {
+            loop {
+                tokio::select! {
+                    // The control channel whose wake never arrives.
+                    () = std::future::pending::<()>() => {}
+                    _ = interval.tick() => {
+                        // Mirrors the fix: the tick arm is NOT gated on
+                        // `!paused`; while paused it only re-enters the loop,
+                        // which is what lets the next poll observe the queued
+                        // resume.
+                        if paused && resume_queued.load(Ordering::Acquire) {
+                            paused = false;
+                        }
+                        if !paused {
+                            break;
+                        }
+                    }
+                }
+            }
+        })
+        .await;
+
+        assert!(
+            outcome.is_ok(),
+            "a paused loop whose ticker is gated off has no wake source left \
+             once a cross-thread wake is dropped; the tick must stay armed \
+             while paused"
         );
     }
 


### PR DESCRIPTION
## Summary

- Root-caused the darwin-only CI hang in [run 30531543739 / job 90845602237](https://github.com/hephbuild/heph/actions/runs/30531543739/job/90845602237): `tui_renders_the_run_and_restores_the_terminal` timed out waiting 180s for the child to exit, even though the target (`sleep 1; echo e2e-ok`) had already finished and the engine reported zero in-flight operations.
- While the interactive TUI is paused for a target (stdin/stdout handed to the child), the render loop's ticker was gated off (`, if !paused`), leaving `control_rx.recv()` and the app `JoinHandle` as the only remaining wake sources. Both are signalled from the app task, which on macOS typically finishes its last target through `block_in_place` (pluginexec's drain path) and goes core-less — so the wake rides tokio's cross-thread path (`mio::Waker` -> kqueue `EVFILT_USER`), which this codebase has already observed dropping wakes under load. A dropped `Control::Resume` wake then parked the loop forever, with no timer left anywhere in the runtime.
- Fix: keep the ticker armed while paused; its body is a no-op `continue`. A timer expiry is a kernel timeout on the parked driver, not an `EVFILT_USER` trigger, so it can't be lost — it bounds any dropped-wake hang to one 80ms tick instead of forever.
- This is a latent bug exposed rather than introduced by a single commit — the pause gating predates the recent `proc_exec` rewrite (#245), which changed macOS timing enough to make the app task's core-less tail (and thus this race) common for fast targets.

## Test plan

- [x] `cargo test -p tui --lib` — 113 passed, including a new regression test (`paused_loop_keeps_ticking_so_a_wakeless_resume_is_still_observed`) that mirrors the loop's shape with an explicitly modelled dropped wake; fails without the fix (verified red), passes with it.
- [x] `lint` (workspace clippy `-D warnings` + fmt) — clean.
- A genuinely dropped tokio/kqueue wake can't be forced deterministically from a test, so this doesn't reproduce the exact CI hang — it proves the mechanism (no-gate ticker recovers from a wake that never arrives; gated ticker hangs).

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>
Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>

https://claude.ai/code/session_015oVd4CMetnsgUzRAFNaCVz