### PR TITLE
fix(engine,tui): count each cacheable target once in cache stats

### DIFF
--- a/crates/engine/src/engine/result.rs
+++ b/crates/engine/src/engine/result.rs
@@ -2508,6 +2508,15 @@ impl Engine {
             // caller needs them.
             Some(manifest) => (None, Some(manifest), RemoteCell::new()),
             None => {
+                // The settled local miss: both probes came back empty under the
+                // write lock, so this fires exactly once per cold target — the
+                // probe itself stays silent on a miss (see
+                // `probe_cache_manifest`). Uncacheable targets never reach this
+                // path (early return above), so the hit/miss stats cover only
+                // targets that could have hit.
+                rs.emit(crate::engine::event::BuildEventKind::LocalCacheMiss {
+                    addr: addr.format(),
+                });
                 // Local miss under the write lock: ask the remote caches whether
                 // this revision exists. Manifest only — no output blob is
                 // downloaded here, and none may be: a dependent that just needs
@@ -3287,10 +3296,27 @@ impl Engine {
     }
 
     /// Probe the **local** manifest for `(addr, hashin)` and decide whether it is
-    /// a usable hit, emitting the hit/miss event. Returns the parsed manifest so
-    /// the per-caller output read in
+    /// a usable hit, emitting `LocalCacheHit` on a hit. Returns the parsed
+    /// manifest so the per-caller output read in
     /// [`execute_and_cache`](Self::execute_and_cache) reuses it instead of
     /// re-reading + re-deserializing it from the cache backend.
+    ///
+    /// A miss emits **nothing** here: this runs twice per cold target (the
+    /// optimistic probe under the read lock, then the re-check under the write
+    /// lock), so emitting the miss inside the probe double-counted every cold
+    /// target in the hit/miss stats. The caller emits `LocalCacheMiss` exactly
+    /// once, at the settled miss under the write lock — see
+    /// [`resolve_locked_inner`](Self::resolve_locked_inner). Only one probe can
+    /// hit (a hit returns before the second probe runs), so the hit emission
+    /// stays here.
+    ///
+    /// Neither event is emitted for a hash-only request. Those are nested
+    /// recomputes — the in_place write-back guard re-deriving a dep's `hashout`
+    /// (see [`Self::meta`]) — not resolutions a user asked for, and the same
+    /// addr is probed again by the real request that wraps them. They carry no
+    /// event sender, so the TUI and CI summaries never saw them either way, but
+    /// hooks (telemetry, the GHA summary) are dispatched regardless of the
+    /// sender and were counting each nested probe as another hit.
     ///
     /// A local manifest is not proof of residency: a revision whose manifest was
     /// mirrored from a remote (see
@@ -3330,15 +3356,11 @@ impl Engine {
             .read_manifest_blocking(rs.ctoken(), addr, hashin)
             .await?
             .map(Arc::new);
-        rs.emit(if hit.is_some() {
-            crate::engine::event::BuildEventKind::LocalCacheHit {
+        if hit.is_some() && !rs.hash_only() {
+            rs.emit(crate::engine::event::BuildEventKind::LocalCacheHit {
                 addr: addr.format(),
-            }
-        } else {
-            crate::engine::event::BuildEventKind::LocalCacheMiss {
-                addr: addr.format(),
-            }
-        });
+            });
+        }
         Ok(hit)
     }
 
@@ -5604,11 +5626,23 @@ mod tests {
             engine_with_remote(vec![static_target("//pkg:t", &[], &[])], &remote_uri)?;
         let (res, events) = resolve_collecting_events(&miss_engine, &addr).await;
         res.expect("target must resolve on a remote miss");
-        assert!(
-            events.iter().any(
-                |e| matches!(&e.kind, BuildEventKind::RemoteCacheMiss { addr } if addr == "//pkg:t")
+        assert_eq!(
+            count_kind(
+                &events,
+                |e| matches!(e, BuildEventKind::RemoteCacheMiss { addr } if addr == "//pkg:t")
             ),
-            "empty remote must emit RemoteCacheMiss: {events:?}"
+            1,
+            "empty remote must emit exactly one RemoteCacheMiss: {events:?}"
+        );
+        // The remote lookup only runs after the local miss settles under the
+        // write lock, and that miss is emitted once — not once per probe.
+        assert_eq!(
+            count_kind(
+                &events,
+                |e| matches!(e, BuildEventKind::LocalCacheMiss { addr } if addr == "//pkg:t")
+            ),
+            1,
+            "expected exactly one LocalCacheMiss: {events:?}"
         );
         assert!(
             !events.iter().any(
@@ -5643,11 +5677,23 @@ mod tests {
             engine_with_remote(vec![static_target("//pkg:t", &[], &[])], &remote_uri)?;
         let (res, events) = resolve_collecting_events(&hit_engine, &addr).await;
         res.expect("target must resolve on a remote hit");
-        assert!(
-            events.iter().any(
-                |e| matches!(&e.kind, BuildEventKind::RemoteCacheHit { addr } if addr == "//pkg:t")
+        assert_eq!(
+            count_kind(
+                &events,
+                |e| matches!(e, BuildEventKind::RemoteCacheHit { addr } if addr == "//pkg:t")
             ),
-            "a remote pull must emit RemoteCacheHit: {events:?}"
+            1,
+            "a remote pull must emit exactly one RemoteCacheHit: {events:?}"
+        );
+        // A remote-served target is a local miss exactly once — the shape the
+        // TUI/telemetry summaries render on a remote-backed cold run.
+        assert_eq!(
+            count_kind(
+                &events,
+                |e| matches!(e, BuildEventKind::LocalCacheMiss { addr } if addr == "//pkg:t")
+            ),
+            1,
+            "expected exactly one LocalCacheMiss: {events:?}"
         );
         assert!(
             !events.iter().any(
@@ -7888,6 +7934,13 @@ mod tests {
         Ok((Arc::new(engine), root))
     }
 
+    /// How many collected events match `pred`. Cache hit/miss assertions want a
+    /// *count*, not an `any` — the bug these tests pin was one event emitted
+    /// twice for one target, which every `any` in the suite happily accepted.
+    fn count_kind(events: &[BuildEvent], pred: impl Fn(&BuildEventKind) -> bool) -> usize {
+        events.iter().filter(|e| pred(&e.kind)).count()
+    }
+
     /// Resolve `addr` with a fresh event-collecting `RequestState`, then drop the
     /// state (closing the sender) and drain every emitted event.
     async fn resolve_collecting_events(
@@ -7935,11 +7988,16 @@ mod tests {
             )),
             "expected ExecuteStart{{driver:exec, cache:true}}, got {events:?}"
         );
-        assert!(
-            events.iter().any(
-                |e| matches!(&e.kind, BuildEventKind::LocalCacheMiss { addr } if addr == "//pkg:a")
+        // Exactly one: the optimistic probe under the read lock stays silent on a
+        // miss, and only the settled re-check under the write lock emits — a cold
+        // target must not count as two misses in the hit/miss stats.
+        assert_eq!(
+            count_kind(
+                &events,
+                |e| matches!(e, BuildEventKind::LocalCacheMiss { addr } if addr == "//pkg:a")
             ),
-            "expected LocalCacheMiss, got {events:?}"
+            1,
+            "expected exactly one LocalCacheMiss, got {events:?}"
         );
         assert!(
             events.iter().any(|e| matches!(
@@ -8003,11 +8061,21 @@ mod tests {
         let (second, events) = resolve_collecting_events(&engine, &addr).await;
         second.expect("second resolve must succeed");
 
-        assert!(
-            events.iter().any(
-                |e| matches!(&e.kind, BuildEventKind::LocalCacheHit { addr } if addr == "//pkg:a")
+        // Exactly one: a hit returns from the first probe, so the second probe
+        // never runs — and a warm target must not also count a miss.
+        assert_eq!(
+            count_kind(
+                &events,
+                |e| matches!(e, BuildEventKind::LocalCacheHit { addr } if addr == "//pkg:a")
             ),
-            "warm resolve must emit LocalCacheHit, got {events:?}"
+            1,
+            "warm resolve must emit exactly one LocalCacheHit, got {events:?}"
+        );
+        assert!(
+            !events
+                .iter()
+                .any(|e| matches!(&e.kind, BuildEventKind::LocalCacheMiss { .. })),
+            "warm resolve must not emit LocalCacheMiss, got {events:?}"
         );
         assert!(
             !events
@@ -8020,6 +8088,131 @@ mod tests {
                 .iter()
                 .any(|e| matches!(&e.kind, BuildEventKind::ExecuteEnd { .. })),
             "warm resolve must not re-execute (no ExecuteEnd), got {events:?}"
+        );
+        Ok(())
+    }
+
+    /// Two requests racing one cold addr produce **one** miss and **one** hit
+    /// between them — never a target counted as both.
+    ///
+    /// This is the other half of the double-count bug. Both requests probe under
+    /// the read lock and both miss; one wins the write lock, executes and
+    /// caches, and the loser's re-probe under that same lock hits. When the probe
+    /// itself emitted the miss, the loser reported `Miss` *and* `Hit` for one
+    /// target — inflating the miss count and letting `built + cached` exceed the
+    /// target count. Only the winner's settled miss may be emitted.
+    ///
+    /// The winner is nondeterministic, but the totals across both streams are
+    /// not: whatever the interleaving (including the degenerate sequential one),
+    /// exactly one execute happens and exactly one of each event.
+    #[tokio::test]
+    async fn concurrent_cold_resolves_emit_one_miss_and_one_hit() -> anyhow::Result<()> {
+        let (engine, _home) = engine_with_home(vec![static_target_run("//pkg:a", "true")])?;
+        let addr = hmodel::htaddr::parse_addr("//pkg:a")?;
+
+        // Separate `RequestState`s: the per-request memoizer dedups within a
+        // request, so only distinct requests can reach the lock protocol at all.
+        let (a, b) = tokio::join!(
+            resolve_collecting_events(&engine, &addr),
+            resolve_collecting_events(&engine, &addr),
+        );
+        a.0.expect("first concurrent resolve must succeed");
+        b.0.expect("second concurrent resolve must succeed");
+
+        let events: Vec<BuildEvent> = a.1.into_iter().chain(b.1).collect();
+        let count = |pred: fn(&BuildEventKind) -> bool| count_kind(&events, pred);
+        assert_eq!(
+            count(|e| matches!(e, BuildEventKind::LocalCacheMiss { addr } if addr == "//pkg:a")),
+            1,
+            "expected exactly one LocalCacheMiss across both requests, got {events:?}"
+        );
+        assert_eq!(
+            count(|e| matches!(e, BuildEventKind::LocalCacheHit { addr } if addr == "//pkg:a")),
+            1,
+            "the loser's re-probe is the only hit, got {events:?}"
+        );
+        assert_eq!(
+            count(|e| matches!(e, BuildEventKind::ExecuteStart { addr, .. } if addr == "//pkg:a")),
+            1,
+            "the write lock must let exactly one request execute, got {events:?}"
+        );
+        Ok(())
+    }
+
+    /// A `cache = False` target can never hit, so it must not show up in the
+    /// hit/miss stats at all — every consumer (TUI, CI summary, GHA, telemetry)
+    /// folds these events, and counting a target that *cannot* be cached as a
+    /// "miss" misreports cache effectiveness on every run.
+    #[tokio::test]
+    async fn uncacheable_target_emits_no_cache_hit_or_miss_events() -> anyhow::Result<()> {
+        let target = pluginstatictarget::Target {
+            cache: Some(hcore::htvalue::Value::Bool(false)),
+            ..static_target_run("//pkg:nocache", "true")
+        };
+        let (engine, _home) = engine_with_home(vec![target])?;
+        let addr = hmodel::htaddr::parse_addr("//pkg:nocache")?;
+
+        // Resolve twice: neither the cold nor the repeat run may emit any
+        // cache hit/miss event for an uncacheable target.
+        for pass in ["cold", "repeat"] {
+            let (res, events) = resolve_collecting_events(&engine, &addr).await;
+            res.unwrap_or_else(|e| panic!("{pass} resolve must succeed: {e:#}"));
+            assert!(
+                !events.iter().any(|e| matches!(
+                    &e.kind,
+                    BuildEventKind::LocalCacheHit { .. }
+                        | BuildEventKind::LocalCacheMiss { .. }
+                        | BuildEventKind::RemoteCacheHit { .. }
+                        | BuildEventKind::RemoteCacheMiss { .. }
+                )),
+                "{pass}: uncacheable target must emit no cache events, got {events:?}"
+            );
+            // It executes every time, announced with `cache: false` so views can
+            // tell an uncacheable execute from a cache-miss execute.
+            assert!(
+                events.iter().any(|e| matches!(
+                    &e.kind,
+                    BuildEventKind::ExecuteStart { addr, cache: false, .. } if addr == "//pkg:nocache"
+                )),
+                "{pass}: expected ExecuteStart{{cache:false}}, got {events:?}"
+            );
+        }
+
+        // `--force` is the other way a resolution becomes uncacheable, and it
+        // shares the same early return today. Pin it separately so splitting
+        // that branch (e.g. teaching force to probe the cache in order to
+        // invalidate it) cannot silently put forced targets back in the stats.
+        let (forced_engine, _forced_home) =
+            engine_with_home(vec![static_target_run("//pkg:forced", "true")])?;
+        let forced_addr = hmodel::htaddr::parse_addr("//pkg:forced")?;
+        let (tx, mut rx) = tokio::sync::mpsc::unbounded_channel();
+        let rs = forced_engine.new_state_with_events(true, Some(tx));
+        Arc::clone(&forced_engine)
+            .result_addr(
+                rs.clone(),
+                &forced_addr,
+                OutputMatcher::All,
+                &ResultOptions {
+                    force: true,
+                    ..Default::default()
+                },
+            )
+            .await
+            .expect("forced resolve must succeed");
+        drop(rs);
+        let mut forced_events = Vec::new();
+        while let Ok(ev) = rx.try_recv() {
+            forced_events.push(ev);
+        }
+        assert!(
+            !forced_events.iter().any(|e| matches!(
+                &e.kind,
+                BuildEventKind::LocalCacheHit { .. }
+                    | BuildEventKind::LocalCacheMiss { .. }
+                    | BuildEventKind::RemoteCacheHit { .. }
+                    | BuildEventKind::RemoteCacheMiss { .. }
+            )),
+            "a forced resolve must emit no cache events, got {forced_events:?}"
         );
         Ok(())
     }
@@ -9163,6 +9356,98 @@ mod tests {
             .meta(engine.new_hash_only_state(addr.clone()), &addr)
             .await
             .expect("a cached target is answerable without building");
+        Ok(())
+    }
+
+    /// A hash-only probe that hits the cache must not report that hit.
+    ///
+    /// These are nested recomputes (the in_place write-back guard and fixpoint
+    /// re-deriving a `hashin`), not resolutions anyone asked for, and the real
+    /// request wrapping them probes the same addrs itself. They carry no event
+    /// sender, so the TUI and the CI summary never saw them — but hooks are
+    /// dispatched regardless of the sender, so telemetry and the GHA summary
+    /// counted each nested probe as another cache hit.
+    #[tokio::test]
+    async fn hash_only_probes_do_not_report_cache_hits_to_hooks() -> anyhow::Result<()> {
+        use crate::engine::hook::Hook;
+
+        #[derive(Default)]
+        struct HitCounter(std::sync::atomic::AtomicUsize);
+        impl Hook for HitCounter {
+            fn name(&self) -> String {
+                "hit-counter".into()
+            }
+            fn on_event(&self, ev: &BuildEvent) {
+                if matches!(ev.kind, BuildEventKind::LocalCacheHit { .. }) {
+                    self.0.fetch_add(1, std::sync::atomic::Ordering::Relaxed);
+                }
+            }
+            fn on_close(&self) {}
+        }
+
+        let root = tempdir()?;
+        let mut engine = Engine::new(Config {
+            root: root.path().to_path_buf(),
+            home_dir: std::path::PathBuf::new(),
+            parallelism: None,
+            ..Default::default()
+        })?;
+        engine
+            .register_managed_driver(|_| Box::new(hplugin_exec::pluginexec::Driver::new_exec()))?;
+        // A dep is what makes the probe run at all: `meta` hashes a target from
+        // its inputs, so it resolves `//pkg:dep` for its `hashout` — and that
+        // resolution is what probes the cache under the hash-only request.
+        let provider = pluginstatictarget::Provider::new(vec![
+            static_target("//pkg:dep", &[], &[]),
+            static_target("//pkg:top", &[], &["//pkg:dep"]),
+        ])?;
+        engine.register_provider(move |_| Box::new(provider))?;
+        let counter = Arc::new(HitCounter::default());
+        engine.register_hook(Arc::clone(&counter) as Arc<dyn Hook>)?;
+        let engine = Arc::new(engine);
+        let addr = hmodel::htaddr::parse_addr("//pkg:top")?;
+
+        // Warm the cache; the cold run reports no hit.
+        let rs = engine.new_state();
+        Arc::clone(&engine)
+            .result_addr(
+                rs.clone(),
+                &addr,
+                OutputMatcher::All,
+                &ResultOptions::default(),
+            )
+            .await
+            .expect("cold resolve");
+        drop(rs);
+        let hits = || counter.0.load(std::sync::atomic::Ordering::Relaxed);
+        assert_eq!(hits(), 0, "a cold resolve reports no cache hit");
+
+        // Hash-only probes hit the cache — and stay silent about it.
+        for _ in 0..3 {
+            Arc::clone(&engine)
+                .meta(engine.new_hash_only_state(addr.clone()), &addr)
+                .await
+                .expect("cached target answerable without building");
+        }
+        assert_eq!(hits(), 0, "hash-only probes must not report cache hits");
+
+        // A real warm resolve still does — one per cached target it resolves.
+        let rs = engine.new_state();
+        Arc::clone(&engine)
+            .result_addr(
+                rs.clone(),
+                &addr,
+                OutputMatcher::All,
+                &ResultOptions::default(),
+            )
+            .await
+            .expect("warm resolve");
+        drop(rs);
+        assert_eq!(
+            hits(),
+            2,
+            "a real warm resolve reports one hit per cached target (top + dep)"
+        );
         Ok(())
     }
 

--- a/crates/tui/src/tui/progress.rs
+++ b/crates/tui/src/tui/progress.rs
@@ -1417,8 +1417,10 @@ pub trait ProgressHeader: Send {
     /// The bottom-border label.
     fn label(&self) -> String;
     /// Final summary segment printed after the run (after the elapsed clock).
-    /// Empty ⇒ nothing is printed.
-    fn last_render(&self, core: &BuildState) -> String;
+    /// Empty ⇒ nothing is printed. `scope` is the count scope the view was left
+    /// on (the `a` toggle), so the printed summary matches the header the user
+    /// was reading; state-private headers ignore it.
+    fn last_render(&self, core: &BuildState, scope: CountScope) -> String;
 }
 
 /// Build/query/inspect header: the elapsed-clock counts segment plus worker
@@ -1479,12 +1481,19 @@ impl ProgressHeader for BuildHeader {
         self.label.clone()
     }
 
-    fn last_render(&self, core: &BuildState) -> String {
-        if core.has_activity() {
-            // The final summary always reports the matched set, the canonical view.
-            core.counts_segment(CountScope::Matched)
-        } else {
-            String::new()
+    fn last_render(&self, core: &BuildState, scope: CountScope) -> String {
+        if !core.has_activity() {
+            return String::new();
+        }
+        // Report the scope the view was left on: switching to `All` mid-run
+        // carries through to the printed exit summary.
+        match scope {
+            CountScope::Matched => core.counts_segment(scope),
+            // The printed line outlives the header (scrollback, copy-paste),
+            // where nothing else says which population the counts cover — so
+            // the non-default scope labels itself. Matched output stays
+            // byte-identical to what it always was.
+            CountScope::All => format!("{} · all targets", core.counts_segment(scope)),
         }
     }
 }
@@ -1538,7 +1547,7 @@ impl ProgressHeader for GcHeader {
         self.label.clone()
     }
 
-    fn last_render(&self, _core: &BuildState) -> String {
+    fn last_render(&self, _core: &BuildState, _scope: CountScope) -> String {
         if self.targets > 0 {
             self.segment()
         } else {
@@ -1606,6 +1615,14 @@ impl TuiProgressView {
             search_query: RefCell::new(String::new()),
             approval: None,
         }
+    }
+
+    /// The final summary segment, scoped to whatever the `a` toggle was left on
+    /// — a user who switched the header to `All` reads the same scope after
+    /// teardown. Split out from [`TUIAppView::last_render`], which writes it
+    /// straight to stderr and so cannot be asserted on.
+    fn final_summary_segment(&self) -> String {
+        self.model.last_render(&self.state, self.scope.get())
     }
 
     /// Attach the shared approval queue so this view renders pending prompts and
@@ -2157,7 +2174,7 @@ impl TUIAppView for TuiProgressView {
     /// when there was nothing to report (e.g. inspect/query, or a no-op gc), in
     /// which case nothing is printed.
     fn last_render(&self) {
-        let segment = self.model.last_render(&self.state);
+        let segment = self.final_summary_segment();
         if segment.is_empty() {
             return;
         }
@@ -2905,7 +2922,7 @@ mod tests {
         assert!(seg.contains("2 targets"), "{seg}");
         assert!(seg.contains("1.0 KiB"), "{seg}");
         assert_eq!(h.label(), "GC");
-        assert!(!h.last_render(&core).is_empty());
+        assert!(!h.last_render(&core, CountScope::Matched).is_empty());
     }
 
     #[test]
@@ -2940,6 +2957,37 @@ mod tests {
             addrs: addrs.iter().map(|s| (*s).to_string()).collect(),
             complete,
         }
+    }
+
+    /// The exit summary follows the `a` scope toggle: a user who switched the
+    /// header to `All` reads the all-targets counts after teardown, not a
+    /// hardcoded matched-scope line that disagrees with the header they were
+    /// just looking at.
+    #[test]
+    fn final_summary_follows_scope_toggle() {
+        let mut v = TuiProgressView::new("L");
+        v.apply(&ev(0, matched(&["//a:b"], true)));
+        v.apply(&ev(1, result_start("//a:b")));
+        v.apply(&ev(2, result_end("//a:b", None)));
+        // A transitive dep: outside the matched set, counted only under `All`.
+        v.apply(&ev(3, result_start("//dep:x")));
+        v.apply(&ev(4, result_end("//dep:x", None)));
+
+        // The production seam itself — `last_render` prints exactly this.
+        let segment = |v: &TuiProgressView| v.final_summary_segment();
+        assert!(segment(&v).contains("1 / 1 done"), "{}", segment(&v));
+        assert!(
+            !segment(&v).contains("all targets"),
+            "matched scope must not be labeled: {}",
+            segment(&v)
+        );
+        v.toggle_scope();
+        assert!(segment(&v).contains("2 / 2 done"), "{}", segment(&v));
+        // The line outlives the header, so the non-default scope names itself.
+        assert!(segment(&v).ends_with("· all targets"), "{}", segment(&v));
+        // Toggling back restores the matched-scope summary.
+        v.toggle_scope();
+        assert!(segment(&v).contains("1 / 1 done"), "{}", segment(&v));
     }
 
     #[test]


### PR DESCRIPTION
The `cache H hit / M miss` summary counted every cold target **twice**, and misreported uncacheable targets as misses.

## Double-count

`probe_cache_manifest` emitted the miss, but it runs twice per cold cacheable target — the optimistic probe under the read lock, then the settled re-check under the write lock. A run over 2 cacheable targets reported `0 hit / 4 miss`.

Worse under contention: the losing racer's read probe missed and its write-lock re-probe hit, so **one target was reported as both a miss and a hit** — the same shape that lets `built + cached` exceed the target count. Confirmed in the new concurrent test, which on the pre-fix code observes `Miss` then `Hit` for a single addr.

The probe now emits only the hit; the miss is emitted once, at the settled miss under the write lock.

| | before | after |
|---|---|---|
| cold, 2 cacheable + 1 uncacheable | `0 hit / 4 miss` | `0 hit / 2 miss` |
| warm | `2 hit / 0 miss` | `2 hit / 0 miss` |

## Uncacheable targets

`cache = False`, `--force` and `--shell` return before either probe, so they emit no cache events at all. A target that *cannot* hit does not belong in a cache-effectiveness stat — counting it as a miss made a repo with many action targets look like it had a broken cache on every run, warm or cold. `ExecuteStart { cache: false }` still distinguishes an uncacheable execute from a cache-miss execute, so "why did this run?" stays answerable from the event stream. Now pinned by test rather than left implicit.

## Hash-only probes

Nested recomputes (the in_place write-back guard, the fixpoint) carry no event sender, so the TUI and CI summaries never saw their probes — but hooks are dispatched regardless of the sender, so **telemetry and the GHA summary counted each nested probe as another hit**. Gated on `!rs.hash_only()`, the symmetric half of the miss fix.

## TUI: `a` toggle carries into the exit summary

The interactive `a` key toggles the header counters between matched and all-targets scope, but the summary printed after teardown always reported matched — disagreeing with the header the user had been reading. It now follows the toggle.

**Rider worth calling out:** the All-scope line labels itself (`… · all targets`). That line outlives the header in scrollback and copy-paste, where nothing else says which population it counts, and a completed run is otherwise byte-identical in either scope while `cached` differs materially. Matched output — everything non-TUI, including CI and anything scripted — is unchanged.

## Testing

`cargo test -p engine` (502) and `-p tui` (114) green, `lint` clean, verified against the real binary. New/tightened tests, each confirmed **red on the pre-fix code**:

- `emits_result_execute_and_cache_miss_for_fresh_target` — exactly one miss (was 2)
- `concurrent_cold_resolves_emit_one_miss_and_one_hit` — one miss + one hit + one execute across two racing requests (was 3 misses); assertion holds for every interleaving including the degenerate sequential one, so it cannot flake
- `remote_hit_and_miss_emit_cache_events` — exact counts on both remote branches (was 2 local misses)
- `hash_only_probes_do_not_report_cache_hits_to_hooks` — hook-observed; 3 nested probes reported 3 phantom hits before
- `uncacheable_target_emits_no_cache_hit_or_miss_events` — cold + repeat + `--force`
- `final_summary_follows_scope_toggle` — round-trips the toggle through the production seam

Reviewed by `code-quality` (PASS), `feature-quality` (PASS) and `product-vision` (OK); every finding they raised is applied.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DKHEjqywHZmXg4KKQ6Zfsw