### PR TITLE
feat(plugin-sdk,plugin-stabby): spawn plugin and host bodies at the ABI seam, symmetrically

### DIFF
--- a/crates/bin-e2e/tests/plugin_dylib.rs
+++ b/crates/bin-e2e/tests/plugin_dylib.rs
@@ -80,6 +80,65 @@ fn shipped_gha_cdylib_loads() {
     );
 }
 
+/// The spawn-at-the-seam host mirror, across a REAL cdylib: the go provider's
+/// `list` calls back into the engine executor (`states_under`, the module
+/// variant universe) from a plugin-runtime worker. In-process tests
+/// structurally cannot cover this — host and plugin share one tokio image
+/// there, so the callback body always finds a runtime to run on. Here the
+/// callback future is built by the host binary and polled by the plugin's own
+/// workers: exactly the asymmetry that panics ("no reactor running") and then
+/// aborts at the extern seam if the host side does not spawn the body onto the
+/// engine runtime.
+///
+/// The fixture mirrors plugingo-e2e's `variant_sibling`: the `release` variant
+/// is declared ONLY at `//cmd`, so it is absent from `//lib`'s ancestry and
+/// `//lib:build_lib@v=release` can be listed only if the module universe came
+/// back through the `states_under` callback — the assertion cannot pass
+/// vacuously. `gotool: host` + query-only keeps the fixture offline: listing
+/// runs no toolchain.
+#[test]
+fn shipped_go_cdylib_list_calls_back_states_under_across_the_seam() {
+    let dist = Dist::locate();
+    let ws = Workspace::new().expect("workspace");
+    let dylib = dist.plugin("go");
+    assert!(dylib.is_file(), "missing {}", dylib.display());
+
+    let manifest = ws.root().join("heph-go-plugin.json");
+    let sum = sha256_file(&dylib).expect("hash go cdylib");
+    write_manifest(&manifest, "go", &dylib, Some(&sum)).expect("write manifest");
+
+    ws.config(&format!(
+        "{BASE_CONFIG}  - path: {}\n    options:\n      gotool: \"host\"\n",
+        manifest.display()
+    ))
+    .expect("write config");
+
+    ws.write("go.mod", "module example.com/seam\n\ngo 1.21\n")
+        .expect("write go.mod");
+    ws.write(
+        "lib/lib.go",
+        "package lib\n\nfunc Greet() string { return \"hi\" }\n",
+    )
+    .expect("write lib.go");
+    ws.write("cmd/main.go", "package main\n\nfunc main() {}\n")
+        .expect("write main.go");
+    ws.write(
+        "cmd/BUILD",
+        "provider_state(\n    provider = \"go\",\n    variants = {\"release\": {\"goos\": \"linux\", \"goarch\": \"amd64\"}},\n)\n",
+    )
+    .expect("write BUILD");
+
+    let out = ws.run(&dist, &["query", "-e", "//lib/..."]).expect("run");
+    assert!(out.status.success(), "{}", describe(&out));
+    let stdout = String::from_utf8_lossy(&out.stdout);
+    assert!(
+        stdout.contains("//lib:build_lib@v=release"),
+        "the sibling-declared variant must come back through the plugin's \
+         states_under callback across the seam: {}",
+        describe(&out)
+    );
+}
+
 /// Regression test for the log-sink-before-`create` ordering bug: if the host
 /// installs its log sink *after* calling the plugin's `create`, a
 /// `tracing::error!` logged during construction failure has no subscriber to

--- a/crates/core/src/hasync/cancellable_std.rs
+++ b/crates/core/src/hasync/cancellable_std.rs
@@ -69,6 +69,13 @@ impl StdCancellationToken {
     pub fn is_cancelled(&self) -> bool {
         self.inner.cancelled.load(Ordering::SeqCst)
     }
+
+    /// Token identity: `true` iff `other` is a clone of `self` (they share the
+    /// same underlying state). Lets a registry keyed by a reusable id confirm an
+    /// entry is *this* token before acting on it.
+    pub fn ptr_eq(&self, other: &Self) -> bool {
+        Arc::ptr_eq(&self.inner, &other.inner)
+    }
 }
 
 /// Future returned by [`StdCancellationToken::cancelled`]. Resolves once the

--- a/crates/core/src/hmemoizer/mod.rs
+++ b/crates/core/src/hmemoizer/mod.rs
@@ -1410,6 +1410,30 @@ where
     tokio::spawn(async move { IN_FLIGHT.scope(inherited_frame, fut).await })
 }
 
+/// [`spawn_with_cycle_ctx`] variant that spawns onto an explicit runtime
+/// [`Handle`](tokio::runtime::Handle) — for spawns issued from a context with
+/// no ambient runtime, such as a plugin ABI `extern "C"` entry point (where a
+/// bare `tokio::spawn` would panic, or land on whichever runtime happens to be
+/// current rather than the intended one). Same frame inheritance as
+/// [`spawn_with_cycle_ctx`]: the spawned task's first `once()` sees the
+/// caller's invocation as its parent in the wait-for graph, so under
+/// `HEPH_DEBUG_MEMOIZER_CYCLE=1` a cycle through the seam errors instead of
+/// hanging.
+pub fn spawn_on_with_cycle_ctx<F>(
+    handle: &tokio::runtime::Handle,
+    fut: F,
+) -> tokio::task::JoinHandle<F::Output>
+where
+    F: Future + Send + 'static,
+    F::Output: Send + 'static,
+{
+    if !cycle_detection_enabled() {
+        return handle.spawn(fut);
+    }
+    let inherited_frame = current_frame();
+    handle.spawn(async move { IN_FLIGHT.scope(inherited_frame, fut).await })
+}
+
 /// `JoinSet::spawn` analogue with the same IN_FLIGHT inheritance semantics
 /// as [`spawn_with_cycle_ctx`].
 pub fn join_set_spawn<F>(set: &mut tokio::task::JoinSet<F::Output>, fut: F)

--- a/crates/core/src/hmemoizer/mod.rs
+++ b/crates/core/src/hmemoizer/mod.rs
@@ -884,7 +884,10 @@ fn cancel_abandoned<K, V>(
 
     // Dropped last, with nothing held: the drop cascades through the retained
     // chain and runs arbitrary destructors — releasing the worker permit,
-    // leaving the semaphore queue, disarming backstop registrations.
+    // leaving the semaphore queue, disarming backstop registrations. (One
+    // exception at the plugin ABI seam: a seam wrapper's drop only *requests*
+    // its spawned body stop via JoinHandle::abort — the body ends on a plugin
+    // worker after this cascade returns, not synchronously within it.)
     //
     // The cascade is *recursive*: this future's state machine holds the
     // `AbandonGuard` + `Await` for the next cell down, whose guard re-enters

--- a/crates/plugin-sdk/src/guest.rs
+++ b/crates/plugin-sdk/src/guest.rs
@@ -389,4 +389,47 @@ mod tests {
         seek.read_to_end(&mut buf2).expect("read seekable");
         assert_eq!(buf2, big_payload());
     }
+
+    // The host-side mirror of the guest's panic containment: a panicking
+    // executor callback body (an engine bug) is spawned on the host runtime,
+    // caught by tokio's task harness, and surfaces to the plugin as an error —
+    // never an unwind through the extern shim (which would abort).
+    #[test]
+    fn host_callback_panic_surfaces_as_error_not_abort() {
+        struct PanicExec;
+        impl ProviderExecutor for PanicExec {
+            fn result<'a>(&'a self, _addr: &'a Addr) -> BoxFuture<'a, Result<Arc<EResult>>> {
+                Box::pin(async { panic!("engine exploded") })
+            }
+            fn query<'a>(
+                &'a self,
+                _m: &'a Matcher,
+                _s: &'a [String],
+            ) -> BoxFuture<'a, Result<Vec<Addr>>> {
+                Box::pin(async { anyhow::bail!("unused") })
+            }
+        }
+
+        // A real runtime so wrap() captures a handle and takes the spawn path.
+        let rt = tokio::runtime::Builder::new_multi_thread()
+            .worker_threads(2)
+            .enable_all()
+            .build()
+            .expect("rt");
+        rt.block_on(async {
+            let dynexec = HostExecutor::wrap(Arc::new(PanicExec) as Arc<dyn ProviderExecutor>);
+            let guest = GuestExecutor::new(dynexec);
+            let addr = parse_addr("//pkg/a:b").expect("parse addr");
+            let msg = match guest.result(&addr).await {
+                Ok(_) => panic!("panic must surface as an error"),
+                Err(e) => format!("{e:#}"),
+            };
+            assert!(msg.contains("result"), "names the callback: {msg}");
+            assert!(msg.contains("panicked"), "states it panicked: {msg}");
+            assert!(
+                msg.contains("engine exploded"),
+                "carries the payload: {msg}"
+            );
+        });
+    }
 }

