### PR TITLE
fix(plugin-buildfile): LSP flags missing required keys, tightens completion, shows driver docs on hover

### DIFF
--- a/crates/plugin-buildfile/src/pluginbuildfile/lsp/diagnostics.rs
+++ b/crates/plugin-buildfile/src/pluginbuildfile/lsp/diagnostics.rs
@@ -7,7 +7,7 @@
 //! spans, but it does not need the buffer to *evaluate* (it works mid-edit, the
 //! moment a bad key is typed, exactly like the textual completion does).
 //!
-//! Two checks per recognized call:
+//! Three checks per recognized call:
 //! - **Wrong type** — a keyword argument whose value is a literal that doesn't
 //!   match the field's declared [`ParamType`]. Non-literal values (variables,
 //!   concatenations, calls) carry no statically-known type, so they're left alone.
@@ -16,6 +16,12 @@
 //!   resolved from a string-literal `driver=` / `provider=` argument and its schema
 //!   is available. Otherwise the key might legitimately belong to an unresolved
 //!   schema, so we stay silent rather than risk a false positive.
+//! - **Missing required key** — a required field (a base field, or a driver/
+//!   provider-schema field once resolved) with no keyword argument supplying
+//!   it. Anchored on the call's callee token, since there's no key token to
+//!   underline. Suppressed entirely when the call includes a `*args`/`**kwargs`
+//!   splat — it could supply any key at runtime, so a "missing" field isn't
+//!   necessarily missing.
 
 use crate::pluginbuildfile::run_file::target_base_fields;
 use hcore::htvalue::Value;
@@ -42,15 +48,15 @@ pub(crate) fn validate(ast: &AstModule, engine: &dyn LspEngine) -> Vec<Diagnosti
     // (e.g. inside a list or another call) are covered too.
     ast.statement().visit_expr(|top| {
         walk_expr(top, &mut |e| {
-            if let Expr::Call(callee, args) = &e.node
-                && let Expr::Identifier(id) = &callee.node
+            if let Expr::Call(callee_expr, args) = &e.node
+                && let Expr::Identifier(id) = &callee_expr.node
             {
                 let callee = match id.node.ident.as_str() {
                     "target" => Callee::Target,
                     "provider_state" => Callee::ProviderState,
                     _ => return,
                 };
-                check_call(ast, engine, &args.args, callee, &mut out);
+                check_call(ast, engine, callee_expr.span, &args.args, callee, &mut out);
             }
         });
     });
