### PR TITLE
fix(plugin-buildfile): keep goto-definition alive on a broken buffer, stop flagging shadowed builtins

### DIFF
--- a/crates/plugin-buildfile/src/pluginbuildfile/lsp/context.rs
+++ b/crates/plugin-buildfile/src/pluginbuildfile/lsp/context.rs
@@ -264,9 +264,10 @@ impl LspContext for HephLspContext {
             Ok(ast) => ast,
             Err(e) => {
                 // Keep the (unparseable) buffer source so prefix-based completion
-                // and hover still work while the user is typing (`heph.` etc.).
+                // and hover still work while the user is typing (`heph.` etc.),
+                // and its `load(...)` imports so goto-definition still resolves.
                 self.shared
-                    .set_index(uri.clone(), DocIndex::source_only(content));
+                    .set_index(uri.clone(), DocIndex::unevaluated(content));
                 return LspEvalResult {
                     diagnostics: vec![eval_message_to_lsp_diagnostic(EvalMessage::from_error(
                         &path, &e,
@@ -282,9 +283,11 @@ impl LspContext for HephLspContext {
         let diagnostics = super::diagnostics::validate(&ast, &*self.shared.engine);
 
         // Best-effort evaluation to populate the provenance / driver index. A
-        // half-typed buffer that fails to evaluate simply yields no provenance —
-        // but we keep the source for prefix-based completion/hover. We do not
-        // surface eval errors as diagnostics (they would be noisy while typing).
+        // half-typed buffer (or one the engine rejects — an unknown key on a
+        // macro call fails the whole evaluation) simply yields no provenance;
+        // the source and its `load(...)` imports survive, so completion, hover
+        // and goto-definition keep working. We do not surface eval errors as
+        // diagnostics (they would be noisy while typing).
         let pkg = self.path_to_pkg(&path);
         let source = content.clone();
         if let Ok(result) = eval_source(&filename, content, &pkg, &self.loader()) {
@@ -292,7 +295,7 @@ impl LspContext for HephLspContext {
                 .set_index(uri.clone(), DocIndex::build(&result, &pkg, source));
         } else {
             self.shared
-                .set_index(uri.clone(), DocIndex::source_only(source));
+                .set_index(uri.clone(), DocIndex::unevaluated(source));
         }
 
         LspEvalResult {
@@ -453,7 +456,7 @@ impl LspContext for HephLspContext {
 
 #[cfg(test)]
 mod tests {
-    use super::{HephLspContext, first_build_file};
+    use super::{HephLspContext, LspContext as _, first_build_file};
     use hplugin::config::Options;
     use hplugin::driver::DriverSchema;
     use hplugin::lsp::LspEngine;
@@ -527,6 +530,50 @@ mod tests {
         assert!(
             packages.iter().any(|p| p == "mypkg"),
             "the package walk must reach the LSP caller: {packages:?}"
+        );
+    }
+
+    /// Goto-definition must survive a buffer the engine refuses to evaluate.
+    ///
+    /// An unknown key on a macro call is an eval error, and the index built from
+    /// a failed eval carries no provenance — but the `load(...)` imports that
+    /// drive cross-file goto-definition are read from the source text, so they
+    /// must still be there. Losing the jump exactly while the user is fixing the
+    /// error is the worst moment to lose it.
+    #[test]
+    fn loaded_symbols_survive_a_buffer_that_fails_to_evaluate() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let rt = tokio::runtime::Builder::new_multi_thread()
+            .worker_threads(1)
+            .enable_all()
+            .build()
+            .expect("runtime");
+        let ctx = rt.block_on(async {
+            HephLspContext::new(Arc::new(FakeEngine {
+                root: dir.path().to_path_buf(),
+            }))
+        });
+
+        // `//lib` does not exist, so the load fails and the whole evaluation
+        // with it — the same shape as any other error in the file.
+        let content = "load(\"//lib\", \"make_name\")\n\ntarget(name = make_name(\"t\"))\n";
+        let uri = super::LspUri::File(dir.path().join("BUILD"));
+        let result = ctx.parse_file_with_contents(&uri, content.to_string());
+        assert!(
+            result.ast.is_some(),
+            "the buffer parses; only evaluation fails"
+        );
+
+        let index = ctx.shared.index(&uri).expect("index");
+        assert!(
+            index.call_targets.is_empty(),
+            "a failed eval yields no provenance"
+        );
+        // Line 1, over the `make_name` inside the load statement.
+        assert_eq!(
+            index.loaded_symbol_at(1, 18),
+            Some(("//lib", "make_name")),
+            "the loaded symbol must still resolve for goto-definition"
         );
     }
 

--- a/crates/plugin-buildfile/src/pluginbuildfile/lsp/diagnostics.rs
+++ b/crates/plugin-buildfile/src/pluginbuildfile/lsp/diagnostics.rs
@@ -22,6 +22,13 @@
 //!   underline. Suppressed entirely when the call includes a `*args`/`**kwargs`
 //!   splat — it could supply any key at runtime, so a "missing" field isn't
 //!   necessarily missing.
+//!
+//! All three apply only to heph's *builtins*. A buffer that binds `target` or
+//! `provider_state` itself — a `def`, an assignment, a `load(...)` import — is
+//! calling its own function, whose signature is nothing the engine knows: a
+//! `def target(name, **kwargs)` macro legitimately takes any key. Checking such
+//! a call against the builtin's schema would underline valid code, so a
+//! shadowed name is skipped entirely.
 
 use crate::pluginbuildfile::run_file::target_base_fields;
 use hcore::htvalue::Value;
@@ -30,8 +37,10 @@ use hplugin::lsp::LspEngine;
 use lsp_types::{Diagnostic, DiagnosticSeverity, Range};
 use starlark::codemap::Span;
 use starlark::syntax::AstModule;
-use starlark::syntax::ast::{Argument, AstArgument, AstExpr, AstLiteral, Expr};
-use std::collections::HashMap;
+use starlark::syntax::ast::{
+    Argument, AssignTarget, AstArgument, AstAssignTarget, AstExpr, AstLiteral, AstStmt, Expr, Stmt,
+};
+use std::collections::{HashMap, HashSet};
 
 /// Which recognized builtin a call site is.
 enum Callee {
@@ -43,6 +52,7 @@ enum Callee {
 /// diagnostic per invalid keyword argument (unknown key or type mismatch).
 pub(crate) fn validate(ast: &AstModule, engine: &dyn LspEngine) -> Vec<Diagnostic> {
     let mut out = Vec::new();
+    let shadowed = bound_names(ast);
     // `Stmt::visit_expr` yields each top-level expression across all nested
     // statements; `walk_expr` then descends into sub-expressions, so nested calls
     // (e.g. inside a list or another call) are covered too.
@@ -51,7 +61,13 @@ pub(crate) fn validate(ast: &AstModule, engine: &dyn LspEngine) -> Vec<Diagnosti
             if let Expr::Call(callee_expr, args) = &e.node
                 && let Expr::Identifier(id) = &callee_expr.node
             {
-                let callee = match id.node.ident.as_str() {
+                let name = id.node.ident.as_str();
+                // The buffer's own `target`/`provider_state`, not heph's — its
+                // signature is unknown here, so there is nothing to check against.
+                if shadowed.contains(name) {
+                    return;
+                }
+                let callee = match name {
                     "target" => Callee::Target,
                     "provider_state" => Callee::ProviderState,
                     _ => return,
@@ -68,6 +84,61 @@ fn walk_expr<'a>(e: &'a AstExpr, f: &mut impl FnMut(&'a AstExpr)) {
     f(e);
     // `Expr::visit_expr` is one level deep; recurse to reach the whole subtree.
     e.visit_expr(|child| walk_expr(child, f));
+}
+
+/// Visit `s` and every statement nested within it.
+fn walk_stmt<'a>(s: &'a AstStmt, f: &mut impl FnMut(&'a AstStmt)) {
+    f(s);
+    // `Stmt::visit_stmt` is one level deep; recurse to reach the whole subtree.
+    s.visit_stmt(|child| walk_stmt(child, f));
+}
+
+/// Every name the module binds: `def`s and their parameters, assignment and loop
+/// targets, and `load(...)` imports.
+///
+/// Deliberately flat — a name bound anywhere counts as bound everywhere, with no
+/// scope tracking. Over-approximating errs toward silence, which is this
+/// module's rule for anything it cannot resolve exactly, and the alternative
+/// (a real scope analysis) would buy nothing: a buffer that defines its own
+/// `target` almost certainly means it at every call site.
+fn bound_names(ast: &AstModule) -> HashSet<&str> {
+    let mut names = HashSet::new();
+    walk_stmt(ast.statement(), &mut |s| match &s.node {
+        Stmt::Def(def) => {
+            names.insert(def.name.node.ident.as_str());
+            names.extend(
+                def.params
+                    .iter()
+                    .filter_map(|p| p.ident())
+                    .map(|i| i.node.ident.as_str()),
+            );
+        }
+        Stmt::Load(load) => {
+            names.extend(load.args.iter().map(|a| a.local.node.ident.as_str()));
+        }
+        Stmt::Assign(assign) => collect_assign_target(&assign.lhs, &mut names),
+        Stmt::AssignModify(target, _, _) => collect_assign_target(target, &mut names),
+        Stmt::For(for_stmt) => collect_assign_target(&for_stmt.var, &mut names),
+        _ => {}
+    });
+    names
+}
+
+/// Add the identifiers an assignment or loop target binds (`a`, `a, b`, `[a, b]`).
+/// Index and attribute targets (`a[0] = …`, `a.b = …`) mutate an existing
+/// binding rather than introducing one, so they bind nothing.
+fn collect_assign_target<'a>(target: &'a AstAssignTarget, names: &mut HashSet<&'a str>) {
+    match &target.node {
+        AssignTarget::Identifier(id) => {
+            names.insert(id.node.ident.as_str());
+        }
+        AssignTarget::Tuple(items) => {
+            for item in items {
+                collect_assign_target(item, names);
+            }
+        }
+        AssignTarget::Index(_) | AssignTarget::Dot(_, _) => {}
+    }
 }
 
 fn check_call(
@@ -150,7 +221,7 @@ fn check_call(
         }
     }
 
-    let mut provided: std::collections::HashSet<&str> = std::collections::HashSet::new();
+    let mut provided: HashSet<&str> = HashSet::new();
     // A `*args`/`**kwargs` splat could supply any key at runtime, so a missing
     // key isn't necessarily missing — stay silent rather than risk a false
     // positive.
@@ -194,7 +265,7 @@ fn check_call(
         // A schema field can share a name with a base field (unusual, but not
         // forbidden); on collision the base field wins, mirroring the
         // first-match `.find()` lookup used for type-checking above.
-        let mut seen: std::collections::HashSet<&str> = std::collections::HashSet::new();
+        let mut seen: HashSet<&str> = HashSet::new();
         for (i, (name, _, required)) in known.iter().enumerate() {
             if !seen.insert(name.as_str()) {
                 continue;
@@ -662,5 +733,116 @@ mod tests {
             msgs.iter().any(|m| m.contains("`labels` expects")),
             "expected labels type mismatch, got {msgs:?}"
         );
+    }
+
+    /// A call that the builtin checks would flag twice — `bogus` is no field of
+    /// `target` or the `exec` driver, and the driver's required `cmd` is absent.
+    /// Shared by the shadowing tests so each one is provably non-vacuous: with
+    /// no shadowing binding it produces both diagnostics
+    /// (`an_unrelated_binding_does_not_suppress_validation`).
+    const FLAGGED_TARGET_CALL: &str = "target(name = \"t\", driver = \"exec\", bogus = 1)\n";
+
+    #[test]
+    fn locally_defined_target_macro_is_not_validated() {
+        // The buffer defines its own `target`, taking `**kwargs`: `bogus` is a
+        // legitimate key there and `cmd` is no requirement of it. Checking the
+        // call against the builtin's schema would underline working code.
+        let msgs = messages(&format!(
+            "def target(name, **kwargs):\n    pass\n\n{FLAGGED_TARGET_CALL}"
+        ));
+        assert!(
+            msgs.is_empty(),
+            "a locally-defined `target` is not the builtin, got {msgs:?}"
+        );
+    }
+
+    #[test]
+    fn loaded_target_macro_is_not_validated() {
+        // Same, via `load(...)` — including the aliased form, where the local
+        // name is what the call site uses.
+        let msgs = messages(&format!(
+            "load(\"//lib\", \"target\")\n\n{FLAGGED_TARGET_CALL}"
+        ));
+        assert!(
+            msgs.is_empty(),
+            "a loaded `target` is not the builtin, got {msgs:?}"
+        );
+
+        let msgs = messages(&format!(
+            "load(\"//lib\", target = \"my_target\")\n\n{FLAGGED_TARGET_CALL}"
+        ));
+        assert!(
+            msgs.is_empty(),
+            "an aliased loaded `target` is not the builtin, got {msgs:?}"
+        );
+    }
+
+    #[test]
+    fn assigned_provider_state_is_not_validated() {
+        // A plain rebinding shadows the builtin just as a `def` does. Without
+        // the binding this reports the builtin's missing required `provider`
+        // (`provider_state_missing_provider_is_flagged`).
+        let msgs = messages("provider_state = my_fn\n\nprovider_state(bogus = 1)\n");
+        assert!(
+            msgs.is_empty(),
+            "a rebound `provider_state` is not the builtin, got {msgs:?}"
+        );
+    }
+
+    #[test]
+    fn an_unrelated_binding_does_not_suppress_validation() {
+        // Shadowing is per-name: binding `foo` must not silence `target`. Also
+        // pins that the shadowing tests above are not vacuous — the very same
+        // call is flagged here.
+        let msgs = messages(&format!(
+            "def foo(a, **kwargs):\n    pass\n\n{FLAGGED_TARGET_CALL}"
+        ));
+        assert!(
+            msgs.iter().any(|m| m.contains("unknown field `bogus`")),
+            "unrelated bindings must not disable the unknown-key check, got {msgs:?}"
+        );
+        assert!(
+            msgs.iter()
+                .any(|m| m.contains("missing required field `cmd`")),
+            "unrelated bindings must not disable the missing-required check, got {msgs:?}"
+        );
+    }
+
+    #[test]
+    fn bound_names_collects_every_binding_form() {
+        let content = "\
+load(\"//lib\", \"imported\", alias = \"exported\")
+assigned = 1
+tuple_a, tuple_b = 1, 2
+augmented = 0
+augmented += 1
+for loop_var in [1]:
+    pass
+
+def fn_name(param, *args_param, **kwargs_param):
+    pass
+";
+        let ast = AstModule::parse("BUILD", content.to_string(), &Dialect::Extended).unwrap();
+        let names = super::bound_names(&ast);
+        for expected in [
+            "imported",
+            "alias",
+            "assigned",
+            "tuple_a",
+            "tuple_b",
+            "augmented",
+            "loop_var",
+            "fn_name",
+            "param",
+            "args_param",
+            "kwargs_param",
+        ] {
+            assert!(
+                names.contains(expected),
+                "missing binding {expected}: {names:?}"
+            );
+        }
+        // `exported` is the name in the *other* module, not a local binding.
+        assert!(!names.contains("exported"), "load alias source: {names:?}");
     }
 }

--- a/crates/plugin-buildfile/src/pluginbuildfile/lsp/index.rs
+++ b/crates/plugin-buildfile/src/pluginbuildfile/lsp/index.rs
@@ -69,11 +69,19 @@ pub(crate) struct DocIndex {
 }
 
 impl DocIndex {
-    /// An index carrying only the buffer text, no provenance. Used when the
-    /// buffer doesn't parse/evaluate (the user is mid-edit, e.g. just typed
-    /// `heph.`) so prefix-based completion/hover still has the current source.
-    pub(crate) fn source_only(source: String) -> DocIndex {
+    /// An index for a buffer that didn't parse or evaluate — the user is
+    /// mid-edit, or the file has an error the engine rejects. Carries the
+    /// buffer text (so prefix-based completion/hover still see the current
+    /// source) and the `load(...)` imports, which are read textually and so
+    /// cost nothing an evaluation would have paid for.
+    ///
+    /// Keeping `loaded` here is what makes cross-file goto-definition survive a
+    /// broken buffer: an unknown key on a macro call fails the whole
+    /// evaluation, and a jump-to-definition that stops working exactly when the
+    /// user is trying to fix the file is the worst moment to lose it.
+    pub(crate) fn unevaluated(source: String) -> DocIndex {
         DocIndex {
+            loaded: parse_load_symbols(&source),
             source,
             ..DocIndex::default()
         }
@@ -393,6 +401,19 @@ load("//other", "x")
             Some(&("//lib".to_string(), "GREETING".to_string()))
         );
         assert_eq!(m.get("x"), Some(&("//other".to_string(), "x".to_string())));
+    }
+
+    #[test]
+    fn unevaluated_index_still_resolves_loaded_symbols() {
+        // No evaluation happened, so there is no provenance — but the load
+        // imports are textual, and goto-definition depends on them.
+        let index = DocIndex::unevaluated(
+            "load(\"//lib\", \"make_name\")\ntarget(name = make_name(\"t\"))\n".to_string(),
+        );
+        assert!(index.call_targets.is_empty());
+        assert_eq!(index.loaded_symbol_at(1, 18), Some(("//lib", "make_name")));
+        // The usage on line 2 resolves to the same import.
+        assert_eq!(index.loaded_symbol_at(2, 16), Some(("//lib", "make_name")));
     }
 
     #[test]

--- a/crates/plugin-buildfile/src/pluginbuildfile/lsp/proxy.rs
+++ b/crates/plugin-buildfile/src/pluginbuildfile/lsp/proxy.rs
@@ -1275,11 +1275,11 @@ mod tests {
             )),
             Arc::default(),
         );
-        // Mirror context.rs: a buffer that fails to eval falls back to a
-        // source-only index (the realistic mid-edit case).
+        // Mirror context.rs: a buffer that fails to eval falls back to an
+        // unevaluated index (the realistic mid-edit case).
         let index = match eval_source("BUILD", content.to_string(), "pkg", &loader) {
             Ok(result) => super::super::index::DocIndex::build(&result, "pkg", content.to_string()),
-            Err(_) => super::super::index::DocIndex::source_only(content.to_string()),
+            Err(_) => super::super::index::DocIndex::unevaluated(content.to_string()),
         };
         let doc_globals =
             crate::pluginbuildfile::run_file::build_globals(&registry).documentation();


### PR DESCRIPTION
Two LSP problems on BUILD files that don't cleanly evaluate.

### Goto-definition died with the evaluation

An unknown key on a macro call fails the whole BUILD evaluation. The index we build from a failed eval carried nothing but the source text, so `loaded` was empty — and cross-file goto-definition, which resolves a `load`ed symbol across every BUILD file in its package, stopped resolving exactly while the user was fixing the error.

Those load imports are read textually from the buffer, not from the evaluation, so they cost nothing an eval would have paid for and there was no reason to drop them. `DocIndex::source_only` becomes `DocIndex::unevaluated` and parses them the same way `DocIndex::build` already did. Same for the parse-error path, which used the same constructor.

### Unknown-key squiggles on the user's own `target`

`validate` matched `target` / `provider_state` by name alone. A buffer that binds those names itself — a `def target(name, **kwargs)` macro, a plain assignment, a `load(...)` import — had each call measured against heph's builtin schema:

```python
def target(name, **kwargs):
    ...

target(name = "t", driver = "exec", bogus = 1)
#                                   ^^^^^ "unknown field `bogus` for `target` or the `exec` driver"
#      ^ and "missing required field `cmd` for the `exec` driver"
```

Both are wrong: `bogus` is a key the macro takes through `**kwargs`, and `cmd` is no requirement of it. A shadowed name is now skipped entirely — its signature is nothing the engine knows, which is the same rule the module already applies to an unresolved driver.

Binding collection (`bound_names`) covers `def`s and their parameters, assignment and loop targets, and load imports. It is deliberately flat, with no scope tracking: over-approximating errs toward silence, and a buffer that defines its own `target` means it at every call site.

### Tests

Five new, each mutation-verified to fail with its fix reverted:

- `loaded_symbols_survive_a_buffer_that_fails_to_evaluate` (context) — the contract end to end: a buffer that parses but fails to eval still resolves its loaded symbol.
- `unevaluated_index_still_resolves_loaded_symbols` (index)
- `locally_defined_target_macro_is_not_validated`, `loaded_target_macro_is_not_validated`, `assigned_provider_state_is_not_validated` (diagnostics) — all reusing one call shape that `an_unrelated_binding_does_not_suppress_validation` proves is flagged without a shadowing binding, so none of them can pass vacuously.
- `bound_names_collects_every_binding_form` pins the binding forms.

`lint` clean; `cargo test -p plugin-buildfile --lib lsp::` green (59).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MW1UarZmkF5NdVDnu8vsa4