### PR TITLE
feat(hmemoizer): task-backed memoizer cell behind the existing Memoizer API

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -878,6 +878,7 @@ dependencies = [
  "tar",
  "tempfile",
  "tokio",
+ "tracing",
  "xxhash-rust",
 ]
 

--- a/crates/bench-corpus/src/lib.rs
+++ b/crates/bench-corpus/src/lib.rs
@@ -504,6 +504,43 @@ mod tests {
         assert!(dir.path().join("go/go.mod").is_file());
     }
 
+    /// The deep-graph shape the memoizer redesign's bench gate runs against:
+    /// one target per layer, exactly one dep each — a 200-deep linear chain.
+    /// Depth is the point (the stack-overflow and depth-serialization
+    /// pathologies scale with it), so the chain being unbroken is asserted,
+    /// not assumed: with `fan_out = 1` every non-root layer picks exactly one
+    /// dep from the layer below.
+    #[test]
+    fn generate_supports_a_deep_thin_chain_corpus() {
+        let params = CorpusParams {
+            seed: 5,
+            target_count: 200,
+            packages: 4,
+            layers: 200,
+            fan_out: 1,
+            ..Default::default()
+        };
+        let dir = tempfile::tempdir().expect("tempdir");
+        let manifest = generate(&params, dir.path()).expect("generate deep corpus");
+        assert_eq!(manifest.bash_addrs.len(), 200);
+
+        // 200 targets over 200 layers = 1 per layer; every target except the
+        // single layer-0 root must carry a deps list.
+        let mut with_deps = 0usize;
+        for pkg in &manifest.bash_packages {
+            let src =
+                std::fs::read_to_string(dir.path().join(pkg).join("BUILD")).expect("read BUILD");
+            with_deps += src
+                .lines()
+                .filter(|l| l.trim_start().starts_with("deps"))
+                .count();
+        }
+        assert_eq!(
+            with_deps, 199,
+            "a fan_out=1, one-target-per-layer corpus must be an unbroken chain"
+        );
+    }
+
     #[test]
     fn incrementalize_touches_requested_fraction() {
         let params = CorpusParams {

--- a/crates/core/Cargo.toml
+++ b/crates/core/Cargo.toml
@@ -18,6 +18,7 @@ rustc-hash = "2"
 libc = "0.2"
 stacker = "0.1"
 tokio = { version = "1.52.3", features = ["rt", "rt-multi-thread", "macros", "sync", "time", "test-util"] }
+tracing = "0.1"
 
 [dev-dependencies]
 tempfile = "3"

--- a/crates/core/src/hmemoizer/mod.rs
+++ b/crates/core/src/hmemoizer/mod.rs
@@ -2172,6 +2172,113 @@ mod tests {
         );
     }
 
+    /// Task-mode twin of `cycle_error_eviction_spares_an_innocent_recreated_cell`:
+    /// the eviction is value-keyed through `TaskInner::evict_if` — a cached
+    /// cycle error is evicted, an in-flight successor and a real value are
+    /// spared.
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn task_mode_cycle_error_eviction_spares_an_innocent_recreated_cell() {
+        type V = Result<Arc<u32>, Arc<anyhow::Error>>;
+        let m: Memoizer<String, V> =
+            Memoizer::with_tag_task("task-cycle-evict-test", tokio::runtime::Handle::current());
+        let key = "k".to_string();
+
+        let v = m
+            .process(key.clone(), || async move {
+                Err(Arc::new(anyhow::Error::new(MemoizerCycleError {
+                    tag: "task-cycle-evict-test",
+                    key: "k".to_string(),
+                    kind: CycleKind::SelfRecursion,
+                    stack: vec![],
+                }))) as V
+            })
+            .await;
+        assert!(v.is_err());
+        m.evict_cached_cycle_error(&key);
+        assert!(
+            m.peek(&key).is_none(),
+            "a cached cycle error must be evicted from the task cell map"
+        );
+
+        // A completed innocent value is spared.
+        let v = m
+            .process(key.clone(), || async move { Ok(Arc::new(5u32)) as V })
+            .await;
+        assert_eq!(**v.as_ref().expect("ok"), 5);
+        m.evict_cached_cycle_error(&key);
+        assert!(
+            m.peek(&key).is_some(),
+            "a real memoized value must survive a stale cycle eviction"
+        );
+    }
+
+    /// Task-mode cycle detection, end to end. The detection flag is
+    /// process-latched (`OnceLock` over the env), so the actual assertion runs
+    /// in a subprocess of this test binary with the env set at startup; this
+    /// driver only checks the subprocess verdict.
+    #[test]
+    fn task_mode_cycle_detection_is_intact() {
+        let exe = std::env::current_exe().expect("current_exe");
+        let out = std::process::Command::new(exe)
+            .args([
+                "--exact",
+                "hmemoizer::tests::task_mode_self_cycle_errors_helper",
+                "--ignored",
+                "--test-threads=1",
+            ])
+            .env("HEPH_DEBUG_MEMOIZER_CYCLE", "1")
+            .output()
+            .expect("spawn helper subprocess");
+        assert!(
+            out.status.success(),
+            "task-mode cycle detection helper failed:\n--- stdout ---\n{}\n--- stderr ---\n{}",
+            String::from_utf8_lossy(&out.stdout),
+            String::from_utf8_lossy(&out.stderr),
+        );
+    }
+
+    /// Body of [`task_mode_cycle_detection_is_intact`] — a same-task re-entry
+    /// through a spawned task-cell body must produce `MemoizerCycleError`, not
+    /// an eternal park. Proves `IN_FLIGHT` scoping survives the spawn (the
+    /// creator-frame wrap travels with the body future into the task).
+    #[tokio::test]
+    #[ignore = "driven by task_mode_cycle_detection_is_intact — needs HEPH_DEBUG_MEMOIZER_CYCLE=1 latched at process start"]
+    async fn task_mode_self_cycle_errors_helper() {
+        assert!(
+            cycle_detection_enabled(),
+            "helper requires the cycle-detection flag latched on at process start"
+        );
+        type V = Result<Arc<u32>, Arc<anyhow::Error>>;
+        let m: Arc<Memoizer<String, V>> = Arc::new(Memoizer::with_tag_task(
+            "task-cycle-detect-test",
+            tokio::runtime::Handle::current(),
+        ));
+        let v = tokio::time::timeout(Duration::from_secs(5), {
+            let m2 = Arc::clone(&m);
+            m.once("A".to_string(), move || async move {
+                // Re-enter our own in-flight key from inside the spawned body.
+                // Without detection this deadlocks (the timeout above catches
+                // it); with it, the inner call must return the typed error.
+                let inner = m2
+                    .once("A".to_string(), || async { Ok(Arc::new(1u32)) })
+                    .await;
+                let err = inner.expect_err("self-recursion must error, not recurse");
+                assert!(
+                    downcast_chain_ref::<MemoizerCycleError>(&err).is_some(),
+                    "the inner error must be the typed cycle error: {err}"
+                );
+                Ok(Arc::new(99u32))
+            })
+        })
+        .await
+        .expect("a self-cycle must error, not hang");
+        assert_eq!(
+            **v.as_ref().expect("outer body completes"),
+            99,
+            "the outer computation proceeds once the inner cycle errored"
+        );
+    }
+
     /// An awaiter that *unwinds* out of `process` still cancels and evicts.
     ///
     /// Raw `process` has no panic guard (`once` adds one), so a computation

--- a/crates/core/src/hmemoizer/mod.rs
+++ b/crates/core/src/hmemoizer/mod.rs
@@ -1,4 +1,5 @@
 mod cell;
+mod task_cell;
 
 use futures::FutureExt;
 use rustc_hash::FxHashMap;
@@ -474,7 +475,16 @@ pub struct StuckCell {
     pub waiters: Option<usize>,
     /// Whether an awaiter is elected to re-poll the inner future. See
     /// [`cell::Cell::has_driver`] for why `false` here is the interesting case.
+    /// For a task-backed cell this is "the spawned task is still live" — same
+    /// meaning (somebody is on the hook to finish this cell), same rendering.
     pub has_driver: bool,
+    /// How many aborted predecessors this cell's key has had (task-backed
+    /// cells only; always 0 for poll cells). A climbing count is abort/rejoin
+    /// thrash — work being redone, not work being slow.
+    pub restarts: u32,
+    /// How long the computation has been in flight (task-backed cells only —
+    /// the poll cell records no spawn instant).
+    pub age: Option<Duration>,
 }
 
 impl StuckCell {
@@ -538,6 +548,8 @@ where
                 key: format!("{key:?}"),
                 waiters: cell.waiters(),
                 has_driver: cell.has_driver(),
+                restarts: 0,
+                age: None,
             });
         }
         true
@@ -638,8 +650,17 @@ pub fn render_inventory(cells: &[StuckCell], limit: usize) -> String {
         } else {
             ""
         };
+        let age = match cell.age {
+            Some(a) => format!(" age={:.1}s", a.as_secs_f64()),
+            None => String::new(),
+        };
+        let restarts = if cell.restarts > 0 {
+            format!(" restarts={}", cell.restarts)
+        } else {
+            String::new()
+        };
         out.push_str(&format!(
-            "    [{}] {} waiters={waiters} driver={}{mark}\n",
+            "    [{}] {} waiters={waiters} driver={}{age}{restarts}{mark}\n",
             cell.tag, cell.key, cell.has_driver
         ));
     }
@@ -913,6 +934,23 @@ const DROP_RED_ZONE: usize = 256 * 1024;
 const DROP_STACK_PER_GROW: usize = 4 * 1024 * 1024;
 
 pub struct Memoizer<K, V> {
+    inner: Inner<K, V>,
+}
+
+/// The two cell implementations behind [`Memoizer`]'s one API.
+///
+/// `Poll` is the shipped cooperative-polling cell (driver election, waker
+/// slab). `Task` spawns each cold computation as a tokio task on a runtime
+/// handle captured at construction — see `task_cell`'s module docs. The
+/// engine still constructs `Poll` everywhere; flipping construction sites to
+/// [`Memoizer::with_tag_task`] is a deliberate, benched change (one small
+/// commit to revert), not a side effect of this enum existing.
+enum Inner<K, V> {
+    Poll(PollInner<K, V>),
+    Task(task_cell::TaskInner<K, V>),
+}
+
+struct PollInner<K, V> {
     /// Behind an `Arc` so the inventory can hold a `Weak` to it: a `Memoizer`
     /// lives in a `RequestState` field, not an `Arc`, so there is nothing else
     /// for the registry to keep a non-owning handle on.
@@ -968,7 +1006,41 @@ where
             tag,
             cache: Arc::downgrade(&cache),
         }));
