### PR TITLE
feat(plugin-js): js_bundle driver, esm/cjs + node/browser variants

### DIFF
--- a/crates/plugin-js-cdylib/src/lib.rs
+++ b/crates/plugin-js-cdylib/src/lib.rs
@@ -1,6 +1,6 @@
 //! The JS/TS plugin as a loadable cdylib behind the stable ABI.
 //!
-//! **M0-M5 scope**: exports the `js` provider (package discovery + pnpm/npm
+//! **M0-M6 scope**: exports the `js` provider (package discovery + pnpm/npm
 //! workspace-member resolution + lockfile-driven dependency wiring + oxc-based
 //! import-graph resolution), its `js_package_info` dependency-wiring driver,
 //! the hermetic `js_install` third-party fetch driver, the `js_typecheck`
@@ -9,23 +9,29 @@
 //! module docs), the `js_test` driver (M4 — one target per test file, via
 //! the configured `testrunner` (`vitest`/`jest`), same disclosed non-hermetic
 //! host-toolchain shape; see `hplugin_js::pluginjs::driver_test` module
-//! docs), and the `js_lint` driver (M5 — one target per package, via the
+//! docs), the `js_lint` driver (M5 — one target per package, via the
 //! configured `linter` (`oxlint`/`eslint`), same disclosed non-hermetic
 //! host-toolchain shape; see `hplugin_js::pluginjs::driver_lint` module
+//! docs), and the `js_bundle` driver (M6 — one target per package entry
+//! point, via the configured `bundler` (`esbuild` only, in this milestone),
+//! same disclosed non-hermetic host-toolchain shape, plus `format`/`target`
+//! addr-arg variants; see `hplugin_js::pluginjs::driver_bundle` module
 //! docs). The host loads this with `hplugin_stabby::load_stable::load`,
 //! which verifies ABI compatibility via stabby's type reports before use.
 //! Calls then run in-process at native speed — no serialization on the hot
 //! path, no IPC.
 //!
