### PR TITLE
perf(engine): parallelize cache_locally artifact writes; cache writers commit-on-success

### DIFF
--- a/crates/engine/src/engine/fanout.rs
+++ b/crates/engine/src/engine/fanout.rs
@@ -66,6 +66,11 @@ where
     }
     if errs.is_empty() {
         Ok(ok)
+    } else if errs.len() == 1 {
+        // A sole failure surfaces directly: wrapping it renders as
+        // "1 errors:\n  [0] …" mid-chain, and every downstream `MultiError`
+        // consumer treats a singleton exactly like the bare error anyway.
+        Err(errs.pop().expect("len checked"))
     } else {
         Err(MultiError(errs).into())
     }
@@ -106,6 +111,17 @@ mod tests {
         let rendered = format!("{multi}");
         assert!(rendered.contains("first"), "got: {rendered}");
         assert!(rendered.contains("second"), "got: {rendered}");
+    }
+
+    /// A sole failure comes back bare — not wrapped in a `MultiError` whose
+    /// Display ("1 errors:") is noise mid-chain for the most common case.
+    #[tokio::test]
+    async fn fail_fast_false_returns_a_sole_error_unwrapped() {
+        let futs: Vec<BoxFuture<'static, anyhow::Result<i32>>> =
+            vec![boxed(Ok(1)), boxed(Err(anyhow::anyhow!("only")))];
+        let err = join_all_failable(futs, false).await.unwrap_err();
+        assert!(err.downcast_ref::<MultiError>().is_none());
+        assert!(err.to_string().contains("only"));
     }
 
     #[tokio::test]

