### PR TITLE
fix(ci): resolve perf baseline to latest published master release, and let a manual run choose both sides

### DIFF
--- a/.github/workflows/heph.yml
+++ b/.github/workflows/heph.yml
@@ -499,6 +499,22 @@ jobs:
       - name: Check plugin ABI version
         run: scripts/abi-check.sh "origin/${{ github.base_ref }}"
 
+  # The Perf workflow's release resolution (which build is the baseline,
+  # which is the candidate) decides what every perf verdict is measured
+  # against, so it is unit-tested with `gh`/`git` stubbed rather than only
+  # exercised by running the real thing. Pure bash, no toolchain, seconds —
+  # and it covers the failure paths (API errors, expired token, partially
+  # published release) that a live run cannot be made to produce on demand.
+  perf_lib:
+    name: Perf lib tests
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+      - name: Test perf release resolution
+        run: bash .github/workflows/perf-release-lib.test.sh
+
   # The gate check-builds every workspace member's libs *and* test targets,
   # three times (default features, --all-features, --no-default-features),
   # where it used to build the root package alone in ~1m35s. A fork PR gets no

--- a/.github/workflows/perf-release-lib.sh
+++ b/.github/workflows/perf-release-lib.sh
@@ -1,0 +1,169 @@
+#!/bin/bash
+# Shared release-resolution helpers for the Perf workflow (perf.yml).
+#
+# heph's release tags are not commit SHAs — a tag is `git describe` plus the
+# CI run_number that built the commit (see version.sh) — so "the release for
+# commit X" always means finding X's master-push CI run first, re-deriving
+# the tag from it, and checking that the tag was actually published. The
+# baseline and the candidate both need exactly that, plus the same
+# partial-download handling, hence one library rather than two copies that
+# drift apart.
+#
+# Source it, don't execute it. Requires in the environment:
+#   REPO            owner/name of the source repo (for run lookups)
+#   GH_TOKEN        token for REPO's Actions API
+#   ARTIFACTS_TOKEN token for the artifacts repo below
+#
+# Functions that cannot continue call `exit 1` after writing an actionable
+# message to stderr, so a caller cannot accidentally proceed on a
+# half-resolved release. Note that `exit` inside a command substitution ends
+# only the substitution's subshell — call sites that capture output must
+# still check the status (`out=$(resolve_spec …) || exit 1`).
+
+ARTIFACTS_REPO="hephbuild/heph-artifacts-v1"
+_LIB_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+
+# 0 = published, 1 = genuinely absent (404). Anything else — a bad or
+# expired PAT, an outage — exits instead of returning 1: treating "cannot
+# check" as "not there" turns a dead token into a confident diagnosis of the
+# wrong system (a walk would report "no published release found" after
+# examining nothing).
+release_exists() {
+  local err
+  if err=$(GH_TOKEN="$ARTIFACTS_TOKEN" gh api "repos/$ARTIFACTS_REPO/releases/tags/$1" 2>&1 >/dev/null); then
+    return 0
+  fi
+  if printf '%s' "$err" | grep -q "HTTP 404"; then
+    return 1
+  fi
+  echo "artifacts-repo API error while checking release '$1': $err" >&2
+  exit 1
+}
+
+# Echoes "run_number<TAB>status<TAB>conclusion" for the master-push CI run
+# whose head commit is $1; fails if there is none.
+#
+# Push runs only: a PR run's tag derives from its ephemeral merge commit,
+# not the head_sha the runs API exposes, so it cannot be re-derived here.
+# The workflow-scoped endpoint avoids both a `.name=="CI"` string coupling
+# and sharing its 50-result window with the other push-triggered workflows.
+#
+# The `select(. != null)` is load-bearing: with no matching run, `first` is
+# null and `@tsv` would render it as the non-empty string "\t\t-", which
+# reads as success and yields a run_number of "" three lines later.
+#
+# "The API call failed" and "there are no such runs" are separated for the
+# same reason release_exists separates them: `gh api --jq` exits 0 on an
+# empty result set, so a non-zero status is a real failure and must not be
+# reported to the user as "this commit has no CI run".
+run_for_sha() {
+  local out
+  out=$(gh api "repos/$REPO/actions/workflows/heph.yml/runs?head_sha=$1&event=push" \
+    --jq '.workflow_runs | first | select(. != null) | [.run_number, .status, .conclusion // "-"] | @tsv') || {
+    echo "failed to query CI runs for $1 — cannot resolve its release" >&2
+    exit 1
+  }
+  [ -n "$out" ] || return 1
+  printf '%s' "$out"
+}
+
+# The tag a given run_number ($1) publishing commit $2 produced.
+version_for_run() {
+  "$_LIB_DIR/version.sh" "$1" "$2"
+}
+
+# The tag commit $1's own master-push CI run published; fails if it has none.
+version_for_sha() {
+  local info
+  info=$(run_for_sha "$1") || return 1
+  version_for_run "${info%%$'\t'*}" "$1"
+}
+
+# Resolves $1 — a commit SHA or an exact release tag — to
+# "version<TAB>sha" on stdout. $2 labels the role ("baseline"/"candidate")
+# in the error messages. The sha is best-effort for the tag form: it is
+# recovered from the tag's own `+g<hash>` suffix, which this checkout may
+# not contain.
+resolve_spec() {
+  local spec="$1" label="$2" sha version info run status conclusion short
+
+  if echo "$spec" | grep -qE '^[0-9a-fA-F]{7,40}$'; then
+    sha=$(git rev-parse --verify --quiet "$spec^{commit}") || {
+      echo "$label '$spec' looks like a commit SHA but is not a commit in this checkout — dispatch from a ref that contains it" >&2
+      exit 1
+    }
+    # "No run" is a normal state rather than proof of the wrong branch: CI
+    # runs once per push, on that push's head commit, so every other commit
+    # in a batched push has no run and no release of its own.
+    info=$(run_for_sha "$sha") || {
+      echo "no master-push CI run found for $label commit $sha — it is either not on master, or landed in a batched push whose CI ran on a later commit; pick a commit that has a CI run, or pass an exact release tag" >&2
+      exit 1
+    }
+    IFS=$'\t' read -r run status conclusion <<< "$info"
+    # Guarded explicitly: `set -e` does not reach inside `$( )` (bash leaves
+    # `inherit_errexit` off), so an unguarded assignment here would carry an
+    # empty tag forward into the messages below.
+    version=$(version_for_run "$run" "$sha") || {
+      echo "could not derive the release tag for $label commit $sha from CI run #$run" >&2
+      exit 1
+    }
+    if ! release_exists "$version"; then
+      # Still running vs published-nothing are the two states worth telling
+      # apart — one is "wait", the other is "this commit has no build".
+      if [ "$status" != "completed" ]; then
+        echo "CI run #$run for $label commit $sha is still $status — wait for its Pre-release job to publish $version, then re-run" >&2
+      else
+        echo "CI run #$run for $label commit $sha completed ($conclusion) but never published release $version" >&2
+      fi
+      exit 1
+    fi
+    printf '%s\t%s' "$version" "$sha"
+    return 0
+  fi
+
+  if ! release_exists "$spec"; then
+    # Anything that is not 7-40 hex reached here as a tag, so a 6-character
+    # abbreviated SHA lands on this message; say what it would have taken to
+    # be read as a commit instead.
+    echo "requested $label release '$spec' not found in $ARTIFACTS_REPO (if you meant a commit, give at least 7 hex characters)" >&2
+    exit 1
+  fi
+  short="${spec##*+g}"
+  sha=""
+  [ "$short" = "$spec" ] || sha=$(git rev-parse --verify --quiet "$short^{commit}" || true)
+  printf '%s\t%s' "$spec" "$sha"
+}
+
+# Downloads the named assets of release $1 into directory $2, best-effort,
+# and echoes one line per asset that did not land. Callers decide whether a
+# miss degrades (baseline) or fails (candidate).
+#
+# The result is judged by filename because `gh release download` exits 0
+# when only SOME of its patterns matched: without this, a partially
+# published release reaches a bare `cp: cannot stat` two steps later
+# instead of a message naming what is absent.
+#
+# `gh`'s own stdout is discarded so this function's return channel is
+# structurally its own — callers read the missing list from stdout, and one
+# future line of chatter from `gh` would otherwise flip every caller's
+# `[ -z … ]` test. A non-zero `gh` status is reported (a transient 5xx is
+# not the same fact as "the release does not have this asset") but does not
+# itself decide the outcome; the filenames do.
+fetch_assets() {
+  local version="$1" dir="$2"
+  shift 2
+  local asset rc=0 patterns=() missing=()
+  for asset in "$@"; do
+    patterns+=(--pattern "$asset")
+  done
+  mkdir -p "$dir"
+  GH_TOKEN="$ARTIFACTS_TOKEN" gh release download "$version" \
+    --repo "$ARTIFACTS_REPO" --dir "$dir" "${patterns[@]}" >/dev/null || rc=$?
+  for asset in "$@"; do
+    [ -f "$dir/$asset" ] || missing+=("$asset")
+  done
+  if [ "$rc" -ne 0 ] && [ ${#missing[@]} -gt 0 ]; then
+    echo "gh release download exited $rc for $version (see its output above)" >&2
+  fi
+  [ ${#missing[@]} -eq 0 ] || printf '%s\n' "${missing[@]}"
+}

--- a/.github/workflows/perf-release-lib.test.sh
+++ b/.github/workflows/perf-release-lib.test.sh
@@ -1,0 +1,260 @@
+#!/bin/bash
+# Unit tests for perf-release-lib.sh — the release resolution the Perf
+# workflow's baseline and candidate both go through.
+#
+# `gh` and `git` are stubbed on PATH, so this runs offline in about a second
+# and can assert the cases that are awkward to provoke against the real API:
+# an Actions API failure, an expired artifacts token, a partially published
+# release. Those are exactly the ones whose handling is easy to regress,
+# because the happy path keeps working when they break.
+#
+#   bash .github/workflows/perf-release-lib.test.sh
+#
+# Run under `set -u` deliberately: the library is sourced into steps that do
+# not, but an unset-variable bug here should fail loudly rather than resolve
+# to the empty string and pick the wrong release.
+
+set -uo pipefail
+
+LIB_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+STUB_DIR="$(mktemp -d)"
+trap 'rm -rf "$STUB_DIR"' EXIT
+
+PASS=0
+FAIL=0
+
+# The stubs read their scripted behaviour from these files, so each case
+# rewrites them rather than redefining functions.
+GH_RUNS_JSON="$STUB_DIR/runs.json"
+GH_RUNS_RC="$STUB_DIR/runs.rc"
+GH_RELEASE_ERR="$STUB_DIR/release.err"
+GH_RELEASE_RC="$STUB_DIR/release.rc"
+GH_DOWNLOAD_RC="$STUB_DIR/download.rc"
+GH_DOWNLOAD_FILES="$STUB_DIR/download.files"
+
+cat > "$STUB_DIR/gh" <<'STUB'
+#!/bin/bash
+# Stub: `gh api .../runs...`, `gh api .../releases/tags/...`, `gh release download`.
+case "$1 ${2:-}" in
+  "api "*"/runs"*)
+    cat "$GH_RUNS_JSON"
+    exit "$(cat "$GH_RUNS_RC")"
+    ;;
+  "release download"*)
+    dir=""
+    prev=""
+    for a in "$@"; do
+      [ "$prev" = "--dir" ] && dir="$a"
+      prev="$a"
+    done
+    while read -r f; do
+      [ -n "$f" ] || continue
+      mkdir -p "$dir"
+      echo stub > "$dir/$f"
+    done < "$GH_DOWNLOAD_FILES"
+    exit "$(cat "$GH_DOWNLOAD_RC")"
+    ;;
+  *)
+    # `gh api repos/<artifacts>/releases/tags/<tag>`
+    cat "$GH_RELEASE_ERR" >&2
+    exit "$(cat "$GH_RELEASE_RC")"
+    ;;
+esac
+STUB
+
+cat > "$STUB_DIR/git" <<'STUB'
+#!/bin/bash
+# Stub: only `rev-parse --verify --quiet <spec>^{commit}` is used by the lib.
+# Anything in KNOWN_COMMITS resolves to itself; everything else fails.
+if [ "$1" = "rev-parse" ]; then
+  spec="${*: -1}"
+  spec="${spec%^\{commit\}}"
+  for k in $KNOWN_COMMITS; do
+    if [ "$k" = "$spec" ]; then echo "$k"; exit 0; fi
+  done
+  exit 1
+fi
+exit 0
+STUB
+
+cat > "$STUB_DIR/version.sh" <<'STUB'
+#!/bin/bash
+# Stub for the real version.sh: tag is derived from run number + sha.
+[ "${VERSION_SH_RC:-0}" = "0" ] || exit "$VERSION_SH_RC"
+echo "v1.2.3-build.9.$1+g${2:0:8}"
+STUB
+
+chmod +x "$STUB_DIR/gh" "$STUB_DIR/git" "$STUB_DIR/version.sh"
+cp "$LIB_DIR/perf-release-lib.sh" "$STUB_DIR/perf-release-lib.sh"
+
+export PATH="$STUB_DIR:$PATH"
+export REPO="acme/heph"
+export GH_TOKEN="t"
+export ARTIFACTS_TOKEN="t"
+export GH_RUNS_JSON GH_RUNS_RC GH_RELEASE_ERR GH_RELEASE_RC GH_DOWNLOAD_RC GH_DOWNLOAD_FILES
+export KNOWN_COMMITS="abc1234def5678abc1234def5678abc1234def56"
+
+# Defaults: one completed run, release published, download yields nothing.
+reset_stubs() {
+  echo "4242	completed	success" > "$GH_RUNS_JSON"
+  echo 0 > "$GH_RUNS_RC"
+  : > "$GH_RELEASE_ERR"
+  echo 0 > "$GH_RELEASE_RC"
+  echo 0 > "$GH_DOWNLOAD_RC"
+  : > "$GH_DOWNLOAD_FILES"
+  unset VERSION_SH_RC
+}
+
+# Runs `$1` (a snippet sourced after the library) in a subshell with `set -e`,
+# capturing stdout+stderr and the exit status — the same shape a workflow step
+# gives the library.
+run_snippet() {
+  (
+    set -e
+    # shellcheck disable=SC1090
+    . "$STUB_DIR/perf-release-lib.sh"
+    eval "$1"
+  ) 2>&1
+}
+
+check() { # $1=name $2=expected-substring $3=actual $4=expected-rc $5=actual-rc
+  if [[ "$3" == *"$2"* ]] && [ "$4" = "$5" ]; then
+    PASS=$((PASS + 1))
+    printf '  ok   %s\n' "$1"
+  else
+    FAIL=$((FAIL + 1))
+    printf '  FAIL %s\n       want rc=%s containing: %s\n       got  rc=%s: %s\n' \
+      "$1" "$4" "$2" "$5" "$3"
+  fi
+}
+
+# --- run_for_sha ------------------------------------------------------------
+
+reset_stubs
+echo '' > "$GH_RUNS_JSON"
+out=$(run_snippet 'run_for_sha deadbeef && echo FOUND || echo NO-RUN'); rc=$?
+check "run_for_sha: no runs returns 1 (not a false hit)" "NO-RUN" "$out" 0 $rc
+
+# The regression this guards: `.workflow_runs | first` is null with no runs,
+# and `@tsv` renders null as the non-empty string "\t\t-", which read as a
+# successful lookup and produced `CI run #- ... is still  —`.
+reset_stubs
+echo '' > "$GH_RUNS_JSON"
+out=$(run_snippet 'v=$(run_for_sha deadbeef) || v="(failed)"; echo "[$v]"'); rc=$?
+check "run_for_sha: empty result is empty, not a tab-rendered null" "[(failed)]" "$out" 0 $rc
+
+reset_stubs
+echo 1 > "$GH_RUNS_RC"
+echo 'gh: Server Error (HTTP 502)' > "$GH_RUNS_JSON"
+out=$(run_snippet 'run_for_sha deadbeef; echo UNREACHABLE'); rc=$?
+check "run_for_sha: API failure is not 'no such run'" "failed to query CI runs" "$out" 1 $rc
+
+# --- release_exists ---------------------------------------------------------
+
+reset_stubs
+out=$(run_snippet 'release_exists v1 && echo YES'); rc=$?
+check "release_exists: published" "YES" "$out" 0 $rc
+
+reset_stubs
+echo 1 > "$GH_RELEASE_RC"
+echo 'gh: Not Found (HTTP 404)' > "$GH_RELEASE_ERR"
+out=$(run_snippet 'release_exists v1 || echo ABSENT'); rc=$?
+check "release_exists: 404 is absent" "ABSENT" "$out" 0 $rc
+
+reset_stubs
+echo 1 > "$GH_RELEASE_RC"
+echo 'gh: Bad credentials (HTTP 401)' > "$GH_RELEASE_ERR"
+out=$(run_snippet 'release_exists v1 || echo ABSENT; echo UNREACHABLE'); rc=$?
+check "release_exists: 401 exits, never reads as absent" "artifacts-repo API error" "$out" 1 $rc
+
+# --- resolve_spec -----------------------------------------------------------
+
+reset_stubs
+out=$(run_snippet 'resolve_spec abc1234def5678abc1234def5678abc1234def56 candidate'); rc=$?
+check "resolve_spec: SHA resolves to its run's tag" \
+  "v1.2.3-build.9.4242+gabc1234d	abc1234def5678abc1234def5678abc1234def56" "$out" 0 $rc
+
+reset_stubs
+out=$(run_snippet 'resolve_spec 0000000000000000000000000000000000000000 candidate'); rc=$?
+check "resolve_spec: unknown SHA fails" "is not a commit in this checkout" "$out" 1 $rc
+
+reset_stubs
+echo '' > "$GH_RUNS_JSON"
+out=$(run_snippet 'resolve_spec abc1234def5678abc1234def5678abc1234def56 baseline'); rc=$?
+check "resolve_spec: SHA with no CI run explains batched pushes" \
+  "landed in a batched push" "$out" 1 $rc
+
+reset_stubs
+echo "4242	in_progress	-" > "$GH_RUNS_JSON"
+echo 1 > "$GH_RELEASE_RC"; echo 'gh: Not Found (HTTP 404)' > "$GH_RELEASE_ERR"
+out=$(run_snippet 'resolve_spec abc1234def5678abc1234def5678abc1234def56 candidate'); rc=$?
+check "resolve_spec: still-running run says wait" "is still in_progress" "$out" 1 $rc
+
+reset_stubs
+echo "4242	completed	failure" > "$GH_RUNS_JSON"
+echo 1 > "$GH_RELEASE_RC"; echo 'gh: Not Found (HTTP 404)' > "$GH_RELEASE_ERR"
+out=$(run_snippet 'resolve_spec abc1234def5678abc1234def5678abc1234def56 candidate'); rc=$?
+check "resolve_spec: completed-but-unpublished is distinct from still-running" \
+  "never published release" "$out" 1 $rc
+
+reset_stubs
+out=$(run_snippet 'resolve_spec v1.2.3-build.9.4242+gabc1234 baseline'); rc=$?
+check "resolve_spec: tag form recovers the sha from +g" \
+  "v1.2.3-build.9.4242+gabc1234	" "$out" 0 $rc
+
+reset_stubs
+echo 1 > "$GH_RELEASE_RC"; echo 'gh: Not Found (HTTP 404)' > "$GH_RELEASE_ERR"
+out=$(run_snippet 'resolve_spec abc123 baseline'); rc=$?
+check "resolve_spec: 6-hex is treated as a tag, and says so" \
+  "at least 7 hex characters" "$out" 1 $rc
+
+reset_stubs
+export VERSION_SH_RC=3
+out=$(run_snippet 'resolve_spec abc1234def5678abc1234def5678abc1234def56 candidate'); rc=$?
+unset VERSION_SH_RC
+check "resolve_spec: version.sh failure does not yield an empty tag" \
+  "could not derive the release tag" "$out" 1 $rc
+
+# --- fetch_assets -----------------------------------------------------------
+
+reset_stubs
+printf 'a\nb\n' > "$GH_DOWNLOAD_FILES"
+out=$(run_snippet 'cd "$STUB_DIR"; m=$(fetch_assets v1 d-all a b); echo "[$m]"'); rc=$?
+check "fetch_assets: all present reports nothing missing" "[]" "$out" 0 $rc
+
+reset_stubs
+printf 'a\n' > "$GH_DOWNLOAD_FILES"
+out=$(run_snippet 'cd "$STUB_DIR"; m=$(fetch_assets v1 d-partial a b); echo "[$(tr "\n" " " <<< "$m")]"'); rc=$?
+check "fetch_assets: partial names only what is absent" "[b ]" "$out" 0 $rc
+
+reset_stubs
+: > "$GH_DOWNLOAD_FILES"
+out=$(run_snippet 'cd "$STUB_DIR"; m=$(fetch_assets v1 d-none a b); echo "[$(tr "\n" " " <<< "$m")]"'); rc=$?
+check "fetch_assets: all absent names them all" "[a b ]" "$out" 0 $rc
+
+# A download that fails outright must not be silently indistinguishable from
+# a release that genuinely lacks the asset.
+reset_stubs
+: > "$GH_DOWNLOAD_FILES"
+echo 1 > "$GH_DOWNLOAD_RC"
+out=$(run_snippet 'cd "$STUB_DIR"; fetch_assets v1 d-err a >/dev/null'); rc=$?
+check "fetch_assets: reports a non-zero gh status" "gh release download exited 1" "$out" 0 $rc
+
+# The return channel must be the function's alone: chatter on gh's stdout
+# would otherwise be read as a missing-asset name by every caller.
+reset_stubs
+printf 'a\n' > "$GH_DOWNLOAD_FILES"
+cat > "$STUB_DIR/gh" <<'STUB'
+#!/bin/bash
+echo "gh: a new release of gh is available"   # stdout chatter
+dir=""; prev=""
+for a in "$@"; do [ "$prev" = "--dir" ] && dir="$a"; prev="$a"; done
+mkdir -p "$dir"; echo stub > "$dir/a"
+exit 0
+STUB
+chmod +x "$STUB_DIR/gh"
+out=$(run_snippet 'cd "$STUB_DIR"; m=$(fetch_assets v1 d-chatter a); echo "[$m]"'); rc=$?
+check "fetch_assets: gh stdout cannot pollute the missing list" "[]" "$out" 0 $rc
+
+printf '\n%d passed, %d failed\n' "$PASS" "$FAIL"
+[ "$FAIL" -eq 0 ]

--- a/.github/workflows/perf.yml
+++ b/.github/workflows/perf.yml
@@ -1,28 +1,57 @@
 name: Perf
 
-# Reusable workflow, not runnable on its own — `heph.yml`'s `perfbench` job
-# calls it (`uses: ./.github/workflows/perf.yml`) only when needed
-# (`pull_request`, or `push` to `master`), after `build` has already
-# published this run's `heph`/`heph-bench`/go-plugin artifacts. Split out of
-# `heph.yml` because this check's cost (real runners, a generated corpus,
-# real timing) and its own release-fetching/issue-filing logic are large
-# enough to read on their own, separate from the compile/lint/test jobs that
-# make up the rest of CI.
+# Two ways in:
+#   - Reusable workflow: `heph.yml`'s `perfbench` job calls it
+#     (`uses: ./.github/workflows/perf.yml`) only when needed
+#     (`pull_request`, or `push` to `master`), after `build` has already
+#     published this run's `heph`/`heph-bench`/go-plugin artifacts. Split out
+#     of `heph.yml` because this check's cost (real runners, a generated
+#     corpus, real timing) and its own release-fetching/issue-filing logic
+#     are large enough to read on their own, separate from the
+#     compile/lint/test jobs that make up the rest of CI.
+#   - `workflow_dispatch`: a manual run against an explicit (or
+#     auto-resolved) baseline release. Nothing is built here either — the
+#     candidate is the release the dispatched commit's own CI run already
+#     published, so dispatching on a commit whose CI hasn't published yet
+#     fails with a clear message rather than silently building something.
+#     Master commits only: PR runs publish tags derived from the ephemeral
+#     merge commit (`gen` describes the refs/pull/N/merge checkout), which
+#     cannot be re-derived from the branch head the runs API exposes — for a
+#     PR, use the `perf-test` label instead.
 on:
   workflow_call:
+  workflow_dispatch:
+    inputs:
+      baseline:
+        description: >-
+          Baseline: a commit SHA (its CI run's published release is used), or
+          an exact release tag in hephbuild/heph-artifacts-v1 (e.g.
+          v0.0.0-build.12.345+gabc1234). Empty = latest published release
+          from master.
+        required: false
+        default: ""
 
 jobs:
   # Perf-regression check: generates one synthetic corpus, times a fixed
-  # scenario set against N and N-1, and reports a regression verdict. Two
-  # triggers, two roles:
-  #   - `pull_request`: N is this PR's head, N-1 its merge-base with the
-  #     target branch. This is the GATE — a real regression fails the check
-  #     for real (see "Enforced for real" below).
+  # scenario set against N and N-1, and reports a regression verdict. Three
+  # triggers, three roles:
+  #   - `pull_request`: N is this PR's head, N-1 the latest published master
+  #     release at or before the merge-base with the target branch (usually
+  #     the merge-base itself). This is the GATE — a real regression fails
+  #     the check for real (see "Enforced for real" below).
   #   - `push` to `master`: N is the commit that just landed, N-1 is the
-  #     commit immediately before it (`github.event.before`). Nothing is
-  #     blocked at this point (the merge already happened) — this is
-  #     continuous monitoring, so a regression instead files a GitHub issue
-  #     (see "File regression issue").
+  #     latest published master release before it — NOT blindly the previous
+  #     commit: master pushes build concurrently (per-sha groups in
+  #     `heph.yml`), so the immediately-previous commit's release may not
+  #     exist yet (or ever, if its build broke); the resolver walks back to
+  #     the newest master release that does. Nothing is blocked at this
+  #     point (the merge already happened) — this is continuous monitoring,
+  #     so a regression instead files a GitHub issue (see "File regression
+  #     issue").
+  #   - `workflow_dispatch`: N is the dispatched commit's own published
+  #     release; N-1 is the `baseline` input if given (an exact release tag,
+  #     failing hard if it doesn't exist), else the latest published master
+  #     release before N — a manual re-run/backfill knob, no gating role.
   #
   # Nothing in this job is built. `heph`, the go plugin cdylib, and
   # `heph-bench` itself are all release assets (the `build` job publishes
@@ -51,15 +80,15 @@ jobs:
   # N-1 is fetched, never built: every push to `master` already publishes a
   # prerelease to hephbuild/heph-artifacts-v1 (the `upload_artifacts` job).
   # The release tag isn't the commit SHA — it's `git describe` plus the CI
-  # run_number that built it — so "resolve baseline release" re-derives that
-  # exact tag by finding the `master`-push CI run for the baseline SHA via
-  # the GitHub API and feeding its run_number through the same `version.sh`
-  # logic that originally produced it. If no such run is found (history
-  # pruned, baseline predates this job, API hiccup, or — on `push` — this is
-  # the first commit on the ref), the job is skipped for that leg with a
-  # note — there is deliberately no "build it instead" fallback, since a slow
-  # silent fallback is exactly what turns into "why is this job suddenly
-  # slow" months from now.
+  # run_number that built it — so "Resolve baseline" re-derives tags by
+  # listing `master`-push CI runs via the GitHub API and feeding each run's
+  # run_number + head_sha through the same `version.sh` logic that
+  # originally produced them, walking newest-first until a tag that actually
+  # exists as a release is found. If nothing is found (history pruned,
+  # baseline predates this job, API hiccup, first commit on the ref), the
+  # job fails for that leg with a note — there is deliberately no "build it
+  # instead" fallback, since a slow silent fallback is exactly what turns
+  # into "why is this job suddenly slow" months from now.
   #
   # Enforced for real: the "Compare and report" step exits non-zero when any
   # scenario regresses past its threshold, on both triggers. On a PR that
@@ -83,9 +112,11 @@ jobs:
     # so consecutive master commits queue on the same runner-flavour lane
     # instead of racing each other for timing noise — cancel-in-progress
     # stays false there so a queued commit's regression check still runs
-    # rather than getting starved forever by the next push.
+    # rather than getting starved forever by the next push. `dispatch`: its
+    # own per-ref lane (falls into the `github.ref` arm), so a manual run
+    # doesn't queue behind the master monitoring lane.
     concurrency:
-      group: perfbench-${{ matrix.os }}-${{ matrix.arch }}-${{ github.event_name == 'pull_request' && github.ref || 'master' }}
+      group: perfbench-${{ matrix.os }}-${{ matrix.arch }}-${{ github.event_name == 'push' && 'master' || github.ref }}
       cancel-in-progress: ${{ github.event_name == 'pull_request' }}
     # Specifying `permissions:` at all makes it exhaustive — everything not
     # listed drops to `none`. `contents: read` for the checkout, `actions:
@@ -151,59 +182,161 @@ jobs:
           go-version: "1.25"
           cache: false
 
-      # PR: the merge-base with the target branch. Push (to master): the
-      # commit immediately before this one — `github.event.before`, the
-      # correct source for "previous commit on this ref" (robust to force-
-      # pushes in a way `HEAD~1` is not). `before` is all-zeros on the very
-      # first push to a ref; treated the same as "no baseline found" below.
-      - name: Resolve baseline SHA
-        id: base
-        run: |
-          if [ "${{ github.event_name }}" = "pull_request" ]; then
-            git fetch origin "${{ github.base_ref }}"
-            echo "sha=$(git merge-base "origin/${{ github.base_ref }}" HEAD)" >> "$GITHUB_OUTPUT"
-          else
-            sha="${{ github.event.before }}"
-            if [ -z "$sha" ] || [ "$sha" = "0000000000000000000000000000000000000000" ]; then
-              echo "no previous commit on this ref (first push) — nothing to compare against"
-              echo "sha=" >> "$GITHUB_OUTPUT"
-            else
-              echo "sha=$sha" >> "$GITHUB_OUTPUT"
-            fi
-          fi
-
-      # Re-derives the exact version tag `master`'s own CI run published the
-      # baseline commit's release under — see the job comment. Only needs
-      # `gh api` (against this repo, default token) and `git describe`
-      # against a commit already present from the full-history checkout
-      # above; no build, no checkout of that commit.
+      # Resolves the baseline RELEASE (tag in hephbuild/heph-artifacts-v1) +
+      # the SHA it was built from. Only needs `gh api` (run listing against
+      # this repo, default token), `gh release view` (existence check against
+      # the artifacts repo, PAT) and `git describe` against commits already
+      # present from the full-history checkout above; no build, no checkout
+      # of any other commit.
       #
-      # Deliberately does NOT filter by the run's overall conclusion: whether
-      # a release was actually published is what "Fetch baseline" below
-      # checks (best-effort `gh release download`), not whether every other
-      # job in that run happened to pass. A run's Perf legs or an unrelated
-      # job (Binary E2E, say) can fail while `upload_artifacts` still
-      # published fine — gating on run-level success here made a single
-      # flake unrecoverable: the next commit's baseline lookup would find no
-      # "successful" run, fail its own Perf job for missing baseline, and the
-      # failure would propagate to every commit after it forever.
-      - name: Resolve baseline release
-        if: steps.base.outputs.sha != ''
+      #   - dispatch with an explicit `baseline` input: a commit SHA (the
+      #     release its own CI run published) or an exact release tag —
+      #     either way verified to exist, and a missing one fails the job,
+      #     it was asked for by name. For a tag, the SHA is recovered
+      #     best-effort from its `+g<hash>` suffix.
+      #   - everything else: the latest published master release at/before
+      #     the baseline point — merge-base (inclusive) on `pull_request`,
+      #     this commit (exclusive: never compare a commit to itself) on
+      #     `push`/dispatch. PRs try the exact merge-base run first (a
+      #     head_sha-filtered lookup still works when the merge-base is
+      #     older than the walk window below), then fall back to the walk:
+      #     newest-first over recent master-push CI runs, keeping the first
+      #     ancestor-of-the-baseline-point whose re-derived tag exists as a
+      #     release.
+      #
+      # Deliberately does NOT filter by any run's overall conclusion: whether
+      # a release was actually published is checked directly (`gh release
+      # view`), not inferred from whether every other job in that run
+      # happened to pass. A run's Perf legs or an unrelated job (Binary E2E,
+      # say) can fail while `upload_artifacts` still published fine — gating
+      # on run-level success here made a single flake unrecoverable: the
+      # next commit's baseline lookup would find no "successful" run, fail
+      # its own Perf job for missing baseline, and the failure would
+      # propagate to every commit after it forever.
+      - name: Resolve baseline
         id: baseline_release
         env:
           GH_TOKEN: ${{ github.token }}
+          ARTIFACTS_TOKEN: ${{ secrets.HEPH_ARTIFACTS_PAT }}
+          EVENT: ${{ github.event_name }}
+          INPUT_BASELINE: ${{ inputs.baseline }}
         run: |
-          RUN_NUMBER=$(gh api "repos/${{ github.repository }}/actions/runs?head_sha=${{ steps.base.outputs.sha }}" \
-            --jq '[.workflow_runs[] | select(.name=="CI" and .event=="push")] | first | .run_number // empty')
-          if [ -z "$RUN_NUMBER" ]; then
-            echo "no master push run found for baseline ${{ steps.base.outputs.sha }}"
-            echo "found=false" >> "$GITHUB_OUTPUT"
+          # A 404 is "release doesn't exist"; anything else (401/403 on a
+          # bad/expired PAT, API outage) fails the step loudly — otherwise an
+          # auth failure walks all 50 runs and reports "no published master
+          # release found", a confident diagnosis of the wrong system.
+          release_exists() {
+            local err
+            if err=$(GH_TOKEN="$ARTIFACTS_TOKEN" gh api \
+                "repos/hephbuild/heph-artifacts-v1/releases/tags/$1" 2>&1 >/dev/null); then
+              return 0
+            fi
+            if printf '%s' "$err" | grep -q "HTTP 404"; then
+              return 1
+            fi
+            echo "artifacts-repo API error while checking release '$1': $err" >&2
+            exit 1
+          }
+          # Echoes the version tag the master-push CI run for sha $1
+          # published under; fails if no such run is found. Push runs only:
+          # a PR run's tag derives from its ephemeral merge commit, not the
+          # head_sha the runs API exposes, so it cannot be re-derived here.
+          # The workflow-scoped endpoint (heph.yml) avoids both the
+          # `.name=="CI"` string coupling and sharing the result window with
+          # other push-triggered workflows.
+          version_for_sha() {
+            local rn
+            rn=$(gh api "repos/${{ github.repository }}/actions/workflows/heph.yml/runs?head_sha=$1&event=push" \
+              --jq '.workflow_runs | first | .run_number // empty')
+            [ -n "$rn" ] || return 1
+            .github/workflows/version.sh "$rn" "$1"
+          }
+          emit() { # $1=version $2=sha $3=mode $4=how
+            echo "resolved baseline release: $1 ($4)"
+            {
+              echo "found=true"
+              echo "version=$1"
+              echo "sha=$2"
+              echo "mode=$3"
+            } >> "$GITHUB_OUTPUT"
+          }
+
+          if [ "$EVENT" = "workflow_dispatch" ] && [ -n "$INPUT_BASELINE" ]; then
+            if echo "$INPUT_BASELINE" | grep -qE '^[0-9a-fA-F]{7,40}$'; then
+              # A commit SHA: use the release its own CI run published.
+              sha=$(git rev-parse --verify --quiet "$INPUT_BASELINE^{commit}") || {
+                echo "baseline '$INPUT_BASELINE' looks like a commit SHA but is not a known commit" >&2
+                exit 1
+              }
+              # No run is normal, not just "wrong branch": CI runs once per
+              # push, on that push's head commit, so every other commit in a
+              # batched push has no run and no release of its own.
+              version=$(version_for_sha "$sha") || {
+                echo "no master-push CI run found for baseline commit $sha — it is either not on master, or landed in a batched push whose CI ran on a later commit; pick a commit that has a CI run, or pass an exact release tag" >&2
+                exit 1
+              }
+              if ! release_exists "$version"; then
+                echo "baseline commit $sha's CI run never published release '$version'" >&2
+                exit 1
+              fi
+              emit "$version" "$sha" "explicit" "explicit input, commit $sha"
+              exit 0
+            fi
+            if ! release_exists "$INPUT_BASELINE"; then
+              echo "requested baseline release '$INPUT_BASELINE' not found in hephbuild/heph-artifacts-v1" >&2
+              exit 1
+            fi
+            short="${INPUT_BASELINE##*+g}"
+            sha=""
+            if [ "$short" != "$INPUT_BASELINE" ]; then
+              sha=$(git rev-parse --verify --quiet "$short^{commit}" || true)
+            fi
+            emit "$INPUT_BASELINE" "$sha" "explicit" "explicit input"
             exit 0
           fi
-          VERSION=$(.github/workflows/version.sh "$RUN_NUMBER" "${{ steps.base.outputs.sha }}")
-          echo "resolved baseline release: $VERSION (run #$RUN_NUMBER)"
-          echo "found=true" >> "$GITHUB_OUTPUT"
-          echo "version=$VERSION" >> "$GITHUB_OUTPUT"
+
+          if [ "$EVENT" = "pull_request" ]; then
+            git fetch origin "${{ github.base_ref }}"
+            upper=$(git merge-base "origin/${{ github.base_ref }}" HEAD)
+            self=""
+            if version=$(version_for_sha "$upper") && release_exists "$version"; then
+              emit "$version" "$upper" "merge-base" "exact merge-base"
+              exit 0
+            fi
+            echo "merge-base $upper has no published release — walking back on master"
+          else
+            upper="${{ github.sha }}"
+            self="${{ github.sha }}"
+          fi
+
+          # Captured, not process-substituted: a failed `gh api` must get
+          # its own message, not silently read as "zero runs" and fall
+          # through to the no-baseline diagnosis below.
+          runs=$(gh api "repos/${{ github.repository }}/actions/workflows/heph.yml/runs?branch=master&event=push&per_page=50" \
+            --jq '.workflow_runs[] | [.run_number, .head_sha] | @tsv') || {
+            echo "failed to list master-push CI runs — cannot resolve a baseline" >&2
+            exit 1
+          }
+          while IFS=$'\t' read -r run_number head_sha; do
+            [ -n "$run_number" ] || continue
+            [ "$head_sha" = "$self" ] && continue
+            git cat-file -e "$head_sha^{commit}" 2>/dev/null || continue
+            git merge-base --is-ancestor "$head_sha" "$upper" || continue
+            version=$(.github/workflows/version.sh "$run_number" "$head_sha")
+            if release_exists "$version"; then
+              emit "$version" "$head_sha" "walk" "run #$run_number, $head_sha"
+              exit 0
+            fi
+            echo "skipping $head_sha (run #$run_number): no published release $version"
+          done <<< "$runs"
+
+          echo "no published master release found in the last 50 master-push CI runs at/before $upper"
+          {
+            echo "found=false"
+            echo "version="
+            echo "sha="
+            echo "mode="
+          } >> "$GITHUB_OUTPUT"
 
       # `heph-bench` may 404 (bootstrap note above) — fetched best-effort,
       # separately from `heph` + the go plugin, so an old baseline still
@@ -216,11 +349,18 @@ jobs:
         run: |
           ext=so; [ "${{ matrix.os }}" = "darwin" ] && ext=dylib
           mkdir -p baseline-dist-raw baseline-dist
-          if gh release download "${{ steps.baseline_release.outputs.version }}" \
-              --repo hephbuild/heph-artifacts-v1 \
-              --dir baseline-dist-raw \
-              --pattern "heph_${{ matrix.os }}_${{ matrix.arch }}" \
-              --pattern "heph-go-plugin_${{ matrix.os }}_${{ matrix.arch }}.$ext"; then
+          # Both downloads are best-effort (`|| true`) and judged by which
+          # files actually landed: `gh release download` exits 0 when only
+          # SOME of its patterns matched, so a partially-published release
+          # would otherwise reach the `cp` and hard-fail the step under
+          # `set -e` instead of degrading to ok=false / bench_ok=false.
+          gh release download "${{ steps.baseline_release.outputs.version }}" \
+            --repo hephbuild/heph-artifacts-v1 \
+            --dir baseline-dist-raw \
+            --pattern "heph_${{ matrix.os }}_${{ matrix.arch }}" \
+            --pattern "heph-go-plugin_${{ matrix.os }}_${{ matrix.arch }}.$ext" || true
+          if [ -f "baseline-dist-raw/heph_${{ matrix.os }}_${{ matrix.arch }}" ] \
+             && [ -f "baseline-dist-raw/heph-go-plugin_${{ matrix.os }}_${{ matrix.arch }}.$ext" ]; then
             cp "baseline-dist-raw/heph_${{ matrix.os }}_${{ matrix.arch }}" baseline-dist/heph
             cp "baseline-dist-raw/heph-go-plugin_${{ matrix.os }}_${{ matrix.arch }}.$ext" "baseline-dist/heph-go-plugin.$ext"
             chmod +x baseline-dist/heph
@@ -229,10 +369,11 @@ jobs:
             echo "release ${{ steps.baseline_release.outputs.version }} found but missing heph/go-plugin for this leg"
             echo "ok=false" >> "$GITHUB_OUTPUT"
           fi
-          if gh release download "${{ steps.baseline_release.outputs.version }}" \
-              --repo hephbuild/heph-artifacts-v1 \
-              --dir baseline-dist-raw \
-              --pattern "heph-bench_${{ matrix.os }}_${{ matrix.arch }}"; then
+          gh release download "${{ steps.baseline_release.outputs.version }}" \
+            --repo hephbuild/heph-artifacts-v1 \
+            --dir baseline-dist-raw \
+            --pattern "heph-bench_${{ matrix.os }}_${{ matrix.arch }}" || true
+          if [ -f "baseline-dist-raw/heph-bench_${{ matrix.os }}_${{ matrix.arch }}" ]; then
             cp "baseline-dist-raw/heph-bench_${{ matrix.os }}_${{ matrix.arch }}" baseline-dist/heph-bench
             chmod +x baseline-dist/heph-bench
             echo "bench_ok=true" >> "$GITHUB_OUTPUT"
@@ -241,12 +382,68 @@ jobs:
             echo "bench_ok=false" >> "$GITHUB_OUTPUT"
           fi
 
+      # workflow_call runs get the candidate from this same run's `build`
+      # artifacts; a dispatch run has no `build` job, so the candidate is the
+      # release the dispatched commit's own master-push CI run published
+      # (master commits only — see the trigger comment at the top). Missing
+      # run or missing assets fail hard: the candidate is mandatory, and
+      # "wait for CI to publish first" is the actionable message.
       - name: Download candidate (N) artifacts
+        if: github.event_name != 'workflow_dispatch'
         uses: actions/download-artifact@v7
         with:
           pattern: heph*_${{ matrix.os }}_${{ matrix.arch }}*
           path: candidate-dist-raw
           merge-multiple: true
+
+      - name: Fetch candidate (N) release artifacts (dispatch)
+        if: github.event_name == 'workflow_dispatch'
+        env:
+          GH_TOKEN: ${{ github.token }}
+          ARTIFACTS_TOKEN: ${{ secrets.HEPH_ARTIFACTS_PAT }}
+        run: |
+          RUN_INFO=$(gh api "repos/${{ github.repository }}/actions/workflows/heph.yml/runs?head_sha=${{ github.sha }}&event=push" \
+            --jq '.workflow_runs | first | [.run_number, .status, .conclusion // "-"] | @tsv')
+          if [ -z "$RUN_INFO" ]; then
+            echo "no master-push CI run found for ${{ github.sha }} — dispatch on a master commit that has its own CI run (CI runs once per push, so a batched push leaves its earlier commits without one); a PR's tag derives from its ephemeral merge commit and cannot be re-derived, so use the \`perf-test\` label for a PR" >&2
+            exit 1
+          fi
+          IFS=$'\t' read -r RUN_NUMBER RUN_STATUS RUN_CONCLUSION <<< "$RUN_INFO"
+          VERSION=$(.github/workflows/version.sh "$RUN_NUMBER" "${{ github.sha }}")
+          # The run existing is not enough — it publishes the release in its
+          # `upload_artifacts` job. Check the release directly and report
+          # still-running vs failed, the two states a dispatcher actually
+          # needs to tell apart.
+          if ! GH_TOKEN="$ARTIFACTS_TOKEN" gh api "repos/hephbuild/heph-artifacts-v1/releases/tags/$VERSION" >/dev/null 2>&1; then
+            if [ "$RUN_STATUS" != "completed" ]; then
+              echo "CI run #$RUN_NUMBER for ${{ github.sha }} is still $RUN_STATUS — wait for its Pre-release job to publish $VERSION, then re-dispatch" >&2
+            else
+              echo "CI run #$RUN_NUMBER completed ($RUN_CONCLUSION) but never published release $VERSION — this commit has no candidate build to test" >&2
+            fi
+            exit 1
+          fi
+          echo "candidate release: $VERSION (run #$RUN_NUMBER)"
+          ext=so; [ "${{ matrix.os }}" = "darwin" ] && ext=dylib
+          mkdir -p candidate-dist-raw
+          GH_TOKEN="$ARTIFACTS_TOKEN" gh release download "$VERSION" \
+            --repo hephbuild/heph-artifacts-v1 \
+            --dir candidate-dist-raw \
+            --pattern "heph_${{ matrix.os }}_${{ matrix.arch }}" \
+            --pattern "heph-bench_${{ matrix.os }}_${{ matrix.arch }}" \
+            --pattern "heph-go-plugin_${{ matrix.os }}_${{ matrix.arch }}.$ext" || true
+          # `gh release download` exits 0 when only SOME patterns matched, so
+          # the assets are checked by name — otherwise a partially-published
+          # release dies on a bare `cp: cannot stat` in the next step.
+          missing=()
+          for asset in "heph_${{ matrix.os }}_${{ matrix.arch }}" \
+                       "heph-bench_${{ matrix.os }}_${{ matrix.arch }}" \
+                       "heph-go-plugin_${{ matrix.os }}_${{ matrix.arch }}.$ext"; do
+            [ -f "candidate-dist-raw/$asset" ] || missing+=("$asset")
+          done
+          if [ ${#missing[@]} -gt 0 ]; then
+            echo "release $VERSION is missing candidate asset(s) for this leg: ${missing[*]}" >&2
+            exit 1
+          fi
 
       - name: Normalize candidate dist layout
         run: |
@@ -279,8 +476,11 @@ jobs:
       # absorb it as "no results" for that leg, same as any other run
       # failure. That's a one-time gap that resolves itself once this PR
       # merges; no fallback branching to maintain for it.
+      # Also gated on `ok`: "Compare and report" hard-fails when the Tier B
+      # assets are missing, so timing Tier A first would burn its minutes
+      # for a report that fails anyway.
       - name: Time Tier A (inprocess) scenarios
-        if: steps.baseline_fetch.outputs.bench_ok == 'true'
+        if: steps.baseline_fetch.outputs.ok == 'true' && steps.baseline_fetch.outputs.bench_ok == 'true'
         continue-on-error: true
         run: |
           for scenario in cold full-hit incremental; do
@@ -324,12 +524,20 @@ jobs:
           BENCH=./candidate-dist/heph-bench
           any_regression=false
           mkdir -p verdicts
+          BASE_SHA="${{ steps.baseline_release.outputs.sha }}"
+          [ -n "$BASE_SHA" ] || BASE_SHA="sha unknown"
           report=$(
             echo "# Perf: ${{ matrix.os }}/${{ matrix.arch }}"
             if [ "${{ steps.baseline_fetch.outputs.ok }}" != "true" ]; then
               echo ""
-              echo "_FAILED: no published release found for baseline \`${{ steps.base.outputs.sha }}\`_"
+              echo "_FAILED: no usable baseline release (resolved: \`${{ steps.baseline_release.outputs.version || 'none' }}\`)_"
             else
+              echo ""
+              echo "_baseline: \`${{ steps.baseline_release.outputs.version }}\` (\`$BASE_SHA\`; via ${{ steps.baseline_release.outputs.mode }})_"
+              if [ "${{ github.event_name }}" = "pull_request" ] && [ "${{ steps.baseline_release.outputs.mode }}" = "walk" ]; then
+                echo ""
+                echo "_note: baseline is older than this PR's merge-base — a regression here may originate in master commits between them, not in this PR_"
+              fi
               for tier in inproc dist; do
                 echo ""
                 echo "## Tier: $tier"
@@ -372,7 +580,7 @@ jobs:
           # detected regressions and would mislabel this.
           if [ "${{ steps.baseline_fetch.outputs.ok }}" != "true" ]; then
             echo "regressed=false" >> "$GITHUB_OUTPUT"
-            echo "no baseline artifacts found for ${{ steps.base.outputs.sha }} — failing rather than reporting a silent pass" >&2
+            echo "no usable baseline release found — failing rather than reporting a silent pass" >&2
             exit 1
           fi
 
@@ -384,6 +592,20 @@ jobs:
             echo "regression detected — see the job summary for the table" >&2
             exit 1
           fi
+
+      # The structured verdicts otherwise only go to PostHog — publishing
+      # them as a run artifact gives a dispatcher (human or agent) a stable
+      # JSON result via `gh run download`, not just a markdown summary and
+      # an exit code.
+      - name: Upload verdicts artifact
+        if: always() && steps.baseline_fetch.outputs.ok == 'true'
+        uses: actions/upload-artifact@v6
+        with:
+          name: perf-verdicts_${{ matrix.os }}_${{ matrix.arch }}
+          path: |
+            verdicts/
+            perf-report.md
+          if-no-files-found: ignore
 
       # `always()`: the step above now genuinely exits non-zero on a real
       # regression, and the numbers are worth having in PostHog regardless of
@@ -405,7 +627,8 @@ jobs:
             tier=$(basename "$f" .json)
             batch=$(jq --arg tier "$tier" \
               --arg os "${{ matrix.os }}" --arg arch "${{ matrix.arch }}" \
-              --arg sha "${{ github.sha }}" --arg base_sha "${{ steps.base.outputs.sha }}" \
+              --arg sha "${{ github.sha }}" --arg base_sha "${{ steps.baseline_release.outputs.sha }}" \
+              --arg baseline_version "${{ steps.baseline_release.outputs.version }}" \
               --arg event_type "${{ github.event_name }}" \
               --arg branch "${{ github.head_ref || github.ref_name }}" \
               --arg run_id "${{ github.run_id }}" \
@@ -415,7 +638,8 @@ jobs:
                 distinct_id: "perfbench",
                 properties: (. + {
                   tier: $tier, os: $os, arch: $arch,
-                  sha: $sha, base_sha: $base_sha, event_type: $event_type,
+                  sha: $sha, base_sha: $base_sha, baseline_version: $baseline_version,
+                  event_type: $event_type,
                   branch: $branch, run_id: $run_id, run_url: $run_url
                 })
               }]' "$f")
@@ -456,8 +680,9 @@ jobs:
           LINKS=$(printf 'Job summary: %s/%s/actions/runs/%s\nCommit: %s/%s/commit/%s\n' \
             "${{ github.server_url }}" "${{ github.repository }}" "${{ github.run_id }}" \
             "${{ github.server_url }}" "${{ github.repository }}" "${{ github.sha }}")
-          BODY=$(printf 'Perf regression on `master` for **%s/%s**, vs the previous commit `%s`:\n\n%s\n%s' \
-            "${{ matrix.os }}" "${{ matrix.arch }}" "${{ steps.base.outputs.sha }}" \
+          BODY=$(printf 'Perf regression on `master` for **%s/%s**, vs baseline release `%s` (`%s`):\n\n%s\n%s' \
+            "${{ matrix.os }}" "${{ matrix.arch }}" \
+            "${{ steps.baseline_release.outputs.version }}" "${{ steps.baseline_release.outputs.sha }}" \
             "$(cat perf-report.md)" "$LINKS")
           gh issue create --repo "${{ github.repository }}" \
             --title "$TITLE" \

--- a/.github/workflows/perf.yml
+++ b/.github/workflows/perf.yml
@@ -9,25 +9,38 @@ name: Perf
 #     corpus, real timing) and its own release-fetching/issue-filing logic
 #     are large enough to read on their own, separate from the
 #     compile/lint/test jobs that make up the rest of CI.
-#   - `workflow_dispatch`: a manual run against an explicit (or
-#     auto-resolved) baseline release. Nothing is built here either — the
-#     candidate is the release the dispatched commit's own CI run already
-#     published, so dispatching on a commit whose CI hasn't published yet
-#     fails with a clear message rather than silently building something.
-#     Master commits only: PR runs publish tags derived from the ephemeral
-#     merge commit (`gen` describes the refs/pull/N/merge checkout), which
-#     cannot be re-derived from the branch head the runs API exposes — for a
-#     PR, use the `perf-test` label instead.
+#   - `workflow_dispatch`: a manual run comparing any two published
+#     releases. BOTH sides are choosable — `candidate` defaults to the
+#     dispatched commit's own release, `baseline` to the latest published
+#     master release before it — so this doubles as "measure these two
+#     specific builds against each other" without touching either default.
+#     Nothing is built here either: both sides are downloads, which is why
+#     both must already be published. Master commits only when naming a
+#     commit: PR runs publish tags derived from the ephemeral merge commit
+#     (`gen` describes the refs/pull/N/merge checkout), which cannot be
+#     re-derived from the branch head the runs API exposes — for a PR, use
+#     the `perf-test` label instead, or pass its release tag directly.
+#
+# The release-resolution logic both sides share (commit -> its CI run -> its
+# tag -> is it published, plus the asset download) lives in
+# `perf-release-lib.sh` next to this file.
 on:
   workflow_call:
   workflow_dispatch:
     inputs:
+      candidate:
+        description: >-
+          Candidate (N), the build under test: a commit SHA on master, or an
+          exact release tag in hephbuild/heph-artifacts-v1 (e.g.
+          v0.0.0-build.12.345+gabc1234). Empty = the release built from the
+          head of the branch selected above. Nothing is built here — both
+          sides must already be published.
+        required: false
+        default: ""
       baseline:
         description: >-
-          Baseline: a commit SHA (its CI run's published release is used), or
-          an exact release tag in hephbuild/heph-artifacts-v1 (e.g.
-          v0.0.0-build.12.345+gabc1234). Empty = latest published release
-          from master.
+          Baseline (N-1), compared against — same forms as Candidate. Empty =
+          the latest published master release before the candidate.
         required: false
         default: ""
 
@@ -48,17 +61,25 @@ jobs:
   #     point (the merge already happened) — this is continuous monitoring,
   #     so a regression instead files a GitHub issue (see "File regression
   #     issue").
-  #   - `workflow_dispatch`: N is the dispatched commit's own published
-  #     release; N-1 is the `baseline` input if given (an exact release tag,
-  #     failing hard if it doesn't exist), else the latest published master
-  #     release before N — a manual re-run/backfill knob, no gating role.
+  #   - `workflow_dispatch`: BOTH sides are inputs, each a commit SHA or an
+  #     exact release tag. N defaults to the dispatched ref's own published
+  #     release and N-1 to the latest published master release before N, so
+  #     a no-input dispatch re-runs what `push` would have — while naming
+  #     both turns it into "compare these two builds". A manual
+  #     re-run/backfill/bisect knob, no gating role:
+  #
+  #       gh workflow run Perf --ref master \
+  #         -f candidate=v0.0.0-build.12.345+gabc1234 \
+  #         -f baseline=v0.0.0-build.12.340+gdef5678
+  #       gh run list --workflow=Perf --limit 1     # `run` prints no id
   #
   # Nothing in this job is built. `heph`, the go plugin cdylib, and
   # `heph-bench` itself are all release assets (the `build` job publishes
   # `heph-bench` alongside `heph` — see its TARGETS comment), so both N and
   # N-1 are pure downloads: N from this run's own `build` job (its artifacts
-  # are visible here too — reusable-workflow jobs share the same run), N-1
-  # from a past release. That is the whole point of publishing `heph-bench`:
+  # are visible here too — reusable-workflow jobs share the same run) or, on
+  # a dispatch, from a past release like N-1. That both sides must already
+  # be published is the price of never building here. That is the whole point of publishing `heph-bench`:
   # without it, comparing engine-in-process cost (Tier A) would need a
   # harness compiled from EACH side's own source, which is exactly the
   # slow-N-1-build this job exists to avoid.
@@ -182,12 +203,39 @@ jobs:
           go-version: "1.25"
           cache: false
 
+      # Dispatch only: pins WHICH build is the candidate before the baseline
+      # is resolved, because an explicitly chosen candidate also moves the
+      # point the baseline is searched back from. Empty input = the
+      # dispatched commit's own published release, which is the same
+      # candidate a `push` run would have used.
+      #
+      # Every other trigger takes its candidate from this run's own `build`
+      # artifacts and leaves these outputs empty.
+      - name: Resolve candidate (dispatch)
+        if: github.event_name == 'workflow_dispatch'
+        id: candidate_release
+        env:
+          REPO: ${{ github.repository }}
+          GH_TOKEN: ${{ github.token }}
+          ARTIFACTS_TOKEN: ${{ secrets.HEPH_ARTIFACTS_PAT }}
+          INPUT_CANDIDATE: ${{ inputs.candidate }}
+        run: |
+          . .github/workflows/perf-release-lib.sh
+          spec="${INPUT_CANDIDATE:-${{ github.sha }}}"
+          out=$(resolve_spec "$spec" candidate) || exit 1
+          IFS=$'\t' read -r version sha <<< "$out"
+          echo "candidate release: $version (${sha:-sha unknown})"
+          {
+            echo "version=$version"
+            echo "sha=$sha"
+          } >> "$GITHUB_OUTPUT"
+
       # Resolves the baseline RELEASE (tag in hephbuild/heph-artifacts-v1) +
       # the SHA it was built from. Only needs `gh api` (run listing against
-      # this repo, default token), `gh release view` (existence check against
-      # the artifacts repo, PAT) and `git describe` against commits already
-      # present from the full-history checkout above; no build, no checkout
-      # of any other commit.
+      # this repo, default token), `gh api` against the artifacts repo (the
+      # published-or-not check, PAT) and `git describe` against commits
+      # already present from the full-history checkout above; no build, no
+      # checkout of any other commit.
       #
       #   - dispatch with an explicit `baseline` input: a commit SHA (the
       #     release its own CI run published) or an exact release tag —
@@ -196,62 +244,43 @@ jobs:
       #     best-effort from its `+g<hash>` suffix.
       #   - everything else: the latest published master release at/before
       #     the baseline point — merge-base (inclusive) on `pull_request`,
-      #     this commit (exclusive: never compare a commit to itself) on
-      #     `push`/dispatch. PRs try the exact merge-base run first (a
-      #     head_sha-filtered lookup still works when the merge-base is
-      #     older than the walk window below), then fall back to the walk:
+      #     the candidate's own commit (exclusive: never compare a build to
+      #     itself) on `push`/dispatch. PRs try the exact merge-base run
+      #     first (a head_sha-filtered lookup still works when the merge-base
+      #     is older than the walk window below), then fall back to the walk:
       #     newest-first over recent master-push CI runs, keeping the first
       #     ancestor-of-the-baseline-point whose re-derived tag exists as a
       #     release.
       #
       # Deliberately does NOT filter by any run's overall conclusion: whether
-      # a release was actually published is checked directly (`gh release
-      # view`), not inferred from whether every other job in that run
-      # happened to pass. A run's Perf legs or an unrelated job (Binary E2E,
-      # say) can fail while `upload_artifacts` still published fine — gating
-      # on run-level success here made a single flake unrecoverable: the
-      # next commit's baseline lookup would find no "successful" run, fail
-      # its own Perf job for missing baseline, and the failure would
-      # propagate to every commit after it forever.
+      # a release was actually published is checked directly, not inferred
+      # from whether every other job in that run happened to pass. A run's
+      # Perf legs or an unrelated job (Binary E2E, say) can fail while
+      # `upload_artifacts` still published fine — gating on run-level success
+      # here made a single flake unrecoverable: the next commit's baseline
+      # lookup would find no "successful" run, fail its own Perf job for
+      # missing baseline, and the failure would propagate to every commit
+      # after it forever.
       - name: Resolve baseline
         id: baseline_release
         env:
+          REPO: ${{ github.repository }}
           GH_TOKEN: ${{ github.token }}
           ARTIFACTS_TOKEN: ${{ secrets.HEPH_ARTIFACTS_PAT }}
           EVENT: ${{ github.event_name }}
           INPUT_BASELINE: ${{ inputs.baseline }}
+          CANDIDATE_SHA: ${{ steps.candidate_release.outputs.sha }}
+          CANDIDATE_VERSION: ${{ steps.candidate_release.outputs.version }}
         run: |
-          # A 404 is "release doesn't exist"; anything else (401/403 on a
-          # bad/expired PAT, API outage) fails the step loudly — otherwise an
-          # auth failure walks all 50 runs and reports "no published master
-          # release found", a confident diagnosis of the wrong system.
-          release_exists() {
-            local err
-            if err=$(GH_TOKEN="$ARTIFACTS_TOKEN" gh api \
-                "repos/hephbuild/heph-artifacts-v1/releases/tags/$1" 2>&1 >/dev/null); then
-              return 0
-            fi
-            if printf '%s' "$err" | grep -q "HTTP 404"; then
-              return 1
-            fi
-            echo "artifacts-repo API error while checking release '$1': $err" >&2
-            exit 1
-          }
-          # Echoes the version tag the master-push CI run for sha $1
-          # published under; fails if no such run is found. Push runs only:
-          # a PR run's tag derives from its ephemeral merge commit, not the
-          # head_sha the runs API exposes, so it cannot be re-derived here.
-          # The workflow-scoped endpoint (heph.yml) avoids both the
-          # `.name=="CI"` string coupling and sharing the result window with
-          # other push-triggered workflows.
-          version_for_sha() {
-            local rn
-            rn=$(gh api "repos/${{ github.repository }}/actions/workflows/heph.yml/runs?head_sha=$1&event=push" \
-              --jq '.workflow_runs | first | .run_number // empty')
-            [ -n "$rn" ] || return 1
-            .github/workflows/version.sh "$rn" "$1"
-          }
+          . .github/workflows/perf-release-lib.sh
           emit() { # $1=version $2=sha $3=mode $4=how
+            # Comparing a build against itself measures nothing and still
+            # costs a full leg, so it is refused rather than reported as a
+            # tidy 0% delta. Only reachable when both sides were named.
+            if [ -n "$CANDIDATE_VERSION" ] && [ "$1" = "$CANDIDATE_VERSION" ]; then
+              echo "candidate and baseline both resolve to release $1 — nothing to compare" >&2
+              exit 1
+            fi
             echo "resolved baseline release: $1 ($4)"
             {
               echo "found=true"
@@ -261,37 +290,20 @@ jobs:
             } >> "$GITHUB_OUTPUT"
           }
 
-          if [ "$EVENT" = "workflow_dispatch" ] && [ -n "$INPUT_BASELINE" ]; then
-            if echo "$INPUT_BASELINE" | grep -qE '^[0-9a-fA-F]{7,40}$'; then
-              # A commit SHA: use the release its own CI run published.
-              sha=$(git rev-parse --verify --quiet "$INPUT_BASELINE^{commit}") || {
-                echo "baseline '$INPUT_BASELINE' looks like a commit SHA but is not a known commit" >&2
-                exit 1
-              }
-              # No run is normal, not just "wrong branch": CI runs once per
-              # push, on that push's head commit, so every other commit in a
-              # batched push has no run and no release of its own.
-              version=$(version_for_sha "$sha") || {
-                echo "no master-push CI run found for baseline commit $sha — it is either not on master, or landed in a batched push whose CI ran on a later commit; pick a commit that has a CI run, or pass an exact release tag" >&2
-                exit 1
-              }
-              if ! release_exists "$version"; then
-                echo "baseline commit $sha's CI run never published release '$version'" >&2
-                exit 1
-              fi
-              emit "$version" "$sha" "explicit" "explicit input, commit $sha"
-              exit 0
+          if [ -n "$INPUT_BASELINE" ]; then
+            out=$(resolve_spec "$INPUT_BASELINE" baseline) || exit 1
+            IFS=$'\t' read -r version sha <<< "$out"
+            # Deliberately not fatal: comparing two release lines, or an
+            # older candidate against a newer baseline, is a legitimate
+            # thing to ask for. The report says so instead (see below).
+            ancestor=true
+            if [ -n "$sha" ] && [ -n "$CANDIDATE_SHA" ] \
+               && ! git merge-base --is-ancestor "$sha" "$CANDIDATE_SHA"; then
+              ancestor=false
+              echo "note: baseline $sha is not an ancestor of candidate $CANDIDATE_SHA"
             fi
-            if ! release_exists "$INPUT_BASELINE"; then
-              echo "requested baseline release '$INPUT_BASELINE' not found in hephbuild/heph-artifacts-v1" >&2
-              exit 1
-            fi
-            short="${INPUT_BASELINE##*+g}"
-            sha=""
-            if [ "$short" != "$INPUT_BASELINE" ]; then
-              sha=$(git rev-parse --verify --quiet "$short^{commit}" || true)
-            fi
-            emit "$INPUT_BASELINE" "$sha" "explicit" "explicit input"
+            echo "ancestor=$ancestor" >> "$GITHUB_OUTPUT"
+            emit "$version" "$sha" "explicit" "explicit input"
             exit 0
           fi
 
@@ -305,14 +317,29 @@ jobs:
             fi
             echo "merge-base $upper has no published release — walking back on master"
           else
-            upper="${{ github.sha }}"
-            self="${{ github.sha }}"
+            # "Latest release before the candidate" is only answerable if we
+            # know where the candidate sits in history. A candidate named by
+            # tag whose commit is absent from this checkout has no such
+            # position — falling back to the dispatched ref would search back
+            # from master's head, which can be NEWER than the candidate and
+            # would invert every delta's sign while reporting a normal
+            # verdict. Refuse, and say which input resolves it.
+            if [ "$EVENT" = "workflow_dispatch" ] && [ -z "$CANDIDATE_SHA" ]; then
+              echo "candidate '$CANDIDATE_VERSION' was named by tag and its commit is not in this checkout, so a baseline cannot be resolved relative to it — pass an explicit \`baseline\`" >&2
+              exit 1
+            fi
+            upper="${CANDIDATE_SHA:-${{ github.sha }}}"
+            # The build under test, which the walk must never pick as its own
+            # baseline. Distinct from `upper` (the search bound): when the
+            # candidate's commit is unknown the two are not interchangeable.
+            self="$CANDIDATE_SHA"
+            [ -n "$self" ] || self="${{ github.sha }}"
           fi
 
           # Captured, not process-substituted: a failed `gh api` must get
           # its own message, not silently read as "zero runs" and fall
           # through to the no-baseline diagnosis below.
-          runs=$(gh api "repos/${{ github.repository }}/actions/workflows/heph.yml/runs?branch=master&event=push&per_page=50" \
+          runs=$(gh api "repos/$REPO/actions/workflows/heph.yml/runs?branch=master&event=push&per_page=50" \
             --jq '.workflow_runs[] | [.run_number, .head_sha] | @tsv') || {
             echo "failed to list master-push CI runs — cannot resolve a baseline" >&2
             exit 1
@@ -322,7 +349,7 @@ jobs:
             [ "$head_sha" = "$self" ] && continue
             git cat-file -e "$head_sha^{commit}" 2>/dev/null || continue
             git merge-base --is-ancestor "$head_sha" "$upper" || continue
-            version=$(.github/workflows/version.sh "$run_number" "$head_sha")
+            version=$(version_for_run "$run_number" "$head_sha")
             if release_exists "$version"; then
               emit "$version" "$head_sha" "walk" "run #$run_number, $head_sha"
               exit 0
@@ -345,49 +372,42 @@ jobs:
         if: steps.baseline_release.outputs.found == 'true'
         id: baseline_fetch
         env:
-          GH_TOKEN: ${{ secrets.HEPH_ARTIFACTS_PAT }}
+          REPO: ${{ github.repository }}
+          GH_TOKEN: ${{ github.token }}
+          ARTIFACTS_TOKEN: ${{ secrets.HEPH_ARTIFACTS_PAT }}
+          VERSION: ${{ steps.baseline_release.outputs.version }}
         run: |
+          . .github/workflows/perf-release-lib.sh
           ext=so; [ "${{ matrix.os }}" = "darwin" ] && ext=dylib
-          mkdir -p baseline-dist-raw baseline-dist
-          # Both downloads are best-effort (`|| true`) and judged by which
-          # files actually landed: `gh release download` exits 0 when only
-          # SOME of its patterns matched, so a partially-published release
-          # would otherwise reach the `cp` and hard-fail the step under
-          # `set -e` instead of degrading to ok=false / bench_ok=false.
-          gh release download "${{ steps.baseline_release.outputs.version }}" \
-            --repo hephbuild/heph-artifacts-v1 \
-            --dir baseline-dist-raw \
-            --pattern "heph_${{ matrix.os }}_${{ matrix.arch }}" \
-            --pattern "heph-go-plugin_${{ matrix.os }}_${{ matrix.arch }}.$ext" || true
-          if [ -f "baseline-dist-raw/heph_${{ matrix.os }}_${{ matrix.arch }}" ] \
-             && [ -f "baseline-dist-raw/heph-go-plugin_${{ matrix.os }}_${{ matrix.arch }}.$ext" ]; then
-            cp "baseline-dist-raw/heph_${{ matrix.os }}_${{ matrix.arch }}" baseline-dist/heph
-            cp "baseline-dist-raw/heph-go-plugin_${{ matrix.os }}_${{ matrix.arch }}.$ext" "baseline-dist/heph-go-plugin.$ext"
+          heph="heph_${{ matrix.os }}_${{ matrix.arch }}"
+          plugin="heph-go-plugin_${{ matrix.os }}_${{ matrix.arch }}.$ext"
+          bench="heph-bench_${{ matrix.os }}_${{ matrix.arch }}"
+          mkdir -p baseline-dist
+          # Both groups are best-effort and judged by what actually landed
+          # (see fetch_assets) — a baseline that is missing something must
+          # degrade to ok=false / bench_ok=false, never hard-fail this step.
+          missing=$(fetch_assets "$VERSION" baseline-dist-raw "$heph" "$plugin")
+          if [ -z "$missing" ]; then
+            cp "baseline-dist-raw/$heph" baseline-dist/heph
+            cp "baseline-dist-raw/$plugin" "baseline-dist/heph-go-plugin.$ext"
             chmod +x baseline-dist/heph
             echo "ok=true" >> "$GITHUB_OUTPUT"
           else
-            echo "release ${{ steps.baseline_release.outputs.version }} found but missing heph/go-plugin for this leg"
+            echo "release $VERSION is missing baseline asset(s) for this leg: $(tr '\n' ' ' <<< "$missing")"
             echo "ok=false" >> "$GITHUB_OUTPUT"
           fi
-          gh release download "${{ steps.baseline_release.outputs.version }}" \
-            --repo hephbuild/heph-artifacts-v1 \
-            --dir baseline-dist-raw \
-            --pattern "heph-bench_${{ matrix.os }}_${{ matrix.arch }}" || true
-          if [ -f "baseline-dist-raw/heph-bench_${{ matrix.os }}_${{ matrix.arch }}" ]; then
-            cp "baseline-dist-raw/heph-bench_${{ matrix.os }}_${{ matrix.arch }}" baseline-dist/heph-bench
+          if [ -z "$(fetch_assets "$VERSION" baseline-dist-raw "$bench")" ]; then
+            cp "baseline-dist-raw/$bench" baseline-dist/heph-bench
             chmod +x baseline-dist/heph-bench
             echo "bench_ok=true" >> "$GITHUB_OUTPUT"
           else
-            echo "no heph-bench asset in ${{ steps.baseline_release.outputs.version }} — predates publishing it, Tier A skipped"
+            echo "no heph-bench asset in $VERSION — predates publishing it, Tier A skipped"
             echo "bench_ok=false" >> "$GITHUB_OUTPUT"
           fi
 
       # workflow_call runs get the candidate from this same run's `build`
-      # artifacts; a dispatch run has no `build` job, so the candidate is the
-      # release the dispatched commit's own master-push CI run published
-      # (master commits only — see the trigger comment at the top). Missing
-      # run or missing assets fail hard: the candidate is mandatory, and
-      # "wait for CI to publish first" is the actionable message.
+      # artifacts; a dispatch run has no `build` job, so it downloads the
+      # release "Resolve candidate" pinned instead.
       - name: Download candidate (N) artifacts
         if: github.event_name != 'workflow_dispatch'
         uses: actions/download-artifact@v7
@@ -396,52 +416,26 @@ jobs:
           path: candidate-dist-raw
           merge-multiple: true
 
+      # The candidate release was already resolved (and proved published) by
+      # "Resolve candidate" above; this only pulls its assets. Unlike the
+      # baseline's, a missing asset here is fatal — there is nothing to
+      # measure without the candidate.
       - name: Fetch candidate (N) release artifacts (dispatch)
         if: github.event_name == 'workflow_dispatch'
         env:
+          REPO: ${{ github.repository }}
           GH_TOKEN: ${{ github.token }}
           ARTIFACTS_TOKEN: ${{ secrets.HEPH_ARTIFACTS_PAT }}
+          VERSION: ${{ steps.candidate_release.outputs.version }}
         run: |
-          RUN_INFO=$(gh api "repos/${{ github.repository }}/actions/workflows/heph.yml/runs?head_sha=${{ github.sha }}&event=push" \
-            --jq '.workflow_runs | first | [.run_number, .status, .conclusion // "-"] | @tsv')
-          if [ -z "$RUN_INFO" ]; then
-            echo "no master-push CI run found for ${{ github.sha }} — dispatch on a master commit that has its own CI run (CI runs once per push, so a batched push leaves its earlier commits without one); a PR's tag derives from its ephemeral merge commit and cannot be re-derived, so use the \`perf-test\` label for a PR" >&2
-            exit 1
-          fi
-          IFS=$'\t' read -r RUN_NUMBER RUN_STATUS RUN_CONCLUSION <<< "$RUN_INFO"
-          VERSION=$(.github/workflows/version.sh "$RUN_NUMBER" "${{ github.sha }}")
-          # The run existing is not enough — it publishes the release in its
-          # `upload_artifacts` job. Check the release directly and report
-          # still-running vs failed, the two states a dispatcher actually
-          # needs to tell apart.
-          if ! GH_TOKEN="$ARTIFACTS_TOKEN" gh api "repos/hephbuild/heph-artifacts-v1/releases/tags/$VERSION" >/dev/null 2>&1; then
-            if [ "$RUN_STATUS" != "completed" ]; then
-              echo "CI run #$RUN_NUMBER for ${{ github.sha }} is still $RUN_STATUS — wait for its Pre-release job to publish $VERSION, then re-dispatch" >&2
-            else
-              echo "CI run #$RUN_NUMBER completed ($RUN_CONCLUSION) but never published release $VERSION — this commit has no candidate build to test" >&2
-            fi
-            exit 1
-          fi
-          echo "candidate release: $VERSION (run #$RUN_NUMBER)"
+          . .github/workflows/perf-release-lib.sh
           ext=so; [ "${{ matrix.os }}" = "darwin" ] && ext=dylib
-          mkdir -p candidate-dist-raw
-          GH_TOKEN="$ARTIFACTS_TOKEN" gh release download "$VERSION" \
-            --repo hephbuild/heph-artifacts-v1 \
-            --dir candidate-dist-raw \
-            --pattern "heph_${{ matrix.os }}_${{ matrix.arch }}" \
-            --pattern "heph-bench_${{ matrix.os }}_${{ matrix.arch }}" \
-            --pattern "heph-go-plugin_${{ matrix.os }}_${{ matrix.arch }}.$ext" || true
-          # `gh release download` exits 0 when only SOME patterns matched, so
-          # the assets are checked by name — otherwise a partially-published
-          # release dies on a bare `cp: cannot stat` in the next step.
-          missing=()
-          for asset in "heph_${{ matrix.os }}_${{ matrix.arch }}" \
-                       "heph-bench_${{ matrix.os }}_${{ matrix.arch }}" \
-                       "heph-go-plugin_${{ matrix.os }}_${{ matrix.arch }}.$ext"; do
-            [ -f "candidate-dist-raw/$asset" ] || missing+=("$asset")
-          done
-          if [ ${#missing[@]} -gt 0 ]; then
-            echo "release $VERSION is missing candidate asset(s) for this leg: ${missing[*]}" >&2
+          missing=$(fetch_assets "$VERSION" candidate-dist-raw \
+            "heph_${{ matrix.os }}_${{ matrix.arch }}" \
+            "heph-bench_${{ matrix.os }}_${{ matrix.arch }}" \
+            "heph-go-plugin_${{ matrix.os }}_${{ matrix.arch }}.$ext")
+          if [ -n "$missing" ]; then
+            echo "release $VERSION is missing candidate asset(s) for ${{ matrix.os }}/${{ matrix.arch }}: $(tr '\n' ' ' <<< "$missing")" >&2
             exit 1
           fi
 
@@ -526,17 +520,29 @@ jobs:
           mkdir -p verdicts
           BASE_SHA="${{ steps.baseline_release.outputs.sha }}"
           [ -n "$BASE_SHA" ] || BASE_SHA="sha unknown"
+          CAND_VERSION="${{ steps.candidate_release.outputs.version }}"
+          CAND_SHA="${{ steps.candidate_release.outputs.sha }}"
           report=$(
             echo "# Perf: ${{ matrix.os }}/${{ matrix.arch }}"
+            echo ""
+            # The candidate is only named on dispatch, where it is
+            # choosable; elsewhere it is this run's own build and the commit
+            # already identifies it. Printed before the baseline branch so a
+            # failed run still says what it was asked to measure.
+            if [ -n "$CAND_VERSION" ]; then
+              echo "_candidate: \`$CAND_VERSION\` (\`${CAND_SHA:-sha unknown}\`)_"
+            fi
             if [ "${{ steps.baseline_fetch.outputs.ok }}" != "true" ]; then
-              echo ""
               echo "_FAILED: no usable baseline release (resolved: \`${{ steps.baseline_release.outputs.version || 'none' }}\`)_"
             else
-              echo ""
               echo "_baseline: \`${{ steps.baseline_release.outputs.version }}\` (\`$BASE_SHA\`; via ${{ steps.baseline_release.outputs.mode }})_"
               if [ "${{ github.event_name }}" = "pull_request" ] && [ "${{ steps.baseline_release.outputs.mode }}" = "walk" ]; then
                 echo ""
                 echo "_note: baseline is older than this PR's merge-base — a regression here may originate in master commits between them, not in this PR_"
+              fi
+              if [ "${{ steps.baseline_release.outputs.ancestor }}" = "false" ]; then
+                echo ""
+                echo "_note: baseline is not an ancestor of the candidate — deltas may read inverted_"
               fi
               for tier in inproc dist; do
                 echo ""
@@ -571,6 +577,34 @@ jobs:
           printf '%s\n' "$report" >> "$GITHUB_STEP_SUMMARY"
           printf '%s\n' "$report" > perf-report.md
 
+          # What was actually compared, in stable fields, next to the
+          # per-tier verdicts in the uploaded artifact — otherwise the only
+          # machine-readable record of it is the PostHog payload, which a
+          # dispatcher cannot `gh run download`. Written on every trigger:
+          # `null` where a field does not apply, never an empty string that
+          # a query cannot tell apart from "unset".
+          jq -n \
+            --arg cand_version "$CAND_VERSION" \
+            --arg cand_sha "${CAND_SHA:-${{ github.sha }}}" \
+            --arg cand_source "${{ github.event_name == 'workflow_dispatch' && (inputs.candidate != '' && 'input' || 'dispatched-ref') || 'build' }}" \
+            --arg base_version "${{ steps.baseline_release.outputs.version }}" \
+            --arg base_sha "${{ steps.baseline_release.outputs.sha }}" \
+            --arg base_mode "${{ steps.baseline_release.outputs.mode }}" \
+            --arg os "${{ matrix.os }}" --arg arch "${{ matrix.arch }}" \
+            '{
+              os: $os, arch: $arch,
+              candidate: {
+                version: (if $cand_version == "" then null else $cand_version end),
+                sha: $cand_sha,
+                source: $cand_source
+              },
+              baseline: {
+                version: (if $base_version == "" then null else $base_version end),
+                sha: (if $base_sha == "" then null else $base_sha end),
+                mode: (if $base_mode == "" then null else $base_mode end)
+              }
+            }' > verdicts/resolution.json
+
           # No baseline is a FAILURE, not a silent pass — every run so far
           # (bootstrap gap, release-lookup misses) has been "no baseline
           # found" reporting green, which means this gate has never actually
@@ -597,8 +631,11 @@ jobs:
       # them as a run artifact gives a dispatcher (human or agent) a stable
       # JSON result via `gh run download`, not just a markdown summary and
       # an exit code.
+      # `always()` without gating on a usable baseline: a run that failed to
+      # resolve one is exactly when "what did it try to compare?" is worth
+      # downloading, and `resolution.json` answers it.
       - name: Upload verdicts artifact
-        if: always() && steps.baseline_fetch.outputs.ok == 'true'
+        if: always()
         uses: actions/upload-artifact@v6
         with:
           name: perf-verdicts_${{ matrix.os }}_${{ matrix.arch }}
@@ -624,10 +661,15 @@ jobs:
             [ -f "$f" ] || continue
             # One file per tier (inproc/dist), each an array of per-scenario
             # verdicts — `scenario` already lives inside each entry.
+            # `resolution.json` sits in the same directory for the artifact's
+            # sake but is an object describing the run, not verdicts.
+            [ "$(basename "$f")" = "resolution.json" ] && continue
             tier=$(basename "$f" .json)
             batch=$(jq --arg tier "$tier" \
               --arg os "${{ matrix.os }}" --arg arch "${{ matrix.arch }}" \
-              --arg sha "${{ github.sha }}" --arg base_sha "${{ steps.baseline_release.outputs.sha }}" \
+              --arg sha "${{ steps.candidate_release.outputs.sha || github.sha }}" \
+              --arg base_sha "${{ steps.baseline_release.outputs.sha }}" \
+              --arg candidate_version "${{ steps.candidate_release.outputs.version }}" \
               --arg baseline_version "${{ steps.baseline_release.outputs.version }}" \
               --arg event_type "${{ github.event_name }}" \
               --arg branch "${{ github.head_ref || github.ref_name }}" \
@@ -638,7 +680,11 @@ jobs:
                 distinct_id: "perfbench",
                 properties: (. + {
                   tier: $tier, os: $os, arch: $arch,
-                  sha: $sha, base_sha: $base_sha, baseline_version: $baseline_version,
+                  sha: $sha, base_sha: $base_sha,
+                  # null, not "": a query must be able to tell "this trigger
+                  # does not name its candidate" from an empty value.
+                  candidate_version: (if $candidate_version == "" then null else $candidate_version end),
+                  baseline_version: $baseline_version,
                   event_type: $event_type,
                   branch: $branch, run_id: $run_id, run_url: $run_url
                 })


### PR DESCRIPTION
## Problem

The perf gate's baseline was the *previous commit* — `github.event.before` on push, the exact merge-base on PRs — and its release tag was re-derived from that single commit's CI run. Both assumptions fail routinely:

- **CI runs once per push, on that push's head commit.** Every other commit in a batched push has no run and no release at all. `59585cc6` is on master with zero CI runs — verified against the live API.
- **master builds run concurrently** (per-sha concurrency groups), so the previous commit's release may not be published yet when this job runs, or ever if its build broke.

Either case failed the job outright with "no baseline found". That is how this gate has spent most of its life: reporting a data-availability problem rather than comparing anything.

## Change

**Baseline = the latest *published* master release at/before the baseline point.** Walk master-push CI runs newest-first and keep the first ancestor whose re-derived tag exists as a release. PRs still try the exact merge-base first and only walk when it has none — and say so in the report, since a walked baseline widens what the gate attributes to the PR.

**Manual runs choose both sides.** `workflow_dispatch` takes `candidate` and `baseline`, each a commit SHA or an exact release tag. Both default to what an automatic run would have used, so a no-input dispatch re-runs what `push` would have, while naming both turns the workflow into "compare these two builds":

```
gh workflow run Perf --ref master                                    # auto both sides
gh workflow run Perf --ref master -f candidate=85b556b3              # pin the candidate
gh workflow run Perf --ref master \
  -f candidate=v1.0.0-alpha-build.312.1247+gd46c6c4f \
  -f baseline=v1.0.0-alpha-build.301.1219+ge9fa09b8
```

Nothing is built on a dispatch, so both sides must already be published. The candidate resolves *before* the baseline, because an explicit candidate also bounds where the baseline walk searches back from — comparing release N against the latest master release would otherwise be wrong whenever N is not the newest build.

Naming a *commit* works for master commits only: a PR run's tag derives from its ephemeral merge commit, which cannot be re-derived from the branch head the runs API exposes. PRs use the `perf-test` label, unchanged, or pass a release tag directly.

## Guards against quietly-wrong comparisons

- A candidate named by tag whose commit is absent from the checkout **fails** instead of searching back from master's head. That fallback could pick a baseline *newer* than the candidate, inverting every delta's sign while reporting an ordinary verdict.
- Candidate and baseline resolving to the same release is refused rather than burning three legs to prove a build equals itself.
- A baseline that is not an ancestor of the candidate is allowed — comparing two release lines is legitimate — but the report says so.

## Shared library, and its tests

Both sides now need the same commit → CI run → tag → is-it-published resolution and the same asset download, so it lives in `perf-release-lib.sh` instead of two copies. It is unit-tested with `gh`/`git` stubbed (`perf-release-lib.test.sh`, wired into CI as `perf_lib`, ~5s). The paths worth freezing are the failure ones, and none can be provoked on demand against the live API.

Extracting it immediately surfaced four bugs:

- `run_for_sha` reported an Actions API failure as *"this commit has no CI run"* — the same misdiagnosis `release_exists` already guards against, reachable on the most common dispatch of all.
- `.workflow_runs | first | @tsv` renders a null run as the **non-empty** string `"\t\t-"`, which read as a successful lookup and produced `CI run #- … is still  —`. Fixed with `select(. != null)`.
- `fetch_assets` discarded `gh release download`'s exit status, so a transient failure reported as "the release is missing assets"; it also shared stdout with `gh`, where one future line of chatter would flip every caller's missing-asset test.
- An unguarded `version=$(version_for_run …)` could carry an empty tag into the error messages — `set -e` does not reach inside `$( )`.

## Other supporting fixes

- A non-404 from the artifacts repo (expired PAT, outage) no longer reads as "release does not exist" — that turned a dead token into a confident `no published master release found` aimed at the wrong system.
- The run listing is captured rather than process-substituted, so a failed `gh api` gets its own message instead of an empty read.
- Assets are verified **by name**: `gh release download` exits 0 when only *some* patterns matched, so a partially published release died on a bare `cp: cannot stat`. Baseline degrades, candidate fails, both naming what is absent.
- Run lookups use the workflow-scoped endpoint — no `.name=="CI"` string coupling, and the 50-run window is no longer shared with the other push-triggered workflows (autodoc roughly halved it).
- Tier A is gated on the Tier B assets too; it used to burn its minutes for a report that then hard-failed.

## Diagnosability

`verdicts/resolution.json` records what was actually compared — both versions, SHAs, and how each was chosen — on every trigger, so a dispatcher reads a stable JSON result instead of scraping markdown. The artifact uploads even when no baseline resolved, which is when that answer matters most. The report names the candidate on the failure path too, and PostHog carries `candidate_version`/`baseline_version`.

## Verification

`perf-release-lib.test.sh` covers 19 cases (green on bash 5.3 and macOS bash 3.2, and in CI). On top of that, every step's script was extracted from the YAML and run against the live GitHub API:

| Case | Result |
|---|---|
| push, auto | walks past self → `v1.0.0-alpha-build.312.1247+gd46c6c4f` |
| dispatch, candidate pins the window | candidate run 1221 → baseline run **1219**, not 1247 |
| dispatch candidate by SHA / by tag | both resolve; tag recovers its sha from `+g` |
| candidate == baseline | refused, exit 1 |
| candidate by tag, sha unknown, no baseline | refused, exit 1 (would have inverted the verdict) |
| baseline newer than candidate | `ancestor=false` + report note |
| bogus tag / bogus SHA / non-master SHA | exit 1, each with its own message |
| expired artifacts token | `Bad credentials (HTTP 401)`, exit 1 — not "no release" |
| asset fetch: real leg / partial / missing | downloads, or names exactly what is absent |
| baseline missing assets | degrades to `ok=false`, does not fail the step |

Plus YAML parse and `bash -n` over every `run:` block.

> [!NOTE]
> This PR's own Perf legs only run if the `perf-test` label is applied — worth adding before merge so the auto-resolution path proves itself end to end.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015zSJ4W6qpxdCMJ1XbXnU5X