### PR TITLE
refactor(core): run blocking work on tokio's pool, bounded, and delete the backstop

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -868,7 +868,6 @@ name = "core"
 version = "0.1.0"
 dependencies = [
  "anyhow",
- "crossbeam-channel",
  "enclose",
  "futures",
  "libc",

--- a/crates/core/Cargo.toml
+++ b/crates/core/Cargo.toml
@@ -8,7 +8,6 @@ workspace = true
 
 [dependencies]
 anyhow = "1.0.102"
-crossbeam-channel = "0.5"
 serde = { version = "1", features = ["derive"] }
 tar = "0.4"
 futures = "0.3.32"

--- a/crates/core/src/blocking.rs
+++ b/crates/core/src/blocking.rs
@@ -1,375 +1,271 @@
-//! Fixed pool of long-lived OS threads for synchronous blocking work that must
-//! not run on a tokio runtime worker.
+//! Bounded [`tokio::task::spawn_blocking`] for synchronous work that must not
+//! run on a tokio runtime worker (tar/copy into the cache, gzip, borsh, sqlite
+//! spool reads, Starlark evaluation, package walks).
 //!
-//! Every other way of running blocking work is unusable here for a different
-//! reason:
+//! Running that work inline on a worker parks the worker with the runtime
+//! unaware — it neither hands the worker's queue off nor spawns a replacement,
+//! so enough concurrent jobs stop the reactor and the timer wheel and the
+//! build looks hung while nothing is deadlocked (the failure #180 fixed).
+//! [`run`] moves the job to tokio's blocking pool and awaits its
+//! `JoinHandle`, bounded by a semaphore.
 //!
-//! - **Inline on the worker** — what `hproc::process_supervisor::block_or_inline`
-//!   does on Linux. The runtime is never told, so it neither hands the worker's
-//!   queue off nor spawns a replacement: that thread simply stops polling. With
-//!   `worker_threads = ncpu` (2–4 on a CI runner) a handful of concurrent cache
-//!   writes park *every* worker, and then the reactor and the timer wheel stop
-//!   running too — in-flight HTTP transfers make no progress, their deadlines
-//!   never fire, the TUI freezes. Nothing is deadlocked and the build looks hung.
-//!   This is the failure this module exists to remove.
-//! - **`tokio::task::block_in_place`** — correct in principle (the runtime hands
-//!   off), but every call burns a worker handoff and pulls a fresh thread out of
-//!   the blocking pool, and it needs a runtime context this module cannot assume
-//!   (see below). A 0.94 → 0.74 concurrency regression was measured against it
-//!   in the #180 era; a 2026-07-31 re-test found parity within noise on macOS
-//!   Tier A (`docs/CONCURRENCY_MEASUREMENTS.md`) — treat the number as
-//!   historical, not as the reason this pool exists.
-//! - **`tokio::task::spawn_blocking`** — its `JoinHandle` wake-up rides tokio's
-//!   cross-thread waker, observed to drop wake-ups on macOS under heavy load (see
-//!   `docs/RCA_MACOS_WAKER.md` and the hazard note in `hproc::proc_exec`), which
-//!   strands the awaiting task.
+//! ## History
 //!
-//! So: a fixed set of named threads, a `crossbeam_channel` queue, and a
-//! `oneshot` for the result. The threads are created once and live for the
-//! process, so a job costs a channel send rather than a thread spawn.
+//! This module used to be a hand-rolled fixed pool of OS threads with a
+//! `crossbeam_channel` queue, plus a process-wide waker registry re-woken by a
+//! 250ms ticker thread ("the backstop"). Both existed because tokio's own
+//! path was unusable or distrusted:
 //!
-//! **Dropped-wake-up backstop.** The result still crosses threads, so [`run`]
-//! does not simply `await` the `oneshot` — a pending waiter is re-woken on a timer
-//! ([`WAKE_BACKSTOP`]). A lost wake-up then costs latency instead of stranding
-//! the caller forever. This is the same defence the macOS child watcher uses for
-//! its own dropped kernel events (`kqueue_macos.rs`).
+//! - **No runtime context.** A cdylib plugin's futures used to be polled by
+//!   host workers, where the plugin's statically-linked tokio saw no runtime
+//!   at all — `spawn_blocking` there panics, and the panic aborts crossing
+//!   the `extern "C"` seam. Since the spawn-at-the-seam change, every ABI
+//!   entry point's body runs as a task on the cdylib's own runtime and every
+//!   host callback body runs as a task on the host runtime, so every caller
+//!   of [`run`] is polled with a runtime context, on both sides of the seam.
+//! - **Distrusted wake-ups.** Tokio's cross-thread wake was believed to drop
+//!   wake-ups on macOS under load (`docs/RCA_MACOS_WAKER.md`), so the result
+//!   wait was insured by the ticker. A 2026-07-31 re-measurement could not
+//!   reproduce the loss across ~40M wakes on the pinned tokio, and the
+//!   `block_in_place` concurrency regression cited alongside it re-measured
+//!   at parity within noise (`docs/CONCURRENCY_MEASUREMENTS.md`). The
+//!   task-backed memoizer already trusts tokio's waker path for every build;
+//!   so does this module.
 //!
-//! The backstop is a plain thread, *not* `tokio::time::timeout`, because [`run`]
-//! is also awaited inside a loaded cdylib plugin: the plugin's statically-linked
-//! tokio is a separate instance from the host's, and the future is polled by a
-//! host worker, so the plugin's tokio sees no runtime context at all. A tokio
-//! timer there panics with "there is no reactor running", and that panic crosses
-//! the plugin's `extern "C"` ABI seam, where it aborts the process. Nothing in
-//! this module may touch the reactor; a `oneshot` is plain waker traffic and is
-//! fine.
+//! The registry's release coupling — GC flushing registered wakers because a
+//! parked waker's `Arc` chain could pin a cache read guard — dissolved with
+//! it: a `JoinHandle` await parks its waker in the task's join slot for
+//! exactly the wait's lifetime, and an abandoned waiter is torn down by the
+//! task-backed memoizer's abort cascade, which drops the chain and everything
+//! it pins. See `Engine::run_trim_batch_with_delay` (`engine/gc.rs`) for the
+//! consumer-side argument.
 //!
-//! Jobs must be `'static`: a caller's future can be dropped (cancellation) while
-//! its job is still running, so the job cannot borrow from the caller's frame.
-//! Clone or `Arc` what it needs.
+//! ## Contract
+//!
+//! - **[`run`] requires a tokio runtime context** (it calls `spawn_blocking`).
+//!   Every production caller has one post-seam; a sync caller that drives the
+//!   future itself must enter a handle first (the buildfile LSP does).
+//! - **Bounded.** Concurrency is capped at [`concurrency_limit`] (the old
+//!   pool's size, `2 * cores`), not tokio's own `8 * cores + 64` blocking
+//!   cap: an unbounded fan-out of gzip/Starlark jobs would thrash the CPU.
+//!   The permit is acquired in async land — so a waiter dropped while
+//!   queueing leaves cleanly, having spawned nothing — and then rides *into*
+//!   the job, so a job whose caller was dropped still counts against the
+//!   bound until it finishes. Right-sizing the bound against tokio's pool is
+//!   a later, measured change.
+//! - **Panics are transparent.** A panicking job resurfaces on the caller's
+//!   task, exactly as the old pool's `catch_unwind` + `resume_unwind` did
+//!   (tokio's task harness is the `catch_unwind` now).
+//! - **Dropping the future detaches the job.** A `spawn_blocking` job cannot
+//!   be aborted mid-run; dropping the `JoinHandle` lets it run to completion
+//!   with the answer discarded — the same run-to-completion semantics the old
+//!   pool had, and callers rely on it (a permit moved into a job is released
+//!   even when nobody is left to await the answer).
+//!
+//! Jobs must be `'static`: a caller's future can be dropped (cancellation)
+//! while its job is still running, so the job cannot borrow from the caller's
+//! frame. Clone or `Arc` what it needs.
 
-use crossbeam_channel::{Sender, unbounded};
-use std::any::Any;
-use std::future::{Future, poll_fn};
-use std::panic::{AssertUnwindSafe, catch_unwind};
-use std::pin::Pin;
-use std::sync::{Mutex, Once, OnceLock};
-use std::task::{Poll, Waker};
-use std::thread;
-use std::time::Duration;
+use std::cell::Cell;
+use std::sync::LazyLock;
+use tokio::sync::Semaphore;
 
-/// One unit of blocking work. Erased to `()` because the result travels back
-/// over a `oneshot` the closure already owns.
-type Job = Box<dyn FnOnce() + Send + 'static>;
-
-/// A panicking job's payload, forwarded so it resurfaces on the caller's task
-/// rather than silently killing a pool thread.
-type Panic = Box<dyn Any + Send + 'static>;
-
-/// How often a pending [`run`] waiter is re-woken.
+/// Concurrency limit for [`run`] jobs.
 ///
-/// Purely a backstop against a dropped cross-thread wake-up: on a healthy wake-up
-/// the result arrives immediately and the tick is never reached. Short enough
-/// that a lost wake-up is a hiccup, long enough that a pool of thousands of
-/// queued jobs isn't paying for a busy poll.
-const WAKE_BACKSTOP: Duration = Duration::from_millis(250);
-
-/// Waiters to re-wake on every tick, keyed by registration.
+/// The work is a mix of filesystem I/O (tar/copy into the cache, `stat`,
+/// rmdir) and CPU (gzip, borsh, starlark evaluation), so it wants more slots
+/// than cores — an I/O-bound job should not hold a slot a CPU-bound one could
+/// use — but not so many that thousands of concurrent targets thrash the
+/// disk. Callers that need a *tighter* bound impose their own (e.g. the
+/// remote cache's `CODEC_SLOTS` caps concurrent gzip at the core count); this
+/// is the ceiling underneath them. The value is the old dedicated pool's
+/// thread count, preserved verbatim across the switch to `spawn_blocking`.
 ///
-/// **Retained**, not drained. The list used to be emptied by each tick, on the
-/// reasoning that waking a waiter provokes a poll and the poll re-registers it.
-/// That holds only if the wake actually reaches the future — and nothing an
-/// arbitrary `Waker` promises guarantees that. When this was written,
-/// `hmemoizer::Cell::wake_by_ref` deliberately dropped a wake when the cell
-/// already had a driver that owed it a re-poll; one swallowed wake meant the
-/// waiter was never polled, never re-registered, and never woken again — with
-/// the blocking pool sitting idle on an empty queue because its job had long
-/// since finished. That stranded twelve targets inside `execute`'s sandbox
-/// cleanup while they held every worker permit, with ninety more queued behind
-/// them on the semaphore and the whole build wedged.
-///
-/// The cell no longer swallows (#236 routes every inner wake to the driver, or
-/// broadcasts), but retention stays because it defends the class, not that
-/// instance: any waker on the chain may coalesce or drop a wake — tokio's own
-/// cross-thread wake has been observed to go missing on macOS under load
-/// (`docs/RCA_MACOS_WAKER.md`), and the next `hmemoizer`-shaped waker is one
-/// refactor away. `a_swallowed_wake_does_not_disarm_the_backstop` pins the
-/// contract with a synthetic swallowing waker. Retaining the registration until
-/// the waiter is done makes the backstop's guarantee hold no matter what the
-/// waker does with a wake.
-static PENDING: Mutex<Vec<(u64, Waker)>> = Mutex::new(Vec::new());
-
-static NEXT_REGISTRATION: std::sync::atomic::AtomicU64 = std::sync::atomic::AtomicU64::new(1);
-
-static BACKSTOP_THREAD: Once = Once::new();
-
-/// One pass of the backstop: wake every live registration, keeping them armed.
-///
-/// Split out of the thread's loop so the retention contract can be asserted by
-/// calling this directly. Timing a real tick means sleeping for a multiple of
-/// [`WAKE_BACKSTOP`] and counting wakes, which on a loaded CI runner measures the
-/// scheduler rather than the invariant.
-///
-/// Returns how many registrations were woken.
-fn tick() -> usize {
-    // Cloned under the lock and woken outside it: a waker may re-enter this
-    // module from inside `wake`.
-    let due: Vec<Waker> = lock_pending().iter().map(|(_, w)| w.clone()).collect();
-    let n = due.len();
-    for waker in due {
-        waker.wake();
-    }
-    n
-}
-
-fn start_backstop_thread() {
-    BACKSTOP_THREAD.call_once(|| {
-        thread::Builder::new()
-            .name("heph-blocking-wake".to_string())
-            .spawn(|| {
-                loop {
-                    thread::sleep(WAKE_BACKSTOP);
-                    tick();
-                }
-            })
-            // Same stance as the pool itself: no fallback worth having.
-            .expect("spawn heph blocking-wake thread");
-    });
-}
-
-/// A live backstop registration. The waker stays armed until this is dropped.
-///
-/// Held by the awaiting future, so the registration's lifetime is exactly the
-/// wait's: it goes away when the result arrives *or* when the future is
-/// cancelled, and never outlives either. That is what lets the tick retain
-/// entries instead of draining them.
-pub struct Backstop {
-    id: u64,
-}
-
-impl Backstop {
-    /// Reserve a registration, starting the backstop thread on first use (a
-    /// process that never blocks never pays for it). Nothing is armed until
-    /// [`arm`](Self::arm) is called with a waker.
-    pub fn new() -> Self {
-        start_backstop_thread();
-        Self {
-            id: NEXT_REGISTRATION.fetch_add(1, std::sync::atomic::Ordering::Relaxed),
-        }
-    }
-
-    /// Arm (or refresh) this registration with the polling task's waker. Call
-    /// from every pending poll; re-arming with the same waker is free.
-    pub fn arm(&self, waker: &Waker) {
-        let mut pending = lock_pending();
-        match pending.iter_mut().find(|(id, _)| *id == self.id) {
-            Some((_, armed)) => {
-                if !armed.will_wake(waker) {
-                    *armed = waker.clone();
-                }
-            }
-            None => pending.push((self.id, waker.clone())),
-        }
-    }
-}
-
-impl Default for Backstop {
-    fn default() -> Self {
-        Self::new()
-    }
-}
-
-impl Drop for Backstop {
-    fn drop(&mut self) {
-        let mut pending = lock_pending();
-        if let Some(i) = pending.iter().position(|(id, _)| *id == self.id) {
-            pending.swap_remove(i);
-        }
-    }
-}
-
-/// Wake every registered backstop waiter now rather than on the next tick, and
-/// hand back the `Waker`s it was holding.
-///
-/// Waking early is always sound: a spurious wake costs one poll, and a waiter
-/// that is genuinely still pending re-arms from the poll that wake provokes.
-///
-/// **Releasing is half the point, and it is not only about *finished* waits.** A
-/// `Waker` owns whatever it can reach — here an `Arc<hmemoizer::Cell>`, whose
-/// memoized value for `mem_locked_result` is the addr's riding cache read. The
-/// post-run cache trim has to take a write lock, so every one of those reads must
-/// be gone before it runs, or the trim finds its target contended and silently
-/// skips.
-///
-/// [`Backstop`] fixes the *finished* half at the source: a registration is
-/// dropped when its wait ends, so a completed waiter no longer pins anything
-/// until a tick sweeps it. But a request can be torn down while background work
-/// is still in flight, and those registrations are live, not stale — the guard
-/// will not release them because the wait genuinely has not ended. Taking them
-/// here is what unpins the read guards, and the still-pending waiter re-arms on
-/// its next poll.
-///
-/// (That re-arm is the same assumption the tick deliberately no longer makes: see
-/// [`PENDING`]. It is sound here because this is a teardown path — the wedge the
-/// tick's retention guards against happens mid-run, under a memoizer cell that
-/// swallows a wake it thinks is redundant.)
-///
-/// Returns how many registrations were taken, so a caller can tell its own flush
-/// from a tick that happened to land first.
-pub fn flush_backstop() -> usize {
-    // Taken, not cloned: releasing the `Waker`s is half the point (see above).
-    // Taken before waking, and the lock released first, so a waker that re-arms
-    // from inside `wake` cannot deadlock against us — its `arm` simply pushes a
-    // fresh entry under the same id.
-    let due: Vec<Waker> = std::mem::take(&mut *lock_pending())
-        .into_iter()
-        .map(|(_, w)| w)
-        .collect();
-    let n = due.len();
-    for waker in due {
-        // Callers reach this from `Drop` on a teardown path. A panicking waker
-        // there would unwind out of a destructor — and abort outright if that
-        // drop is itself already unwinding — so one bad waker is contained
-        // rather than allowed to take the process with it. The panic is still
-        // reported by the default hook before this returns, and this crate has
-        // no `tracing` (it is linked into cdylib plugins, where no subscriber is
-        // ever installed), so there is nothing further to say about it here.
-        // `lock_pending` already contemplates this case for the tick thread.
-        drop(catch_unwind(AssertUnwindSafe(|| waker.wake())));
-    }
-    n
-}
-
-/// A waker panicking mid-`wake` would poison the list and strand every later
-/// waiter, so poisoning is ignored — the `Vec` is still consistent.
-fn lock_pending() -> std::sync::MutexGuard<'static, Vec<(u64, Waker)>> {
-    PENDING.lock().unwrap_or_else(|e| e.into_inner())
-}
-
-/// Pool size.
-///
-/// The work is a mix of filesystem I/O (tar/copy into the cache, `stat`, rmdir)
-/// and CPU (gzip, borsh, starlark evaluation), so it wants more threads than
-/// cores — an I/O-bound job should not hold a slot a CPU-bound one could use —
-/// but not so many that thousands of concurrent targets thrash the disk. Callers
-/// that need a *tighter* bound impose their own (e.g. the remote cache's
-/// `CODEC_SLOTS` caps concurrent gzip at the core count); this is the ceiling
-/// underneath them.
-/// Public so callers that park a pool thread to wait on *another* pool thread
-/// can assert their bound stays strictly below it (e.g. `pluginbuildfile`'s
+/// Public so callers that park inside a job to wait on *another* job can
+/// assert their bound stays strictly below it (e.g. `pluginbuildfile`'s
 /// `PKG_EVAL_SLOTS`, whose `LoadRegistry` condvar wait is deadlock-free only