--- a/crates/plugin-sdk/src/guest.rs
+++ b/crates/plugin-sdk/src/guest.rs
@@ -278,7 +278,7 @@ mod tests {
         let mock = Arc::new(MockExec {
             note_deps: AtomicU32::new(0),
         });
-        let dynexec = HostExecutor::wrap(mock.clone() as Arc<dyn ProviderExecutor>);
+        let dynexec = HostExecutor::wrap_inline(mock.clone() as Arc<dyn ProviderExecutor>);
         let guest = GuestExecutor::new(dynexec);
         let addr = parse_addr("//pkg/a:b").expect("parse addr");
 
@@ -365,7 +365,7 @@ mod tests {
         std::fs::write(&path, big_payload()).expect("write artifact");
 
         let mock = Arc::new(MockExecFile { path });
-        let dynexec = HostExecutor::wrap(mock as Arc<dyn ProviderExecutor>);
+        let dynexec = HostExecutor::wrap_inline(mock as Arc<dyn ProviderExecutor>);
         let guest = GuestExecutor::new(dynexec);
         let addr = parse_addr("//pkg/a:b").expect("parse addr");
 
@@ -417,7 +417,10 @@ mod tests {
             .build()
             .expect("rt");
         rt.block_on(async {
-            let dynexec = HostExecutor::wrap(Arc::new(PanicExec) as Arc<dyn ProviderExecutor>);
+            let dynexec = HostExecutor::wrap(
+                Arc::new(PanicExec) as Arc<dyn ProviderExecutor>,
+                tokio::runtime::Handle::current(),
+            );
             let guest = GuestExecutor::new(dynexec);
             let addr = parse_addr("//pkg/a:b").expect("parse addr");
             let msg = match guest.result(&addr).await {

--- a/crates/plugin-sdk/src/serve.rs
+++ b/crates/plugin-sdk/src/serve.rs
@@ -37,6 +37,7 @@ use prost::Message;
 use stabby::future::DynFutureUnsync as DynFuture;
 use stabby::vec::Vec as SVec;
 use std::collections::{HashMap, HashSet};
+use std::future::Future;
 use std::io::Read;
 use std::path::PathBuf;
 use std::sync::Arc;
@@ -57,10 +58,125 @@ fn cdylib_runtime() -> &'static tokio::runtime::Runtime {
         tokio::runtime::Builder::new_multi_thread()
             .worker_threads(n)
             .max_blocking_threads(8 * n + 64)
+            .thread_name("heph-plugin-worker")
             .enable_all()
             .build()
             .expect("build cdylib plugin runtime")
     })
+}
+
+/// Awaits a seam task's `JoinHandle` from the wrapper future the host polls.
+///
+/// - **Abort-on-drop**: the host dropping the wrapper (rather than cancelling
+///   cooperatively) is the only stop signal for entry points with no
+///   `CancelRegistry` wiring (`list`, `list_packages`, `call_function`), so the
+///   spawned body is aborted when the wrapper goes away. The cooperative path
+///   (`await_with_cancel` host-side) cancels then keeps polling — it never
+///   drops, so it is unaffected.
+/// - **Backstop**: the completion wake crosses from a plugin-runtime worker to
+///   the host's waker through the stabby seam. That hazard has not been
+///   reproduced in isolation (docs/CONCURRENCY_MEASUREMENTS.md §2); arming
+///   `hcore::blocking::Backstop` on every pending poll is defense-in-depth,
+///   the same treatment `hcore::blocking::run` gives its oneshot wait.
+///
+/// `JoinHandle::poll` is runtime-free, so polling this from a host worker (or
+/// a plain `futures::executor::block_on`) is sound — `hook_on_events` is the
+/// in-tree precedent of a guest `JoinHandle` awaited across the seam.
+struct SeamTask<T> {
+    handle: tokio::task::JoinHandle<T>,
+    backstop: hcore::blocking::Backstop,
+}
+
+impl<T> std::future::Future for SeamTask<T> {
+    type Output = Result<T, tokio::task::JoinError>;
+
+    fn poll(
+        self: std::pin::Pin<&mut Self>,
+        cx: &mut std::task::Context<'_>,
+    ) -> std::task::Poll<Self::Output> {
+        let this = self.get_mut();
+        match std::pin::Pin::new(&mut this.handle).poll(cx) {
+            std::task::Poll::Ready(out) => std::task::Poll::Ready(out),
+            std::task::Poll::Pending => {
+                this.backstop.arm(cx.waker());
+                std::task::Poll::Pending
+            }
+        }
+    }
+}
+
+impl<T> Drop for SeamTask<T> {
+    fn drop(&mut self) {
+        // No-op on a finished task; stops an abandoned body otherwise.
+        self.handle.abort();
+    }
+}
+
+/// Best-effort text of a panic payload (`panic!` string/`String`, else a stub).
+fn panic_text(p: &(dyn std::any::Any + Send)) -> &str {
+    if let Some(s) = p.downcast_ref::<&'static str>() {
+        s
+    } else if let Some(s) = p.downcast_ref::<String>() {
+        s.as_str()
+    } else {
+        "<non-string panic payload>"
+    }
+}
+
+/// Spawn an ABI entry point's body onto the plugin runtime and return the
+/// wrapper future handed back across the seam.
+///
+/// **Seam invariant — eager start**: the body starts running the moment the
+/// `extern "C"` entry point is called, *before* the host first polls the
+/// returned future. Request decode, `CancelRegistry::enter`, `note_dep`
+/// inserts — any prefix of the body — may already have happened by first poll.
+/// `enter` stays INSIDE the spawned body so a cancel racing ahead of the spawn
+/// is parked in `precancelled` and applied when the body enters, never lost.
+///
+/// A panicking body surfaces as `JoinError::is_panic` (tokio's task harness is
+/// the `catch_unwind`) and is mapped to an error payload via `mk_err` — never
+/// `resume_unwind`, since this wrapper's poll runs inside the host's
+/// `extern "C"` shim where an unwind would abort the process. A
+/// runtime-shutdown `JoinError` maps to an error the same way.
+fn spawn_seam<T, F>(
+    plugin: &Arc<str>,
+    method: &'static str,
+    key: String,
+    fut: F,
+    mk_err: fn(String) -> T,
+) -> impl Future<Output = T> + Send + 'static
+where
+    F: Future<Output = T> + Send + 'static,
+    T: Send + 'static,
+{
+    let task = SeamTask {
+        handle: hcore::hmemoizer::spawn_on_with_cycle_ctx(cdylib_runtime().handle(), fut),
+        backstop: hcore::blocking::Backstop::new(),
+    };
+    let plugin = Arc::clone(plugin);
+    async move {
+        match task.await {
+            Ok(v) => v,
+            Err(e) if e.is_panic() => {
+                let payload = e.into_panic();
+                mk_err(format!(
+                    "plugin {plugin}: {method}({key}) panicked: {}",
+                    panic_text(payload.as_ref())
+                ))
+            }
+            Err(_) => mk_err(format!(
+                "plugin {plugin}: {method}({key}) aborted: plugin runtime shut down"
+            )),
+        }
+    }
+}
+
+/// Render a pb addr for seam diagnostics (no full `Addr` reconstruction).
+fn pb_addr_key(a: Option<&pb::Addr>) -> String {
+    match a {
+        Some(a) => format!("//{}:{}", a.package, a.name),
+        None => String::new(),
+    }
 }
 
 fn unary(body: Body) -> SVec<u8> {
@@ -185,8 +301,17 @@ fn get_error_kind(e: &anyhow::Error) -> pb::get_error::Kind {
 /// Wrap a real provider as an ABI-stable [`hplugin_stabby::abi::DynProvider`] handle
 /// (in-process; the cdylib entry produces the same handle across the boundary).
 pub fn make_dyn_provider(provider: Arc<dyn Provider>) -> hplugin_stabby::abi::DynProvider {
+    // Captured once for seam diagnostics (panic messages) — `config` is static
+    // metadata; calling it lazily on the error path would run author code
+    // inside the extern shim's poll.
+    let name: Arc<str> = provider
+        .config(ConfigRequest {})
+        .map(|r| r.name)
+        .unwrap_or_default()
+        .into();
     dynify(stabby::boxed::Box::new(StableProviderImpl {
         provider,
+        name,
         cancels: Arc::new(CancelRegistry::default()),
     }))
 }
@@ -195,8 +320,14 @@ pub fn make_dyn_provider(provider: Arc<dyn Provider>) -> hplugin_stabby::abi::Dy
 pub fn make_dyn_managed_driver(
     driver: Arc<dyn ManagedDriver>,
 ) -> hplugin_stabby::abi::DynManagedDriver {
+    let name: Arc<str> = driver
+        .config(DriverConfigRequest {})
+        .map(|r| r.name)
+        .unwrap_or_default()
+        .into();
     dynify(stabby::boxed::Box::new(StableManagedDriverImpl {
         driver,
+        name,
         cancels: Arc::new(CancelRegistry::default()),
     }))
 }
@@ -214,9 +345,22 @@ struct CancelRegistry {
 impl CancelRegistry {
     /// Register a fresh token for `id` and return a guard that deregisters on drop.
     /// An empty id (no cancellation wired for this call) is a no-op passthrough.
+    ///
+    /// Ordering pairs with [`cancel`](Self::cancel): each side *publishes* (the
+    /// token into `inflight` / the id into `precancelled`) before it *checks*
+    /// the other's map, so whichever side loses the race, at least one of the
+    /// two checks observes the other's write — a cancel is applied by one of
+    /// them (possibly both; `cancel()` on a token is idempotent), never
+    /// dropped. Checking before publishing (the old order) had a window where
+    /// `enter` saw no parked cancel and `cancel` saw no in-flight token, losing
+    /// the cancel — the eager seam spawn makes that window hittable.
     fn enter(self: &Arc<Self>, id: &str) -> CancelGuard {
         let token = StdCancellationToken::new();
         if !id.is_empty() {
+            self.inflight
+                .lock()
+                .unwrap_or_else(|e| e.into_inner())
+                .insert(id.to_string(), token.clone());
             if self
                 .precancelled
                 .lock()
@@ -225,10 +369,6 @@ impl CancelRegistry {
             {
                 token.cancel();
             }
-            self.inflight
-                .lock()
-                .unwrap_or_else(|e| e.into_inner())
-                .insert(id.to_string(), token.clone());
         }
         CancelGuard {
             reg: Arc::clone(self),
@@ -237,19 +377,21 @@ impl CancelRegistry {
         }
     }
 
+    /// See [`enter`](Self::enter) for the publish-then-check pairing. A parked
+    /// id not consumed here is consumed (and applied) by the next `enter` under
+    /// the same id — ids name an engine request, and a cancelled request stays
+    /// cancelled, so applying it to that later call is correct.
     fn cancel(&self, id: &str) {
         if id.is_empty() {
             return;
         }
+        self.precancelled
+            .lock()
+            .unwrap_or_else(|e| e.into_inner())
+            .insert(id.to_string());
         let map = self.inflight.lock().unwrap_or_else(|e| e.into_inner());
         if let Some(t) = map.get(id) {
             t.cancel();
-        } else {
-            drop(map);
-            self.precancelled
-                .lock()
-                .unwrap_or_else(|e| e.into_inner())
-                .insert(id.to_string());
         }
     }
 }
@@ -270,11 +412,13 @@ impl CancelGuard {
 impl Drop for CancelGuard {
     fn drop(&mut self) {
         if !self.id.is_empty() {
-            self.reg
-                .inflight
-                .lock()
-                .unwrap_or_else(|e| e.into_inner())
-                .remove(&self.id);
+            let mut map = self.reg.inflight.lock().unwrap_or_else(|e| e.into_inner());
+            // Identity-checked: a request id names an engine request, not a
+            // single call, so a later call under the same id may have replaced
+            // this entry — a stale guard's late drop must not deregister it.
+            if map.get(&self.id).is_some_and(|t| t.ptr_eq(&self.token)) {
+                map.remove(&self.id);
+            }
         }
     }
 }
@@ -282,6 +426,8 @@ impl Drop for CancelGuard {
 /// Wraps an author `Provider` as a [`StableProvider`].
 pub struct StableProviderImpl {
     pub provider: Arc<dyn Provider>,
+    /// Provider name, for seam diagnostics (panic/abort error messages).
+    name: Arc<str>,
     cancels: Arc<CancelRegistry>,
 }
 
@@ -302,17 +448,18 @@ fn unimplemented(method: u32) -> SVec<u8> {
 }
 
 // ---- Provider RPC bodies (moved verbatim out of the old per-method vtable slots
-// into helpers; the dispatch impls below route method ids to them) ----
+// into helpers; the dispatch impls below route method ids to them). Each takes
+// its already-decoded request: the dispatch decodes eagerly (to derive the seam
+// diagnostic key) before spawning the body onto the plugin runtime. ----
 
 // Server-streaming: the provider's iterator is pulled lazily across the seam (one
 // item per `StableItemStream::next`), never materialized into one blob.
 
 async fn provider_list_stream(
     provider: Arc<dyn Provider>,
-    req: SVec<u8>,
+    req: pb::ListRequest,
     exec: DynExecutor,
 ) -> DynItemStream {
-    let req = pb::ListRequest::decode(&req[..]).unwrap_or_default();
     let tok = StdCancellationToken::new();
     let executor: Arc<dyn ProviderExecutor> = Arc::new(GuestExecutor::new(exec));
     let lreq = ListRequest {
@@ -334,9 +481,8 @@ async fn provider_list_stream(
 
 async fn provider_list_packages_stream(
     provider: Arc<dyn Provider>,
-    req: SVec<u8>,
+    req: pb::ListPackagesRequest,
 ) -> DynItemStream {
-    let req = pb::ListPackagesRequest::decode(&req[..]).unwrap_or_default();
     let tok = StdCancellationToken::new();
     let lreq = ListPackagesRequest {
         prefix: PkgBuf::from(req.prefix),
@@ -354,11 +500,10 @@ async fn provider_list_packages_stream(
 
 async fn provider_get(
     provider: Arc<dyn Provider>,
-    req: SVec<u8>,
+    req: pb::GetRequest,
     exec: DynExecutor,
     cancels: Arc<CancelRegistry>,
 ) -> SVec<u8> {
-    let req = pb::GetRequest::decode(&req[..]).unwrap_or_default();
     let executor: Arc<dyn ProviderExecutor> = Arc::new(GuestExecutor::new(exec));
     let guard = cancels.enter(&req.request_id);
     let greq = GetRequest {
@@ -385,10 +530,9 @@ async fn provider_get(
 
 async fn provider_probe(
     provider: Arc<dyn Provider>,
-    req: SVec<u8>,
+    req: pb::ProbeRequest,
     cancels: Arc<CancelRegistry>,
 ) -> SVec<u8> {
-    let req = pb::ProbeRequest::decode(&req[..]).unwrap_or_default();
     let guard = cancels.enter(&req.request_id);
     let preq = ProbeRequest {
         request_id: req.request_id,
@@ -403,8 +547,10 @@ async fn provider_probe(
     unary(body)
 }
 
-async fn provider_call_function(provider: Arc<dyn Provider>, req: SVec<u8>) -> SVec<u8> {
-    let req = pb::CallFunctionRequest::decode(&req[..]).unwrap_or_default();
+async fn provider_call_function(
+    provider: Arc<dyn Provider>,
+    req: pb::CallFunctionRequest,
+) -> SVec<u8> {
     // Re-derive the def each call (cheap; provider functions are static
     // metadata). The handler is not transmissible, so it must be invoked
     // here on the guest side.
@@ -527,17 +673,43 @@ impl StableMeta for StableProviderImpl {
     }
 }
 
+// Entry-point dispatch. Every implemented method body is spawned onto the
+// plugin's own runtime via [`spawn_seam`] — the returned future only awaits the
+// `JoinHandle`, so the host worker polling it never executes plugin code (whose
+// reactor/timer use would panic outside the plugin runtime), and a panicking
+// body surfaces as an error instead of unwinding through the extern shim.
+// Seam invariant (eager start): the body starts at `invoke*()` call time, before
+// the host's first poll — see [`spawn_seam`].
 impl StableProvider for StableProviderImpl {
     extern "C" fn invoke<'a>(&'a self, method: u32, req: SVec<u8>) -> DynFuture<'a, SVec<u8>> {
         let provider = Arc::clone(&self.provider);
-        let cancels = Arc::clone(&self.cancels);
-        dynify(stabby::boxed::Box::new(async move {
-            match pb::ProviderMethod::try_from(method as i32) {
-                Ok(pb::ProviderMethod::Probe) => provider_probe(provider, req, cancels).await,
-                Ok(pb::ProviderMethod::CallFunction) => provider_call_function(provider, req).await,
-                _ => unimplemented(method),
+        match pb::ProviderMethod::try_from(method as i32) {
+            Ok(pb::ProviderMethod::Probe) => {
+                let req = pb::ProbeRequest::decode(&req[..]).unwrap_or_default();
+                let key = req.package.clone();
+                dynify(stabby::boxed::Box::new(spawn_seam(
+                    &self.name,
+                    "probe",
+                    key,
+                    provider_probe(provider, req, Arc::clone(&self.cancels)),
+                    |m| unary(err_body(m)),
+                )))
             }
-        }))
+            Ok(pb::ProviderMethod::CallFunction) => {
+                let req = pb::CallFunctionRequest::decode(&req[..]).unwrap_or_default();
+                let key = req.name.clone();
+                dynify(stabby::boxed::Box::new(spawn_seam(
+                    &self.name,
+                    "call_function",
+                    key,
+                    provider_call_function(provider, req),
+                    |m| unary(err_body(m)),
+                )))
+            }
+            _ => dynify(stabby::boxed::Box::new(
+                async move { unimplemented(method) },
+            )),
+        }
     }
 
     extern "C" fn invoke_server_stream<'a>(
@@ -546,15 +718,23 @@ impl StableProvider for StableProviderImpl {
         req: SVec<u8>,
     ) -> DynFuture<'a, DynItemStream> {
         let provider = Arc::clone(&self.provider);
-        dynify(stabby::boxed::Box::new(async move {
-            match pb::ProviderMethod::try_from(method as i32) {
-                // `List` rides `invoke_exec_server_stream` (it needs an executor).
-                Ok(pb::ProviderMethod::ListPackages) => {
-                    provider_list_packages_stream(provider, req).await
-                }
-                _ => unimplemented_item_stream(method),
+        match pb::ProviderMethod::try_from(method as i32) {
+            // `List` rides `invoke_exec_server_stream` (it needs an executor).
+            Ok(pb::ProviderMethod::ListPackages) => {
+                let req = pb::ListPackagesRequest::decode(&req[..]).unwrap_or_default();
+                let key = req.prefix.clone();
+                dynify(stabby::boxed::Box::new(spawn_seam(
+                    &self.name,
+                    "list_packages",
+                    key,
+                    provider_list_packages_stream(provider, req),
+                    error_item_stream,
+                )))
             }
-        }))
+            _ => dynify(stabby::boxed::Box::new(async move {
+                unimplemented_item_stream(method)
+            })),
+        }
     }
 
     extern "C" fn invoke_exec_server_stream<'a>(
@@ -564,12 +744,22 @@ impl StableProvider for StableProviderImpl {
         exec: DynExecutor,
     ) -> DynFuture<'a, DynItemStream> {
         let provider = Arc::clone(&self.provider);
-        dynify(stabby::boxed::Box::new(async move {
-            match pb::ProviderMethod::try_from(method as i32) {
-                Ok(pb::ProviderMethod::List) => provider_list_stream(provider, req, exec).await,
-                _ => unimplemented_item_stream(method),
+        match pb::ProviderMethod::try_from(method as i32) {
+            Ok(pb::ProviderMethod::List) => {
+                let req = pb::ListRequest::decode(&req[..]).unwrap_or_default();
+                let key = req.package.clone();
+                dynify(stabby::boxed::Box::new(spawn_seam(
+                    &self.name,
+                    "list",
+                    key,
+                    provider_list_stream(provider, req, exec),
+                    error_item_stream,
+                )))
             }
-        }))
+            _ => dynify(stabby::boxed::Box::new(async move {
+                unimplemented_item_stream(method)
+            })),
+        }
     }
 
     extern "C" fn invoke_client_stream<'a>(
@@ -600,13 +790,29 @@ impl StableProvider for StableProviderImpl {
         exec: DynExecutor,
     ) -> DynFuture<'a, SVec<u8>> {
         let provider = Arc::clone(&self.provider);
-        let cancels = Arc::clone(&self.cancels);
-        dynify(stabby::boxed::Box::new(async move {
-            match pb::ProviderMethod::try_from(method as i32) {
-                Ok(pb::ProviderMethod::Get) => provider_get(provider, req, exec, cancels).await,
-                _ => unimplemented(method),
+        match pb::ProviderMethod::try_from(method as i32) {
+            Ok(pb::ProviderMethod::Get) => {
+                let req = pb::GetRequest::decode(&req[..]).unwrap_or_default();
+                let key = pb_addr_key(req.addr.as_ref());
+                dynify(stabby::boxed::Box::new(spawn_seam(
+                    &self.name,
+                    "get",
+                    key,
+                    provider_get(provider, req, exec, Arc::clone(&self.cancels)),
+                    // A panic/abort is a GetErr (not a bare Error) so the host's
+                    // `get` decode surfaces the message as-is.
+                    |m| {
+                        unary(Body::GetErr(pb::GetError {
+                            kind: pb::get_error::Kind::Other as i32,
+                            message: m,
+                        }))
+                    },
+                )))
             }
-        }))
+            _ => dynify(stabby::boxed::Box::new(
+                async move { unimplemented(method) },
+            )),
+        }
     }
 
     extern "C" fn invoke_registry(&self, method: u32, req: SVec<u8>, reg: DynFunctionRegistry) {
@@ -670,6 +876,8 @@ fn stream_err(message: String) -> Body {
 /// Wraps an author `ManagedDriver` as a [`StableManagedDriver`].
 pub struct StableManagedDriverImpl {
     pub driver: Arc<dyn ManagedDriver>,
+    /// Driver name, for seam diagnostics (panic/abort error messages).
+    name: Arc<str>,
     cancels: Arc<CancelRegistry>,
 }
 
@@ -697,10 +905,9 @@ fn driver_schema(driver: &Arc<dyn ManagedDriver>) -> SVec<u8> {
 
 async fn driver_parse(
     driver: Arc<dyn ManagedDriver>,
-    req: SVec<u8>,
+    req: pb::ParseRequest,
     cancels: Arc<CancelRegistry>,
 ) -> SVec<u8> {
-    let req = pb::ParseRequest::decode(&req[..]).unwrap_or_default();
     let guard = cancels.enter(&req.request_id);
     let preq = ParseRequest {
         request_id: req.request_id,
@@ -722,10 +929,9 @@ async fn driver_parse(
 
 async fn driver_apply_transitive(
     driver: Arc<dyn ManagedDriver>,
-    req: SVec<u8>,
+    req: pb::ApplyTransitiveRequest,
     cancels: Arc<CancelRegistry>,
 ) -> SVec<u8> {
-    let req = pb::ApplyTransitiveRequest::decode(&req[..]).unwrap_or_default();
     let guard = cancels.enter(&req.request_id);
     let target_def = match convert::target_def_from_pb(req.target_def.unwrap_or_default()) {
         Ok(td) => td,
@@ -758,19 +964,39 @@ impl StableMeta for StableManagedDriverImpl {
     }
 }
 
+// Same seam shape as [`StableProvider`]: bodies spawn onto the plugin runtime,
+// the host polls only a `JoinHandle` await, panics become errors (never an
+// unwind through the extern shim), and bodies start eagerly at call time.
 impl StableManagedDriver for StableManagedDriverImpl {
     extern "C" fn invoke<'a>(&'a self, method: u32, req: SVec<u8>) -> DynFuture<'a, SVec<u8>> {
         let driver = Arc::clone(&self.driver);
-        let cancels = Arc::clone(&self.cancels);
-        dynify(stabby::boxed::Box::new(async move {
-            match pb::DriverMethod::try_from(method as i32) {
-                Ok(pb::DriverMethod::Parse) => driver_parse(driver, req, cancels).await,
-                Ok(pb::DriverMethod::ApplyTransitive) => {
-                    driver_apply_transitive(driver, req, cancels).await
-                }
-                _ => unimplemented(method),
+        match pb::DriverMethod::try_from(method as i32) {
+            Ok(pb::DriverMethod::Parse) => {
+                let req = pb::ParseRequest::decode(&req[..]).unwrap_or_default();
+                let key = pb_addr_key(req.target_spec.as_ref().and_then(|t| t.addr.as_ref()));
+                dynify(stabby::boxed::Box::new(spawn_seam(
+                    &self.name,
+                    "parse",
+                    key,
+                    driver_parse(driver, req, Arc::clone(&self.cancels)),
+                    |m| unary(err_body(m)),
+                )))
             }
-        }))
+            Ok(pb::DriverMethod::ApplyTransitive) => {
+                let req = pb::ApplyTransitiveRequest::decode(&req[..]).unwrap_or_default();
+                let key = pb_addr_key(req.target_def.as_ref().and_then(|t| t.addr.as_ref()));
+                dynify(stabby::boxed::Box::new(spawn_seam(
+                    &self.name,
+                    "apply_transitive",
+                    key,
+                    driver_apply_transitive(driver, req, Arc::clone(&self.cancels)),
+                    |m| unary(err_body(m)),
+                )))
+            }
+            _ => dynify(stabby::boxed::Box::new(
+                async move { unimplemented(method) },
+            )),
+        }
     }
 
     // No unary->stream or stream->unary driver RPC yet; provisioned, Unimplemented.
@@ -869,8 +1095,10 @@ async fn run_bidi(
     // The run shells out via the reactor — execute on the cdylib's own runtime,
     // feeding RunOutFrames into a channel the host drains. (Live stdin/stdout will
     // ride `req` / the channel later; today only the terminal result is sent.)
+    // `spawn_on_with_cycle_ctx` (not a bare `spawn`) so the run task inherits the
+    // caller's memoizer frame chain for cycle detection.
     let (tx, rx) = tokio::sync::mpsc::channel::<Vec<u8>>(16);
-    cdylib_runtime().spawn(async move {
+    hcore::hmemoizer::spawn_on_with_cycle_ctx(cdylib_runtime().handle(), async move {
         let guard = cancels.enter(&start.request_id);
         let out = run_once(driver, start, guard.token()).await;
         // Host gone => receiver dropped; ignore send failure.
@@ -2305,5 +2533,353 @@ mod tests {
             !host.supports_shell(),
             "remote proxy must defer --shell to the host pluginexec fallback"
         );
+    }
+
+    /// Base provider for the seam tests below: every method is a benign stub;
+    /// individual tests override the one they exercise.
+    macro_rules! stub_provider_boilerplate {
+        ($name:literal) => {
+            fn config(&self, _r: ConfigRequest) -> Result<ConfigResponse> {
+                Ok(ConfigResponse { name: $name.into() })
+            }
+            fn list<'a>(
+                &'a self,
+                _r: ListRequest,
+                _c: &'a (dyn Cancellable + Send + Sync),
+            ) -> futures::future::BoxFuture<
+                'a,
+                Result<Box<dyn Iterator<Item = Result<ListResponse>> + Send>>,
+            > {
+                Box::pin(async { Ok(Box::new(std::iter::empty()) as Box<_>) })
+            }
+            fn list_packages<'a>(
+                &'a self,
+                _r: ListPackagesRequest,
+                _c: &'a (dyn Cancellable + Send + Sync),
+            ) -> futures::future::BoxFuture<
+                'a,
+                Result<Box<dyn Iterator<Item = Result<ListPackageResponse>> + Send>>,
+            > {
+                Box::pin(async { Ok(Box::new(std::iter::empty()) as Box<_>) })
+            }
+        };
+    }
+
+    // A panicking provider body must surface as an actionable seam error —
+    // plugin name, method, key, payload — never unwind through the extern shim
+    // (which would abort the process). Tokio's task harness is the catch_unwind;
+    // the wrapper maps JoinError::is_panic to the error body.
+    #[test]
+    fn panicking_provider_body_is_contained_as_error() {
+        use hplugin_stabby::load_stable::StableRemoteProvider;
+
+        struct Boomer;
+        impl Provider for Boomer {
+            stub_provider_boilerplate!("boomer");
+            fn get<'a>(
+                &'a self,
+                _r: GetRequest,
+                _c: &'a (dyn Cancellable + Send + Sync),
+            ) -> futures::future::BoxFuture<'a, std::result::Result<GetResponse, GetError>>
+            {
+                Box::pin(async { Err(GetError::NotFound) })
+            }
+            fn probe<'a>(
+                &'a self,
+                _r: ProbeRequest,
+                _c: &'a (dyn Cancellable + Send + Sync),
+            ) -> futures::future::BoxFuture<'a, Result<ProbeResponse>> {
+                Box::pin(async { panic!("probe exploded") })
+            }
+        }
+
+        let host = StableRemoteProvider::new(make_dyn_provider(Arc::new(Boomer)), "boomer");
+        let ct = StdCancellationToken::new();
+        let msg = match futures::executor::block_on(host.probe(
+            ProbeRequest {
+                request_id: String::new(),
+                package: PkgBuf::from("p"),
+            },
+            &ct,
+        )) {
+            Ok(_) => panic!("panic must surface as an error, not success"),
+            Err(e) => format!("{e:#}"),
+        };
+        assert!(msg.contains("plugin boomer"), "names the plugin: {msg}");
+        assert!(msg.contains("probe(p)"), "names method + key: {msg}");
+        assert!(msg.contains("panicked"), "states it panicked: {msg}");
+        assert!(msg.contains("probe exploded"), "carries the payload: {msg}");
+    }
+
+    // Abort-on-drop: dropping the seam wrapper without a cooperative cancel is
+    // the only stop signal for entry points with no CancelRegistry wiring — the
+    // spawned guest body must provably stop, not leak on the plugin runtime.
+    #[test]
+    fn dropped_seam_future_aborts_the_spawned_body() {
+        use hplugin_stabby::abi::StableProviderDyn;
+        use std::sync::atomic::{AtomicBool, Ordering};
+        use std::time::{Duration, Instant};
+
+        struct SetOnDrop(Arc<AtomicBool>);
+        impl Drop for SetOnDrop {
+            fn drop(&mut self) {
+                self.0.store(true, Ordering::SeqCst);
+            }
+        }
+
+        struct Hanger {
+            started: Arc<AtomicBool>,
+            stopped: Arc<AtomicBool>,
+        }
+        impl Provider for Hanger {
+            stub_provider_boilerplate!("hanger");
+            fn get<'a>(
+                &'a self,
+                _r: GetRequest,
+                _c: &'a (dyn Cancellable + Send + Sync),
+            ) -> futures::future::BoxFuture<'a, std::result::Result<GetResponse, GetError>>
+            {
+                Box::pin(async { Err(GetError::NotFound) })
+            }
+            fn probe<'a>(
+                &'a self,
+                _r: ProbeRequest,
+                _c: &'a (dyn Cancellable + Send + Sync),
+            ) -> futures::future::BoxFuture<'a, Result<ProbeResponse>> {
+                let started = Arc::clone(&self.started);
+                let stopped = Arc::clone(&self.stopped);
+                Box::pin(async move {
+                    // Dropped only when this future is dropped — i.e. when the
+                    // spawned task is aborted (it never completes on its own).
+                    let _guard = SetOnDrop(stopped);
+                    started.store(true, Ordering::SeqCst);
+                    futures::future::pending::<()>().await;
+                    Ok(ProbeResponse { states: vec![] })
+                })
+            }
+        }
+
+        let started = Arc::new(AtomicBool::new(false));
+        let stopped = Arc::new(AtomicBool::new(false));
+        let dynp = make_dyn_provider(Arc::new(Hanger {
+            started: Arc::clone(&started),
+            stopped: Arc::clone(&stopped),
+        }) as Arc<dyn Provider>);
+
+        let req = pb::ProbeRequest {
+            request_id: String::new(),
+            package: "p".into(),
+        }
+        .encode_to_vec();
+        let fut = dynp.invoke(pb::ProviderMethod::Probe as u32, SVec::from(req.as_slice()));
+
+        // Eager start: the body begins without the wrapper ever being polled.
+        let deadline = Instant::now() + Duration::from_secs(10);
+        while !started.load(Ordering::SeqCst) {
+            assert!(Instant::now() < deadline, "spawned body never started");
+            std::thread::sleep(Duration::from_millis(5));
+        }
+
+        // Host abandons the call: drop without polling to completion.
+        drop(fut);
+
+        while !stopped.load(Ordering::SeqCst) {
+            assert!(
+                Instant::now() < deadline,
+                "spawned body still running after the wrapper was dropped"
+            );
+            std::thread::sleep(Duration::from_millis(5));
+        }
+    }
+
+    // Pre-cancel race loop: a cancel issued through the extern cancel path may
+    // arrive before the (eagerly spawned) body reaches CancelRegistry::enter.
+    // The registry parks it in `precancelled` and applies it at enter — the
+    // cancel must never be lost, whichever side wins the race.
+    #[test]
+    fn precancel_racing_the_spawn_is_never_lost() {
+        use hplugin_stabby::abi::{StableCancelDyn, StableProviderDyn};
+        use std::time::Duration;
+
+        struct CancelWait;
+        impl Provider for CancelWait {
+            stub_provider_boilerplate!("cancelwait");
+            fn get<'a>(
+                &'a self,
+                _r: GetRequest,
+                _c: &'a (dyn Cancellable + Send + Sync),
+            ) -> futures::future::BoxFuture<'a, std::result::Result<GetResponse, GetError>>
+            {
+                Box::pin(async { Err(GetError::NotFound) })
+            }
+            // Returns only once the token this call was handed trips.
+            fn probe<'a>(
+                &'a self,
+                _r: ProbeRequest,
+                ct: &'a (dyn Cancellable + Send + Sync),
+            ) -> futures::future::BoxFuture<'a, Result<ProbeResponse>> {
+                Box::pin(async move {
+                    ct.cancelled().await;
+                    Ok(ProbeResponse { states: vec![] })
+                })
+            }
+        }
+
+        let dynp = make_dyn_provider(Arc::new(CancelWait) as Arc<dyn Provider>);
+        let rt = tokio::runtime::Builder::new_multi_thread()
+            .worker_threads(2)
+            .enable_all()
+            .build()
+            .expect("rt");
+
+        for i in 0..100 {
+            let id = format!("rq-{i}");
+            let req = pb::ProbeRequest {
+                request_id: id.clone(),
+                package: "p".into(),
+            }
+            .encode_to_vec();
+            // Spawn (eager) ...
+            let fut = dynp.invoke(pb::ProviderMethod::Probe as u32, SVec::from(req.as_slice()));
+            // ... and race the cancel against the body reaching `enter`.
+            dynp.cancel(id.into());
+            rt.block_on(async {
+                tokio::time::timeout(Duration::from_secs(10), fut)
+                    .await
+                    .unwrap_or_else(|_| panic!("cancel lost on iteration {i}: probe never woke"));
+            });
+        }
+    }
+
+    // Reentrancy through the seam: a provider `get` whose body calls the host
+    // executor's `result`, whose resolution issues a SECOND provider `get` —
+    // a second spawn into the same plugin runtime while the first body is
+    // parked on the callback. Must complete, not deadlock. (Also exercises the
+    // host-side mirror: the executor body is spawned onto the host runtime
+    // captured at wrap() time, not run inline on a guest worker.)
+    #[test]
+    fn nested_seam_get_completes_without_deadlock() {
+        use hmodel::htaddr::Addr;
+        use hplugin::provider::{NoopExecutor, ProviderExecutor};
+        use hplugin_stabby::load_stable::StableRemoteProvider;
+        use std::sync::OnceLock;
+        use std::time::Duration;
+
+        struct Nester;
+        impl Provider for Nester {
+            stub_provider_boilerplate!("nester");
+            fn probe<'a>(
+                &'a self,
+                _r: ProbeRequest,
+                _c: &'a (dyn Cancellable + Send + Sync),
+            ) -> futures::future::BoxFuture<'a, Result<ProbeResponse>> {
+                Box::pin(async { Ok(ProbeResponse { states: vec![] }) })
+            }
+            fn get<'a>(
+                &'a self,
+                req: GetRequest,
+                _c: &'a (dyn Cancellable + Send + Sync),
+            ) -> futures::future::BoxFuture<'a, std::result::Result<GetResponse, GetError>>
+            {
+                Box::pin(async move {
+                    if req.addr.name != "top" {
+                        return Err(GetError::NotFound);
+                    }
+                    let dep = Addr::new(PkgBuf::from("p"), "dep".into(), Default::default());
+                    match req.executor.result(&dep).await {
+                        // The nested chain completed; surface a recognizable
+                        // marker instead of fabricating a TargetSpec.
+                        Ok(_) => Err(GetError::Other(anyhow::anyhow!("nested-complete"))),
+                        Err(e) => Err(GetError::Other(e.context("nested result failed"))),
+                    }
+                })
+            }
+        }
+
+        /// Host-side executor whose `result` resolves by issuing a second `get`
+        /// through the real seam.
+        struct NestedExec {
+            host: OnceLock<StableRemoteProvider>,
+        }
+        impl ProviderExecutor for NestedExec {
+            fn result<'a>(
+                &'a self,
+                addr: &'a Addr,
+            ) -> futures::future::BoxFuture<'a, Result<Arc<hplugin::eresult::EResult>>>
+            {
+                Box::pin(async move {
+                    let host = self.host.get().expect("host handle wired");
+                    let ct = StdCancellationToken::new();
+                    let req = GetRequest {
+                        request_id: String::new(),
+                        addr: addr.clone(),
+                        states: vec![],
+                        executor: Arc::new(NoopExecutor),
+                    };
+                    match host.get(req, &ct).await {
+                        Err(GetError::NotFound) => Ok(Arc::new(hplugin::eresult::EResult {
+                            artifacts: vec![],
+                            support_artifacts: vec![],
+                            artifacts_meta: vec![],
+                        })),
+                        Ok(_) => anyhow::bail!("dep get unexpectedly found a spec"),
+                        Err(GetError::Other(e)) => Err(e.context("nested dep get")),
+                    }
+                })
+            }
+            fn query<'a>(
+                &'a self,
+                _m: &'a hmodel::htmatcher::Matcher,
+                _s: &'a [String],
+            ) -> futures::future::BoxFuture<'a, Result<Vec<Addr>>> {
+                Box::pin(async { anyhow::bail!("unused") })
+            }
+        }
+
+        let host = StableRemoteProvider::new(
+            make_dyn_provider(Arc::new(Nester) as Arc<dyn Provider>),
+            "nester",
+        );
+        let exec = Arc::new(NestedExec {
+            host: OnceLock::new(),
+        });
+        exec.host
+            .set(host.clone())
+            .unwrap_or_else(|_| panic!("set host"));
+
+        let rt = tokio::runtime::Builder::new_multi_thread()
+            .worker_threads(2)
+            .enable_all()
+            .build()
+            .expect("rt");
+        let out = rt
+            .block_on(async {
+                let ct = StdCancellationToken::new();
+                tokio::time::timeout(
+                    Duration::from_secs(30),
+                    host.get(
+                        GetRequest {
+                            request_id: "rq-top".into(),
+                            addr: Addr::new(PkgBuf::from("p"), "top".into(), Default::default()),
+                            states: vec![],
+                            executor: exec.clone() as Arc<dyn ProviderExecutor>,
+                        },
+                        &ct,
+                    ),
+                )
+                .await
+            })
+            .expect("deadlock: nested seam get did not complete");
+        match out {
+            Err(GetError::Other(e)) => {
+                let msg = format!("{e:#}");
+                assert!(
+                    msg.contains("nested-complete"),
+                    "nested chain must have completed: {msg}"
+                );
+            }
+            Err(GetError::NotFound) => panic!("top get must run the nested body"),
+            Ok(_) => panic!("top get returns the marker error"),
+        }
     }
 }

--- a/crates/plugin-sdk/src/serve.rs
+++ b/crates/plugin-sdk/src/serve.rs
@@ -29,6 +29,7 @@ use hplugin_stabby::abi::{
     StableHook, StableItemStream, StableItemStreamDyn, StableManagedDriver, StableMeta,
     StableProvider,
 };
+use hplugin_stabby::seam::panic_text;
 use hplugin_stabby::vtable::dynify;
 use plugin_abi::convert;
 use plugin_abi::pb;
@@ -75,9 +76,10 @@ fn cdylib_runtime() -> &'static tokio::runtime::Runtime {
 ///   drops, so it is unaffected.
 /// - **Backstop**: the completion wake crosses from a plugin-runtime worker to
 ///   the host's waker through the stabby seam. That hazard has not been
-///   reproduced in isolation (docs/CONCURRENCY_MEASUREMENTS.md §2); arming
-///   `hcore::blocking::Backstop` on every pending poll is defense-in-depth,
-///   the same treatment `hcore::blocking::run` gives its oneshot wait.
+///   reproduced in isolation (docs/CONCURRENCY_MEASUREMENTS.md §2, lands with
+///   #298 below this PR in the stack); arming `hcore::blocking::Backstop` on
+///   every pending poll is defense-in-depth, the same treatment
+///   `hcore::blocking::run` gives its oneshot wait.
 ///
 /// `JoinHandle::poll` is runtime-free, so polling this from a host worker (or
 /// a plain `futures::executor::block_on`) is sound — `hook_on_events` is the
@@ -109,17 +111,6 @@ impl<T> Drop for SeamTask<T> {
     fn drop(&mut self) {
         // No-op on a finished task; stops an abandoned body otherwise.
         self.handle.abort();
-    }
-}
-
-/// Best-effort text of a panic payload (`panic!` string/`String`, else a stub).
-fn panic_text(p: &(dyn std::any::Any + Send)) -> &str {
-    if let Some(s) = p.downcast_ref::<&'static str>() {
-        s
-    } else if let Some(s) = p.downcast_ref::<String>() {
-        s.as_str()
-    } else {
-        "<non-string panic payload>"
     }
 }
 
@@ -168,6 +159,15 @@ where
                 "plugin {plugin}: {method}({key}) aborted: plugin runtime shut down"
             )),
         }
+    }
+}
+
+/// Component name for seam diagnostics: the configured name, or `<unnamed>`
+/// when `config()` failed or returned an empty name.
+fn seam_name(configured: Result<String>) -> Arc<str> {
+    match configured {
+        Ok(n) if !n.is_empty() => n.into(),
+        _ => "<unnamed>".into(),
     }
 }
 
@@ -303,12 +303,9 @@ fn get_error_kind(e: &anyhow::Error) -> pb::get_error::Kind {
 pub fn make_dyn_provider(provider: Arc<dyn Provider>) -> hplugin_stabby::abi::DynProvider {
     // Captured once for seam diagnostics (panic messages) — `config` is static
     // metadata; calling it lazily on the error path would run author code
-    // inside the extern shim's poll.
-    let name: Arc<str> = provider
-        .config(ConfigRequest {})
-        .map(|r| r.name)
-        .unwrap_or_default()
-        .into();
+    // inside the extern shim's poll. `<unnamed>` rather than an empty string,
+    // so a failing config still yields a readable "plugin <unnamed>: …" error.
+    let name: Arc<str> = seam_name(provider.config(ConfigRequest {}).map(|r| r.name));
     dynify(stabby::boxed::Box::new(StableProviderImpl {
         provider,
         name,
@@ -320,11 +317,7 @@ pub fn make_dyn_provider(provider: Arc<dyn Provider>) -> hplugin_stabby::abi::Dy
 pub fn make_dyn_managed_driver(
     driver: Arc<dyn ManagedDriver>,
 ) -> hplugin_stabby::abi::DynManagedDriver {
-    let name: Arc<str> = driver
-        .config(DriverConfigRequest {})
-        .map(|r| r.name)
-        .unwrap_or_default()
-        .into();
+    let name: Arc<str> = seam_name(driver.config(DriverConfigRequest {}).map(|r| r.name));
     dynify(stabby::boxed::Box::new(StableManagedDriverImpl {
         driver,
         name,
@@ -336,9 +329,14 @@ pub fn make_dyn_managed_driver(
 /// token a running call handed the provider/driver. A cancel that races ahead of
 /// its call (arrives before the call registers) is parked in `precancelled` and
 /// applied when the call enters — so it is never lost.
+///
+/// A request id names an engine *request* (`req-{n}`), not a single call — the
+/// whole request subtree shares it — so multiple calls can be in flight under
+/// one id concurrently. Each keeps its own token in the `Vec`; `cancel` trips
+/// them all (a request cancel means the whole subtree stops).
 #[derive(Default)]
 struct CancelRegistry {
-    inflight: Mutex<HashMap<String, StdCancellationToken>>,
+    inflight: Mutex<HashMap<String, Vec<StdCancellationToken>>>,
     precancelled: Mutex<HashSet<String>>,
 }
 
@@ -360,7 +358,9 @@ impl CancelRegistry {
             self.inflight
                 .lock()
                 .unwrap_or_else(|e| e.into_inner())
-                .insert(id.to_string(), token.clone());
+                .entry(id.to_string())
+                .or_default()
+                .push(token.clone());
             if self
                 .precancelled
                 .lock()
@@ -390,8 +390,11 @@ impl CancelRegistry {
             .unwrap_or_else(|e| e.into_inner())
             .insert(id.to_string());
         let map = self.inflight.lock().unwrap_or_else(|e| e.into_inner());
-        if let Some(t) = map.get(id) {
-            t.cancel();
+        if let Some(tokens) = map.get(id) {
+            // Every call in flight under this request id, not just the latest.
+            for t in tokens {
+                t.cancel();
+            }
         }
     }
 }
@@ -412,12 +415,34 @@ impl CancelGuard {
 impl Drop for CancelGuard {
     fn drop(&mut self) {
         if !self.id.is_empty() {
-            let mut map = self.reg.inflight.lock().unwrap_or_else(|e| e.into_inner());
-            // Identity-checked: a request id names an engine request, not a
-            // single call, so a later call under the same id may have replaced
-            // this entry — a stale guard's late drop must not deregister it.
-            if map.get(&self.id).is_some_and(|t| t.ptr_eq(&self.token)) {
-                map.remove(&self.id);
+            {
+                let mut map = self.reg.inflight.lock().unwrap_or_else(|e| e.into_inner());
+                // Identity-checked: a request id names an engine request, not a
+                // single call, so sibling calls' tokens share this entry — a
+                // guard removes only its OWN token, never a sibling's.
+                if let Some(tokens) = map.get_mut(&self.id) {
+                    if let Some(i) = tokens.iter().position(|t| t.ptr_eq(&self.token)) {
+                        tokens.swap_remove(i);
+                    }
+                    if tokens.is_empty() {
+                        map.remove(&self.id);
+                    }
+                }
+            }
+            // A cancelled call consumes its request's parked pre-cancel marker,
+            // so a cancelled request with no later `enter` doesn't park its id
+            // forever (unbounded in a long-lived LSP/watch process). Safe to
+            // consume: every token in flight under this id was already tripped
+            // by `cancel`, and any *later* call under this (cancelled) request
+            // gets re-cancelled by its own host-side `await_with_cancel`, which
+            // observes the already-tripped request token on first poll and
+            // fires `provider_cancel` again.
+            if self.token.is_cancelled() {
+                self.reg
+                    .precancelled
+                    .lock()
+                    .unwrap_or_else(|e| e.into_inner())
+                    .remove(&self.id);
             }
         }
     }
@@ -2532,6 +2557,88 @@ mod tests {
         assert!(
             !host.supports_shell(),
             "remote proxy must defer --shell to the host pluginexec fallback"
+        );
+    }
+
+    // ---- CancelRegistry: deterministic coverage of the enter/cancel/drop
+    // contract. The race-loop test below exercises the concurrent interleaving;
+    // these pin each ordering on its own. ----
+
+    // (a) A cancel that arrives before its call registers is parked and applied
+    // at enter — the token starts cancelled.
+    #[test]
+    fn registry_cancel_before_enter_starts_cancelled() {
+        let reg = Arc::new(CancelRegistry::default());
+        reg.cancel("x");
+        let g = reg.enter("x");
+        assert!(
+            g.token().is_cancelled(),
+            "parked pre-cancel must apply at enter"
+        );
+    }
+
+    // (b) The plain order: enter, then cancel trips the registered token.
+    #[test]
+    fn registry_cancel_after_enter_trips_the_token() {
+        let reg = Arc::new(CancelRegistry::default());
+        let g = reg.enter("x");
+        reg.cancel("x");
+        assert!(g.token().is_cancelled(), "cancel must trip the live token");
+    }
+
+    // (c) Request ids are shared by the whole request subtree, so a stale
+    // guard's late drop must not deregister a successor call's token. With the
+    // old unconditional `remove(&self.id)` this goes red: g1's drop removed the
+    // entry g2 re-registered, and the cancel found nothing to trip.
+    #[test]
+    fn registry_stale_guard_drop_does_not_deregister_successor() {
+        let reg = Arc::new(CancelRegistry::default());
+        let g1 = reg.enter("x");
+        let g2 = reg.enter("x");
+        drop(g1);
+        reg.cancel("x");
+        assert!(
+            g2.token().is_cancelled(),
+            "g1's late drop must not have deregistered g2's token"
+        );
+    }
+
+    // Concurrent calls under ONE request id each keep their own token, and a
+    // request cancel trips them ALL. With the old single-slot map this goes
+    // red: the second enter replaced the first's token, so the cancel tripped
+    // only the last registrant while the first call ran to completion.
+    #[test]
+    fn registry_cancel_trips_every_concurrent_call_under_one_id() {
+        let reg = Arc::new(CancelRegistry::default());
+        let g1 = reg.enter("x");
+        let g2 = reg.enter("x");
+        reg.cancel("x");
+        assert!(g1.token().is_cancelled(), "first call's token must trip");
+        assert!(g2.token().is_cancelled(), "second call's token must trip");
+    }
+
+    // A cancelled guard's drop consumes the parked pre-cancel marker and its
+    // own inflight slot, so a long-lived process (LSP/watch) doesn't accumulate
+    // one parked id per cancelled request.
+    #[test]
+    fn registry_cancelled_guard_drop_leaves_no_state_behind() {
+        let reg = Arc::new(CancelRegistry::default());
+        let g = reg.enter("x");
+        reg.cancel("x");
+        drop(g);
+        assert!(
+            reg.precancelled
+                .lock()
+                .unwrap_or_else(|e| e.into_inner())
+                .is_empty(),
+            "the parked marker must be consumed by the cancelled guard's drop"
+        );
+        assert!(
+            reg.inflight
+                .lock()
+                .unwrap_or_else(|e| e.into_inner())
+                .is_empty(),
+            "the guard's token (and the emptied entry) must be gone"
         );
     }
 

--- a/crates/plugin-stabby/src/host.rs
+++ b/crates/plugin-stabby/src/host.rs
@@ -185,27 +185,148 @@ fn err_body(message: String) -> Body {
     })
 }
 
+/// The host-side mirror of the guest's spawn-at-the-seam shape.
+///
+/// A `DynFuture` a host callback returns is polled by a *guest* runtime worker
+/// (the plugin body that awaits it runs on the plugin's own runtime). Running
+/// the callback body inline in that poll would execute engine futures — which
+/// touch the host reactor and timer wheel — on a thread with no host runtime
+/// context, which panics ("there is no reactor running") and then aborts at the
+/// extern seam. So the body is spawned onto the host runtime captured at
+/// `wrap()` time, and the returned future only awaits the `JoinHandle`
+/// (runtime-free to poll). Symmetric with `plugin-sdk::serve`.
+///
+/// `handle` is `None` when `wrap()` ran outside any tokio runtime — an
+/// in-process context (unit tests, `futures::executor`-driven harnesses) where
+/// host and caller share one image and the caller drives the future itself; the
+/// body then runs inline exactly as before. Every production wrap site (`get`/
+/// `list` bodies, provider-function wiring) runs on the engine runtime.
+struct SeamSpawn {
+    handle: Option<tokio::runtime::Handle>,
+    /// Request span captured at `wrap()` time, re-entered by the spawned body so
+    /// engine logs from plugin callbacks keep the request's tracing context.
+    span: tracing::Span,
+}
+
+impl SeamSpawn {
+    fn capture() -> Self {
+        Self {
+            handle: tokio::runtime::Handle::try_current().ok(),
+            span: tracing::Span::current(),
+        }
+    }
+}
+
+/// Abort-on-drop await of a host-side callback task: dropping the wrapper
+/// (the guest abandoned the call — e.g. its own seam task was aborted) stops
+/// the spawned body instead of leaking it. No backstop here: the guest-side
+/// seam wrapper arms one for the whole call (see `plugin-sdk::serve`).
+struct HostTask<T> {
+    handle: tokio::task::JoinHandle<T>,
+}
+
+impl<T> std::future::Future for HostTask<T> {
+    type Output = Result<T, tokio::task::JoinError>;
+
+    fn poll(
+        self: std::pin::Pin<&mut Self>,
+        cx: &mut std::task::Context<'_>,
+    ) -> std::task::Poll<Self::Output> {
+        std::pin::Pin::new(&mut self.get_mut().handle).poll(cx)
+    }
+}
+
+impl<T> Drop for HostTask<T> {
+    fn drop(&mut self) {
+        self.handle.abort();
+    }
+}
+
+/// Best-effort text of a panic payload.
+fn panic_text(p: &(dyn std::any::Any + Send)) -> &str {
+    if let Some(s) = p.downcast_ref::<&'static str>() {
+        s
+    } else if let Some(s) = p.downcast_ref::<String>() {
+        s.as_str()
+    } else {
+        "<non-string panic payload>"
+    }
+}
+
+impl SeamSpawn {
+    /// Run `fut` (a host callback body) to a future safe to hand across the
+    /// seam: spawned on the captured host runtime when there is one, inline
+    /// otherwise. A panicking body maps to `mk_err` (host-side bug, surfaced to
+    /// the guest as an error) — never an unwind out of the wrapper's poll,
+    /// which runs inside the extern shim.
+    async fn run<T, F>(
+        &self,
+        method: &'static str,
+        key: String,
+        fut: F,
+        mk_err: fn(String) -> T,
+    ) -> T
+    where
+        F: std::future::Future<Output = T> + Send + 'static,
+        T: Send + 'static,
+    {
+        use tracing::Instrument;
+        let Some(handle) = &self.handle else {
+            return fut.instrument(self.span.clone()).await;
+        };
+        let task = HostTask {
+            handle: hcore::hmemoizer::spawn_on_with_cycle_ctx(
+                handle,
+                fut.instrument(self.span.clone()),
+            ),
+        };
+        match task.await {
+            Ok(v) => v,
+            Err(e) if e.is_panic() => {
+                let payload = e.into_panic();
+                mk_err(format!(
+                    "host callback {method}({key}) panicked: {}",
+                    panic_text(payload.as_ref())
+                ))
+            }
+            Err(_) => mk_err(format!(
+                "host callback {method}({key}) aborted: host runtime shut down"
+            )),
+        }
+    }
+}
+
 /// Wraps the host's aggregate function registry; handed to a plugin as a
 /// [`DynFunctionRegistry`] so it can invoke any registered function.
 pub struct HostFunctionRegistry {
     inner: Arc<ProviderFunctionRegistry>,
+    seam: SeamSpawn,
 }
 
 impl HostFunctionRegistry {
     /// Wrap the aggregate registry as an ABI-stable [`DynFunctionRegistry`].
+    /// Captures the current runtime handle and span — see [`SeamSpawn`].
     pub fn wrap(inner: Arc<ProviderFunctionRegistry>) -> DynFunctionRegistry {
-        dynify(stabby::boxed::Box::new(HostFunctionRegistry { inner }))
+        dynify(stabby::boxed::Box::new(HostFunctionRegistry {
+            inner,
+            seam: SeamSpawn::capture(),
+        }))
     }
 }
 
 impl StableFunctionRegistry for HostFunctionRegistry {
     extern "C" fn call_registered<'a>(&'a self, req: SVec<u8>) -> DynFuture<'a, SVec<u8>> {
-        dynify(stabby::boxed::Box::new(async move {
-            let req = match pb::CallRegisteredRequest::decode(&req[..]) {
-                Ok(r) => r,
-                Err(e) => return unary(err_body(format!("call_registered decode: {e}"))),
-            };
-            let Some(rf) = self.inner.get(&req.provider, &req.name) else {
+        let req = match pb::CallRegisteredRequest::decode(&req[..]) {
+            Ok(r) => r,
+            Err(e) => {
+                let body = unary(err_body(format!("call_registered decode: {e}")));
+                return dynify(stabby::boxed::Box::new(async move { body }));
+            }
+        };
+        let key = format!("{}.{}", req.provider, req.name);
+        let inner = Arc::clone(&self.inner);
+        let fut = async move {
+            let Some(rf) = inner.get(&req.provider, &req.name) else {
                 return unary(err_body(format!(
                     "unknown registered function `{}.{}`",
                     req.provider, req.name
@@ -234,19 +355,31 @@ impl StableFunctionRegistry for HostFunctionRegistry {
                 })),
                 Err(e) => unary(err_body(format!("{e:#}"))),
             }
-        }))
+        };
+        dynify(stabby::boxed::Box::new(self.seam.run(
+            "call_registered",
+            key,
+            fut,
+            |m| unary(err_body(m)),
+        )))
     }
 }
 
 /// Wraps the per-request engine executor; handed to the plugin as a [`DynExecutor`].
 pub struct HostExecutor {
     inner: Arc<dyn ProviderExecutor>,
+    seam: SeamSpawn,
 }
 
 impl HostExecutor {
     /// Wrap a per-request engine executor as an ABI-stable [`DynExecutor`].
+    /// Captures the current runtime handle and span so callback bodies run on
+    /// the host runtime, not on the guest worker polling them — see [`SeamSpawn`].
     pub fn wrap(inner: Arc<dyn ProviderExecutor>) -> DynExecutor {
-        dynify(stabby::boxed::Box::new(HostExecutor { inner }))
+        dynify(stabby::boxed::Box::new(HostExecutor {
+            inner,
+            seam: SeamSpawn::capture(),
+        }))
     }
 }
 
@@ -288,9 +421,11 @@ impl StableExecutor for HostExecutor {
     }
 
     extern "C" fn result<'a>(&'a self, addr: StableAddr) -> DynFuture<'a, ResultOutcome> {
-        dynify(stabby::boxed::Box::new(async move {
-            let parsed = addr_from_stable(&addr);
-            match self.inner.result(&parsed).await {
+        let parsed = addr_from_stable(&addr);
+        let key = parsed.to_string();
+        let inner = Arc::clone(&self.inner);
+        let fut = async move {
+            match inner.result(&parsed).await {
                 Ok(eres) => {
                     // Hand each artifact across as a lazy streaming handle — the
                     // Arc<dyn Content> moves into the handle (keeping its cache
@@ -320,7 +455,19 @@ impl StableExecutor for HostExecutor {
                     artifacts: SVec::new(),
                 },
             }
-        }))
+        };
+        dynify(stabby::boxed::Box::new(self.seam.run(
+            "result",
+            key,
+            fut,
+            |m| ResultOutcome {
+                ok: false,
+                cycle: false,
+                cancelled: false,
+                message: m.into(),
+                artifacts: SVec::new(),
+            },
+        )))
     }
 
     extern "C" fn query<'a>(
@@ -328,7 +475,8 @@ impl StableExecutor for HostExecutor {
         matcher_pb: SVec<u8>,
         extra_skip: SVec<SString>,
     ) -> DynFuture<'a, QueryOutcome> {
-        dynify(stabby::boxed::Box::new(async move {
+        let inner = Arc::clone(&self.inner);
+        let fut = async move {
             let matcher = match plugin_abi::pb::Matcher::decode(&matcher_pb[..]) {
                 Ok(m) => plugin_abi::convert::matcher_from_pb(m),
                 Err(e) => {
@@ -340,7 +488,7 @@ impl StableExecutor for HostExecutor {
                 }
             };
             let skip: Vec<String> = extra_skip.iter().map(|s| s.to_string()).collect();
-            match self.inner.query(&matcher, &skip).await {
+            match inner.query(&matcher, &skip).await {
                 Ok(addrs) => QueryOutcome {
                     ok: true,
                     message: SString::new(),
@@ -352,13 +500,25 @@ impl StableExecutor for HostExecutor {
                     addrs: SVec::new(),
                 },
             }
-        }))
+        };
+        dynify(stabby::boxed::Box::new(self.seam.run(
+            "query",
+            String::new(),
+            fut,
+            |m| QueryOutcome {
+                ok: false,
+                message: m.into(),
+                addrs: SVec::new(),
+            },
+        )))
     }
 
     extern "C" fn states_under<'a>(&'a self, prefix: SString) -> DynFuture<'a, StatesOutcome> {
-        dynify(stabby::boxed::Box::new(async move {
-            let prefix = PkgBuf::from(prefix.to_string());
-            match self.inner.states_under(&prefix).await {
+        let prefix = PkgBuf::from(prefix.to_string());
+        let key = prefix.as_str().to_string();
+        let inner = Arc::clone(&self.inner);
+        let fut = async move {
+            match inner.states_under(&prefix).await {
                 Ok(states) => StatesOutcome {
                     ok: true,
                     message: SString::new(),
@@ -373,7 +533,17 @@ impl StableExecutor for HostExecutor {
                     states: SVec::new(),
                 },
             }
-        }))
+        };
+        dynify(stabby::boxed::Box::new(self.seam.run(
+            "states_under",
+            key,
+            fut,
+            |m| StatesOutcome {
+                ok: false,
+                message: m.into(),
+                states: SVec::new(),
+            },
+        )))
     }
 }
 

--- a/crates/plugin-stabby/src/host.rs
+++ b/crates/plugin-stabby/src/host.rs
@@ -6,6 +6,7 @@ use crate::abi::{
     NoteDepOutcome, QueryOutcome, ResultOutcome, StableAddr, StableArtifactContent, StableExecutor,
     StableFunctionRegistry, StableLogSink, StableRead, StableSupervisor, StatesOutcome,
 };
+use crate::seam::panic_text;
 use crate::vtable::dynify;
 use hcore::hartifactcontent::Content;
 use hmodel::htaddr::Addr;
@@ -192,37 +193,53 @@ fn err_body(message: String) -> Body {
 /// the callback body inline in that poll would execute engine futures — which
 /// touch the host reactor and timer wheel — on a thread with no host runtime
 /// context, which panics ("there is no reactor running") and then aborts at the
-/// extern seam. So the body is spawned onto the host runtime captured at
+/// extern seam. So the body is spawned onto the host runtime handed in at
 /// `wrap()` time, and the returned future only awaits the `JoinHandle`
 /// (runtime-free to poll). Symmetric with `plugin-sdk::serve`.
 ///
-/// `handle` is `None` when `wrap()` ran outside any tokio runtime — an
-/// in-process context (unit tests, `futures::executor`-driven harnesses) where
-/// host and caller share one image and the caller drives the future itself; the
-/// body then runs inline exactly as before. Every production wrap site (`get`/
-/// `list` bodies, provider-function wiring) runs on the engine runtime.
+/// The two constructors make the mode an explicit caller decision rather than
+/// a silent runtime probe: [`SeamSpawn::on`] for production (the caller passes
+/// the runtime it is on), [`SeamSpawn::inline`] for runtime-less in-process
+/// harnesses (`futures::executor`-driven tests), where the caller drives the
+/// future itself and there is no host reactor to protect.
 struct SeamSpawn {
     handle: Option<tokio::runtime::Handle>,
-    /// Request span captured at `wrap()` time, re-entered by the spawned body so
-    /// engine logs from plugin callbacks keep the request's tracing context.
+    /// Span re-entered by the spawned body so engine logs from plugin
+    /// callbacks keep their tracing context.
     span: tracing::Span,
 }
 
 impl SeamSpawn {
-    fn capture() -> Self {
+    /// Spawn callback bodies on `handle`, instrumented with `span`.
+    fn on(handle: tokio::runtime::Handle, span: tracing::Span) -> Self {
         Self {
-            handle: tokio::runtime::Handle::try_current().ok(),
-            span: tracing::Span::current(),
+            handle: Some(handle),
+            span,
         }
+    }
+
+    /// Run callback bodies inline on the polling thread. Only sound where the
+    /// caller drives the future itself (in-process test harnesses).
+    fn inline(span: tracing::Span) -> Self {
+        Self { handle: None, span }
     }
 }
 
 /// Abort-on-drop await of a host-side callback task: dropping the wrapper
 /// (the guest abandoned the call — e.g. its own seam task was aborted) stops
-/// the spawned body instead of leaking it. No backstop here: the guest-side
-/// seam wrapper arms one for the whole call (see `plugin-sdk::serve`).
+/// the spawned body instead of leaking it.
+///
+/// The backstop is armed on every pending poll, same as the guest's
+/// `SeamTask`: this future is polled by a *guest* worker, so the completion
+/// wake (host task → guest worker) crosses the stabby waker seam. A lost wake
+/// here parks the plugin task on this JoinHandle forever — the guest-side
+/// backstop can't help, since re-polling the guest wrapper only re-polls a
+/// never-woken `JoinHandle` if the wake that was lost is this one. Same
+/// defense-in-depth as `hcore::blocking::run` (docs/CONCURRENCY_MEASUREMENTS.md
+/// §2, lands with #298 below this PR in the stack).
 struct HostTask<T> {
     handle: tokio::task::JoinHandle<T>,
+    backstop: hcore::blocking::Backstop,
 }
 
 impl<T> std::future::Future for HostTask<T> {
@@ -232,7 +249,14 @@ impl<T> std::future::Future for HostTask<T> {
         self: std::pin::Pin<&mut Self>,
         cx: &mut std::task::Context<'_>,
     ) -> std::task::Poll<Self::Output> {
-        std::pin::Pin::new(&mut self.get_mut().handle).poll(cx)
+        let this = self.get_mut();
+        match std::pin::Pin::new(&mut this.handle).poll(cx) {
+            std::task::Poll::Ready(out) => std::task::Poll::Ready(out),
+            std::task::Poll::Pending => {
+                this.backstop.arm(cx.waker());
+                std::task::Poll::Pending
+            }
+        }
     }
 }
 
@@ -242,20 +266,9 @@ impl<T> Drop for HostTask<T> {
     }
 }
 
-/// Best-effort text of a panic payload.
-fn panic_text(p: &(dyn std::any::Any + Send)) -> &str {
-    if let Some(s) = p.downcast_ref::<&'static str>() {
-        s
-    } else if let Some(s) = p.downcast_ref::<String>() {
-        s.as_str()
-    } else {
-        "<non-string panic payload>"
-    }
-}
-
 impl SeamSpawn {
     /// Run `fut` (a host callback body) to a future safe to hand across the
-    /// seam: spawned on the captured host runtime when there is one, inline
+    /// seam: spawned on the runtime this wrapper was constructed with, inline
     /// otherwise. A panicking body maps to `mk_err` (host-side bug, surfaced to
     /// the guest as an error) — never an unwind out of the wrapper's poll,
     /// which runs inside the extern shim.
@@ -279,6 +292,7 @@ impl SeamSpawn {
                 handle,
                 fut.instrument(self.span.clone()),
             ),
+            backstop: hcore::blocking::Backstop::new(),
         };
         match task.await {
             Ok(v) => v,
@@ -304,12 +318,33 @@ pub struct HostFunctionRegistry {
 }
 
 impl HostFunctionRegistry {
-    /// Wrap the aggregate registry as an ABI-stable [`DynFunctionRegistry`].
-    /// Captures the current runtime handle and span — see [`SeamSpawn`].
-    pub fn wrap(inner: Arc<ProviderFunctionRegistry>) -> DynFunctionRegistry {
+    /// The span callback bodies run under. Purpose-made rather than
+    /// `Span::current()`: the registry is wired once per process, so capturing
+    /// the ambient span would attribute every later call to whichever request
+    /// happened to wire it first — and pin that request's span for the process
+    /// lifetime.
+    fn span() -> tracing::Span {
+        tracing::info_span!("provider_functions")
+    }
+
+    /// Wrap the aggregate registry as an ABI-stable [`DynFunctionRegistry`],
+    /// spawning callback bodies on `handle` — see [`SeamSpawn`].
+    pub fn wrap(
+        inner: Arc<ProviderFunctionRegistry>,
+        handle: tokio::runtime::Handle,
+    ) -> DynFunctionRegistry {
         dynify(stabby::boxed::Box::new(HostFunctionRegistry {
             inner,
-            seam: SeamSpawn::capture(),
+            seam: SeamSpawn::on(handle, Self::span()),
+        }))
+    }
+
+    /// Runtime-less variant for in-process test harnesses: callback bodies run
+    /// inline on the polling thread, which is the caller's own driver.
+    pub fn wrap_inline(inner: Arc<ProviderFunctionRegistry>) -> DynFunctionRegistry {
+        dynify(stabby::boxed::Box::new(HostFunctionRegistry {
+            inner,
+            seam: SeamSpawn::inline(Self::span()),
         }))
     }
 }
@@ -372,13 +407,23 @@ pub struct HostExecutor {
 }
 
 impl HostExecutor {
-    /// Wrap a per-request engine executor as an ABI-stable [`DynExecutor`].
-    /// Captures the current runtime handle and span so callback bodies run on
-    /// the host runtime, not on the guest worker polling them — see [`SeamSpawn`].
-    pub fn wrap(inner: Arc<dyn ProviderExecutor>) -> DynExecutor {
+    /// Wrap a per-request engine executor as an ABI-stable [`DynExecutor`],
+    /// spawning callback bodies on `handle` (instrumented with the caller's
+    /// current span) so they run on the host runtime, not on the guest worker
+    /// polling them — see [`SeamSpawn`].
+    pub fn wrap(inner: Arc<dyn ProviderExecutor>, handle: tokio::runtime::Handle) -> DynExecutor {
         dynify(stabby::boxed::Box::new(HostExecutor {
             inner,
-            seam: SeamSpawn::capture(),
+            seam: SeamSpawn::on(handle, tracing::Span::current()),
+        }))
+    }
+
+    /// Runtime-less variant for in-process test harnesses: callback bodies run
+    /// inline on the polling thread, which is the caller's own driver.
+    pub fn wrap_inline(inner: Arc<dyn ProviderExecutor>) -> DynExecutor {
+        dynify(stabby::boxed::Box::new(HostExecutor {
+            inner,
+            seam: SeamSpawn::inline(tracing::Span::current()),
         }))
     }
 }
@@ -628,6 +673,103 @@ mod tests {
                 assert_eq!(got.as_slice(), [$n as u8], "vtable dispatched to the wrong impl");
             })*
         };
+    }
+
+    /// Abort-on-drop on the host mirror: the guest abandoning a callback future
+    /// (dropping it — e.g. its own seam task was aborted) must stop the spawned
+    /// host body, not leak it on the engine runtime. Same shape as the guest's
+    /// `dropped_seam_future_aborts_the_spawned_body`: side-effect flag +
+    /// deadline poll. The host spawn is lazy (first poll of the returned
+    /// future), so the future is polled once before the drop.
+    #[test]
+    fn dropped_callback_future_aborts_the_spawned_host_body() {
+        use crate::abi::{StableAddr, StableExecutorDyn};
+        use futures::future::BoxFuture;
+        use hmodel::htaddr::Addr;
+        use hplugin::provider::ProviderExecutor;
+        use std::future::Future as _;
+        use std::sync::Arc;
+        use std::sync::atomic::{AtomicBool, Ordering};
+        use std::time::{Duration, Instant};
+
+        struct SetOnDrop(Arc<AtomicBool>);
+        impl Drop for SetOnDrop {
+            fn drop(&mut self) {
+                self.0.store(true, Ordering::SeqCst);
+            }
+        }
+
+        struct Hanger {
+            started: Arc<AtomicBool>,
+            stopped: Arc<AtomicBool>,
+        }
+        impl ProviderExecutor for Hanger {
+            fn result<'a>(
+                &'a self,
+                _addr: &'a Addr,
+            ) -> BoxFuture<'a, anyhow::Result<Arc<hplugin::eresult::EResult>>> {
+                let started = Arc::clone(&self.started);
+                let stopped = Arc::clone(&self.stopped);
+                Box::pin(async move {
+                    // Dropped only when this body's future is dropped — i.e.
+                    // when the spawned host task is aborted.
+                    let _guard = SetOnDrop(stopped);
+                    started.store(true, Ordering::SeqCst);
+                    futures::future::pending::<()>().await;
+                    anyhow::bail!("unreachable: pending never resolves")
+                })
+            }
+            fn query<'a>(
+                &'a self,
+                _m: &'a hmodel::htmatcher::Matcher,
+                _s: &'a [String],
+            ) -> BoxFuture<'a, anyhow::Result<Vec<Addr>>> {
+                Box::pin(async { anyhow::bail!("unused") })
+            }
+        }
+
+        let started = Arc::new(AtomicBool::new(false));
+        let stopped = Arc::new(AtomicBool::new(false));
+        let rt = tokio::runtime::Builder::new_multi_thread()
+            .worker_threads(2)
+            .enable_all()
+            .build()
+            .expect("rt");
+        let dynexec = super::HostExecutor::wrap(
+            Arc::new(Hanger {
+                started: Arc::clone(&started),
+                stopped: Arc::clone(&stopped),
+            }) as Arc<dyn ProviderExecutor>,
+            rt.handle().clone(),
+        );
+
+        let deadline = Instant::now() + Duration::from_secs(10);
+        {
+            let fut = dynexec.result(StableAddr {
+                package: "p".into(),
+                name: "t".into(),
+                args: stabby::vec::Vec::new(),
+            });
+            futures::pin_mut!(fut);
+            let waker = futures::task::noop_waker();
+            let mut cx = std::task::Context::from_waker(&waker);
+            assert!(
+                fut.as_mut().poll(&mut cx).is_pending(),
+                "callback body must still be running"
+            );
+            while !started.load(Ordering::SeqCst) {
+                assert!(Instant::now() < deadline, "spawned host body never started");
+                std::thread::sleep(Duration::from_millis(5));
+            }
+            // The guest abandons the call: the future drops at end of scope.
+        }
+        while !stopped.load(Ordering::SeqCst) {
+            assert!(
+                Instant::now() < deadline,
+                "host body still running after the callback future was dropped"
+            );
+            std::thread::sleep(Duration::from_millis(5));
+        }
     }
 
     /// The host's `wrap` constructors run on the plugin-load path, which is driven

--- a/crates/plugin-stabby/src/lib.rs
+++ b/crates/plugin-stabby/src/lib.rs
@@ -26,6 +26,7 @@
 )]
 
 pub mod abi;
+pub mod seam;
 pub mod vtable;
 
 #[cfg(feature = "host")]

--- a/crates/plugin-stabby/src/load_stable.rs
+++ b/crates/plugin-stabby/src/load_stable.rs
@@ -42,6 +42,22 @@ fn sv(bytes: &[u8]) -> SVec<u8> {
     SVec::from(bytes)
 }
 
+/// Wrap the engine executor for the seam, choosing the spawn mode explicitly.
+///
+/// Production always reaches this on the engine runtime (these methods are
+/// engine-driven futures), so callback bodies spawn there. The `Err` arm is
+/// the in-process test harnesses (`futures::executor`-driven, no tokio
+/// runtime): there the *caller* is the driver of every future involved, so
+/// inline execution on the polling thread is exactly right — and there is no
+/// host reactor a callback body could touch. The fork is explicit here, at
+/// the one layer that serves both, rather than a silent probe inside `wrap`.
+fn wrap_executor(exec: &Arc<dyn hplugin::provider::ProviderExecutor>) -> DynExecutor {
+    match tokio::runtime::Handle::try_current() {
+        Ok(handle) => HostExecutor::wrap(Arc::clone(exec), handle),
+        Err(_) => HostExecutor::wrap_inline(Arc::clone(exec)),
+    }
+}
+
 /// A loaded plugin's host-side handles: an optional provider + named drivers +
 /// named hooks.
 pub type LoadedComponents = (
@@ -338,7 +354,7 @@ impl Provider for StableRemoteProvider {
             // Server-streaming **with** the executor, so the plugin's `list` can
             // call back (e.g. the go module variant universe via `states_under`).
             // Items still stream lazily across the seam.
-            let exec: DynExecutor = HostExecutor::wrap(Arc::clone(&req.executor));
+            let exec: DynExecutor = wrap_executor(&req.executor);
             let stream = self
                 .inner
                 .invoke_exec_server_stream(pb::ProviderMethod::List as u32, sv(&pb_req), exec)
@@ -394,7 +410,7 @@ impl Provider for StableRemoteProvider {
                 states: req.states.iter().map(convert::state_to_pb).collect(),
             }
             .encode_to_vec();
-            let exec: DynExecutor = HostExecutor::wrap(Arc::clone(&req.executor));
+            let exec: DynExecutor = wrap_executor(&req.executor);
             let fut = self
                 .inner
                 .invoke_exec(pb::ProviderMethod::Get as u32, sv(&pb_req), exec);
@@ -504,7 +520,13 @@ impl Provider for StableRemoteProvider {
             })
             .collect();
         let metadata = pb::FunctionRegistry { functions }.encode_to_vec();
-        let cb = crate::host::HostFunctionRegistry::wrap(reg);
+        // Same explicit fork as `wrap_executor`: production wiring happens on
+        // the engine runtime; only runtime-less in-process harnesses take the
+        // inline arm, and they drive the callback futures themselves.
+        let cb = match tokio::runtime::Handle::try_current() {
+            Ok(handle) => crate::host::HostFunctionRegistry::wrap(reg, handle),
+            Err(_) => crate::host::HostFunctionRegistry::wrap_inline(reg),
+        };
         self.inner.invoke_registry(
             pb::ProviderMethod::SetFunctionRegistry as u32,
             sv(&metadata),

--- a/crates/plugin-stabby/src/seam.rs
+++ b/crates/plugin-stabby/src/seam.rs
@@ -1,0 +1,19 @@
+//! Small helpers shared by both sides of the spawn-at-the-seam wrappers
+//! (host adapters here; guest wrappers in `plugin-sdk::serve`). Always
+//! compiled — no transport or host deps — so the guest SDK can use them with
+//! `default-features = false`.
+
+/// Best-effort text of a panic payload (`panic!` `&str`/`String`, else a stub).
+///
+/// Used when mapping a seam task's `JoinError::is_panic` payload into an error
+/// body — the wrapper futures must never `resume_unwind` (their polls run
+/// inside `extern "C"` shims, where an unwind aborts the process).
+pub fn panic_text(p: &(dyn std::any::Any + Send)) -> &str {
+    if let Some(s) = p.downcast_ref::<&'static str>() {
+        s
+    } else if let Some(s) = p.downcast_ref::<String>() {
+        s.as_str()
+    } else {
+        "<non-string panic payload>"
+    }
+}


### PR DESCRIPTION
Stacked on #300 (`raphaelvigee/provider-list-guard`) — the executor-carried `IN_PROVIDER_LIST` guard is the prerequisite that makes spawning provider bodies safe.

## Design

A cdylib statically links its own tokio; a plugin body polled by a host worker (or a host callback body polled by a plugin worker) that touches its reactor/timer panics ("there is no reactor running"), and a panic across the `extern "C"` seam is a non-unwinding process **abort**. Until now only driver `run` and hook drains were spawned onto the right runtime — every other entry-point body ran inline on the peer's workers.

This PR makes the spawn **symmetric at the seam**:

- **Guest** (`plugin-sdk::serve`): every ABI entry-point body — provider `get`/`probe`/`list`/`list_packages`/`call_function`, driver `parse`/`apply_transitive` — spawns onto the plugin's own runtime (workers named `heph-plugin-worker`); the returned `DynFuture` only awaits the `JoinHandle` (runtime-free to poll; `hook_on_events` was the in-tree precedent).
- **Host** (`plugin-stabby::host`): `HostExecutor::{result,query,states_under}` and `HostFunctionRegistry::call_registered` capture `Handle::current()` + `Span::current()` at `wrap()` time and spawn their bodies there, `.instrument()`ed. `note_dep` stays synchronous (ready future, reactor-free). Without this mirror, the first uncached dep resolved through a real cdylib aborts the process — in-process tests structurally cannot catch it (host and plugin share one image); only the bin-e2e dlopen seam can.
- **Mechanics**: `JoinHandle` (tokio's task harness is the `catch_unwind`), never `resume_unwind` in the wrapper (its poll runs inside the extern shim); panic → `plugin <name>: <method>(<key>) panicked: <payload>` error body; abort-on-drop guard around the handle (drop is the only stop signal for the entry points with no `CancelRegistry` wiring; the cooperative `await_with_cancel` path is untouched); new `hcore::hmemoizer::spawn_on_with_cycle_ctx(&Handle, fut)` used at every seam spawn on both sides (and retrofitted onto `run_bidi`'s existing spawn) so cycle-detection frames survive the spawn; the guest wrapper arms `hcore::blocking::Backstop` on every pending poll (hazard not reproduced in isolation — defense-in-depth consistent with `blocking::run`, see docs/CONCURRENCY_MEASUREMENTS.md §2).

## Review-board verdicts

Design (consolidated v2):

- product-vision: **SHIP WITH CHANGES** (panic error shape, named threads, diagnosability) — incorporated.
- compatibility: **BREAKING-as-proposed** — fixed by the prerequisite PR #300 (task-local list guard moved onto the executor instance).
- feature-quality: **BLOCKED-as-proposed** — fixed by the symmetric host mirror + the Tier B cost gate below.
- code-quality: **PASS WITH NITS** on this symmetric shape.

Implementation review (second pass, addressed in the review-fixes commit):

- compatibility: **COMPATIBLE**, no ABI bump.
- code-quality: **PASS WITH NITS** — majors fixed: multi-token `inflight` (`HashMap<String, Vec<Token>>`; a request cancel trips every concurrent call under the shared `req-{n}` id, not just the last registrant), explicit `wrap(handle)`/`wrap_inline` constructors instead of a silent `try_current` probe, purpose-made `provider_functions` span for the once-per-process registry wrapper, `panic_text` deduped into `hplugin_stabby::seam`, `<unnamed>` fallback for a failed `config()`, bounded `precancelled` (consumed by a cancelled guard's drop), doc-citation reword, `cancel_abandoned` comment addendum for the seam's async-abort exception.
- feature-quality: **BLOCKED** — both blockers fixed: a bin-e2e test crossing the host mirror over the real dlopen'd go cdylib (`states_under` callback from a plugin worker; sibling-declared variant makes the assertion non-vacuous), and deterministic `CancelRegistry` unit tests (each verified red against the pre-fix registry). `HostTask` now arms the Backstop on pending polls (its completion wake crosses the seam toward a guest worker — the guest-side backstop cannot cover it) and has its own abort-on-drop test.

## Semantic deltas

- **Eager start**: `invoke()` now runs guest code before the wrapper's first poll (request decode, `CancelRegistry::enter`, `note_dep` inserts). Documented as a seam invariant on the dispatch impls. `CancelRegistry::enter` stays inside the spawned body so pre-cancel parking still applies. DepDag note: an abandoned-pre-poll body can now have inserted edges before its wrapper is dropped; edges live in the per-request DepDag, which dies with the request, and re-issued calls re-insert idempotently.
- **Drop-cancel is now asynchronous**: the abort lands on a plugin worker after the host's drop returns, where the old inline body died synchronously with the destructor.

## Latent races fixed (found by the new tests / flagged by review)

- `CancelRegistry` `enter`/`cancel` each *checked* the other's map before *publishing* to its own — a cancel landing between a call's precancelled check and its inflight insert was lost. Hittable once spawn is eager; the race-loop test caught it at iteration 2. Both sides now publish before checking.
- `CancelGuard::drop` removed its request id unconditionally, but request ids name an engine request, not a call — a stale guard's late drop could deregister a live successor's token. Removal is now identity-checked (`StdCancellationToken::ptr_eq`).

## Cost

~2 spawns per target per warm run (get/parse ride per-run memoizers). **Tier B bench pending (gate)**: real-cdylib cold (go corpus) + full-hit warm, baseline vs candidate, run serially on this PR before merge; results go into docs/CONCURRENCY_MEASUREMENTS.md. If the warm delta is real, the spawn scopes down to reactor-needing entry points only. Guest runtime sizing (currently ncores, justified by driver `run`) is a visible decision surfaced for perf-measurement sign-off with those numbers.

## Tests

- `serve::tests::panicking_provider_body_is_contained_as_error` — panic → actionable error (plugin, method, key, payload), process survives.
- `serve::tests::dropped_seam_future_aborts_the_spawned_body` — guest abort-on-drop: side-effect flag + deadline poll.
- `host::tests::dropped_callback_future_aborts_the_spawned_host_body` — host-mirror abort-on-drop, same shape.
- `serve::tests::precancel_racing_the_spawn_is_never_lost` — 100-iteration race loop; caught the enter/cancel TOCTOU.
- `serve::tests::registry_cancel_before_enter_starts_cancelled`, `registry_cancel_after_enter_trips_the_token`, `registry_stale_guard_drop_does_not_deregister_successor`, `registry_cancel_trips_every_concurrent_call_under_one_id`, `registry_cancelled_guard_drop_leaves_no_state_behind` — deterministic registry contract; the stale-drop and multi-token tests verified red against the pre-fix registry.
- `serve::tests::nested_seam_get_completes_without_deadlock` — get → executor.result(dep) → second get spawned into the same plugin runtime; completes under timeout. Exercises the host mirror's spawn path too.
- `guest::tests::host_callback_panic_surfaces_as_error_not_abort` — host-side mirror of panic containment.
- bin-e2e `plugin_dylib::shipped_go_cdylib_list_calls_back_states_under_across_the_seam` — the host mirror over the REAL dlopen'd go cdylib: `list` calls back `states_under` from a plugin worker; the `release` variant declared only at the sibling `//cmd` makes `//lib:build_lib@v=release` provable only via the callback.
- Existing suites green: plugin-sdk, plugin-stabby, core, engine, e2e; plugingo-e2e build suite (16/16). `cancellation_propagates_to_plugin` green unchanged.

## Follow-ups (recorded, not in this PR)

- A panic inside a lazily-pulled list iterator still unwinds through the extern `GuestItemStream::next` → abort (pre-existing). Fix shape: `catch_unwind` in `frame_iter`, mapping to a `stream_err` frame.
- `run_bidi`'s fire-and-forget run task surfaces a panic only as a channel close ("run stream ended without a result"). Fix shape: await its `JoinHandle` and emit the panic text as the terminal error frame.
- A bin-e2e deliberate-panic fixture cdylib, so panic containment (not just reactor safety) is also proven across the real dlopen seam.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014wDi9n2Fi1aN6jwy8ET7WG