--- a/crates/engine/src/engine/gc.rs
+++ b/crates/engine/src/engine/gc.rs
@@ -940,7 +940,7 @@ mod tests {
     use super::*;
     use crate::engine::Config;
     use crate::engine::local_cache::{
-        Existence, LocalCache, MANIFEST_V1, Manifest, ManifestArtifact,
+        EntryWriter, Existence, LocalCache, MANIFEST_V1, Manifest, ManifestArtifact,
         ManifestArtifactContentType, ManifestArtifactEncoding, ManifestArtifactType, PendingWrite,
         SizedReader, TargetStream,
     };
@@ -1052,7 +1052,7 @@ mod tests {
             addr: &Addr,
             hashin: &str,
             name: &str,
-        ) -> anyhow::Result<Box<dyn std::io::Write>> {
+        ) -> anyhow::Result<Box<dyn EntryWriter>> {
             self.inner.writer(addr, hashin, name)
         }
         fn exists(&self, addr: &Addr, hashin: &str, name: &str) -> anyhow::Result<bool> {
@@ -1195,7 +1195,7 @@ mod tests {
                 .writer(addr, hashin, name)
                 .expect("writer");
             w.write_all(b"data").expect("write artifact");
-            drop(w);
+            w.commit().expect("commit artifact");
         }
         let manifest = Manifest {
             version: "1.0.0".to_string(),
@@ -1220,7 +1220,7 @@ mod tests {
             .writer(addr, hashin, MANIFEST_V1)
             .expect("manifest writer");
         borsh::to_writer(&mut w, &manifest).expect("write manifest");
-        drop(w);
+        w.commit().expect("commit manifest");
         // Barrier: ensure the write landed before callers enumerate.
         assert!(
             engine
@@ -1875,7 +1875,7 @@ mod tests {
                 .writer(&a, "h1", MANIFEST_V1)
                 .expect("writer");
             w.write_all(b"not a valid borsh manifest").expect("write");
-            drop(w);
+            w.commit().expect("commit");
         }
         write_revision(&engine, &a, "h2", 200, &["o.tar"]);
 
@@ -2168,7 +2168,7 @@ mod tests {
                 .writer(&bad, "h1", MANIFEST_V1)
                 .expect("writer");
             w.write_all(b"not a valid borsh manifest").expect("write");
-            drop(w);
+            w.commit().expect("commit");
             assert!(
                 engine
                     .local_cache
@@ -2207,7 +2207,7 @@ mod tests {
         {
             let mut w = engine.local_cache.writer(&a, "h1", name).expect("writer");
             w.write_all(&big).expect("write blob");
-            drop(w);
+            w.commit().expect("commit blob");
         }
         let manifest = Manifest {
             version: "1.0.0".to_string(),
@@ -2230,7 +2230,7 @@ mod tests {
                 .writer(&a, "h1", MANIFEST_V1)
                 .expect("manifest writer");
             borsh::to_writer(&mut w, &manifest).expect("write manifest");
-            drop(w);
+            w.commit().expect("commit manifest");
         }
         // Barrier + precondition: both the spilled blob and the manifest must
         // have landed before GC. `gc_all` enumerates targets via `list_targets`

--- a/crates/engine/src/engine/local_cache.rs
+++ b/crates/engine/src/engine/local_cache.rs
@@ -31,6 +31,12 @@ impl<W: io::Write> CountingWriter<W> {
     fn bytes_written(&self) -> u64 {
         self.count
     }
+
+    /// Hand back the wrapped writer, so a caller that finished a pack can
+    /// [`EntryWriter::commit`] it.
+    fn into_inner(self) -> W {
+        self.inner
+    }
 }
 
 impl<W: io::Write> io::Write for CountingWriter<W> {
@@ -180,9 +186,21 @@ pub enum Existence {
     Queued(PendingWrite),
 }
 
+/// A cache-entry writer. The entry becomes durable only on [`commit`](Self::commit);
+/// dropping without commit discards everything written. This is what keeps a
+/// mid-stream failure or an abandoned attempt from ever surfacing as (or
+/// replacing!) a readable entry: the blocking pool runs jobs to completion even
+/// when their awaiting future is dropped, so "the caller stopped" must never
+/// imply "the bytes landed".
+pub trait EntryWriter: io::Write + Send {
+    /// Make the entry durable. Consumes the writer; errors are the write's.
+    fn commit(self: Box<Self>) -> anyhow::Result<()>;
+}
+
 pub trait LocalCache: Send + Sync {
     fn reader(&self, addr: &Addr, hashin: &str, name: &str) -> anyhow::Result<SizedReader>;
-    fn writer(&self, addr: &Addr, hashin: &str, name: &str) -> anyhow::Result<Box<dyn io::Write>>;
+    fn writer(&self, addr: &Addr, hashin: &str, name: &str)
+    -> anyhow::Result<Box<dyn EntryWriter>>;
     fn exists(&self, addr: &Addr, hashin: &str, name: &str) -> anyhow::Result<bool>;
     /// [`exists`](Self::exists), minus the wait on the backend's write-behind
     /// queue — it reports the queue instead of blocking on it, so it is safe to
@@ -383,6 +401,46 @@ fn artifact_is_needed(a: &ManifestArtifact, outputs: &[String], support_needed: 
     }
 }
 
+/// Concurrent local pack jobs (tar/copy of one artifact into the cache).
+///
+/// Same convention as `CODEC_SLOTS` (remote gzip) and `PKG_EVAL_SLOTS`
+/// (Starlark eval): a class of hundreds-of-ms jobs on the shared, arrival-fair
+/// `hcore::blocking` pool caps itself at the core count so it cannot fill every
+/// pool thread and put the sub-millisecond jobs (warm-hit manifest reads) behind
+/// a queue of long ones. Before `cache_locally` fanned artifacts out this class
+/// was implicitly bounded at one job per running target; the fan-out multiplies
+/// that by artifacts-per-target, so the bound has to be explicit. It also caps
+/// concurrent spool memory, which is allocated inside the job.
+static LOCAL_PACK_SLOTS: std::sync::LazyLock<tokio::sync::Semaphore> =
+    std::sync::LazyLock::new(|| tokio::sync::Semaphore::new(local_pack_slots()));
+
+fn local_pack_slots() -> usize {
+    std::thread::available_parallelism()
+        .map(|p| p.get())
+        .unwrap_or(8)
+}
+
+/// The cache entry name an artifact's blob is stored under. One place, used by
+/// both the write arms and `cache_locally`'s duplicate check, so the two cannot
+/// drift.
+fn cache_entry_name(artifact: &outputartifact::OutputArtifact) -> String {
+    let type_prefix = match artifact.r#type {
+        outputartifact::Type::Output => "out",
+        outputartifact::Type::Log => "log",
+        outputartifact::Type::SupportFile => "support",
+    };
+    match &artifact.content {
+        // Packed on the way in, so the entry carries the container suffix.
+        outputartifact::Content::Raw(_) | outputartifact::Content::File(_) => {
+            format!("{}_{}.tar", type_prefix, artifact.name)
+        }
+        // Already a container on disk; copied verbatim.
+        outputartifact::Content::TarPath(_) | outputartifact::Content::CpioPath(_) => {
+            format!("{}_{}", type_prefix, artifact.name)
+        }
+    }
+}
+
 impl Engine {
     pub async fn cache_artifact_locally(
         &self,
@@ -393,6 +451,14 @@ impl Engine {
         artifact: &outputartifact::OutputArtifact,
     ) -> anyhow::Result<(CacheArtifact, ManifestArtifact)> {
         let hashin = hashin.to_string();
+        // Waited for in async-land, before queueing — parking a pool thread to
+        // wait for a pool thread is the deadlock. The permit rides *into* the
+        // job (released on the pool thread) so a caller that stops being polled
+        // cannot strand it; same discipline as `PKG_EVAL_SLOTS`.
+        let slot = LOCAL_PACK_SLOTS
+            .acquire()
+            .await
+            .context("acquiring a local pack slot")?;
         // Writing a revision tars and copies every output — the heaviest
         // synchronous work in a build, once per target. It runs on the dedicated
         // blocking pool: not inline (that parks a runtime worker with the runtime
@@ -401,19 +467,15 @@ impl Engine {
         // waker, observed to drop wakeups on macOS under load — see
         // the macOS waker hazard in `hproc::proc_exec`). See `hcore::blocking`.
         hcore::blocking::run(enclose!((cache => local_cache, addr, artifact) move || {
+            let _slot = slot;
             let open_writer =
-                |name: &str| -> anyhow::Result<Box<dyn io::Write>> {
+                |name: &str| -> anyhow::Result<Box<dyn EntryWriter>> {
                     local_cache.writer(&addr, &hashin, name)
                 };
-            let type_prefix = match artifact.r#type {
-                outputartifact::Type::Output => "out",
-                outputartifact::Type::Log => "log",
-                outputartifact::Type::SupportFile => "support",
-            };
+            let name = cache_entry_name(&artifact);
 
-            let (size, content_type, name) = match &artifact.content {
+            let (size, content_type) = match &artifact.content {
                 outputartifact::Content::Raw(raw) => {
-                    let name = format!("{}_{}.tar", type_prefix, artifact.name);
                     let mut cw = CountingWriter::new(
                         open_writer(&name).with_context(|| {
                             format!("open cache writer for {addr} {name}")
@@ -423,10 +485,13 @@ impl Engine {
                     p.create_raw(raw.data.clone(), raw.path.clone(), raw.x);
                     p.pack(&mut cw)
                         .with_context(|| format!("pack raw artifact into {addr} {name}"))?;
-                    (cw.bytes_written(), hartifactcontent::Type::Tar, name)
+                    let size = cw.bytes_written();
+                    cw.into_inner().commit().with_context(|| {
+                        format!("commit raw artifact {addr} {name}")
+                    })?;
+                    (size, hartifactcontent::Type::Tar)
                 }
                 outputartifact::Content::File(file) => {
-                    let name = format!("{}_{}.tar", type_prefix, artifact.name);
                     let mut cw = CountingWriter::new(
                         open_writer(&name).with_context(|| {
                             format!("open cache writer for {addr} {name}")
@@ -440,10 +505,13 @@ impl Engine {
                             file.source_path
                         )
                     })?;
-                    (cw.bytes_written(), hartifactcontent::Type::Tar, name)
+                    let size = cw.bytes_written();
+                    cw.into_inner().commit().with_context(|| {
+                        format!("commit file artifact {addr} {name}")
+                    })?;
+                    (size, hartifactcontent::Type::Tar)
                 }
                 outputartifact::Content::TarPath(path) => {
-                    let name = format!("{}_{}", type_prefix, artifact.name);
                     let mut f = File::open(path)
                         .with_context(|| format!("open tar artifact {path}"))?;
                     let size = f
@@ -455,10 +523,12 @@ impl Engine {
                     io::copy(&mut f, &mut w).with_context(|| {
                         format!("copy tar artifact {path} into {addr} {name}")
                     })?;
-                    (size, hartifactcontent::Type::Tar, name)
+                    w.commit().with_context(|| {
+                        format!("commit tar artifact {addr} {name}")
+                    })?;
+                    (size, hartifactcontent::Type::Tar)
                 }
                 outputartifact::Content::CpioPath(path) => {
-                    let name = format!("{}_{}", type_prefix, artifact.name);
                     let mut f = File::open(path)
                         .with_context(|| format!("open cpio artifact {path}"))?;
                     let size = f
@@ -470,7 +540,10 @@ impl Engine {
                     io::copy(&mut f, &mut w).with_context(|| {
                         format!("copy cpio artifact {path} into {addr} {name}")
                     })?;
-                    (size, hartifactcontent::Type::Cpio, name)
+                    w.commit().with_context(|| {
+                        format!("commit cpio artifact {addr} {name}")
+                    })?;
+                    (size, hartifactcontent::Type::Cpio)
                 }
             };
 
@@ -518,8 +591,24 @@ impl Engine {
         artifacts: Vec<outputartifact::OutputArtifact>,
         tmp: bool,
     ) -> anyhow::Result<Vec<CacheArtifact>> {
-        let mut res_artifacts = Vec::with_capacity(artifacts.len());
-        let mut manifest_artifacts = Vec::with_capacity(artifacts.len());
+        // Two artifacts mapping to one cache entry name used to resolve
+        // deterministically (sequential loop — last one won); under the
+        // concurrent fan-out the winner would be pool scheduling, i.e. the
+        // committed bytes would vary run to run under a manifest that lists
+        // both. A colliding name is a driver bug either way — reject it before
+        // writing anything.
+        {
+            let mut seen = std::collections::HashSet::with_capacity(artifacts.len());
+            for artifact in &artifacts {
+                let name = cache_entry_name(artifact);
+                if !seen.insert(name.clone()) {
+                    anyhow::bail!(
+                        "duplicate cache entry name `{name}` among the artifacts of {addr}: \
+                         artifact names must be unique per (type, name) within a target"
+                    );
+                }
+            }
+        }
 
         let key = if tmp {
             let nanos = time::SystemTime::now()
@@ -542,15 +631,36 @@ impl Engine {
             &self.local_cache
         };
 
-        for artifact in artifacts {
-            let artifact_name = artifact.name.clone();
-            let (cached_artifact, manifest_artifact) = self
-                .cache_artifact_locally(ctoken, cache, addr, &key, &artifact)
-                .await
-                .with_context(|| format!("cache artifact {artifact_name} for {addr}"))?;
-            res_artifacts.push(cached_artifact);
-            manifest_artifacts.push(manifest_artifact);
-        }
+        // All artifacts in flight at once, not one at a time: each write is a
+        // whole tar/copy on the blocking pool, so a multi-output target was
+        // paying its writes back to back while the pool sat idle. Order is
+        // preserved (join over an ordered iterator), so the manifest's artifact
+        // list stays equal to the input order regardless of which write finishes
+        // first — the manifest must not become a function of pool scheduling.
+        //
+        // Wait-all, **never fail-fast**: a `hcore::blocking` job runs to
+        // completion even when its awaiting future is dropped, so a fail-fast
+        // join would return an error while sibling tar jobs are still *reading
+        // the sandbox* — racing the sandbox cleanup that execute runs right
+        // after cache_locally errors. Driving every write to completion keeps
+        // "no artifact job outlives this call" for every *polled-to-completion*
+        // call, and reports every failure rather than the first. Dropping this
+        // future mid-join still detaches up to a pack-slot's worth of submitted
+        // jobs — that is inherent to the pool's run-to-completion contract, and
+        // it is safe because an uncommitted `EntryWriter` discards on drop: a
+        // detached straggler can neither surface a partial blob nor replace a
+        // retry's good one.
+        let key_ref = &key;
+        let written = crate::engine::fanout::join_all_failable(
+            artifacts.iter().map(|artifact| async move {
+                self.cache_artifact_locally(ctoken, cache, addr, key_ref, artifact)
+                    .await
+                    .with_context(|| format!("cache artifact {} for {addr}", artifact.name))
+            }),
+            false,
+        )
+        .await?;
+        let (res_artifacts, manifest_artifacts): (Vec<_>, Vec<_>) = written.into_iter().unzip();
 
         let manifest = Manifest {
             version: "1.0.0".to_string(),
@@ -560,11 +670,27 @@ impl Engine {
             artifacts: manifest_artifacts,
         };
 
+        // Manifest strictly last — it is the revision's commit record, so a
+        // reader that finds it finds every artifact it names, or degrades to a
+        // miss (same invariant as the remote cache's manifest-last upload). The
+        // one exemption: the sqlite writer thread batches transactions, and a
+        // failed *earlier* batch completes its slots and moves on — {manifest
+        // committed, blob absent} is reachable there, and is exactly the state a
+        // remote-mirrored revision starts in; the residency probe
+        // (`missing_local_blobs`) covers both by degrading the hit to a miss.
+        // Written only when every artifact write above succeeded, and written
+        // inline: it lands in the sqlite cache's spooled writer (a memcpy plus a
+        // channel send to the writer thread), so queueing it behind the blocking
+        // pool's tar jobs would only delay the moment dependents can read this
+        // result.
         let mut manifest_writer = cache
             .writer(addr, &key, MANIFEST_V1)
             .with_context(|| format!("open manifest writer for {addr}"))?;
         borsh::to_writer(&mut manifest_writer, &manifest)
             .with_context(|| format!("write manifest for {addr}"))?;
+        manifest_writer
+            .commit()
+            .with_context(|| format!("commit manifest for {addr}"))?;
 
         // Remote push happens on a background task driven from the execute path
         // (see `Engine::spawn_remote_upload`), not here — it must not block the
@@ -654,6 +780,9 @@ impl Engine {
             io::copy(&mut reader, &mut writer).with_context(|| {
                 format!("copy blob {} for {addr} into {dst_key}", artifact.name)
             })?;
+            writer.commit().with_context(|| {
+                format!("commit blob {} for {addr} into {dst_key}", artifact.name)
+            })?;
         }
 
         // Stamp the duplicate with a freshly-sampled, strictly-newer timestamp.
@@ -678,6 +807,9 @@ impl Engine {
             .with_context(|| format!("open manifest writer for {addr} {dst_key}"))?;
         borsh::to_writer(&mut manifest_writer, &dup_manifest)
             .with_context(|| format!("write manifest for {addr} {dst_key}"))?;
+        manifest_writer
+            .commit()
+            .with_context(|| format!("commit manifest for {addr} {dst_key}"))?;
 
         Ok(())
     }
@@ -1318,6 +1450,297 @@ mod tests {
         removed
     }
 
+    /// The artifact writes fan out concurrently, so two properties that were
+    /// implicit in the old sequential loop have to be pinned: the manifest's
+    /// artifact list keeps the *input* order (not completion order — the
+    /// manifest must not become a function of pool scheduling), and every
+    /// artifact a manifest names is readable once the manifest is.
+    #[tokio::test]
+    async fn multi_artifact_revision_keeps_input_order() {
+        let (engine, _dir) = test_engine();
+        let ctoken = StdCancellationToken::new();
+        let addr = test_addr();
+
+        // Enough artifacts to actually overlap on the pool, with sizes varied
+        // so completion order differs from input order.
+        let artifacts: Vec<_> = (0..16)
+            .map(|i| {
+                let payload = vec![b'x'; if i % 2 == 0 { 512 * 1024 } else { 8 }];
+                raw_artifact(&format!("a{i:02}"), &payload)
+            })
+            .collect();
+        engine
+            .cache_locally(&ctoken, &addr, "HASHIN_ORDER", artifacts, false)
+            .await
+            .expect("cache_locally");
+
+        let manifest = engine
+            .read_manifest(&addr, "HASHIN_ORDER")
+            .expect("read manifest")
+            .expect("manifest present");
+        let names: Vec<_> = manifest.artifacts.iter().map(|a| a.name.as_str()).collect();
+        let expected: Vec<_> = (0..16).map(|i| format!("out_a{i:02}.tar")).collect();
+        assert_eq!(
+            names,
+            expected.iter().map(String::as_str).collect::<Vec<_>>()
+        );
+    }
+
+    /// Manifest-last, the strong form: the manifest writer must not even be
+    /// *opened* until every artifact's writer has been dropped (write complete).
+    /// This is the test that reddens if the manifest write is ever folded into
+    /// the artifact fan-out.
+    #[tokio::test]
+    async fn manifest_opens_only_after_every_artifact_write_completes() {
+        let (mut engine, _dir) = test_engine();
+        let ctoken = StdCancellationToken::new();
+        let addr = test_addr();
+
+        #[derive(Default)]
+        struct Log {
+            events: std::sync::Mutex<Vec<(String, &'static str)>>,
+        }
+        let log = Arc::new(Log::default());
+        engine.local_cache = Arc::new(
+            crate::engine::local_cache_test_double::ForwardingCache::new(Arc::clone(
+                &engine.local_cache,
+            ))
+            .on_writer(enclose!((log) move |_, _, name| {
+                log.events.lock().unwrap().push((name.to_string(), "open"));
+            }))
+            .on_writer_done(enclose!((log) move |_, _, name| {
+                log.events.lock().unwrap().push((name.to_string(), "done"));
+            })),
+        );
+
+        let artifacts: Vec<_> = (0..8)
+            .map(|i| raw_artifact(&format!("a{i}"), &vec![b'x'; 256 * 1024]))
+            .collect();
+        engine
+            .cache_locally(&ctoken, &addr, "HASHIN_LAST", artifacts, false)
+            .await
+            .expect("cache_locally");
+
+        let events = log.events.lock().unwrap();
+        let manifest_open = events
+            .iter()
+            .position(|(name, ev)| name == MANIFEST_V1 && *ev == "open")
+            .expect("manifest opened");
+        let artifact_dones = events
+            .iter()
+            .enumerate()
+            .filter(|(_, (name, ev))| name != MANIFEST_V1 && *ev == "done")
+            .map(|(i, _)| i)
+            .collect::<Vec<_>>();
+        assert_eq!(artifact_dones.len(), 8, "events: {events:?}");
+        assert!(
+            artifact_dones.iter().all(|&i| i < manifest_open),
+            "manifest opened before an artifact write finished: {events:?}"
+        );
+    }
+
+    /// Wait-all fan-out: when several artifact writes fail, every failure is
+    /// reported — not just the first. The behavior change from the old
+    /// stop-at-first loop is deliberate and user-visible, so freeze it.
+    #[tokio::test]
+    async fn all_failing_artifacts_are_reported() {
+        let (engine, _dir) = test_engine();
+        let ctoken = StdCancellationToken::new();
+        let addr = test_addr();
+
+        let missing = |name: &str| outputartifact::OutputArtifact {
+            group: "out".to_string(),
+            name: name.to_string(),
+            r#type: outputartifact::Type::Output,
+            content: outputartifact::Content::TarPath(format!("/nonexistent/heph-{name}")),
+            hashout: format!("hashout-{name}"),
+        };
+        let Err(err) = engine
+            .cache_locally(
+                &ctoken,
+                &addr,
+                "HASHIN_MULTIFAIL",
+                vec![
+                    missing("first"),
+                    raw_artifact("ok", b"fine"),
+                    missing("second"),
+                ],
+                false,
+            )
+            .await
+        else {
+            panic!("missing tar paths must fail the write");
+        };
+        let rendered = format!("{err:#}");
+        assert!(rendered.contains("first"), "got: {rendered}");
+        assert!(rendered.contains("second"), "got: {rendered}");
+    }
+
+    /// The pack cap gates the path to the blocking pool: with every slot held,
+    /// an artifact write must not reach the cache writer; releasing the slots
+    /// lets it through. (Borrows a process-wide semaphore, so it briefly delays
+    /// any concurrently-running test that writes to a cache.)
+    #[tokio::test]
+    async fn artifact_write_waits_for_a_pack_slot() {
+        let (engine, _dir) = test_engine();
+        let ctoken = StdCancellationToken::new();
+        let addr = test_addr();
+
+        // The full capacity, not `available_permits()`: a snapshot of what is
+        // free right now races other tests' in-flight writes — one of them
+        // returning its permit after the snapshot hands this test's gated write
+        // a free slot and flakes the assertion. `acquire_many(capacity)` instead
+        // waits for every straggler and then genuinely holds the whole class.
+        let held = LOCAL_PACK_SLOTS
+            .acquire_many(u32::try_from(local_pack_slots()).unwrap())
+            .await
+            .expect("hold every pack slot");
+
+        let write = engine.cache_locally(
+            &ctoken,
+            &addr,
+            "HASHIN_SLOT",
+            vec![raw_artifact("gated", b"payload")],
+            false,
+        );
+        tokio::pin!(write);
+        assert!(
+            tokio::time::timeout(std::time::Duration::from_millis(250), &mut write)
+                .await
+                .is_err(),
+            "a write must not reach the pool while every pack slot is held",
+        );
+
+        drop(held);
+        tokio::time::timeout(std::time::Duration::from_secs(30), write)
+            .await
+            .expect("releasing the slots must let the write through")
+            .expect("cache_locally");
+    }
+
+    /// Two artifacts that map to the same cache entry name must be rejected up
+    /// front: under the concurrent fan-out the committed bytes would otherwise
+    /// depend on pool scheduling.
+    #[tokio::test]
+    async fn duplicate_entry_names_are_rejected_before_any_write() {
+        let (engine, _dir) = test_engine();
+        let ctoken = StdCancellationToken::new();
+        let addr = test_addr();
+
+        let Err(err) = engine
+            .cache_locally(
+                &ctoken,
+                &addr,
+                "HASHIN_DUP",
+                vec![raw_artifact("same", b"a"), raw_artifact("same", b"b")],
+                false,
+            )
+            .await
+        else {
+            panic!("duplicate entry names must fail");
+        };
+        assert!(format!("{err:#}").contains("same"), "got: {err:#}");
+        assert!(
+            engine
+                .read_manifest(&addr, "HASHIN_DUP")
+                .expect("read manifest")
+                .is_none(),
+            "nothing may be committed for a rejected revision"
+        );
+    }
+
+    /// An empty artifact set still commits a manifest (an empty revision is a
+    /// valid, readable result), unchanged by the fan-out.
+    #[tokio::test]
+    async fn empty_artifact_set_still_commits_a_manifest() {
+        let (engine, _dir) = test_engine();
+        let ctoken = StdCancellationToken::new();
+        let addr = test_addr();
+        engine
+            .cache_locally(&ctoken, &addr, "HASHIN_EMPTY", vec![], false)
+            .await
+            .expect("cache_locally");
+        let manifest = engine
+            .read_manifest(&addr, "HASHIN_EMPTY")
+            .expect("read manifest")
+            .expect("manifest present");
+        assert!(manifest.artifacts.is_empty());
+    }
+
+    /// Dropping `cache_locally` mid-fan-out must not wedge anything: already
+    /// submitted pool jobs finish on their own, and a subsequent write of the
+    /// same revision succeeds.
+    #[tokio::test]
+    async fn dropping_cache_locally_mid_write_leaves_the_engine_usable() {
+        let (engine, _dir) = test_engine();
+        let ctoken = StdCancellationToken::new();
+        let addr = test_addr();
+
+        let artifacts: Vec<_> = (0..8)
+            .map(|i| raw_artifact(&format!("a{i}"), &vec![b'x'; 512 * 1024]))
+            .collect();
+        {
+            let write =
+                engine.cache_locally(&ctoken, &addr, "HASHIN_DROP", artifacts.clone(), false);
+            tokio::pin!(write);
+            // Poll it exactly once to start the fan-out, then drop it.
+            let _ = futures::poll!(&mut write);
+        }
+
+        engine
+            .cache_locally(&ctoken, &addr, "HASHIN_DROP", artifacts, false)
+            .await
+            .expect("a fresh write after an abandoned one must succeed");
+        assert!(
+            engine
+                .read_manifest(&addr, "HASHIN_DROP")
+                .expect("read manifest")
+                .is_some()
+        );
+    }
+
+    /// Manifest-last: a failed artifact write must error out of `cache_locally`
+    /// with *no* manifest committed — a reader that finds a manifest must find
+    /// every artifact it names, so an incomplete revision has to stay invisible.
+    #[tokio::test]
+    async fn failed_artifact_write_commits_no_manifest() {
+        let (engine, _dir) = test_engine();
+        let ctoken = StdCancellationToken::new();
+        let addr = test_addr();
+
+        let missing = outputartifact::OutputArtifact {
+            group: "out".to_string(),
+            name: "gone".to_string(),
+            r#type: outputartifact::Type::Output,
+            content: outputartifact::Content::TarPath("/nonexistent/heph-test-tar".to_string()),
+            hashout: "hashout-gone".to_string(),
+        };
+        let Err(err) = engine
+            .cache_locally(
+                &ctoken,
+                &addr,
+                "HASHIN_FAIL",
+                vec![raw_artifact("ok", b"fine"), missing],
+                false,
+            )
+            .await
+        else {
+            panic!("missing tar path must fail the write");
+        };
+        assert!(
+            format!("{err:#}").contains("gone"),
+            "error names the artifact: {err:#}"
+        );
+
+        assert!(
+            engine
+                .read_manifest(&addr, "HASHIN_FAIL")
+                .expect("read manifest")
+                .is_none(),
+            "a failed revision must not commit a manifest"
+        );
+    }
+
     fn test_addr() -> Addr {
         Addr::new(PkgBuf::from("pkg"), "tgt".to_string(), BTreeMap::new())
     }
@@ -1455,7 +1878,7 @@ mod tests {
         fn reader(&self, _: &Addr, _: &str, _: &str) -> anyhow::Result<SizedReader> {
             Err(anyhow::anyhow!(NotFoundError))
         }
-        fn writer(&self, _: &Addr, _: &str, _: &str) -> anyhow::Result<Box<dyn io::Write>> {
+        fn writer(&self, _: &Addr, _: &str, _: &str) -> anyhow::Result<Box<dyn EntryWriter>> {
             unreachable!("the probe path never writes")
         }
         fn exists(&self, _: &Addr, _: &str, _: &str) -> anyhow::Result<bool> {

--- a/crates/engine/src/engine/local_cache_fs.rs
+++ b/crates/engine/src/engine/local_cache_fs.rs
@@ -1,5 +1,6 @@
 use crate::engine::local_cache::{
-    Existence, LocalCache, MANIFEST_V1, Manifest, NotFoundError, SizedReader, TargetStream,
+    EntryWriter, Existence, LocalCache, MANIFEST_V1, Manifest, NotFoundError, SizedReader,
+    TargetStream,
 };
 use anyhow::{Context, Result};
 use hcore::hartifactcontent;
@@ -39,15 +40,16 @@ impl LocalCacheFS {
 }
 
 /// Staging writer behind [`LocalCacheFS::writer`]: bytes land in a temp file that
-/// is renamed over the final path when the writer is dropped, so the blob appears
-/// atomically. A write error (or a failed final flush) drops the temp instead,
-/// leaving whatever was already at the destination untouched rather than
-/// replacing it with a truncated blob.
+/// is renamed over the final path on [`EntryWriter::commit`], so the blob appears
+/// atomically. Dropping without commit — a write error, an abandoned attempt —
+/// deletes the temp instead, leaving whatever was already at the destination
+/// untouched rather than replacing it with a truncated blob.
 struct AtomicFileWriter {
     file: Option<fs::File>,
     temp: PathBuf,
     dest: PathBuf,
     failed: bool,
+    committed: bool,
 }
 
 impl io::Write for AtomicFileWriter {
@@ -74,15 +76,37 @@ impl io::Write for AtomicFileWriter {
     }
 }
 
+impl EntryWriter for AtomicFileWriter {
+    fn commit(mut self: Box<Self>) -> anyhow::Result<()> {
+        anyhow::ensure!(
+            !self.failed,
+            "cannot commit cache file {:?}: an earlier write failed",
+            self.dest
+        );
+        let mut file = self
+            .file
+            .take()
+            .with_context(|| format!("cache writer for {:?} already finalized", self.dest))?;
+        file.flush()
+            .with_context(|| format!("flush cache file {:?}", self.temp))?;
+        drop(file);
+        fs::rename(&self.temp, &self.dest)
+            .with_context(|| format!("rename cache file {:?} into place", self.dest))?;
+        // The temp no longer exists; tell Drop there is nothing to discard.
+        self.committed = true;
+        Ok(())
+    }
+}
+
 impl Drop for AtomicFileWriter {
     fn drop(&mut self) {
-        let flushed = match self.file.take() {
-            Some(mut file) => file.flush().is_ok(),
-            None => false,
-        };
-        if self.failed || !flushed || fs::rename(&self.temp, &self.dest).is_err() {
-            drop(fs::remove_file(&self.temp));
+        if self.committed {
+            return;
         }
+        // Dropped without commit (or commit failed part-way): discard the temp.
+        // The destination keeps whatever complete blob it already had.
+        drop(self.file.take());
+        drop(fs::remove_file(&self.temp));
     }
 }
 
@@ -108,8 +132,7 @@ impl LocalCache for LocalCacheFS {
         })
     }
 
-    /// Write to a sibling temp file and rename it into place once the writer is
-    /// dropped.
+    /// Write to a sibling temp file and rename it into place on commit.
     ///
     /// The rename makes a blob appear atomically: a concurrent reader either sees
     /// the previous complete file or the new one, never a truncated write in
@@ -118,7 +141,7 @@ impl LocalCache for LocalCacheFS {
     /// materializes into an entry other callers are already reading. Both writers
     /// store the same content-addressed bytes, so whichever rename lands last is
     /// equally correct.
-    fn writer(&self, addr: &Addr, hashin: &str, name: &str) -> Result<Box<dyn io::Write>> {
+    fn writer(&self, addr: &Addr, hashin: &str, name: &str) -> Result<Box<dyn EntryWriter>> {
         let path = self.get_path(addr, hashin, name);
         if let Some(parent) = path.parent() {
             fs::create_dir_all(parent)
@@ -136,6 +159,7 @@ impl LocalCache for LocalCacheFS {
             temp,
             dest: path,
             failed: false,
+            committed: false,
         }))
     }
 
@@ -334,7 +358,7 @@ mod tests {
         // Test writer
         let mut writer = cache.writer(&addr, hashin, name)?;
         writer.write_all(b"hello cache")?;
-        drop(writer);
+        writer.commit()?;
 
         // Test existence
         assert!(cache.exists(&addr, hashin, name)?);
@@ -378,7 +402,7 @@ mod tests {
 
         let mut w = cache.writer(&addr, "h", "out.tar")?;
         w.write_all(b"bytes")?;
-        drop(w);
+        w.commit()?;
 
         let path = cache
             .file_path(&addr, "h", "out.tar")
@@ -413,7 +437,7 @@ mod tests {
             };
             let mut w = cache.writer(&addr, h, MANIFEST_V1)?;
             borsh::to_writer(&mut w, &manifest)?;
-            drop(w);
+            w.commit()?;
         }
 
         // One distinct target, recovered from the manifest's `target` field.
@@ -439,7 +463,7 @@ mod tests {
         );
         let mut w = cache.writer(&addr, "h", "blob")?;
         w.write_all(b"0123456789abcdef")?;
-        drop(w);
+        w.commit()?;
 
         let mut r = cache
             .seekable_reader(&addr, "h", "blob")?

--- a/crates/engine/src/engine/local_cache_mem.rs
+++ b/crates/engine/src/engine/local_cache_mem.rs
@@ -1,4 +1,4 @@
-use crate::engine::local_cache::{Existence, LocalCache, SizedReader, TargetStream};
+use crate::engine::local_cache::{EntryWriter, Existence, LocalCache, SizedReader, TargetStream};
 use anyhow::{Context, Result};
 use hcore::hartifactcontent;
 use hmodel::htaddr::Addr;
@@ -83,11 +83,12 @@ impl LocalCache for LocalCacheMem {
         })
     }
 
-    fn writer(&self, addr: &Addr, hashin: &str, name: &str) -> Result<Box<dyn io::Write>> {
+    fn writer(&self, addr: &Addr, hashin: &str, name: &str) -> Result<Box<dyn EntryWriter>> {
         let key = Self::key(addr, hashin, name);
-        // Invalidate before forwarding. A reader arriving after this point misses the mem
-        // cache and falls through to the inner backend, which is responsible for its own
-        // read-after-write ordering (e.g. LocalCacheSQLite's PendingTracker).
+        // Invalidate before forwarding, at open rather than at commit. A reader
+        // arriving after this point misses the mem cache and falls through to the
+        // inner backend, which is responsible for its own read-after-write
+        // ordering (e.g. LocalCacheSQLite's PendingTracker).
         self.cache.remove(&key);
         self.inner.writer(addr, hashin, name)
     }
@@ -229,11 +230,12 @@ mod tests {
         }
     }
 
-    impl Drop for VecWriter {
-        fn drop(&mut self) {
+    impl EntryWriter for VecWriter {
+        fn commit(mut self: Box<Self>) -> Result<()> {
             self.store
                 .lock()
                 .insert(self.key.clone(), std::mem::take(&mut self.buf));
+            Ok(())
         }
     }
 
@@ -255,7 +257,7 @@ mod tests {
             }
         }
 
-        fn writer(&self, addr: &Addr, hashin: &str, name: &str) -> Result<Box<dyn io::Write>> {
+        fn writer(&self, addr: &Addr, hashin: &str, name: &str) -> Result<Box<dyn EntryWriter>> {
             self.writer_calls.fetch_add(1, Ordering::Relaxed);
             let key = CountingCache::key(addr, hashin, name);
             Ok(Box::new(VecWriter {
@@ -321,7 +323,7 @@ mod tests {
     fn write_blob(cache: &dyn LocalCache, addr: &Addr, name: &str, data: &[u8]) {
         let mut w = cache.writer(addr, "h1", name).expect("writer");
         w.write_all(data).expect("write");
-        drop(w);
+        w.commit().expect("commit");
     }
 
     /// This tier sits at the top of the cacheable stack, so a method left to the
@@ -465,7 +467,7 @@ mod tests {
                 bytes: Some(self.arc.clone()),
             })
         }
-        fn writer(&self, _: &Addr, _: &str, _: &str) -> Result<Box<dyn io::Write>> {
+        fn writer(&self, _: &Addr, _: &str, _: &str) -> Result<Box<dyn EntryWriter>> {
             unreachable!()
         }
         fn exists(&self, _: &Addr, _: &str, _: &str) -> Result<bool> {

--- a/crates/engine/src/engine/local_cache_spill.rs
+++ b/crates/engine/src/engine/local_cache_spill.rs
@@ -43,7 +43,7 @@
 //! ephemeral tmp store, not this one.
 
 use crate::engine::local_cache::{
-    Existence, LocalCache, MANIFEST_V1, NotFoundError, SizedReader, TargetStream,
+    EntryWriter, Existence, LocalCache, MANIFEST_V1, NotFoundError, SizedReader, TargetStream,
 };
 use crate::engine::local_cache_fs::LocalCacheFS;
 use anyhow::{Context, Result};
@@ -89,7 +89,7 @@ impl LocalCache for LocalCacheSpill {
         }
     }
 
-    fn writer(&self, addr: &Addr, hashin: &str, name: &str) -> Result<Box<dyn io::Write>> {
+    fn writer(&self, addr: &Addr, hashin: &str, name: &str) -> Result<Box<dyn EntryWriter>> {
         // The manifest is the GC index — keep it in the primary unconditionally.
         if Self::is_manifest(name) {
             return self.primary.writer(addr, hashin, name);
@@ -242,9 +242,9 @@ struct SpillWriter {
     /// Bytes written so far, used only to detect the threshold crossing.
     size: usize,
     /// Open until the blob spills; `None` afterwards.
-    primary_writer: Option<Box<dyn io::Write>>,
+    primary_writer: Option<Box<dyn EntryWriter>>,
     /// `Some` once spilled; further writes stream directly into it.
-    blob_writer: Option<Box<dyn io::Write>>,
+    blob_writer: Option<Box<dyn EntryWriter>>,
 }
 
 impl SpillWriter {
@@ -252,15 +252,16 @@ impl SpillWriter {
     /// prefix, copy it into a fresh FS writer, drop it from the primary, and
     /// retain the FS writer for the remaining bytes.
     fn spill(&mut self) -> io::Result<()> {
-        // Commit the staged prefix to the primary so it can be read back. The
-        // sqlite writer persists on drop; its PendingTracker makes the following
+        // Commit the staged prefix to the primary so it can be read back — the
+        // one mid-stream commit in the protocol, and it is deleted again below
+        // once copied. The sqlite writer's PendingTracker makes the following
         // reader/delete wait for that write to land.
         let mut pw = self
             .primary_writer
             .take()
             .expect("spill called without an open primary writer");
         pw.flush()?;
-        drop(pw);
+        pw.commit().map_err(io::Error::other)?;
 
         let mut blob_writer = self
             .blobs
@@ -316,17 +317,25 @@ impl io::Write for SpillWriter {
     }
 }
 
-impl Drop for SpillWriter {
-    fn drop(&mut self) {
-        // Whichever backend writer is open owns the bytes; flushing + dropping it
-        // persists the blob (the sqlite writer commits on drop, the FS file is
-        // already on disk). Nothing is staged in `self`, so there is no
-        // finalize-time write that could fail here.
-        if let Some(mut w) = self.blob_writer.take() {
-            drop(w.flush());
-        } else if let Some(mut w) = self.primary_writer.take() {
-            drop(w.flush());
-        }
+impl EntryWriter for SpillWriter {
+    fn commit(mut self: Box<Self>) -> Result<()> {
+        // Whichever backend writer is open owns the bytes; committing it makes
+        // the blob durable in its final home. Nothing is staged in `self`.
+        // Dropped without commit, that same writer discards its staging — an
+        // abandoned blob lands in neither backend.
+        let (w, backend) = match (self.blob_writer.take(), self.primary_writer.take()) {
+            (Some(w), _) => (w, "spilled"),
+            (None, Some(w)) => (w, "primary"),
+            // `spill` always leaves exactly one backend writer open, and commit
+            // consumes `self` — so this is unreachable short of a logic bug.
+            (None, None) => anyhow::bail!(
+                "spill writer for {} {} has no open backend writer to commit",
+                self.addr,
+                self.name
+            ),
+        };
+        w.commit()
+            .with_context(|| format!("commit {backend} blob {} for {}", self.name, self.addr))
     }
 }
 
@@ -371,7 +380,7 @@ mod tests {
     fn write(cache: &dyn LocalCache, a: &Addr, name: &str, data: &[u8]) {
         let mut w = cache.writer(a, "h", name).expect("writer");
         w.write_all(data).expect("write");
-        drop(w);
+        w.commit().expect("commit");
     }
 
     fn read(cache: &dyn LocalCache, a: &Addr, name: &str) -> Vec<u8> {
@@ -531,7 +540,7 @@ mod tests {
         for _ in 0..20 {
             w.write_all(&[7u8; 10]).expect("chunk"); // 200 bytes total
         }
-        drop(w);
+        w.commit().expect("commit");
 
         assert!(
             fs.exists(&a, "h", "blob").expect("ex"),

--- a/crates/engine/src/engine/local_cache_sqlite.rs
+++ b/crates/engine/src/engine/local_cache_sqlite.rs
@@ -1,5 +1,5 @@
 use crate::engine::local_cache::{
-    Existence, LocalCache, NotFoundError, PendingWrite, SizedReader, TargetStream,
+    EntryWriter, Existence, LocalCache, NotFoundError, PendingWrite, SizedReader, TargetStream,
 };
 use anyhow::{Context, Result};
 use hcore::hartifactcontent;
@@ -794,11 +794,13 @@ impl LocalCache for LocalCacheSQLite {
         })
     }
 
-    fn writer(&self, addr: &Addr, hashin: &str, name: &str) -> Result<Box<dyn io::Write>> {
+    fn writer(&self, addr: &Addr, hashin: &str, name: &str) -> Result<Box<dyn EntryWriter>> {
         // No pending registration here: the key becomes pending when the finished
-        // spool is *queued*, in `SqliteCacheWriter::drop`. Registering at open
+        // spool is *queued*, in `SqliteCacheWriter::commit`. Registering at open
         // would make every reader of the key wait out the caller's whole
-        // streaming write — see `PendingTracker::register_and_send`.
+        // streaming write — see `PendingTracker::register_and_send`. A writer
+        // dropped without commit therefore strands no waiter: nothing was ever
+        // registered for it.
         Ok(Box::new(SqliteCacheWriter {
             writer_tx: self.writer_tx()?.clone(),
             pending: self.pending.clone(),
@@ -1028,27 +1030,25 @@ impl io::Write for SqliteCacheWriter {
     }
 }
 
-impl Drop for SqliteCacheWriter {
-    fn drop(&mut self) {
+impl EntryWriter for SqliteCacheWriter {
+    fn commit(mut self: Box<Self>) -> Result<()> {
         let (Some(key), Some(buf)) = (self.key.take(), self.buf.take()) else {
-            return;
+            // `commit` consumes the writer, so the fields can only be gone if a
+            // previous commit already took them.
+            anyhow::bail!("sqlite cache writer already committed");
         };
 
-        let Ok(size) = i64::try_from(self.size) else {
-            // Pathological size. Nothing was ever registered for this key — that
-            // now happens at enqueue — so dropping the write strands no waiter.
-            tracing::error!(
-                addr = key.0,
-                hashin = key.1,
-                name = key.2,
-                size = self.size,
-                "sqlite cache write is too large to address; dropping it"
-            );
-            return;
-        };
+        let size = i64::try_from(self.size).with_context(|| {
+            format!(
+                "sqlite cache write of {}/{}/{} is too large to address ({} bytes)",
+                key.0, key.1, key.2, self.size
+            )
+        })?;
 
-        if self
-            .pending
+        // The key becomes pending here, at enqueue — see `writer` for why not at
+        // open. From this point `exists`/`reader` wait for the writer thread's
+        // batch commit rather than answering from stale committed state.
+        self.pending
             .register_and_send(&self.writer_tx, key, move |key, slot| {
                 WriterCmd::Write(WriteJob {
                     key,
@@ -1057,13 +1057,29 @@ impl Drop for SqliteCacheWriter {
                     slot,
                 })
             })
-            .is_none()
-        {
-            // Writer thread is gone; the registration was rolled back inside
-            // `register_and_send`, so readers fall through to the DB and observe
-            // NotFound rather than waiting for a commit that will never come.
-            tracing::error!("sqlite cache writer thread is gone; write dropped");
-        }
+            // The registration was rolled back inside `register_and_send`, so
+            // readers fall through to the DB and observe NotFound rather than
+            // waiting for a commit that will never come.
+            .context("queueing a cache write: sqlite writer thread is gone")?;
+        Ok(())
+    }
+}
+
+impl Drop for SqliteCacheWriter {
+    fn drop(&mut self) {
+        // Dropped without commit: discard the spool. Nothing was registered for
+        // this key (that happens at enqueue, in `commit`), so no waiter is
+        // stranded — the entry simply never existed.
+        let (Some(key), Some(buf)) = (self.key.take(), self.buf.take()) else {
+            return;
+        };
+        drop(buf);
+        tracing::debug!(
+            addr = key.0,
+            hashin = key.1,
+            name = key.2,
+            "uncommitted sqlite cache write discarded"
+        );
     }
 }
 
@@ -1182,7 +1198,7 @@ mod tests {
         for i in 0..HELD_PIPES {
             let mut w = cache.writer(addr, "h", &format!("blob{i}"))?;
             w.write_all(&payload)?;
-            drop(w);
+            w.commit()?;
         }
         (0..HELD_PIPES)
             .map(|i| cache.reader(addr, "h", &format!("blob{i}")))
@@ -1283,7 +1299,7 @@ mod tests {
         let addr = make_addr("pkg", "t");
         let mut w = cache.writer(&addr, "h", "blob")?;
         w.write_all(&vec![7u8; 4 * 1024 * 1024])?;
-        drop(w);
+        w.commit()?;
         let _held = cache.reader(&addr, "h", "blob")?;
 
         let err = cache
@@ -1315,7 +1331,7 @@ mod tests {
 
         let mut writer = cache.writer(&addr, hashin, name)?;
         writer.write_all(b"hello sqlite cache")?;
-        drop(writer);
+        writer.commit()?;
 
         assert!(cache.exists(&addr, hashin, name)?);
 
@@ -1370,8 +1386,8 @@ mod tests {
             "an unfinished write has no committed bytes, so the key is absent"
         );
 
-        // And once queued, the wait is back on: the committed value is visible.
-        drop(writer);
+        // And once committed (queued), the wait is back on: the value is visible.
+        writer.commit()?;
         assert!(cache.exists(&addr, "h", "blob")?);
         Ok(())
     }
@@ -1553,7 +1569,7 @@ mod tests {
     fn queued_write(cache: &LocalCacheSQLite, addr: &Addr, name: &str, bytes: &[u8]) {
         let mut w = cache.writer(addr, "h", name).expect("writer");
         w.write_all(bytes).expect("write");
-        drop(w);
+        w.commit().expect("commit");
     }
 
     fn committed(e: Existence) -> bool {
@@ -1909,9 +1925,9 @@ mod tests {
         let mut second = cache.writer(&addr, "h", "blob")?;
         second.write_all(b"second")?;
 
-        // Reverse of the open order, so last-opened != last-enqueued.
-        drop(second);
-        drop(first);
+        // Committed in reverse of the open order, so last-opened != last-enqueued.
+        second.commit()?;
+        first.commit()?;
         cache.gate.open();
 
         let mut got = String::new();
@@ -1995,7 +2011,7 @@ mod tests {
         let payload: Vec<u8> = (0..1024u16).map(|i| (i & 0xff) as u8).collect();
         let mut w = cache.writer(&addr, "h", "blob")?;
         w.write_all(&payload)?;
-        drop(w);
+        w.commit()?;
 
         let mut r = cache
             .seekable_reader(&addr, "h", "blob")?
@@ -2046,7 +2062,7 @@ mod tests {
 
         let mut writer = cache.writer(&addr, hashin, name)?;
         writer.write_all(b"concurrent read data")?;
-        drop(writer);
+        writer.commit()?;
 
         let handles: Vec<_> = (0..4)
             .map(|_| {
@@ -2081,7 +2097,7 @@ mod tests {
         for (addr, h) in [(&a, "h1"), (&a, "h2"), (&b, "h9")] {
             let mut w = cache.writer(addr, h, "out.tar")?;
             w.write_all(b"x")?;
-            drop(w);
+            w.commit()?;
             assert!(cache.exists(addr, h, "out.tar")?); // barrier
         }
 
@@ -2100,8 +2116,8 @@ mod tests {
     fn test_local_cache_sqlite_read_after_pending_write() -> Result<()> {
         use std::sync::Arc;
 
-        // Reader started before the writer Drop returns from enqueue must still observe
-        // the write once it lands. This exercises the PendingTracker wait path.
+        // Reader started before the writer's commit returns from enqueue must still
+        // observe the write once it lands. This exercises the PendingTracker wait path.
         let dir = tempdir()?;
         let cache = Arc::new(LocalCacheSQLite::with_pipe_limit(
             dir.path().join("cache.db"),
@@ -2115,9 +2131,9 @@ mod tests {
         for i in 0..16 {
             let mut writer = cache.writer(&addr, hashin, name)?;
             writer.write_all(format!("iter-{i}").as_bytes())?;
-            drop(writer);
+            writer.commit()?;
 
-            // Right after drop, the write is enqueued but may not be persisted yet.
+            // Right after commit, the write is enqueued but may not be persisted yet.
             // exists() must wait until the bg thread completes the slot.
             assert!(cache.exists(&addr, hashin, name)?);
 
@@ -2127,6 +2143,84 @@ mod tests {
             assert_eq!(got, format!("iter-{i}"));
         }
 
+        Ok(())
+    }
+
+    /// The commit-on-success contract at the backend that had the hole: a writer
+    /// dropped without commit leaves no trace — not a readable entry, not a
+    /// queued write — and does not poison the key for a later attempt.
+    #[test]
+    fn dropped_writer_commits_nothing() -> Result<()> {
+        let dir = tempdir()?;
+        let cache = LocalCacheSQLite::with_pipe_limit(
+            dir.path().join("cache.db"),
+            16 * 1024,
+            DEFAULT_MAX_CONCURRENT_PIPES,
+        )?;
+        let addr = make_addr("pkg", "abandoned");
+
+        let mut w = cache.writer(&addr, "h", "blob")?;
+        w.write_all(b"partial bytes")?;
+        drop(w);
+
+        assert!(
+            !cache.exists(&addr, "h", "blob")?,
+            "an uncommitted write must not surface as a readable entry"
+        );
+        let err = match cache.reader(&addr, "h", "blob") {
+            Ok(_) => panic!("reader must not find an uncommitted write"),
+            Err(e) => e,
+        };
+        assert!(err.is::<NotFoundError>(), "{err:#}");
+
+        // A fresh writer for the same key, committed this time, is readable with
+        // the new bytes only.
+        let mut w = cache.writer(&addr, "h", "blob")?;
+        w.write_all(b"committed bytes")?;
+        w.commit()?;
+        let mut got = String::new();
+        cache
+            .reader(&addr, "h", "blob")?
+            .reader
+            .read_to_string(&mut got)?;
+        assert_eq!(got, "committed bytes");
+        Ok(())
+    }
+
+    /// The poisoning schedule that motivated commit-on-success: a
+    /// `hcore::blocking` pack job runs to completion even when its awaiting
+    /// future is dropped, so a job that errors mid-tar abandons its writer with
+    /// a partial spool. Under commit-on-drop that partial spool was enqueued and
+    /// *replaced* the good entry under the same key; it must be discarded.
+    #[test]
+    fn mid_stream_failure_cannot_replace_a_good_entry() -> Result<()> {
+        let dir = tempdir()?;
+        let cache = LocalCacheSQLite::with_pipe_limit(
+            dir.path().join("cache.db"),
+            16 * 1024,
+            DEFAULT_MAX_CONCURRENT_PIPES,
+        )?;
+        let addr = make_addr("pkg", "poisoned");
+
+        let mut w = cache.writer(&addr, "h", "blob")?;
+        w.write_all(b"good bytes")?;
+        w.commit()?;
+        assert!(cache.exists(&addr, "h", "blob")?); // barrier
+
+        // A rewrite of the same key fails mid-stream and is abandoned.
+        let mut second = cache.writer(&addr, "h", "blob")?;
+        second.write_all(b"par")?;
+        drop(second);
+
+        let mut got = String::new();
+        cache
+            .reader(&addr, "h", "blob")?
+            .reader
+            .read_to_string(&mut got)?;
+        assert_eq!(
+            got, "good bytes",
+            "an abandoned rewrite must not replace the committed entry"
+        );
         Ok(())
     }
 }

--- a/crates/engine/src/engine/local_cache_test_double.rs
+++ b/crates/engine/src/engine/local_cache_test_double.rs
@@ -14,7 +14,7 @@
 //! Add another `on_*` hook here, not another struct, if a test needs to watch
 //! a different call.
 
-use crate::engine::local_cache::{Existence, LocalCache, SizedReader, TargetStream};
+use crate::engine::local_cache::{EntryWriter, Existence, LocalCache, SizedReader, TargetStream};
 use hmodel::htaddr::Addr;
 use std::io;
 use std::path::PathBuf;
@@ -23,12 +23,15 @@ use std::sync::Arc;
 type ReaderHook = Box<dyn Fn(&Addr, &str, &str) + Send + Sync>;
 type ExistsHook = Box<dyn Fn(&Addr, &str, &str) + Send + Sync>;
 type ListTargetEntriesHook = Box<dyn Fn(&Addr) + Send + Sync>;
+type WriterHook = Arc<dyn Fn(&Addr, &str, &str) + Send + Sync>;
 
 pub(crate) struct ForwardingCache {
     inner: Arc<dyn LocalCache>,
     on_reader: ReaderHook,
     on_exists: ExistsHook,
     on_list_target_entries: ListTargetEntriesHook,
+    on_writer: WriterHook,
+    on_writer_done: Option<WriterHook>,
 }
 
 impl ForwardingCache {
@@ -38,6 +41,8 @@ impl ForwardingCache {
             on_reader: Box::new(|_, _, _| {}),
             on_exists: Box::new(|_, _, _| {}),
             on_list_target_entries: Box::new(|_| {}),
+            on_writer: Arc::new(|_, _, _| {}),
+            on_writer_done: None,
         }
     }
 
@@ -70,6 +75,76 @@ impl ForwardingCache {
         self.on_list_target_entries = Box::new(f);
         self
     }
+
+    /// Run `f` when a `writer` is opened, then forward regardless of what it
+    /// does.
+    pub(crate) fn on_writer(
+        mut self,
+        f: impl Fn(&Addr, &str, &str) + Send + Sync + 'static,
+    ) -> Self {
+        self.on_writer = Arc::new(f);
+        self
+    }
+
+    /// Run `f` when a writer handed out by `writer` is finished with — committed,
+    /// or dropped uncommitted — i.e. when that write has *completed*, not merely
+    /// started. Lets ordering tests assert "B opened only after A finished"
+    /// rather than the weaker "after A opened". The hook also fires when a write
+    /// is abandoned on an error path, after the inner writer has discarded it.
+    pub(crate) fn on_writer_done(
+        mut self,
+        f: impl Fn(&Addr, &str, &str) + Send + Sync + 'static,
+    ) -> Self {
+        self.on_writer_done = Some(Arc::new(f));
+        self
+    }
+}
+
+/// Forwards writes; fires the `on_writer_done` hook exactly once, when the write
+/// finishes — on commit, or on drop for an abandoned write. Either way the inner
+/// writer is finalized (committed or discarded) *before* the hook runs, so a
+/// hook that probes the cache observes the write's final state.
+struct DoneWriter {
+    inner: Option<Box<dyn EntryWriter>>,
+    done: Option<Box<dyn FnOnce() + Send>>,
+}
+
+impl io::Write for DoneWriter {
+    fn write(&mut self, buf: &[u8]) -> io::Result<usize> {
+        match self.inner.as_mut() {
+            Some(w) => w.write(buf),
+            None => Err(io::Error::other("writer already finalized")),
+        }
+    }
+    fn flush(&mut self) -> io::Result<()> {
+        match self.inner.as_mut() {
+            Some(w) => w.flush(),
+            None => Ok(()),
+        }
+    }
+}
+
+impl EntryWriter for DoneWriter {
+    fn commit(mut self: Box<Self>) -> anyhow::Result<()> {
+        let res = match self.inner.take() {
+            Some(w) => w.commit(),
+            None => Ok(()),
+        };
+        if let Some(done) = self.done.take() {
+            done();
+        }
+        res
+    }
+}
+
+impl Drop for DoneWriter {
+    fn drop(&mut self) {
+        // Discard the inner writer before signaling done — see the type doc.
+        drop(self.inner.take());
+        if let Some(done) = self.done.take() {
+            done();
+        }
+    }
 }
 
 impl LocalCache for ForwardingCache {
@@ -78,8 +153,25 @@ impl LocalCache for ForwardingCache {
         self.inner.reader(addr, hashin, name)
     }
 
-    fn writer(&self, addr: &Addr, hashin: &str, name: &str) -> anyhow::Result<Box<dyn io::Write>> {
-        self.inner.writer(addr, hashin, name)
+    fn writer(
+        &self,
+        addr: &Addr,
+        hashin: &str,
+        name: &str,
+    ) -> anyhow::Result<Box<dyn EntryWriter>> {
+        (self.on_writer)(addr, hashin, name);
+        let inner = self.inner.writer(addr, hashin, name)?;
+        Ok(match &self.on_writer_done {
+            Some(done) => {
+                let done = Arc::clone(done);
+                let (addr, hashin, name) = (addr.clone(), hashin.to_string(), name.to_string());
+                Box::new(DoneWriter {
+                    inner: Some(inner),
+                    done: Some(Box::new(move || done(&addr, &hashin, &name))),
+                })
+            }
+            None => inner,
+        })
     }
 
     fn exists(&self, addr: &Addr, hashin: &str, name: &str) -> anyhow::Result<bool> {
@@ -176,7 +268,7 @@ mod tests {
 
         let mut w = cache.writer(&a, "h", "out").expect("writer");
         w.write_all(b"data").expect("write");
-        drop(w);
+        w.commit().expect("commit");
 
         assert_eq!(
             reader_calls.load(Ordering::SeqCst),

--- a/crates/engine/src/engine/local_cache_tmp.rs
+++ b/crates/engine/src/engine/local_cache_tmp.rs
@@ -20,8 +20,8 @@
 //! run, so it grows by at most one entry per uncacheable target (within the
 //! capacity budget) and is reclaimed when the process exits.
 
-use crate::engine::local_cache::{Existence, LocalCache, SizedReader, TargetStream};
-use anyhow::Result;
+use crate::engine::local_cache::{EntryWriter, Existence, LocalCache, SizedReader, TargetStream};
+use anyhow::{Context, Result};
 use hcore::hartifactcontent;
 use hmodel::htaddr::Addr;
 use parking_lot::RwLock;
@@ -107,7 +107,7 @@ impl LocalCache for LocalCacheTmp {
         self.durable.reader(addr, hashin, name)
     }
 
-    fn writer(&self, addr: &Addr, hashin: &str, name: &str) -> Result<Box<dyn io::Write>> {
+    fn writer(&self, addr: &Addr, hashin: &str, name: &str) -> Result<Box<dyn EntryWriter>> {
         let key = Self::key(addr, hashin, name);
         // Drop any stale value before the write lands (tmp keys are unique, so
         // this is belt-and-suspenders for repeated writes of the same key).
@@ -215,23 +215,25 @@ impl LocalCache for LocalCacheTmp {
     }
 }
 
-/// Writer that buffers in memory and publishes on drop. It spills to the durable
-/// cache when the stream exceeds the per-entry cap, or (on drop) when admitting
-/// the buffered entry would exceed the capacity budget.
+/// Writer that buffers in memory and publishes on commit. It spills to the
+/// durable cache when the stream exceeds the per-entry cap, or (on commit) when
+/// admitting the buffered entry would exceed the capacity budget. Dropped
+/// without commit, the buffer is discarded — and a spilled stream's durable
+/// writer discards with it, so an abandoned write never lands anywhere.
 struct TmpWriter {
     key: Key,
     addr: Addr,
     hashin: String,
     name: String,
     buf: Vec<u8>,
-    spilled: Option<Box<dyn io::Write>>,
+    spilled: Option<Box<dyn EntryWriter>>,
     durable: Arc<dyn LocalCache>,
     store: Arc<Store>,
 }
 
 impl TmpWriter {
     /// Open the durable writer and flush the buffered bytes into it.
-    fn begin_spill(&mut self) -> io::Result<&mut Box<dyn io::Write>> {
+    fn begin_spill(&mut self) -> io::Result<&mut Box<dyn EntryWriter>> {
         let mut w = self
             .durable
             .writer(&self.addr, &self.hashin, &self.name)
@@ -265,25 +267,35 @@ impl io::Write for TmpWriter {
     }
 }
 
-impl Drop for TmpWriter {
-    fn drop(&mut self) {
-        // Spilled entries are finalized by the durable writer's own Drop.
-        if self.spilled.is_some() {
-            return;
+impl EntryWriter for TmpWriter {
+    fn commit(mut self: Box<Self>) -> Result<()> {
+        // A spilled stream's bytes live in the durable writer; committing it is
+        // committing the entry.
+        if let Some(w) = self.spilled.take() {
+            return w
+                .commit()
+                .with_context(|| format!("commit spilled tmp cache entry {}", self.name));
         }
         let len = self.buf.len() as u64;
         if self.store.try_reserve(len) {
             let arc: Arc<[u8]> = Arc::from(std::mem::take(&mut self.buf));
             self.store.map.write().insert(self.key.clone(), arc);
-        } else if let Ok(mut w) = self.durable.writer(&self.addr, &self.hashin, &self.name) {
-            // Over the capacity budget: spill to durable instead of mem. Nothing
-            // actionable on a write error inside Drop; surface it and move on.
-            if let Err(e) = w.write_all(&self.buf) {
-                tracing::error!(error = %e, "tmp cache spill-on-drop write failed");
-            }
+            return Ok(());
         }
+        // Over the capacity budget: spill to durable instead of mem.
+        let mut w = self
+            .durable
+            .writer(&self.addr, &self.hashin, &self.name)
+            .with_context(|| format!("open durable writer for tmp cache entry {}", self.name))?;
+        w.write_all(&self.buf)
+            .with_context(|| format!("spill tmp cache entry {} to durable", self.name))?;
+        w.commit()
+            .with_context(|| format!("commit spilled tmp cache entry {}", self.name))
     }
 }
+
+// No Drop impl: dropped without commit, the buffer is simply discarded, and a
+// spilled stream's durable writer discards its own staging on drop too.
 
 #[cfg(test)]
 mod tests {
@@ -315,11 +327,12 @@ mod tests {
             Ok(())
         }
     }
-    impl Drop for RecordingWriter {
-        fn drop(&mut self) {
+    impl EntryWriter for RecordingWriter {
+        fn commit(mut self: Box<Self>) -> Result<()> {
             self.store
                 .write()
                 .insert(self.key.clone(), Arc::from(std::mem::take(&mut self.buf)));
+            Ok(())
         }
     }
 
@@ -335,7 +348,7 @@ mod tests {
                 None => Err(anyhow::anyhow!(NotFoundError)),
             }
         }
-        fn writer(&self, addr: &Addr, hashin: &str, name: &str) -> Result<Box<dyn io::Write>> {
+        fn writer(&self, addr: &Addr, hashin: &str, name: &str) -> Result<Box<dyn EntryWriter>> {
             Ok(Box::new(RecordingWriter {
                 key: (addr.format(), hashin.to_string(), name.to_string()),
                 buf: Vec::new(),
@@ -377,7 +390,7 @@ mod tests {
     fn write_all(cache: &dyn LocalCache, a: &Addr, h: &str, n: &str, bytes: &[u8]) {
         let mut w = cache.writer(a, h, n).expect("writer");
         w.write_all(bytes).expect("write");
-        drop(w);
+        w.commit().expect("commit");
     }
 
     fn read_all(cache: &dyn LocalCache, a: &Addr, h: &str, n: &str) -> Vec<u8> {

--- a/crates/engine/src/engine/remote_cache.rs
+++ b/crates/engine/src/engine/remote_cache.rs
@@ -1834,6 +1834,7 @@ impl Engine {
                 .writer(&addr_owned, &hashin_owned, MANIFEST_V1)
                 .context("open local writer for remote manifest")?;
             w.write_all(&bytes).context("write remote manifest")?;
+            w.commit().context("commit remote manifest")?;
             anyhow::Ok(())
         })
         .await
@@ -1891,9 +1892,9 @@ impl Engine {
     /// The [`TempBlob`] is handed **into** the decode closure rather than held
     /// here. Once [`run_codec`] has queued the job it runs whatever the caller
     /// does, so a guard left on this side would unlink the temp out from under a
-    /// decode that is about to read it — and the local-cache writer publishes
-    /// what it has when dropped, so that loses the race by writing an empty blob
-    /// over a manifest that already claims the artifact is present.
+    /// decode that is about to read it — turning a served blob into a spurious
+    /// decode failure. (The local-cache writer commits only on success, so the
+    /// failed decode at least discards rather than publishing a truncated blob.)
     async fn pull_remote_blob(
         &self,
         ctoken: &dyn Cancellable,
@@ -1940,6 +1941,8 @@ impl Engine {
                 _ => copy_file_to(temp.path(), &mut w)
                     .with_context(|| format!("write downloaded blob {name_owned}"))?,
             }
+            w.commit()
+                .with_context(|| format!("commit downloaded blob {name_owned}"))?;
             Ok(())
         })
         .await

--- a/crates/engine/src/engine/request_state.rs
+++ b/crates/engine/src/engine/request_state.rs
@@ -1084,7 +1084,7 @@ mod tests {
                 .writer(&a, hashin, crate::engine::local_cache::MANIFEST_V1)
                 .expect("manifest writer");
             std::io::Write::write_all(&mut w, b"x").expect("write");
-            drop(w);
+            w.commit().expect("commit");
             assert!(
                 engine
                     .local_cache


### PR DESCRIPTION
Part of the concurrency-architecture review follow-ups (see #298 for the measurement groundwork).

## What

**1. `cache_locally` fans a target's artifact writes out concurrently.** Previously sequential per artifact — a multi-output target (go compile + vetx facts, oci multi-group) paid its tar/copy writes back to back while the blocking pool sat idle. Now: wait-all join (`join_all_failable(fail_fast=false)`), input-order-preserving (the manifest's artifact list must not become a function of pool scheduling), every failure reported. Bounded by a new `LOCAL_PACK_SLOTS` semaphore at the core count — the same per-class convention as `CODEC_SLOTS`/`PKG_EVAL_SLOTS`, permit riding into the pool job. Manifest write stays inline and strictly after the join.

Wait-all rather than fail-fast is load-bearing: `hcore::blocking` jobs run to completion after their awaiting future is dropped, so a fail-fast join would return while sibling tars still read the sandbox — racing the cleanup that execute runs on the failed-cache-write path.

**2. `LocalCache` writers become commit-on-success (`EntryWriter`).** The hermeticity consult on this diff found a real poisoning window in the previous commit-on-drop protocol: a detached pool job erroring mid-tar drops its writer, the sqlite writer queued the *partial* spool anyway, and FIFO scheduling can land it **after** a retry's good write of the same key — `INSERT OR REPLACE` then serves a truncated blob under a manifest-covered entry forever, and the remote upload propagates it. The fan-out widened that window from one straggler to a pack-slot's worth, so this PR closes the class: durability now requires an explicit `commit()`, drop-without-commit discards (sqlite: spool dropped, pending registration unchanged at enqueue-time so no waiter strands; fs: temp deleted instead of renamed; tmp: buffer dropped; spill: forwards, with the promotion prefix as the one documented mid-stream commit).

**3. Review nits:** duplicate cache entry names within one target's artifacts are rejected before any write (the concurrent winner would otherwise be pool scheduling); `join_all_failable` returns a sole failure bare instead of a one-element `MultiError` ("1 errors:" mid-chain).

## Review board

- **feature-quality** (design): shaped wait-all + core-count cap + manifest-stays-inline (offloading the manifest borsh write was rejected as a pessimization — it is a spooled memcpy + channel send, and the result lock is held across this path).
- **hermeticity** (review): NOT HERMETIC verdict on the fan-out over commit-on-drop writers — resolved by the `EntryWriter` protocol; duplicate-name MAJOR and manifest-comment MINOR applied.
- **code-quality** (review): PASS WITH NITS, applied (unzip, singleton `MultiError`, test-double drop ordering).

## Tests

New: input-order manifest determinism; manifest opens only after every artifact write completes (writer-done hooks on the test double); failed artifact ⇒ no manifest; all failures reported; pack-slot gating; empty-set manifest; drop-mid-fan-out leaves engine usable; duplicate names rejected; `dropped_writer_commits_nothing`; `mid_stream_failure_cannot_replace_a_good_entry` (the poisoning schedule); singleton fanout error unwrapped.

Full `tst` green locally (writer-protocol change = caching blast radius). `lint` clean.

## Perf

Tier A serial bench (this host, 1000-target bash corpus): cold +4.8%, full-hit +5.3% — both well inside noise thresholds (14.5% / 26.3%); the corpus has 1–2 artifacts per target so the parallel win doesn't show there. Read path untouched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014wDi9n2Fi1aN6jwy8ET7WG