-        Self { cache, tag }
+        Self {
+            inner: Inner::Poll(PollInner { cache, tag }),
+        }
+    }
+
+    /// Task-backed variant: every cold computation is spawned as a task on
+    /// `handle` (captured here, never discovered at spawn time). See
+    /// `task_cell`'s module docs for the state machine and its guarantees.
+    /// The engine's construction sites stay on [`with_tag`](Self::with_tag)
+    /// until the flip PR switches them, measured.
+    pub fn with_tag_task(tag: &'static str, handle: tokio::runtime::Handle) -> Self {
+        Self {
+            inner: Inner::Task(task_cell::TaskInner::new(tag, handle)),
+        }
+    }
+
+    fn tag(&self) -> &'static str {
+        match &self.inner {
+            Inner::Poll(p) => p.tag,
+            Inner::Task(t) => t.tag(),
+        }
+    }
+
+    /// Test-only reach into the poll cell map, for the interleaving proofs
+    /// that drive `cancel_abandoned` by hand.
+    #[cfg(test)]
+    #[expect(
+        clippy::type_complexity,
+        reason = "the full map type is the point — the tests hand it to cancel_abandoned"
+    )]
+    fn poll_cache(&self) -> &Arc<Mutex<FxHashMap<K, Arc<cell::Cell<V>>>>> {
+        match &self.inner {
+            Inner::Poll(p) => &p.cache,
+            Inner::Task(_) => panic!("poll_cache on a task-backed memoizer"),
+        }
     }
 
     /// Non-inserting peek: returns the memoized value only if it is already
@@ -976,11 +1048,33 @@ where
     /// on a cache hit (e.g. registering a dep edge with `note_dep` instead of a
     /// full `result`) without disturbing the cache or deduping with in-flight work.
     pub fn peek(&self, key: &K) -> Option<V> {
-        let cache = self.cache.lock().expect("memoizer lock poisoned");
-        cache.get(key).and_then(|cell| cell.peek().cloned())
+        match &self.inner {
+            Inner::Poll(p) => {
+                let cache = p.cache.lock().expect("memoizer lock poisoned");
+                cache.get(key).and_then(|cell| cell.peek().cloned())
+            }
+            Inner::Task(t) => t.peek(key),
+        }
     }
 
     pub async fn process<F, Fut>(&self, key: K, f: F) -> V
+    where
+        F: FnOnce() -> Fut,
+        Fut: Future<Output = V> + Send + 'static,
+    {
+        match &self.inner {
+            Inner::Poll(p) => p.process(key, f).await,
+            Inner::Task(t) => t.process(key, f).await,
+        }
+    }
+}
+
+impl<K, V> PollInner<K, V>
+where
+    K: std::hash::Hash + Eq + Send + Sync + 'static + fmt::Debug + Clone,
+    V: Clone + Send + Sync + 'static,
+{
+    async fn process<F, Fut>(&self, key: K, f: F) -> V
     where
         F: FnOnce() -> Fut,
         Fut: Future<Output = V> + Send + 'static,
@@ -1070,14 +1164,16 @@ where
     }
 }
 