-//! Formatting and bundling drivers are later milestones (see
-//! `ai-docs/js-plugin-plan.md`) and are not wired up here yet.
+//! `js_format` (the one remaining driver named in
+//! `ai-docs/js-plugin-plan.md`'s v1 scope table) has no milestone in the
+//! plan's Milestones list and is not wired up here — see that doc.
 //!
 //! Plugin-specific settings are read from the environment; only the
 //! workspace root crosses in [`CreateConfig`].
 
 use hdriver_support::driver_managed::ManagedDriver;
 use hplugin_js::pluginjs::{
-    JsInstallDriver, JsLintDriver, JsPackageInfoDriver, JsTestDriver, JsTypecheckDriver, Provider,
+    JsBundleDriver, JsInstallDriver, JsLintDriver, JsPackageInfoDriver, JsTestDriver,
+    JsTypecheckDriver, Provider,
 };
 use plugin_sdk::stabby::abi::{DynLogSink, DynSupervisor, NamedDriver, PluginComponents};
 use plugin_sdk::stabby::{
@@ -130,6 +136,16 @@ fn build(cfg: &[u8]) -> anyhow::Result<PluginComponents> {
     drivers.push(NamedDriver {
         name: "js_lint".into(),
         driver: make_dyn_managed_driver(lint),
+    });
+    // `js_bundle` (M6): runs the configured bundler (`esbuild` default, the
+    // only value implemented this milestone) over one package's entry point
+    // at a time — see `hplugin_js::pluginjs::driver_bundle` module docs,
+    // including its disclosed non-hermetic host-toolchain gap and its
+    // `format`/`target` addr-arg variant mechanism.
+    let bundle: Arc<dyn ManagedDriver> = Arc::new(JsBundleDriver::new());
+    drivers.push(NamedDriver {
+        name: "js_bundle".into(),
+        driver: make_dyn_managed_driver(bundle),
     });
 
     Ok(PluginComponents {

--- a/crates/plugin-js/src/pluginjs/deps.rs
+++ b/crates/plugin-js/src/pluginjs/deps.rs
@@ -209,6 +209,7 @@ mod tests {
         }
         PackageManifest {
             name: "a".to_string(),
+            main: None,
             dependencies,
             dev_dependencies: to_map(dev),
             optional_dependencies,

--- a/crates/plugin-js/src/pluginjs/driver_bundle.rs
+++ b/crates/plugin-js/src/pluginjs/driver_bundle.rs
@@ -1,0 +1,1162 @@
+//! `js_bundle` — runs the configured bundler (`esbuild` default, the only
+//! value implemented this milestone) over **one package's entry point at a
+//! time**, producing a bundled output directory.
+//!
+//! ## Variants: `format` (esm/cjs) and `target` (node/browser)
+//!
+//! Per `ai-docs/js-plugin-plan.md`'s Variants section, module format and
+//! target environment are addr args scoped to `js_bundle` only —
+//! `js_install`/`js_typecheck`/`js_test`/`js_lint` stay variant-free, never
+//! see either arg, and are unaffected by this milestone.
+//!
+//! **Design decision, and where this disagrees with a literal reading of the
+//! plan doc's "reuse the existing `provider_state(provider=…,
+//! variants={…})` mechanism (ancestry-vs-universe resolution)":** this
+//! driver does **not** port `plugin-go`'s `variant.rs` ancestry/universe
+//! resolver. That machinery exists to solve two problems specific to Go's
+//! model — arbitrarily-nested `go.mod` module trees (an "ancestry" to walk
+//! at all) and a binary's variant choice needing to propagate consistently
+//! to transitive library deps possibly living in a sibling subtree (the
+//! `vp`-pinned "universe" lookup) — neither of which exists here:
+//! `pluginjs::workspace` is a single flat workspace root (nested workspaces
+//! are explicitly rejected, see `workspace.rs`), so there is no ancestor
+//! chain to walk and at most one enclosing scope per package. And per the
+//! plan doc itself, this axis is scoped to bundle targets only — it does not
+//! need to propagate to or agree with any other driver's own resolution the
+//! way a Go variant must propagate through `build_lib`/`_golist`. Building
+//! the ancestry/universe/inheritance/cycle-detection machinery for an axis
+//! with nothing to inherit from and nothing to propagate to would be exactly
+//! the unused generality this crate's own review history repeatedly flags.
+//!
+//! Instead, `format`/`target` are plain addr args resolved with a flat
+//! default when absent (`format` → `"esm"`, `target` → `"node"`) — the same
+//! shape `js_test`'s `file` addr arg already uses in this crate (see
+//! `provider.rs`'s `Provider::get` handling of [`crate::pluginjs::TEST_TARGET`]),
+//! just with a default rather than a hard "must specify" requirement. A
+//! default (rather than Go's mandatory-`@v=`-with-no-default) is deliberate:
+//! Go's "no implicit default" rule exists because an ancestry walk can make
+//! *which* declaration applies genuinely ambiguous; there is no equivalent
+//! ambiguity here to protect against, and requiring every caller to spell
+//! out `@format=esm,target=node` for the common case would be pure
+//! ceremony.
+//!
+//! ## Toolchain: `bundler = "esbuild"`, a disclosed non-hermetic escape hatch
+//!
+//! Exactly the same shape as `js_typecheck`'s `tstool = "host"` /
+//! `js_test`'s `testrunner` / `js_lint`'s `linter` (see `toolchain.rs` module
+//! docs): no hermetic Node/bundler toolchain exists anywhere in this plugin
+//! yet, so `Provider::get` (`provider.rs::bundle_config`) resolves the
+//! configured bundler's binary from the host
+//! (`toolchain::resolve_host_bundler`) and queries its `--version` once,
+//! threading both through this target's config. `rollup`/`webpack`/`vite`
+//! are a stated M6+ follow-up — `bundler` is a real, checked option (not an
+//! assumption baked into the driver), so setting it to anything but
+//! `"esbuild"` today fails loudly at `Provider::get`, never silently.
+//!
+//! ## Entry points
+//!
+//! One entry file per target: the package's own `package.json` `"main"`
+//! field by default, or an explicit `entry=<workspace-relative-path>` addr
+//! arg override. An override is validated against workspace/package
+//! containment the same way `js_test`'s `file` addr arg is — see
+//! `provider.rs`'s `reject_path_escape`/`path_under_package` and their
+//! `js_bundle`-specific tests in this module and in `provider.rs`.
+//!
+//! **Known scope trim, disclosed rather than silent**: exactly one entry
+//! point per target, not `package.json` `"exports"`-map-driven multi-entry
+//! bundling. A package needing several bundled entry points today addresses
+//! several `js_bundle@entry=…` targets explicitly (each independently
+//! cached). TODO M6+: multi-entry-point single-invocation bundling (matching
+//! esbuild's own native multi-entry support) once a real need for it shows
+//! up — building it speculatively now would be exactly the unused
+//! generality this crate's own review history flags.
+//!
+//! ## Inputs / cache key
+//!
+//! Per `ai-docs/js-plugin-plan.md`'s `js_bundle` bullet under Caching/
+//! incrementality: *"whole-graph by construction — cache key is the full
+//! transitive closure's content hash plus bundler config/version. This is
+//! the one driver where per-file incrementality is not the goal;
+//! correctness of the entry-point closure is."* Concretely
+//! (`provider.rs`'s `Provider::bundle_closure`):
+//!
+//! - Every first-party file transitively reachable from the entry point via
+//!   `ImportGraph::runtime_edges` (**not** `type_edges` — a bundler erases
+//!   type-only imports, it never emits them, so following them would
+//!   over-declare the Input set), **recursing across workspace-package
+//!   boundaries** — unlike `js_test`/`js_typecheck`'s deliberate "one-hop
+//!   external" trim (per-package granularity is *correct* for those, so a
+//!   sibling package's own further imports are out of scope), a bundler
+//!   genuinely inlines a sibling package's entire reachable source into the
+//!   same output, so under-declaring past one hop here would be a real
+//!   cache-correctness bug, not merely a narrower one. This is the
+//!   structural reason `js_bundle`'s closure builder cannot reuse
+//!   `importgraph::build_test_closure` as-is — see that function's own doc
+//!   for the trim this driver deliberately does not inherit.
+//! - Every third-party package the closure's own unresolved bare specifiers
+//!   name, resolved via `deps::resolve_one_dependency` — the lockfile-driven
+//!   mechanism, never by walking `oxc_resolver` paths against an ambient
+//!   `node_modules` (the M3-review lesson recorded in `provider.rs`, applied
+//!   again here). Third-party packages are **not** recursed into further —
+//!   the whole `js_install`/thirdparty addr is depended on as one opaque
+//!   unit, whose own declared `DirPath` output already content-hashes
+//!   everything inside it, so there is nothing to gain by walking its
+//!   internals (mirrors `js_typecheck`/`js_test`'s identical one-hop
+//!   treatment of third-party edges). The bare specifier name each such
+//!   package was actually imported by (not just its resolved addr) is
+//!   carried alongside it and fed to esbuild's own `--external:<name>` flag
+//!   (`run()`, below) — see `provider.rs`'s `BundleClosureResult::external_names`
+//!   doc for the feature-quality M6 review BLOCKER this fixes: previously
+//!   only a bundler-config-file's own opt-in `"external"` array reached that
+//!   flag, so every real third-party import (never listed there) made a real
+//!   `esbuild --bundle` hard-fail trying to inline it.
+//! - The resolved bundler config file, if any (`esbuild.config.json`, walked
+//!   up the ancestor chain the same way a tsconfig is — see
+//!   `importgraph::find_nearest_bundler_config`), plus every file it itself
+//!   references via a relative `import`/`require` (`importgraph::
+//!   resolve_runner_config_referenced_files`, reused as-is — see that
+//!   function's doc; it degrades to a no-op for a `.json` config, which
+//!   cannot `import` anything, and exists to future-proof a later JS/TS
+//!   config format without new plumbing).
+//! - The entry package's own resolved tsconfig, if any, plus its whole
+//!   `extends` chain — the same treatment `js_typecheck` gives its tsconfig
+//!   (`provider.rs`'s `bundle_deps_config`, mirroring `typecheck_deps_config`).
+//!   esbuild auto-discovers and applies a tsconfig's `compilerOptions`
+//!   (`paths`/`baseUrl`/`jsx`/`target`/`experimentalDecorators`) the same way
+//!   `tsc` does; `run()` passes it an explicit `--tsconfig=<path>` rather
+//!   than relying on that auto-discovery (see `run()`'s own comment) —
+//!   without this, a `paths`-aliased entry point (a mainstream TS-monorepo
+//!   pattern) would fail at real `esbuild` execution because the sandbox
+//!   never had a `tsconfig.json` at all (code-quality M6 review BLOCKER).
+//!   Only the *entry package's* tsconfig is resolved — the same scope
+//!   `esbuild`'s own single-directory-walk auto-discovery would apply from
+//!   the entry file, so a sibling package crossed via the whole-graph
+//!   closure never contributes a second, conflicting tsconfig.
+//! - The queried `bundler_version`.
+//!
+//! Beyond the declared `Input`s (content-hashed automatically by the
+//! engine), [`JsBundleDef::hash`] additionally hashes `entry_file`, `format`,
+//! `target`, `outdir`, `bundler_config_path`, `bundler_config_content`,
+//! `external`, `tsconfig_path`, `tsconfig_content` and `bundler_version`
+//! directly — the same deliberate redundancy-with-declared-Inputs discipline
+//! `js_typecheck`'s `tsconfig_content` / `js_test`'s `runner_config_content`
+//! already have (an independently-verifiable-at-`parse()`-level
+//! cache-sensitivity proof, see this module's tests). `bundler_bin` (an
+//! absolute host path) is deliberately **excluded** — see that field's own
+//! doc comment.
+//!
+//! **Native/optional-dependency platform axis**: not hashed directly on this
+//! `Def` — a third-party dependency resolved through
+//! `deps::resolve_one_dependency` already carries `goos`/`goarch` in its own
+//! `js_install` addr args (see `thirdparty.rs`), so a platform-restricted
+//! third-party dependency naturally produces a different declared `Input`
+//! addr, and therefore a different `js_bundle` hash, per platform — mirrors
+//! `js_typecheck`/`js_test`'s identical choice not to hash `goos`/`goarch`
+//! a second time on top of that.
+//!
+//! **Known scope trims, disclosed rather than silent (hermeticity M6
+//! review)**:
+//! - **`target=node`/`target=browser` doesn't change what's resolved or
+//!   declared.** `Resolvers`/`import_graph` are not parameterized by
+//!   `target`, so a package with a `package.json` `"browser"` field/exports
+//!   condition gets the identical declared closure for both variants, while
+//!   `esbuild --platform=browser` (driven directly by `def.target`) *does*
+//!   honor that field — either the browser variant fails loudly (the
+//!   browser-specific file was never staged) or, if it happens to already be
+//!   in the closure via an unrelated edge, its presence was never actually
+//!   established for the browser-resolution reason. Not fixed this
+//!   milestone: parameterizing `Resolvers`/`import_graph`/`graph_cache` by
+//!   platform is a real design change (a resolver + per-package cache this
+//!   crate shares with `js_typecheck`/`js_test`, neither of which has a
+//!   platform axis to key on today) rather than a contained fix, and is left
+//!   as a stated M6+ follow-up rather than rushed into this milestone's
+//!   close-out.
+//! - **An ambiently-`node_modules`-resolved third-party edge is hashed as a
+//!   first-party file Input, not routed through the lockfile.** Only
+//!   possible when `node_modules` happens to exist on the host at
+//!   `Provider::get` time (see `provider.rs`'s `bundle_closure_step`) —
+//!   mirrors `typecheck_deps_config`'s identical, already-reviewed (M3)
+//!   treatment of the same case, not new to this milestone. Flagged again
+//!   here only because `js_bundle` is the driver whose whole stated purpose
+//!   is closure correctness, so the general "avoid ambient node_modules"
+//!   discipline this module's Inputs section states above still has this one
+//!   documented edge-case exception.
+//!
+//! ## Failure reporting
+//!
+//! A bundler error (syntax error, unresolvable import esbuild itself catches
+//! that this crate's own resolver didn't) is a plain, non-zero-exit driver
+//! failure with both stdout and stderr tails surfaced
+//! (`bundle_failure_detail`, identical shape to
+//! `driver_typecheck.rs`'s `tsc_failure_detail` / `driver_test.rs`'s
+//! `test_failure_detail`) — esbuild's actual diagnostic output must reach
+//! the user, never be swallowed into a bare "failed".
+//!
+//! ## Output
+//!
+//! `run()` invokes esbuild with `--outdir=<sandbox_ws_dir>/<outdir>`; the
+//! `TargetDef` declares a single `Content::DirPath(outdir)` output, `collect:
+//! true` — the same shape `js_install` uses for a driver that produces file
+//! outputs (see `driver_install.rs`), chosen over a single `FilePath` output
+//! so a later multi-entry-point milestone can widen `run()`'s invocation
+//! without an output-declaration change. `outdir` includes `format`/`target`
+//! (`"<pkg>/dist/<format>-<target>"`, `Provider::bundle_config`) — without
+//! this, `js_bundle@format=esm` and `js_bundle@format=cjs` for the same
+//! package declared the identical output directory, colliding whenever both
+//! are built together, the milestone's own headline dual-format-publish
+//! shape (feature-quality M6 review BLOCKER).
+
+use anyhow::Context;
+use async_trait::async_trait;
+use hcore::debug_hash::DebugHasher;
+use hcore::hasync::Cancellable;
+use hdriver_support::driver_managed::{ManagedDriver, ManagedRunRequest, ManagedRunResponse};
+use hplugin::driver::targetdef::path::{CodegenMode, Content, Path};
+use hplugin::driver::targetdef::{CacheConfig, Input, InputMode, Output, TargetDef};
+use hplugin::driver::{
+    ApplyTransitiveRequest, ApplyTransitiveResponse, ConfigRequest, ConfigResponse, ParseRequest,
+    ParseResponse, TargetAddr,
+};
+use hplugin::htspec::Spec;
+use hproc::proc_exec;
+use std::collections::HashMap;
+use std::ffi::OsString;
+use std::hash::{Hash, Hasher};
+use std::sync::Arc;
+use xxhash_rust::xxh3::Xxh3Default;
+
+/// Config for a `js_bundle` target. Entirely engine-generated by the `js`
+/// provider's `Provider::get` (see `pluginjs::provider::Provider::bundle_config`)
+/// — never authored by hand in a BUILD file.
+#[derive(Spec)]
+struct JsBundleSpec {
+    /// Which bundler this target invokes — only `"esbuild"` in this
+    /// milestone (see `toolchain::is_supported_bundler`).
+    #[spec(required)]
+    bundler: String,
+    /// Absolute host path to the resolved bundler binary
+    /// (`toolchain::resolve_host_bundler`). Deliberately **not** part of
+    /// `JsBundleDef`'s hash — see that struct's `bundler_bin` field doc.
+    #[spec(required)]
+    bundler_bin: String,
+    /// The bundler's own `--version` output, trimmed, queried once by
+    /// `Provider::get`. Hashed: a host bundler upgrade/downgrade must bust
+    /// the cache.
+    #[spec(required)]
+    bundler_version: String,
+    /// Workspace-root-relative path to the one entry file this target
+    /// bundles.
+    #[spec(required)]
+    entry_file: String,
+    /// Module format: `"esm"` or `"cjs"`.
+    #[spec(required)]
+    format: String,
+    /// Target environment: `"node"` or `"browser"` — maps to esbuild's own
+    /// `--platform` flag (not its separate `--target` syntax-level flag,
+    /// which this milestone does not expose).
+    #[spec(required)]
+    target: String,
+    /// Workspace-root-relative output directory this target writes into.
+    #[spec(required)]
+    outdir: String,
+    /// Workspace-root-relative path to the resolved bundler config
+    /// (`esbuild.config.json`), or empty when none exists on the ancestor
+    /// chain.
+    bundler_config_path: String,
+    /// The resolved bundler config's own raw bytes, hashed directly — see
+    /// module docs' "Inputs / cache key" section.
+    bundler_config_content: String,
+    /// Package names esbuild's own `--external:<name>` flag needs, one per
+    /// entry: the union of the closure's own discovered third-party bare
+    /// specifiers and the resolved bundler config's opt-in `"external"`
+    /// array — computed once by `Provider::get`
+    /// (`Provider::bundle_deps_config`) so `run()` never re-derives it.
+    external: Vec<String>,
+    /// Workspace-root-relative path to the entry package's resolved
+    /// tsconfig (the package's own, or the nearest ancestor's — see
+    /// `importgraph::find_nearest_tsconfig`). Empty when no tsconfig exists
+    /// anywhere on the ancestor chain.
+    tsconfig_path: String,
+    /// The resolved tsconfig's own raw bytes (leaf plus its whole `extends`
+    /// chain), hashed directly — see module docs' "Inputs / cache key"
+    /// section.
+    tsconfig_content: String,
+    /// Dependencies, grouped by name → target addresses: `""` = every
+    /// first-party file transitively reachable from the entry point
+    /// (recursing across workspace-package boundaries — see module docs),
+    /// `"external"` = every third-party package the closure's own
+    /// unresolved bare specifiers name, `"bundler_config"` = the resolved
+    /// bundler config file plus anything it references, if any, `"tsconfig"`
+    /// = the resolved tsconfig plus its whole `extends` chain, if any.
+    deps: HashMap<String, Vec<String>>,
+}
+
+#[derive(Clone, serde::Serialize, serde::Deserialize)]
+struct JsBundleDef {
+    bundler: String,
+    bundler_version: String,
+    entry_file: String,
+    format: String,
+    target: String,
+    outdir: String,
+    bundler_config_path: String,
+    bundler_config_content: String,
+    external: Vec<String>,
+    tsconfig_path: String,
+    tsconfig_content: String,
+    /// Absolute host bundler path — carried through so `run()` can exec it,
+    /// but see `Hash` impl below: deliberately excluded from the cache key.
+    bundler_bin: String,
+}
+
+/// Bump to invalidate every cached `js_bundle` result whenever the
+/// invocation shape (flags, config-lookup rule, what counts as a hashed
+/// config field) changes in a way the declared `Input` content hash alone
+/// would not already capture.
+const JS_BUNDLE_FORMAT_VERSION: u32 = 1;
+
+impl Hash for JsBundleDef {
+    fn hash<H: Hasher>(&self, state: &mut H) {
+        JS_BUNDLE_FORMAT_VERSION.hash(state);
+        self.bundler.hash(state);
+        self.bundler_version.hash(state);
+        self.entry_file.hash(state);
+        self.format.hash(state);
+        self.target.hash(state);
+        self.outdir.hash(state);
+        self.bundler_config_path.hash(state);
+        self.bundler_config_content.hash(state);
+        self.external.hash(state);
+        self.tsconfig_path.hash(state);
+        self.tsconfig_content.hash(state);
+        // `bundler_bin` is deliberately NOT hashed — an absolute host
+        // filesystem path that differs across machines/checkouts for the
+        // exact same effective toolchain; see `JsTypecheckDef::hash`'s
+        // identical `tsc_bin` exclusion for the full rationale.
+        //
+        // Source/closure file *content* arrives via declared `Input`s; the
+        // engine hashes that separately (architecture.md's "Automatic
+        // hashing"), so it is not duplicated here.
+    }
+}
+
+pub struct JsBundleDriver;
+
+impl JsBundleDriver {
+    pub fn new() -> Self {
+        Self
+    }
+}
+
+impl Default for JsBundleDriver {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+#[async_trait]
+impl ManagedDriver for JsBundleDriver {
+    fn config(&self, _req: ConfigRequest) -> anyhow::Result<ConfigResponse> {
+        Ok(ConfigResponse {
+            name: "js_bundle".to_string(),
+        })
+    }
+
+    fn schema(&self) -> hplugin::driver::DriverSchema {
+        JsBundleSpec::schema()
+    }
+
+    async fn parse(
+        &self,
+        req: ParseRequest,
+        _ctoken: &(dyn Cancellable + Send + Sync),
+    ) -> anyhow::Result<ParseResponse> {
+        let addr = &req.target_spec.addr;
+        let pkg = addr.package.clone();
+        let spec =
+            JsBundleSpec::from(req.target_spec.config.clone()).context("parse js_bundle config")?;
+
+        anyhow::ensure!(
+            spec.format == "esm" || spec.format == "cjs",
+            "js_bundle: unsupported format {:?} for {} — expected \"esm\" or \"cjs\"",
+            spec.format,
+            addr.format()
+        );
+        anyhow::ensure!(
+            spec.target == "node" || spec.target == "browser",
+            "js_bundle: unsupported target {:?} for {} — expected \"node\" or \"browser\"",
+            spec.target,
+            addr.format()
+        );
+
+        // Dep groups arrive from a HashMap — sort by group name so the
+        // resulting `inputs` is deterministic across parses, not HashMap-
+        // iteration order. Same regression class as `js_typecheck`/
+        // `js_test`'s own dep-input ordering.
+        let mut groups: Vec<(&String, &Vec<String>)> = spec.deps.iter().collect();
+        groups.sort_by_key(|(group, _)| *group);
+        let mut inputs: Vec<Input> = Vec::new();
+        for (group, addrs) in groups {
+            for (i, addr_str) in addrs.iter().enumerate() {
+                inputs.push(Input {
+                    r#ref: TargetAddr::parse(addr_str, &pkg)
+                        .with_context(|| format!("parse dep addr {addr_str}"))?,
+                    mode: InputMode::Standard,
+                    origin_id: format!("dep|{group}|{i}"),
+                    annotations: Default::default(),
+                    hashed: true,
+                    runtime: true,
+                });
+            }
+        }
+
+        let mut external = spec.external.clone();
+        external.sort();
+
+        let def = JsBundleDef {
+            bundler: spec.bundler,
+            bundler_version: spec.bundler_version,
+            entry_file: spec.entry_file,
+            format: spec.format,
+            target: spec.target,
+            outdir: spec.outdir,
+            bundler_config_path: spec.bundler_config_path,
+            bundler_config_content: spec.bundler_config_content,
+            external,
+            tsconfig_path: spec.tsconfig_path,
+            tsconfig_content: spec.tsconfig_content,
+            bundler_bin: spec.bundler_bin,
+        };
+
+        let hash = {
+            let mut h = DebugHasher::new(Xxh3Default::new(), || {
+                format!("js_bundle_{}", addr.format())
+            });
+            def.hash(&mut h);
+            format!("{:x}", h.finish()).into_bytes()
+        };
+
+        let outdir = def.outdir.clone();
+
+        Ok(ParseResponse {
+            target_def: TargetDef {
+                addr: addr.clone(),
+                labels: req.target_spec.labels.clone(),
+                raw_def: Arc::new(def),
+                inputs,
+                outputs: vec![Output {
+                    group: String::new(),
+                    paths: vec![Path {
+                        content: Content::DirPath(outdir),
+                        codegen_tree: CodegenMode::None,
+                        collect: true,
+                    }],
+                }],
+                support_files: vec![],
+                cache: CacheConfig::on(true),
+                pty: false,
+                hash,
+                transparent: false,
+            },
+        })
+    }
+
+    async fn apply_transitive(
+        &self,
+        req: ApplyTransitiveRequest,
+        _ctoken: &(dyn Cancellable + Send + Sync),
+    ) -> anyhow::Result<ApplyTransitiveResponse> {
+        Ok(ApplyTransitiveResponse {
+            target_def: req.target_def,
+        })
+    }
+
+    async fn run<'a, 'io>(
+        &self,
+        req: ManagedRunRequest<'a, 'io>,
+        ctoken: &(dyn Cancellable + Send + Sync),
+    ) -> anyhow::Result<ManagedRunResponse> {
+        let def = req.request.target.def_de::<JsBundleDef>();
+        // Defense in depth: `Provider::get` already rejects an absolute or
+        // `..`-escaping `entry`/config-referenced path before ever building
+        // this `TargetDef` (see `provider::reject_path_escape`'s doc — a
+        // code-quality review BLOCKER), but a cached `JsBundleDef` read back
+        // from disk is untrusted input to this driver too, so the same check
+        // runs again here, before either ever reaches `sandbox_ws_dir.join`.
+        crate::pluginjs::provider::reject_path_escape("entry_file", &def.entry_file)
+            .context("validating cached js_bundle def before running")?;
+        crate::pluginjs::provider::reject_path_escape("outdir", &def.outdir)
+            .context("validating cached js_bundle def before running")?;
+        if !def.tsconfig_path.is_empty() {
+            crate::pluginjs::provider::reject_path_escape("tsconfig_path", &def.tsconfig_path)
+                .context("validating cached js_bundle def before running")?;
+        }
+
+        let bundler_bin = std::path::PathBuf::from(&def.bundler_bin);
+        let entry_abs = req.sandbox_ws_dir.join(&def.entry_file);
+        let outdir_abs = req.sandbox_ws_dir.join(&def.outdir);
+
+        // `bundler = "esbuild"` is explicitly non-hermetic (see module
+        // docs): the resolved binary's own `node_modules/.bin/esbuild` shim
+        // is very likely a `#!/usr/bin/env node` script, so executing it
+        // needs `node` reachable via PATH — mirrors `js_typecheck::run`'s
+        // identical PATH-only passthrough and its own doc comment for why
+        // only `PATH` (not `HOME`/`TMPDIR`/etc.) is forwarded.
+        let mut env: HashMap<String, String> = HashMap::new();
+        if let Ok(v) = std::env::var("PATH") {
+            env.insert("PATH".to_string(), v);
+        }
+
+        let mut outdir_arg = OsString::from("--outdir=");
+        outdir_arg.push(outdir_abs.as_os_str());
+
+        let mut args: Vec<OsString> = vec![
+            entry_abs.into_os_string(),
+            OsString::from("--bundle"),
+            OsString::from(format!("--format={}", def.format)),
+            OsString::from(format!("--platform={}", def.target)),
+            outdir_arg,
+        ];
+        // Explicit `--tsconfig=<path>` rather than relying on esbuild's own
+        // ancestor-directory auto-discovery — the same reasoning
+        // `driver_typecheck.rs::run()` passes `tsc` an explicit `--project`
+        // instead of letting it walk up on its own: the resolved tsconfig
+        // (code-quality M6 review BLOCKER) is staged at exactly this path,
+        // and an explicit flag can never disagree with what `Provider::get`
+        // actually declared/hashed as an Input.
+        if !def.tsconfig_path.is_empty() {
+            let tsconfig_abs = req.sandbox_ws_dir.join(&def.tsconfig_path);
+            let mut tsconfig_arg = OsString::from("--tsconfig=");
+            tsconfig_arg.push(tsconfig_abs.as_os_str());
+            args.push(tsconfig_arg);
+        }
+        for name in &def.external {
+            args.push(OsString::from(format!("--external:{name}")));
+        }
+
+        self.exec_bundler(&bundler_bin, args, &env, &req.sandbox_ws_dir, ctoken)
+            .await?;
+
+        Ok(ManagedRunResponse { artifacts: vec![] })
+    }
+}
+
+impl JsBundleDriver {
+    async fn exec_bundler(
+        &self,
+        bundler_bin: &std::path::Path,
+        args: Vec<OsString>,
+        env: &HashMap<String, String>,
+        cwd: &std::path::Path,
+        ctoken: &(dyn Cancellable + Send + Sync),
+    ) -> anyhow::Result<()> {
+        let env_pairs: Vec<(OsString, OsString)> = env
+            .iter()
+            .map(|(k, v)| (OsString::from(k), OsString::from(v)))
+            .collect();
+        let spec = proc_exec::Spec {
+            program: bundler_bin.to_path_buf(),
+            args,
+            env: env_pairs,
+            cwd: cwd.to_path_buf(),
+            stdin: proc_exec::StdioSpec::Null,
+            stdout: proc_exec::StdioSpec::Piped,
+            stderr: proc_exec::StdioSpec::Piped,
+            setsid: false,
+            ctty: false,
+        };
+        let output = proc_exec::output(spec, ctoken)
+            .await
+            .with_context(|| format!("wait for bundler ({bundler_bin:?})"))?;
+        if !output.status.success() {
+            let stdout = String::from_utf8_lossy(&output.stdout);
+            let stderr = String::from_utf8_lossy(&output.stderr);
+            anyhow::bail!(
+                "js_bundle failed ({}):\n{}",
+                output.status,
+                bundle_failure_detail(&stdout, &stderr)
+            );
+        }
+        Ok(())
+    }
+}
+
+/// Build the human-readable detail for a failed bundler invocation — both
+/// stdout and stderr tails included, mirroring `driver_typecheck.rs`'s
+/// `tsc_failure_detail` / `driver_test.rs`'s `test_failure_detail` for the
+/// identical reason: a failing bundle's actual output (a syntax error, an
+/// unresolvable import) must reach the user, never come back silently blank.
+fn bundle_failure_detail(stdout: &str, stderr: &str) -> String {
+    let stdout_tail = hplugin::error::last_n_lines(stdout.trim(), 60);
+    let stderr_tail = hplugin::error::last_n_lines(stderr.trim(), 60);
+    let mut detail = String::new();
+    if !stdout_tail.is_empty() {
+        detail.push_str("stdout:\n");
+        detail.push_str(&stdout_tail);
+    }
+    if !stderr_tail.is_empty() {
+        if !detail.is_empty() {
+            detail.push('\n');
+        }
+        detail.push_str("stderr:\n");
+        detail.push_str(&stderr_tail);
+    }
+    if detail.is_empty() {
+        "<no output on stdout or stderr>".to_string()
+    } else {
+        detail
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use hcore::hasync::StdCancellationToken;
+    use hcore::htvalue::Value;
+    use hmodel::htaddr::Addr;
+    use hmodel::htpkg::PkgBuf;
+    use hplugin::provider::TargetSpec;
+    use std::collections::HashMap;
+
+    fn driver() -> JsBundleDriver {
+        JsBundleDriver::new()
+    }
+
+    fn ctoken() -> StdCancellationToken {
+        StdCancellationToken::new()
+    }
+
+    fn config(extra: &[(&str, Value)]) -> HashMap<String, Value> {
+        let mut c: HashMap<String, Value> = HashMap::from([
+            ("bundler".to_string(), Value::String("esbuild".to_string())),
+            (
+                "bundler_bin".to_string(),
+                Value::String("/usr/bin/esbuild".to_string()),
+            ),
+            (
+                "bundler_version".to_string(),
+                Value::String("0.19.2".to_string()),
+            ),
+            (
+                "entry_file".to_string(),
+                Value::String("packages/a/src/index.ts".to_string()),
+            ),
+            ("format".to_string(), Value::String("esm".to_string())),
+            ("target".to_string(), Value::String("node".to_string())),
+            (
+                "outdir".to_string(),
+                Value::String("packages/a/dist".to_string()),
+            ),
+            (
+                "bundler_config_path".to_string(),
+                Value::String(String::new()),
+            ),
+            (
+                "bundler_config_content".to_string(),
+                Value::String(String::new()),
+            ),
+            ("tsconfig_path".to_string(), Value::String(String::new())),
+            ("tsconfig_content".to_string(), Value::String(String::new())),
+        ]);
+        for (k, v) in extra {
+            c.insert((*k).to_string(), v.clone());
+        }
+        c
+    }
+
+    fn make_parse_request(extra: &[(&str, Value)]) -> ParseRequest {
+        ParseRequest {
+            request_id: "test".to_string(),
+            target_spec: Arc::new(TargetSpec {
+                addr: Addr::new(
+                    PkgBuf::from("packages/a"),
+                    "js_bundle".to_string(),
+                    Default::default(),
+                ),
+                driver: "js_bundle".to_string(),
+                config: config(extra),
+                ..Default::default()
+            }),
+        }
+    }
+
+    #[tokio::test]
+    async fn driver_name_is_js_bundle() {
+        let resp = driver().config(ConfigRequest {}).unwrap();
+        assert_eq!(resp.name, "js_bundle");
+    }
+
+    #[tokio::test]
+    async fn parse_missing_required_field_errors() {
+        let ct = ctoken();
+        let req = ParseRequest {
+            request_id: "test".to_string(),
+            target_spec: Arc::new(TargetSpec {
+                addr: Addr::new(
+                    PkgBuf::from("packages/a"),
+                    "js_bundle".to_string(),
+                    Default::default(),
+                ),
+                driver: "js_bundle".to_string(),
+                ..Default::default()
+            }),
+        };
+        assert!(driver().parse(req, &ct).await.is_err());
+    }
+
+    #[tokio::test]
+    async fn parse_rejects_unsupported_format() {
+        let ct = ctoken();
+        let req = make_parse_request(&[("format", Value::String("umd".to_string()))]);
+        let err = driver()
+            .parse(req, &ct)
+            .await
+            .err()
+            .expect("an unsupported format must fail parse");
+        assert!(format!("{err:#}").contains("umd"));
+    }
+
+    #[tokio::test]
+    async fn parse_rejects_unsupported_target() {
+        let ct = ctoken();
+        let req = make_parse_request(&[("target", Value::String("deno".to_string()))]);
+        let err = driver()
+            .parse(req, &ct)
+            .await
+            .err()
+            .expect("an unsupported target must fail parse");
+        assert!(format!("{err:#}").contains("deno"));
+    }
+
+    #[tokio::test]
+    async fn parse_accepts_cjs_and_browser() {
+        let ct = ctoken();
+        let req = make_parse_request(&[
+            ("format", Value::String("cjs".to_string())),
+            ("target", Value::String("browser".to_string())),
+        ]);
+        driver()
+            .parse(req, &ct)
+            .await
+            .expect("cjs/browser must be accepted");
+    }
+
+    #[tokio::test]
+    async fn parse_hash_stable_across_identical_parses() {
+        let ct = ctoken();
+        let a = driver().parse(make_parse_request(&[]), &ct).await.unwrap();
+        let b = driver().parse(make_parse_request(&[]), &ct).await.unwrap();
+        assert_eq!(a.target_def.hash, b.target_def.hash);
+    }
+
+    /// Task requirement: a bundler-*version* change must bust the cache.
+    #[tokio::test]
+    async fn parse_hash_changes_when_bundler_version_changes() {
+        let ct = ctoken();
+        let a = driver().parse(make_parse_request(&[]), &ct).await.unwrap();
+        let b = driver()
+            .parse(
+                make_parse_request(&[("bundler_version", Value::String("0.20.0".to_string()))]),
+                &ct,
+            )
+            .await
+            .unwrap();
+        assert_ne!(a.target_def.hash, b.target_def.hash);
+    }
+
+    /// Task requirement: esm vs cjs must be genuinely different cache
+    /// entries for the same source.
+    #[tokio::test]
+    async fn parse_hash_changes_between_esm_and_cjs() {
+        let ct = ctoken();
+        let a = driver()
+            .parse(
+                make_parse_request(&[("format", Value::String("esm".to_string()))]),
+                &ct,
+            )
+            .await
+            .unwrap();
+        let b = driver()
+            .parse(
+                make_parse_request(&[("format", Value::String("cjs".to_string()))]),
+                &ct,
+            )
+            .await
+            .unwrap();
+        assert_ne!(
+            a.target_def.hash, b.target_def.hash,
+            "esm and cjs must produce different cache entries"
+        );
+    }
+
+    /// Same requirement, the node/browser axis.
+    #[tokio::test]
+    async fn parse_hash_changes_between_node_and_browser() {
+        let ct = ctoken();
+        let a = driver()
+            .parse(
+                make_parse_request(&[("target", Value::String("node".to_string()))]),
+                &ct,
+            )
+            .await
+            .unwrap();
+        let b = driver()
+            .parse(
+                make_parse_request(&[("target", Value::String("browser".to_string()))]),
+                &ct,
+            )
+            .await
+            .unwrap();
+        assert_ne!(
+            a.target_def.hash, b.target_def.hash,
+            "node and browser must produce different cache entries"
+        );
+    }
+
+    /// Task requirement: a bundler-config content change must bust the
+    /// cache.
+    #[tokio::test]
+    async fn parse_hash_changes_when_bundler_config_content_changes() {
+        let ct = ctoken();
+        let a = driver().parse(make_parse_request(&[]), &ct).await.unwrap();
+        let b = driver()
+            .parse(
+                make_parse_request(&[(
+                    "bundler_config_content",
+                    Value::String(r#"{"external":["react"]}"#.to_string()),
+                )]),
+                &ct,
+            )
+            .await
+            .unwrap();
+        assert_ne!(a.target_def.hash, b.target_def.hash);
+    }
+
+    /// Code-quality M6 review BLOCKER: a tsconfig content change (a `paths`
+    /// alias edit, a `jsx`/`target`/decorators option flip) must bust the
+    /// cache the same way `js_typecheck`'s identical `tsconfig_content`
+    /// field already does — esbuild reads `compilerOptions` from it too.
+    #[tokio::test]
+    async fn parse_hash_changes_when_tsconfig_content_changes() {
+        let ct = ctoken();
+        let a = driver().parse(make_parse_request(&[]), &ct).await.unwrap();
+        let b = driver()
+            .parse(
+                make_parse_request(&[(
+                    "tsconfig_content",
+                    Value::String(
+                        r#"{"compilerOptions":{"paths":{"@app/*":["src/*"]}}}"#.to_string(),
+                    ),
+                )]),
+                &ct,
+            )
+            .await
+            .unwrap();
+        assert_ne!(a.target_def.hash, b.target_def.hash);
+    }
+
+    /// `bundler_bin` is an absolute host path — must NOT affect the cache
+    /// key.
+    #[tokio::test]
+    async fn parse_hash_unaffected_by_bundler_bin_path_difference() {
+        let ct = ctoken();
+        let a = driver().parse(make_parse_request(&[]), &ct).await.unwrap();
+        let b = driver()
+            .parse(
+                make_parse_request(&[(
+                    "bundler_bin",
+                    Value::String("/home/someone/project/node_modules/.bin/esbuild".to_string()),
+                )]),
+                &ct,
+            )
+            .await
+            .unwrap();
+        assert_eq!(
+            a.target_def.hash, b.target_def.hash,
+            "a different host bundler path for the same effective toolchain must not bust the cache"
+        );
+    }
+
+    #[tokio::test]
+    async fn parse_declares_one_dir_output_and_caches_locally_and_remotely() {
+        let ct = ctoken();
+        let resp = driver().parse(make_parse_request(&[]), &ct).await.unwrap();
+        assert_eq!(resp.target_def.outputs.len(), 1);
+        assert!(matches!(
+            &resp.target_def.outputs[0].paths[0].content,
+            Content::DirPath(p) if p == "packages/a/dist"
+        ));
+        assert!(resp.target_def.cache.enabled);
+        assert!(resp.target_def.cache.remote_enabled);
+    }
+
+    fn make_parse_request_with_deps(deps: Vec<(&str, Vec<&str>)>) -> ParseRequest {
+        let mut c = config(&[]);
+        let deps_map: HashMap<String, Value> = deps
+            .into_iter()
+            .map(|(k, vs)| {
+                (
+                    k.to_string(),
+                    Value::List(
+                        vs.into_iter()
+                            .map(|v| Value::String(v.to_string()))
+                            .collect(),
+                    ),
+                )
+            })
+            .collect();
+        c.insert("deps".to_string(), Value::Map(deps_map));
+        ParseRequest {
+            request_id: "test".to_string(),
+            target_spec: Arc::new(TargetSpec {
+                addr: Addr::new(
+                    PkgBuf::from("packages/a"),
+                    "js_bundle".to_string(),
+                    Default::default(),
+                ),
+                driver: "js_bundle".to_string(),
+                config: c,
+                ..Default::default()
+            }),
+        }
+    }
+
+    #[tokio::test]
+    async fn parse_deps_become_target_dep_inputs_ordered_by_group() {
+        let ct = ctoken();
+        let req = make_parse_request_with_deps(vec![
+            (
+                "external",
+                vec!["//@heph/js/thirdparty/lodash@4.17.21:js_install@goos=linux,goarch=amd64"],
+            ),
+            ("", vec!["//@heph/fs:file@f=packages/a/src/index.ts"]),
+            (
+                "bundler_config",
+                vec!["//@heph/fs:file@f=esbuild.config.json"],
+            ),
+        ]);
+        let resp = driver().parse(req, &ct).await.unwrap();
+        let origin_ids: Vec<&str> = resp
+            .target_def
+            .inputs
+            .iter()
+            .map(|i| i.origin_id.as_str())
+            .collect();
+        // Sorted group order: "" < "bundler_config" < "external".
+        assert_eq!(
+            origin_ids,
+            vec!["dep||0", "dep|bundler_config|0", "dep|external|0"]
+        );
+    }
+
+    // ---- run(): gated on a real esbuild binary being available in this devenv ----
+    //
+    // Everything above tests cache-key/Input-declaration behavior and needs no
+    // real bundler. These exercise the actual subprocess invocation and its
+    // success/failure surfacing (task requirement 7) — they require a real
+    // `esbuild` (checked via PATH / `node_modules/.bin` convention) and are
+    // #[ignore]d, with an honest message, when it isn't present, rather than
+    // silently skipping.
+
+    fn find_real_bin(name: &str) -> Option<std::path::PathBuf> {
+        let path = std::env::var_os("PATH")?;
+        for dir in std::env::split_paths(&path) {
+            let cand = dir.join(name);
+            if std::fs::metadata(&cand)
+                .map(|m| m.is_file())
+                .unwrap_or(false)
+            {
+                return Some(cand);
+            }
+        }
+        None
+    }
+
+    fn write(dir: &std::path::Path, rel: &str, contents: &str) {
+        let path = dir.join(rel);
+        if let Some(parent) = path.parent() {
+            std::fs::create_dir_all(parent).expect("create parent dir");
+        }
+        std::fs::write(path, contents).expect("write fixture file");
+    }
+
+    fn make_run_request<'a>(
+        target: &'a TargetDef,
+        request_id: &'a String,
+        ws_dir: std::path::PathBuf,
+        pkg_dir: std::path::PathBuf,
+        hashin: &'a str,
+    ) -> ManagedRunRequest<'a, 'a> {
+        use hplugin::driver::{RunInput, RunRequest};
+        ManagedRunRequest {
+            request: RunRequest {
+                request_id,
+                target,
+                tree_root_path: ws_dir.clone(),
+                inputs: Vec::<RunInput>::new(),
+                hashin,
+                stdin: None,
+                stdout: None,
+                stderr: None,
+                sandbox_dir: ws_dir.clone(),
+            },
+            sandbox_dir: ws_dir.clone(),
+            sandbox_ws_dir: ws_dir,
+            sandbox_pkg_dir: pkg_dir,
+            inputs: Vec::new(),
+        }
+    }
+
+    #[tokio::test]
+    #[ignore = "requires a real `esbuild` on PATH — devenv.nix provisions no Node/esbuild \
+                toolchain (see toolchain.rs module docs); run explicitly with \
+                `cargo test -- --ignored` on a host with esbuild installed"]
+    async fn run_succeeds_and_produces_expected_output() {
+        let esbuild = find_real_bin("esbuild").expect(
+            "this test is #[ignore]d precisely because esbuild isn't guaranteed on PATH — it \
+             was run explicitly, so a missing esbuild here is a real failure, not a skip",
+        );
+
+        let dir = tempfile::tempdir().expect("tempdir");
+        write(
+            dir.path(),
+            "packages/a/src/index.ts",
+            "export const greeting: string = 'hello';\nconsole.log(greeting);\n",
+        );
+
+        let ct = ctoken();
+        let req = make_parse_request(&[(
+            "bundler_bin",
+            Value::String(esbuild.to_string_lossy().into_owned()),
+        )]);
+        let parsed = driver().parse(req, &ct).await.unwrap();
+
+        let request_id = "test".to_string();
+        let run_req = make_run_request(
+            &parsed.target_def,
+            &request_id,
+            dir.path().to_path_buf(),
+            dir.path().join("packages/a"),
+            "deadbeef",
+        );
+        driver()
+            .run(run_req, &ct)
+            .await
+            .expect("a well-formed entry point must bundle successfully");
+
+        let output = std::fs::read_to_string(dir.path().join("packages/a/dist/index.js"))
+            .expect("bundled output file must exist");
+        assert!(
+            output.contains("hello"),
+            "bundled output must contain the entry point's own content: {output}"
+        );
+    }
+
+    #[tokio::test]
+    #[ignore = "requires a real `esbuild` on PATH — devenv.nix provisions no Node/esbuild \
+                toolchain (see toolchain.rs module docs); run explicitly with \
+                `cargo test -- --ignored` on a host with esbuild installed"]
+    async fn run_fails_and_surfaces_bundler_output_on_an_unresolvable_import() {
+        let esbuild = find_real_bin("esbuild").expect(
+            "this test is #[ignore]d precisely because esbuild isn't guaranteed on PATH — it \
+             was run explicitly, so a missing esbuild here is a real failure, not a skip",
+        );
+
+        let dir = tempfile::tempdir().expect("tempdir");
+        write(
+            dir.path(),
+            "packages/a/src/index.ts",
+            "import { missing } from './does-not-exist';\nconsole.log(missing);\n",
+        );
+
+        let ct = ctoken();
+        let req = make_parse_request(&[(
+            "bundler_bin",
+            Value::String(esbuild.to_string_lossy().into_owned()),
+        )]);
+        let parsed = driver().parse(req, &ct).await.unwrap();
+
+        let request_id = "test".to_string();
+        let run_req = make_run_request(
+            &parsed.target_def,
+            &request_id,
+            dir.path().to_path_buf(),
+            dir.path().join("packages/a"),
+            "deadbeef",
+        );
+        let err = driver()
+            .run(run_req, &ct)
+            .await
+            .err()
+            .expect("an unresolvable import must fail the driver, not succeed silently");
+        let msg = format!("{err:#}");
+        assert!(msg.contains("js_bundle failed"), "{msg}");
+        assert!(
+            msg.contains("does-not-exist") || msg.contains("Could not resolve"),
+            "{msg}"
+        );
+    }
+
+    /// Feature-quality M6 review BLOCKER: `--external:<name>` flags were
+    /// never derived from the discovered third-party closure, so every real
+    /// npm dependency (never on disk on a fresh checkout, and never
+    /// hand-enumerated in an `esbuild.config.json`) made a real `esbuild
+    /// --bundle` hard-fail with "Could not resolve". `lodash` here is
+    /// deliberately never installed on disk — proving the entry bundles
+    /// successfully with no `node_modules/lodash` present at all, and that
+    /// the import survives un-inlined (esbuild never attempts to resolve an
+    /// externalized specifier, so its absence from disk is exactly the
+    /// point).
+    #[tokio::test]
+    #[ignore = "requires a real `esbuild` on PATH — devenv.nix provisions no Node/esbuild \
+                toolchain (see toolchain.rs module docs); run explicitly with \
+                `cargo test -- --ignored` on a host with esbuild installed"]
+    async fn run_succeeds_with_a_real_third_party_import_marked_external() {
+        let esbuild = find_real_bin("esbuild").expect(
+            "this test is #[ignore]d precisely because esbuild isn't guaranteed on PATH — it \
+             was run explicitly, so a missing esbuild here is a real failure, not a skip",
+        );
+
+        let dir = tempfile::tempdir().expect("tempdir");
+        write(
+            dir.path(),
+            "packages/a/src/index.ts",
+            "import _ from 'lodash';\nconsole.log(_);\n",
+        );
+        // Deliberately no `node_modules/lodash` anywhere on disk.
+
+        let ct = ctoken();
+        let req = make_parse_request(&[
+            (
+                "bundler_bin",
+                Value::String(esbuild.to_string_lossy().into_owned()),
+            ),
+            (
+                "external",
+                Value::List(vec![Value::String("lodash".to_string())]),
+            ),
+        ]);
+        let parsed = driver().parse(req, &ct).await.unwrap();
+
+        let request_id = "test".to_string();
+        let run_req = make_run_request(
+            &parsed.target_def,
+            &request_id,
+            dir.path().to_path_buf(),
+            dir.path().join("packages/a"),
+            "deadbeef",
+        );
+        driver().run(run_req, &ct).await.expect(
+            "a third-party import marked external must bundle successfully with no \
+             node_modules present at all",
+        );
+
+        let output = std::fs::read_to_string(dir.path().join("packages/a/dist/index.js"))
+            .expect("bundled output file must exist");
+        assert!(
+            output.contains("lodash"),
+            "the externalized import must survive un-inlined in the output, not be silently \
+             dropped or inlined as if it resolved: {output}"
+        );
+    }
+}

--- a/crates/plugin-js/src/pluginjs/driver_bundle.rs
+++ b/crates/plugin-js/src/pluginjs/driver_bundle.rs
@@ -373,8 +373,7 @@ impl ManagedDriver for JsBundleDriver {
     ) -> anyhow::Result<ParseResponse> {
         let addr = &req.target_spec.addr;
         let pkg = addr.package.clone();
-        let spec =
-            JsBundleSpec::from(req.target_spec.config.clone()).context("parse js_bundle config")?;
+        let spec = JsBundleSpec::from(&req.target_spec.config).context("parse js_bundle config")?;
 
         anyhow::ensure!(
             spec.format == "esm" || spec.format == "cjs",

--- a/crates/plugin-js/src/pluginjs/importgraph.rs
+++ b/crates/plugin-js/src/pluginjs/importgraph.rs
@@ -3414,4 +3414,213 @@ mod tests {
             extract_eslint_module_refs(Path::new(".eslintrc.json"), content).expect("scan config");
         assert!(refs.is_empty(), "{refs:?}");
     }
+
+    // ---- Ad hoc perf measurement (not a regression test; see task) ----
+    //
+    // Standalone, self-contained timing of `build_package_import_graph`
+    // across a synthetic multi-package workspace. NOT wired into
+    // `crates/bench`'s Tier A/B baseline-vs-candidate harness (that's a
+    // separate, bigger project) — this is a one-off measurement to answer
+    // "is the import-graph build actually fast" for the perf-measurement
+    // task. `#[ignore]`d so `tst` never runs it; run explicitly:
+    //
+    //   cargo test -p plugin-js --lib pluginjs::importgraph::tests::adhoc_bench \
+    //     -- --ignored --nocapture --test-threads=1
+    mod adhoc_bench {
+        use super::*;
+        use std::sync::Arc;
+        use std::time::Instant;
+
+        /// Build a synthetic workspace of `n_pkgs` packages, `files_per_pkg`
+        /// source files each. Each file has: 2 relative same-package imports
+        /// (to other files in the same package, wrapping), 1 relative
+        /// cross-package import (first-party edge into a sibling package —
+        /// pnpm/npm workspaces resolve these via `node_modules` symlinks in
+        /// reality, but the resolver doesn't care how it got there, only that
+        /// the specifier resolves to a real path, so a direct relative path
+        /// exercises the same resolution cost), and 1 bare specifier
+        /// (`lodash`, third-party, deliberately left unresolvable since no
+        /// real `node_modules` is staged — this is the worst case for
+        /// resolution cost: `oxc_resolver` must walk every ancestor
+        /// `node_modules` directory before giving up).
+        fn build_corpus(dir: &Path, n_pkgs: usize, files_per_pkg: usize) {
+            for i in 0..n_pkgs {
+                write(
+                    dir,
+                    &format!("packages/pkg{i}/package.json"),
+                    &format!(r#"{{"name":"pkg{i}","dependencies":{{"lodash":"^4.0.0"}}}}"#),
+                );
+                for j in 0..files_per_pkg {
+                    let next_local = (j + 1) % files_per_pkg;
+                    let next_pkg = (i + 1) % n_pkgs;
+                    let content = format!(
+                        "import {{ v{next_local} }} from \"./file{next_local}\";\n\
+                         import {{ x0 }} from \"../pkg{next_pkg}/src/file0\";\n\
+                         import lodash from \"lodash\";\n\
+                         export const v{j} = 1;\n"
+                    );
+                    write(dir, &format!("packages/pkg{i}/src/file{j}.ts"), &content);
+                }
+            }
+        }
+
+        /// Cold (first build) vs warm (`ResolveCache`/graph reused — this
+        /// mimics `Provider::import_graph`'s per-package `OnceCell`, which on
+        /// a warm hit just returns the cached `Arc` with no re-parse/re-resolve
+        /// at all) timings for one workspace size. Prints absolute numbers;
+        /// asserts nothing about wall-clock (perf numbers vary by machine —
+        /// this is a measurement tool, not a regression gate).
+        fn run_cold_warm(label: &str, n_pkgs: usize, files_per_pkg: usize) {
+            let dir = tempfile::tempdir().expect("tempdir");
+            build_corpus(dir.path(), n_pkgs, files_per_pkg);
+            let w = walker();
+
+            // Cold: one fresh Resolvers + ResolveCache per package, exactly
+            // as `Provider::import_graph` does on a graph_cache miss.
+            let cold_start = Instant::now();
+            let mut total_edges = 0usize;
+            for i in 0..n_pkgs {
+                let pkg = format!("packages/pkg{i}");
+                let resolvers = Resolvers::new(None);
+                let resolve_cache = ResolveCache::new();
+                let graph = build_package_import_graph(
+                    &w,
+                    dir.path(),
+                    &pkg,
+                    &resolvers,
+                    &resolve_cache,
+                    None,
+                )
+                .expect("build import graph");
+                total_edges += graph.runtime_edges.len();
+            }
+            let cold = cold_start.elapsed();
+
+            // Warm: what `Provider::import_graph`'s `OnceCell` actually saves
+            // on a second request for the same package is the ENTIRE
+            // parse+resolve pass (it never re-enters `build_package_import_graph`
+            // at all) — so the honest "warm" number here is a second
+            // Arc-cached lookup, which is why we don't even call
+            // `build_package_import_graph` again: that would measure a
+            // *different, uncached* pipeline (fresh `ResolveCache`), not what
+            // M5's cache actually delivers. Instead we time the trivial
+            // `OnceCell::get` re-fetch cost directly against the same graphs
+            // built above, to make the "what does the cache save" comparison
+            // honest rather than re-running the expensive path a second time.
+            let cached: Vec<Arc<ImportGraph>> = (0..n_pkgs)
+                .map(|i| {
+                    let pkg = format!("packages/pkg{i}");
+                    let resolvers = Resolvers::new(None);
+                    let resolve_cache = ResolveCache::new();
+                    Arc::new(
+                        build_package_import_graph(
+                            &w,
+                            dir.path(),
+                            &pkg,
+                            &resolvers,
+                            &resolve_cache,
+                            None,
+                        )
+                        .expect("build import graph"),
+                    )
+                })
+                .collect();
+            let warm_start = Instant::now();
+            let mut warm_edges = 0usize;
+            for g in &cached {
+                warm_edges += g.runtime_edges.len();
+            }
+            let warm = warm_start.elapsed();
+
+            let total_files = n_pkgs * files_per_pkg;
+            println!(
+                "[adhoc-bench] {label}: {n_pkgs} pkgs x {files_per_pkg} files = {total_files} files\n\
+                 \x20 cold total  = {cold:?}  ({:.3} ms/pkg, {:.4} ms/file)\n\
+                 \x20 warm total  = {warm:?}  (Arc-cache re-fetch; ~0 by construction — the real\n\
+                 \x20              saving IS the {cold:?} avoided, not a re-run)\n\
+                 \x20 edges       = {total_edges} cold, {warm_edges} warm (sanity: equal)",
+                cold.as_secs_f64() * 1000.0 / n_pkgs as f64,
+                cold.as_secs_f64() * 1000.0 / total_files as f64,
+            );
+            assert_eq!(total_edges, warm_edges, "sanity: same graphs");
+        }
+
+        #[test]
+        #[ignore]
+        fn adhoc_bench_cold_warm_small() {
+            run_cold_warm("small", 20, 15);
+        }
+
+        #[test]
+        #[ignore]
+        fn adhoc_bench_cold_warm_large() {
+            run_cold_warm("large", 150, 15);
+        }
+
+        /// Splits the cold-build cost into parse time (`importparse::parse_file_imports`,
+        /// pure `oxc_parser`) vs resolve time (`ResolveCache::get_or_resolve`,
+        /// `oxc_resolver`) by manually replicating `build_package_import_graph`'s
+        /// loop with two separate `Instant` accumulators — the production
+        /// function doesn't expose this split itself, so this is a deliberate
+        /// duplicate of its loop body for measurement purposes only.
+        #[test]
+        #[ignore]
+        fn adhoc_bench_parse_vs_resolve_phase() {
+            let n_pkgs = 150;
+            let files_per_pkg = 15;
+            let dir = tempfile::tempdir().expect("tempdir");
+            build_corpus(dir.path(), n_pkgs, files_per_pkg);
+            let w = walker();
+
+            let mut parse_total = std::time::Duration::ZERO;
+            let mut resolve_total = std::time::Duration::ZERO;
+            let mut file_count = 0usize;
+            let mut site_count = 0usize;
+
+            for i in 0..n_pkgs {
+                let pkg = format!("packages/pkg{i}");
+                let resolvers = Resolvers::new(None);
+                let resolve_cache = ResolveCache::new();
+                let files = package_source_files(&w, dir.path(), &pkg).expect("list files");
+                for file in files {
+                    file_count += 1;
+                    let text = std::fs::read_to_string(&file).expect("read file");
+
+                    let t0 = Instant::now();
+                    let parsed =
+                        importparse::parse_file_imports(&file, &text).expect("parse imports");
+                    parse_total += t0.elapsed();
+
+                    let dir_of_file = file.parent().unwrap_or(&file);
+                    let t1 = Instant::now();
+                    for site in &parsed.sites {
+                        site_count += 1;
+                        let flavor = if site.type_only {
+                            CacheFlavor::Types
+                        } else {
+                            match site.context {
+                                ModuleContext::Esm => CacheFlavor::RuntimeEsm,
+                                ModuleContext::Cjs => CacheFlavor::RuntimeCjs,
+                            }
+                        };
+                        let base = if site.type_only { &file } else { dir_of_file };
+                        let _ =
+                            resolve_cache.get_or_resolve(&resolvers, flavor, base, &site.specifier);
+                    }
+                    resolve_total += t1.elapsed();
+                }
+            }
+
+            let total = parse_total + resolve_total;
+            println!(
+                "[adhoc-bench] phase split: {n_pkgs} pkgs x {files_per_pkg} files = {file_count} files, {site_count} import sites\n\
+                 \x20 parse   = {parse_total:?}  ({:.1}% of parse+resolve, {:.4} ms/file)\n\
+                 \x20 resolve = {resolve_total:?}  ({:.1}% of parse+resolve, {:.4} ms/site)",
+                parse_total.as_secs_f64() / total.as_secs_f64() * 100.0,
+                parse_total.as_secs_f64() * 1000.0 / file_count as f64,
+                resolve_total.as_secs_f64() / total.as_secs_f64() * 100.0,
+                resolve_total.as_secs_f64() * 1000.0 / site_count as f64,
+            );
+        }
+    }
 }

--- a/crates/plugin-js/src/pluginjs/importgraph.rs
+++ b/crates/plugin-js/src/pluginjs/importgraph.rs
@@ -461,6 +461,20 @@ pub fn find_nearest_lint_config(
     find_nearest_file(workspace_root, pkg_dir, candidates)
 }
 
+/// Same ancestor walk, generalized once more to `js_bundle`'s bundler config
+/// file — see `driver_bundle.rs` module docs. Only `esbuild.config.json` is
+/// recognized in this milestone (the esbuild CLI has no auto-discovered
+/// config file convention of its own; a JS/TS esbuild config driven through
+/// its Node API is out of scope for this CLI-based driver — a disclosed gap,
+/// not a silently missing feature).
+pub fn find_nearest_bundler_config(
+    workspace_root: &Path,
+    pkg_dir: &Path,
+    candidates: &[&str],
+) -> Option<PathBuf> {
+    find_nearest_file(workspace_root, pkg_dir, candidates)
+}
+
 /// Walk up from `pkg_dir` (inclusive) to `workspace_root` looking for the
 /// nearest `package.json` whose own `"jest"` field is present — jest's other
 /// documented config location, alongside the dedicated `jest.config.*`
@@ -2017,7 +2031,14 @@ pub(crate) fn thirdparty_pkg_name_from_path(resolved: &Path) -> Option<String> {
 /// owns it — `None` if it escaped `workspace_root` entirely (shouldn't
 /// happen for a first-party resolution, but resolution is not proof of
 /// that).
-fn firstparty_owning_pkg_dir(resolved: &Path, workspace_root: &Path) -> Option<PathBuf> {
+///
+/// `pub(crate)`, not private: `provider.rs`'s `js_bundle` cross-package
+/// closure walk (`Provider::bundle_closure`) reuses this to find which
+/// sibling package a first-party edge crossed into, so it knows which
+/// package's own `ImportGraph` to fetch next — the exact "which package owns
+/// this resolved path" question [`check_phantom_dependencies`] already
+/// answers for a one-hop edge.
+pub(crate) fn firstparty_owning_pkg_dir(resolved: &Path, workspace_root: &Path) -> Option<PathBuf> {
     let mut dir = if resolved.is_dir() {
         resolved
     } else {
@@ -2175,6 +2196,7 @@ mod tests {
     ) -> PackageManifest {
         PackageManifest {
             name: name.to_string(),
+            main: None,
             dependencies: deps
                 .iter()
                 .map(|d| (d.to_string(), "*".to_string()))

--- a/crates/plugin-js/src/pluginjs/mod.rs
+++ b/crates/plugin-js/src/pluginjs/mod.rs
@@ -1,6 +1,7 @@
 #[cfg(test)]
 mod conformance;
 mod deps;
+mod driver_bundle;
 mod driver_install;
 mod driver_lint;
 mod driver_package_info;
@@ -17,6 +18,7 @@ mod thirdparty;
 mod toolchain;
 mod workspace;
 
+pub use driver_bundle::JsBundleDriver;
 pub use driver_install::JsInstallDriver;
 pub use driver_lint::JsLintDriver;
 pub use driver_package_info::JsPackageInfoDriver;
@@ -55,6 +57,13 @@ pub const TEST_TARGET: &str = "js_test";
 /// granularity, the same as `js_typecheck` (see `driver_lint.rs` module docs
 /// for why per-file caching isn't worth the bookkeeping here either).
 pub const LINT_TARGET: &str = "js_lint";
+
+/// Target name of the M6 `js_bundle` target: runs the configured bundler
+/// (`esbuild` default) over one package's entry point at a time — whole
+/// first-party-transitive-closure granularity, deliberately not per-file or
+/// per-package (see `driver_bundle.rs` module docs' "Inputs / cache key"
+/// section for why per-file incrementality is explicitly not the goal here).
+pub const BUNDLE_TARGET: &str = "js_bundle";
 
 /// Directory names that are never a package boundary or workspace member,
 /// however deep they appear: `node_modules` is third-party/manager-owned

--- a/crates/plugin-js/src/pluginjs/package_json.rs
+++ b/crates/plugin-js/src/pluginjs/package_json.rs
@@ -15,6 +15,13 @@ use std::path::Path;
 #[derive(Debug, Clone, Default, PartialEq, Eq)]
 pub struct PackageManifest {
     pub name: String,
+    /// The package's own `"main"` field — `js_bundle`'s default entry point
+    /// when no `entry=` addr arg overrides it (see
+    /// `pluginjs::provider::Provider::default_entry_for_package`). `None`
+    /// when the field is absent; a package with no `"main"` and no `entry=`
+    /// override simply has no default `js_bundle` target listed (mirrors
+    /// `js_test`'s "no matched files, no listed target" shape).
+    pub main: Option<String>,
     pub dependencies: BTreeMap<String, String>,
     pub dev_dependencies: BTreeMap<String, String>,
     pub optional_dependencies: BTreeMap<String, String>,
@@ -53,6 +60,8 @@ struct RawManifest {
     #[serde(default)]
     name: Option<String>,
     #[serde(default)]
+    main: Option<String>,
+    #[serde(default)]
     dependencies: BTreeMap<String, String>,
     #[serde(default)]
     dev_dependencies: BTreeMap<String, String>,
@@ -82,6 +91,7 @@ pub fn read_package_manifest(package_json: &Path) -> anyhow::Result<PackageManif
     }
     Ok(PackageManifest {
         name,
+        main: parsed.main,
         dependencies,
         dev_dependencies: parsed.dev_dependencies,
         optional_dependencies: parsed.optional_dependencies,
@@ -158,6 +168,22 @@ mod tests {
             Some("^18.0.0")
         );
         assert!(!manifest.dependencies.contains_key("react"));
+    }
+
+    #[test]
+    fn reads_main_field() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let path = write(dir.path(), r#"{"name": "a", "main": "src/index.ts"}"#);
+        let manifest = read_package_manifest(&path).expect("parse manifest");
+        assert_eq!(manifest.main.as_deref(), Some("src/index.ts"));
+    }
+
+    #[test]
+    fn missing_main_field_is_none() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let path = write(dir.path(), r#"{"name": "a"}"#);
+        let manifest = read_package_manifest(&path).expect("parse manifest");
+        assert_eq!(manifest.main, None);
     }
 
     #[test]

--- a/crates/plugin-js/src/pluginjs/provider.rs
+++ b/crates/plugin-js/src/pluginjs/provider.rs
@@ -1,8 +1,9 @@
 use crate::pluginjs::lockfile::{self, Lockfile, ResolvedGraph};
 use crate::pluginjs::workspace::{self, PkgManager, WorkspaceMember};
 use crate::pluginjs::{
-    LINT_TARGET, PACKAGE_INFO_TARGET, PACKAGE_JSON, TEST_TARGET, TYPECHECK_TARGET, deps,
-    importgraph, is_skipped_dir_name, package_json, platform, resolvers, thirdparty, toolchain,
+    BUNDLE_TARGET, LINT_TARGET, PACKAGE_INFO_TARGET, PACKAGE_JSON, TEST_TARGET, TYPECHECK_TARGET,
+    deps, importgraph, is_skipped_dir_name, package_json, platform, resolvers, thirdparty,
+    toolchain,
 };
 use anyhow::Context;
 use enclose::enclose;
@@ -18,7 +19,7 @@ use hplugin::provider::{
 };
 use hwalk::{CachedWalker, EntryKind, Ignore};
 use std::collections::BTreeSet;
-use std::collections::{BTreeMap, HashMap};
+use std::collections::{BTreeMap, HashMap, HashSet, VecDeque};
 use std::path::{Path, PathBuf};
 use std::sync::Arc;
 use tokio::sync::OnceCell;
@@ -72,6 +73,11 @@ pub struct Config {
     /// host-toolchain shape as `tstool`/`testrunner` — see
     /// `toolchain::resolve_host_linter`.
     pub linter: String,
+    /// Which bundler `js_bundle` invokes — `"esbuild"` (default, the only
+    /// value implemented this milestone), per `ai-docs/js-plugin-plan.md`'s
+    /// `js_bundle` row. Same provider-level, host-toolchain shape as
+    /// `tstool`/`testrunner`/`linter` — see `toolchain::resolve_host_bundler`.
+    pub bundler: String,
 }
 
 impl Config {
@@ -88,6 +94,7 @@ impl Config {
                 .map(|s| (*s).to_string())
                 .collect(),
             linter: toolchain::OXLINT.to_string(),
+            bundler: toolchain::ESBUILD.to_string(),
         }
     }
 }
@@ -136,6 +143,17 @@ pub struct Provider {
     /// (the same M3/M4-review-flagged mistake this milestone's task
     /// explicitly calls out not to repeat).
     linter_cache: OnceCell<Arc<(PathBuf, String)>>,
+    /// Which bundler `js_bundle` invokes — see [`Config::bundler`]'s doc.
+    bundler: String,
+    /// Lazily resolved host bundler binary path + queried `--version`,
+    /// cached once for the `Provider`'s lifetime — same rationale as
+    /// `tsc_cache`/`testrunner_cache`/`linter_cache`: `bundle_config` runs
+    /// once per `js_bundle` target per `Provider::get`, so re-resolving and
+    /// re-spawning `<bundler> --version` per target would scale a real
+    /// subprocess cost with target count, including a 100%-cache-hit run
+    /// (the same M3/M4-review-flagged mistake this milestone's task
+    /// explicitly calls out not to repeat).
+    bundler_cache: OnceCell<Arc<(PathBuf, String)>>,
     /// Workspace-member `{name -> addr}` map, resolved once and cached for
     /// the `Provider`'s lifetime — same rationale as `tsc_cache`/
     /// `testrunner_cache`/`linter_cache`: `deps_config`/`typecheck_config`/
@@ -177,7 +195,25 @@ pub struct Provider {
     /// tests.
     #[cfg(test)]
     graph_build_count: Arc<std::sync::atomic::AtomicUsize>,
+    /// Per-`(entry_pkg, entry_file_rel)` [`BundleClosureResult`], built once
+    /// and cached for the `Provider`'s lifetime — same `Arc<OnceCell<_>>`-
+    /// per-key shape as `graph_cache`, applied to `Provider::bundle_closure`'s
+    /// whole-graph BFS (feature-quality/hermeticity M6 review finding): the
+    /// closure is provably invariant across `js_bundle`'s `format`/`target`
+    /// variant axis for the same entry point, but was recomputed from
+    /// scratch — manifest re-reads, phantom-dependency cross-checks, edge
+    /// walk and all — on every single `Provider::get`, unlike every other
+    /// expensive per-target-kind computation in this file. Requesting the
+    /// common esm+cjs (or four-way esm/cjs × node/browser) pair for one
+    /// package now pays the BFS once, not once per variant.
+    bundle_closure_cache: BundleClosureCache,
 }
+
+/// Key: `(entry_pkg, entry_file_rel)`. See [`Provider::bundle_closure_cache`]'s
+/// doc — factored into its own alias since the nested `Arc<OnceCell<_>>>`
+/// shape trips clippy's `type_complexity` inline.
+type BundleClosureCache =
+    tokio::sync::Mutex<HashMap<(String, String), Arc<OnceCell<Arc<BundleClosureResult>>>>>;
 
 impl Provider {
     pub fn new(workspace_root: PathBuf, pkgmanager: PkgManager) -> Self {
@@ -206,6 +242,7 @@ impl Provider {
                 "testrunner",
                 "test_glob",
                 "linter",
+                "bundler",
             ],
         )?;
         let pkgmanager_str: String =
@@ -261,6 +298,17 @@ impl Provider {
             "js provider: unsupported `linter` {linter:?} — expected \"oxlint\" or \"eslint\""
         );
 
+        // See `Config::bundler`'s doc: defaults to the design doc's
+        // recommended default (`esbuild`, the fast oxc-family-adjacent
+        // bundler; `rollup`/`webpack`/`vite` are a stated M6+ follow-up).
+        let bundler: String = hplugin::config::decode_opt(opts, "js provider", "bundler")?
+            .unwrap_or_else(|| toolchain::ESBUILD.to_string());
+        anyhow::ensure!(
+            toolchain::is_supported_bundler(&bundler),
+            "js provider: unsupported `bundler` {bundler:?} — expected \"esbuild\" \
+             (rollup/webpack/vite are a stated M6+ follow-up, not yet supported)"
+        );
+
         Ok(Self::with_config(
             workspace_root,
             Config {
@@ -272,6 +320,7 @@ impl Provider {
                 testrunner,
                 test_glob,
                 linter,
+                bundler,
             },
         ))
     }
@@ -292,10 +341,13 @@ impl Provider {
             testrunner_cache: OnceCell::new(),
             linter: config.linter,
             linter_cache: OnceCell::new(),
+            bundler: config.bundler,
+            bundler_cache: OnceCell::new(),
             member_addrs_cache: OnceCell::new(),
             graph_cache: tokio::sync::Mutex::new(HashMap::new()),
             #[cfg(test)]
             graph_build_count: Arc::new(std::sync::atomic::AtomicUsize::new(0)),
+            bundle_closure_cache: tokio::sync::Mutex::new(HashMap::new()),
         }
     }
 
@@ -461,6 +513,33 @@ impl Provider {
                     let linter_version = toolchain::query_linter_version(&linter_bin)
                         .with_context(|| format!("querying {linter_bin:?} --version"))?;
                     Ok(Arc::new((linter_bin, linter_version)))
+                })
+                .await
+            })
+            .await?;
+        Ok(Arc::clone(result))
+    }
+
+    /// The host bundler binary path and its queried `--version`, resolved
+    /// once and cached for the `Provider`'s lifetime — see
+    /// [`Provider::bundler_cache`]'s doc for why this matters.
+    async fn resolved_host_bundler(&self) -> anyhow::Result<Arc<(PathBuf, String)>> {
+        let workspace_root = self.workspace_root.clone();
+        let bundler = self.bundler.clone();
+        let result = self
+            .bundler_cache
+            .get_or_try_init(|| async move {
+                anyhow::ensure!(
+                    toolchain::is_supported_bundler(&bundler),
+                    "js provider: unsupported bundler {bundler:?} — only \"esbuild\" is \
+                     supported in this milestone; see pluginjs::toolchain module docs"
+                );
+                hcore::blocking::run(move || -> anyhow::Result<Arc<(PathBuf, String)>> {
+                    let bundler_bin = toolchain::resolve_host_bundler(&workspace_root, &bundler)
+                        .context("resolving the js_bundle bundler toolchain")?;
+                    let bundler_version = toolchain::query_bundler_version(&bundler_bin)
+                        .with_context(|| format!("querying {bundler_bin:?} --version"))?;
+                    Ok(Arc::new((bundler_bin, bundler_version)))
                 })
                 .await
             })
@@ -912,6 +991,750 @@ impl Provider {
             approval: Default::default(),
         })
     }
+
+    /// The workspace-relative path to a package's default `js_bundle` entry
+    /// point — its own `package.json` `"main"` field, resolved against the
+    /// package directory and checked to actually exist. `None` when the
+    /// package has no `"main"` field, `"main"` fails the same escape/
+    /// containment checks a user-supplied `entry=` addr arg gets (see module
+    /// docs' bug-class (c) note), or `"main"` names a file that doesn't
+    /// exist — any of these simply means there is no usable default, so
+    /// `Provider::list` lists no `js_bundle` target for this package
+    /// (mirrors `js_test`'s "no matched files, no listed target" shape); an
+    /// explicit `entry=` addr arg still works via `Provider::get` regardless.
+    async fn default_entry_for_package(&self, pkg: &PkgBuf) -> anyhow::Result<Option<String>> {
+        let workspace_root = self.workspace_root.clone();
+        let pkg_str = pkg.as_str().to_string();
+        hcore::blocking::run(move || -> anyhow::Result<Option<String>> {
+            let pkg_dir = if pkg_str.is_empty() {
+                workspace_root.clone()
+            } else {
+                workspace_root.join(&pkg_str)
+            };
+            let manifest = package_json::read_package_manifest(&pkg_dir.join(PACKAGE_JSON))
+                .with_context(|| {
+                    format!("reading {pkg_str:?}'s package.json for its default js_bundle entry")
+                })?;
+            let Some(main) = manifest.main else {
+                return Ok(None);
+            };
+            let main_rel = main.trim_start_matches("./");
+            let entry_rel = if pkg_str.is_empty() {
+                main_rel.to_string()
+            } else {
+                format!("{pkg_str}/{main_rel}")
+            };
+            // `package.json`'s own `"main"` is first-party content this
+            // package fully controls — trusted the same way this crate
+            // already trusts tsconfig/runner-config content elsewhere — but
+            // still run through the same escape/containment checks a
+            // user-supplied `entry=` addr arg gets (bug class (c) in this
+            // milestone's task): a malformed `"main"` (e.g.
+            // `"../../../etc/passwd"`) must not become a default entry.
+            if reject_path_escape("package.json main", &entry_rel).is_err()
+                || !path_under_package(&pkg_str, &entry_rel)
+            {
+                return Ok(None);
+            }
+            let entry_abs = workspace_root.join(&entry_rel);
+            if !entry_abs.is_file() {
+                return Ok(None);
+            }
+            Ok(Some(entry_rel))
+        })
+        .await
+    }
+
+    /// The full transitive first-party closure reachable from
+    /// `entry_pkg`'s `entry_file_rel` via `ImportGraph::runtime_edges`,
+    /// recursing across workspace-package boundaries, plus every
+    /// third-party package the closure's own unresolved bare specifiers (or
+    /// ambiently-resolved `node_modules` edges) name — see
+    /// `driver_bundle.rs` module docs' "Inputs / cache key" section for why
+    /// this cannot reuse `importgraph::build_test_closure`'s one-hop-external
+    /// trim. `entry_file_rel` is workspace-relative and must already be
+    /// validated (`reject_path_escape` + `path_under_package`) by the
+    /// caller.
+    ///
+    /// Memoized per `(entry_pkg, entry_file_rel)` on the `Provider` — see
+    /// [`Provider::bundle_closure_cache`]'s doc — since the BFS below is
+    /// provably invariant across `js_bundle`'s `format`/`target` variant
+    /// axis for the same entry point; callers requesting more than one
+    /// variant of the same package share one BFS.
+    async fn bundle_closure(
+        &self,
+        entry_pkg: &str,
+        entry_file_rel: &str,
+    ) -> anyhow::Result<Arc<BundleClosureResult>> {
+        let key = (entry_pkg.to_string(), entry_file_rel.to_string());
+        let cell = {
+            let mut cache = self.bundle_closure_cache.lock().await;
+            Arc::clone(
+                cache
+                    .entry(key)
+                    .or_insert_with(|| Arc::new(OnceCell::new())),
+            )
+        };
+        let result = cell
+            .get_or_try_init(|| self.bundle_closure_uncached(entry_pkg, entry_file_rel))
+            .await?;
+        Ok(Arc::clone(result))
+    }
+
+    /// The actual BFS behind [`Provider::bundle_closure`] — split out so the
+    /// memoizing wrapper stays a thin, easy-to-audit cache lookup. Returns
+    /// `(first_party_files, third_party_addrs, third_party_names)` bundled
+    /// as a [`BundleClosureResult`]: `third_party_names` (the bare specifier
+    /// each third-party edge was actually imported by, e.g. `"lodash"`) is
+    /// what `Provider::bundle_config` feeds esbuild's own `--external:<name>`
+    /// flag — see that field's doc and the feature-quality M6 review BLOCKER
+    /// it fixes (the discovered closure and the bundler's `--external` flags
+    /// were previously two disconnected sources, so every real third-party
+    /// import made `esbuild --bundle` hard-fail with "Could not resolve").
+    ///
+    /// **Known perf trim, disclosed rather than silent**: each dequeued file
+    /// (and each newly-visited package's manifest read + phantom check)
+    /// gets its own `hcore::blocking::run` round trip rather than batching a
+    /// whole package's worth of files into one blocking call — correct, but
+    /// more blocking-pool hops than necessary for a package with many
+    /// closure-reached files. `Provider::import_graph`'s own per-package
+    /// memoization means no *parse* work is repeated, so this is scheduling
+    /// overhead, not redundant computation — acceptable for this milestone,
+    /// a real target for batching if profiling ever names it a bottleneck.
+    async fn bundle_closure_uncached(
+        &self,
+        entry_pkg: &str,
+        entry_file_rel: &str,
+    ) -> anyhow::Result<Arc<BundleClosureResult>> {
+        let workspace_root = self.workspace_root.clone();
+        let canonical_root = hcore::blocking::run(enclose!((workspace_root) move || {
+            workspace_root
+                .canonicalize()
+                .with_context(|| format!("canonicalize workspace root {workspace_root:?}"))
+        }))
+        .await?;
+
+        let lockfile = self.lockfile().await?;
+        let resolved_graph = self.resolved_graph().await?;
+        let member_addrs_by_name = self.member_addrs_by_name().await?;
+        let goos = platform::current_goos();
+        let goarch = platform::current_goarch();
+
+        let mut files: BTreeSet<String> = BTreeSet::new();
+        let mut external_addrs: BTreeSet<String> = BTreeSet::new();
+        let mut external_names: BTreeSet<String> = BTreeSet::new();
+        let mut visited_pkgs: HashSet<String> = HashSet::new();
+        let mut manifests: HashMap<String, package_json::PackageManifest> = HashMap::new();
+        let mut queue: VecDeque<(String, String)> = VecDeque::new();
+        files.insert(entry_file_rel.to_string());
+        queue.push_back((entry_pkg.to_string(), entry_file_rel.to_string()));
+
+        while let Some((cur_pkg, cur_file)) = queue.pop_front() {
+            let graph = self.import_graph(&PkgBuf::from(cur_pkg.clone())).await?;
+
+            if !manifests.contains_key(&cur_pkg) {
+                let manifest = hcore::blocking::run(enclose!(
+                    (workspace_root, cur_pkg) move || -> anyhow::Result<package_json::PackageManifest> {
+                        let pkg_dir = if cur_pkg.is_empty() {
+                            workspace_root.clone()
+                        } else {
+                            workspace_root.join(&cur_pkg)
+                        };
+                        package_json::read_package_manifest(&pkg_dir.join(PACKAGE_JSON))
+                            .with_context(|| {
+                                format!("reading {cur_pkg:?}'s package.json for js_bundle")
+                            })
+                    }
+                ))
+                .await?;
+                manifests.insert(cur_pkg.clone(), manifest);
+            }
+            let manifest = manifests
+                .get(&cur_pkg)
+                .expect("just inserted above")
+                .clone();
+
+            // Defense in depth, mirroring `deps_config`/`typecheck_deps_config`'s
+            // identical phantom-dependency cross-check — each package this
+            // closure reaches gets checked exactly once, even though its own
+            // `js_package_info`/`js_typecheck` targets (if requested
+            // separately) already check it too; a `js_bundle`-only workflow
+            // that never requests those targets for a *sibling* package must
+            // not silently skip this.
+            if visited_pkgs.insert(cur_pkg.clone()) {
+                hcore::blocking::run(enclose!(
+                    (workspace_root, cur_pkg, graph, manifest) move || -> anyhow::Result<()> {
+                        let declared = importgraph::declared_closure(&manifest);
+                        importgraph::check_phantom_dependencies(
+                            &workspace_root,
+                            &cur_pkg,
+                            &graph,
+                            &declared,
+                        )
+                    }
+                ))
+                .await
+                .with_context(|| {
+                    format!(
+                        "cross-checking {cur_pkg:?}'s import graph against its declared \
+                         dependencies for js_bundle"
+                    )
+                })?;
+            }
+
+            let step = hcore::blocking::run(enclose!(
+                (canonical_root, cur_pkg, cur_file, graph, manifest, lockfile, resolved_graph,
+                 member_addrs_by_name, goos, goarch) move || {
+                    bundle_closure_step(
+                        &canonical_root,
+                        &cur_pkg,
+                        &cur_file,
+                        &graph,
+                        &manifest,
+                        lockfile.as_deref(),
+                        resolved_graph.as_deref(),
+                        &member_addrs_by_name,
+                        &goos,
+                        &goarch,
+                    )
+                }
+            ))
+            .await
+            .with_context(|| {
+                format!("walking js_bundle closure edges for {cur_pkg:?}'s {cur_file:?}")
+            })?;
+
+            for (name, addr) in step.new_external {
+                external_names.insert(name);
+                external_addrs.insert(addr);
+            }
+            for (owning_pkg, rel) in step.new_files {
+                if files.insert(rel.clone()) {
+                    queue.push_back((owning_pkg, rel));
+                }
+            }
+        }
+
+        Ok(Arc::new(BundleClosureResult {
+            files,
+            external_addrs,
+            external_names,
+        }))
+    }
+
+    /// Build everything about a `js_bundle` target's config *except* the
+    /// bundler toolchain resolution/version-query: `bundle_closure`'s full
+    /// transitive first-party/third-party Input scoping, the resolved
+    /// bundler config file (if any) and anything it itself references, and
+    /// the entry package's resolved tsconfig (if any) plus its `extends`
+    /// chain. Deliberately split out from [`Provider::bundle_config`] so it
+    /// never touches the host bundler binary — unit-testable **without** a
+    /// real `esbuild` installed, mirroring `typecheck_deps_config`/
+    /// `test_deps_config`/`lint_deps_config`'s identical split (this
+    /// milestone's own "single most important test" precedent).
+    async fn bundle_deps_config(
+        &self,
+        pkg: &PkgBuf,
+        entry_file_rel: &str,
+    ) -> anyhow::Result<BundleDepsConfig> {
+        let closure = self.bundle_closure(pkg.as_str(), entry_file_rel).await?;
+
+        let workspace_root = self.workspace_root.clone();
+        let pkg_str = pkg.as_str().to_string();
+
+        let ancillary =
+            hcore::blocking::run(move || -> anyhow::Result<BundleAncillary> {
+                let canonical_root = workspace_root
+                    .canonicalize()
+                    .with_context(|| format!("canonicalize workspace root {workspace_root:?}"))?;
+                let pkg_dir = if pkg_str.is_empty() {
+                    workspace_root.clone()
+                } else {
+                    workspace_root.join(&pkg_str)
+                };
+
+                // The bundler config file (`esbuild.config.json`), if any, plus
+                // every file it itself references.
+                let config_path = importgraph::find_nearest_bundler_config(
+                    &workspace_root,
+                    &pkg_dir,
+                    &["esbuild.config.json"],
+                );
+                let (
+                    bundler_config_path,
+                    bundler_config_content,
+                    bundler_config_refs,
+                    config_external,
+                ) = match &config_path {
+                    Some(p) => {
+                        let rel = p
+                            .strip_prefix(&workspace_root)
+                            .unwrap_or(p)
+                            .to_string_lossy()
+                            .replace('\\', "/");
+                        let content = std::fs::read_to_string(p)
+                            .with_context(|| format!("reading bundler config {p:?}"))?;
+                        let refs = importgraph::resolve_runner_config_referenced_files(p, &content)
+                            .with_context(|| {
+                                format!("resolving files referenced by bundler config {p:?}")
+                            })?;
+                        // Hard error (never a silent same-path fallback) on
+                        // workspace-root escape — the exact M5-review-fixed
+                        // anti-pattern (`strip_prefix(...).unwrap_or(...)`
+                        // quietly keeping a raw, possibly-absolute host path),
+                        // recurring in this sibling call site (code-quality
+                        // M6 review MAJOR).
+                        let refs_rel: Vec<String> = refs
+                            .iter()
+                            .map(|r| {
+                                anyhow::ensure!(
+                                    r.starts_with(&canonical_root),
+                                    "js_bundle: bundler config {p:?} references {r:?}, which \
+                                     resolved outside the workspace root ({canonical_root:?})"
+                                );
+                                Ok(r.strip_prefix(&canonical_root)
+                                    .unwrap_or(r)
+                                    .to_string_lossy()
+                                    .replace('\\', "/"))
+                            })
+                            .collect::<anyhow::Result<Vec<String>>>()
+                            .with_context(|| {
+                                format!("scoping files referenced by bundler config {p:?}")
+                            })?;
+                        let external = parse_bundler_config_external(&content)
+                            .with_context(|| format!("parsing bundler config {p:?}"))?;
+                        (rel, content, refs_rel, external)
+                    }
+                    None => (String::new(), String::new(), Vec::new(), Vec::new()),
+                };
+
+                // The entry package's own resolved tsconfig (if any) plus its
+                // `extends` chain — esbuild auto-discovers and applies a
+                // tsconfig's `compilerOptions` (`paths`/`baseUrl`/`jsx`/`target`/
+                // `experimentalDecorators`) the same way `tsc` does, so it must
+                // be a declared, staged, hashed Input the same way
+                // `typecheck_deps_config` already treats it (code-quality M6
+                // review BLOCKER).
+                let tsconfig = importgraph::find_nearest_tsconfig(&workspace_root, &pkg_dir);
+                let (tsconfig_path, mut tsconfig_content) = match &tsconfig {
+                    Some(p) => {
+                        let rel = p
+                            .strip_prefix(&workspace_root)
+                            .unwrap_or(p)
+                            .to_string_lossy()
+                            .replace('\\', "/");
+                        let content = std::fs::read_to_string(p)
+                            .with_context(|| format!("reading tsconfig {p:?}"))?;
+                        (rel, content)
+                    }
+                    None => (String::new(), String::new()),
+                };
+                let mut tsconfig_refs: Vec<String> = Vec::new();
+                if let Some(leaf) = &tsconfig {
+                    let chain = importgraph::resolve_tsconfig_extends_chain(&workspace_root, leaf)
+                        .with_context(|| {
+                            format!("resolving tsconfig extends chain for {pkg_str:?}")
+                        })?;
+                    for ancestor in &chain {
+                        anyhow::ensure!(
+                            ancestor.starts_with(&canonical_root),
+                            "js_bundle: tsconfig {leaf:?}'s extends chain resolved {ancestor:?} \
+                         outside the workspace root ({canonical_root:?})"
+                        );
+                        let rel = ancestor
+                            .strip_prefix(&canonical_root)
+                            .unwrap_or(ancestor)
+                            .to_string_lossy()
+                            .replace('\\', "/");
+                        tsconfig_refs.push(rel);
+                        let content = std::fs::read_to_string(ancestor)
+                            .with_context(|| format!("reading extended tsconfig {ancestor:?}"))?;
+                        tsconfig_content.push('\n');
+                        tsconfig_content.push_str(&content);
+                    }
+                }
+
+                Ok(BundleAncillary {
+                    bundler_config_path,
+                    bundler_config_content,
+                    bundler_config_refs,
+                    config_external,
+                    tsconfig_path,
+                    tsconfig_content,
+                    tsconfig_refs,
+                })
+            })
+            .await?;
+
+        let mut deps: HashMap<String, Value> = HashMap::new();
+        deps.insert(
+            String::new(),
+            Value::List(
+                closure
+                    .files
+                    .iter()
+                    .map(|p| Value::String(hbuiltins::pluginfs::file_addr(p).format()))
+                    .collect(),
+            ),
+        );
+        if !closure.external_addrs.is_empty() {
+            deps.insert(
+                "external".to_string(),
+                Value::List(
+                    closure
+                        .external_addrs
+                        .iter()
+                        .cloned()
+                        .map(Value::String)
+                        .collect(),
+                ),
+            );
+        }
+        let mut bundler_config_addrs: BTreeSet<String> = BTreeSet::new();
+        if !ancillary.bundler_config_path.is_empty() {
+            bundler_config_addrs
+                .insert(hbuiltins::pluginfs::file_addr(&ancillary.bundler_config_path).format());
+        }
+        for rel in &ancillary.bundler_config_refs {
+            bundler_config_addrs.insert(hbuiltins::pluginfs::file_addr(rel).format());
+        }
+        if !bundler_config_addrs.is_empty() {
+            deps.insert(
+                "bundler_config".to_string(),
+                Value::List(
+                    bundler_config_addrs
+                        .into_iter()
+                        .map(Value::String)
+                        .collect(),
+                ),
+            );
+        }
+        let mut tsconfig_addrs: BTreeSet<String> = BTreeSet::new();
+        if !ancillary.tsconfig_path.is_empty() {
+            tsconfig_addrs
+                .insert(hbuiltins::pluginfs::file_addr(&ancillary.tsconfig_path).format());
+        }
+        for rel in &ancillary.tsconfig_refs {
+            tsconfig_addrs.insert(hbuiltins::pluginfs::file_addr(rel).format());
+        }
+        if !tsconfig_addrs.is_empty() {
+            deps.insert(
+                "tsconfig".to_string(),
+                Value::List(tsconfig_addrs.into_iter().map(Value::String).collect()),
+            );
+        }
+
+        // Union the closure's own discovered third-party bare-specifier
+        // names with the bundler config's opt-in `"external"` list — see
+        // `BundleClosureResult::external_names`'s doc and the feature-quality
+        // M6 review BLOCKER this fixes.
+        let mut external_set: BTreeSet<String> = closure.external_names.clone();
+        external_set.extend(ancillary.config_external.iter().cloned());
+
+        Ok(BundleDepsConfig {
+            deps,
+            bundler_config_path: ancillary.bundler_config_path,
+            bundler_config_content: ancillary.bundler_config_content,
+            external: external_set.into_iter().collect(),
+            tsconfig_path: ancillary.tsconfig_path,
+            tsconfig_content: ancillary.tsconfig_content,
+        })
+    }
+
+    /// Build the config for a `js_bundle` target: the host bundler toolchain
+    /// resolution/version-query this milestone's disclosed
+    /// `bundler`-is-host-resolved escape hatch requires (see `toolchain.rs`
+    /// module docs for why the version is queried here, at spec-resolution
+    /// time, rather than deferred to the driver's `run()`), plus
+    /// `bundle_deps_config`'s pure, bundler-binary-free Input-scoping.
+    async fn bundle_config(
+        &self,
+        pkg: &PkgBuf,
+        entry_file_rel: &str,
+        format: &str,
+        target_env: &str,
+    ) -> anyhow::Result<HashMap<String, Value>> {
+        let resolved_bundler = self.resolved_host_bundler().await?;
+        let bundler_bin = resolved_bundler.0.to_string_lossy().into_owned();
+        let bundler_version = resolved_bundler.1.clone();
+        let bundler = self.bundler.clone();
+
+        let deps_config = self.bundle_deps_config(pkg, entry_file_rel).await?;
+
+        // `format`/`target_env` are part of the output path — otherwise
+        // `js_bundle@format=esm` and `js_bundle@format=cjs` for the same
+        // package both declare the identical `Content::DirPath` output,
+        // colliding whenever both are built together (the common dual-
+        // format-publish shape this milestone's own headline variant axis
+        // exists for — feature-quality M6 review BLOCKER).
+        let outdir = if pkg.as_str().is_empty() {
+            format!("dist/{format}-{target_env}")
+        } else {
+            format!("{}/dist/{format}-{target_env}", pkg.as_str())
+        };
+
+        let mut config: HashMap<String, Value> = HashMap::new();
+        config.insert("bundler".to_string(), Value::String(bundler));
+        config.insert("bundler_bin".to_string(), Value::String(bundler_bin));
+        config.insert(
+            "bundler_version".to_string(),
+            Value::String(bundler_version),
+        );
+        config.insert(
+            "entry_file".to_string(),
+            Value::String(entry_file_rel.to_string()),
+        );
+        config.insert("format".to_string(), Value::String(format.to_string()));
+        config.insert("target".to_string(), Value::String(target_env.to_string()));
+        config.insert("outdir".to_string(), Value::String(outdir));
+        config.insert(
+            "bundler_config_path".to_string(),
+            Value::String(deps_config.bundler_config_path),
+        );
+        config.insert(
+            "bundler_config_content".to_string(),
+            Value::String(deps_config.bundler_config_content),
+        );
+        config.insert(
+            "external".to_string(),
+            Value::List(
+                deps_config
+                    .external
+                    .into_iter()
+                    .map(Value::String)
+                    .collect(),
+            ),
+        );
+        config.insert(
+            "tsconfig_path".to_string(),
+            Value::String(deps_config.tsconfig_path),
+        );
+        config.insert(
+            "tsconfig_content".to_string(),
+            Value::String(deps_config.tsconfig_content),
+        );
+        config.insert("deps".to_string(), Value::Map(deps_config.deps));
+        Ok(config)
+    }
+}
+
+/// Result of [`Provider::bundle_closure`]: the full transitive first-party
+/// closure plus the third-party packages it reaches, both by declared
+/// `Input` addr (`external_addrs`) and by the bare-specifier name esbuild's
+/// own `--external:<name>` flag needs (`external_names`) — see that field's
+/// doc.
+struct BundleClosureResult {
+    files: BTreeSet<String>,
+    external_addrs: BTreeSet<String>,
+    /// The bare specifier name (e.g. `"lodash"`, `"@scope/pkg"`) each
+    /// third-party edge in `external_addrs` was actually imported by —
+    /// captured from `graph.unresolved_bare_specifiers`' own
+    /// `site.package_name` (the lockfile-driven path) or
+    /// `importgraph::thirdparty_pkg_name_from_path` (the ambient-
+    /// `node_modules` path), never re-derived from the resolved addr, which
+    /// carries only a version-pinned `js_install` target, not the specifier
+    /// text a source file actually wrote. Feeds esbuild's `--external:<name>`
+    /// flag directly (`Provider::bundle_deps_config`) — the piece the
+    /// feature-quality M6 review found missing entirely: previously only a
+    /// bundler-config-file's own opt-in `"external"` array reached `--external`,
+    /// so every real third-party import (never listed there) made
+    /// `esbuild --bundle` hard-fail trying to inline it.
+    external_names: BTreeSet<String>,
+}
+
+/// Result of [`Provider::bundle_deps_config`]: the `deps` map (see that
+/// function's doc) plus the resolved bundler config's and tsconfig's own
+/// workspace-relative paths/raw content, and the merged `--external` name
+/// list, for a `js_bundle` target. A plain tuple would work but — same
+/// precedent as [`LintDepsConfig`] — a 6-element one is too easy to
+/// mis-order at the call site; a named struct makes each field
+/// self-documenting instead.
+struct BundleDepsConfig {
+    deps: HashMap<String, Value>,
+    bundler_config_path: String,
+    bundler_config_content: String,
+    /// The closure's own discovered third-party bare-specifier names, unioned
+    /// with the bundler config's opt-in `"external"` array — see
+    /// [`BundleClosureResult::external_names`]'s doc.
+    external: Vec<String>,
+    tsconfig_path: String,
+    tsconfig_content: String,
+}
+
+/// Filesystem-only resolution [`Provider::bundle_deps_config`] performs
+/// inside a single `hcore::blocking::run` round trip: the bundler config (if
+/// any) plus its own referenced files, and the entry package's tsconfig (if
+/// any) plus its `extends` chain.
+struct BundleAncillary {
+    bundler_config_path: String,
+    bundler_config_content: String,
+    bundler_config_refs: Vec<String>,
+    config_external: Vec<String>,
+    tsconfig_path: String,
+    tsconfig_content: String,
+    tsconfig_refs: Vec<String>,
+}
+
+/// One BFS step's discoveries when walking `file_rel`'s own `runtime_edges`
+/// in `pkg`'s [`importgraph::ImportGraph`] — see [`Provider::bundle_closure`].
+struct BundleClosureStep {
+    /// `(owning_pkg, workspace_rel_path)` pairs for every not-yet-seen
+    /// first-party edge target — `owning_pkg` may differ from `pkg` when the
+    /// edge crosses into a sibling workspace package (see
+    /// `importgraph::firstparty_owning_pkg_dir`).
+    new_files: Vec<(String, String)>,
+    /// `(bare_specifier_name, target_addr)` pairs for every third-party
+    /// package this step's edges/bare specifiers reached — see
+    /// `driver_bundle.rs` module docs' "Inputs / cache key" section and
+    /// [`BundleClosureResult::external_names`]'s doc for why the name is
+    /// carried alongside the addr, not discarded.
+    new_external: Vec<(String, String)>,
+}
+
+/// Pure (no async, only what's already loaded) per-file edge walk:
+/// everything [`importgraph::build_test_closure`] does for one file,
+/// generalized to (a) recurse across package boundaries instead of stopping
+/// at one hop and (b) only follow `runtime_edges`, never `type_edges` (a
+/// bundler erases type-only imports — see `driver_bundle.rs` module docs).
+/// Split out from [`Provider::bundle_closure`] so the per-file work can run
+/// on the blocking pool without an `async fn` in the way, and so it is
+/// unit-testable without a real bundler binary.
+#[expect(
+    clippy::too_many_arguments,
+    reason = "mirrors typecheck_deps_config's/test_deps_config's own lockfile/graph/member/\
+              platform parameter set, needed here too for the same on-demand third-party-input \
+              resolution"
+)]
+fn bundle_closure_step(
+    canonical_root: &Path,
+    pkg: &str,
+    file_rel: &str,
+    graph: &importgraph::ImportGraph,
+    manifest: &package_json::PackageManifest,
+    lockfile: Option<&Lockfile>,
+    resolved_graph: Option<&ResolvedGraph>,
+    member_addrs_by_name: &BTreeMap<String, String>,
+    goos: &str,
+    goarch: &str,
+) -> anyhow::Result<BundleClosureStep> {
+    let mut new_files = Vec::new();
+    let mut new_external = Vec::new();
+
+    for edge in graph.runtime_edges.iter().filter(|e| e.file == file_rel) {
+        if let Some(name) = importgraph::thirdparty_pkg_name_from_path(&edge.resolved) {
+            // Resolved into `node_modules` — only possible when it happens
+            // to exist ambient on this host (`Provider::get` runs before
+            // `js_install` ever executes; see importgraph.rs module docs'
+            // "Hermeticity" section). Declared as a plain file Input at the
+            // resolved path, mirroring `typecheck_deps_config`'s identical
+            // treatment of an ambient-resolved third-party edge — the
+            // hermetically-correct path (a fresh checkout with no
+            // `node_modules`) instead surfaces this specifier as an
+            // `unresolved_bare_specifiers` site, handled below via the
+            // lockfile-driven mechanism (bug class (b): never resolve
+            // third-party inputs via ambient `node_modules`).
+            let rel = edge
+                .resolved
+                .strip_prefix(canonical_root)
+                .with_context(|| {
+                    format!(
+                        "js_bundle: {:?} imports from {:?}, a third-party path outside the \
+                         workspace root ({:?})",
+                        edge.file, edge.resolved, canonical_root
+                    )
+                })?
+                .to_string_lossy()
+                .replace('\\', "/");
+            new_external.push((name, hbuiltins::pluginfs::file_addr(&rel).format()));
+            continue;
+        }
+
+        anyhow::ensure!(
+            edge.resolved.starts_with(canonical_root),
+            "js_bundle: {:?} imports from {:?}, which resolved outside the workspace root \
+             ({:?}) — cannot express it as a declared js_bundle input (this typically means \
+             node_modules is a symlink to a global store outside the workspace)",
+            edge.file,
+            edge.resolved,
+            canonical_root
+        );
+        let rel = edge
+            .resolved
+            .strip_prefix(canonical_root)
+            .unwrap_or(&edge.resolved)
+            .to_string_lossy()
+            .replace('\\', "/");
+        let owning_pkg = importgraph::firstparty_owning_pkg_dir(&edge.resolved, canonical_root)
+            .ok_or_else(|| {
+                anyhow::anyhow!(
+                    "js_bundle: {:?} imports from {:?}, which resolved inside the workspace \
+                     root but has no owning package.json ancestor",
+                    edge.file,
+                    edge.resolved
+                )
+            })?
+            .to_string_lossy()
+            .replace('\\', "/");
+        new_files.push((owning_pkg, rel));
+    }
+
+    for site in graph
+        .unresolved_bare_specifiers
+        .iter()
+        .filter(|s| s.file == file_rel)
+    {
+        if let Some(addr) = deps::resolve_one_dependency(
+            pkg,
+            &site.package_name,
+            manifest,
+            lockfile,
+            resolved_graph,
+            member_addrs_by_name,
+            goos,
+            goarch,
+        )
+        .with_context(|| {
+            format!(
+                "resolving {:?}'s unresolved import of `{}` for js_bundle",
+                site.file, site.package_name
+            )
+        })? {
+            new_external.push((site.package_name.clone(), addr));
+        }
+    }
+
+    Ok(BundleClosureStep {
+        new_files,
+        new_external,
+    })
+}
+
+/// Parse a `js_bundle` bundler config's `"external"` array (esbuild's own
+/// `--external:<name>` flag, one per entry) — the only field this
+/// milestone's minimal `esbuild.config.json` schema recognizes (the esbuild
+/// CLI has no config-file convention of its own; see `driver_bundle.rs`
+/// module docs and `importgraph::find_nearest_bundler_config`'s doc for why
+/// this crate defines its own small schema instead). `Ok(vec![])` for a
+/// config with no `"external"` key. A malformed JSON document, or a present
+/// `"external"` value that isn't an array of strings, is a hard
+/// `Provider::get` error naming the problem — never a silently ignored
+/// config.
+fn parse_bundler_config_external(content: &str) -> anyhow::Result<Vec<String>> {
+    let value: serde_json::Value =
+        serde_json::from_str(content).context("parsing bundler config as JSON")?;
+    let Some(external) = value.get("external") else {
+        return Ok(Vec::new());
+    };
+    let arr = external.as_array().ok_or_else(|| {
+        anyhow::anyhow!("bundler config's \"external\" field must be an array of strings")
+    })?;
+    arr.iter()
+        .map(|v| {
+            v.as_str().map(str::to_string).ok_or_else(|| {
+                anyhow::anyhow!("bundler config's \"external\" array must contain only strings")
+            })
+        })
+        .collect()
 }
 
 /// Build the `deps` map (`""` = the package's own first-party source files,
@@ -1216,45 +2039,53 @@ fn runner_config_candidates(testrunner: &str) -> anyhow::Result<&'static [&'stat
     }
 }
 
-/// Reject a `js_test` addr's `file` arg — or, defensively, a resolved
-/// `runner_config_path` read back out of a cached `JsTestDef` — that is
+/// Reject an addr arg or a resolved/cached config field — `js_test`'s `file`
+/// arg, `js_bundle`'s `entry` arg/`entry_file`/`outdir`, `package.json`'s own
+/// `"main"`, or any of these read back out of a cached `TargetDef` — that is
 /// anything other than a plain workspace-relative path: absolute, or
 /// `..`-escaping. `Path::join` silently *replaces* the base when the joined
-/// argument is absolute, so an unvalidated `file=/etc/passwd` addr would
+/// argument is absolute, so an unvalidated e.g. `file=/etc/passwd` addr would
 /// otherwise resolve to the literal host path in both `Provider::get`
-/// (`workspace_root.join(&test_file)`) and `driver_test.rs::run()`
-/// (`sandbox_ws_dir.join(&def.test_file)`) — a direct violation of
-/// architecture.md's target-isolation invariant ("It sees only its declared
-/// inputs; no ambient filesystem access"). Mirrors
-/// `hbuiltins::pluginfs::normalize_path`'s escape rejection (this crate
-/// cannot depend on `builtins`, and the fs-provider's own protection never
-/// fires here: `def.test_file` is a raw config string consumed directly, not
-/// a `fs:file` dep-group addr the engine resolves through it).
+/// (`workspace_root.join(...)`) and a driver's `run()`
+/// (`sandbox_ws_dir.join(...)`) — a direct violation of architecture.md's
+/// target-isolation invariant ("It sees only its declared inputs; no ambient
+/// filesystem access"). Mirrors `hbuiltins::pluginfs::normalize_path`'s
+/// escape rejection (this crate cannot depend on `builtins`, and the
+/// fs-provider's own protection never fires here: the caller's value is a
+/// raw config string consumed directly, not a `fs:file` dep-group addr the
+/// engine resolves through it).
+///
+/// `field` names the caller's own field/arg (e.g. `"entry_file"`,
+/// `"file arg"`, `"package.json main"`) so the error always names the value
+/// that actually failed — a code-quality review MAJOR previously found this
+/// hardcoding `"js_test"` even when validating an unrelated `js_bundle`
+/// field, actively misleading during debugging.
 pub(crate) fn reject_path_escape(field: &str, path: &str) -> anyhow::Result<()> {
     anyhow::ensure!(
         !Path::new(path).is_absolute(),
-        "js_test {field} {path:?} must be a workspace-relative path, not absolute"
+        "{field} {path:?} must be a workspace-relative path, not absolute"
     );
     anyhow::ensure!(
         !path.split('/').any(|c| c == ".."),
-        "js_test {field} {path:?} must not contain a `..` path component"
+        "{field} {path:?} must not contain a `..` path component"
     );
     Ok(())
 }
 
-/// A validated `test_file` must additionally live under the addressed
-/// package's own directory — otherwise `//packages/a:js_test@file=<path>`
-/// could address any other real, existing, non-test file anywhere in the
-/// workspace (e.g. a sibling package's source file never surfaced by
-/// `Provider::list`), confined to the workspace but still never a real
-/// `js_test` target. `package` empty means the root package (everything not
-/// already claimed by a nested `package.json` is "under" it).
-fn test_file_under_package(package: &str, test_file: &str) -> bool {
+/// A validated workspace-relative path must additionally live under the
+/// addressed package's own directory — otherwise
+/// `//packages/a:js_test@file=<path>` (or, since M6,
+/// `//packages/a:js_bundle@entry=<path>`) could address any other real,
+/// existing file anywhere in the workspace (e.g. a sibling package's source
+/// file never surfaced by `Provider::list`), confined to the workspace but
+/// still never a real target for the addressed package. `package` empty
+/// means the root package (everything not already claimed by a nested
+/// `package.json` is "under" it).
+fn path_under_package(package: &str, path: &str) -> bool {
     if package.is_empty() {
         return true;
     }
-    test_file
-        .strip_prefix(package)
+    path.strip_prefix(package)
         .is_some_and(|rest| rest.starts_with('/'))
 }
 
@@ -2086,6 +2917,37 @@ impl ProviderTrait for Provider {
                 }
             }
 
+            // A default (bare, no `format=`/`target=`/`entry=` addr args —
+            // resolved to `esm`/`node`/`package.json`'s own `"main"` by
+            // `Provider::get`) `js_bundle` target, listed only when the
+            // package actually has a usable default entry point — same
+            // "optional, additive listing" shape `js_test`'s discovery has
+            // just above; an entry-resolution failure here must not take
+            // `package_info` (or any other target kind in this package) down
+            // with it. Addressing a non-default variant/entry
+            // (`//pkg:js_bundle@format=cjs`, `@entry=…`) always works via
+            // `Provider::get` regardless of what's listed here — mirrors
+            // `js_test`'s identical "not every valid addr is enumerated"
+            // shape for an explicit `file=` override.
+            match self.default_entry_for_package(&req.package).await {
+                Ok(Some(_)) => {
+                    responses.push(Ok(ListResponse {
+                        addr: Addr::new(
+                            req.package.clone(),
+                            BUNDLE_TARGET.to_string(),
+                            Default::default(),
+                        ),
+                    }));
+                }
+                Ok(None) => {}
+                Err(e) => {
+                    responses.push(Err(e.context(format!(
+                        "resolving the default js_bundle entry point for {}",
+                        req.package.as_str()
+                    ))));
+                }
+            }
+
             Ok(Box::new(responses.into_iter())
                 as Box<
                     dyn Iterator<Item = anyhow::Result<ListResponse>> + Send,
@@ -2259,7 +3121,7 @@ impl ProviderTrait for Provider {
                 // doc for why (a code-quality review BLOCKER — `Path::join`
                 // silently replaces the base for an absolute argument).
                 reject_path_escape("file arg", &test_file).map_err(GetError::Other)?;
-                if !test_file_under_package(req.addr.package.as_str(), &test_file) {
+                if !path_under_package(req.addr.package.as_str(), &test_file) {
                     return Err(GetError::Other(anyhow::anyhow!(
                         "js_test addr {} names file {test_file:?} outside its own package {:?}",
                         req.addr.format(),
@@ -2283,6 +3145,121 @@ impl ProviderTrait for Provider {
                     target_spec: TargetSpec {
                         addr: req.addr.clone(),
                         driver: "js_test".to_string(),
+                        config,
+                        labels: vec![],
+                        transitive: Default::default(),
+                        approval: Default::default(),
+                    },
+                });
+            }
+
+            // `js_bundle` (M6) is a fifth per-package target kind: one addr
+            // per package, with `format`/`target`/`entry` addr args scoped
+            // to it alone — see `driver_bundle.rs` module docs for why these
+            // are plain addr args with a flat default, not a
+            // `provider_state`/ancestry-resolved variant. Checked before the
+            // `PACKAGE_INFO_TARGET` gate below for the same reason
+            // `TYPECHECK_TARGET`/`LINT_TARGET`/`TEST_TARGET` are.
+            if req.addr.name == BUNDLE_TARGET {
+                if self
+                    .skip
+                    .prunes_package(&self.workspace_root, Path::new(req.addr.package.as_str()))
+                {
+                    return Err(GetError::NotFound);
+                }
+                let package_json = self
+                    .workspace_root
+                    .join(req.addr.package.as_str())
+                    .join(PACKAGE_JSON);
+                if !package_json.is_file() {
+                    return Err(GetError::NotFound);
+                }
+
+                let format = req
+                    .addr
+                    .args
+                    .get("format")
+                    .cloned()
+                    .unwrap_or_else(|| "esm".to_string());
+                if format != "esm" && format != "cjs" {
+                    return Err(GetError::Other(anyhow::anyhow!(
+                        "js_bundle addr {} has unsupported `format` arg {format:?} — expected \
+                         \"esm\" or \"cjs\"",
+                        req.addr.format()
+                    )));
+                }
+                let target_env = req
+                    .addr
+                    .args
+                    .get("target")
+                    .cloned()
+                    .unwrap_or_else(|| "node".to_string());
+                if target_env != "node" && target_env != "browser" {
+                    return Err(GetError::Other(anyhow::anyhow!(
+                        "js_bundle addr {} has unsupported `target` arg {target_env:?} — \
+                         expected \"node\" or \"browser\"",
+                        req.addr.format()
+                    )));
+                }
+
+                let entry_file = match req.addr.args.get("entry").cloned() {
+                    Some(entry) => {
+                        // Validated *before* ever touching the filesystem —
+                        // see `js_test`'s identical `file` arg handling
+                        // above for why (a code-quality review BLOCKER).
+                        reject_path_escape("entry arg", &entry).map_err(GetError::Other)?;
+                        if !path_under_package(req.addr.package.as_str(), &entry) {
+                            return Err(GetError::Other(anyhow::anyhow!(
+                                "js_bundle addr {} names entry {entry:?} outside its own \
+                                 package {:?}",
+                                req.addr.format(),
+                                req.addr.package.as_str()
+                            )));
+                        }
+                        let entry_abs = self.workspace_root.join(&entry);
+                        let is_file = hcore::blocking::run(enclose!((entry_abs) move || {
+                            entry_abs.is_file()
+                        }))
+                        .await;
+                        if !is_file {
+                            return Err(GetError::NotFound);
+                        }
+                        entry
+                    }
+                    None => match self
+                        .default_entry_for_package(&req.addr.package)
+                        .await
+                        .with_context(|| {
+                            format!(
+                                "resolving the default js_bundle entry point for {}",
+                                req.addr.format()
+                            )
+                        })
+                        .map_err(GetError::Other)?
+                    {
+                        Some(entry) => entry,
+                        None => {
+                            return Err(GetError::Other(anyhow::anyhow!(
+                                "js_bundle addr {} has no entry point: package.json has no \
+                                 usable \"main\" field (or it names a file that doesn't exist) \
+                                 and no `entry=` addr arg was given",
+                                req.addr.format()
+                            )));
+                        }
+                    },
+                };
+
+                let config = self
+                    .bundle_config(&req.addr.package, &entry_file, &format, &target_env)
+                    .await
+                    .with_context(|| {
+                        format!("resolving js_bundle config for {}", req.addr.format())
+                    })
+                    .map_err(GetError::Other)?;
+                return Ok(GetResponse {
+                    target_spec: TargetSpec {
+                        addr: req.addr.clone(),
+                        driver: "js_bundle".to_string(),
                         config,
                         labels: vec![],
                         transitive: Default::default(),
@@ -2368,6 +3345,21 @@ mod tests {
 
     fn ctoken() -> StdCancellationToken {
         StdCancellationToken::new()
+    }
+
+    /// `GetError` implements neither `Debug` nor `Display` (it wraps a
+    /// non-`Debug` `TargetSpec`/`GetResponse` on the `Ok` side via
+    /// `Result::expect_err`'s bound, and its own `Other` variant's inner
+    /// `anyhow::Error` is the only formattable part) — assert on a
+    /// `Provider::get` failure by matching `GetError::Other` directly and
+    /// formatting its inner error, rather than via `.expect_err()`/`{err:#}`
+    /// the way a plain `anyhow::Result` failure elsewhere in this module can.
+    fn expect_get_other_error(result: Result<GetResponse, GetError>, msg: &str) -> String {
+        match result {
+            Err(GetError::Other(e)) => format!("{e:#}"),
+            Err(GetError::NotFound) => panic!("{msg}: got GetError::NotFound, expected Other(_)"),
+            Ok(_) => panic!("{msg}: got Ok(_), expected an error"),
+        }
     }
 
     /// Synthetic pnpm workspace: root + two members, one nested `node_modules`
@@ -3135,6 +4127,7 @@ mod tests {
                 testrunner: toolchain::VITEST.to_string(),
                 test_glob: Vec::new(),
                 linter: toolchain::OXLINT.to_string(),
+                bundler: toolchain::ESBUILD.to_string(),
             },
         );
 
@@ -4342,22 +5335,19 @@ mod tests {
     }
 
     #[test]
-    fn test_file_under_package_confines_to_the_addressed_package() {
-        assert!(test_file_under_package(
+    fn path_under_package_confines_to_the_addressed_package() {
+        assert!(path_under_package(
             "packages/a",
             "packages/a/src/index.test.ts"
         ));
-        assert!(!test_file_under_package(
-            "packages/a",
-            "packages/b/src/index.ts"
-        ));
+        assert!(!path_under_package("packages/a", "packages/b/src/index.ts"));
         // A sibling directory that merely shares a prefix with the package
         // name must not be treated as "under" it.
-        assert!(!test_file_under_package(
+        assert!(!path_under_package(
             "packages/a",
             "packages/a-other/src/index.ts"
         ));
-        assert!(test_file_under_package("", "packages/a/src/index.test.ts"));
+        assert!(path_under_package("", "packages/a/src/index.test.ts"));
     }
 
     #[tokio::test]
@@ -5256,5 +6246,872 @@ mod tests {
             .expect("get js_test target_spec");
         assert_eq!(resp.target_spec.driver, "js_test");
         assert!(resp.target_spec.config.contains_key("runner_version"));
+    }
+
+    // ---- M6: `js_bundle` entry-point validation, cross-package closure, ----
+    // ---- and variant addr-arg wiring                                    ----
+    //
+    // `bundle_closure` (like `typecheck_deps_config`/`test_deps_config`) is
+    // deliberately bundler-binary-free, so its Input-scoping is testable
+    // unconditionally — this is the "single most important test" shape this
+    // milestone's task calls out, applied to `js_bundle`'s own differentiator:
+    // a *cross-package* transitive closure, not a one-hop trim.
+
+    /// The package's own `package.json` `"main"` becomes the default entry
+    /// — proven directly against `default_entry_for_package` (no real
+    /// bundler binary needed; the full `Provider::get` path is additionally
+    /// covered, `#[ignore]`d, by `get_resolves_js_bundle_target_end_to_end`
+    /// below). `list_discovers_js_bundle_target_only_when_main_resolves`
+    /// proves the same default drives `Provider::list`'s discovery.
+    #[tokio::test]
+    async fn default_entry_for_package_uses_package_json_main() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        write(
+            dir.path(),
+            "packages/a/package.json",
+            r#"{"name": "a", "main": "src/index.ts"}"#,
+        );
+        write(
+            dir.path(),
+            "packages/a/src/index.ts",
+            "export const x = 1;\n",
+        );
+
+        let provider = Provider::new(dir.path().to_path_buf(), PkgManager::Npm);
+        let entry = provider
+            .default_entry_for_package(&PkgBuf::from("packages/a"))
+            .await
+            .expect("default_entry_for_package");
+        assert_eq!(entry.as_deref(), Some("packages/a/src/index.ts"));
+    }
+
+    #[tokio::test]
+    async fn get_js_bundle_errors_when_no_main_and_no_entry_override() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        write(dir.path(), "packages/a/package.json", r#"{"name": "a"}"#);
+
+        let provider = Provider::new(dir.path().to_path_buf(), PkgManager::Npm);
+        let ct = ctoken();
+        let executor = Arc::new(NoopExecutor);
+        let result = provider
+            .get(
+                GetRequest {
+                    request_id: "test".to_string(),
+                    addr: Addr::new(
+                        PkgBuf::from("packages/a"),
+                        BUNDLE_TARGET.to_string(),
+                        Default::default(),
+                    ),
+                    states: vec![],
+                    executor,
+                },
+                &ct,
+            )
+            .await;
+        let msg = expect_get_other_error(
+            result,
+            "no main field and no entry= override must fail, not silently succeed",
+        );
+        assert!(msg.contains("entry point") || msg.contains("main"), "{msg}");
+    }
+
+    /// Task requirement: entry-point path-escape validation gets its own
+    /// unconditional test, mirroring `js_test`'s `file` addr arg tests.
+    #[tokio::test]
+    async fn get_js_bundle_rejects_dotdot_escaping_entry_arg() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        write(dir.path(), "packages/a/package.json", r#"{"name": "a"}"#);
+
+        let provider = Provider::new(dir.path().to_path_buf(), PkgManager::Npm);
+        let ct = ctoken();
+        let executor = Arc::new(NoopExecutor);
+        let mut args = BTreeMap::new();
+        args.insert(
+            "entry".to_string(),
+            "packages/a/../../../etc/passwd".to_string(),
+        );
+        let result = provider
+            .get(
+                GetRequest {
+                    request_id: "test".to_string(),
+                    addr: Addr::new(PkgBuf::from("packages/a"), BUNDLE_TARGET.to_string(), args),
+                    states: vec![],
+                    executor,
+                },
+                &ct,
+            )
+            .await;
+        let msg = expect_get_other_error(result, "a `..`-escaping entry arg must be rejected");
+        assert!(msg.contains(".."));
+    }
+
+    #[tokio::test]
+    async fn get_js_bundle_rejects_absolute_entry_arg() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        write(dir.path(), "packages/a/package.json", r#"{"name": "a"}"#);
+
+        let provider = Provider::new(dir.path().to_path_buf(), PkgManager::Npm);
+        let ct = ctoken();
+        let executor = Arc::new(NoopExecutor);
+        let mut args = BTreeMap::new();
+        args.insert("entry".to_string(), "/etc/passwd".to_string());
+        let result = provider
+            .get(
+                GetRequest {
+                    request_id: "test".to_string(),
+                    addr: Addr::new(PkgBuf::from("packages/a"), BUNDLE_TARGET.to_string(), args),
+                    states: vec![],
+                    executor,
+                },
+                &ct,
+            )
+            .await;
+        let msg = expect_get_other_error(result, "an absolute entry arg must be rejected");
+        assert!(msg.contains("absolute"));
+    }
+
+    #[tokio::test]
+    async fn get_js_bundle_rejects_entry_outside_addressed_package() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        write(dir.path(), "packages/a/package.json", r#"{"name": "a"}"#);
+        write(dir.path(), "packages/b/package.json", r#"{"name": "b"}"#);
+        write(
+            dir.path(),
+            "packages/b/src/index.ts",
+            "export const x = 1;\n",
+        );
+
+        let provider = Provider::new(dir.path().to_path_buf(), PkgManager::Npm);
+        let ct = ctoken();
+        let executor = Arc::new(NoopExecutor);
+        let mut args = BTreeMap::new();
+        args.insert("entry".to_string(), "packages/b/src/index.ts".to_string());
+        let result = provider
+            .get(
+                GetRequest {
+                    request_id: "test".to_string(),
+                    addr: Addr::new(PkgBuf::from("packages/a"), BUNDLE_TARGET.to_string(), args),
+                    states: vec![],
+                    executor,
+                },
+                &ct,
+            )
+            .await;
+        let msg = expect_get_other_error(
+            result,
+            "an entry outside the addressed package must be rejected",
+        );
+        assert!(msg.contains("outside its own package"));
+    }
+
+    #[tokio::test]
+    async fn get_js_bundle_not_found_for_nonexistent_entry_override() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        write(dir.path(), "packages/a/package.json", r#"{"name": "a"}"#);
+
+        let provider = Provider::new(dir.path().to_path_buf(), PkgManager::Npm);
+        let ct = ctoken();
+        let executor = Arc::new(NoopExecutor);
+        let mut args = BTreeMap::new();
+        args.insert(
+            "entry".to_string(),
+            "packages/a/src/does-not-exist.ts".to_string(),
+        );
+        let result = provider
+            .get(
+                GetRequest {
+                    request_id: "test".to_string(),
+                    addr: Addr::new(PkgBuf::from("packages/a"), BUNDLE_TARGET.to_string(), args),
+                    states: vec![],
+                    executor,
+                },
+                &ct,
+            )
+            .await;
+        assert!(matches!(result, Err(GetError::NotFound)));
+    }
+
+    // Task requirement: esm/cjs (and node/browser) must produce genuinely
+    // different `js_bundle` config. Proven two ways: `driver_bundle.rs`'s
+    // `parse_hash_changes_between_esm_and_cjs`/`parse_hash_changes_between_node_and_browser`
+    // (no real bundler needed — those exercise `JsBundleDef::hash` directly),
+    // and, end to end through `Provider::get`'s own addr-arg parsing,
+    // `get_js_bundle_format_and_target_addr_args_flow_into_config_e2e` below
+    // (`#[ignore]`d — reaching a *successful* `Provider::get` return
+    // additionally resolves+queries the host `esbuild` binary via
+    // `bundle_config`, unlike the rejection-path tests above which fail
+    // before ever reaching it).
+
+    #[tokio::test]
+    async fn get_js_bundle_rejects_unsupported_format_arg() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        write(
+            dir.path(),
+            "packages/a/package.json",
+            r#"{"name": "a", "main": "src/index.ts"}"#,
+        );
+        write(
+            dir.path(),
+            "packages/a/src/index.ts",
+            "export const x = 1;\n",
+        );
+
+        let provider = Provider::new(dir.path().to_path_buf(), PkgManager::Npm);
+        let ct = ctoken();
+        let mut args = BTreeMap::new();
+        args.insert("format".to_string(), "umd".to_string());
+        let result = provider
+            .get(
+                GetRequest {
+                    request_id: "test".to_string(),
+                    addr: Addr::new(PkgBuf::from("packages/a"), BUNDLE_TARGET.to_string(), args),
+                    states: vec![],
+                    executor: Arc::new(NoopExecutor),
+                },
+                &ct,
+            )
+            .await;
+        let msg = expect_get_other_error(result, "an unsupported format addr arg must be rejected");
+        assert!(msg.contains("umd"));
+    }
+
+    /// `Provider::list` only lists the default `js_bundle` target for a
+    /// package with a usable `"main"` — mirrors `js_test`'s "no matched
+    /// files, no listed target" shape. An explicit `entry=` addr still works
+    /// via `Provider::get` regardless (proven by the tests above).
+    #[tokio::test]
+    async fn list_discovers_js_bundle_target_only_when_main_resolves() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        write(
+            dir.path(),
+            "packages/a/package.json",
+            r#"{"name": "a", "main": "src/index.ts"}"#,
+        );
+        write(
+            dir.path(),
+            "packages/a/src/index.ts",
+            "export const x = 1;\n",
+        );
+        // No "main" field at all.
+        write(dir.path(), "packages/b/package.json", r#"{"name": "b"}"#);
+        // A "main" field naming a file that doesn't exist.
+        write(
+            dir.path(),
+            "packages/c/package.json",
+            r#"{"name": "c", "main": "src/missing.ts"}"#,
+        );
+
+        let provider = Provider::new(dir.path().to_path_buf(), PkgManager::Npm);
+        let ct = ctoken();
+
+        for (pkg, expect_bundle) in [
+            ("packages/a", true),
+            ("packages/b", false),
+            ("packages/c", false),
+        ] {
+            let responses = provider
+                .list(
+                    ListRequest {
+                        request_id: "test".to_string(),
+                        package: PkgBuf::from(pkg),
+                        states: vec![],
+                        executor: Arc::new(NoopExecutor),
+                    },
+                    &ct,
+                )
+                .await
+                .expect("list")
+                .collect::<anyhow::Result<Vec<_>>>()
+                .expect("no per-entry errors");
+            let has_bundle = responses.iter().any(|r| r.addr.name == BUNDLE_TARGET);
+            let addr_names: Vec<&str> = responses.iter().map(|r| r.addr.name.as_str()).collect();
+            assert_eq!(
+                has_bundle, expect_bundle,
+                "{pkg}: expected js_bundle listed = {expect_bundle}, listed target names = \
+                 {addr_names:?}"
+            );
+        }
+    }
+
+    // ---- `bundle_closure`: cross-package transitive-closure scoping ----
+
+    /// The closure must recurse *through* a sibling workspace package, not
+    /// stop at one hop the way `build_test_closure` deliberately does for
+    /// `js_test`/`js_typecheck` — this is `js_bundle`'s stated
+    /// differentiator (see `driver_bundle.rs` module docs). Fixture: `a`'s
+    /// entry reaches sibling `b` via a relative import (the same shape
+    /// `importgraph.rs`'s own
+    /// `build_test_closure_records_cross_package_import_as_external_one_hop`
+    /// fixture uses to cross a package boundary, without needing a real
+    /// `node_modules` symlink), `b`'s own entry imports a second first-party
+    /// file `b/src/helper.ts` — both must be in the closure. A third,
+    /// unrelated workspace file must NOT be in the closure, proving the
+    /// whole-graph-not-whole-workspace scoping the task calls for.
+    #[tokio::test]
+    async fn bundle_closure_recurses_across_package_boundaries_and_excludes_unrelated_files() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        write(
+            dir.path(),
+            "package.json",
+            r#"{"name": "root", "workspaces": ["packages/*"]}"#,
+        );
+        write(
+            dir.path(),
+            "packages/a/package.json",
+            r#"{"name": "a", "dependencies": {"b": "workspace:*"}}"#,
+        );
+        write(
+            dir.path(),
+            "packages/a/src/index.ts",
+            "import { helper } from '../../b/src/index';\nhelper();\n",
+        );
+        write(dir.path(), "packages/b/package.json", r#"{"name": "b"}"#);
+        write(
+            dir.path(),
+            "packages/b/src/index.ts",
+            "export { helper } from './helper';\n",
+        );
+        write(
+            dir.path(),
+            "packages/b/src/helper.ts",
+            "export function helper() {}\n",
+        );
+        // Unrelated workspace content nothing in the closure ever imports.
+        write(
+            dir.path(),
+            "packages/a/src/unrelated.ts",
+            "export const unrelated = 1;\n",
+        );
+
+        let provider = Provider::new(dir.path().to_path_buf(), PkgManager::Npm);
+        let closure = provider
+            .bundle_closure("packages/a", "packages/a/src/index.ts")
+            .await
+            .expect("bundle_closure over the cross-package fixture");
+        let files = &closure.files;
+
+        assert!(
+            files.contains("packages/a/src/index.ts"),
+            "entry file itself must be in the closure: {files:?}"
+        );
+        assert!(
+            files.contains("packages/b/src/index.ts"),
+            "the sibling package's own entry, reached one hop out, must be in the closure: \
+             {files:?}"
+        );
+        assert!(
+            files.contains("packages/b/src/helper.ts"),
+            "a file the sibling package's entry itself imports — reached TWO hops from js_bundle's \
+             own entry — must also be in the closure; this is the whole point of not reusing \
+             build_test_closure's one-hop trim: {files:?}"
+        );
+        assert!(
+            !files.contains("packages/a/src/unrelated.ts"),
+            "a workspace file nothing in the closure imports must NOT be declared as an input \
+             (whole-graph, not whole-workspace): {files:?}"
+        );
+        assert!(
+            closure.external_addrs.is_empty(),
+            "every import in this fixture resolved to first-party content; nothing should have \
+             been treated as third-party: {:?}",
+            closure.external_addrs
+        );
+    }
+
+    /// An unresolved bare specifier (the realistic steady state on a fresh
+    /// checkout with no `node_modules` installed yet) inside the closure
+    /// must resolve to the third-party package's `js_install` addr via the
+    /// lockfile-driven mechanism — never left silently unaddressed, and
+    /// never resolved by walking an ambient `node_modules` on disk (bug
+    /// class (b) this milestone's task calls out).
+    #[tokio::test]
+    async fn bundle_closure_resolves_thirdparty_import_via_lockfile_with_no_ambient_node_modules() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        write(
+            dir.path(),
+            "package.json",
+            r#"{"name": "root", "dependencies": {"lodash": "^4.17.21"}}"#,
+        );
+        write(dir.path(), "src/index.ts", "import _ from 'lodash';\n");
+        write(
+            dir.path(),
+            "package-lock.json",
+            r#"{
+                "lockfileVersion": 3,
+                "packages": {
+                    "": { "name": "root", "dependencies": { "lodash": "^4.17.21" } },
+                    "node_modules/lodash": {
+                        "version": "4.17.21",
+                        "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
+                        "integrity": "sha512-abc"
+                    }
+                }
+            }"#,
+        );
+        // Deliberately no `node_modules/lodash` on disk — the realistic
+        // fresh-checkout state this test is named for.
+
+        let provider = Provider::new(dir.path().to_path_buf(), PkgManager::Npm);
+        let closure = provider
+            .bundle_closure("", "src/index.ts")
+            .await
+            .expect("bundle_closure with a lockfile-resolved, not-yet-installed third-party dep");
+
+        assert!(closure.files.contains("src/index.ts"));
+        assert_eq!(
+            closure.external_addrs.len(),
+            1,
+            "{:?}",
+            closure.external_addrs
+        );
+        let addr = closure
+            .external_addrs
+            .iter()
+            .next()
+            .expect("one external addr");
+        assert!(
+            addr.contains("@heph/js/thirdparty/lodash@4.17.21"),
+            "must be the lockfile-resolved js_install addr, not an ambient node_modules path: {addr}"
+        );
+        assert_eq!(
+            closure.external_names,
+            BTreeSet::from(["lodash".to_string()]),
+            "the bare specifier name esbuild's own --external:<name> flag needs must be \
+             captured alongside the resolved addr: {:?}",
+            closure.external_names
+        );
+    }
+
+    // ---- bundler config discovery (bundle_deps_config: no real bundler binary needed) ----
+
+    #[tokio::test]
+    async fn bundle_deps_config_declares_bundler_config_when_present() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        write(
+            dir.path(),
+            "packages/a/package.json",
+            r#"{"name": "a", "main": "src/index.ts"}"#,
+        );
+        write(
+            dir.path(),
+            "packages/a/src/index.ts",
+            "export const x = 1;\n",
+        );
+        write(
+            dir.path(),
+            "packages/a/esbuild.config.json",
+            r#"{"external": ["react", "react-dom"]}"#,
+        );
+
+        let provider = Provider::new(dir.path().to_path_buf(), PkgManager::Npm);
+        let result = provider
+            .bundle_deps_config(&PkgBuf::from("packages/a"), "packages/a/src/index.ts")
+            .await
+            .expect("bundle_deps_config with a real esbuild.config.json present");
+
+        assert_eq!(result.bundler_config_path, "packages/a/esbuild.config.json");
+        assert_eq!(result.external, vec!["react", "react-dom"]);
+        assert!(
+            dep_addrs(&result.deps, "bundler_config")
+                .iter()
+                .any(|a| a.contains("esbuild.config.json")),
+            "the resolved bundler config file must be a declared \"bundler_config\" input: \
+             {:?}",
+            result.deps
+        );
+    }
+
+    #[tokio::test]
+    async fn bundle_deps_config_no_bundler_config_group_when_absent() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        write(
+            dir.path(),
+            "packages/a/package.json",
+            r#"{"name": "a", "main": "src/index.ts"}"#,
+        );
+        write(
+            dir.path(),
+            "packages/a/src/index.ts",
+            "export const x = 1;\n",
+        );
+
+        let provider = Provider::new(dir.path().to_path_buf(), PkgManager::Npm);
+        let result = provider
+            .bundle_deps_config(&PkgBuf::from("packages/a"), "packages/a/src/index.ts")
+            .await
+            .expect("bundle_deps_config with no esbuild.config.json");
+
+        assert_eq!(result.bundler_config_path, "");
+        assert_eq!(result.bundler_config_content, "");
+        assert!(result.external.is_empty());
+        assert!(dep_addrs(&result.deps, "bundler_config").is_empty());
+    }
+
+    /// Feature-quality M6 review BLOCKER: `--external` bundler flags were
+    /// derived only from a bundler config file's own opt-in `"external"`
+    /// array — the closure's own discovered third-party bare specifiers
+    /// (the realistic case for essentially every real npm dependency) never
+    /// reached it, so `esbuild --bundle` hard-failed on every real
+    /// third-party import. Proves the union: a closure-discovered name
+    /// (`lodash`, no config file at all) and a config-file-only name
+    /// (`react`, via the config's `"external"` array) both end up in
+    /// `BundleDepsConfig::external`.
+    #[tokio::test]
+    async fn bundle_deps_config_externals_union_closure_discovered_and_config_file_names() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        write(
+            dir.path(),
+            "package.json",
+            r#"{"name": "root", "dependencies": {"lodash": "^4.17.21"}}"#,
+        );
+        write(dir.path(), "src/index.ts", "import _ from 'lodash';\n");
+        write(
+            dir.path(),
+            "package-lock.json",
+            r#"{
+                "lockfileVersion": 3,
+                "packages": {
+                    "": { "name": "root", "dependencies": { "lodash": "^4.17.21" } },
+                    "node_modules/lodash": {
+                        "version": "4.17.21",
+                        "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
+                        "integrity": "sha512-abc"
+                    }
+                }
+            }"#,
+        );
+        // "moment" is never actually imported — an opt-in-only config entry
+        // (e.g. externalizing a peer dep the entry doesn't itself import
+        // yet) must still survive the union, not be dropped in favor of the
+        // closure's own discoveries.
+        write(
+            dir.path(),
+            "esbuild.config.json",
+            r#"{"external": ["moment"]}"#,
+        );
+
+        let provider = Provider::new(dir.path().to_path_buf(), PkgManager::Npm);
+        let result = provider
+            .bundle_deps_config(&PkgBuf::from(""), "src/index.ts")
+            .await
+            .expect(
+                "bundle_deps_config over a mixed closure-discovered/config-file external fixture",
+            );
+
+        assert_eq!(
+            result.external,
+            vec!["lodash".to_string(), "moment".to_string()],
+            "must union the closure's own discovered third-party name (lodash, no config entry) \
+             with the bundler config's opt-in name (moment, never actually imported): {:?}",
+            result.external
+        );
+    }
+
+    /// Code-quality M6 review BLOCKER: `js_bundle` never declared/staged/
+    /// hashed the entry package's own tsconfig, even though esbuild reads
+    /// `compilerOptions` (`paths`/`baseUrl`/`jsx`/decorators/target) from it
+    /// the same way `tsc` does — a package using a tsconfig `paths` alias
+    /// (a mainstream TS-monorepo pattern) would fail at real `esbuild`
+    /// execution because the sandbox never had a `tsconfig.json` at all.
+    /// Proves the resolved tsconfig is both declared as a `"tsconfig"` Input
+    /// (so it's staged) and returned for direct hashing, for a package whose
+    /// entry point only resolves via a `paths` alias.
+    #[tokio::test]
+    async fn bundle_deps_config_declares_and_hashes_tsconfig_for_a_paths_aliased_entry() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        write(dir.path(), "packages/a/package.json", r#"{"name": "a"}"#);
+        write(
+            dir.path(),
+            "packages/a/tsconfig.json",
+            r#"{"compilerOptions": {"baseUrl": ".", "paths": {"@app/*": ["src/*"]}}}"#,
+        );
+        write(
+            dir.path(),
+            "packages/a/src/index.ts",
+            "export { helper } from '@app/utils';\n",
+        );
+        write(
+            dir.path(),
+            "packages/a/src/utils.ts",
+            "export function helper() {}\n",
+        );
+
+        let provider = Provider::new(dir.path().to_path_buf(), PkgManager::Npm);
+        let result = provider
+            .bundle_deps_config(&PkgBuf::from("packages/a"), "packages/a/src/index.ts")
+            .await
+            .expect("bundle_deps_config over a paths-aliased entry point");
+
+        assert_eq!(result.tsconfig_path, "packages/a/tsconfig.json");
+        assert!(
+            result.tsconfig_content.contains("@app/*"),
+            "the resolved tsconfig's own raw content must be hashed directly: {:?}",
+            result.tsconfig_content
+        );
+        assert!(
+            dep_addrs(&result.deps, "tsconfig")
+                .iter()
+                .any(|a| a.contains("packages/a/tsconfig.json")),
+            "the resolved tsconfig must be a declared \"tsconfig\" input so it's staged into the \
+             sandbox at the path esbuild expects: {:?}",
+            result.deps
+        );
+    }
+
+    /// No tsconfig anywhere on the ancestor chain: `bundle_deps_config` must
+    /// not declare a `"tsconfig"` group or fail — mirrors
+    /// `bundle_deps_config_no_bundler_config_group_when_absent`'s identical
+    /// "absence is not an error" shape for the bundler config.
+    #[tokio::test]
+    async fn bundle_deps_config_no_tsconfig_group_when_absent() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        write(
+            dir.path(),
+            "packages/a/package.json",
+            r#"{"name": "a", "main": "src/index.ts"}"#,
+        );
+        write(
+            dir.path(),
+            "packages/a/src/index.ts",
+            "export const x = 1;\n",
+        );
+
+        let provider = Provider::new(dir.path().to_path_buf(), PkgManager::Npm);
+        let result = provider
+            .bundle_deps_config(&PkgBuf::from("packages/a"), "packages/a/src/index.ts")
+            .await
+            .expect("bundle_deps_config with no tsconfig.json");
+
+        assert_eq!(result.tsconfig_path, "");
+        assert_eq!(result.tsconfig_content, "");
+        assert!(dep_addrs(&result.deps, "tsconfig").is_empty());
+    }
+
+    /// Feature-quality/hermeticity M6 review finding: `bundle_closure`'s BFS
+    /// is provably invariant across `js_bundle`'s `format`/`target` variant
+    /// axis for the same entry point, but was recomputed from scratch on
+    /// every `Provider::get` — unlike every other expensive per-target-kind
+    /// computation in this file. Proves two independent `bundle_closure`
+    /// calls for the same `(entry_pkg, entry_file_rel)` share one BFS
+    /// (mirrors `import_graph_is_shared_across_independent_callers`'s own
+    /// `graph_build_count` proof technique, one layer up: a shared
+    /// `import_graph` call underneath is *also* memoized, so a second
+    /// `bundle_closure` call that actually re-walks would still show as a
+    /// second `import_graph` build).
+    #[tokio::test]
+    async fn bundle_closure_is_shared_across_independent_callers() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        write(dir.path(), "packages/a/package.json", r#"{"name": "a"}"#);
+        write(
+            dir.path(),
+            "packages/a/src/index.ts",
+            "export const x = 1;\n",
+        );
+
+        let provider = Provider::new(dir.path().to_path_buf(), PkgManager::Npm);
+
+        provider
+            .bundle_closure("packages/a", "packages/a/src/index.ts")
+            .await
+            .expect("first bundle_closure call");
+        assert_eq!(
+            provider
+                .graph_build_count
+                .load(std::sync::atomic::Ordering::SeqCst),
+            1,
+            "first bundle_closure call must build the import graph exactly once"
+        );
+
+        provider
+            .bundle_closure("packages/a", "packages/a/src/index.ts")
+            .await
+            .expect("second bundle_closure call for the same entry point (a different variant)");
+        assert_eq!(
+            provider
+                .graph_build_count
+                .load(std::sync::atomic::Ordering::SeqCst),
+            1,
+            "a second bundle_closure call for the same (entry_pkg, entry_file_rel) — e.g. a \
+             sibling format=cjs variant of the same package — must reuse the memoized closure, \
+             not re-walk the BFS (and, one layer down, not re-build the import graph either)"
+        );
+    }
+
+    // ---- run() precondition: Provider::get end to end, gated on a real ----
+    // ---- esbuild binary being available in this devenv                 ----
+    //
+    // Everything above (bundle_closure/bundle_deps_config) tests Input-scoping
+    // behavior and needs no real bundler. `Provider::get` for `js_bundle`
+    // additionally resolves+queries the host `esbuild` binary's own
+    // `--version` (see `resolved_host_bundler`), so these two mirror
+    // `get_resolves_js_typecheck_target_end_to_end`'s identical `#[ignore]`
+    // gating and reasoning.
+
+    #[tokio::test]
+    #[ignore = "requires a real `esbuild` on PATH — devenv.nix provisions no Node/esbuild \
+                toolchain (see toolchain.rs module docs); run explicitly with \
+                `cargo test -- --ignored` on a host with esbuild installed"]
+    async fn get_resolves_js_bundle_target_end_to_end() {
+        find_real_bin_for_test("esbuild").expect(
+            "this test is #[ignore]d precisely because esbuild isn't guaranteed on PATH — it \
+             was run explicitly, so a missing esbuild here is a real failure, not a skip",
+        );
+
+        let dir = tempfile::tempdir().expect("tempdir");
+        write(
+            dir.path(),
+            "packages/a/package.json",
+            r#"{"name": "a", "main": "src/index.ts"}"#,
+        );
+        write(
+            dir.path(),
+            "packages/a/src/index.ts",
+            "export const x = 1;\n",
+        );
+
+        let provider = Provider::new(dir.path().to_path_buf(), PkgManager::Npm);
+        let ct = ctoken();
+        let resp = provider
+            .get(
+                GetRequest {
+                    request_id: "test".to_string(),
+                    addr: Addr::new(
+                        PkgBuf::from("packages/a"),
+                        BUNDLE_TARGET.to_string(),
+                        Default::default(),
+                    ),
+                    states: vec![],
+                    executor: Arc::new(NoopExecutor),
+                },
+                &ct,
+            )
+            .await
+            .expect("get js_bundle target_spec");
+        assert_eq!(resp.target_spec.driver, "js_bundle");
+        assert!(resp.target_spec.config.contains_key("bundler_version"));
+    }
+
+    #[tokio::test]
+    #[ignore = "requires a real `esbuild` on PATH — devenv.nix provisions no Node/esbuild \
+                toolchain (see toolchain.rs module docs); run explicitly with \
+                `cargo test -- --ignored` on a host with esbuild installed"]
+    async fn get_js_bundle_format_and_target_addr_args_flow_into_config_e2e() {
+        find_real_bin_for_test("esbuild").expect(
+            "this test is #[ignore]d precisely because esbuild isn't guaranteed on PATH — it \
+             was run explicitly, so a missing esbuild here is a real failure, not a skip",
+        );
+
+        let dir = tempfile::tempdir().expect("tempdir");
+        write(
+            dir.path(),
+            "packages/a/package.json",
+            r#"{"name": "a", "main": "src/index.ts"}"#,
+        );
+        write(
+            dir.path(),
+            "packages/a/src/index.ts",
+            "export const x = 1;\n",
+        );
+
+        let provider = Provider::new(dir.path().to_path_buf(), PkgManager::Npm);
+        let ct = ctoken();
+
+        let mut args = BTreeMap::new();
+        args.insert("format".to_string(), "cjs".to_string());
+        args.insert("target".to_string(), "browser".to_string());
+        let resp = provider
+            .get(
+                GetRequest {
+                    request_id: "test".to_string(),
+                    addr: Addr::new(PkgBuf::from("packages/a"), BUNDLE_TARGET.to_string(), args),
+                    states: vec![],
+                    executor: Arc::new(NoopExecutor),
+                },
+                &ct,
+            )
+            .await
+            .expect("get js_bundle target_spec with explicit format/target args");
+        assert_eq!(
+            resp.target_spec.config.get("format"),
+            Some(&Value::String("cjs".to_string()))
+        );
+        assert_eq!(
+            resp.target_spec.config.get("target"),
+            Some(&Value::String("browser".to_string()))
+        );
+    }
+
+    /// Feature-quality M6 review BLOCKER: `outdir` was computed purely from
+    /// the package path, with no `format`/`target` component, so
+    /// `js_bundle@format=esm` and `js_bundle@format=cjs` for the same
+    /// package declared the identical `Content::DirPath` output — the
+    /// milestone's own headline dual-format-publish use case collided on
+    /// the same declared output directory. Proves two variants of the same
+    /// package now produce distinct `outdir` values.
+    #[tokio::test]
+    #[ignore = "requires a real `esbuild` on PATH — devenv.nix provisions no Node/esbuild \
+                toolchain (see toolchain.rs module docs); run explicitly with \
+                `cargo test -- --ignored` on a host with esbuild installed"]
+    async fn get_js_bundle_variants_of_the_same_package_get_distinct_outdirs() {
+        find_real_bin_for_test("esbuild").expect(
+            "this test is #[ignore]d precisely because esbuild isn't guaranteed on PATH — it \
+             was run explicitly, so a missing esbuild here is a real failure, not a skip",
+        );
+
+        let dir = tempfile::tempdir().expect("tempdir");
+        write(
+            dir.path(),
+            "packages/a/package.json",
+            r#"{"name": "a", "main": "src/index.ts"}"#,
+        );
+        write(
+            dir.path(),
+            "packages/a/src/index.ts",
+            "export const x = 1;\n",
+        );
+
+        let provider = Provider::new(dir.path().to_path_buf(), PkgManager::Npm);
+        let ct = ctoken();
+
+        let get_outdir = |args: BTreeMap<String, String>| {
+            let provider = &provider;
+            let ct = &ct;
+            async move {
+                let resp = provider
+                    .get(
+                        GetRequest {
+                            request_id: "test".to_string(),
+                            addr: Addr::new(
+                                PkgBuf::from("packages/a"),
+                                BUNDLE_TARGET.to_string(),
+                                args,
+                            ),
+                            states: vec![],
+                            executor: Arc::new(NoopExecutor),
+                        },
+                        ct,
+                    )
+                    .await
+                    .expect("get js_bundle target_spec");
+                match resp.target_spec.config.get("outdir") {
+                    Some(Value::String(s)) => s.clone(),
+                    other => panic!("expected outdir to be a string, got {other:?}"),
+                }
+            }
+        };
+
+        let esm_node_outdir = get_outdir(BTreeMap::new()).await;
+
+        let mut cjs_browser_args = BTreeMap::new();
+        cjs_browser_args.insert("format".to_string(), "cjs".to_string());
+        cjs_browser_args.insert("target".to_string(), "browser".to_string());
+        let cjs_browser_outdir = get_outdir(cjs_browser_args).await;
+
+        assert_ne!(
+            esm_node_outdir, cjs_browser_outdir,
+            "two variants of the same package must not declare the same output directory — the \
+             default esm/node outdir was {esm_node_outdir:?}, cjs/browser was \
+             {cjs_browser_outdir:?}"
+        );
     }
 }

--- a/crates/plugin-js/src/pluginjs/toolchain.rs
+++ b/crates/plugin-js/src/pluginjs/toolchain.rs
@@ -246,6 +246,79 @@ pub(crate) fn query_test_runner_version(runner_bin: &Path) -> anyhow::Result<Str
     Ok(version)
 }
 
+/// Sentinel `bundler` value `js_bundle` accepts in this milestone — see this
+/// module's `resolve_host_bundler` doc and `driver_bundle.rs` module docs for
+/// the same disclosed non-hermetic-toolchain shape `tstool = "host"`/
+/// `testrunner`/`linter` already have. Mirrors
+/// `ai-docs/js-plugin-plan.md`'s `js_bundle` row: `bundler` defaults to
+/// `esbuild` (the only value implemented this milestone — `rollup`/
+/// `webpack`/`vite` are a stated M6+ follow-up, not silently pretended to
+/// work).
+pub const ESBUILD: &str = "esbuild";
+
+/// Whether `bundler` names a supported bundler — only `esbuild` in this
+/// milestone.
+pub fn is_supported_bundler(bundler: &str) -> bool {
+    bundler == ESBUILD
+}
+
+/// Resolve the configured `bundler`'s binary:
+/// `<workspace_root>/node_modules/.bin/<bundler>` first, then the process's
+/// own `PATH` — the same disclosed non-hermetic escape hatch
+/// `tstool = "host"`/`testrunner`/`linter` already have (see
+/// [`resolve_host_tsc`]), extended to `js_bundle`'s toolchain axis. Fails
+/// loudly, naming both places checked, when neither has it.
+pub(crate) fn resolve_host_bundler(
+    workspace_root: &Path,
+    bundler: &str,
+) -> anyhow::Result<PathBuf> {
+    anyhow::ensure!(
+        is_supported_bundler(bundler),
+        "js_bundle: unsupported bundler {bundler:?} — expected \"esbuild\" (rollup/webpack/vite \
+         are a stated M6+ follow-up, not yet supported)"
+    );
+    let local = workspace_root
+        .join("node_modules")
+        .join(".bin")
+        .join(bundler);
+    find_host_bin(workspace_root, bundler).ok_or_else(|| {
+        anyhow::anyhow!(
+            "js_bundle: no `{bundler}` binary found at {local:?} or on PATH — install it (`npm \
+             install -D {bundler}` / `pnpm add -D {bundler}`) so `node_modules/.bin/{bundler}` \
+             exists, or make a `{bundler}` binary available on PATH. There is no hermetic \
+             {bundler} toolchain yet in this plugin — `bundler=\"{bundler}\"` requires one of \
+             those two to be reachable."
+        )
+    })
+}
+
+/// Query the resolved bundler's own `--version` output, trimmed — hashed
+/// into `JsBundleDef` so a host bundler upgrade/downgrade busts the cache,
+/// mirroring [`query_tsc_version`]/[`query_test_runner_version`]/
+/// [`query_linter_version`]'s identical "query once at `Provider::get` time,
+/// not `run()` time" rationale.
+pub(crate) fn query_bundler_version(bundler_bin: &Path) -> anyhow::Result<String> {
+    let out = std::process::Command::new(bundler_bin)
+        .arg("--version")
+        .output()
+        .with_context(|| format!("run {bundler_bin:?} --version"))?;
+    anyhow::ensure!(
+        out.status.success(),
+        "`{bundler_bin:?} --version` failed ({}): {}",
+        out.status,
+        String::from_utf8_lossy(&out.stderr)
+    );
+    let version = String::from_utf8(out.stdout)
+        .with_context(|| format!("{bundler_bin:?} --version output is not utf8"))?
+        .trim()
+        .to_string();
+    anyhow::ensure!(
+        !version.is_empty(),
+        "`{bundler_bin:?} --version` returned empty output"
+    );
+    Ok(version)
+}
+
 /// Query `tsc --version`'s full trimmed output (e.g. `"Version 5.6.2"`) —
 /// hashed into `JsTypecheckDef` so a host tsc upgrade/downgrade busts the
 /// cache. See module docs for why this runs at `Provider::get` time.
@@ -522,6 +595,92 @@ mod tests {
             std::fs::set_permissions(&fake_bin, perms).expect("chmod");
         }
         let err = query_linter_version(&fake_bin).expect_err("nonzero exit must error");
+        assert!(format!("{err:#}").contains("failed"));
+    }
+
+    // ---- bundler (js_bundle) ----
+
+    #[test]
+    fn is_supported_bundler_recognizes_only_esbuild() {
+        assert!(is_supported_bundler(ESBUILD));
+        assert!(!is_supported_bundler("rollup"));
+        assert!(!is_supported_bundler("webpack"));
+        assert!(!is_supported_bundler(""));
+    }
+
+    #[test]
+    fn resolve_host_bundler_rejects_unsupported_value() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let err =
+            resolve_host_bundler(dir.path(), "rollup").expect_err("unsupported bundler must error");
+        assert!(format!("{err:#}").contains("rollup"));
+    }
+
+    #[test]
+    fn resolve_host_bundler_prefers_local_node_modules_bin_over_path() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let local_bin_dir = dir.path().join("node_modules").join(".bin");
+        std::fs::create_dir_all(&local_bin_dir).expect("mkdir");
+        let local_esbuild = local_bin_dir.join(ESBUILD);
+        std::fs::write(&local_esbuild, b"#!/bin/sh\necho local\n").expect("write local esbuild");
+
+        let found = resolve_host_bundler(dir.path(), ESBUILD).expect("resolve");
+        assert_eq!(found, local_esbuild);
+    }
+
+    #[test]
+    fn resolve_host_bundler_errors_clearly_when_absent_everywhere() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let prior = std::env::var_os("PATH");
+        // SAFETY: test-only, single-threaded within this process for the
+        // duration of the mutation; restored immediately below.
+        unsafe { std::env::set_var("PATH", "") };
+        let result = resolve_host_bundler(dir.path(), ESBUILD);
+        match &prior {
+            // SAFETY: test-only, restoring the prior value we saved above.
+            Some(v) => unsafe { std::env::set_var("PATH", v) },
+            // SAFETY: test-only, restoring the prior (unset) state.
+            None => unsafe { std::env::remove_var("PATH") },
+        }
+        let err = result.expect_err("no esbuild anywhere must error, not silently succeed");
+        let msg = format!("{err:#}");
+        assert!(msg.contains("esbuild"), "{msg}");
+        assert!(msg.contains("PATH"), "{msg}");
+    }
+
+    #[test]
+    fn query_bundler_version_reads_trimmed_stdout() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let fake_bin = dir.path().join("esbuild");
+        std::fs::write(&fake_bin, "#!/bin/sh\necho '0.19.2'\n").expect("write fake bundler");
+        #[cfg(unix)]
+        {
+            use std::os::unix::fs::PermissionsExt;
+            let mut perms = std::fs::metadata(&fake_bin)
+                .expect("metadata")
+                .permissions();
+            perms.set_mode(0o755);
+            std::fs::set_permissions(&fake_bin, perms).expect("chmod");
+        }
+        let version = query_bundler_version(&fake_bin).expect("query version");
+        assert_eq!(version, "0.19.2");
+    }
+
+    #[test]
+    fn query_bundler_version_errors_on_nonzero_exit() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let fake_bin = dir.path().join("esbuild");
+        std::fs::write(&fake_bin, "#!/bin/sh\nexit 2\n").expect("write fake bundler");
+        #[cfg(unix)]
+        {
+            use std::os::unix::fs::PermissionsExt;
+            let mut perms = std::fs::metadata(&fake_bin)
+                .expect("metadata")
+                .permissions();
+            perms.set_mode(0o755);
+            std::fs::set_permissions(&fake_bin, perms).expect("chmod");
+        }
+        let err = query_bundler_version(&fake_bin).expect_err("nonzero exit must error");
         assert!(format!("{err:#}").contains("failed"));
     }
 }


### PR DESCRIPTION
M6 of the JS/TS heph plugin plan (part 6/6, top of the stack) — the final milestone, plus a first performance baseline for the whole plugin.

A cacheable js_bundle ManagedDriver wrapping esbuild, with format (esm/cjs) and target (node/browser) as plain addr args resolved with a flat default rather than porting the Go plugin's ancestry/universe variant machinery — this plugin's addr model is a single flat workspace, so there's no ancestor chain or cross-subtree variant-pin problem for that machinery to solve (researched and confirmed against `crates/plugin-go/src/plugingo/variant.rs` and this crate's own flat `workspace.rs` model before deciding).

Whole-graph cache key by design (the entry point's full transitive closure via ImportGraph::runtime_edges, cross-package recursion unlike js_test's one-hop trim), third-party deps resolved via the same lockfile-driven mechanism as every other driver, tsconfig (plus its extends chain) declared and staged the same way js_typecheck does.

Reviewed by feature-quality/code-quality/hermeticity. Two functional BLOCKERs found and fixed: the discovered third-party import closure was never wired into esbuild's `--external` flags, so bundling any package with a real npm runtime dependency failed outright; and the output directory didn't vary by format/target, so esm and cjs variants of the same package collided on the same declared output path. A third BLOCKER (missing tsconfig Input) meant path-aliased/JSX/decorator-configured TS entry points silently failed or cached wrong. All three fixed with regression tests, including a real-esbuild end-to-end proof for the external-deps fix.

Explicitly deferred (disclosed in module docs): `target=browser` doesn't yet change what's resolved (only what esbuild is told to assume) since the resolver has no browser condition/main-field support; a config-reference-scanning helper shared with js_test/js_lint reads a config-referenced file before checking workspace containment rather than after (dormant for js_bundle's only supported config format today, live for js_test already — flagged as a cross-cutting follow-up); rollup/webpack/vite bundlers.

**Open item for a future PR**: the design doc's v1 scope table lists six drivers including `js_format`, but the Milestones list only ever defined M0-M6 for the other five (install/typecheck/test/lint/bundle) — `js_format` has no milestone and isn't built yet.

## Performance baseline

Speed was the plugin's stated #1 design goal from the start — this had never actually been measured until now. Added `#[ignore]`d ad-hoc benches (never run under `tst`/default `cargo test`) measuring `Provider::import_graph`'s cold cost (first parse+resolve per package) vs warm cost (the M5 per-package memoization) on synthetic 20- and 150-package workspaces, plus a parse-vs-resolve phase split.

Results (darwin/arm64, this machine only — not transferable to other targets without re-running there):
- **Cold**: ~2.5-3ms/package, ~0.16-0.2ms/file (150 packages × 15 files: median 385ms, range 352-679ms across 8 runs — this machine's noise floor is large).
- **Warm**: ~500ns total across 150 packages — a cache hit never re-enters the build path at all, confirming M5's fix delivers as designed.
- **Phase split**: resolution (`oxc_resolver`) is 97%+ of cold cost; parsing (`oxc_parser`) is noise by comparison (~2.6-2.7%).

No prior baseline existed, so this establishes one rather than comparing against one — no regression, no obvious hotspot found. Real gap flagged: there's no JS/TS scenario in `crates/bench`/`crates/bench-corpus` (Go-only today), so this path has no standing CI perf-regression coverage yet — building that out is the natural follow-up.

With this PR, M0-M6 of `ai-docs/js-plugin-plan.md` are all implemented across the stack below.

## Test plan
- [x] `cargo build -p plugin-js -p plugin-js-cdylib`
- [x] `cargo test -p plugin-js` (319 passed, 18 ignored — require real `tsc`/`vitest`/`jest`/`oxlint`/`esbuild` binaries not provisioned in this devenv)
- [x] `cargo clippy -p plugin-js -p plugin-js-cdylib --all-targets -- -D warnings` (clean)
- [x] `cargo fmt --check -p plugin-js -p plugin-js-cdylib`
- [ ] CI (`tst`, `lint`) on this PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01M3wZfyPsG8stfRQuybLRjN