### PR TITLE
fix(ci): resolve perf baseline by presence, not run-level success

### DIFF
--- a/.github/workflows/perf.yml
+++ b/.github/workflows/perf.yml
@@ -177,16 +177,26 @@ jobs:
       # `gh api` (against this repo, default token) and `git describe`
       # against a commit already present from the full-history checkout
       # above; no build, no checkout of that commit.
+      #
+      # Deliberately does NOT filter by the run's overall conclusion: whether
+      # a release was actually published is what "Fetch baseline" below
+      # checks (best-effort `gh release download`), not whether every other
+      # job in that run happened to pass. A run's Perf legs or an unrelated
+      # job (Binary E2E, say) can fail while `upload_artifacts` still
+      # published fine — gating on run-level success here made a single
+      # flake unrecoverable: the next commit's baseline lookup would find no
+      # "successful" run, fail its own Perf job for missing baseline, and the
+      # failure would propagate to every commit after it forever.
       - name: Resolve baseline release
         if: steps.base.outputs.sha != ''
         id: baseline_release
         env:
           GH_TOKEN: ${{ github.token }}
         run: |
-          RUN_NUMBER=$(gh api "repos/${{ github.repository }}/actions/runs?head_sha=${{ steps.base.outputs.sha }}&status=success" \
+          RUN_NUMBER=$(gh api "repos/${{ github.repository }}/actions/runs?head_sha=${{ steps.base.outputs.sha }}" \
             --jq '[.workflow_runs[] | select(.name=="CI" and .event=="push")] | first | .run_number // empty')
           if [ -z "$RUN_NUMBER" ]; then
-            echo "no successful master push run found for baseline ${{ steps.base.outputs.sha }}"
+            echo "no master push run found for baseline ${{ steps.base.outputs.sha }}"
             echo "found=false" >> "$GITHUB_OUTPUT"
             exit 0
           fi


### PR DESCRIPTION
## Summary
- Master CI's Perf job has been failing every push with "no baseline artifacts found" since ~09:39 today: a single unrelated job (`Binary E2E darwin/arm64`) flaked on one commit, marking that run's overall conclusion `failure` even though Perf itself passed and the release published fine.
- The baseline-resolution step filtered `gh api .../actions/runs` by `status=success` (whole-run conclusion), so the next commit couldn't find a "successful" run to derive its baseline release tag from, failed its own Perf job for missing baseline, and that failure cascaded to every commit since — self-perpetuating, never recovers on its own.
- Drop the `status=success` filter. Whether a baseline release actually exists is already checked by "Fetch baseline" (`gh release download`, best-effort) — that's the real gate, not whether every unrelated job in that run happened to pass.

## Test plan
- [ ] CI green on this PR
- [ ] Next master push resolves a baseline again (breaks the current failure streak)