@@ -67,27 +73,49 @@ fn walk_expr<'a>(e: &'a AstExpr, f: &mut impl FnMut(&'a AstExpr)) {
 fn check_call(
     ast: &AstModule,
     engine: &dyn LspEngine,
+    callee_span: Span,
     args: &[AstArgument],
     callee: Callee,
     out: &mut Vec<Diagnostic>,
 ) {
-    // The known fields (name → type) and whether that set is exhaustive.
-    let mut known: Vec<(String, ParamType)> = Vec::new();
+    // The known fields (name, type, required). Base fields (`target`'s
+    // `name`/`driver`/…, or `provider_state`'s `provider`) are always pushed
+    // first; `base_count` marks where they end and driver/provider-schema
+    // fields begin, so a missing-required message can attribute a field to
+    // the right source without formatting/cloning a label for every field up
+    // front — only the (at most one) field that's actually missing needs it.
+    let mut known: Vec<(String, ParamType, bool)> = Vec::new();
+    let base_label: &str;
+    let base_count: usize;
+    let mut schema_label: Option<String> = None;
     let complete;
     let ctx;
     match callee {
         Callee::Target => {
-            known.extend(target_base_fields().into_iter().map(|f| (f.name, f.ty)));
+            base_label = "`target`";
+            known.extend(
+                target_base_fields()
+                    .into_iter()
+                    .map(|f| (f.name, f.ty, f.required)),
+            );
+            base_count = known.len();
             // Driver-specific config fields are only known once the driver is
             // resolved from a string-literal `driver=`. Without it (or with an
-            // unknown driver) any extra key might be a valid driver field.
+            // unknown driver) any extra key might be a valid driver field, and
+            // we can't tell whether the driver's required fields are missing.
             match named_str_literal(args, "driver")
                 .and_then(|d| engine.driver_schema(&d).map(|s| (d, s)))
             {
                 Some((driver, schema)) => {
-                    known.extend(schema.fields.into_iter().map(|f| (f.name, f.ty)));
+                    known.extend(
+                        schema
+                            .fields
+                            .into_iter()
+                            .map(|f| (f.name, f.ty, f.required)),
+                    );
                     complete = true;
                     ctx = format!("`target` or the `{driver}` driver");
+                    schema_label = Some(format!("the `{driver}` driver"));
                 }
                 None => {
                     complete = false;
@@ -96,15 +124,23 @@ fn check_call(
             }
         }
         Callee::ProviderState => {
-            // `provider` is always a valid (string) key.
-            known.push(("provider".to_string(), ParamType::String));
+            base_label = "`provider_state`";
+            // `provider` is always a valid (string) key, and required.
+            known.push(("provider".to_string(), ParamType::String, true));
+            base_count = known.len();
             match named_str_literal(args, "provider")
                 .and_then(|p| engine.provider_state_schema(&p).map(|s| (p, s)))
             {
                 Some((provider, schema)) => {
-                    known.extend(schema.fields.into_iter().map(|f| (f.name, f.ty)));
+                    known.extend(
+                        schema
+                            .fields
+                            .into_iter()
+                            .map(|f| (f.name, f.ty, f.required)),
+                    );
                     complete = true;
                     ctx = format!("the `{provider}` provider");
+                    schema_label = Some(format!("the `{provider}` provider"));
                 }
                 None => {
                     complete = false;
@@ -114,33 +150,69 @@ fn check_call(
         }
     }
 
+    let mut provided: std::collections::HashSet<&str> = std::collections::HashSet::new();
+    // A `*args`/`**kwargs` splat could supply any key at runtime, so a missing
+    // key isn't necessarily missing — stay silent rather than risk a false
+    // positive.
+    let mut has_splat = false;
+
     for arg in args {
-        let Argument::Named(name, value) = &arg.node else {
-            continue;
-        };
-        let key = name.node.as_str();
-        match known.iter().find(|(n, _)| n == key) {
-            // A known field: flag a literal value whose type doesn't match.
-            Some((_, ty)) => {
-                if let Some(v) = literal_value(value)
-                    && !value_matches(ty, &v)
-                {
-                    out.push(diag(
-                        ast,
-                        value.span,
-                        format!("`{key}` expects {}, got {}", ty.render(), value_kind(&v)),
-                    ));
+        match &arg.node {
+            Argument::Named(name, value) => {
+                let key = name.node.as_str();
+                provided.insert(key);
+                match known.iter().find(|(n, _, _)| n == key) {
+                    // A known field: flag a literal value whose type doesn't match.
+                    Some((_, ty, _)) => {
+                        if let Some(v) = literal_value(value)
+                            && !value_matches(ty, &v)
+                        {
+                            out.push(diag(
+                                ast,
+                                value.span,
+                                format!("`{key}` expects {}, got {}", ty.render(), value_kind(&v)),
+                            ));
+                        }
+                    }
+                    // An unknown key — only an error when the valid set is exhaustive.
+                    None if complete => {
+                        out.push(diag(
+                            ast,
+                            name.span,
+                            format!("unknown field `{key}` for {ctx}"),
+                        ));
+                    }
+                    None => {}
                 }
             }
-            // An unknown key — only an error when the valid set is exhaustive.
-            None if complete => {
+            Argument::Args(_) | Argument::KwArgs(_) => has_splat = true,
+            Argument::Positional(_) => {}
+        }
+    }
+
+    if !has_splat {
+        // A schema field can share a name with a base field (unusual, but not
+        // forbidden); on collision the base field wins, mirroring the
+        // first-match `.find()` lookup used for type-checking above.
+        let mut seen: std::collections::HashSet<&str> = std::collections::HashSet::new();
+        for (i, (name, _, required)) in known.iter().enumerate() {
+            if !seen.insert(name.as_str()) {
+                continue;
+            }
+            if *required && !provided.contains(name.as_str()) {
+                let label = if i < base_count {
+                    base_label
+                } else {
+                    schema_label.as_deref().expect(
+                        "schema fields are only appended to `known` once resolved, alongside `schema_label`",
+                    )
+                };
                 out.push(diag(
                     ast,
-                    name.span,
-                    format!("unknown field `{key}` for {ctx}"),
+                    callee_span,
+                    format!("missing required field `{name}` for {label}"),
                 ));
             }
-            None => {}
         }
     }
 }
@@ -279,25 +351,39 @@ mod tests {
             std::sync::Arc::new(hplugin::provider::ProviderFunctionRegistry::default())
         }
         fn driver_schema(&self, name: &str) -> Option<DriverSchema> {
-            (name == "exec").then(|| DriverSchema {
-                fields: vec![
-                    DriverField {
-                        name: "cmd".to_string(),
-                        ty: ParamType::String,
+            match name {
+                "exec" => Some(DriverSchema {
+                    fields: vec![
+                        DriverField {
+                            name: "cmd".to_string(),
+                            ty: ParamType::String,
+                            doc: String::new(),
+                            required: true,
+                        },
+                        DriverField {
+                            name: "verbose".to_string(),
+                            ty: ParamType::Bool,
+                            doc: String::new(),
+                            required: false,
+                        },
+                    ],
+                }),
+                // A required field that collides with a base `target` field
+                // name — exercises the dedup/first-wins path in the
+                // missing-required check.
+                "shadow" => Some(DriverSchema {
+                    fields: vec![DriverField {
+                        name: "name".to_string(),
+                        ty: ParamType::Int,
                         doc: String::new(),
                         required: true,
-                    },
-                    DriverField {
-                        name: "verbose".to_string(),
-                        ty: ParamType::Bool,
-                        doc: String::new(),
-                        required: false,
-                    },
-                ],
-            })
+                    }],
+                }),
+                _ => None,
+            }
         }
         fn driver_names(&self) -> Vec<String> {
-            vec!["exec".to_string()]
+            vec!["exec".to_string(), "shadow".to_string()]
         }
         fn provider_state_schema(&self, name: &str) -> Option<StateSchema> {
             (name == "go").then(|| StateSchema {
@@ -378,7 +464,9 @@ mod tests {
     #[test]
     fn non_literal_value_is_not_type_checked() {
         // A concatenation has no statically-known type → no false positive.
-        let msgs = messages("target(name = PREFIX + \"_t\", driver = \"exec\")\n");
+        // `cmd` is supplied so this doesn't also trip the missing-required check.
+        let msgs =
+            messages("target(name = PREFIX + \"_t\", driver = \"exec\", cmd = \"echo hi\")\n");
         assert!(
             msgs.is_empty(),
             "non-literal value must be skipped, got {msgs:?}"
@@ -413,6 +501,129 @@ mod tests {
     }
 
     #[test]
+    fn missing_required_driver_field_is_flagged() {
+        // `exec` requires `cmd`; the driver is selected but `cmd` is absent.
+        let msgs = messages("target(name = \"t\", driver = \"exec\")\n");
+        assert!(
+            msgs.iter()
+                .any(|m| m.contains("missing required field `cmd`") && m.contains("`exec` driver")),
+            "expected missing-required error for cmd, got {msgs:?}"
+        );
+    }
+
+    #[test]
+    fn missing_required_driver_field_is_silent_when_driver_unresolved() {
+        // No driver selected → the driver's required fields are unknown, so no
+        // missing-required error for them (only the base `name` field is checked).
+        let msgs = messages("target(name = \"t\")\n");
+        assert!(
+            msgs.is_empty(),
+            "must not guess required driver fields without a driver, got {msgs:?}"
+        );
+    }
+
+    #[test]
+    fn missing_required_base_field_is_flagged() {
+        // `name` is always required, driver or not.
+        let msgs = messages("target(driver = \"exec\", cmd = \"echo hi\")\n");
+        assert!(
+            msgs.iter()
+                .any(|m| m.contains("missing required field `name`")),
+            "expected missing-required error for name, got {msgs:?}"
+        );
+    }
+
+    #[test]
+    fn missing_required_field_is_silent_with_kwargs_splat() {
+        // A `**kwargs`-style splat could supply `cmd` at runtime — stay silent.
+        let msgs = messages("target(name = \"t\", driver = \"exec\", **extra)\n");
+        assert!(
+            msgs.is_empty(),
+            "a splat argument must suppress the missing-required check, got {msgs:?}"
+        );
+    }
+
+    #[test]
+    fn missing_required_field_is_silent_with_args_splat() {
+        // A bare `*args` splat is the same shape as `**kwargs` here.
+        let msgs = messages("target(name = \"t\", driver = \"exec\", *extra)\n");
+        assert!(
+            msgs.is_empty(),
+            "a positional splat must also suppress the missing-required check, got {msgs:?}"
+        );
+    }
+
+    #[test]
+    fn missing_required_driver_field_is_silent_for_unknown_driver() {
+        // An unresolvable driver name is just as unknowable as no driver at
+        // all — the unknown-key check already stays silent here (see
+        // `unknown_target_field_is_silent_when_driver_unresolved`); the
+        // missing-required check must too.
+        let msgs = messages("target(name = \"t\", driver = \"nope\")\n");
+        assert!(
+            msgs.is_empty(),
+            "must not guess required fields for an unresolvable driver, got {msgs:?}"
+        );
+    }
+
+    #[test]
+    fn missing_required_field_on_shadowed_base_field_reports_once() {
+        // `shadow`'s required `name` field collides with the base `name`
+        // field; omitting `name` entirely must produce exactly one
+        // missing-required diagnostic for it, not one per source.
+        let msgs = messages("target(driver = \"shadow\")\n");
+        let name_msgs: Vec<_> = msgs
+            .iter()
+            .filter(|m| m.contains("missing required field `name`"))
+            .collect();
+        assert_eq!(
+            name_msgs.len(),
+            1,
+            "expected exactly one missing-required diagnostic for the shadowed field, got {msgs:?}"
+        );
+    }
+
+    #[test]
+    fn missing_required_field_on_multiline_call_anchors_on_callee_token() {
+        // The diagnostic must land on the `target` token (line 0), regardless
+        // of which line the call's arguments span.
+        let content = "target(\n    name = \"t\",\n    driver = \"exec\",\n)\n";
+        let ast = AstModule::parse("BUILD", content.to_string(), &Dialect::Extended).unwrap();
+        let diags = validate(&ast, &FakeEngine);
+        let d = diags
+            .iter()
+            .find(|d| d.message.contains("missing required field `cmd`"))
+            .expect("missing-cmd diagnostic");
+        assert_eq!(
+            d.range.start.line, 0,
+            "must anchor on the `target` token line"
+        );
+        assert_eq!(d.range.start.character, 0);
+        assert_eq!(d.range.end.character, "target".len() as u32);
+    }
+
+    #[test]
+    fn missing_required_field_fires_inside_list_comprehension() {
+        // The AST walk covers comprehension bodies, not just top-level calls.
+        let msgs = messages("y = [target(name = str(i), driver = \"exec\") for i in [1, 2]]\n");
+        assert!(
+            msgs.iter()
+                .any(|m| m.contains("missing required field `cmd`")),
+            "expected missing-required to fire inside a list comprehension, got {msgs:?}"
+        );
+    }
+
+    #[test]
+    fn provider_state_missing_provider_is_flagged() {
+        let msgs = messages("provider_state(bogus = 1)\n");
+        assert!(
+            msgs.iter()
+                .any(|m| m.contains("missing required field `provider`")),
+            "expected missing-required error for provider, got {msgs:?}"
+        );
+    }
+
+    #[test]
     fn diagnostic_range_targets_the_offending_token() {
         // The unknown-key squiggle must land on the key, not the whole call.
         let content = "target(name = \"t\", driver = \"exec\", bogus = 1)\n";
@@ -432,8 +643,11 @@ mod tests {
     #[test]
     fn list_with_non_literal_element_is_not_type_checked() {
         // labels accepts string | list[string]; a list containing a variable can't
-        // be fully typed, so it must be skipped rather than mis-flagged.
-        let msgs = messages("target(name = \"t\", driver = \"exec\", labels = [\"a\", X])\n");
+        // be fully typed, so it must be skipped rather than mis-flagged. `cmd` is
+        // supplied so this doesn't also trip the missing-required check.
+        let msgs = messages(
+            "target(name = \"t\", driver = \"exec\", cmd = \"echo hi\", labels = [\"a\", X])\n",
+        );
         assert!(
             msgs.is_empty(),
             "partial list must be skipped, got {msgs:?}"

--- a/crates/plugin-buildfile/src/pluginbuildfile/lsp/proxy.rs
+++ b/crates/plugin-buildfile/src/pluginbuildfile/lsp/proxy.rs
@@ -3,10 +3,16 @@
 //! untouched except `textDocument/hover` and `textDocument/completion`: those are
 //! forwarded too, but their responses are enriched on the way back with heph
 //! specifics the stock server can't know about —
-//! - hover gains a "Targets" block (the addresses produced by the
-//!   symbol under the cursor), and
-//! - completion gains the config fields of the target's `driver` (from the
-//!   driver's [`schema`](hplugin::driver::Driver::schema)).
+//! - hover gains a "Targets" block (the addresses produced by the symbol
+//!   under the cursor), plus, once a `target(...)` call's driver is resolved,
+//!   a section documenting that driver's config fields;
+//! - completion, at an exact syntactic position (a `heph.` namespace member, a
+//!   `driver = "…"` value, or a keyword-argument *key* inside
+//!   `target(...)`/`provider_state(...)`), replaces the stock server's
+//!   proposals with heph's own — exhaustive there, so the stock server's
+//!   generic globals/keywords would otherwise just be noise. On the *value*
+//!   side of a keyword argument (e.g. `cmd = SOME_VAR`), heph adds nothing and
+//!   the stock server's completions (locals, globals) pass through untouched.
 
 use super::index::SharedState;
 use crate::pluginbuildfile::run_file::resolve_load_target;
@@ -420,6 +426,28 @@ fn enrich_hover(
         md.push_str("```\n");
     }
 
+    // Once the target has been provided (its addresses resolved above) and the
+    // call site names a driver, append that driver's config-field docs — the
+    // same detail/doc a completion item for these keys would show. Without
+    // this, hovering a target only ever explained the base `target(...)`
+    // signature, never the driver-specific keys actually in play.
+    if !targets.is_empty()
+        && let Some(driver) = target_driver_at(&index.source, byte_offset(&index.source, line, col))
+            .filter(|d| !d.is_empty())
+        && let Some(schema) = shared.engine.driver_schema(&driver)
+        && !schema.fields.is_empty()
+    {
+        md.push_str(&format!("\n\n---\n\n**`{driver}` driver**\n\n"));
+        for f in &schema.fields {
+            let req = if f.required { " (required)" } else { "" };
+            md.push_str(&format!("- `{}`: {}{req}", f.name, f.ty.render()));
+            if !f.doc.is_empty() {
+                md.push_str(&format!(" — {}", f.doc));
+            }
+            md.push('\n');
+        }
+    }
+
     let hover = Hover {
         contents: HoverContents::Markup(MarkupContent {
             kind: MarkupKind::Markdown,
@@ -761,6 +789,55 @@ fn in_driver_value(prefix: &str) -> bool {
         .is_none_or(|ch| !ch.is_alphanumeric() && ch != '_')
 }
 
+/// Whether byte `offset` — inside the call whose argument list opens at `open`
+/// (the byte index of its `(`) — sits on the *value* side of a `key = value`
+/// pair (a bare `=` already typed since the nearest depth-0 comma), as opposed
+/// to the key-name side, where only a keyword-argument identifier is valid.
+/// Depth-aware: an `=` inside a nested call/list/dict/string (e.g. a default
+/// argument to a nested function, or a `{"a": "b"}` value) doesn't count.
+/// Schema-field key completion must not fire on the value side — that slot is
+/// already filled, and whatever the cursor is completing there (a local
+/// variable, a call) is the stock server's job, not ours.
+fn in_value_position(source: &str, open: usize, offset: usize) -> bool {
+    let b = source.as_bytes();
+    let offset = offset.min(b.len());
+    let mut i = open + 1;
+    let mut depth = 0i32;
+    let mut quote: Option<u8> = None;
+    let mut escaped = false;
+    let mut seg_has_eq = false;
+    while i < offset {
+        let Some(&c) = b.get(i) else { break };
+        if let Some(q) = quote {
+            if escaped {
+                escaped = false;
+            } else if c == b'\\' {
+                escaped = true;
+            } else if c == q {
+                quote = None;
+            }
+        } else {
+            match c {
+                b'"' | b'\'' => quote = Some(c),
+                b'(' | b'[' | b'{' => depth += 1,
+                b')' | b']' | b'}' => depth -= 1,
+                b',' if depth == 0 => seg_has_eq = false,
+                // A bare `=`, not part of `==`. `i` starts at `open + 1 >= 1`,
+                // so `i - 1` is always in bounds.
+                b'=' if depth == 0
+                    && b.get(i + 1) != Some(&b'=')
+                    && b.get(i - 1) != Some(&b'=') =>
+                {
+                    seg_has_eq = true;
+                }
+                _ => {}
+            }
+        }
+        i += 1;
+    }
+    seg_has_eq
+}
+
 /// Byte offset into `source` for a 0-based `(line, col)`, clamped to bounds. The
 /// column is treated as a byte column — BUILD structure (identifiers, `=`, parens)
 /// is ASCII, so this is exact at the positions we resolve.
@@ -1057,7 +1134,10 @@ fn enrich_completion(
             .collect()
     } else if in_string(prefix) {
         vec![]
-    } else if let Some(driver) = target_driver_at(&index.source, offset) {
+    } else if let Some(open) = innermost_call_open("target", &index.source, offset)
+        && !in_value_position(&index.source, open, offset)
+        && let Some(driver) = target_driver_at(&index.source, offset)
+    {
         let mut items: Vec<CompletionItem> = crate::pluginbuildfile::run_file::target_base_fields()
             .into_iter()
             .map(|f| field_item(&f.name, &f.ty.render(), f.doc, "target", f.required))
@@ -1073,8 +1153,9 @@ fn enrich_completion(
             );
         }
         items
-    } else if let Some(provider) =
-        provider_state_at(&index.source, offset).filter(|p| !p.is_empty())
+    } else if let Some(open) = innermost_call_open("provider_state", &index.source, offset)
+        && !in_value_position(&index.source, open, offset)
+        && let Some(provider) = provider_state_at(&index.source, offset).filter(|p| !p.is_empty())
     {
         shared
             .engine
@@ -1093,18 +1174,15 @@ fn enrich_completion(
         return;
     }
 
-    let mut items: Vec<CompletionItem> = match resp.result.take() {
-        Some(v) => match serde_json::from_value::<CompletionResponse>(v) {
-            Ok(CompletionResponse::Array(a)) => a,
-            Ok(CompletionResponse::List(l)) => l.items,
-            Err(_) => vec![],
-        },
-        None => vec![],
-    };
-    // Driver fields first, then whatever the stock server proposed.
-    let mut merged = extra;
-    merged.append(&mut items);
-    resp.result = Some(serde_json::to_value(CompletionResponse::Array(merged)).expect("serialize"));
+    // Every branch above is exhaustive for its syntactic position — a `heph.`
+    // member, a `driver = "…"` value, or a keyword-argument *key* inside
+    // `target(...)`/`provider_state(...)` (the `in_value_position` guard keeps
+    // this branch from firing on the *value* side, e.g. `cmd = M`, where a
+    // local variable is exactly what the stock server should offer) — so the
+    // stock server's proposals (its global/keyword completions, meaningless
+    // at a key position) are replaced rather than merged in. Merging used to
+    // bury the handful of valid keys under a pile of unrelated globals.
+    resp.result = Some(serde_json::to_value(CompletionResponse::Array(extra)).expect("serialize"));
     resp.error = None;
 }
 
@@ -1130,20 +1208,23 @@ mod tests {
         fn driver_schema(&self, name: &str) -> Option<hplugin::driver::DriverSchema> {
             use hcore::htvalue::signature::ParamType;
             use hplugin::driver::{DriverField, DriverSchema};
-            if name != "exec" {
-                return None;
+            match name {
+                "exec" => Some(DriverSchema {
+                    fields: vec![DriverField {
+                        name: "cmd".to_string(),
+                        ty: ParamType::String,
+                        doc: "Command line to run.".to_string(),
+                        required: true,
+                    }],
+                }),
+                // A driver with no config at all — `DriverSchema::default()`,
+                // the shape several real drivers use.
+                "bare" => Some(DriverSchema::default()),
+                _ => None,
             }
-            Some(DriverSchema {
-                fields: vec![DriverField {
-                    name: "cmd".to_string(),
-                    ty: ParamType::String,
-                    doc: "Command line to run.".to_string(),
-                    required: true,
-                }],
-            })
         }
         fn driver_names(&self) -> Vec<String> {
-            vec!["exec".to_string()]
+            vec!["exec".to_string(), "bare".to_string()]
         }
         fn provider_state_schema(&self, name: &str) -> Option<hplugin::provider::StateSchema> {
             use hcore::htvalue::signature::ParamType;
@@ -1300,6 +1381,59 @@ mod tests {
     }
 
     #[test]
+    fn completion_at_value_position_does_not_offer_schema_fields() {
+        // Cursor on a bare-identifier VALUE (`cmd = M`), not a key name —
+        // that slot is already filled, so schema-field completions must not
+        // apply here. Whatever the cursor is actually completing (a local
+        // variable, a call) is the stock server's job, not ours — offering
+        // our (exhaustive, stock-replacing) field list here would silently
+        // hide it.
+        let content = "target(name = \"t\", driver = \"exec\", cmd = M)\n";
+        let (shared, uri) = shared_with_index(content);
+        let col = content.find('M').unwrap() as u32 + 1;
+        let labels = completion_labels(&shared, &uri, 0, col);
+        assert!(
+            !labels.iter().any(|l| l == "cmd" || l == "name"),
+            "must not offer schema-field keys at a value position, got {labels:?}"
+        );
+    }
+
+    #[test]
+    fn completion_leaves_stock_items_untouched_when_nothing_heph_specific() {
+        // At a position where heph has nothing to add (a bare top-level spot),
+        // any stock completions already in the response must survive
+        // unmodified — the replace-instead-of-merge change must only kick in
+        // when `extra` is actually non-empty.
+        let content = "x = 1\n";
+        let (shared, uri) = shared_with_index(content);
+        let mut resp = lsp_server::Response {
+            id: 1.into(),
+            result: Some(
+                serde_json::to_value(lsp_types::CompletionResponse::Array(vec![
+                    lsp_types::CompletionItem {
+                        label: "stock_item".to_string(),
+                        ..Default::default()
+                    },
+                ]))
+                .unwrap(),
+            ),
+            error: None,
+        };
+        super::enrich_completion(&mut resp, &uri, 0, 0, &shared);
+        let value = resp.result.expect("result preserved");
+        let labels: Vec<String> =
+            match serde_json::from_value::<lsp_types::CompletionResponse>(value).unwrap() {
+                lsp_types::CompletionResponse::Array(items) => {
+                    items.into_iter().map(|i| i.label).collect()
+                }
+                lsp_types::CompletionResponse::List(l) => {
+                    l.items.into_iter().map(|i| i.label).collect()
+                }
+            };
+        assert_eq!(labels, vec!["stock_item".to_string()]);
+    }
+
+    #[test]
     fn completion_inside_provider_state_offers_state_fields() {
         // Cursor inside a fully-valid call, after the provider arg.
         let content = "provider_state(provider = \"go\", )\n";
@@ -1358,6 +1492,38 @@ mod tests {
         assert!(md.contains("name"), "names base arg: {md}");
         assert!(md.contains("**config"), "shows config kwargs: {md}");
         assert!(!md.contains("**kwargs"), "not the raw prototype: {md}");
+    }
+
+    #[test]
+    fn hover_on_target_shows_driver_field_docs_once_resolved() {
+        // Once the target has been provided (its address resolved) and its
+        // driver is known, hover should also explain the driver's config keys.
+        let content = "target(name = \"t\", driver = \"exec\")\n";
+        let (shared, uri) = shared_with_index(content);
+        let col = content.find(')').unwrap() as u32;
+        let md = hover_value(&shared, &uri, 0, col).expect("hover");
+        assert!(md.contains("`exec` driver"), "names the driver: {md}");
+        assert!(md.contains("cmd"), "shows the driver field: {md}");
+        assert!(
+            md.contains("Command line to run."),
+            "shows the field doc: {md}"
+        );
+    }
+
+    #[test]
+    fn hover_on_target_omits_driver_section_when_schema_has_no_fields() {
+        // A driver with no config at all (`DriverSchema::default()`, the
+        // shape several real drivers use) must not render an empty
+        // `**`bare` driver**` header with nothing under it.
+        let content = "target(name = \"t\", driver = \"bare\")\n";
+        let (shared, uri) = shared_with_index(content);
+        let col = content.find(')').unwrap() as u32;
+        let md = hover_value(&shared, &uri, 0, col);
+        let md = md.unwrap_or_default();
+        assert!(
+            !md.contains("driver**"),
+            "must not render a driver section for a schema with no fields: {md}"
+        );
     }
 
     #[test]


### PR DESCRIPTION
## Summary
- Diagnostics: red squiggle when a `target(...)`/`provider_state(...)` call has a resolved driver/provider but a required field (base, or driver/provider-schema) is missing a keyword arg. Silent when the driver/provider can't be resolved, or the call has a `*args`/`**kwargs` splat.
- Completion: at an exact syntactic position (`heph.` namespace members, `driver = "…"` values, a keyword-argument *key* inside `target(...)`/`provider_state(...)`), heph's completions now replace the stock `starlark_lsp` server's proposals instead of merging with them — cuts the unrelated global/keyword noise mixed into every key-position completion. A cursor on the *value* side of a keyword arg (e.g. `cmd = SOME_VAR`) is excluded, so stock local/global completions still pass through there.
- Hover: once a target's address resolves and its driver is known, hover also renders that driver's config-field docs (name/type/required/doc), not just the resolved target addresses.

## Test plan
- [x] `cargo test -p plugin-buildfile --lib pluginbuildfile::lsp::` — 51 passed, 0 failed
- [x] `cargo fmt --check -p plugin-buildfile`
- [x] `cargo clippy -p plugin-buildfile --all-targets -- -D warnings`
- [x] Reviewed by `code-quality` and `feature-quality` agents (both PASS after fixing a value-position completion regression they independently flagged)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011xkjkcMxUcLuCw1ZTGtJkm