-/// while every claim holder can be running on some thread of this pool).
-pub fn pool_size() -> usize {
-    let cores = std::thread::available_parallelism()
-        .map(|p| p.get())
-        .unwrap_or(8);
-    (cores * 2).max(4)
+/// while every claim holder can hold a slot of its own).
+pub fn concurrency_limit() -> usize {
+    /// Snapshotted once, not recomputed per call: [`SLOTS`] is sized from it
+    /// at first touch, and `pluginbuildfile`'s `PKG_EVAL_SLOTS` asserts
+    /// against it at its own first touch. Were `available_parallelism` ever to
+    /// change under us (a cgroup resize), a recomputing function would let the
+    /// reported limit, the asserted invariant, and the actual semaphore size
+    /// disagree.
+    static LIMIT: LazyLock<usize> = LazyLock::new(|| {
+        let cores = std::thread::available_parallelism()
+            .map(|p| p.get())
+            .unwrap_or(8);
+        (cores * 2).max(4)
+    });
+    *LIMIT
 }
 
-static POOL: OnceLock<Sender<Job>> = OnceLock::new();
+/// The bound. A static per linkage unit, not per runtime: the host binary and
+/// each plugin cdylib statically link their own copy of this crate, each with
+/// its own runtime and its own limit — exactly as each used to have its own
+/// pool.
+static SLOTS: LazyLock<Semaphore> = LazyLock::new(|| Semaphore::new(concurrency_limit()));
 
-fn sender() -> &'static Sender<Job> {
-    POOL.get_or_init(|| {
-        let (tx, rx) = unbounded::<Job>();
-        for i in 0..pool_size() {
-            let rx = rx.clone();
-            thread::Builder::new()
-                .name(format!("heph-blocking-{i}"))
-                .spawn(move || {
-                    // Ends only when every sender is dropped, which for a
-                    // process-lifetime static means at exit.
-                    for job in rx.iter() {
-                        job();
-                    }
-                })
-                // Same stance as the sandbox cleaner: a process that cannot spawn
-                // its worker threads at startup has nothing to fall back to.
-                .expect("spawn heph blocking-io thread");
-        }
-        tx
-    })
+thread_local! {
+    /// True while this thread is executing a [`run`] job.
+    static IN_JOB: Cell<bool> = const { Cell::new(false) };
 }
 
-/// Fail a [`run`] the same way a panicking job does, for the two states that
-/// cannot happen unless the pool itself is broken (its queue closed, or a thread
-/// dropping a job without answering — `catch_unwind` means even a panic answers).
-/// Raised as a panic rather than folded into the return type so [`run`] stays a
-/// drop-in for the synchronous call it replaced.
-fn pool_broken(what: &'static str) -> ! {
-    std::panic::resume_unwind(Box::new(format!("heph blocking pool {what}")))
-}
-
-/// Run `f` on the blocking pool and await its result.
+/// True while the calling thread is running a [`run`] job.
 ///
-/// Panics are transparent: a panicking job resurfaces on the caller's task
-/// instead of taking down a pool thread and stranding every later job.
+/// The witness for "this leaf was routed through [`run`]": tokio's blocking
+/// threads carry no distinguishing name (a runtime names all its threads
+/// alike), so tests that used to assert on the old pool's `heph-blocking-*`
+/// thread names record this instead. Deliberately scoped to [`run`] jobs — a
+/// bare `spawn_blocking` or `tokio::fs` op on the same pool reads `false`.
+pub fn in_blocking_job() -> bool {
+    IN_JOB.with(Cell::get)
+}
+
+/// Marks the job's thread for [`in_blocking_job`], reset on drop so a
+/// panicking job cannot leave the flag set on a pool thread tokio will reuse.
+struct JobMarker;
+
+impl JobMarker {
+    fn set() -> Self {
+        IN_JOB.with(|c| c.set(true));
+        Self
+    }
+}
+
+impl Drop for JobMarker {
+    fn drop(&mut self) {
+        IN_JOB.with(|c| c.set(false));
+    }
+}
+
+/// Run `f` on tokio's blocking pool, bounded by [`concurrency_limit`], and
+/// await its result.
+///
+/// Requires a tokio runtime context — see the module docs for the full
+/// contract, including panic transparency and drop-detaches semantics.
 pub async fn run<F, R>(f: F) -> R
 where
     F: FnOnce() -> R + Send + 'static,
     R: Send + 'static,
 {
-    let (tx, mut rx) = tokio::sync::oneshot::channel::<Result<R, Panic>>();
-    let job: Job = Box::new(move || {
-        let out = catch_unwind(AssertUnwindSafe(f));
-        // The receiver is gone when the caller's future was dropped — the job
-        // still had to run to completion, but nobody wants the answer.
-        drop(tx.send(out));
+    // Queue in async land: a waiter dropped here (cancellation) leaves the
+    // semaphore's queue cleanly, having spawned nothing — and the closure,
+    // with whatever it owns (a caller's permit riding into the job), is
+    // dropped on the cancelling thread.
+    let permit = SLOTS
+        .acquire()
+        .await
+        .expect("heph blocking slots semaphore is never closed");
+    let handle = tokio::task::spawn_blocking(move || {
+        // The permit rides into the job: once spawned, the job occupies a
+        // slot until it *finishes*, even when the caller's future is dropped
+        // mid-run — the same occupancy the old pool's threads enforced. Kept
+        // in the caller's future instead, every detached job would run
+        // outside the bound.
+        let _permit = permit;
+        let _marker = JobMarker::set();
+        f()
     });
-    if sender().send(job).is_err() {
-        pool_broken("queue closed");
-    }
-
-    // Arm the backstop on every pending poll rather than trusting a single
-    // wake-up: see the dropped-wake-up note in the module docs. The registration
-    // is held for the whole wait and released here on the way out — including on
-    // cancellation, when this future is dropped mid-`await`.
-    let armed = Backstop::new();
-    let received = poll_fn(|cx| match Pin::new(&mut rx).poll(cx) {
-        Poll::Ready(out) => Poll::Ready(out),
-        Poll::Pending => {
-            armed.arm(cx.waker());
-            Poll::Pending
-        }
-    })
-    .await;
-    drop(armed);
-
-    match received {
-        Ok(Ok(value)) => value,
-        Ok(Err(panic)) => std::panic::resume_unwind(panic),
-        Err(_closed) => pool_broken("dropped a job unanswered"),
+    match handle.await {
+        Ok(value) => value,
+        // Transparent panic propagation: resurface the job's panic on the
+        // caller's task rather than wrapping it in a `JoinError`.
+        Err(e) => match e.try_into_panic() {
+            Ok(panic) => std::panic::resume_unwind(panic),
+            // Not a panic, and `run` never aborts the handle — so this is the
+            // runtime refusing the job outright, i.e. submitting to a runtime
+            // that is already gone (the LSP shape: an external thread holding
+            // an entered handle whose server runtime shut down). A job merely
+            // *queued* when a shutdown starts is not this case: tokio drains
+            // its blocking queue on the way down and runs it (measured, see
+            // `a_job_the_runtime_will_never_run_surfaces_as_a_panic`).
+            //
+            // Raised as a panic (via `resume_unwind`, the same shape a
+            // panicking job produces) rather than folded into the return type
+            // so `run` stays a drop-in for the synchronous call it replaced.
+            Err(e) => std::panic::resume_unwind(Box::new(format!("heph blocking job lost: {e}"))),
+        },
     }
 }
 
 #[cfg(test)]
 mod tests {
     use super::*;
-    use std::sync::Arc;
     use std::sync::atomic::{AtomicUsize, Ordering};
+    use std::sync::{Arc, Condvar, Mutex};
+    use std::thread;
+    use std::time::Duration;
 
-    /// [`PENDING`] is process-wide, and `flush_backstop` takes *everything* in
-    /// it. Cargo runs these tests in threads of one process, so a test that
-    /// flushes will happily disarm a registration another test is still watching.
-    /// Every test that touches the shared list holds this first.
-    static EXCLUSIVE: Mutex<()> = Mutex::new(());
+    /// [`SLOTS`] is process-wide and cargo runs these tests concurrently in
+    /// one process, so a test that reasons about permit counts (holding them
+    /// all, or parking jobs on a gate for its whole body) must not overlap
+    /// another doing the same. Async-aware so holding it across `await` is
+    /// sound.
+    static EXCLUSIVE: tokio::sync::Mutex<()> = tokio::sync::Mutex::const_new(());
 
-    /// Poisoning is ignored: the guard protects no invariant of its own, and a
-    /// failing test must not cascade into every later one.
-    fn exclusive() -> std::sync::MutexGuard<'static, ()> {
-        EXCLUSIVE.lock().unwrap_or_else(|e| e.into_inner())
+    /// Take every run slot, without ever parking in the semaphore's queue.
+    ///
+    /// A fair semaphore serves waiters in order, so a parked bulk acquire
+    /// blocks every later acquire behind it — deadlocking against any job that
+    /// holds a permit and needs another. Callers hold `EXCLUSIVE`.
+    async fn drain_all_slots() -> tokio::sync::SemaphorePermit<'static> {
+        let want = u32::try_from(concurrency_limit()).expect("limit fits u32");
+        let deadline = std::time::Instant::now() + Duration::from_secs(10);
+        loop {
+            if let Ok(all) = SLOTS.try_acquire_many(want) {
+                return all;
+            }
+            assert!(
+                std::time::Instant::now() < deadline,
+                "every run slot must come free"
+            );
+            tokio::task::yield_now().await;
+        }
+    }
+
+    /// A gate jobs park on, so a test controls exactly when its jobs finish.
+    struct Gate {
+        open: Mutex<bool>,
+        cond: Condvar,
+    }
+
+    impl Gate {
+        fn closed() -> Arc<Self> {
+            Arc::new(Self {
+                open: Mutex::new(false),
+                cond: Condvar::new(),
+            })
+        }
+
+        fn wait(&self) {
+            let mut open = self.open.lock().expect("gate lock");
+            while !*open {
+                open = self.cond.wait(open).expect("gate wait");
+            }
+        }
+
+        fn open(&self) {
+            *self.open.lock().expect("gate lock") = true;
+            self.cond.notify_all();
+        }
     }
 
     #[tokio::test]
     async fn runs_off_the_calling_thread_and_returns_the_value() {
         let here = thread::current().id();
-        let (value, ran_on) = run(move || (41 + 1, thread::current().id())).await;
+        let (value, ran_on, marked) =
+            run(move || (41 + 1, thread::current().id(), in_blocking_job())).await;
         assert_eq!(value, 42);
         assert_ne!(ran_on, here, "job must not run on the caller's thread");
+        assert!(marked, "a job must observe in_blocking_job()");
     }
 
-    /// The whole point: a job that blocks its thread outright must not stop the
-    /// runtime from making progress. If the work ran inline on the worker (what
-    /// `block_or_inline` does on Linux) a single-worker runtime would never poll
-    /// the timer, and this test would hang.
+    /// The whole point: a job that blocks its thread outright must not stop
+    /// the runtime from making progress. If the work ran inline on the worker
+    /// a single-worker runtime would never poll the timer, and this test
+    /// would hang.
     #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
     async fn blocking_work_does_not_stall_the_runtime() {
         let ticks = Arc::new(AtomicUsize::new(0));
@@ -386,261 +282,151 @@ mod tests {
         run(|| thread::sleep(Duration::from_millis(120))).await;
         assert!(
             ticks.load(Ordering::SeqCst) > 0,
-            "the runtime must keep polling while a pool job blocks",
+            "the runtime must keep polling while a blocking job runs",
         );
         ticker.await.expect("ticker");
     }
 
-    /// A panicking job must not kill its pool thread — that would silently strand
-    /// every job scheduled onto it for the rest of the process.
+    /// A panicking job resurfaces on the caller's task, and later jobs are
+    /// unaffected — under the old pool a leaked panic would have killed a
+    /// pool thread and stranded every job scheduled onto it.
     #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
-    async fn panic_surfaces_on_the_caller_and_the_pool_survives() {
+    async fn panic_surfaces_on_the_caller_and_later_jobs_still_run() {
         let panicked = tokio::spawn(run(|| panic!("boom"))).await;
         assert!(panicked.is_err(), "panic must propagate to the caller");
-        assert_eq!(run(|| 7).await, 7, "the pool must still serve jobs");
+        assert_eq!(run(|| 7).await, 7, "later jobs must still be served");
     }
 
-    /// Inside a loaded cdylib plugin the plugin's own tokio has no runtime
-    /// context — the host worker polls the plugin's future through the stable ABI
-    /// seam. Anything here that touched the reactor panicked there, and that panic
-    /// aborts the process on its way back across the `extern "C"` boundary.
-    /// `block_on` with no runtime installed reproduces exactly that context.
-    #[test]
-    fn works_with_no_tokio_runtime_installed() {
-        assert_eq!(futures::executor::block_on(run(|| 7)), 7);
+    /// The witness is scoped to [`run`] jobs: a bare `spawn_blocking` on the
+    /// same tokio pool must read `false`, or every test using the witness
+    /// would pass for work that dodged this module (and its bound) entirely.
+    #[tokio::test]
+    async fn the_marker_identifies_run_jobs_not_the_shared_pool() {
+        assert!(!in_blocking_job(), "an async caller is not a job");
+        assert!(run(in_blocking_job).await, "inside a job it is set");
+        let bare = tokio::task::spawn_blocking(in_blocking_job)
+            .await
+            .expect("bare spawn_blocking");
+        assert!(!bare, "a bare spawn_blocking job is not a run job");
     }
 
-    /// Same, for a job slow enough that the waiter actually parks and arms the
-    /// backstop — the reactor-free path has to carry the pending case too.
-    #[test]
-    fn pending_job_completes_with_no_tokio_runtime_installed() {
-        let out = futures::executor::block_on(run(|| {
-            thread::sleep(WAKE_BACKSTOP * 2);
-            "done"
-        }));
-        assert_eq!(out, "done");
-    }
+    /// The bound: with every job parked on a gate, at most
+    /// [`concurrency_limit`] of them may be running at once no matter how
+    /// many are submitted. Mutation-verified: lifting the semaphore lets
+    /// every submitted job start and `peak` overshoots.
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn concurrency_is_bounded_at_the_limit() {
+        let _exclusive = EXCLUSIVE.lock().await;
+        let limit = concurrency_limit();
+        let n = limit + 4;
+        let running = Arc::new(AtomicUsize::new(0));
+        let peak = Arc::new(AtomicUsize::new(0));
+        let gate = Gate::closed();
 
-    /// A registration owns its waker, and a waker owns its task — so anything a
-    /// finished task still holds would stay reachable from `PENDING` for as long
-    /// as the registration does. It must therefore end with the wait, not with a
-    /// tick or a flush, which is what the post-run cache trim depends on.
-    #[test]
-    fn a_registration_is_released_when_its_wait_ends() {
-        let _exclusive = exclusive();
-        struct Owning(#[expect(dead_code, reason = "held to observe the refcount")] Arc<()>);
-        impl futures::task::ArcWake for Owning {
-            fn wake_by_ref(_: &Arc<Self>) {}
-        }
+        let jobs: Vec<_> = (0..n)
+            .map(|_| {
+                let running = Arc::clone(&running);
+                let peak = Arc::clone(&peak);
+                let gate = Arc::clone(&gate);
+                tokio::spawn(run(move || {
+                    let now = running.fetch_add(1, Ordering::SeqCst) + 1;
+                    peak.fetch_max(now, Ordering::SeqCst);
+                    gate.wait();
+                    running.fetch_sub(1, Ordering::SeqCst);
+                }))
+            })
+            .collect();
 
-        let owned = Arc::new(());
-        let armed = Backstop::new();
-
-        // Cloning a `Waker` clones the `Arc<Owning>`, so every clone shares the
-        // one inner `Arc<()>`: the count moves only when the last `Waker` goes.
-        // Drop the local one here so what remains is the registration's alone.
-        {
-            let waker = futures::task::waker(Arc::new(Owning(Arc::clone(&owned))));
-            armed.arm(&waker);
-        }
-        assert_eq!(
-            Arc::strong_count(&owned),
-            2,
-            "armed: the registration is the only thing still holding the waker"
-        );
-
-        drop(armed);
-        assert_eq!(
-            Arc::strong_count(&owned),
-            1,
-            "ending the wait must release the waker the registration held"
-        );
-    }
-
-    /// A flush must hand back the wakers of waits that are *still pending*, not
-    /// only of finished ones.
-    ///
-    /// A `Waker` owns whatever it can reach — an `Arc<hmemoizer::Cell>`, whose
-    /// memoized `mem_locked_result` value is the addr's riding cache read. A
-    /// request can be torn down while background uploads are still in flight, and
-    /// those registrations are live rather than stale, so [`Backstop`]'s
-    /// end-of-wait release does not cover them. Leaving them armed pins the read
-    /// guards, and the post-run cache-history trim then finds every target
-    /// contended and silently skips
-    /// (`e2e::cache_history_is_enforced_by_the_end_of_the_run`).
-    #[test]
-    fn a_flush_releases_a_still_pending_registration() {
-        let _exclusive = exclusive();
-        struct Owning(#[expect(dead_code, reason = "held to observe the refcount")] Arc<()>);
-        impl futures::task::ArcWake for Owning {
-            fn wake_by_ref(_: &Arc<Self>) {}
-        }
-
-        let owned = Arc::new(());
-        // Deliberately kept alive for the whole test: this stands for a wait that
-        // has not ended, so nothing but the flush can release its waker.
-        let armed = Backstop::new();
-        {
-            let waker = futures::task::waker(Arc::new(Owning(Arc::clone(&owned))));
-            armed.arm(&waker);
-        }
-        assert_eq!(Arc::strong_count(&owned), 2, "armed");
-
-        assert!(
-            flush_backstop() >= 1,
-            "the flush must take our registration"
-        );
-        assert_eq!(
-            Arc::strong_count(&owned),
-            1,
-            "a flush must release the waker even though the wait is still live"
-        );
-
-        drop(armed);
-    }
-
-    /// The bug this module's retention exists to prevent.
-    ///
-    /// The list used to be drained by each tick, on the reasoning that waking a
-    /// waiter provokes a poll that re-registers it. A waker that swallows the
-    /// wake — `hmemoizer`'s cell does, when it already has a driver owing it a
-    /// re-poll — broke that: one dropped wake and the waiter was never polled,
-    /// never re-registered, and never woken again. That stranded twelve targets
-    /// in `execute`'s sandbox cleanup holding every worker permit, with the
-    /// blocking pool idle because their jobs had already finished.
-    #[test]
-    fn a_swallowed_wake_does_not_disarm_the_backstop() {
-        let _exclusive = exclusive();
-        /// Counts wakes and drops every one, like a cell that already has a
-        /// driver on the hook.
-        struct Swallowing(Arc<AtomicUsize>);
-        impl futures::task::ArcWake for Swallowing {
-            fn wake_by_ref(me: &Arc<Self>) {
-                me.0.fetch_add(1, Ordering::SeqCst);
-            }
-        }
-
-        let wakes = Arc::new(AtomicUsize::new(0));
-        let waker = futures::task::waker(Arc::new(Swallowing(Arc::clone(&wakes))));
-
-        let armed = Backstop::new();
-        armed.arm(&waker);
-
-        // Driven, not timed. Under the old drain-once list the first tick would
-        // consume the registration and the second would find nothing, because a
-        // swallowed wake never produces the re-registering poll. Calling `tick`
-        // directly asserts exactly that and nothing about the scheduler.
-        for round in 1..=3 {
-            tick();
-            assert_eq!(
-                wakes.load(Ordering::SeqCst),
-                round,
-                "a waiter whose wakes are swallowed must be re-woken on every tick"
+        // Eventual, bounded: the limit's worth of slots fill while the excess
+        // queues on the semaphore.
+        let deadline = std::time::Instant::now() + Duration::from_secs(10);
+        while running.load(Ordering::SeqCst) < limit {
+            assert!(
+                std::time::Instant::now() < deadline,
+                "the limit's worth of jobs must start"
             );
+            tokio::task::yield_now().await;
         }
 
-        drop(armed);
-        let before = wakes.load(Ordering::SeqCst);
-        tick();
+        gate.open();
+        for job in jobs {
+            job.await.expect("job");
+        }
         assert_eq!(
-            wakes.load(Ordering::SeqCst),
-            before,
-            "and must stop being woken once its wait has ended"
+            peak.load(Ordering::SeqCst),
+            limit,
+            "no more than the limit may ever run at once, and the limit must be reachable",
         );
     }
 
-    /// A waiter that is genuinely still pending must survive a flush: it is
-    /// woken, re-polls, finds its job unfinished and re-registers. This is the
-    /// invariant that makes `flush_backstop` safe to call from anywhere.
-    #[test]
-    fn flush_backstop_does_not_strand_a_still_pending_waiter() {
-        let _exclusive = exclusive();
-        let out = futures::executor::block_on(async {
-            let job = run(|| {
-                thread::sleep(WAKE_BACKSTOP / 2);
-                "done"
-            });
-            futures::pin_mut!(job);
-            // Flush repeatedly while the job is still running; each one takes the
-            // waiter's registration out from under it.
-            loop {
-                let mut flushed = 0;
-                let polled = futures::poll!(&mut job);
-                if let Poll::Ready(v) = polled {
-                    break v;
-                }
-                while flushed < 3 {
-                    flush_backstop();
-                    flushed += 1;
-                    thread::sleep(Duration::from_millis(20));
-                }
+    /// Dropping the awaiting future mid-job detaches the job: it still runs
+    /// to completion (its side effect lands) and hands its slot back when it
+    /// finishes. Callers rely on run-to-completion — a permit moved into a
+    /// job must be released even when nobody is left to await the answer.
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn a_dropped_caller_detaches_the_job_which_still_completes() {
+        let _exclusive = EXCLUSIVE.lock().await;
+        let gate = Gate::closed();
+        let done = Arc::new(AtomicUsize::new(0));
+
+        let mut fut = Box::pin(run({
+            let gate = Arc::clone(&gate);
+            let done = Arc::clone(&done);
+            move || {
+                gate.wait();
+                done.fetch_add(1, Ordering::SeqCst);
             }
-        });
-        assert_eq!(
-            out, "done",
-            "a flushed-but-pending waiter must still finish"
-        );
-    }
-
-    /// A waiter must be re-woken while its job is still running — that spare
-    /// wake-up is the whole defence against a dropped one. Counted with a waker
-    /// nothing else can wake: the job is still asleep, so any wake seen here came
-    /// from the backstop and not from the job answering.
-    #[test]
-    fn backstop_re_wakes_a_waiter_while_its_job_is_still_running() {
-        let _exclusive = exclusive();
-        use std::task::{Context, RawWaker, RawWakerVTable, Waker};
-
-        static WAKES: AtomicUsize = AtomicUsize::new(0);
-        unsafe fn clone(p: *const ()) -> RawWaker {
-            RawWaker::new(p, &VTABLE)
-        }
-        unsafe fn wake(_: *const ()) {
-            WAKES.fetch_add(1, Ordering::SeqCst);
-        }
-        unsafe fn noop(_: *const ()) {}
-        static VTABLE: RawWakerVTable = RawWakerVTable::new(clone, wake, wake, noop);
-        let counting = unsafe { Waker::from_raw(RawWaker::new(std::ptr::null(), &VTABLE)) };
-
-        let mut fut = Box::pin(run(|| {
-            thread::sleep(WAKE_BACKSTOP * 4);
-            11
         }));
+        // One poll acquires the (uncontended) permit and spawns the job.
         assert!(
-            fut.as_mut()
-                .poll(&mut Context::from_waker(&counting))
-                .is_pending(),
-            "a job that sleeps cannot answer before its first poll returns",
+            futures::poll!(&mut fut).is_pending(),
+            "a gated job cannot answer before its first poll returns"
         );
+        drop(fut);
 
-        thread::sleep(WAKE_BACKSTOP * 2);
-        assert!(
-            WAKES.load(Ordering::SeqCst) > 0,
-            "the backstop must re-wake a waiter whose job is still running",
-        );
-
-        assert_eq!(futures::executor::block_on(fut), 11);
+        gate.open();
+        let deadline = std::time::Instant::now() + Duration::from_secs(10);
+        while done.load(Ordering::SeqCst) == 0 {
+            assert!(
+                std::time::Instant::now() < deadline,
+                "a detached job must still run to completion"
+            );
+            tokio::task::yield_now().await;
+        }
+        // And its slot comes back once the job finishes (eventual: the permit
+        // is dropped inside the job as it returns). Under EXCLUSIVE, the only
+        // other holders are the transient quick-job tests, so the full limit
+        // becoming acquirable is exactly the detached slot's return.
+        let want = u32::try_from(concurrency_limit()).expect("limit fits u32");
+        let deadline = std::time::Instant::now() + Duration::from_secs(10);
+        loop {
+            if let Ok(all) = SLOTS.try_acquire_many(want) {
+                drop(all);
+                break;
+            }
+            assert!(
+                std::time::Instant::now() < deadline,
+                "a detached job must release its slot when it finishes"
+            );
+            tokio::task::yield_now().await;
+        }
     }
 
     /// The production wedge's leaf, driven through the real machinery: a
-    /// memoized chain whose innermost computation holds a semaphore permit and
-    /// parks inside [`run`], with a live backstop registration — then the
-    /// chain's only awaiter is dropped, as fail-fast does.
+    /// memoized chain whose innermost computation holds a semaphore permit
+    /// and parks inside [`run`] — then the chain's only awaiter is dropped,
+    /// as fail-fast does. Everything the parked leaf holds must come back via
+    /// the task-backed memoizer's abort cascade: the permit returns to the
+    /// semaphore even though the blocking job is still running, detached.
     ///
-    /// Everything the parked leaf holds must come back: the permit returns to
-    /// the semaphore, and the backstop registration is disarmed (a `tick()`
-    /// wakes nobody). Pre-fix, the memoizer cell retained the whole chain, the
-    /// permit stayed captured, and the backstop re-woke the abandoned cell
-    /// every 250ms forever — the dumps show ~1000 such ticks over 269s.
+    /// (This is the release edge that replaced the old backstop registry's
+    /// `flush_backstop`: nothing retains the abandoned chain, so nothing
+    /// needs a flush to let go of it.)
     #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
-    #[expect(
-        clippy::await_holding_lock,
-        reason = "`exclusive()` serializes whole tests against each other, so its guard is meant to outlive every await below"
-    )]
-    async fn an_abandoned_memoized_wait_releases_its_permit_and_its_backstop() {
+    async fn an_abandoned_memoized_wait_releases_its_permit() {
         use crate::hmemoizer::Memoizer;
 
-        let _exclusive = exclusive();
+        let _exclusive = EXCLUSIVE.lock().await;
 
         let mem_result: Arc<Memoizer<String, u32>> = Arc::new(Memoizer::with_tag_task(
             "bk-result",
@@ -652,13 +438,14 @@ mod tests {
         ));
         let permits = Arc::new(tokio::sync::Semaphore::new(1));
 
-        // The job blocks until released, so the wait is genuinely pending (and
-        // the backstop genuinely armed) when the abandonment happens.
-        let (release_tx, release_rx) = crossbeam_channel::bounded::<()>(1);
+        // The job parks until released, so the wait is genuinely pending when
+        // the abandonment happens.
+        let gate = Gate::closed();
 
         let mut outer = Box::pin(mem_result.process("//pkg:tgt".to_string(), {
             let mem_execute = Arc::clone(&mem_execute);
             let permits = Arc::clone(&permits);
+            let gate = Arc::clone(&gate);
             move || async move {
                 mem_execute
                     .process("//pkg:tgt".to_string(), move || async move {
@@ -667,9 +454,7 @@ mod tests {
                             .await
                             .expect("semaphore is never closed");
                         run(move || {
-                            // Park until the test releases us (or drops the
-                            // sender); either outcome means "carry on".
-                            let _released = release_rx.recv();
+                            gate.wait();
                             7
                         })
                         .await
@@ -692,11 +477,12 @@ mod tests {
             tokio::task::yield_now().await;
         }
 
-        // Fail-fast: the only awaiter goes away while the job is still running.
+        // Fail-fast: the only awaiter goes away while the job is still
+        // running.
         drop(outer);
 
-        // Task-cell teardown is asynchronous: the abort cascade lands when the
-        // runtime processes it. Eventual, bounded.
+        // Task-cell teardown is asynchronous: the abort cascade lands when
+        // the runtime processes it. Eventual, bounded.
         let deadline = std::time::Instant::now() + Duration::from_secs(5);
         while permits.available_permits() != 1 {
             assert!(
@@ -705,20 +491,181 @@ mod tests {
             );
             tokio::task::yield_now().await;
         }
-        // The permit coming back proves the innermost future was dropped, and
-        // dropping it drops its `Backstop` — whose registration removal is
-        // proven deterministically by `a_registration_is_released_when_its_wait_ends`.
-        // Asserting `tick() == 0` here instead would race the non-exclusive
-        // tests in this module, which arm registrations of their own.
 
-        // Let the job finish; its answer goes nowhere, and that is fine.
-        release_tx.send(()).expect("job is waiting on this");
+        // Let the detached job finish; its answer goes nowhere, and that is
+        // fine.
+        gate.open();
     }
 
-    /// Many jobs at once all complete, exercising the queue past the pool size.
+    /// A job the runtime will never run surfaces on the caller as a panic —
+    /// not as a hang, and not as a bogus value.
+    ///
+    /// The one non-panic `JoinError` [`run`] can see. Provoked by submitting
+    /// to an already-shut-down runtime, which is deterministic; racing a
+    /// shutdown against a *queued* job is not, because tokio drains its
+    /// blocking queue on the way down (a queued job runs rather than being
+    /// dropped — measured, not assumed).
+    ///
+    /// The reachable production shape is the LSP's: an external thread
+    /// awaiting through an entered handle whose server runtime has gone away.
+    #[test]
+    fn a_job_the_runtime_will_never_run_surfaces_as_a_panic() {
+        let rt = tokio::runtime::Builder::new_multi_thread()
+            .worker_threads(1)
+            .enable_all()
+            .build()
+            .expect("runtime");
+        let handle = rt.handle().clone();
+        rt.shutdown_background();
+
+        let ran = Arc::new(AtomicUsize::new(0));
+        let ran_in_job = Arc::clone(&ran);
+        let out = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
+            let _entered = handle.enter();
+            futures::executor::block_on(run(move || {
+                ran_in_job.fetch_add(1, Ordering::SeqCst);
+                42
+            }))
+        }));
+
+        let payload = out.expect_err("a job that cannot run must not yield a value");
+        let msg = payload
+            .downcast_ref::<String>()
+            .map_or("<not a string payload>", String::as_str);
+        assert!(
+            msg.contains("heph blocking job lost"),
+            "a lost job must say so; got {msg:?}"
+        );
+        assert_eq!(
+            ran.load(Ordering::SeqCst),
+            0,
+            "the job must not have run at all"
+        );
+    }
+
+    /// A job may itself call [`run`] and drive it to completion.
+    ///
+    /// Load-bearing, not hypothetical: a Starlark handler `block_on`s a
+    /// provider function from inside a package-evaluation job, and anything
+    /// below that may reach [`run`] again. The old pool needed no runtime
+    /// context for this; `spawn_blocking` does, and it works only because
+    /// tokio propagates the runtime context into a blocking closure. It is
+    /// also the premise of `PKG_EVAL_SLOTS < concurrency_limit`: a claim
+    /// holder inside a job must be able to take a slot of its own.
     #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
-    async fn queues_beyond_the_pool_size() {
-        let n = pool_size() * 4;
+    async fn a_job_can_run_a_nested_job() {
+        // Serialized: this is the one test that holds a slot while acquiring a
+        // second, so letting it interleave with the tests that park jobs on a
+        // gate to fill every slot would deadlock both until their deadline.
+        let _exclusive = EXCLUSIVE.lock().await;
+        // Two permits, deadlock-free against the min-4 limit.
+        let out = run(|| futures::executor::block_on(run(|| 7))).await;
+        assert_eq!(out, 7);
+    }
+
+    /// A panicking job releases its slot — the permit rides into the closure,
+    /// so the release is on the unwind path. Leaking one per panic would wedge
+    /// the process after `limit` of them, which the panic-propagation test
+    /// cannot see.
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn a_panicking_job_releases_its_slot() {
+        let _exclusive = EXCLUSIVE.lock().await;
+        let panicked = tokio::spawn(run(|| panic!("boom"))).await;
+        assert!(panicked.is_err(), "the job must have panicked");
+
+        let want = u32::try_from(concurrency_limit()).expect("limit fits u32");
+        let deadline = std::time::Instant::now() + Duration::from_secs(10);
+        loop {
+            if let Ok(all) = SLOTS.try_acquire_many(want) {
+                drop(all);
+                break;
+            }
+            assert!(
+                std::time::Instant::now() < deadline,
+                "a panicking job must hand its slot back"
+            );
+            tokio::task::yield_now().await;
+        }
+    }
+
+    /// A panicking job must not leave [`IN_JOB`] set on the thread tokio will
+    /// reuse — every `in_blocking_job` witness in the tree would then pass for
+    /// work that never went through [`run`]. Pinned deterministically with a
+    /// one-thread blocking pool, so the bare probe *must* land on the thread
+    /// the panicking job used.
+    #[test]
+    fn a_panicking_job_clears_the_marker_for_the_next_user_of_its_thread() {
+        let rt = tokio::runtime::Builder::new_multi_thread()
+            .worker_threads(1)
+            .max_blocking_threads(1)
+            .enable_all()
+            .build()
+            .expect("runtime");
+        rt.block_on(async {
+            let panicked = tokio::spawn(run(|| panic!("boom"))).await;
+            assert!(panicked.is_err(), "the job must have panicked");
+            let reused = tokio::task::spawn_blocking(in_blocking_job)
+                .await
+                .expect("probe");
+            assert!(
+                !reused,
+                "a panicked job left the marker set on a reused blocking thread"
+            );
+        });
+    }
+
+    /// A waiter dropped *while still queued* spawns nothing and drops the
+    /// closure — which is what releases anything the caller moved into it (a
+    /// `PKG_EVAL_SLOTS` permit, in production).
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn a_caller_dropped_while_queued_spawns_nothing_and_drops_the_closure() {
+        let _exclusive = EXCLUSIVE.lock().await;
+        // Drained with try + yield rather than `acquire_many().await`: the
+        // semaphore is fair, so a parked bulk acquire sits at the queue head
+        // and blocks every later single acquire behind it — including one a
+        // permit-holder is waiting on. `EXCLUSIVE` already excludes the tests
+        // that could form that cycle; not parking means this cannot form one
+        // with anything else either.
+        let all = drain_all_slots().await;
+
+        let ran = Arc::new(AtomicUsize::new(0));
+        let dropped = Arc::new(AtomicUsize::new(0));
+        /// Stands in for a permit moved into the job.
+        struct DropFlag(Arc<AtomicUsize>);
+        impl Drop for DropFlag {
+            fn drop(&mut self) {
+                self.0.fetch_add(1, Ordering::SeqCst);
+            }
+        }
+
+        let mut fut = Box::pin(run({
+            let ran = Arc::clone(&ran);
+            let carried = DropFlag(Arc::clone(&dropped));
+            move || {
+                let _carried = carried;
+                ran.fetch_add(1, Ordering::SeqCst);
+            }
+        }));
+        // Every slot is held, so this parks on the semaphore having spawned
+        // nothing.
+        assert!(futures::poll!(&mut fut).is_pending(), "must queue");
+        drop(fut);
+        drop(all);
+
+        // Nothing to wait for: the drop is synchronous with the future's.
+        assert_eq!(ran.load(Ordering::SeqCst), 0, "a queued job must not run");
+        assert_eq!(
+            dropped.load(Ordering::SeqCst),
+            1,
+            "dropping a queued caller must drop the job closure, releasing what it carried"
+        );
+    }
+
+    /// Many jobs at once all complete, exercising queueing past the limit.
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn queues_beyond_the_concurrency_limit() {
+        let _exclusive = EXCLUSIVE.lock().await;
+        let n = concurrency_limit() * 4;
         let jobs = (0..n).map(|i| run(move || i * 2));
         let out = futures::future::join_all(jobs).await;
         assert_eq!(out, (0..n).map(|i| i * 2).collect::<Vec<_>>());

--- a/crates/core/src/hmemoizer/mod.rs
+++ b/crates/core/src/hmemoizer/mod.rs
@@ -1374,8 +1374,8 @@ mod tests {
     /// `waker_ref(cell)`, and every clone of that waker is a strong clone of
     /// `Arc<Cell>`. Real leaves store the waker they are polled with — a
     /// `tokio::sync::oneshot` keeps it in the channel, `Semaphore::acquire`
-    /// parks it in the wait list, and `hcore::blocking::run` clones it into the
-    /// global `PENDING` backstop list on every pending poll. Each of those is a
+    /// parks it in the wait list, and `hcore::blocking::run` parks it in its
+    /// blocking task's join slot for the whole wait. Each of those is a
     /// phantom "joiner" to `Arc::strong_count > 2`, so the guard bails and the
     /// abandoned future — and the worker permit it holds — is retained forever.
     /// `futures::future::pending()` is the one pending future that never stores
@@ -1497,7 +1497,7 @@ mod tests {
     /// `locked_result` cell, which computes by awaiting an `execute_cache`
     /// cell, whose computation takes a real semaphore permit and then parks on
     /// a leaf that **stores the waker it is polled with** — what
-    /// `hcore::blocking::run`'s oneshot does. That stored waker is a strong
+    /// `hcore::blocking::run`'s `JoinHandle` await does. That stored waker is a strong
     /// clone of the `execute_cache` cell, which is what made any
     /// `Arc::strong_count` gate a false pass; `futures::future::pending()`
     /// stores nothing and is forbidden here, and the stash assertion below
@@ -1528,7 +1528,7 @@ mod tests {
         ));
 
         let permits = Arc::new(tokio::sync::Semaphore::new(1));
-        // Held by the test past the drop, like the oneshot channel inside
+        // Held by the test past the drop, like the join slot inside
         // `blocking::run`: the leaf's stored waker must survive the abandonment
         // so the job-finished-late wake can be delivered into the torn-down
         // chain, exactly as the idle-pool-jobs-finished dumps describe.

--- a/crates/core/src/hmemoizer/stall.rs
+++ b/crates/core/src/hmemoizer/stall.rs
@@ -45,8 +45,8 @@ fn stall_backstop(waker: Waker) {
                     }
                 }
             })
-            // Same stance as `hcore::blocking`: a process that cannot spawn its
-            // diagnostic thread has nothing to fall back to.
+            // Same stance as the sandbox cleaner: a process that cannot spawn
+            // its diagnostic thread has nothing to fall back to.
             .expect("spawn heph memoizer stall thread");
     });
     stall_pending().push(waker);

--- a/crates/driver-bridge/src/driver_managed_fuse.rs
+++ b/crates/driver-bridge/src/driver_managed_fuse.rs
@@ -339,12 +339,15 @@ mod tests {
     use hplugin::driver::inputartifact::{InputArtifact, Type};
     use std::collections::BTreeMap;
 
-    /// A tar-backed input whose `seekable_reader` records the thread it was
-    /// opened on. Both the reader open and the `TarIndex` build happen inside
-    /// `try_register_slot`'s `par_iter`, so this witnesses the whole fan-out.
+    /// A tar-backed input whose `seekable_reader` records whether it was
+    /// opened inside a `blocking::run` job. Both the reader open and the
+    /// `TarIndex` build happen inside `try_register_slot`'s `par_iter`, so
+    /// this witnesses the whole fan-out. (A single-input `par_iter` runs on
+    /// the calling thread — the job's — which is also what kept the old
+    /// thread-name witness deterministic here.)
     struct ThreadRecordingTar {
         bytes: Vec<u8>,
-        thread: Arc<std::sync::Mutex<Option<String>>>,
+        in_job: Arc<std::sync::Mutex<Option<bool>>>,
     }
 
     impl Content for ThreadRecordingTar {
@@ -362,10 +365,8 @@ mod tests {
         fn seekable_reader(&self) -> anyhow::Result<Option<Box<dyn ReadSeek + Send>>> {
             // Not an `expect`: this returns a `Result`, and a poisoned slot would
             // only hide the assertion rather than signal anything.
-            let mut slot = self.thread.lock().unwrap_or_else(|e| e.into_inner());
-            *slot = std::thread::current()
-                .name()
-                .map(std::borrow::ToOwned::to_owned);
+            let mut slot = self.in_job.lock().unwrap_or_else(|e| e.into_inner());
+            *slot = Some(hcore::blocking::in_blocking_job());
             drop(slot);
             Ok(Some(Box::new(std::io::Cursor::new(self.bytes.clone()))))
         }
@@ -394,7 +395,7 @@ mod tests {
         packer.create_raw(b"payload".to_vec(), "pkg/x.txt", false);
         let mut bytes = Vec::new();
         packer.pack(&mut bytes).expect("pack");
-        let thread = Arc::new(std::sync::Mutex::new(None));
+        let in_job = Arc::new(std::sync::Mutex::new(None));
 
         let input = RunInput {
             artifact: InputArtifact {
@@ -402,7 +403,7 @@ mod tests {
                 origin_id: "dep|a|0".to_string(),
                 content: Arc::new(ThreadRecordingTar {
                     bytes,
-                    thread: Arc::clone(&thread),
+                    in_job: Arc::clone(&in_job),
                 }),
             },
             origin_id: "dep|a|0".to_string(),
@@ -419,12 +420,11 @@ mod tests {
 
         assert!(slot.is_some(), "a seekable input must register a slot");
         assert_eq!(group.len(), 1, "the group must come back to the caller");
-        let ran_on = thread.lock().unwrap_or_else(|e| e.into_inner()).clone();
-        assert!(
-            ran_on
-                .as_deref()
-                .is_some_and(|n| n.starts_with("heph-blocking")),
-            "slot registration must run on the blocking pool, ran on {ran_on:?}"
+        let recorded = *in_job.lock().unwrap_or_else(|e| e.into_inner());
+        assert_eq!(
+            recorded,
+            Some(true),
+            "slot registration must run inside a blocking::run job (None = never opened)"
         );
     }
 }

--- a/crates/driver-support/src/driver_managed.rs
+++ b/crates/driver-support/src/driver_managed.rs
@@ -233,8 +233,8 @@ async fn run_shell_fallback<'a, 'io>(
     shell_fallback.driver.run_shell(new_mreq, ctoken).await
 }
 
-/// Tar, hash and stage every collectable output of a finished run, on the
-/// blocking pool.
+/// Tar, hash and stage every collectable output of a finished run, through
+/// `hcore::blocking::run`.
 ///
 /// This reads, tars and xxh3-hashes **every output byte** the target produced.
 /// Run inline in an `async fn` it holds a tokio worker for that whole time, and
@@ -262,7 +262,7 @@ pub async fn collect_outputs(
 }
 
 /// The synchronous body of [`collect_outputs`], split out so it can be handed to
-/// the blocking pool whole.
+/// `hcore::blocking::run` whole.
 fn collect_outputs_inner(
     target_outputs: &[hplugin::driver::targetdef::Output],
     support_files: &[hplugin::driver::targetdef::path::Path],
@@ -369,7 +369,7 @@ pub(crate) fn build_source_map(
 /// least one input opted in. With no opted-in inputs the map is empty and the
 /// file is skipped entirely — consumers (e.g. golist) treat a missing file as
 /// an empty map.
-/// [`write_source_map`] on the blocking pool, taking and returning the inputs so
+/// [`write_source_map`] through `hcore::blocking::run`, taking and returning the inputs so
 /// the job can own them.
 ///
 /// Cheap when nothing opts in — but an input that does costs an `entry_paths()`
@@ -499,7 +499,7 @@ pub fn detect_output_collisions(groups: &BTreeMap<PathBuf, Vec<RunInput>>) -> an
     Ok(())
 }
 
-/// [`hartifactcontent::unpack::unpack`] on the blocking pool.
+/// [`hartifactcontent::unpack::unpack`] through `hcore::blocking::run`.
 ///
 /// Unpacking reads every byte of the artifact out of the cache and writes the
 /// whole tree to disk. Inline in an `async fn` it holds a runtime worker for the
@@ -531,7 +531,7 @@ pub async fn unpack_blocking(
     .await
 }
 
-/// [`detect_output_collisions`] on the blocking pool, taking and returning the
+/// [`detect_output_collisions`] through `hcore::blocking::run`, taking and returning the
 /// groups so the job can own them.
 ///
 /// The check is not the cheap map walk it looks like: `entry_paths()` on a
@@ -539,7 +539,7 @@ pub async fn unpack_blocking(
 /// `LocalCacheSQLite::seekable_reader`, which parks the calling thread until any
 /// queued write to that key has been committed by the single writer thread.
 /// Inline in an `async fn` that is exactly the runtime-worker stall
-/// `hcore::blocking` exists to remove; on a pool thread the park is the
+/// `hcore::blocking` exists to remove; inside a blocking job the park is the
 /// backend's documented contract.
 pub async fn detect_output_collisions_blocking(
     groups: BTreeMap<PathBuf, Vec<RunInput>>,
@@ -999,14 +999,15 @@ mod source_map_tests {
         detect_output_collisions(&groups).expect("filtered-out path must not collide");
     }
 
-    /// Records the thread its bytes were read on, then behaves like `TarBytes`.
+    /// Records whether its bytes were read inside a `blocking::run` job, then
+    /// behaves like `TarBytes`.
     ///
     /// The witness for every "runs off the runtime workers" test in this module:
     /// `entry_paths` (the default) and `unpack` both go through `walk`, so one
     /// recorder covers path enumeration and full materialization alike.
     struct ThreadRecordingTar {
         inner: TarBytes,
-        thread: Arc<std::sync::Mutex<Option<String>>>,
+        in_job: Arc<std::sync::Mutex<Option<bool>>>,
     }
 
     impl Content for ThreadRecordingTar {
@@ -1014,7 +1015,7 @@ mod source_map_tests {
             self.inner.reader()
         }
         fn walk(&self) -> anyhow::Result<Box<dyn Iterator<Item = anyhow::Result<WalkEntry>> + '_>> {
-            record_current_thread(&self.thread);
+            record_in_blocking_job(&self.in_job);
             self.inner.walk()
         }
         fn hashout(&self) -> anyhow::Result<String> {
@@ -1022,45 +1023,44 @@ mod source_map_tests {
         }
     }
 
-    /// Record the name of the thread this runs on into `slot`.
+    /// Record whether this runs inside a `blocking::run` job into `slot`.
     ///
     /// A free function returning `()` rather than a lock inside `walk`: `walk`
     /// returns a `Result`, and `clippy::unwrap_in_result` (denied in this crate)
     /// rejects an `expect` there. Poisoning is ignored — the `Option` is still
     /// consistent, and a poisoned slot would only hide the assertion.
-    fn record_current_thread(slot: &std::sync::Mutex<Option<String>>) {
+    fn record_in_blocking_job(slot: &std::sync::Mutex<Option<bool>>) {
         let mut g = slot.lock().unwrap_or_else(|e| e.into_inner());
-        *g = std::thread::current()
-            .name()
-            .map(std::borrow::ToOwned::to_owned);
+        *g = Some(hcore::blocking::in_blocking_job());
     }
 
     /// A `ThreadRecordingTar` over `files`, plus the slot it reports into.
     fn recording_content(
         files: &[(&str, &str)],
-    ) -> (Arc<dyn Content>, Arc<std::sync::Mutex<Option<String>>>) {
-        let thread = Arc::new(std::sync::Mutex::new(None));
+    ) -> (Arc<dyn Content>, Arc<std::sync::Mutex<Option<bool>>>) {
+        let in_job = Arc::new(std::sync::Mutex::new(None));
         let content = Arc::new(ThreadRecordingTar {
             inner: TarBytes(pack_files(files)),
-            thread: Arc::clone(&thread),
+            in_job: Arc::clone(&in_job),
         });
-        (content, thread)
+        (content, in_job)
     }
 
-    /// The witness itself: `hcore::blocking`'s pool threads are the only ones
-    /// named `heph-blocking-*`, so the name separates them from a runtime worker
-    /// (`tokio-runtime-worker`) and from the test thread.
+    /// The witness itself: `hcore::blocking::in_blocking_job` is true only
+    /// while a `blocking::run` job runs on the calling thread — a runtime
+    /// worker, the test thread, and even a bare `spawn_blocking` all read
+    /// false. (The old pool's `heph-blocking-*` thread names used to be the
+    /// witness; tokio's blocking threads carry no distinguishing name.)
     ///
-    /// Positive rather than negative on purpose — asserting `!= "tokio-runtime-
-    /// worker"` passes vacuously under `#[tokio::test]`, whose current-thread
-    /// flavor runs the body on the test thread.
-    fn assert_ran_on_blocking_pool(thread: &Arc<std::sync::Mutex<Option<String>>>, what: &str) {
-        let ran_on = thread.lock().unwrap_or_else(|e| e.into_inner()).clone();
-        assert!(
-            ran_on
-                .as_deref()
-                .is_some_and(|n| n.starts_with("heph-blocking")),
-            "{what} must run on the blocking pool, ran on {ran_on:?}"
+    /// Positive rather than negative on purpose — asserting "not on a worker"
+    /// passes vacuously under `#[tokio::test]`, whose current-thread flavor
+    /// runs the body on the test thread.
+    fn assert_ran_on_blocking_pool(in_job: &Arc<std::sync::Mutex<Option<bool>>>, what: &str) {
+        let recorded = *in_job.lock().unwrap_or_else(|e| e.into_inner());
+        assert_eq!(
+            recorded,
+            Some(true),
+            "{what} must run inside a blocking::run job (None = never walked)"
         );
     }
 
@@ -1071,9 +1071,9 @@ mod source_map_tests {
     /// `async fn` that holds a worker; with `2 * ncpu` execute permits against
     /// `ncpu` workers, enough targets in this window park the whole runtime.
     ///
-    /// Asserted where the work is actually observable: the content itself records
-    /// the thread it was enumerated on. `hcore::blocking`'s pool threads are the
-    /// only ones named `heph-blocking-*`, so the name is the witness.
+    /// Asserted where the work is actually observable: the content itself
+    /// records whether it was enumerated inside a `blocking::run` job
+    /// (`hcore::blocking::in_blocking_job` is the witness).
     #[tokio::test]
     async fn source_map_generation_runs_off_the_runtime_workers() {
         let dir = tempfile::tempdir().expect("tempdir");

--- a/crates/driver-support/src/stage.rs
+++ b/crates/driver-support/src/stage.rs
@@ -1374,16 +1374,16 @@ mod tests {
     /// that key. It also runs under the stage `FLock`, so a parked worker holds
     /// the lock every other consumer of that artifact is waiting on.
     ///
-    /// The content records the thread it was walked on;
-    /// `hcore::blocking`'s pool threads are the only ones named
-    /// `heph-blocking-*`. Asserted positively — `!= "tokio-runtime-worker"`
-    /// would pass vacuously, since `#[tokio::test]` runs the body on the test
-    /// thread.
+    /// The content records whether it was walked inside a `blocking::run` job
+    /// (`hcore::blocking::in_blocking_job` is the witness — tokio's blocking
+    /// threads carry no distinguishing name). Asserted positively — "not on a
+    /// worker" would pass vacuously, since `#[tokio::test]` runs the body on
+    /// the test thread.
     #[tokio::test]
     async fn stage_materialization_runs_off_the_runtime_workers() {
         struct ThreadRecordingTar {
             inner: TarBytes,
-            thread: Arc<std::sync::Mutex<Option<String>>>,
+            in_job: Arc<std::sync::Mutex<Option<bool>>>,
         }
 
         impl Content for ThreadRecordingTar {
@@ -1394,7 +1394,7 @@ mod tests {
                 &self,
             ) -> anyhow::Result<Box<dyn Iterator<Item = anyhow::Result<WalkEntry>> + '_>>
             {
-                record_current_thread(&self.thread);
+                record_in_blocking_job(&self.in_job);
                 self.inner.walk()
             }
             fn hashout(&self) -> anyhow::Result<String> {
@@ -1402,24 +1402,22 @@ mod tests {
             }
         }
 
-        /// Record the name of the thread this runs on into `slot`.
+        /// Record whether this runs inside a `blocking::run` job into `slot`.
         ///
         /// A free function returning `()` rather than a lock inside `walk`:
         /// `walk` returns a `Result`, and `clippy::unwrap_in_result` (denied in
         /// this crate) rejects an `expect` there. Poisoning is ignored — the
         /// `Option` is still consistent, and a poisoned slot would only hide the
         /// assertion.
-        fn record_current_thread(slot: &std::sync::Mutex<Option<String>>) {
+        fn record_in_blocking_job(slot: &std::sync::Mutex<Option<bool>>) {
             let mut g = slot.lock().unwrap_or_else(|e| e.into_inner());
-            *g = std::thread::current()
-                .name()
-                .map(std::borrow::ToOwned::to_owned);
+            *g = Some(hcore::blocking::in_blocking_job());
         }
 
         let tmp = tempfile::tempdir().expect("tempdir");
         let stage = tmp.path().join("stage");
         let link = tmp.path().join("ws");
-        let thread = Arc::new(std::sync::Mutex::new(None));
+        let in_job = Arc::new(std::sync::Mutex::new(None));
         // A real hashout, so this takes the staged path and not the
         // `unpack_blocking` fallback `no_content_hash_falls_back_to_copy` covers.
         let inner = content("stagethread", &[("pkg/x.txt", "hello", false)]);
@@ -1428,7 +1426,7 @@ mod tests {
                 bytes: drain_tar(&inner),
                 hash: "stagethread".to_string(),
             },
-            thread: Arc::clone(&thread),
+            in_job: Arc::clone(&in_job),
         });
 
         stage_and_link(&c, &stage, "k", &link, None, &[], false, &ct())
@@ -1440,12 +1438,11 @@ mod tests {
             "hello",
             "the tree must still be staged and linked"
         );
-        let ran_on = thread.lock().unwrap_or_else(|e| e.into_inner()).clone();
-        assert!(
-            ran_on
-                .as_deref()
-                .is_some_and(|n| n.starts_with("heph-blocking")),
-            "stage materialization must run on the blocking pool, ran on {ran_on:?}"
+        let recorded = *in_job.lock().unwrap_or_else(|e| e.into_inner());
+        assert_eq!(
+            recorded,
+            Some(true),
+            "stage materialization must run inside a blocking::run job (None = never walked)"
         );
     }
 

--- a/crates/engine/src/engine/approval.rs
+++ b/crates/engine/src/engine/approval.rs
@@ -308,15 +308,16 @@ mod tests {
     /// every matched artifact and reads its bytes out of the cache, and that read
     /// parks the calling thread on any queued sqlite write to those keys.
     ///
-    /// The content records the thread it was walked on; `hcore::blocking`'s pool
-    /// threads are the only ones named `heph-blocking-*`. Asserted positively —
-    /// `!= "tokio-runtime-worker"` would pass vacuously, since `#[tokio::test]`
-    /// runs the body on the test thread.
+    /// The content records whether it was walked inside a `blocking::run` job
+    /// (`hcore::blocking::in_blocking_job` is the witness — tokio's blocking
+    /// threads carry no distinguishing name). Asserted positively — "not on a
+    /// worker" would pass vacuously, since `#[tokio::test]` runs the body on
+    /// the test thread.
     #[tokio::test]
     async fn notice_rendering_runs_off_the_runtime_workers() {
         struct ThreadRecordingTar {
             inner: TarBytes,
-            thread: Arc<std::sync::Mutex<Option<String>>>,
+            in_job: Arc<std::sync::Mutex<Option<bool>>>,
         }
 
         impl Content for ThreadRecordingTar {
@@ -327,10 +328,8 @@ mod tests {
                 &self,
             ) -> anyhow::Result<Box<dyn Iterator<Item = anyhow::Result<WalkEntry>> + '_>>
             {
-                let mut slot = self.thread.lock().unwrap_or_else(|e| e.into_inner());
-                *slot = std::thread::current()
-                    .name()
-                    .map(std::borrow::ToOwned::to_owned);
+                let mut slot = self.in_job.lock().unwrap_or_else(|e| e.into_inner());
+                *slot = Some(hcore::blocking::in_blocking_job());
                 drop(slot);
                 self.inner.walk()
             }
@@ -343,21 +342,20 @@ mod tests {
         packer.create_raw(b"notice body\n".to_vec(), "NOTICE.txt", false);
         let mut bytes = Vec::new();
         packer.pack(&mut bytes).expect("pack");
-        let thread = Arc::new(std::sync::Mutex::new(None));
+        let in_job = Arc::new(std::sync::Mutex::new(None));
         let artifacts: Vec<Arc<dyn Content>> = vec![Arc::new(ThreadRecordingTar {
             inner: TarBytes(bytes),
-            thread: Arc::clone(&thread),
+            in_job: Arc::clone(&in_job),
         })];
 
         let out = read_notice_text_blocking(artifacts).await.expect("render");
 
         assert_eq!(out, "notice body\n", "the notice must still be rendered");
-        let ran_on = thread.lock().unwrap_or_else(|e| e.into_inner()).clone();
-        assert!(
-            ran_on
-                .as_deref()
-                .is_some_and(|n| n.starts_with("heph-blocking")),
-            "notice rendering must run on the blocking pool, ran on {ran_on:?}"
+        let recorded = *in_job.lock().unwrap_or_else(|e| e.into_inner());
+        assert_eq!(
+            recorded,
+            Some(true),
+            "notice rendering must run inside a blocking::run job (None = never walked)"
         );
     }
 

--- a/crates/engine/src/engine/diag.rs
+++ b/crates/engine/src/engine/diag.rs
@@ -1186,13 +1186,12 @@ impl StallLog {
 /// Poll [`DiagState::evaluate`] and emit a report when it detects a stall.
 ///
 /// Runs on a plain OS thread, never a tokio timer: the whole point is to keep
-/// working when the runtime is saturated or the reactor is not turning, which is
-/// the condition being diagnosed. It is deliberately *not* merged into
-/// `hcore::blocking`'s backstop thread — that one is a correctness mechanism for
-/// dropped wake-ups, and this one ends in blocking I/O. In CI stderr is a pipe;
-/// a stalled consumer would fill the 64 KiB buffer and block forever, freezing
-/// waker delivery for the entire blocking pool. The watchdog would then hang the
-/// process it exists to diagnose.
+/// working when the runtime is saturated or the reactor is not turning, which
+/// is the condition being diagnosed. It must also never share a thread with
+/// anything correctness-bearing, because it ends in blocking I/O: in CI stderr
+/// is a pipe, and a stalled consumer would fill the 64 KiB buffer and park
+/// this thread forever. On a thread of its own that only silences the
+/// watchdog, not the process it exists to diagnose.
 ///
 /// `emit` takes the report, not the rendered text: the caller decides what goes
 /// to the file and what goes to the terminal, and rendering inside the watchdog

--- a/crates/engine/src/engine/execute.rs
+++ b/crates/engine/src/engine/execute.rs
@@ -270,11 +270,11 @@ impl Engine {
     }
 }
 
-/// Run a synchronous `std::fs` operation on the dedicated blocking pool.
+/// Run a synchronous `std::fs` operation through `hcore::blocking::run`.
 ///
-/// Not `tokio::fs::*` (which routes through `spawn_blocking`, observed to lose
-/// wake-ups on macOS under heavy load) and not inline on the worker (which parks
-/// it without telling the runtime). See `hcore::blocking`.
+/// Not `tokio::fs::*` — that routes through `spawn_blocking` too, but outside
+/// `hcore::blocking`'s concurrency bound — and not inline on the worker (which
+/// parks it without telling the runtime). See `hcore::blocking`.
 async fn sync_fs_op_on_thread<F, T>(f: F) -> std::io::Result<T>
 where
     F: FnOnce() -> std::io::Result<T> + Send + 'static,

--- a/crates/engine/src/engine/fanout.rs
+++ b/crates/engine/src/engine/fanout.rs
@@ -4,8 +4,9 @@ use std::future::Future;
 /// In-flight cap for the discovery walks (`Engine::query`,
 /// `EngineProviderExecutor::query`, `states_under`).
 ///
-/// Sized to [`hcore::blocking`]'s pool (`2 * cores`), because that pool is what
-/// the discovery work actually lands on: a package's `list` is a whole-package
+/// Sized to [`hcore::blocking`]'s concurrency limit (`2 * cores`), because
+/// those run slots are what the discovery work actually lands on: a package's
+/// `list` is a whole-package
 /// Starlark evaluation submitted there. This is an *orchestration* bound — the
 /// real admission control lives further down (`PKG_EVAL_SLOTS` caps concurrent
 /// package evaluations at the core count, in async-land, before queueing) — so

--- a/crates/engine/src/engine/gc.rs
+++ b/crates/engine/src/engine/gc.rs
@@ -36,71 +36,36 @@ use tokio::task::JoinSet;
 /// retry, when an immediate re-probe of the contended subset has already failed.
 ///
 /// **This is a hedge, not a synchronization edge, and it is best-effort.** The
-/// batch is submitted by `RequestStateData`'s drop, which flushes the blocking
-/// pool's backstop registrations (`hcore::blocking::flush_backstop`) —
-/// releasing, per its own contract, the `Waker`s it was holding. Those `Waker`s
-/// are what reach the addr's riding cache read: one is an `Arc<hmemoizer::Cell>`
-/// whose memoized `mem_locked_result` value *is* that read guard.
+/// batch is submitted by `RequestStateData`'s drop, and the read guards its
+/// trims contend with are released by whatever still owns them letting go.
+/// Chiefly that is the task-backed memoizer's abort cascade tearing down the
+/// request's abandoned chains — one chain's `mem_locked_result` value *is* the
+/// addr's riding cache read — which lands when the runtime processes the
+/// aborts, unordered with respect to the `try_write` this batch is about to
+/// attempt. Any other live owner — an in-flight remote upload, a task mid-poll
+/// on a runtime worker — keeps the read alive until it finishes. A trim can
+/// still be lost, and a lost trim leaves a revision on disk until the next
+/// write's trim or the next `heph gc`.
 ///
-/// For that shape the flush **is** the release edge, and a synchronous one: the
-/// flush drops its last `Arc<Cell>` inline, on the flushing thread, before it
-/// returns. What is not guaranteed is that it is the *last* owner. Another live
-/// `Arc` — an in-flight remote upload, a task mid-poll on a runtime worker —
-/// keeps the read alive, and then the release lands whenever that owner
-/// finishes, unordered with respect to the `try_write` this batch is about to
-/// attempt. A trim can still be lost, and a lost trim leaves a revision on disk
-/// until the next write's trim or the next `heph gc`.
+/// (This used to be where the blocking pool's backstop registry got flushed:
+/// a registered `Waker`'s `Arc` chain could own the riding read past its
+/// wait's end, so the batch had to force the registry to let go. That registry
+/// is gone — `blocking::run` awaits a `JoinHandle`, whose waker lives in the
+/// task's join slot for exactly the wait's lifetime — so nothing retains a
+/// guard that its owning task hasn't kept alive itself, and there is nothing
+/// left to flush.)
 ///
-/// One owner that used to belong on that list no longer does: an abandoned
-/// memoizer cell, retained after its last awaiter was dropped by a `fail_fast`
-/// fanout, pinned its riding read indefinitely. `hmemoizer` now evicts a key and
-/// drops its in-flight future when the last holder goes (#241), which disarms
-/// the backstop registration with it. So the population this hedge is covering
-/// is smaller than it was, and it should reach the delayed attempt below less
-/// often — which costs nothing extra, because the free re-probe is what absorbs
-/// the difference.
-///
-/// So the delay is sized against the cases the wait can actually recover: a
-/// woken task that needs a scheduler hop to reach its next poll, and the tail of
-/// a concurrent backstop tick finishing its own wake loop. Both are typically
-/// microseconds to low milliseconds — usually shorter still, which is why the
-/// batch re-probes *before* sleeping and skips the delay entirely when the flush
-/// already did the job — and long-tailed under load, so single-digit
-/// milliseconds would be too tight for the tail. The ceiling is that the wait is
-/// charged to the cleaner thread that gates process exit, *after* the user has
-/// their output, ahead of every sandbox rmdir still queued behind it — so it has
-/// to stay well under the ~100ms at which an exit stall becomes noticeable.
-///
-/// Related to, but deliberately not derived from,
-/// `hcore::blocking::WAKE_BACKSTOP` (250ms): that tick is the upper bound on how
-/// late a *missed* wake can still arrive, so a delay at or above it would cover
-/// strictly more — at ten times the exit cost, on every contended run, to buy a
-/// case the flush is already designed to prevent. 25ms is the cost decision, not
-/// an independence claim. Raising it towards the tick is the knob if enforcement
-/// is ever measured to be losing.
+/// So the delay is sized against the cases the wait can actually recover: an
+/// abort cascade or a finishing task that needs a scheduler hop or two to
+/// reach its drop. Both are typically microseconds to low milliseconds —
+/// usually shorter still, which is why the batch re-probes *before* sleeping
+/// and skips the delay entirely when the release has already landed — and
+/// long-tailed under load, so single-digit milliseconds would be too tight for
+/// the tail. The ceiling is that the wait is charged to the cleaner thread
+/// that gates process exit, *after* the user has their output, ahead of every
+/// sandbox rmdir still queued behind it — so it has to stay well under the
+/// ~100ms at which an exit stall becomes noticeable.
 pub(crate) const TRIM_RETRY_DELAY: Duration = Duration::from_millis(25);
-
-/// Serialises the tests that arm a backstop registration and then assert on
-/// *which* of a batch's flushes released it.
-///
-/// `hcore::blocking`'s pending list is process-wide and `flush_backstop` takes
-/// all of it, so any other test in this binary that drops a request state with
-/// deferred trims can wake — and therefore advance — a registration this one is
-/// still counting. Held by every test here that cares, and by the request-state
-/// test that measures the batch's wait.
-///
-/// It cannot cover the flushes that happen inside unrelated `result.rs` tests,
-/// so a foreign wake landing inside a microsecond-wide window remains possible.
-/// It would make an assertion on the *phase* fail, never a reclamation
-/// assertion; the residual is documented rather than engineered away, because
-/// the alternative is a lock every request teardown in the crate must take.
-#[cfg(test)]
-pub(crate) fn backstop_exclusive() -> std::sync::MutexGuard<'static, ()> {
-    static EXCLUSIVE: std::sync::Mutex<()> = std::sync::Mutex::new(());
-    // Poisoning is ignored: the guard protects no invariant of its own, and one
-    // failing test must not cascade into every later one.
-    EXCLUSIVE.lock().unwrap_or_else(|e| e.into_inner())
-}
 
 /// What one [`Engine::try_trim_after_write`] attempt did.
 #[derive(Debug, PartialEq, Eq)]
@@ -148,8 +113,8 @@ pub(crate) struct TrimBatchReport {
     pub retried: usize,
     /// Targets still contended after the immediate re-probe, i.e. the subset the
     /// batch actually paid [`TRIM_RETRY_DELAY`] for. Zero here with `retried`
-    /// non-zero is the good case: the flush released the guards synchronously and
-    /// no delay was charged.
+    /// non-zero is the good case: the release edge landed before the re-probe
+    /// and no delay was charged.
     pub delayed: usize,
     /// Targets still contended after the final attempt. Their `cache.history`
     /// was not enforced by this run.
@@ -160,14 +125,6 @@ pub(crate) struct TrimBatchReport {
     /// Revisions actually reclaimed, and their bytes.
     pub removed: usize,
     pub bytes: u64,
-    /// Backstop registrations handed back by this batch's flushes, summed.
-    ///
-    /// The one number that says whether the hedge is *doing* anything: with it at
-    /// zero, `still_contended` means the release edge is somewhere this batch
-    /// cannot reach, and the delay is being paid for nothing. `flush_backstop`
-    /// returns it for exactly this reason. It counts every registration in the
-    /// process-wide list, not only this request's.
-    pub flushed: usize,
 }
 
 /// Outcome of a [`Engine::gc_all`] sweep.
@@ -466,12 +423,11 @@ impl Engine {
     /// bounded attempts per target and **at most one sleep for the whole batch**:
     ///
     /// 1. one pass over the batch;
-    /// 2. a flush, then an *immediate* re-probe of whatever came back contended
-    ///    — free, and it is the pass that usually wins, because the flush hands
-    ///    back the `Waker` that owns the riding read and drops it inline on this
-    ///    thread (see [`TRIM_RETRY_DELAY`]);
-    /// 3. only if that still loses: sleep once, flush once more, and try that
-    ///    subset a final time.
+    /// 2. an *immediate* re-probe of whatever came back contended — free, and
+    ///    it wins whenever the release edge (see [`TRIM_RETRY_DELAY`]) landed
+    ///    between the two probes;
+    /// 3. only if that still loses: sleep once, and try that subset a final
+    ///    time.
     ///
     /// Never a loop, and never a blocking `write`: either would trade a
     /// recoverable skip for an unbounded stall of every queued sandbox rmdir on
@@ -489,20 +445,10 @@ impl Engine {
     ) -> TrimBatchReport {
         let mut report = TrimBatchReport::default();
 
-        // INVARIANT for every `flush_backstop` below: **no result-lock guard is
-        // held on this thread across a flush.** A flush wakes arbitrary `Waker`s
-        // and hands their registrations back, which can drop an entire abandoned
-        // future graph inline, here — including read guards on addrs this batch
-        // is about to lock. That is the point. But it also means a flush must
-        // never run underneath one of our own guards: `try_trim_after_write`
-        // takes the write lock and drops it before returning, so flushing from
-        // inside it would let a woken task's drop path meet a lock we hold.
-        // Flushes belong here, between attempts, and nowhere else.
-        //
-        // This first one is not redundant with the drop site's: that one ran on
-        // the *dropping* thread, and this batch is dequeued an unbounded time
-        // later. Anything armed in that gap still pins whatever its task holds.
-        report.flushed += hcore::blocking::flush_backstop();
+        // Nothing to flush before the first pass: the release edge is the
+        // memoizer's abort cascade, which this thread cannot force and does
+        // not need to — see [`TRIM_RETRY_DELAY`]. The passes below are what
+        // absorb its being asynchronous to us.
 
         // Consumed lazily; the `Vec` is allocated only if something is contended
         // and is *moved* into, never cloned into. Not pre-sized: the expected
@@ -520,15 +466,10 @@ impl Engine {
         }
         report.retried = contended.len();
 
-        // Flush, then re-probe *before* sleeping. `flush_backstop` releases the
-        // `Waker`s it takes, and for the shape that matters here — an
-        // `Arc<hmemoizer::Cell>` whose memoized value is the addr's riding read —
-        // dropping the last one tears the cell down inline, on this thread,
-        // before the call returns. When that was the only owner the guard is
-        // already gone by now and the delay would be pure exit latency. One
-        // non-blocking `flock` per contended addr to find out is a good trade
-        // against 25ms.
-        report.flushed += hcore::blocking::flush_backstop();
+        // Re-probe *before* sleeping. The release edge is asynchronous to this
+        // thread (see above), so a guard whose owner was torn down during the
+        // first pass may already be free. One non-blocking `flock` per
+        // contended addr to find out is a good trade against sleeping 25ms.
         let mut delayed: Vec<(Addr, u32, String)> = Vec::new();
         for trim in contended {
             self.attempt_trim(trim, &mut report, &mut delayed);
@@ -538,12 +479,9 @@ impl Engine {
         }
         report.delayed = delayed.len();
 
-        // Somebody else's release edge, then: give it one bounded wait. The
-        // flush after the sleep collects anything that finished during it — the
-        // registrations taken above are gone, and a waiter still genuinely
-        // pending re-armed from the poll that wake provoked.
+        // A slower release edge, then: give it one bounded wait and a final
+        // attempt.
         std::thread::sleep(delay);
-        report.flushed += hcore::blocking::flush_backstop();
 
         for (addr, keep, hashin) in delayed {
             match self.trim_contained(&addr, keep, &hashin) {
@@ -1938,175 +1876,80 @@ mod tests {
         );
     }
 
-    /// A waker that releases a held write guard on its `nth` wake, re-arming
-    /// itself on every earlier one — the shape `hcore::blocking`'s contract
-    /// requires of a waiter that is still pending.
-    ///
-    /// This is the whole mechanism the batch's flushes exist for, in miniature:
-    /// `flush_backstop` hands back the `Waker`s it holds, and dropping one can
-    /// release a cache read guard inline on the flushing thread. Choosing which
-    /// wake releases is what lets a test name *which* flush it is pinning.
-    ///
-    /// **Only wakes arriving on `only_from` are counted.** `hcore::blocking`'s
-    /// pending list is process-wide, so the backstop tick and every other test in
-    /// this binary that tears down a request state can wake this registration
-    /// too. An uncounted foreign wake would advance the phase and release the
-    /// guard a flush early — which does not break reclamation, but does make an
-    /// assertion about *which* flush released it fail for an unrelated reason
-    /// (observed, before this filter existed). `flush_backstop` wakes inline on
-    /// the flushing thread and the tick has a thread of its own, so the thread id
-    /// is exactly the discriminator: a wake from anywhere else re-arms and is
-    /// ignored.
-    struct ReleasingWaker {
-        remaining: std::sync::atomic::AtomicUsize,
-        guard: std::sync::Mutex<Option<ResultWriteGuard>>,
-        backstop: hcore::blocking::Backstop,
-        only_from: std::thread::ThreadId,
-    }
-
-    impl ReleasingWaker {
-        /// Arm a waker that releases `guard` on the `nth` wake delivered by the
-        /// calling thread — which must also be the thread that runs the batch.
-        fn arm(guard: ResultWriteGuard, nth: usize) -> Arc<Self> {
-            let me = Arc::new(Self {
-                remaining: std::sync::atomic::AtomicUsize::new(nth),
-                guard: std::sync::Mutex::new(Some(guard)),
-                backstop: hcore::blocking::Backstop::new(),
-                only_from: std::thread::current().id(),
-            });
-            Self::rearm(&me);
-            me
-        }
-
-        fn released(&self) -> bool {
-            self.guard.lock().expect("guard lock").is_none()
-        }
-
-        fn rearm(me: &Arc<Self>) {
-            me.backstop.arm(&futures::task::waker(Arc::clone(me)));
-        }
-    }
-
-    impl futures::task::ArcWake for ReleasingWaker {
-        fn wake_by_ref(me: &Arc<Self>) {
-            use std::sync::atomic::Ordering;
-            if std::thread::current().id() != me.only_from {
-                // Somebody else's flush, or the tick. It took our registration;
-                // put it back, and do not advance the phase.
-                Self::rearm(me);
-                return;
-            }
-            let before = me
-                .remaining
-                .fetch_update(Ordering::SeqCst, Ordering::SeqCst, |v| {
-                    Some(v.saturating_sub(1))
-                })
-                .unwrap_or(0);
-            if before <= 1 {
-                // The wait is over: release, and deliberately do not re-arm.
-                drop(me.guard.lock().expect("guard lock").take());
-            } else {
-                Self::rearm(me);
-            }
-        }
-    }
-
-    /// The batch flushes *before* its first pass.
-    ///
-    /// Not redundant with the flush `DeferredTrims::drop` already does: that one
-    /// runs on the dropping thread, and the batch is dequeued an unbounded time
-    /// later. A registration armed in that gap still pins whatever its task
-    /// holds — here, literally the write guard the trim needs.
-    ///
-    /// Pinned by `retried == 0`: with the flush the guard is gone before the
-    /// first pass, so nothing is ever contended. Remove it and the first pass
-    /// loses, and the *second* flush recovers it — same reclamation, different
-    /// count.
+    /// An uncontended batch settles on its first pass: no retry, no delay,
+    /// and the revision is reclaimed. This is the overwhelmingly common case,
+    /// and the timing bound is what keeps the delay from ever being charged
+    /// to a run that lost nothing.
     #[test]
-    fn trim_batch_flushes_before_the_first_pass() {
-        let _exclusive = crate::engine::gc::backstop_exclusive();
+    fn trim_batch_settles_without_delay_when_nothing_is_contended() {
         let (engine, _dir) = test_engine();
         let a = two_revisions(&engine, "t");
 
-        let waker = ReleasingWaker::arm(hold_write(&engine, &a), 1);
-        let report = engine
-            .run_trim_batch_with_delay(vec![(a.clone(), 1, "h2".to_string())], Duration::ZERO);
-
-        assert!(waker.released(), "the flush must have woken our waker");
-        assert!(report.flushed >= 1, "the batch must flush: {report:?}");
-        assert_eq!(
-            (report.retried, report.removed),
-            (0, 1),
-            "the pre-pass flush released the guard before anything was contended: {report:?}",
-        );
-    }
-
-    /// The batch flushes again before it *re-probes* the contended subset, and
-    /// that re-probe is what usually spares the delay.
-    ///
-    /// Pinned by `delayed == 0`: the guard is released by the second flush, the
-    /// immediate re-probe wins, and no wait is charged. Remove that flush and the
-    /// re-probe loses, the batch sleeps, and the post-sleep flush recovers it —
-    /// same reclamation, but the run paid `TRIM_RETRY_DELAY` for nothing.
-    #[test]
-    fn trim_batch_reprobes_after_a_flush_before_paying_the_delay() {
-        let _exclusive = crate::engine::gc::backstop_exclusive();
-        let (engine, _dir) = test_engine();
-        let a = two_revisions(&engine, "t");
-
-        // Releases on the *second* wake, so the first flush cannot do it.
-        let waker = ReleasingWaker::arm(hold_write(&engine, &a), 2);
         let delay = Duration::from_secs(30);
         let started = std::time::Instant::now();
         let report =
             engine.run_trim_batch_with_delay(vec![(a.clone(), 1, "h2".to_string())], delay);
 
-        assert!(waker.released());
         assert!(
             started.elapsed() < delay,
-            "the re-probe must land before any wait is charged",
+            "an uncontended batch must not charge the delay",
         );
         assert_eq!(
             (report.retried, report.delayed, report.removed),
-            (1, 0, 1),
-            "contended once, then reclaimed by the free re-probe: {report:?}",
+            (0, 0, 1),
+            "{report:?}",
         );
-    }
-
-    /// And the batch flushes once more *after* the wait, before its final
-    /// attempt.
-    ///
-    /// The pre-sleep flush took every registration it found; anything that
-    /// re-armed during the wait — a waiter that was genuinely still pending — is
-    /// only handed back by a flush on the far side of it. Without this one the
-    /// batch sleeps and then asks for a lock whose owner it never woke.
-    ///
-    /// Pinned by `still_contended == 0` with the guard released on the third
-    /// wake, which only the third flush can deliver.
-    #[test]
-    fn trim_batch_flushes_again_after_the_delay() {
-        let _exclusive = crate::engine::gc::backstop_exclusive();
-        let (engine, _dir) = test_engine();
-        let a = two_revisions(&engine, "t");
-
-        let waker = ReleasingWaker::arm(hold_write(&engine, &a), 3);
-        let report = engine.run_trim_batch_with_delay(
-            vec![(a.clone(), 1, "h2".to_string())],
-            Duration::from_millis(20),
-        );
-
-        assert!(waker.released());
-        assert_eq!(
-            (report.retried, report.delayed, report.still_contended),
-            (1, 1, 0),
-            "the post-wait flush released the guard for the final attempt: {report:?}",
-        );
-        assert_eq!(report.removed, 1, "{report:?}");
         assert!(!present(&engine, &a, "h1"));
     }
 
-    /// The delay is exit latency paid by every run whose contention outlives a
-    /// flush, so it is held to a band rather than left to drift. Below ~10ms it
+    /// A guard released while the batch sleeps is recovered by the final
+    /// attempt — the case the delay exists to buy.
+    ///
+    /// **Timed, because nothing else is left to drive.** The batch used to be
+    /// steppable: each phase flushed the blocking pool's backstop, so a waker
+    /// that released on its Nth wake named exactly which flush recovered the
+    /// guard. With the flushes gone the batch has no in-process hook at all —
+    /// it probes, re-probes and sleeps behind a single synchronous call — so
+    /// the release edge can only be placed in time.
+    ///
+    /// The margins are therefore wide rather than tight, in both directions:
+    /// the two probes before the sleep are a pair of `flock` attempts plus a
+    /// revision count (tens of microseconds, unloaded), and they get 500ms;
+    /// the release then has 1.5s of the sleep left to land in. An earlier
+    /// 50ms/3s version of this test failed once under a concurrent `lint`,
+    /// where the probes lost their scheduling slice and the guard was already
+    /// free by the first one — the failure this widening is sized against.
+    #[test]
+    fn trim_batch_recovers_a_guard_released_during_the_delay() {
+        let (engine, _dir) = test_engine();
+        let a = two_revisions(&engine, "t");
+
+        let guard = hold_write(&engine, &a);
+        let releaser = std::thread::spawn(move || {
+            std::thread::sleep(Duration::from_millis(500));
+            drop(guard);
+        });
+        let report = engine.run_trim_batch_with_delay(
+            vec![(a.clone(), 1, "h2".to_string())],
+            Duration::from_secs(2),
+        );
+        releaser.join().expect("releaser thread");
+
+        assert_eq!(
+            (
+                report.retried,
+                report.delayed,
+                report.still_contended,
+                report.removed
+            ),
+            (1, 1, 0, 1),
+            "contended through both probes, reclaimed by the delayed attempt: {report:?}",
+        );
+        assert!(!present(&engine, &a, "h1"));
+    }
+
+    /// The delay is exit latency paid by every run whose contention outlives
+    /// the re-probe, so it is held to a band rather than left to drift. Below ~10ms it
     /// cannot cover a scheduler hop on a loaded runner and the wait is theatre;
     /// above ~50ms it is a visible stall after the user already has their output,
     /// on the thread that also owes every queued sandbox rmdir.

--- a/crates/engine/src/engine/local_cache.rs
+++ b/crates/engine/src/engine/local_cache.rs
@@ -189,7 +189,7 @@ pub enum Existence {
 /// A cache-entry writer. The entry becomes durable only on [`commit`](Self::commit);
 /// dropping without commit discards everything written. This is what keeps a
 /// mid-stream failure or an abandoned attempt from ever surfacing as (or
-/// replacing!) a readable entry: the blocking pool runs jobs to completion even
+/// replacing!) a readable entry: `hcore::blocking` jobs run to completion even
 /// when their awaiting future is dropped, so "the caller stopped" must never
 /// imply "the bytes landed".
 pub trait EntryWriter: io::Write + Send {
@@ -405,8 +405,8 @@ fn artifact_is_needed(a: &ManifestArtifact, outputs: &[String], support_needed: 
 ///
 /// Same convention as `CODEC_SLOTS` (remote gzip) and `PKG_EVAL_SLOTS`
 /// (Starlark eval): a class of hundreds-of-ms jobs on the shared, arrival-fair
-/// `hcore::blocking` pool caps itself at the core count so it cannot fill every
-/// pool thread and put the sub-millisecond jobs (warm-hit manifest reads) behind
+/// `hcore::blocking` run slots caps itself at the core count so it cannot fill
+/// every slot and put the sub-millisecond jobs (warm-hit manifest reads) behind
 /// a queue of long ones. Before `cache_locally` fanned artifacts out this class
 /// was implicitly bounded at one job per running target; the fan-out multiplies
 /// that by artifacts-per-target, so the bound has to be explicit. It also caps
@@ -451,21 +451,19 @@ impl Engine {
         artifact: &outputartifact::OutputArtifact,
     ) -> anyhow::Result<(CacheArtifact, ManifestArtifact)> {
         let hashin = hashin.to_string();
-        // Waited for in async-land, before queueing — parking a pool thread to
-        // wait for a pool thread is the deadlock. The permit rides *into* the
-        // job (released on the pool thread) so a caller that stops being polled
+        // Waited for in async-land, before queueing — parking a run slot to
+        // wait for a run slot is the deadlock. The permit rides *into* the
+        // job (released as the job ends) so a caller that stops being polled
         // cannot strand it; same discipline as `PKG_EVAL_SLOTS`.
         let slot = LOCAL_PACK_SLOTS
             .acquire()
             .await
             .context("acquiring a local pack slot")?;
         // Writing a revision tars and copies every output — the heaviest
-        // synchronous work in a build, once per target. It runs on the dedicated
-        // blocking pool: not inline (that parks a runtime worker with the runtime
-        // unaware, and enough concurrent writes stop the reactor entirely) and not
-        // `spawn_blocking` (whose JoinHandle wake-up rides tokio's cross-thread
-        // waker, observed to drop wakeups on macOS under load — see
-        // the macOS waker hazard in `hproc::proc_exec`). See `hcore::blocking`.
+        // synchronous work in a build, once per target. It goes through
+        // `hcore::blocking::run`, never inline: inline parks a runtime worker
+        // with the runtime unaware, and enough concurrent writes stop the
+        // reactor entirely.
         hcore::blocking::run(enclose!((cache => local_cache, addr, artifact) move || {
             let _slot = slot;
             let open_writer =
@@ -632,8 +630,8 @@ impl Engine {
         };
 
         // All artifacts in flight at once, not one at a time: each write is a
-        // whole tar/copy on the blocking pool, so a multi-output target was
-        // paying its writes back to back while the pool sat idle. Order is
+        // whole tar/copy in a blocking job, so a multi-output target was
+        // paying its writes back to back while its run slots sat idle. Order is
         // preserved (join over an ordered iterator), so the manifest's artifact
         // list stays equal to the input order regardless of which write finishes
         // first — the manifest must not become a function of pool scheduling.
@@ -708,8 +706,8 @@ impl Engine {
     }
 
     /// [`read_manifest`](Self::read_manifest) against a cache handle rather than
-    /// `&self`, so it can be moved onto the blocking pool (which needs a `'static`
-    /// job — see [`read_manifest_blocking`](Self::read_manifest_blocking)).
+    /// `&self`, so it can be moved into a blocking job (which must be `'static`
+    /// — see [`read_manifest_blocking`](Self::read_manifest_blocking)).
     pub(crate) fn read_manifest_from(
         cache: &Arc<dyn LocalCache>,
         addr: &Addr,
@@ -819,10 +817,9 @@ impl Engine {
     /// half of a cache lookup, so its result is stashed and reused across the
     /// presence-probe and the per-caller output read (see `LockedResolution::manifest`).
     ///
-    /// On the dedicated blocking pool (see `hcore::blocking`, and
-    /// `cache_artifact_locally` for why neither inline nor `spawn_blocking` works):
-    /// this runs once per target on the hot path, and a backend read plus a borsh
-    /// parse is more than a runtime worker should disappear into.
+    /// Through `hcore::blocking::run` (see `hcore::blocking` for why not
+    /// inline): this runs once per target on the hot path, and a backend read
+    /// plus a borsh parse is more than a runtime worker should disappear into.
     pub(crate) async fn read_manifest_blocking(
         &self,
         _ctoken: &dyn Cancellable,
@@ -1576,7 +1573,7 @@ mod tests {
         assert!(rendered.contains("second"), "got: {rendered}");
     }
 
-    /// The pack cap gates the path to the blocking pool: with every slot held,
+    /// The pack cap gates the path to the blocking job: with every slot held,
     /// an artifact write must not reach the cache writer; releasing the slots
     /// lets it through. (Borrows a process-wide semaphore, so it briefly delays
     /// any concurrently-running test that writes to a cache.)

--- a/crates/engine/src/engine/local_cache_sqlite.rs
+++ b/crates/engine/src/engine/local_cache_sqlite.rs
@@ -46,7 +46,7 @@ const READ_POOL_TIMEOUT: Duration = Duration::from_secs(30);
 /// capacity and the copy gets to run.
 ///
 /// **A budget, not a proof.** The demand it covers is real threads — tokio
-/// workers, the `hcore::blocking` pool, rayon, and on Linux one FUSE session
+/// workers, `hcore::blocking` jobs, rayon, and on Linux one FUSE session
 /// thread per core, each of which takes an unpermitted connection per `read` and
 /// per `copy_up` — and under simultaneous peak load from all of them the pool can
 /// still be exhausted. Two of the callers are not brief either: `list_targets`'
@@ -94,7 +94,7 @@ impl PipeSemaphore {
     /// Blocks the calling thread until a permit is available.
     ///
     /// **Contract:** callers must be on a thread that may block — a dedicated OS
-    /// thread (the sqlite writer thread, the `hcore::blocking` pool, a rayon
+    /// thread (the sqlite writer thread, a `hcore::blocking` job, a rayon
     /// worker) or a tokio worker that has handed off its core via
     /// `tokio::task::block_in_place`. Calling this directly from a tokio task
     /// parks the worker and can starve the runtime; so does
@@ -157,11 +157,10 @@ struct SlotState {
     done: bool,
     /// Tasks awaiting this slot.
     ///
-    /// Raw wakers rather than a `tokio::sync::Notify`/`oneshot` so the slot needs
-    /// no runtime to exist: a cdylib plugin's futures are polled by host workers
-    /// with no reactor of the plugin's own, and any tokio timer/IO type there
-    /// panics across the `extern "C"` seam, which aborts. Plain waker traffic is
-    /// safe (same stance as `hcore::blocking`).
+    /// Raw wakers rather than a `tokio::sync::Notify`/`oneshot` so the slot
+    /// needs no runtime to exist: plain waker traffic works from any polling
+    /// context, costs nothing extra, and keeps this type free of assumptions
+    /// about who drives it.
     wakers: Vec<Waker>,
 }
 
@@ -187,11 +186,14 @@ impl PendingSlot {
 
     /// Suspend the calling *task* until the command lands, leaving its worker
     /// free to poll everything else.
+    ///
+    /// The wake-up is issued by the sqlite writer thread, off-runtime — plain
+    /// cross-thread waker traffic, which is trusted: the dropped-wake hazard
+    /// this wait used to insure with `hcore::blocking`'s backstop failed to
+    /// reproduce across ~40M wakes (`docs/CONCURRENCY_MEASUREMENTS.md` §2),
+    /// and the registry it armed no longer exists.
     fn wait_async(self: &Arc<Self>) -> impl Future<Output = ()> + Send + 'static {
         let slot = self.clone();
-        // Held for the whole wait and dropped with the future, so the
-        // registration never outlives what it is waking. See `hcore::blocking`.
-        let armed = hcore::blocking::Backstop::new();
         poll_fn(move |cx| {
             let mut state = slot.state.lock().expect("pending slot mutex poisoned");
             if state.done {
@@ -201,11 +203,6 @@ impl PendingSlot {
                 state.wakers.push(cx.waker().clone());
             }
             drop(state);
-            // The wake-up is issued by the sqlite writer thread, off-runtime —
-            // the same dropped-cross-thread-wake-up exposure `hcore::blocking`
-            // documents, so the same backstop. A lost wake costs latency instead
-            // of stranding the task.
-            armed.arm(cx.waker());
             Poll::Pending
         })
     }

--- a/crates/engine/src/engine/remote_cache.rs
+++ b/crates/engine/src/engine/remote_cache.rs
@@ -156,8 +156,8 @@ static CODEC_SLOTS: LazyLock<Semaphore> = LazyLock::new(|| {
     )
 });
 
-/// Run the synchronous codec step (gzip/gunzip plus local-cache reads/writes) on
-/// the dedicated blocking pool, bounded by [`CODEC_SLOTS`].
+/// Run the synchronous codec step (gzip/gunzip plus local-cache reads/writes)
+/// through `hcore::blocking::run`, bounded by [`CODEC_SLOTS`].
 ///
 /// It must **not** run on a runtime worker. Compressing or decompressing a
 /// revision takes hundreds of milliseconds to seconds of straight CPU; with
@@ -167,9 +167,8 @@ static CODEC_SLOTS: LazyLock<Semaphore> = LazyLock::new(|| {
 /// though no lock is actually deadlocked. (The previous `block_or_inline` did
 /// exactly that: inline on Linux, `block_in_place` on macOS.)
 ///
-/// `hcore::blocking` rather than `spawn_blocking`: the latter's `JoinHandle`
-/// wake-up rides tokio's cross-thread waker, observed to drop wake-ups on macOS
-/// under load (see `hproc::proc_exec`) — the same load this path generates.
+/// `hcore::blocking` rather than a bare `spawn_blocking` for its concurrency
+/// bound — `CODEC_SLOTS` caps this class tighter still.
 ///
 /// The closure is `Send`, but the values it builds are not required to be — the
 /// non-`Send` local-cache reader/writer is created and dropped entirely inside

--- a/crates/engine/src/engine/request_state.rs
+++ b/crates/engine/src/engine/request_state.rs
@@ -421,17 +421,16 @@ impl Drop for DeferredTrims {
             );
             return;
         };
-        // Hand back the blocking pool's backstop registrations first. Each is a
-        // `Waker` that owns whatever its task holds, and one of those tasks is
-        // this request's `mem_locked_result` cell — whose memoized value *is* the
-        // addr's riding cache read. `flush_backstop` releases them, not just
-        // wakes them, which is what unpins the guard the trims below need. See
-        // `hcore::blocking::flush_backstop`.
-        //
-        // This one is on the dropping thread, so it covers what is armed *now*;
-        // the batch flushes again on the cleaner thread, where it can also see
-        // whatever armed in between.
-        hcore::blocking::flush_backstop();
+        // The read guards the batch's trims contend with are unpinned by this
+        // request's own teardown: `deferred_trims` is the last field of
+        // `RequestStateData`, so by the time this drop runs, the request's
+        // memoizers are gone and their abort cascades are in flight — each
+        // tears down a chain whose `mem_locked_result` value *is* an addr's
+        // riding cache read. The cascade lands when the runtime processes it,
+        // which is why the batch below probes, re-probes, and retries once
+        // rather than expecting the guards to be gone already. (The blocking
+        // pool's backstop registry, which used to be flushed here because it
+        // could retain those guards past their wait's end, no longer exists.)
 
         // One job for the batch: `try_trim_after_write` is non-blocking and
         // short, and a job per target would allocate a boxed closure per
@@ -476,7 +475,6 @@ impl Drop for DeferredTrims {
                     failed = report.failed,
                     removed = report.removed,
                     bytes = report.bytes,
-                    flushed = report.flushed,
                     "deferred cache-history trims drained",
                 );
                 // Losing *every* target is not ordinary contention, it is the
@@ -488,7 +486,6 @@ impl Drop for DeferredTrims {
                 if report.batch > 0 && report.still_contended == report.batch {
                     tracing::warn!(
                         batch = report.batch,
-                        flushed = report.flushed,
                         "every deferred cache-history trim lost its lock; \
                          cache.history was not enforced by this run",
                     );
@@ -1059,12 +1056,7 @@ mod tests {
     /// The delay is widened well past the production 25ms first, so the margin is
     /// not something a loaded runner can close by accident.
     #[tokio::test]
-    #[expect(
-        clippy::await_holding_lock,
-        reason = "`backstop_exclusive()` serializes whole tests against each other, so its guard is meant to outlive the awaits below. No deadlock: nothing on the awaited path takes this mutex — `wait_drained` polls an `AtomicUsize` and sleeps, and neither the cleaner thread nor `flush_backstop` touches it; the only other holders are the three plain `#[test]` fns in `gc.rs`. And `#[tokio::test]` drives this body via `block_on` on the calling thread, so the `!Send` guard cannot migrate"
-    )]
     async fn the_exit_gate_is_held_across_the_trim_retry() -> anyhow::Result<()> {
-        let _exclusive = crate::engine::gc::backstop_exclusive();
         let (_dir, engine) = test_engine()?;
         let (bg, rs) = bg_state(&engine);
         let a = addr("t");

--- a/crates/engine/src/engine/result.rs
+++ b/crates/engine/src/engine/result.rs
@@ -10846,18 +10846,20 @@ mod tests {
     /// has been committed — and the artifacts it walks come straight from
     /// `cache_locally`, which queues them.
     ///
-    /// The content records the thread it was walked on. `hcore::blocking`'s pool
-    /// threads are the only ones named `heph-blocking-*`, so the name is the
-    /// witness. Asserted positively: `!= "tokio-runtime-worker"` would pass
-    /// vacuously, since `#[tokio::test]` runs the body on the test thread.
+    /// The content records whether it was walked inside a `blocking::run` job
+    /// (`hcore::blocking::in_blocking_job` is the witness — tokio's blocking
+    /// threads carry no distinguishing name). Asserted positively: "not on a
+    /// worker" would pass vacuously, since `#[tokio::test]` runs the body on
+    /// the test thread.
     #[tokio::test]
     async fn codegen_write_back_runs_off_the_runtime_workers() -> anyhow::Result<()> {
         use crate::engine::driver::targetdef::path;
 
-        /// A one-file tar that records the thread its walk ran on.
+        /// A one-file tar that records whether its walk ran inside a
+        /// `blocking::run` job.
         struct ThreadRecordingTar {
             bytes: Vec<u8>,
-            thread: Arc<std::sync::Mutex<Option<String>>>,
+            in_job: Arc<std::sync::Mutex<Option<bool>>>,
         }
 
         impl Content for ThreadRecordingTar {
@@ -10868,9 +10870,8 @@ mod tests {
                 &self,
             ) -> anyhow::Result<Box<dyn Iterator<Item = anyhow::Result<WalkEntry>> + '_>>
             {
-                *self.thread.lock().expect("thread slot") = std::thread::current()
-                    .name()
-                    .map(std::borrow::ToOwned::to_owned);
+                *self.in_job.lock().expect("witness slot") =
+                    Some(hcore::blocking::in_blocking_job());
                 Ok(Box::new(hcore::hartifactcontent::tar::TarWalker::new(
                     std::io::Cursor::new(self.bytes.clone()),
                 )?))
@@ -10892,7 +10893,7 @@ mod tests {
         packer.create_raw(b"generated\n".to_vec(), "gen.txt", false);
         let mut bytes = Vec::new();
         packer.pack(&mut bytes)?;
-        let thread = Arc::new(std::sync::Mutex::new(None));
+        let in_job = Arc::new(std::sync::Mutex::new(None));
 
         let def = LinkedTargetDef {
             target: Arc::new(TargetDef {
@@ -10919,7 +10920,7 @@ mod tests {
         let cached = vec![ResultArtifact {
             content: Arc::new(ThreadRecordingTar {
                 bytes,
-                thread: Arc::clone(&thread),
+                in_job: Arc::clone(&in_job),
             }),
             group: "out".to_string(),
             r#type: ManifestArtifactType::Output,
@@ -10934,12 +10935,11 @@ mod tests {
             std::fs::read_to_string(root.path().join("gen.txt"))?,
             "generated\n",
         );
-        let ran_on = thread.lock().expect("thread slot").clone();
-        assert!(
-            ran_on
-                .as_deref()
-                .is_some_and(|n| n.starts_with("heph-blocking")),
-            "the codegen write-back must run on the blocking pool, ran on {ran_on:?}"
+        let recorded = *in_job.lock().expect("witness slot");
+        assert_eq!(
+            recorded,
+            Some(true),
+            "the codegen write-back must run inside a blocking::run job (None = never walked)"
         );
         Ok(())
     }

--- a/crates/plugin-buildfile/src/pluginbuildfile/lsp/context.rs
+++ b/crates/plugin-buildfile/src/pluginbuildfile/lsp/context.rs
@@ -159,6 +159,13 @@ impl HephLspContext {
             },
             &ctoken,
         );
+        // Entered, not spawned: this runs on the LSP server's sync request
+        // thread, which has no runtime context of its own, and the provider's
+        // walk calls `hcore::blocking::run` — which requires one
+        // (`spawn_blocking` under the hood). Entering the captured server
+        // runtime satisfies it; the block_on itself parks only this thread.
+        // `listing_works_from_a_thread_with_no_ambient_runtime` pins it.
+        let _rt = self.runtime.enter();
         match futures::executor::block_on(fut) {
             Ok(iter) => iter
                 .filter_map(Result::ok)
@@ -188,6 +195,9 @@ impl HephLspContext {
             },
             &ctoken,
         );
+        // Same contract as `list_packages`: the provider may reach
+        // `hcore::blocking::run`, which needs a runtime context.
+        let _rt = self.runtime.enter();
         match futures::executor::block_on(fut) {
             Ok(iter) => iter
                 .filter_map(Result::ok)
@@ -443,7 +453,82 @@ impl LspContext for HephLspContext {
 
 #[cfg(test)]
 mod tests {
-    use super::first_build_file;
+    use super::{HephLspContext, first_build_file};
+    use hplugin::config::Options;
+    use hplugin::driver::DriverSchema;
+    use hplugin::lsp::LspEngine;
+    use hplugin::provider::{ProviderFunctionRegistry, StateSchema};
+    use std::path::{Path, PathBuf};
+    use std::sync::Arc;
+
+    /// Minimal `LspEngine` over a workspace root: enough for the listing
+    /// provider, which is all the walk path needs.
+    struct FakeEngine {
+        root: PathBuf,
+    }
+
+    impl LspEngine for FakeEngine {
+        fn root(&self) -> &Path {
+            &self.root
+        }
+        fn provider_function_registry(&self) -> Arc<ProviderFunctionRegistry> {
+            Arc::default()
+        }
+        fn driver_schema(&self, _name: &str) -> Option<DriverSchema> {
+            None
+        }
+        fn driver_names(&self) -> Vec<String> {
+            Vec::new()
+        }
+        fn provider_state_schema(&self, _name: &str) -> Option<StateSchema> {
+            None
+        }
+        fn provider_options(&self, _name: &str) -> Options {
+            Options::default()
+        }
+    }
+
+    /// The LSP's listing calls must work from its own request thread, which has
+    /// no ambient tokio runtime.
+    ///
+    /// This is the one production caller of `hcore::blocking::run` that is not
+    /// already polled with a runtime context: `starlark_lsp` dispatches
+    /// completion on a plain `std::thread`, and the package walk underneath
+    /// reaches `blocking::run`, which needs a runtime to `spawn_blocking` on.
+    /// `HephLspContext` captures the server's `Handle` at construction and
+    /// enters it around each `block_on` for exactly this reason.
+    ///
+    /// Driven from a thread spawned outside the runtime, so the context's
+    /// captured handle is the *only* runtime in reach. Remove either `enter()`
+    /// and this panics with "there is no reactor running" (mutation-verified).
+    #[test]
+    fn listing_works_from_a_thread_with_no_ambient_runtime() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let pkg = dir.path().join("mypkg");
+        std::fs::create_dir_all(&pkg).expect("mkdir pkg");
+        std::fs::write(pkg.join("BUILD"), "").expect("write BUILD");
+
+        // Built inside a runtime (as the real server does — it captures
+        // `Handle::current()`), then used from outside one.
+        let rt = tokio::runtime::Builder::new_multi_thread()
+            .worker_threads(1)
+            .enable_all()
+            .build()
+            .expect("runtime");
+        let ctx = rt.block_on(async {
+            HephLspContext::new(Arc::new(FakeEngine {
+                root: dir.path().to_path_buf(),
+            }))
+        });
+
+        let packages = std::thread::spawn(move || ctx.list_packages(""))
+            .join()
+            .expect("the listing thread must not panic for want of a runtime");
+        assert!(
+            packages.iter().any(|p| p == "mypkg"),
+            "the package walk must reach the LSP caller: {packages:?}"
+        );
+    }
 
     #[test]
     fn first_build_file_matches_literal_and_glob_patterns() {

--- a/crates/plugin-buildfile/src/pluginbuildfile/run_file.rs
+++ b/crates/plugin-buildfile/src/pluginbuildfile/run_file.rs
@@ -1048,38 +1048,43 @@ fn heph_core_module(builder: &mut GlobalsBuilder) {
 
 /// Concurrent whole-package Starlark evaluations.
 ///
-/// [`hcore::blocking`] is `2 * cores` threads behind one unbounded FIFO, shared
-/// by four classes of work with no reserve between them: sub-millisecond
-/// manifest reads, tar-and-copy into the cache, gzip (already self-capped at the
-/// core count by the remote cache's `CODEC_SLOTS`) — and this, the single
-/// heaviest synchronous unit in a build, at hundreds of milliseconds per
-/// package.
+/// [`hcore::blocking`] is `2 * cores` run slots behind one FIFO semaphore,
+/// shared by four classes of work with no reserve between them:
+/// sub-millisecond manifest reads, tar-and-copy into the cache, gzip (already
+/// self-capped at the core count by the remote cache's `CODEC_SLOTS`) — and
+/// this, the single heaviest synchronous unit in a build, at hundreds of
+/// milliseconds per package.
 ///
-/// The pool is arrival-fair and work-conserving, so an unbounded fan-out of
+/// The slots are arrival-fair and work-conserving, so an unbounded fan-out of
 /// package evaluations does not *starve* the short jobs, it puts them behind a
-/// queue of long ones. `run_pkg` is the only class that can occupy every thread
+/// queue of long ones. `run_pkg` is the only class that can occupy every slot
 /// for that long, and it was the only one not bounded.
 ///
 /// The core count, for the same reason `CODEC_SLOTS` uses it: the work is
 /// CPU-bound, so more concurrent evaluations than cores buys nothing, and half
-/// the pool stays free for the short jobs that were queueing behind them. It is
+/// the slots stay free for the short jobs that were queueing behind them. It is
 /// a cap on this class, not a reserve for the others — with gzip also at its own
-/// core-count cap, a build that peaks on both at once can still fill the pool.
-/// Guaranteeing a reserve is a change to the pool itself.
+/// core-count cap, a build that peaks on both at once can still fill the slots.
+/// Guaranteeing a reserve is a change to `hcore::blocking` itself.
 static PKG_EVAL_SLOTS: std::sync::LazyLock<tokio::sync::Semaphore> =
     std::sync::LazyLock::new(|| {
         let slots = pkg_eval_slots();
-        // `LoadRegistry`'s cross-chain claim parks a pool thread on a condvar while
-        // the claim's holder evaluates on another pool thread. That is deadlock-free
-        // only while every holder can actually be running — i.e. while the number of
-        // concurrent evaluations stays strictly below the pool size. The two
-        // constants live in different crates and nothing ties their formulas
-        // together, so enforce the invariant where the slots are minted.
+        // `LoadRegistry`'s cross-chain claim parks its blocking job on a condvar
+        // while the claim's holder evaluates inside a blocking job of its own.
+        // That is deadlock-free only while every holder can actually be running —
+        // i.e. while the number of concurrent evaluations stays strictly below
+        // `hcore::blocking`'s concurrency limit, so a claim holder can always
+        // take a run slot. (Thread supply is not the binding resource anymore —
+        // tokio's blocking pool is capped at `8 * cores + 64` — the run slots
+        // are.) The two constants live in different crates and nothing ties
+        // their formulas together, so enforce the invariant where the slots are
+        // minted.
         assert!(
-            slots < hcore::blocking::pool_size(),
-            "PKG_EVAL_SLOTS ({slots}) must stay strictly below hcore::blocking::pool_size() \
-         ({}): a LoadRegistry claim waiter parks a pool thread while its holder needs one",
-            hcore::blocking::pool_size()
+            slots < hcore::blocking::concurrency_limit(),
+            "PKG_EVAL_SLOTS ({slots}) must stay strictly below \
+         hcore::blocking::concurrency_limit() ({}): a LoadRegistry claim waiter \
+         parks its run slot while its holder needs one",
+            hcore::blocking::concurrency_limit()
         );
         tokio::sync::Semaphore::new(slots)
     });
@@ -1108,8 +1113,8 @@ impl Provider {
                 enclose!((key) move || async move {
                     // Bound the fan-out before queueing: see `PKG_EVAL_SLOTS`.
                     // Waited for here rather than inside the closure so the wait
-                    // happens in async-land, not on a pool thread — parking a
-                    // pool thread to wait for a pool thread is the deadlock.
+                    // happens in async-land, not inside a blocking job — parking
+                    // a run slot to wait for a run slot is the deadlock.
                     let slot = PKG_EVAL_SLOTS
                         .acquire()
                         .await
@@ -1124,21 +1129,19 @@ impl Provider {
                         // guard is already `'static`, and this costs nothing.
                         //
                         // It matters because a permit held across an await is
-                        // released only by a poll of this future — and callers
-                        // exist that stop polling. The discovery fan-out in
-                        // `Engine::query` buffers K of these and its consumer
-                        // parks in the `MatchShrug` arm awaiting a *different*
-                        // package's spec, which needs a permit of its own: the
-                        // holders go unpollable exactly when the consumer needs
-                        // what they hold, and the semaphore is FIFO. That walk
-                        // spawns each package as a task so the runtime keeps
-                        // polling them, which breaks the cycle — but that is the
-                        // caller's discipline, and `list` here is reachable from
-                        // arbitrary provider code. Submitted jobs run to
-                        // completion even when the receiver is gone
-                        // (`hcore::blocking::run`), so releasing on the pool
-                        // thread makes the class impossible rather than merely
-                        // unreached.
+                        // released only by a poll of this future — and plain
+                        // futures can stop being polled without being dropped
+                        // (a `buffered(K)` walk whose consumer parks, the shape
+                        // `Engine::query` used to have). Moved into the job's
+                        // closure, the permit has exactly two fates, neither of
+                        // which needs the caller polled: the job runs to
+                        // completion even when its awaiter is gone (detached,
+                        // `hcore::blocking::run`) and releases at job end, or
+                        // the closure is dropped un-run with the future and
+                        // releases then. This body is also a memoized *task*
+                        // (`pkg_cache` spawns it), so it is either polled by the
+                        // runtime or aborted-and-dropped — never parked forever
+                        // mid-await holding the permit.
                         let _slot = slot;
                         let loader =
                             BuildFileLoader::new(root, patterns, file_cache, dir_cache, registry, globals, walker, packages, loads);
@@ -2371,7 +2374,7 @@ target(
             tokio::time::timeout(std::time::Duration::from_millis(250), &mut eval)
                 .await
                 .is_err(),
-            "an evaluation must not reach the blocking pool while every slot is held",
+            "an evaluation must not reach a blocking job while every slot is held",
         );
 
         drop(held);
@@ -2382,20 +2385,21 @@ target(
         assert_eq!(result.targets.len(), 1);
     }
 
-    /// `LoadRegistry::claim` parks a pool thread on a condvar until the claim's
-    /// holder — another evaluation, on another pool thread — finishes the file.
-    /// Every holder must therefore be able to run, which requires strictly
-    /// fewer concurrent evaluations than pool threads. The formulas live in
-    /// different crates (`pkg_eval_slots` here, `pool_size` in `hcore`), so pin
-    /// the inequality; the `PKG_EVAL_SLOTS` initializer asserts it at runtime
-    /// for non-test binaries.
+    /// `LoadRegistry::claim` parks its blocking job on a condvar until the
+    /// claim's holder — another evaluation, in another blocking job — finishes
+    /// the file. Every holder must therefore be able to run, which requires
+    /// strictly fewer concurrent evaluations than `hcore::blocking` run slots.
+    /// The formulas live in different crates (`pkg_eval_slots` here,
+    /// `concurrency_limit` in `hcore`), so pin the inequality; the
+    /// `PKG_EVAL_SLOTS` initializer asserts it at runtime for non-test
+    /// binaries.
     #[test]
-    fn eval_slots_stay_strictly_below_the_blocking_pool() {
+    fn eval_slots_stay_strictly_below_the_blocking_limit() {
         assert!(
-            pkg_eval_slots() < hcore::blocking::pool_size(),
-            "pkg_eval_slots ({}) must stay strictly below hcore::blocking::pool_size ({})",
+            pkg_eval_slots() < hcore::blocking::concurrency_limit(),
+            "pkg_eval_slots ({}) must stay strictly below hcore::blocking::concurrency_limit ({})",
             pkg_eval_slots(),
-            hcore::blocking::pool_size()
+            hcore::blocking::concurrency_limit()
         );
     }
 

--- a/crates/plugin-sdk/src/serve.rs
+++ b/crates/plugin-sdk/src/serve.rs
@@ -77,25 +77,24 @@ pub fn cdylib_runtime_handle() -> tokio::runtime::Handle {
 
 /// Awaits a seam task's `JoinHandle` from the wrapper future the host polls.
 ///
-/// - **Abort-on-drop**: the host dropping the wrapper (rather than cancelling
-///   cooperatively) is the only stop signal for entry points with no
-///   `CancelRegistry` wiring (`list`, `list_packages`, `call_function`), so the
-///   spawned body is aborted when the wrapper goes away. The cooperative path
-///   (`await_with_cancel` host-side) cancels then keeps polling — it never
-///   drops, so it is unaffected.
-/// - **Backstop**: the completion wake crosses from a plugin-runtime worker to
-///   the host's waker through the stabby seam. That hazard has not been
-///   reproduced in isolation (docs/CONCURRENCY_MEASUREMENTS.md §2, lands with
-///   #298 below this PR in the stack); arming `hcore::blocking::Backstop` on
-///   every pending poll is defense-in-depth, the same treatment
-///   `hcore::blocking::run` gives its oneshot wait.
+/// **Abort-on-drop**: the host dropping the wrapper (rather than cancelling
+/// cooperatively) is the only stop signal for entry points with no
+/// `CancelRegistry` wiring (`list`, `list_packages`, `call_function`), so the
+/// spawned body is aborted when the wrapper goes away. The cooperative path
+/// (`await_with_cancel` host-side) cancels then keeps polling — it never
+/// drops, so it is unaffected.
+///
+/// The completion wake crosses from a plugin-runtime worker to the host's
+/// waker through the stabby seam — plain waker forwarding, which is trusted:
+/// the dropped-wake hazard this wrapper used to insure with
+/// `hcore::blocking::Backstop` failed to reproduce across ~40M wakes
+/// (docs/CONCURRENCY_MEASUREMENTS.md §2), and that registry no longer exists.
 ///
 /// `JoinHandle::poll` is runtime-free, so polling this from a host worker (or
 /// a plain `futures::executor::block_on`) is sound — `hook_on_events` is the
 /// in-tree precedent of a guest `JoinHandle` awaited across the seam.
 struct SeamTask<T> {
     handle: tokio::task::JoinHandle<T>,
-    backstop: hcore::blocking::Backstop,
 }
 
 impl<T> std::future::Future for SeamTask<T> {
@@ -105,14 +104,7 @@ impl<T> std::future::Future for SeamTask<T> {
         self: std::pin::Pin<&mut Self>,
         cx: &mut std::task::Context<'_>,
     ) -> std::task::Poll<Self::Output> {
-        let this = self.get_mut();
-        match std::pin::Pin::new(&mut this.handle).poll(cx) {
-            std::task::Poll::Ready(out) => std::task::Poll::Ready(out),
-            std::task::Poll::Pending => {
-                this.backstop.arm(cx.waker());
-                std::task::Poll::Pending
-            }
-        }
+        std::pin::Pin::new(&mut self.get_mut().handle).poll(cx)
     }
 }
 
@@ -151,7 +143,6 @@ where
 {
     let task = SeamTask {
         handle: hcore::hmemoizer::spawn_on_with_cycle_ctx(cdylib_runtime().handle(), fut),
-        backstop: hcore::blocking::Backstop::new(),
     };
     let plugin = Arc::clone(plugin);
     async move {

--- a/crates/plugin-stabby/src/host.rs
+++ b/crates/plugin-stabby/src/host.rs
@@ -229,17 +229,14 @@ impl SeamSpawn {
 /// (the guest abandoned the call — e.g. its own seam task was aborted) stops
 /// the spawned body instead of leaking it.
 ///
-/// The backstop is armed on every pending poll, same as the guest's
-/// `SeamTask`: this future is polled by a *guest* worker, so the completion
-/// wake (host task → guest worker) crosses the stabby waker seam. A lost wake
-/// here parks the plugin task on this JoinHandle forever — the guest-side
-/// backstop can't help, since re-polling the guest wrapper only re-polls a
-/// never-woken `JoinHandle` if the wake that was lost is this one. Same
-/// defense-in-depth as `hcore::blocking::run` (docs/CONCURRENCY_MEASUREMENTS.md
-/// §2, lands with #298 below this PR in the stack).
+/// This future is polled by a *guest* worker, so the completion wake (host
+/// task → guest worker) crosses the stabby waker seam — plain waker
+/// forwarding, which is trusted: the dropped-wake hazard this wrapper used to
+/// insure with `hcore::blocking::Backstop` failed to reproduce across ~40M
+/// wakes (docs/CONCURRENCY_MEASUREMENTS.md §2), and that registry no longer
+/// exists.
 struct HostTask<T> {
     handle: tokio::task::JoinHandle<T>,
-    backstop: hcore::blocking::Backstop,
 }
 
 impl<T> std::future::Future for HostTask<T> {
@@ -249,14 +246,7 @@ impl<T> std::future::Future for HostTask<T> {
         self: std::pin::Pin<&mut Self>,
         cx: &mut std::task::Context<'_>,
     ) -> std::task::Poll<Self::Output> {
-        let this = self.get_mut();
-        match std::pin::Pin::new(&mut this.handle).poll(cx) {
-            std::task::Poll::Ready(out) => std::task::Poll::Ready(out),
-            std::task::Poll::Pending => {
-                this.backstop.arm(cx.waker());
-                std::task::Poll::Pending
-            }
-        }
+        std::pin::Pin::new(&mut self.get_mut().handle).poll(cx)
     }
 }
 
@@ -292,7 +282,6 @@ impl SeamSpawn {
                 handle,
                 fut.instrument(self.span.clone()),
             ),
-            backstop: hcore::blocking::Backstop::new(),
         };
         match task.await {
             Ok(v) => v,


### PR DESCRIPTION
Replaces `hcore::blocking`'s hand-rolled OS-thread pool with `tokio::task::spawn_blocking`, and deletes the machinery that existed only because tokio's own path couldn't be used or trusted.

## Why now — both premises are gone

`hcore::blocking` was `2 * cores` named OS threads behind a crossbeam queue, plus a process-wide `PENDING` waker registry re-woken every 250ms by a `heph-blocking-wake` ticker thread. Two reasons justified that; neither survives:

- **No runtime context.** A cdylib plugin's futures used to be polled by host workers, where the plugin's statically-linked tokio saw no runtime at all — `spawn_blocking` there panics, and a panic crossing the `extern "C"` seam is a non-unwinding process abort. Spawn-at-the-seam (#302–#308) ended that: ABI entry-point bodies run as tasks on the cdylib's own runtime, host callback bodies as tasks on the host runtime. Callers of `run` now have a runtime context on both sides.
- **Distrusted wake-ups.** The backstop insured the result wait against tokio's cross-thread waker "dropping wake-ups on macOS under load". `docs/CONCURRENCY_MEASUREMENTS.md` (checked in) could not reproduce that across ~40M wakes on the pinned tokio, and re-measured the `block_in_place` 0.94→0.74 concurrency regression cited alongside it at parity within noise. The task-backed memoizer already trusts tokio's waker path for every build.

**Net −163 lines**, and the deletions are the point: pool threads, queue, `PENDING`, ticker, `Backstop`, `flush_backstop`, and the GC waker-release coupling.

## The GC coupling dissolves

`flush_backstop` existed because a registered `Waker` could own an `Arc<hmemoizer::Cell>` whose memoized `mem_locked_result` value *is* an addr's riding cache read — so a registration outliving its wait pinned the very guard the post-write trim needs, and the trim batch had to force the registry to let go (three flushes, one per phase). This coupling was flagged in the architecture audit as the most fragile thing in the codebase.

A `JoinHandle` await parks its waker in the task's join slot for exactly the wait's lifetime, and an abandoned request's chains are torn down by the task-backed memoizer's abort cascade, which drops the guards with them. Nothing retains a guard its owning task hasn't kept alive, so there is nothing to flush. The batch keeps its probe / re-probe / one delayed retry — the release edge is now the cascade, still asynchronous to the cleaner thread — and `TrimBatchReport::flushed` goes with the mechanism it measured.

## Sharp-edge decisions

| Edge | Decision |
|---|---|
| **No-runtime contract** | **Changed.** Every `blocking::run` call site was audited; all are post-seam paths polled with a runtime **except the buildfile LSP**, whose `starlark_lsp` request threads are plain `std::thread`s. Fixed by entering the handle the LSP context already captures. The two no-runtime tests are deleted (they pinned a retired contract) and replaced by a test driving the LSP listing from a thread with no ambient runtime. |
| **Concurrency bound** | **Preserved, not widened.** Tokio's blocking cap is `8 * cores + 64`; a `Semaphore` sized exactly like the old pool (`(cores * 2).max(4)`) sits in front. Permit acquired in async land (a waiter dropped while queueing leaves cleanly, having spawned nothing), then rides *into* the job so a detached job still counts against the bound. Right-sizing is a later, measured change. |
| **`PKG_EVAL_SLOTS`** | Invariant kept, restated against the semaphore: a `LoadRegistry` claim waiter parks its run slot while its holder needs one, so evaluations stay strictly below `concurrency_limit()`. Thread supply is no longer the binding resource; run slots are. |
| **Panics / cancellation** | Unchanged semantics. Panics stay transparent (tokio's harness is the `catch_unwind`, payload `resume_unwind`-ed on the caller). Dropping the future still *detaches* a running job — `spawn_blocking` can't be cancelled mid-run, and `JoinHandle` drop gives the same run-to-completion callers rely on to release permits moved into a job. |

## Test evidence

The old pool's threads were the only ones named `heph-blocking-*`, which five "runs off the runtime workers" tests asserted on. Tokio names all its threads alike, so they now record a thread-local `in_blocking_job()` — set only inside a `run` job, so a bare `spawn_blocking` or `tokio::fs` op reads false and can't satisfy a witness by dodging the bound.

- `cargo test --workspace --exclude bin-e2e --exclude plugingo-e2e` — green (~1900 tests)
- `plugingo-e2e` — solo-green (16 + 9 codegen serially). Under full parallel load its codegen tests ENOSPC on this host; that is the known environmental issue, and re-running them alone passes.
- `lint` — clean. `blocking::` suite 12× consecutively and the full `core` suite 4× to clear a flake (below).
- **Mutation-verified** (broken, confirmed red, reverted): lifting the semaphore overshoots the bound test; dropping the job marker fails the marker + witness tests; removing the LSP `enter()` panics with "there is no reactor running"; a non-String lost-job payload fails the lost-job test.

Two defects in the *tests* surfaced and are fixed here, both worth naming:

1. `a_job_can_run_a_nested_job` holds a run slot while acquiring a second — interleaved with a test that drains every slot, it deadlocked the whole `core` binary on the fair semaphore. It now takes the suite mutex, and the one drain-all that *parked* on the queue uses try-acquire + yield so it can never head-block a permit holder.
2. `trim_batch_recovers_a_guard_released_during_the_delay` is timed (the batch lost its last steppable hook along with the flushes), and a concurrent `lint` starved its probes so the guard was free by the first one. Margins widened 50ms/3s → 500ms/2s and re-verified under that same load.

One measured surprise, recorded in the code: **tokio 1.52 drains its blocking queue on shutdown**, so a job merely queued when a shutdown begins runs rather than being dropped. My first lost-job test assumed the opposite and failed; `run`'s non-panic `JoinError` branch is therefore the already-shut-down-runtime case, which the final test provokes deterministically.

## Review board

- **code-quality**: BLOCKED on the cross-test deadlock above (found independently) → fixed, stress-verified.
- **feature-quality**: BLOCKED on the LSP contract being untested → fixed, plus both MAJORs (lost-job branch, nested `run`) and three MINORs on permit/marker release paths.

## Bench gate pending

`heph-bench` was deliberately **not** run here — the serial bench session is coordinated separately, and a contended local run's noise floor would not be trustworthy. Performance parity for the mechanism switch was already measured in `docs/CONCURRENCY_MEASUREMENTS.md`; the Tier A/B comparison on this PR is still owed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016hThPHt4MzWRrtRazBxZ7d
