### PR TITLE
fix(engine): let hash-only requests resolve uncacheable deps

### DIFF
--- a/crates/engine/src/engine/result.rs
+++ b/crates/engine/src/engine/result.rs
@@ -3171,6 +3171,14 @@ impl Engine {
         let current = Arc::clone(&self)
             .meta(self.new_hash_only_state(addr.clone()), addr)
             .await
+            // Seal the chain: it may carry request-property markers
+            // (`HashUnknownError` from the nested hash-only request) that
+            // `classify_failure` deliberately refuses to record — correct for
+            // the marker itself, wrong once this guard turns it into a real
+            // target failure. Left unsealed, the failure shows in the event
+            // stream (the TUI's failed tab) but never lands in the failure
+            // registry, so the run exits non-zero with nothing printed.
+            .map_err(|e| anyhow::anyhow!("{e:#}"))
             .with_context(|| {
                 format!(
                     "re-reading the sources of {addr} to confirm they still match what it \
@@ -9205,6 +9213,86 @@ mod tests {
             std::fs::read(pkg_dir.join("in.txt"))?,
             b"HELLO\n",
             "the in_place write-back must still land",
+        );
+        Ok(())
+    }
+
+    /// A write-back-guard failure must land in the failure registry — not just
+    /// the event stream.
+    ///
+    /// The guard's nested hash-only recompute can fail with
+    /// `HashUnknownError` in its chain (a cacheable dep whose inputs moved
+    /// mid-run misses at its new hash). That marker is deliberately never
+    /// recorded by `classify_failure` — correct while it is a request
+    /// property, wrong once the guard converts it into a real target failure.
+    /// Unsealed, the run showed the failure in the TUI's failed tab (events)
+    /// but exited with an empty registry and nothing printed. The guard now
+    /// seals the chain; this pins both the recording and the refusal to
+    /// write back.
+    #[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+    async fn in_place_guard_failure_is_recorded_not_just_evented() -> anyhow::Result<()> {
+        let escape = tempdir()?;
+        let started = escape.path().join("started");
+        let release = escape.path().join("release");
+        let src = hbuiltins::pluginfs::file_addr("pkg/other.txt").format();
+        let (engine, root) = engine_with_home_fs(vec![
+            // Cacheable dep hashing a file the test mutates mid-run.
+            bash_target("//pkg:probe", &[&src]),
+            codegen_run_target_with_deps(
+                "//pkg:fmt",
+                "in_place",
+                &["in.txt"],
+                &format!(
+                    "touch {started}; until [ -f {release} ]; do sleep 0.05; done; \
+                     printf '%s\n' \"$(tr a-z A-Z < in.txt)\" > in.txt.tmp && mv in.txt.tmp in.txt",
+                    started = started.display(),
+                    release = release.display(),
+                ),
+                &["//pkg:probe"],
+            ),
+        ])?;
+        let pkg_dir = root.path().join("pkg");
+        std::fs::create_dir_all(&pkg_dir)?;
+        std::fs::write(pkg_dir.join("in.txt"), b"hello")?;
+        std::fs::write(pkg_dir.join("other.txt"), b"v1")?;
+
+        let addr = hmodel::htaddr::parse_addr("//pkg:fmt")?;
+        let rs = engine.new_state();
+        let resolve = tokio::spawn(enclose!((engine, rs) async move {
+            engine
+                .result_addr(rs, &addr, OutputMatcher::All, &ResultOptions::default())
+                .await
+        }));
+
+        // The run is provably in flight; move the tree under the dep, then
+        // let the run finish. The guard's fresh recompute now hashes `probe`
+        // at inputs nothing has cached → HashUnknownError inside its chain.
+        let deadline = std::time::Instant::now() + Duration::from_secs(30);
+        while !started.exists() {
+            assert!(std::time::Instant::now() < deadline, "run never started");
+            tokio::time::sleep(Duration::from_millis(20)).await;
+        }
+        std::fs::write(pkg_dir.join("other.txt"), b"v2")?;
+        std::fs::write(&release, b"go")?;
+
+        let res = tokio::time::timeout(Duration::from_secs(60), resolve)
+            .await
+            .expect("run must finish")
+            .expect("join");
+        res.err()
+            .expect("the guard must refuse: it cannot confirm the tree");
+
+        let failures = rs.take_failures();
+        assert_eq!(
+            failures.len(),
+            1,
+            "the guard failure must be recorded so the exit path renders it"
+        );
+        assert_eq!(failures[0].addr.format(), "//pkg:fmt");
+        assert_eq!(
+            std::fs::read(pkg_dir.join("in.txt"))?,
+            b"hello",
+            "an unconfirmed write-back must not touch the tree"
         );
         Ok(())
     }

--- a/crates/engine/src/engine/result.rs
+++ b/crates/engine/src/engine/result.rs
@@ -2432,13 +2432,16 @@ impl Engine {
             let _w = if skip_lock {
                 None
             } else {
-                // A hash-only request must not take the write lock — its own
-                // caller is holding guards it will not release until we return.
-                // Reading the tree is what these requests are for, and that is
-                // exactly the `skip_lock` branch above; anything else is a build.
-                if rs.hash_only() {
-                    return Err(HashUnknownError { addr: addr.clone() }.into());
-                }
+                // Hash-only requests may take THIS write lock, unlike the
+                // cacheable paths below. The self-deadlock they guard against
+                // needs the outer request to be riding a read guard on the
+                // addr, and uncacheable resolutions hand out no guard at all
+                // (`guard: None` below) — by the time a nested recompute runs,
+                // the outer request holds nothing here. Blanket-refusing made
+                // the in_place write-back guard structurally unable to verify
+                // any target whose meta chain crosses a cache-off dep (e.g. a
+                // toolchain reached through `//@heph/bin:*` — hostbin is
+                // cache-off), failing `r lint //...` on already-linted trees.
                 Some(
                     self.acquire_with_notice(&rs, addr, self.result_lock().write(addr, ctoken))
                         .await?,
@@ -9340,6 +9343,64 @@ mod tests {
         );
         // The tree is unchanged by the no-op second run.
         assert_eq!(std::fs::read(pkg_dir.join("in.txt"))?, b"HELLO\n");
+        Ok(())
+    }
+
+    /// The in_place write-back guard must survive an uncacheable (non-fs)
+    /// dependency in the target's meta chain.
+    ///
+    /// The guard re-hashes the target on a fresh hash-only request. #193
+    /// forbade hash-only requests from taking the result lock and answered
+    /// `HashUnknownError` for EVERY non-fs target that would need it — but
+    /// the self-deadlock it closed requires the outer request to be riding a
+    /// read guard on the addr, and uncacheable resolutions hand out no guard
+    /// at all (`LockedResolution { guard: None }`). The blanket raise made
+    /// the guard structurally unable to verify any in_place target whose
+    /// meta chain crosses a cache-off dep — `heph r lint //...` over
+    /// toolchains reached through `//@heph/bin:*` (hostbin is cache-off)
+    /// failed on every already-linted target.
+    #[tokio::test]
+    async fn in_place_write_back_survives_an_uncacheable_dep() -> anyhow::Result<()> {
+        let (engine, root) = engine_with_home_fs(vec![
+            // A cache-off, non-fs dependency — the hostbin shape.
+            pluginstatictarget::Target {
+                addr: "//pkg:tool".to_string(),
+                driver: "bash".to_string(),
+                run: Some("true".to_string()),
+                out: HashMap::new(),
+                codegen: None,
+                deps: HashMap::new(),
+                labels: vec![],
+                cache: Some(hcore::htvalue::Value::Bool(false)),
+                ..Default::default()
+            },
+            codegen_run_target_with_deps(
+                "//pkg:fmt",
+                "in_place",
+                &["in.txt"],
+                "printf '%s\n' \"$(tr a-z A-Z < in.txt)\" > in.txt.tmp && mv in.txt.tmp in.txt",
+                &["//pkg:tool"],
+            ),
+        ])?;
+        let pkg_dir = root.path().join("pkg");
+        std::fs::create_dir_all(&pkg_dir)?;
+        std::fs::write(pkg_dir.join("in.txt"), b"hello")?;
+
+        let fmt = hmodel::htaddr::parse_addr("//pkg:fmt")?;
+        let (res, _ev) = resolve_collecting_events(&engine, &fmt).await;
+        res.with_context(
+            || "the write-back guard must be able to re-hash across an uncacheable dep",
+        )?;
+        assert_eq!(
+            std::fs::read(pkg_dir.join("in.txt"))?,
+            b"HELLO\n",
+            "the in_place transform must have been written back"
+        );
+
+        // Second run: already-transformed tree — the cached-hit path runs the
+        // same guard (this is the `r lint //...` on an already-linted repo).
+        let (res, _ev) = resolve_collecting_events(&engine, &fmt).await;
+        res.with_context(|| "the guard must also pass on the cached re-run")?;
         Ok(())
     }
 

--- a/src/commands/errors.rs
+++ b/src/commands/errors.rs
@@ -186,6 +186,41 @@ pub fn is_cancelled(e: &anyhow::Error) -> bool {
 ///
 /// The `$val => $body` clause is optional: omit it for commands that print
 /// incrementally and need no end-of-run output (the success value is discarded).
+/// Fold a keep-going batch into the single `res` that [`finalize!`] expects.
+///
+/// `Engine::result` reports keep-going failures INSIDE its `Ok`
+/// (`BatchResult::errors`); they are normally duplicated into the failure
+/// registry, which `finalize!` renders. This fold must still exist: an error
+/// class the registry declines to record (a request-property marker leaking
+/// out of a conversion boundary) would otherwise be dropped on the floor —
+/// the run prints its "err N" summary, then exits 0 in silence, which a
+/// 308-failure lint run did. The registry branch still wins the rendering
+/// whenever it has entries; this is the belt for when it does not.
+///
+/// Cancellation collapses to [`CancelledError`] only when nothing else
+/// failed — a genuine failure must never be masked by the cancellations it
+/// caused.
+pub fn fold_batch(
+    batch: crate::engine::BatchResult,
+) -> anyhow::Result<Vec<Arc<crate::engine::EResult>>> {
+    if batch.errors.is_empty() {
+        return Ok(batch.ok);
+    }
+    let (cancelled, genuine): (Vec<_>, Vec<_>) =
+        batch.errors.into_iter().partition(|(_, e)| is_cancelled(e));
+    if genuine.is_empty() {
+        drop(cancelled);
+        return Err(CancelledError.into());
+    }
+    Err(crate::engine::error::MultiError(
+        genuine
+            .into_iter()
+            .map(|(addr, e)| e.context(addr.format()))
+            .collect(),
+    )
+    .into())
+}
+
 macro_rules! finalize {
     ($ctx:expr, $rs:expr, $res:expr $(,)?) => {
         $crate::commands::errors::finalize!($ctx, $rs, $res, _ => { Ok(()) })
@@ -548,6 +583,60 @@ mod tests {
             self.pauses.set(self.pauses.get() + 1);
             FakeGuard
         }
+    }
+
+    fn addr(s: &str) -> crate::htaddr::Addr {
+        hmodel::htaddr::parse_addr(s).expect("addr")
+    }
+
+    /// Keep-going failures inside an `Ok` batch must fold into `res` — the
+    /// registry normally duplicates them, but an unrecorded class (the
+    /// silent-exit-0 lint incident) must still fail the run.
+    #[test]
+    fn fold_batch_surfaces_keep_going_errors() {
+        let batch = crate::engine::BatchResult {
+            ok: vec![],
+            errors: vec![(addr("//pkg:a"), anyhow::anyhow!("boom"))],
+        };
+        let err = fold_batch(batch).err().expect("errors must fold into Err");
+        let rendered = format!("{err:#}");
+        assert!(rendered.contains("//pkg:a"), "{rendered}");
+        assert!(rendered.contains("boom"), "{rendered}");
+    }
+
+    #[test]
+    fn fold_batch_passes_a_clean_batch_through() {
+        let batch = crate::engine::BatchResult {
+            ok: vec![],
+            errors: vec![],
+        };
+        assert!(fold_batch(batch).is_ok());
+    }
+
+    /// All-cancelled collapses to the cancellation `finalize!` recognises…
+    #[test]
+    fn fold_batch_collapses_pure_cancellation() {
+        let batch = crate::engine::BatchResult {
+            ok: vec![],
+            errors: vec![(addr("//pkg:a"), CancelledError.into())],
+        };
+        let err = fold_batch(batch).err().expect("cancelled folds to Err");
+        assert!(is_cancelled(&err), "{err:#}");
+    }
+
+    /// …but a genuine failure is never masked by the cancellations it caused.
+    #[test]
+    fn fold_batch_prefers_genuine_failures_over_cancellation() {
+        let batch = crate::engine::BatchResult {
+            ok: vec![],
+            errors: vec![
+                (addr("//pkg:a"), CancelledError.into()),
+                (addr("//pkg:b"), anyhow::anyhow!("boom")),
+            ],
+        };
+        let err = fold_batch(batch).err().expect("must fail");
+        assert!(!is_cancelled(&err), "{err:#}");
+        assert!(format!("{err:#}").contains("//pkg:b"));
     }
 
     struct FakeRs(std::cell::RefCell<Vec<Arc<TargetFailure>>>);

--- a/src/commands/run.rs
+++ b/src/commands/run.rs
@@ -217,7 +217,10 @@ impl App for RunApp {
                 .clone()
                 .result(rs.clone(), &m, outputs, &opts)
                 .await
-                .map(|batch| batch.ok),
+                // NOT `.map(|batch| batch.ok)`: keep-going failures ride
+                // inside the Ok and must fold into `res`, or an error the
+                // registry didn't record exits 0 in silence. See `fold_batch`.
+                .and_then(crate::commands::errors::fold_batch),
         };
 
         // On success print `--cat-out` / `--list-out`; failures/cancellation are


### PR DESCRIPTION
`heph r lint //...` on an already-linted tree failed 308 targets with
"//@heph/bin:nix is not cached at its current inputs, and this
hash-only resolution may not build it": the in_place write-back guard
re-hashes each lint target on a fresh hash-only request, and #193 made
those requests answer HashUnknownError for EVERY non-fs target that
would need the result lock — including uncacheable ones.

The self-deadlock #193 closed requires the outer request to be riding a
read guard on the addr the nested request wants to write-lock. That is
a property of the cacheable paths (whose hits hand out riding read
guards); an uncacheable resolution hands out no guard at all
(`LockedResolution { guard: None }`), so by the time a nested recompute
runs, the outer request holds nothing on the addr — the write acquire
is at worst contention with a mid-execute holder, never a deadlock. The
blanket refusal made the guard structurally unable to verify any
in_place target whose meta chain crosses a cache-off dep — hostbin
(`//@heph/bin:*`, how nix-provided toolchains are reached) is exactly
that shape.

Uncacheable targets in a hash-only request now execute normally under
the write lock, as they did before #193 — their revisions go to the
mem-only tmp tier, spawn no remote upload and enqueue no GC. The two
raises that embody #193's actual deadlock (a cacheable miss, and a
confirmed-hit rebuild) stay.

Repro test: an in_place transform with a cache-off non-fs dep, run
twice (execute, then the cached re-run an already-linted tree takes) —
red with the exact production error before the fix, green after. The
#193 regression tests stay green.

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_016hThPHt4MzWRrtRazBxZ7d

---

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>