### PR TITLE
fix(bin-e2e): assert running addr against raw pty bytes, not per-read screen dumps

### DIFF
--- a/crates/bin-e2e/tests/tui_pty.rs
+++ b/crates/bin-e2e/tests/tui_pty.rs
@@ -64,9 +64,17 @@ fn tui_renders_the_run_and_restores_the_terminal() {
         "interactive TUI never engaged with a tty attached\n{}",
         session.report()
     );
+    // Raw bytes, not the vt100-rendered screen: `rendered` snapshots the
+    // screen once per pty `read()`, and on a loaded CI runner several ticks'
+    // worth of draws can land in one read before the pump thread gets
+    // scheduled — the in-progress frame is overwritten by the next one before
+    // it is ever sampled, even though it was genuinely painted. The address
+    // only ever reaches stderr as literal text drawn by the viewport (there is
+    // no other path that would write it), so its presence in the byte stream
+    // still proves it was rendered, just not caught at a read boundary.
     assert!(
-        session.rendered.contains("//pkg:ok"),
-        "the target never appeared on the rendered screen\n{}",
+        contains(&session.raw, b"//pkg:ok"),
+        "the target never appeared in the rendered output\n{}",
         session.report()
     );
 


### PR DESCRIPTION
## Summary

Fixes the darwin/arm64 `Binary E2E` flake seen at https://github.com/hephbuild/heph/actions/runs/30586760498/job/91022848661:

```
thread 'tui_renders_the_run_and_restores_the_terminal' panicked at crates/bin-e2e/tests/tui_pty.rs:67:5:
the target never appeared on the rendered screen
```

`#288` fixed the pre-existing hang in this same test (`child did not exit within 180s`). With that fixed, the process now reliably exits fast, exposing this second, separate flake in the test harness itself.

Root cause: `run_in_pty`'s pump thread snapshots `vt100::Parser::screen().contents()` once per pty `read()` call, not once per TUI draw. Ratatui redraws the inline viewport on every 80ms tick. On a loaded CI runner, several ticks' worth of draws can be buffered in the pty before the reader thread gets scheduled again, so one `read()` can contain multiple whole frames concatenated — only the *last* frame in that batch survives into the snapshot, since each draw fully overwrites the previous one's cells. The in-progress `//pkg:ok` frame was genuinely painted, just never sampled at a read boundary.

Fix: assert the address's presence against the raw byte stream (`session.raw`) instead of the per-read `rendered` screen dumps — consistent with how the test already checks the DSR/cursor-hide/cursor-show signals. The address only ever reaches stderr as literal text drawn by the ratatui viewport, so its presence in the raw bytes still proves it was rendered; it's just no longer sensitive to read/tick coalescing.

No production code changed — this is a test-harness fix only.

## Test plan

- [x] `cargo clippy -p bin-e2e --all-targets` clean
- [x] `cargo check -p bin-e2e --tests`
- [ ] CI `Binary E2E` job on all 3 platforms (can't run the release-binary bin-e2e suite locally per repo convention; relying on CI)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XpJxJgwBvUBtveDAcW1yBr