-async fn await_with_stall_check<V, K>(waiter: cell::Await<V>, key: &K, tag: &'static str) -> V
+async fn await_with_stall_check<V, K, Fut>(waiter: Fut, key: &K, tag: &'static str) -> V
 where
-    V: Clone + Send + Sync + 'static,
+    Fut: Future<Output = V>,
     K: fmt::Debug,
 {
     let Some(threshold) = stall_threshold() else {
         return waiter.await;
     };
+    // `timeout_without_reactor` needs `Unpin`; a pinned `&mut` reference is.
+    let waiter = std::pin::pin!(waiter);
     match cell::timeout_without_reactor(threshold, waiter).await {
         Ok(v) => v,
         Err(()) => {
@@ -1214,7 +1310,7 @@ where
         F: FnOnce() -> Fut + Send + 'static,
         Fut: Future<Output = anyhow::Result<T>> + Send + 'static,
     {
-        let tag = self.tag;
+        let tag = self.tag();
 
         // Fast path: cycle detection disabled. Skip key hashing, the frame
         // push, the task_local::scope wrap, AND the wait-for graph bookkeeping
@@ -1222,7 +1318,7 @@ where
         // deadlocking the runtime, and most runs don't have cycles. Opt back in
         // with `HEPH_DEBUG_MEMOIZER_CYCLE=1`.
         if !cycle_detection_enabled() {
-            return self.process(key, || guard_panics(f())).await;
+            return self.process_result(key, || guard_panics(f())).await;
         }
 
         let key_hash = compute_key_hash(&key);
@@ -1323,7 +1419,7 @@ where
         let result = IN_FLIGHT
             .scope(
                 frame,
-                self.process(key, move || {
+                self.process_result(key, move || {
                     IN_FLIGHT.scope(creator_frame, guard_panics(f()))
                 }),
             )
@@ -1361,6 +1457,25 @@ where
         result
     }
 
+    /// `process` with the task-mode poison contract applied: a poisoned
+    /// task cell panics its joiners (`task_cell::wait_done`), and for this
+    /// `Result`-typed surface that panic is caught and memoized-shaped as an
+    /// `Err` — a shut-down runtime or an unguarded body panic degrades to a
+    /// failed target instead of unwinding into a cdylib seam, where an unwind
+    /// is an abort. Poll mode is untouched: no wrapper, identical behavior to
+    /// before the enum existed. Any non-poison panic is resumed, so the
+    /// debug-only stall panic stays loud in both modes.
+    async fn process_result<F, Fut>(&self, key: K, f: F) -> Result<T, Arc<anyhow::Error>>
+    where
+        F: FnOnce() -> Fut + Send + 'static,
+        Fut: Future<Output = Result<T, Arc<anyhow::Error>>> + Send + 'static,
+    {
+        match &self.inner {
+            Inner::Poll(_) => self.process(key, f).await,
+            Inner::Task(_) => task_cell::catch_poison(self.process(key, f)).await,
+        }
+    }
+
     /// Evict `key` iff its cell completed with a cycle error.
     ///
     /// Cycle errors are context-dependent — valid only for the call chain that
@@ -1374,15 +1489,21 @@ where
     /// exactly the cells it exists for; an in-flight cell (`peek() == None`)
     /// is never touched.
     fn evict_cached_cycle_error(&self, key: &K) {
-        let mut cache = self.cache.lock().expect("memoizer lock poisoned");
-        let holds_cycle_error = cache.get(key).is_some_and(|cell| {
-            cell.peek().is_some_and(|v| match v {
-                Err(e) => downcast_chain_ref::<MemoizerCycleError>(e).is_some(),
-                Ok(_) => false,
-            })
-        });
-        if holds_cycle_error {
-            cache.remove(key);
+        let holds_cycle_error = |v: &Result<T, Arc<anyhow::Error>>| match v {
+            Err(e) => downcast_chain_ref::<MemoizerCycleError>(e).is_some(),
+            Ok(_) => false,
+        };
+        match &self.inner {
+            Inner::Poll(p) => {
+                let mut cache = p.cache.lock().expect("memoizer lock poisoned");
+                if cache
+                    .get(key)
+                    .is_some_and(|cell| cell.peek().is_some_and(holds_cycle_error))
+                {
+                    cache.remove(key);
+                }
+            }
+            Inner::Task(t) => t.evict_if(key, holds_cycle_error),
         }
     }
 }
@@ -1851,14 +1972,14 @@ mod tests {
         // The completed cell stays in the map with interest back at zero — the
         // state a stale cancellation finds after losing the race.
         let cell = m
-            .cache
+            .poll_cache()
             .lock()
             .expect("memoizer lock poisoned")
             .get("k")
             .cloned()
             .expect("a completed cell is retained as the memoized answer");
         assert_eq!(cell.interest(), 0);
-        cancel_abandoned(&m.cache, &"k".to_string(), &cell);
+        cancel_abandoned(m.poll_cache(), &"k".to_string(), &cell);
 
         let v = m
             .process("k".to_string(), {
@@ -1894,7 +2015,7 @@ mod tests {
         }));
         assert!(futures::poll!(&mut first).is_pending());
         let old_cell = m
-            .cache
+            .poll_cache()
             .lock()
             .expect("memoizer lock poisoned")
             .get("k")
@@ -1903,7 +2024,7 @@ mod tests {
         drop(first); // cancels and evicts
 
         // Idempotence against the (now evicted, future-less) old cell.
-        cancel_abandoned(&m.cache, &"k".to_string(), &old_cell);
+        cancel_abandoned(m.poll_cache(), &"k".to_string(), &old_cell);
 
         // A fresh computation under the same key, still in flight.
         let gate = std::sync::Arc::new(tokio::sync::Notify::new());
@@ -1917,7 +2038,7 @@ mod tests {
         assert!(futures::poll!(&mut second).is_pending());
 
         // The stale cancellation arrives now. It must not touch the fresh cell.
-        cancel_abandoned(&m.cache, &"k".to_string(), &old_cell);
+        cancel_abandoned(m.poll_cache(), &"k".to_string(), &old_cell);
 
         gate.notify_waiters();
         let v = tokio::time::timeout(Duration::from_secs(5), &mut second)
@@ -1954,7 +2075,7 @@ mod tests {
         assert!(v.is_err());
         m.evict_cached_cycle_error(&key);
         assert!(
-            !m.cache.lock().expect("lock").contains_key(&key),
+            !m.poll_cache().lock().expect("lock").contains_key(&key),
             "a cached cycle error must be evicted — it is only valid for the \
              chain that produced it"
         );
@@ -1970,7 +2091,7 @@ mod tests {
         assert!(futures::poll!(&mut inflight).is_pending());
         m.evict_cached_cycle_error(&key);
         assert!(
-            m.cache.lock().expect("lock").contains_key(&key),
+            m.poll_cache().lock().expect("lock").contains_key(&key),
             "an in-flight successor must be spared by a stale cycle eviction"
         );
         gate.notify_waiters();
@@ -1982,8 +2103,72 @@ mod tests {
         // A cell completed with a real value is spared too.
         m.evict_cached_cycle_error(&key);
         assert!(
-            m.cache.lock().expect("lock").contains_key(&key),
+            m.poll_cache().lock().expect("lock").contains_key(&key),
             "a real memoized value must survive a stale cycle eviction"
+        );
+    }
+
+    /// Task-mode `once`: values memoize, and a panicking body memoizes as an
+    /// `Err` (the panic guard runs *inside* the spawned task) — the full
+    /// `once` surface works unchanged over the task cell.
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn task_mode_once_memoizes_values_and_guards_panics() {
+        type V = Result<Arc<u32>, Arc<anyhow::Error>>;
+        let m: Memoizer<String, V> =
+            Memoizer::with_tag_task("task-once-test", tokio::runtime::Handle::current());
+
+        let runs = Arc::new(std::sync::atomic::AtomicU32::new(0));
+        for _ in 0..2 {
+            let v = m
+                .once("k".to_string(), {
+                    enclose!((runs) move || async move {
+                        runs.fetch_add(1, Ordering::SeqCst);
+                        Ok(Arc::new(5u32))
+                    })
+                })
+                .await;
+            assert_eq!(**v.as_ref().expect("ok"), 5);
+        }
+        assert_eq!(runs.load(Ordering::SeqCst), 1, "second call is a warm hit");
+
+        let v = m
+            .once("p".to_string(), || async { panic!("task body panic") })
+            .await;
+        let err = v.expect_err("a panicking body memoizes as Err");
+        assert!(
+            err.to_string().contains("panicked"),
+            "the Err carries the panic provenance: {err}"
+        );
+    }
+
+    /// Task-mode `once` against a shut-down runtime: the spawn failure
+    /// surfaces as a memoized `Err`, never a hang and never an unwind out of
+    /// `once` (inside a cdylib that unwind would be an abort).
+    #[tokio::test]
+    async fn task_mode_once_on_a_dead_runtime_returns_err() {
+        type V = Result<Arc<u32>, Arc<anyhow::Error>>;
+        let rt = tokio::runtime::Builder::new_multi_thread()
+            .worker_threads(1)
+            .enable_all()
+            .build()
+            .expect("build runtime");
+        let m: Memoizer<String, V> =
+            Memoizer::with_tag_task("dead-rt-once-test", rt.handle().clone());
+        // A runtime cannot be dropped from async context.
+        tokio::task::spawn_blocking(move || drop(rt))
+            .await
+            .expect("shut down the runtime");
+
+        let v = tokio::time::timeout(
+            Duration::from_secs(5),
+            m.once("k".to_string(), || async { Ok(Arc::new(1u32)) }),
+        )
+        .await
+        .expect("a dead runtime must fail fast, not hang");
+        let err = v.expect_err("spawn on a dead runtime memoizes as Err");
+        assert!(
+            err.to_string().contains("runtime shut down"),
+            "the Err names the cause: {err}"
         );
     }
 
@@ -2290,12 +2475,16 @@ mod tests {
                 key: "//a:b".to_string(),
                 waiters: Some(3),
                 has_driver: false,
+                restarts: 0,
+                age: None,
             },
             StuckCell {
                 tag: "spec",
                 key: "//c:d".to_string(),
                 waiters: Some(1),
                 has_driver: true,
+                restarts: 0,
+                age: None,
             },
         ];
         let text = render_inventory(&cells, 10);
@@ -2326,12 +2515,16 @@ mod tests {
                 key: "//a:stranded".to_string(),
                 waiters: Some(2),
                 has_driver: false,
+                restarts: 0,
+                age: None,
             },
             StuckCell {
                 tag: "result",
                 key: "//a:abandoned".to_string(),
                 waiters: Some(0),
                 has_driver: false,
+                restarts: 0,
+                age: None,
             },
         ];
         // Enough to trip any cap a future edit might reintroduce.
@@ -2340,6 +2533,8 @@ mod tests {
             key: format!("//p:{i}"),
             waiters: Some(1),
             has_driver: true,
+            restarts: 0,
+            age: None,
         }));
 
         let text = render_report(&ReportSnapshot::from_parts(
@@ -2462,6 +2657,8 @@ mod tests {
                 key: format!("//p:{i}"),
                 waiters: Some(1),
                 has_driver: true,
+                restarts: 0,
+                age: None,
             })
             .collect();
         let text = render_inventory(&cells, 2);

--- a/crates/core/src/hmemoizer/task_cell.rs
+++ b/crates/core/src/hmemoizer/task_cell.rs
@@ -33,12 +33,22 @@
 //! and its destructors run on a runtime worker, not on the canceller's stack.
 //! A successor spawned in that window must not overlap the predecessor, so the
 //! canceller parks the aborted `JoinHandle` in a per-key grave and the
-//! successor's task awaits it before running its own body. If the successor is
-//! itself aborted *while still awaiting the grave*, its drop re-parks the
-//! not-yet-dead predecessor handle (`ReGrave`) — it never started its body, so
-//! its own handle is the wrong thing for generation N+2 to wait on. The grave
-//! insert happens *before* the abort is issued so the re-park can never race
-//! the canceller's own insert.
+//! successor's task awaits it before running its own body. Three orderings
+//! make this airtight rather than merely likely:
+//!
+//! * The eviction, the handle-take, and the grave park are **one cache-lock
+//!   critical section** — a caller that finds the map vacant is guaranteed to
+//!   also find the grave (park-after-unlock would let it spawn grave-less).
+//! * A successor aborted *while still awaiting the grave* never started its
+//!   body, so its own handle is the wrong thing for generation N+2 to wait
+//!   on: its drop **re-parks** the not-yet-dead predecessor handle
+//!   (`ReGrave`), with the canceller's own insert ordered before the abort so
+//!   the re-park can never race it.
+//! * The successor **drains the grave in a loop** — a handle it awaited
+//!   resolves only after that task's drop ran, and any re-park that drop
+//!   performed is therefore visible to the re-check. Without the loop,
+//!   generation N+2 could take the dead N+1 handle before N+1's drop re-parks
+//!   the still-live N, and overlap it.
 
 use std::future::Future;
 use std::sync::atomic::{AtomicUsize, Ordering};
@@ -89,9 +99,11 @@ impl<V> TaskCell<V> {
         self.interest.fetch_add(1, Ordering::Relaxed);
     }
 
-    /// Returns the remaining count. AcqRel so the "exactly one guard observes
-    /// each zero crossing" property holds; the *decision* still re-reads under
-    /// the cache lock.
+    /// Returns the remaining count. "Exactly one guard observes each zero
+    /// crossing" comes from RMW atomicity (any ordering would do); the AcqRel
+    /// is kept only so the guard's unlocked pre-check is a sensible hint. The
+    /// *decision* is always re-taken under the cache lock — nothing correct
+    /// rests on this atomic's ordering.
     pub(crate) fn release_interest(&self) -> usize {
         let prev = self.interest.fetch_sub(1, Ordering::AcqRel);
         debug_assert!(prev > 0, "interest release without a matching acquire");
@@ -113,12 +125,17 @@ impl<V> TaskCell<V> {
     /// cancelled away). `false` on an incomplete cell is the stranded signal:
     /// the task died without publishing.
     pub(crate) fn task_live(&self) -> bool {
-        self.task
-            .try_lock()
-            .map(|slot| slot.as_ref().is_some_and(|h| !h.is_finished()))
+        match self.task.try_lock() {
+            Ok(slot) => slot.as_ref().is_some_and(|h| !h.is_finished()),
+            // Same stance as `task_slot` / `TaskSource::collect`: a poisoned
+            // slot is structurally intact — read through it.
+            Err(std::sync::TryLockError::Poisoned(e)) => {
+                e.into_inner().as_ref().is_some_and(|h| !h.is_finished())
+            }
             // Slot briefly held (spawn/publish/cancel in progress) — the task
             // is being worked on, which is the opposite of stranded.
-            .unwrap_or(true)
+            Err(std::sync::TryLockError::WouldBlock) => true,
+        }
     }
 
     pub(crate) fn age(&self) -> std::time::Duration {
@@ -217,6 +234,14 @@ where
                     Arc::clone(e.get())
                 }
                 std::collections::hash_map::Entry::Vacant(e) => {
+                    // Lazy async blocks: `f()` only builds the state machine,
+                    // so constructing it under the lock is free. Built BEFORE
+                    // the grave is taken out of the map: a caller closure that
+                    // panics here would otherwise unwind with the removed
+                    // grave in hand, losing the predecessor's handle — the
+                    // next caller would then spawn against a still-dying
+                    // predecessor with nothing to serialize on.
+                    let fut = f();
                     let grave = self
                         .graves
                         .lock()
@@ -233,11 +258,6 @@ where
                         restarts,
                     });
                     cell.acquire_interest();
-                    // Lazy async blocks: `f()` only builds the state machine,
-                    // so constructing it under the lock is free (and spares
-                    // insert-race losers a wasted allocation — not that a
-                    // vacant entry has racers under this lock).
-                    let fut = f();
                     let body = BodyTask {
                         cell: Arc::clone(&cell),
                         cache: Arc::clone(&self.cache),
@@ -283,17 +303,24 @@ where
             cell: Arc::clone(&cell),
             armed: true,
         };
-        let out = super::await_with_stall_check(wait_done(&cell, self.tag), &key, self.tag).await;
+        let out =
+            super::await_with_stall_check(wait_done(&cell, self.tag, &key), &key, self.tag).await;
         abandon.armed = false;
         out
     }
 
     /// Evict-and-abort, unless somebody wants the cell after all. The decision
-    /// re-checks under the cache lock (the arbiter — see module docs); the
-    /// abort itself happens with no lock held, matching the poll cell's
-    /// "never hold the cache lock across teardown" discipline.
+    /// re-checks under the cache lock (the arbiter — see module docs), and the
+    /// eviction, handle-take, and grave-park all happen inside that one
+    /// critical section: a successor that finds the map vacant is thereby
+    /// guaranteed to also find the grave — evict-then-unlock-then-park would
+    /// open a window where it spawns grave-less against a still-live
+    /// predecessor. Only the `abort()` itself runs outside the lock (it is a
+    /// request, not teardown — the "never hold the cache lock across
+    /// teardown" discipline is about the destructors, which run on a runtime
+    /// worker here, never on this stack).
     fn cancel_abandoned(&self, key: &K, cell: &Arc<TaskCell<V>>) {
-        {
+        let abort = {
             let mut cache = self.cache_lock();
             if cell.interest() != 0 || cell.is_done() {
                 return;
@@ -305,12 +332,30 @@ where
             if cache.get(key).is_some_and(|c| Arc::ptr_eq(c, cell)) {
                 cache.remove(key);
             }
-        }
 
-        // Idempotent across two zero-crossings on the same cell: the loser
-        // finds the slot empty.
-        let Some(task) = cell.task_slot().take() else {
-            return;
+            // Idempotent across two zero-crossings on the same cell: the loser
+            // finds the slot empty. Lock nesting cache → task-slot and cache →
+            // graves is the established order (publish and the vacant arm use
+            // the same nesting); nothing takes them the other way around.
+            let Some(task) = cell.task_slot().take() else {
+                return;
+            };
+            // Grave park ordered before the abort is issued: once aborted, the
+            // task can be dropped at any instant and `ReGrave` (its drop path)
+            // may re-park a predecessor under this key — that insert must find
+            // ours already present, never overwrite-race it.
+            let abort = task.abort_handle();
+            self.graves
+                .lock()
+                .unwrap_or_else(|p| p.into_inner())
+                .insert(
+                    key.clone(),
+                    Grave {
+                        handle: task,
+                        restarts: cell.restarts,
+                    },
+                );
+            abort
         };
         tracing::debug!(
             tag = self.tag,
@@ -318,21 +363,6 @@ where
             restarts = cell.restarts,
             "memoized computation abandoned; aborting its task"
         );
-        // Grave BEFORE abort: once the abort is issued the task can be dropped
-        // at any instant, and `ReGrave` (its drop path) may re-park a
-        // predecessor under this key — that insert must find ours already
-        // present, never overwrite-race it.
-        let abort = task.abort_handle();
-        self.graves
-            .lock()
-            .unwrap_or_else(|p| p.into_inner())
-            .insert(
-                key.clone(),
-                Grave {
-                    handle: task,
-                    restarts: cell.restarts,
-                },
-            );
         abort.abort();
     }
 }
@@ -360,16 +390,42 @@ where
     V: Clone + Send + Sync + 'static,
 {
     async fn run<Fut: Future<Output = V>>(mut self, fut: Fut) {
-        if let Some(g) = self.grave.as_mut() {
-            // `&mut JoinHandle` is a future (JoinHandle is Unpin), so an abort
-            // landing mid-await leaves the handle in place for `Drop` to
-            // re-park. A JoinError here is the expected `is_cancelled` — the
-            // predecessor was aborted, that's why it's in a grave.
-            let _cancelled = (&mut g.handle).await;
+        // Serialize on every predecessor before touching the body — not just
+        // the spawn-time grave. After each observed death the map is
+        // re-checked: a successor aborted mid-grave-await re-parks *its*
+        // predecessor (`ReGrave` in `Drop`), and that insert runs during the
+        // very drop the JoinHandle await just observed, so the re-check is
+        // guaranteed to see any deeper still-dying handle. Without the loop,
+        // generation N+2 can take the (already dead, body-less) N+1 handle
+        // from the grave before N+1's drop re-parks the still-live N — and
+        // overlap it.
+        //
+        // Whatever is currently being awaited sits in `self.grave`, so this
+        // task's own abort re-parks it for the next generation.
+        loop {
+            match self.grave.as_mut() {
+                Some(g) => {
+                    // `&mut JoinHandle` is a future (JoinHandle is Unpin), so
+                    // an abort landing mid-await leaves the handle in place
+                    // for `Drop` to re-park. A JoinError here is the expected
+                    // `is_cancelled` — the predecessor was aborted, that's
+                    // why it's in a grave.
+                    let _cancelled = (&mut g.handle).await;
+                    self.grave = None;
+                }
+                None => {
+                    let next = self
+                        .graves
+                        .lock()
+                        .unwrap_or_else(|p| p.into_inner())
+                        .remove(&self.key);
+                    match next {
+                        Some(g) => self.grave = Some(g),
+                        None => break,
+                    }
+                }
+            }
         }
-        // Predecessor observed dead: it can no longer touch anything. Only now
-        // is the body allowed to run.
-        self.grave = None;
         let v = fut.await;
         self.publish(v);
     }
@@ -395,13 +451,19 @@ where
     K: std::hash::Hash + Eq + Clone,
 {
     fn drop(&mut self) {
-        // Aborted while still awaiting the predecessor's grave: this task
-        // never ran its body, so its own handle is the wrong thing for the
-        // next generation to serialize on — re-park the predecessor's.
-        // (The canceller's own grave insert always precedes the abort, so
-        // this overwrite replaces *this* task's handle with the still-dying
-        // predecessor's — the one that might still have body state.)
-        if let Some(g) = self.grave.take() {
+        // Aborted while still awaiting a predecessor's grave: this task never
+        // ran its body, so its own handle is the wrong thing for the next
+        // generation to serialize on — re-park the predecessor's. (The
+        // canceller's own grave insert always precedes the abort, so this
+        // overwrite replaces *this* task's handle with the still-dying
+        // predecessor's — the one that might still have body state. A
+        // successor that took this task's handle *before* this overwrite
+        // re-checks the map after that handle resolves — `run`'s drain loop —
+        // and this insert is ordered before that resolve, so it is seen.)
+        if let Some(mut g) = self.grave.take() {
+            // The chain's restart count, not the re-parked handle's own: this
+            // generation died too, and the next one's counter must say so.
+            g.restarts = self.cell.restarts;
             self.graves
                 .lock()
                 .unwrap_or_else(|p| p.into_inner())
@@ -433,7 +495,11 @@ where
               (PoisonPanic) so once() converts it to a memoized Err, and a raw \
               process() joiner fails loudly instead of parking forever"
 )]
-async fn wait_done<V: Clone>(cell: &TaskCell<V>, tag: &'static str) -> V {
+async fn wait_done<K: std::fmt::Debug, V: Clone>(
+    cell: &TaskCell<V>,
+    tag: &'static str,
+    key: &K,
+) -> V {
     loop {
         let notified = cell.notify.notified();
         tokio::pin!(notified);
@@ -447,9 +513,11 @@ async fn wait_done<V: Clone>(cell: &TaskCell<V>, tag: &'static str) -> V {
             // `process()` caller surfaces it as a panic in the joiner. A typed
             // payload, so `catch_poison` converts exactly this panic and
             // resumes every other one (the debug stall panic must stay loud).
+            // The key rides along — "which target's cell died" is the first
+            // question the failure raises.
             std::panic::panic_any(PoisonPanic {
                 tag,
-                msg: (*msg).to_string(),
+                msg: format!("{msg} (key={key:?})"),
             });
         }
         notified.await;
@@ -577,65 +645,181 @@ mod tests {
             .expect("test future must complete within the timeout")
     }
 
-    /// The core no-overlap guarantee: an aborted body's destructors complete
-    /// before the successor's body starts. The body holds an RAII occupancy
-    /// guard; the successor asserts the section is empty on entry. Without the
-    /// grave await this fails whenever the runtime processes the abort after
-    /// the successor spawns.
+    /// RAII occupancy guard for the no-overlap tests: `enter` fails the body
+    /// (and thereby the test, via the poison path) if another body for the
+    /// same key is still alive — including still running its destructors.
+    struct Occupancy(Arc<AtomicUsize>);
+    impl Occupancy {
+        fn enter(counter: &Arc<AtomicUsize>) -> Self {
+            let prev = counter.fetch_add(1, Ordering::SeqCst);
+            assert_eq!(prev, 0, "two bodies for one key are executing concurrently");
+            Self(Arc::clone(counter))
+        }
+    }
+    impl Drop for Occupancy {
+        fn drop(&mut self) {
+            self.0.fetch_sub(1, Ordering::SeqCst);
+        }
+    }
+
+    /// A body that holds the occupancy guard and busy-spins on `release`
+    /// WITHOUT an await point: the abort issued against it cannot take effect
+    /// until the flag flips (an aborted task dies only at a yield boundary),
+    /// which makes the "predecessor still alive after its abort" window a
+    /// deterministic state instead of a nanosecond race.
+    async fn spinning_body(
+        occupancy: Arc<AtomicUsize>,
+        entered: Arc<std::sync::atomic::AtomicBool>,
+        release: Arc<std::sync::atomic::AtomicBool>,
+    ) -> u32 {
+        let _occ = Occupancy::enter(&occupancy);
+        entered.store(true, Ordering::SeqCst);
+        // Time-bounded: if the test panics before flipping `release`, the
+        // spin must still end — a poll that never returns wedges runtime
+        // shutdown and turns a red test into a hung binary.
+        let start = Instant::now();
+        while !release.load(Ordering::SeqCst) && start.elapsed() < Duration::from_secs(10) {
+            std::thread::yield_now();
+        }
+        // First yield point after release: a pending abort lands here and
+        // the guard drops with the future.
+        futures::future::pending::<()>().await;
+        0u32
+    }
+
+    /// The core no-overlap guarantee, deterministically: the predecessor is
+    /// kept alive *through* its abort by a spin with no await point, the
+    /// successor is spawned into exactly that window, and only releasing the
+    /// spin may let the successor's body run. Mutation-verified: deleting the
+    /// grave await in `BodyTask::run` turns this red every run (the successor
+    /// enters while the predecessor's guard is live → poison → joiner fails).
     #[tokio::test(flavor = "multi_thread", worker_threads = 4)]
     async fn no_two_bodies_for_one_key_ever_overlap() {
-        struct Occupancy(Arc<AtomicUsize>);
-        impl Occupancy {
-            fn enter(counter: &Arc<AtomicUsize>) -> Self {
-                let prev = counter.fetch_add(1, Ordering::SeqCst);
-                assert_eq!(prev, 0, "two bodies for one key are executing concurrently");
-                Self(Arc::clone(counter))
-            }
-        }
-        impl Drop for Occupancy {
-            fn drop(&mut self) {
-                self.0.fetch_sub(1, Ordering::SeqCst);
-            }
-        }
-
         let m: Arc<TaskInner<String, u32>> = Arc::new(inner("overlap-test"));
         let occupancy = Arc::new(AtomicUsize::new(0));
+        let entered = Arc::new(std::sync::atomic::AtomicBool::new(false));
+        let release = Arc::new(std::sync::atomic::AtomicBool::new(false));
 
-        for round in 0..50u32 {
-            // Fresh key per round: a completed successor stays memoized, so
-            // reusing one key would make every later round a warm hit.
-            let key = format!("k{round}");
-            // First joiner: body enters the section and parks forever. Dropping
-            // the joiner is the last-interest abort.
-            let first = {
-                let occupancy = Arc::clone(&occupancy);
-                let m = Arc::clone(&m);
-                let key = key.clone();
-                let mut fut = Box::pin(async move {
-                    m.process(key, move || async move {
-                        let _occ = Occupancy::enter(&occupancy);
-                        futures::future::pending::<()>().await;
-                        0u32
-                    })
-                    .await
-                });
-                // Poll once so the cell exists and the task is spawned.
-                assert!(futures::poll!(&mut fut).is_pending());
-                fut
-            };
-            // Give the spawned body a chance to actually enter the section.
-            tokio::task::yield_now().await;
-            drop(first);
+        let first = {
+            let m = Arc::clone(&m);
+            let body = spinning_body(
+                Arc::clone(&occupancy),
+                Arc::clone(&entered),
+                Arc::clone(&release),
+            );
+            let mut fut = Box::pin(async move { m.process("k".to_string(), move || body).await });
+            assert!(futures::poll!(&mut fut).is_pending());
+            fut
+        };
+        // Wait until the predecessor is provably inside the section.
+        within(async {
+            while !entered.load(Ordering::SeqCst) {
+                tokio::task::yield_now().await;
+            }
+        })
+        .await;
 
-            // Immediate re-join: the successor body asserts sole occupancy.
-            let occupancy2 = Arc::clone(&occupancy);
-            let v = within(m.process(key, move || async move {
-                let _occ = Occupancy::enter(&occupancy2);
-                round
-            }))
-            .await;
-            assert_eq!(v, round);
-        }
+        // Last-interest abort. The predecessor CANNOT die yet — it is spinning
+        // with no await point — so the no-overlap window is held open.
+        drop(first);
+
+        // Successor into the held-open window. Its body asserts sole
+        // occupancy; without the grave await it runs immediately and trips.
+        let successor = {
+            let (m, occupancy) = (Arc::clone(&m), Arc::clone(&occupancy));
+            tokio::spawn(async move {
+                m.process("k".to_string(), move || async move {
+                    let _occ = Occupancy::enter(&occupancy);
+                    7u32
+                })
+                .await
+            })
+        };
+        // Give a broken implementation ample room to run the successor's body
+        // while the predecessor still holds the guard.
+        tokio::time::sleep(Duration::from_millis(100)).await;
+        assert_eq!(
+            occupancy.load(Ordering::SeqCst),
+            1,
+            "the successor's body must not have started while the predecessor lives"
+        );
+
+        // Let the predecessor reach an await point and die; the successor may
+        // only now proceed.
+        release.store(true, Ordering::SeqCst);
+        let v = within(successor).await.expect("successor joiner");
+        assert_eq!(v, 7);
+    }
+
+    /// Transitive no-overlap across three generations — the `ReGrave` path.
+    /// Gen 1 is held alive by the spin; gen 2 is aborted while still awaiting
+    /// gen 1's grave (it never runs its body); gen 3 must serialize on gen 1,
+    /// not on gen 2's already-dead handle, and must report the chain's
+    /// restart count. Deterministic by the same no-await-point construction.
+    #[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+    async fn a_regraved_predecessor_still_serializes_generation_three() {
+        let m: Arc<TaskInner<String, u32>> = Arc::new(inner("regrave-test"));
+        let occupancy = Arc::new(AtomicUsize::new(0));
+        let entered = Arc::new(std::sync::atomic::AtomicBool::new(false));
+        let release = Arc::new(std::sync::atomic::AtomicBool::new(false));
+
+        // Gen 1: spinning in the section.
+        let gen1 = {
+            let m = Arc::clone(&m);
+            let body = spinning_body(
+                Arc::clone(&occupancy),
+                Arc::clone(&entered),
+                Arc::clone(&release),
+            );
+            let mut fut = Box::pin(async move { m.process("k".to_string(), move || body).await });
+            assert!(futures::poll!(&mut fut).is_pending());
+            fut
+        };
+        within(async {
+            while !entered.load(Ordering::SeqCst) {
+                tokio::task::yield_now().await;
+            }
+        })
+        .await;
+        drop(gen1); // aborted; cannot die while spinning
+
+        // Gen 2: its task parks awaiting gen 1's grave (gen 1 is alive).
+        let gen2 = {
+            let m = Arc::clone(&m);
+            let mut fut =
+                Box::pin(async move { m.process("k".to_string(), || async { 1u32 }).await });
+            assert!(futures::poll!(&mut fut).is_pending());
+            fut
+        };
+        // Let gen 2's spawned task actually reach the grave await.
+        tokio::time::sleep(Duration::from_millis(50)).await;
+        // Abort gen 2 mid-grave-await: its Drop must re-park gen 1's handle.
+        drop(gen2);
+
+        // Gen 3: must wait for gen 1 (still spinning), and must carry
+        // restarts == 2 (two dead generations before it).
+        let gen3 = {
+            let (m, occupancy) = (Arc::clone(&m), Arc::clone(&occupancy));
+            tokio::spawn(async move {
+                m.process("k".to_string(), move || async move {
+                    let _occ = Occupancy::enter(&occupancy);
+                    3u32
+                })
+                .await
+            })
+        };
+        tokio::time::sleep(Duration::from_millis(100)).await;
+        assert_eq!(
+            occupancy.load(Ordering::SeqCst),
+            1,
+            "gen 3 must not run while gen 1 still lives — it serialized on the wrong grave"
+        );
+        let cell = m.cache_lock().get("k").cloned().expect("gen 3 cell in map");
+        assert_eq!(cell.restarts(), 2, "two generations died before gen 3");
+
+        release.store(true, Ordering::SeqCst);
+        let v = within(gen3).await.expect("gen 3 joiner");
+        assert_eq!(v, 3);
     }
 
     /// A stale cancellation must never evict a completed cell — the value
@@ -730,8 +914,16 @@ mod tests {
         );
     }
 
-    /// Register-then-recheck: a joiner racing the publish must never park
-    /// forever. Loop hard enough that both interleavings actually occur.
+    /// Smoke test: two concurrent joiners per key both complete, 2000 keys.
+    ///
+    /// Honesty note: this does NOT prove the register-then-recheck ordering in
+    /// `wait_done` — the check-then-register bug's window is nanoseconds
+    /// inside one poll, and a black-box test cannot force a publish into it
+    /// (mutation-tested: the inverted ordering still passes here). That
+    /// ordering is proven by review against the documented discipline (see
+    /// `wait_done`'s comment and the `WorkerPool::acquire` pattern it copies);
+    /// what this test freezes is the end-to-end join/publish path staying
+    /// live under churn.
     #[tokio::test(flavor = "multi_thread", worker_threads = 4)]
     async fn joiner_racing_completion_never_parks_forever() {
         let m: Arc<TaskInner<u32, u32>> = Arc::new(inner("race-test"));

--- a/crates/core/src/hmemoizer/task_cell.rs
+++ b/crates/core/src/hmemoizer/task_cell.rs
@@ -1,0 +1,883 @@
+//! Task-backed memoizer cell: the computation is a spawned tokio task, not a
+//! future cooperatively polled by its awaiters.
+//!
+//! The poll-based cell (`cell.rs`) exists for two constraints that no longer
+//! hold: plugin-linked code had no runtime context (fixed by spawn-at-the-seam
+//! — every ABI entry point body now runs on its side's runtime), and
+//! cancellation-by-abandonment (a future nobody polls) broke `futures::Shared`
+//! and fair-semaphore semantics. Here the computation is always polled by the
+//! runtime, and cancellation is an explicit `JoinHandle::abort`, so the driver
+//! election, the hand-rolled waker slab, and the stall-ticker insurance all
+//! have nothing left to insure.
+//!
+//! State machine: a cell is spawned `Running` and only ever moves to `Done`.
+//! There is no `Idle` and no reuse: cancellation *evicts* the cell from the
+//! map (the `cancel_abandoned` protocol carried over from the poll cell, with
+//! `abort()` in place of take-future-and-drop), and a later caller builds a
+//! fresh cell. A task publishes only into its own cell, so a publish that
+//! races eviction lands in an unreachable cell and is harmless.
+//!
+//! ## The arbiter lock
+//!
+//! The poll cell proves "interest == 0 ∧ !done ⇒ abandoned" through the
+//! completer's own interest release. That proof's premise dies here — the
+//! completer is the task, and it holds no interest. Instead, publish and the
+//! cancel decision serialize on the *cache* lock: publish sets `done` (and
+//! drops the task handle) inside a cache-lock section, and cancellation
+//! re-reads `interest` and `is_done` under that same lock before evicting.
+//! No fence argument, no reasoning from the atomic alone.
+//!
+//! ## No two bodies for one key, ever
+//!
+//! `abort()` is a request — the task dies when the runtime next processes it,
+//! and its destructors run on a runtime worker, not on the canceller's stack.
+//! A successor spawned in that window must not overlap the predecessor, so the
+//! canceller parks the aborted `JoinHandle` in a per-key grave and the
+//! successor's task awaits it before running its own body. If the successor is
+//! itself aborted *while still awaiting the grave*, its drop re-parks the
+//! not-yet-dead predecessor handle (`ReGrave`) — it never started its body, so
+//! its own handle is the wrong thing for generation N+2 to wait on. The grave
+//! insert happens *before* the abort is issued so the re-park can never race
+//! the canceller's own insert.
+
+use std::future::Future;
+use std::sync::atomic::{AtomicUsize, Ordering};
+use std::sync::{Arc, Mutex, MutexGuard, OnceLock};
+use std::time::Instant;
+
+use futures::FutureExt as _;
+use rustc_hash::FxHashMap;
+
+/// One memoized computation. `Running` while the spawned task lives; `Done`
+/// once `done` is set (at which point `task` is empty — a completed cell pins
+/// no dead task harness).
+pub(crate) struct TaskCell<V> {
+    done: OnceLock<V>,
+    /// Terminal failure that is not a value: the task was dropped without
+    /// publishing (a panicking body outside `once()`'s guard, or its runtime
+    /// shut down). Waiters surface it loudly instead of parking forever.
+    poison: OnceLock<&'static str>,
+    /// Wakes waiters on publish/poison. Waiters use the register-then-recheck
+    /// discipline (see `wait_done`) — `notify_waiters` leaves nothing behind
+    /// for a waiter that registers later, so the recheck is what's load-bearing.
+    notify: tokio::sync::Notify,
+    /// Callers currently interested. Fast-path counter only: the abandonment
+    /// *decision* is always re-taken under the cache lock (module docs).
+    interest: AtomicUsize,
+    /// The running task. Taken on publish (`Done` holds no handle) and on
+    /// cancellation (moved to the grave).
+    task: Mutex<Option<tokio::task::JoinHandle<()>>>,
+    /// When the computation was spawned — diagnostic age in the SIGQUIT dump.
+    created: Instant,
+    /// How many aborted predecessors this key has had. Rendered in the dump so
+    /// abort/rejoin thrash is visible instead of read as "mysteriously slow".
+    restarts: u32,
+}
+
+impl<V> TaskCell<V> {
+    pub(crate) fn peek(&self) -> Option<&V> {
+        self.done.get()
+    }
+
+    pub(crate) fn is_done(&self) -> bool {
+        self.done.get().is_some()
+    }
+
+    pub(crate) fn acquire_interest(&self) {
+        // Always taken under the cache lock (both `process` arms), so Relaxed
+        // suffices — the lock orders it against every decision that reads it.
+        self.interest.fetch_add(1, Ordering::Relaxed);
+    }
+
+    /// Returns the remaining count. AcqRel so the "exactly one guard observes
+    /// each zero crossing" property holds; the *decision* still re-reads under
+    /// the cache lock.
+    pub(crate) fn release_interest(&self) -> usize {
+        let prev = self.interest.fetch_sub(1, Ordering::AcqRel);
+        debug_assert!(prev > 0, "interest release without a matching acquire");
+        prev - 1
+    }
+
+    pub(crate) fn interest(&self) -> usize {
+        self.interest.load(Ordering::Acquire)
+    }
+
+    fn task_slot(&self) -> MutexGuard<'_, Option<tokio::task::JoinHandle<()>>> {
+        // Poisoning ignored for the same reason as the poll cell's waker set:
+        // the critical sections only move a handle around, so the slot is
+        // structurally intact, and refusing it would strand the protocol.
+        self.task.lock().unwrap_or_else(|e| e.into_inner())
+    }
+
+    /// Whether the spawned task is still live (spawned, not finished, not yet
+    /// cancelled away). `false` on an incomplete cell is the stranded signal:
+    /// the task died without publishing.
+    pub(crate) fn task_live(&self) -> bool {
+        self.task
+            .try_lock()
+            .map(|slot| slot.as_ref().is_some_and(|h| !h.is_finished()))
+            // Slot briefly held (spawn/publish/cancel in progress) — the task
+            // is being worked on, which is the opposite of stranded.
+            .unwrap_or(true)
+    }
+
+    pub(crate) fn age(&self) -> std::time::Duration {
+        self.created.elapsed()
+    }
+
+    pub(crate) fn restarts(&self) -> u32 {
+        self.restarts
+    }
+}
+
+/// An aborted predecessor for a key: its handle (awaited by the successor
+/// before the successor's body runs) and its accumulated restart count.
+struct Grave {
+    handle: tokio::task::JoinHandle<()>,
+    restarts: u32,
+}
+
+/// Task-backed implementation behind `Memoizer`. Same map + interest protocol
+/// as the poll implementation; the computation lifecycle is the module docs'
+/// state machine.
+pub(crate) struct TaskInner<K, V> {
+    cache: Arc<Mutex<FxHashMap<K, Arc<TaskCell<V>>>>>,
+    /// Aborted-but-possibly-still-dying predecessors, per key. Entries are
+    /// consumed by the next caller for the key; unconsumed entries die with
+    /// the memoizer (bounded by cancelled keys per request).
+    graves: Arc<Mutex<FxHashMap<K, Grave>>>,
+    tag: &'static str,
+    /// Captured at construction — the runtime every cold cell spawns on. Never
+    /// discovered via `Handle::current()` at spawn time: whichever runtime the
+    /// first caller happened to be on winning silently is exactly the
+    /// environment assumption the plugin rules ban.
+    handle: tokio::runtime::Handle,
+}
+
+impl<K, V> TaskInner<K, V>
+where
+    K: std::hash::Hash + Eq + Send + Sync + 'static + std::fmt::Debug + Clone,
+    V: Clone + Send + Sync + 'static,
+{
+    pub(crate) fn new(tag: &'static str, handle: tokio::runtime::Handle) -> Self {
+        let cache = Arc::new(Mutex::new(FxHashMap::default()));
+        super::register_source(Box::new(TaskSource {
+            tag,
+            cache: Arc::downgrade(&cache),
+        }));
+        Self {
+            cache,
+            graves: Arc::new(Mutex::new(FxHashMap::default())),
+            tag,
+            handle,
+        }
+    }
+
+    pub(crate) fn tag(&self) -> &'static str {
+        self.tag
+    }
+
+    /// Remove `key` iff its cell is completed and its value satisfies `pred`.
+    /// An in-flight cell is never touched — same contract as the poll path's
+    /// cycle-error eviction.
+    pub(crate) fn evict_if(&self, key: &K, pred: impl FnOnce(&V) -> bool) {
+        let mut cache = self.cache_lock();
+        if cache
+            .get(key)
+            .is_some_and(|cell| cell.peek().is_some_and(pred))
+        {
+            cache.remove(key);
+        }
+    }
+
+    fn cache_lock(&self) -> MutexGuard<'_, FxHashMap<K, Arc<TaskCell<V>>>> {
+        self.cache.lock().unwrap_or_else(|e| e.into_inner())
+    }
+
+    pub(crate) fn peek(&self, key: &K) -> Option<V> {
+        self.cache_lock().get(key).and_then(|c| c.peek().cloned())
+    }
+
+    pub(crate) async fn process<F, Fut>(&self, key: K, f: F) -> V
+    where
+        F: FnOnce() -> Fut,
+        Fut: Future<Output = V> + Send + 'static,
+    {
+        let cell = {
+            let mut cache = self.cache_lock();
+            match cache.entry(key.clone()) {
+                std::collections::hash_map::Entry::Occupied(e) => {
+                    if let Some(v) = e.get().peek() {
+                        return v.clone();
+                    }
+                    // Under the lock, so a cancellation racing us either sees
+                    // this interest and stands down, or already evicted the
+                    // entry and we never find it — same rule as the poll cell.
+                    e.get().acquire_interest();
+                    Arc::clone(e.get())
+                }
+                std::collections::hash_map::Entry::Vacant(e) => {
+                    let grave = self
+                        .graves
+                        .lock()
+                        .unwrap_or_else(|p| p.into_inner())
+                        .remove(&key);
+                    let restarts = grave.as_ref().map_or(0, |g| g.restarts + 1);
+                    let cell = Arc::new(TaskCell {
+                        done: OnceLock::new(),
+                        poison: OnceLock::new(),
+                        notify: tokio::sync::Notify::new(),
+                        interest: AtomicUsize::new(0),
+                        task: Mutex::new(None),
+                        created: Instant::now(),
+                        restarts,
+                    });
+                    cell.acquire_interest();
+                    // Lazy async blocks: `f()` only builds the state machine,
+                    // so constructing it under the lock is free (and spares
+                    // insert-race losers a wasted allocation — not that a
+                    // vacant entry has racers under this lock).
+                    let fut = f();
+                    let body = BodyTask {
+                        cell: Arc::clone(&cell),
+                        cache: Arc::clone(&self.cache),
+                        graves: Arc::clone(&self.graves),
+                        key: key.clone(),
+                        grave,
+                    };
+                    // Spawn while still holding the cache lock: publish also
+                    // takes that lock, so the task cannot publish before its
+                    // handle is stored below — a `Done` cell never ends up
+                    // holding a live handle.
+                    //
+                    // The spawn itself is guarded: on a shut-down runtime,
+                    // tokio either panics the spawn or drops the task without
+                    // ever polling it. Both degrade to a poisoned cell (the
+                    // drop path via `BodyTask::drop`), so a joiner gets a loud
+                    // failure — never an eternal park, and never an unwind out
+                    // of this frame into a cdylib seam.
+                    let spawned = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
+                        super::spawn_on_with_cycle_ctx(&self.handle, body.run(fut))
+                    }));
+                    match spawned {
+                        Ok(task) => {
+                            *cell.task_slot() = Some(task);
+                        }
+                        Err(_) => {
+                            let _already_poisoned = cell
+                                .poison
+                                .set("memoized task could not spawn (runtime shut down)");
+                        }
+                    }
+                    e.insert(Arc::clone(&cell));
+                    cell
+                }
+            }
+        };
+
+        // Cancel the computation if we turn out to be its last awaiter —
+        // declared before the await so it drops after the wait is gone.
+        let mut abandon = TaskAbandonGuard {
+            inner: self,
+            key: &key,
+            cell: Arc::clone(&cell),
+            armed: true,
+        };
+        let out = super::await_with_stall_check(wait_done(&cell, self.tag), &key, self.tag).await;
+        abandon.armed = false;
+        out
+    }
+
+    /// Evict-and-abort, unless somebody wants the cell after all. The decision
+    /// re-checks under the cache lock (the arbiter — see module docs); the
+    /// abort itself happens with no lock held, matching the poll cell's
+    /// "never hold the cache lock across teardown" discipline.
+    fn cancel_abandoned(&self, key: &K, cell: &Arc<TaskCell<V>>) {
+        {
+            let mut cache = self.cache_lock();
+            if cell.interest() != 0 || cell.is_done() {
+                return;
+            }
+            // Evict before aborting, so a later caller builds a fresh cell
+            // rather than joining one that can never complete. `ptr_eq`-guarded:
+            // a fresh cell under the same key is never evicted by a stale
+            // cancellation.
+            if cache.get(key).is_some_and(|c| Arc::ptr_eq(c, cell)) {
+                cache.remove(key);
+            }
+        }
+
+        // Idempotent across two zero-crossings on the same cell: the loser
+        // finds the slot empty.
+        let Some(task) = cell.task_slot().take() else {
+            return;
+        };
+        tracing::debug!(
+            tag = self.tag,
+            key = ?key,
+            restarts = cell.restarts,
+            "memoized computation abandoned; aborting its task"
+        );
+        // Grave BEFORE abort: once the abort is issued the task can be dropped
+        // at any instant, and `ReGrave` (its drop path) may re-park a
+        // predecessor under this key — that insert must find ours already
+        // present, never overwrite-race it.
+        let abort = task.abort_handle();
+        self.graves
+            .lock()
+            .unwrap_or_else(|p| p.into_inner())
+            .insert(
+                key.clone(),
+                Grave {
+                    handle: task,
+                    restarts: cell.restarts,
+                },
+            );
+        abort.abort();
+    }
+}
+
+/// The spawned computation: await the predecessor's grave (no two bodies for
+/// one key overlap — module docs), run the body, publish. Publishing is
+/// infallible from the waiters' perspective: if this future is dropped without
+/// publishing (panic in the body outside `once()`'s guard, runtime shutdown),
+/// the drop poisons the cell so waiters fail loudly instead of parking
+/// forever.
+struct BodyTask<K, V>
+where
+    K: std::hash::Hash + Eq + Clone,
+{
+    cell: Arc<TaskCell<V>>,
+    cache: Arc<Mutex<FxHashMap<K, Arc<TaskCell<V>>>>>,
+    graves: Arc<Mutex<FxHashMap<K, Grave>>>,
+    key: K,
+    grave: Option<Grave>,
+}
+
+impl<K, V> BodyTask<K, V>
+where
+    K: std::hash::Hash + Eq + Send + Sync + 'static + Clone,
+    V: Clone + Send + Sync + 'static,
+{
+    async fn run<Fut: Future<Output = V>>(mut self, fut: Fut) {
+        if let Some(g) = self.grave.as_mut() {
+            // `&mut JoinHandle` is a future (JoinHandle is Unpin), so an abort
+            // landing mid-await leaves the handle in place for `Drop` to
+            // re-park. A JoinError here is the expected `is_cancelled` — the
+            // predecessor was aborted, that's why it's in a grave.
+            let _cancelled = (&mut g.handle).await;
+        }
+        // Predecessor observed dead: it can no longer touch anything. Only now
+        // is the body allowed to run.
+        self.grave = None;
+        let v = fut.await;
+        self.publish(v);
+    }
+
+    fn publish(self, v: V) {
+        // Under the cache lock — the arbiter between publish and the cancel
+        // decision (module docs). Also drops the task's own handle: a `Done`
+        // cell holds no dead task harness. (Dropping one's own JoinHandle is a
+        // detach, which is exactly right — the task is finishing.)
+        {
+            let _arbiter = self.cache.lock().unwrap_or_else(|p| p.into_inner());
+            let _first_publish = self.cell.done.set(v);
+            *self.cell.task_slot() = None;
+        }
+        self.cell.notify.notify_waiters();
+        // `self` drops disarmed: `done` is set, so `Drop` won't poison.
+        // The consumed grave (if any) is gone — nothing to re-park.
+    }
+}
+
+impl<K, V> Drop for BodyTask<K, V>
+where
+    K: std::hash::Hash + Eq + Clone,
+{
+    fn drop(&mut self) {
+        // Aborted while still awaiting the predecessor's grave: this task
+        // never ran its body, so its own handle is the wrong thing for the
+        // next generation to serialize on — re-park the predecessor's.
+        // (The canceller's own grave insert always precedes the abort, so
+        // this overwrite replaces *this* task's handle with the still-dying
+        // predecessor's — the one that might still have body state.)
+        if let Some(g) = self.grave.take() {
+            self.graves
+                .lock()
+                .unwrap_or_else(|p| p.into_inner())
+                .insert(self.key.clone(), g);
+        }
+        if self.cell.done.get().is_some() {
+            return;
+        }
+        // Dropped without publishing. For an aborted cell this is ordinary
+        // (evicted, zero interest — the notify wakes nobody). For a live cell
+        // it means the body panicked (only reachable outside `once()`'s
+        // guard) or the runtime shut down mid-flight: poison so waiters fail
+        // loudly instead of parking forever.
+        let _already_poisoned = self.cell.poison.set(
+            "memoized task dropped without publishing (body panicked or its runtime shut down)",
+        );
+        self.cell.notify.notify_waiters();
+    }
+}
+
+/// Await a cell's publication. Register-then-recheck: the `Notified` is
+/// registered (`enable`) *before* the `done`/`poison` check, so a publish
+/// landing between the check and the await is observed — `notify_waiters`
+/// stores nothing for late registrants, making this ordering load-bearing
+/// (same discipline as the engine's `WorkerPool` acquire loop).
+#[expect(
+    clippy::panic,
+    reason = "a poisoned cell has no value and never will; the panic is typed \
+              (PoisonPanic) so once() converts it to a memoized Err, and a raw \
+              process() joiner fails loudly instead of parking forever"
+)]
+async fn wait_done<V: Clone>(cell: &TaskCell<V>, tag: &'static str) -> V {
+    loop {
+        let notified = cell.notify.notified();
+        tokio::pin!(notified);
+        notified.as_mut().enable();
+        if let Some(v) = cell.done.get() {
+            return v.clone();
+        }
+        if let Some(msg) = cell.poison.get() {
+            // Loud on purpose: a poisoned cell has no value and never will.
+            // `once()` catches this and memoizes it as an `Err`; a raw
+            // `process()` caller surfaces it as a panic in the joiner. A typed
+            // payload, so `catch_poison` converts exactly this panic and
+            // resumes every other one (the debug stall panic must stay loud).
+            std::panic::panic_any(PoisonPanic {
+                tag,
+                msg: (*msg).to_string(),
+            });
+        }
+        notified.await;
+    }
+}
+
+/// Panic payload for a poisoned cell — typed so [`catch_poison`] can tell it
+/// apart from panics that must propagate.
+struct PoisonPanic {
+    tag: &'static str,
+    msg: String,
+}
+
+/// `once()`-side wrapper: a poisoned task cell panics its joiners (see
+/// [`wait_done`]); for the `Result`-typed `once` surface that panic is caught
+/// here and memoized-shaped as an `Err`, so a shut-down runtime or an
+/// unguarded panic degrades to a failed target instead of unwinding into a
+/// cdylib seam (where an unwind is an abort).
+pub(crate) async fn catch_poison<T, Fut>(fut: Fut) -> Result<T, Arc<anyhow::Error>>
+where
+    Fut: Future<Output = Result<T, Arc<anyhow::Error>>>,
+{
+    match std::panic::AssertUnwindSafe(fut).catch_unwind().await {
+        Ok(r) => r,
+        Err(panic) => match panic.downcast::<PoisonPanic>() {
+            Ok(poison) => Err(Arc::new(anyhow::anyhow!(
+                "[memoizer:{}] {}",
+                poison.tag,
+                poison.msg
+            ))),
+            // Anything else (the debug-only stall panic, a bug) stays loud.
+            Err(other) => std::panic::resume_unwind(other),
+        },
+    }
+}
+
+/// Last-awaiter cancellation for the task cell — the poll cell's
+/// `AbandonGuard`, with the decision delegated to [`TaskInner::cancel_abandoned`].
+struct TaskAbandonGuard<'a, K, V>
+where
+    K: std::hash::Hash + Eq + Send + Sync + 'static + std::fmt::Debug + Clone,
+    V: Clone + Send + Sync + 'static,
+{
+    inner: &'a TaskInner<K, V>,
+    key: &'a K,
+    cell: Arc<TaskCell<V>>,
+    armed: bool,
+}
+
+impl<K, V> Drop for TaskAbandonGuard<'_, K, V>
+where
+    K: std::hash::Hash + Eq + Send + Sync + 'static + std::fmt::Debug + Clone,
+    V: Clone + Send + Sync + 'static,
+{
+    fn drop(&mut self) {
+        let remaining = self.cell.release_interest();
+        if !self.armed || remaining != 0 || self.cell.is_done() {
+            return;
+        }
+        self.inner.cancel_abandoned(self.key, &self.cell);
+    }
+}
+
+/// Inventory source for task-cell maps. The existing `StuckCell` semantics
+/// carry over exactly: `has_driver` maps to "the task is live", so
+/// `is_stranded` (waiters, no driver) becomes "the task died without
+/// publishing while joiners wait" — the signal that used to require the
+/// driver-election bookkeeping now falls out of `JoinHandle::is_finished`.
+struct TaskSource<K, V> {
+    tag: &'static str,
+    cache: std::sync::Weak<Mutex<FxHashMap<K, Arc<TaskCell<V>>>>>,
+}
+
+impl<K, V> super::CellSource for TaskSource<K, V>
+where
+    K: std::fmt::Debug + Send + Sync + 'static,
+    V: Send + Sync + 'static,
+{
+    fn collect(&self, out: &mut Vec<super::StuckCell>) -> bool {
+        let Some(cache) = self.cache.upgrade() else {
+            return false;
+        };
+        // `try_lock`: never block a diagnostic dump on the process being dumped.
+        let map = match cache.try_lock() {
+            Ok(m) => m,
+            Err(std::sync::TryLockError::Poisoned(e)) => e.into_inner(),
+            Err(std::sync::TryLockError::WouldBlock) => return true,
+        };
+        for (key, cell) in map.iter() {
+            if cell.is_done() {
+                continue;
+            }
+            out.push(super::StuckCell {
+                tag: self.tag,
+                key: format!("{key:?}"),
+                waiters: Some(cell.interest()),
+                has_driver: cell.task_live(),
+                restarts: cell.restarts(),
+                age: Some(cell.age()),
+            });
+        }
+        true
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::sync::atomic::AtomicU32;
+    use std::time::Duration;
+
+    fn inner<K, V>(tag: &'static str) -> TaskInner<K, V>
+    where
+        K: std::hash::Hash + Eq + Send + Sync + 'static + std::fmt::Debug + Clone,
+        V: Clone + Send + Sync + 'static,
+    {
+        TaskInner::new(tag, tokio::runtime::Handle::current())
+    }
+
+    const TIMEOUT: Duration = Duration::from_secs(5);
+
+    async fn within<T>(fut: impl Future<Output = T>) -> T {
+        tokio::time::timeout(TIMEOUT, fut)
+            .await
+            .expect("test future must complete within the timeout")
+    }
+
+    /// The core no-overlap guarantee: an aborted body's destructors complete
+    /// before the successor's body starts. The body holds an RAII occupancy
+    /// guard; the successor asserts the section is empty on entry. Without the
+    /// grave await this fails whenever the runtime processes the abort after
+    /// the successor spawns.
+    #[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+    async fn no_two_bodies_for_one_key_ever_overlap() {
+        struct Occupancy(Arc<AtomicUsize>);
+        impl Occupancy {
+            fn enter(counter: &Arc<AtomicUsize>) -> Self {
+                let prev = counter.fetch_add(1, Ordering::SeqCst);
+                assert_eq!(prev, 0, "two bodies for one key are executing concurrently");
+                Self(Arc::clone(counter))
+            }
+        }
+        impl Drop for Occupancy {
+            fn drop(&mut self) {
+                self.0.fetch_sub(1, Ordering::SeqCst);
+            }
+        }
+
+        let m: Arc<TaskInner<String, u32>> = Arc::new(inner("overlap-test"));
+        let occupancy = Arc::new(AtomicUsize::new(0));
+
+        for round in 0..50u32 {
+            // Fresh key per round: a completed successor stays memoized, so
+            // reusing one key would make every later round a warm hit.
+            let key = format!("k{round}");
+            // First joiner: body enters the section and parks forever. Dropping
+            // the joiner is the last-interest abort.
+            let first = {
+                let occupancy = Arc::clone(&occupancy);
+                let m = Arc::clone(&m);
+                let key = key.clone();
+                let mut fut = Box::pin(async move {
+                    m.process(key, move || async move {
+                        let _occ = Occupancy::enter(&occupancy);
+                        futures::future::pending::<()>().await;
+                        0u32
+                    })
+                    .await
+                });
+                // Poll once so the cell exists and the task is spawned.
+                assert!(futures::poll!(&mut fut).is_pending());
+                fut
+            };
+            // Give the spawned body a chance to actually enter the section.
+            tokio::task::yield_now().await;
+            drop(first);
+
+            // Immediate re-join: the successor body asserts sole occupancy.
+            let occupancy2 = Arc::clone(&occupancy);
+            let v = within(m.process(key, move || async move {
+                let _occ = Occupancy::enter(&occupancy2);
+                round
+            }))
+            .await;
+            assert_eq!(v, round);
+        }
+    }
+
+    /// A stale cancellation must never evict a completed cell — the value
+    /// survives and no recompute happens. (The publish/cancel arbitration is
+    /// the cache lock; this drives the loser's path by hand.)
+    #[tokio::test]
+    async fn a_stale_cancellation_never_evicts_a_completed_cell() {
+        let m: TaskInner<String, u32> = inner("stale-vs-done-test");
+        let runs = Arc::new(AtomicU32::new(0));
+
+        let v = within(m.process("k".to_string(), {
+            let runs = Arc::clone(&runs);
+            move || async move {
+                runs.fetch_add(1, Ordering::SeqCst);
+                5
+            }
+        }))
+        .await;
+        assert_eq!(v, 5);
+
+        let cell = m
+            .cache_lock()
+            .get("k")
+            .cloned()
+            .expect("a completed cell is retained as the memoized answer");
+        m.cancel_abandoned(&"k".to_string(), &cell);
+
+        let v = within(m.process("k".to_string(), {
+            let runs = Arc::clone(&runs);
+            move || async move {
+                runs.fetch_add(1, Ordering::SeqCst);
+                7
+            }
+        }))
+        .await;
+        assert_eq!(v, 5, "the memoized value must survive a stale cancellation");
+        assert_eq!(runs.load(Ordering::SeqCst), 1, "no recompute");
+    }
+
+    /// The `ptr_eq` eviction guard: a stale cancellation of an old cell never
+    /// evicts the fresh cell a later caller re-created under the same key.
+    #[tokio::test]
+    async fn a_stale_cancellation_never_evicts_a_recreated_cell() {
+        let m: TaskInner<String, u32> = inner("stale-vs-fresh-test");
+
+        let mut first = Box::pin(m.process("k".to_string(), || async {
+            futures::future::pending::<u32>().await
+        }));
+        assert!(futures::poll!(&mut first).is_pending());
+        let old_cell = m
+            .cache_lock()
+            .get("k")
+            .cloned()
+            .expect("in-flight cell is in the map");
+        drop(first); // last-interest abort + evict
+
+        // Idempotent against the already-evicted cell.
+        m.cancel_abandoned(&"k".to_string(), &old_cell);
+
+        let gate = Arc::new(tokio::sync::Notify::new());
+        let mut second = Box::pin(m.process("k".to_string(), {
+            let gate = Arc::clone(&gate);
+            move || async move {
+                gate.notified().await;
+                3
+            }
+        }));
+        assert!(futures::poll!(&mut second).is_pending());
+
+        // The stale cancellation must not touch the fresh cell.
+        m.cancel_abandoned(&"k".to_string(), &old_cell);
+
+        // `notify_one`, not `notify_waiters`: the body runs in a spawned task
+        // that may not have registered yet — `notify_one` leaves a permit for
+        // it, where `notify_waiters` would be lost and the body would park.
+        gate.notify_one();
+        let v = within(&mut second).await;
+        assert_eq!(v, 3);
+    }
+
+    /// A `Done` cell holds no `JoinHandle` — a completed computation must not
+    /// pin a dead task harness for the life of the request.
+    #[tokio::test]
+    async fn a_done_cell_holds_no_join_handle() {
+        let m: TaskInner<String, u32> = inner("done-handle-test");
+        let v = within(m.process("k".to_string(), || async { 9 })).await;
+        assert_eq!(v, 9);
+        let cell = m.cache_lock().get("k").cloned().expect("completed cell");
+        assert!(
+            cell.task_slot().is_none(),
+            "a Done cell must not retain its JoinHandle"
+        );
+    }
+
+    /// Register-then-recheck: a joiner racing the publish must never park
+    /// forever. Loop hard enough that both interleavings actually occur.
+    #[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+    async fn joiner_racing_completion_never_parks_forever() {
+        let m: Arc<TaskInner<u32, u32>> = Arc::new(inner("race-test"));
+        for i in 0..2000u32 {
+            let a = {
+                let m = Arc::clone(&m);
+                tokio::spawn(async move { m.process(i, move || async move { i }).await })
+            };
+            let b = {
+                let m = Arc::clone(&m);
+                tokio::spawn(async move { m.process(i, move || async move { i }).await })
+            };
+            let (a, b) = within(async { tokio::join!(a, b) }).await;
+            assert_eq!(a.expect("joiner a"), i);
+            assert_eq!(b.expect("joiner b"), i);
+        }
+    }
+
+    /// Cross-runtime: a joiner on runtime A awaits a cell whose task runs on
+    /// runtime B; publish crosses runtimes. Abort from A of a task on B is
+    /// clean, and a successor completes.
+    #[tokio::test]
+    async fn cross_runtime_join_publish_and_abort() {
+        let rt_b = tokio::runtime::Builder::new_multi_thread()
+            .worker_threads(2)
+            .enable_all()
+            .build()
+            .expect("build runtime B");
+        let m: Arc<TaskInner<String, u32>> =
+            Arc::new(TaskInner::new("cross-rt-test", rt_b.handle().clone()));
+
+        // Publish crosses from B to this (A) runtime's joiner.
+        let v = within(m.process("k1".to_string(), || async { 11 })).await;
+        assert_eq!(v, 11);
+
+        // Abort from A of a task running on B, then a successor completes.
+        let mut hung = Box::pin(m.process("k2".to_string(), || async {
+            futures::future::pending::<u32>().await
+        }));
+        assert!(futures::poll!(&mut hung).is_pending());
+        drop(hung);
+        let v = within(m.process("k2".to_string(), || async { 12 })).await;
+        assert_eq!(v, 12);
+
+        // A runtime cannot be dropped from async context.
+        tokio::task::spawn_blocking(move || drop(rt_b))
+            .await
+            .expect("drop runtime B");
+    }
+
+    /// A cold join against a shut-down runtime fails loudly — poisoned cell,
+    /// not an eternal park. (`once()` additionally converts the loud failure
+    /// into a memoized `Err`; that conversion is asserted separately below.)
+    #[tokio::test]
+    async fn spawn_on_a_shut_down_runtime_is_loud_not_a_hang() {
+        let rt = tokio::runtime::Builder::new_multi_thread()
+            .worker_threads(1)
+            .enable_all()
+            .build()
+            .expect("build runtime");
+        let m: Arc<TaskInner<String, u32>> =
+            Arc::new(TaskInner::new("dead-rt-test", rt.handle().clone()));
+        // A runtime cannot be dropped from async context.
+        tokio::task::spawn_blocking(move || drop(rt))
+            .await
+            .expect("shut down the runtime");
+
+        let joined = within(
+            std::panic::AssertUnwindSafe(m.process("k".to_string(), || async { 1 })).catch_unwind(),
+        )
+        .await;
+        let panic = joined.expect_err("a dead runtime must not produce a value");
+        assert!(
+            panic.downcast_ref::<PoisonPanic>().is_some(),
+            "the failure must be the typed poison panic"
+        );
+    }
+
+    /// `catch_poison` converts exactly the poison panic into an `Err` and
+    /// resumes everything else.
+    #[tokio::test]
+    async fn catch_poison_converts_poison_and_resumes_other_panics() {
+        let converted = catch_poison::<u32, _>(async {
+            std::panic::panic_any(PoisonPanic {
+                tag: "t",
+                msg: "boom".to_string(),
+            })
+        })
+        .await;
+        let err = converted.expect_err("poison must convert to Err");
+        assert!(err.to_string().contains("boom"));
+
+        let resumed =
+            std::panic::AssertUnwindSafe(catch_poison::<u32, _>(async { panic!("not poison") }))
+                .catch_unwind()
+                .await;
+        assert!(resumed.is_err(), "a non-poison panic must be resumed");
+    }
+
+    /// A body that panics in raw `process` (no `once` guard) poisons the cell:
+    /// the joiner fails loudly instead of parking forever.
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn a_panicking_body_poisons_the_cell_instead_of_stranding_joiners() {
+        let m: Arc<TaskInner<String, u32>> = Arc::new(inner("panic-test"));
+        let joined = within(
+            std::panic::AssertUnwindSafe(m.process("k".to_string(), || async {
+                panic!("body panic");
+            }))
+            .catch_unwind(),
+        )
+        .await;
+        let panic = joined.expect_err("a panicking body must not produce a value");
+        assert!(panic.downcast_ref::<PoisonPanic>().is_some());
+    }
+
+    /// Restart accounting: each abort→rejoin generation increments the
+    /// successor cell's counter, and the inventory carries it (with an age)
+    /// so thrash is visible in the dump.
+    #[tokio::test]
+    async fn restarts_are_counted_and_reported() {
+        let m: TaskInner<String, u32> = inner("restart-count-test");
+
+        for expected in 0..3u32 {
+            let mut hung = Box::pin(m.process("k".to_string(), || async {
+                futures::future::pending::<u32>().await
+            }));
+            assert!(futures::poll!(&mut hung).is_pending());
+            let cell = m.cache_lock().get("k").cloned().expect("in-flight cell");
+            assert_eq!(cell.restarts(), expected);
+            drop(hung);
+        }
+
+        // The next generation appears in the inventory with its restart count.
+        let mut hung = Box::pin(m.process("k".to_string(), || async {
+            futures::future::pending::<u32>().await
+        }));
+        assert!(futures::poll!(&mut hung).is_pending());
+        let stuck = super::super::inventory();
+        let mine = stuck
+            .iter()
+            .find(|c| c.tag == "restart-count-test")
+            .expect("in-flight task cell must appear in the inventory");
+        assert_eq!(mine.restarts, 3);
+        assert!(mine.age.is_some(), "task cells report their age");
+        assert_eq!(mine.waiters, Some(1));
+        assert!(mine.has_driver, "a live task is the driver");
+        drop(hung);
+    }
+}

--- a/crates/engine/src/engine/diag.rs
+++ b/crates/engine/src/engine/diag.rs
@@ -1343,6 +1343,8 @@ mod tests {
                     key: format!("//call:{}", calls.get()),
                     waiters: Some(1),
                     has_driver: false,
+                    restarts: 0,
+                    age: None,
                 }],
                 0,
                 String::new(),
@@ -1564,6 +1566,8 @@ mod tests {
             key: "//a:b".to_string(),
             waiters: Some(4),
             has_driver: false,
+            restarts: 0,
+            age: None,
         }];
         let text = render_stall(&r);
         assert!(text.contains("The process is"), "{text}");
@@ -1600,6 +1604,8 @@ mod tests {
                 key: format!("@heph/fs:file {i}"),
                 waiters: Some(1),
                 has_driver: true,
+                restarts: 0,
+                age: None,
             })
             .collect();
 
@@ -1642,6 +1648,8 @@ mod tests {
             key: "//a:b".to_string(),
             waiters: Some(1),
             has_driver: true,
+            restarts: 0,
+            age: None,
         }];
         assert!(!r.no_work_in_flight(), "an execute span is real work");
         let text = render_stall(&r);
@@ -1671,6 +1679,8 @@ mod tests {
             key: "//a:b".to_string(),
             waiters: Some(1),
             has_driver: true,
+            restarts: 0,
+            age: None,
         }];
         assert!(!r.no_work_in_flight());
         let text = render_stall(&r);
@@ -1723,6 +1733,8 @@ mod tests {
             key: "//a:b".to_string(),
             waiters: Some(1),
             has_driver: true,
+            restarts: 0,
+            age: None,
         }];
         let text = render_stall(&r);
         assert!(


### PR DESCRIPTION
First of the memoizer-redesign PRs (design reviewed by the full board;
spawn-at-the-seam made hcore runtime-context-safe on both sides of the
ABI seam, and docs/CONCURRENCY_MEASUREMENTS.md retired the folklore that
justified the hand-rolled machinery).

Memoizer becomes a two-variant dispatch: `with_tag` still builds the
shipped poll cell (driver election, waker slab) and every engine/plugin
construction site is untouched; `with_tag_task(tag, Handle)` builds the
new task-backed cell. The engine flip is a later, separately measured PR.

The task cell: cold computations spawn on a Handle captured at
construction (never discovered at spawn time); joiners await a Notify
with register-then-recheck; publish and the cancel decision serialize on
the cache lock (the poll cell's AcqRel completer-holds-interest proof
does not survive task-per-cell, so the lock is the arbiter); cancellation
evicts (ptr_eq-guarded) and aborts, and the successor's task awaits the
aborted predecessor's JoinHandle from a per-key grave before running its
body — no two bodies for one key ever overlap, transitively across
generations (an aborted-mid-grave-await successor re-parks the
predecessor handle it never outlived). A Done cell drops its JoinHandle.
A task dropped without publishing (unguarded panic, runtime shutdown)
poisons the cell: raw process() joiners fail loudly, once() converts the
typed poison panic into a memoized Err — never an eternal park, never an
unwind across a cdylib seam.

Diagnostics carry over: StuckCell gains restarts + age; has_driver maps
to "the task is live", so is_stranded (waiters, no driver) becomes "task
died without publishing" with no election bookkeeping behind it.

bench-corpus grows the deep-thin-chain proof (200 layers, fan_out 1,
asserted unbroken) that the flip PR's stack-depth and depth-parallelism
gates run against.

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_016hThPHt4MzWRrtRazBxZ7d

---

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>