### PR TITLE
feat(plugin-buildfile): narrow the target/provider_state hover to the driver it selects

### DIFF
--- a/crates/plugin-buildfile/src/pluginbuildfile/lsp/context.rs
+++ b/crates/plugin-buildfile/src/pluginbuildfile/lsp/context.rs
@@ -62,7 +62,7 @@ impl HephLspContext {
         let registry = engine.provider_function_registry();
         let doc_globals = build_globals(&registry).documentation();
         let core_members = crate::pluginbuildfile::run_file::heph_core_members(&doc_globals);
-        let builtin_hovers = crate::pluginbuildfile::run_file::builtin_call_hovers(&doc_globals);
+        let builtin_hovers = crate::pluginbuildfile::run_file::BuiltinHovers::new(&doc_globals);
         let patterns = buildfile_patterns(&*engine);
         let runtime = tokio::runtime::Handle::current();
         let provider = build_listing_provider(&root, &patterns, &registry, runtime.clone());

--- a/crates/plugin-buildfile/src/pluginbuildfile/lsp/index.rs
+++ b/crates/plugin-buildfile/src/pluginbuildfile/lsp/index.rs
@@ -277,9 +277,11 @@ pub(crate) struct SharedState {
     /// The `heph.core` builtin functions, for member completion/hover of that
     /// static namespace (which isn't in the provider-function registry).
     pub core_members: Vec<crate::pluginbuildfile::run_file::CoreMember>,
-    /// Rendered hover markdown for the `target` / `provider_state` builtins, keyed
-    /// by name — the stock server only knows their raw `*args, **kwargs` prototype.
-    pub builtin_hovers: HashMap<String, String>,
+    /// Renders hover markdown for the `target` / `provider_state` builtins — the
+    /// stock server only knows their raw `*args, **kwargs` prototype. Rendered
+    /// per hover so the prototype can narrow to the driver/provider the call
+    /// site names.
+    pub builtin_hovers: crate::pluginbuildfile::run_file::BuiltinHovers,
     docs: Mutex<HashMap<LspUri, DocIndex>>,
 }
 
@@ -289,7 +291,7 @@ impl SharedState {
         root: std::path::PathBuf,
         patterns: Vec<glob::Pattern>,
         core_members: Vec<crate::pluginbuildfile::run_file::CoreMember>,
-        builtin_hovers: HashMap<String, String>,
+        builtin_hovers: crate::pluginbuildfile::run_file::BuiltinHovers,
     ) -> Arc<SharedState> {
         Arc::new(SharedState {
             engine,

--- a/crates/plugin-buildfile/src/pluginbuildfile/lsp/proxy.rs
+++ b/crates/plugin-buildfile/src/pluginbuildfile/lsp/proxy.rs
@@ -394,13 +394,11 @@ fn enrich_hover(
         // the stock server has no docs for these dynamic kwargs, so render the
         // schema field's type + doc ourselves.
         md = field_md;
-    } else if let Some(builtin_md) =
-        builtin_call_name_at(&index.source, byte_offset(&index.source, line, col))
-            .and_then(|name| shared.builtin_hovers.get(name))
-    {
+    } else if let Some(builtin_md) = builtin_call_hover(&index.source, line, col, shared) {
         // The `target` / `provider_state` callee name: both take a raw `*args,
-        // **kwargs`, so the stock hover is meaningless — render the real signature.
-        md = builtin_md.clone();
+        // **kwargs`, so the stock hover is meaningless — render the real
+        // signature, narrowed to the driver/provider this call selects.
+        md = builtin_md;
     } else if md.is_empty()
         && let Some(doc) = index.def_hover_at(line + 1, col + 1)
     {
@@ -411,9 +409,6 @@ fn enrich_hover(
 
     // Append the targets this call site produced, if any.
     let targets = index.targets_at(line + 1, col + 1).unwrap_or(&[]);
-    if md.is_empty() && targets.is_empty() {
-        return;
-    }
     if !targets.is_empty() {
         if !md.is_empty() {
             md.push_str("\n\n---\n\n");
@@ -426,14 +421,18 @@ fn enrich_hover(
         md.push_str("```\n");
     }
 
-    // Once the target has been provided (its addresses resolved above) and the
-    // call site names a driver, append that driver's config-field docs — the
-    // same detail/doc a completion item for these keys would show. Without
-    // this, hovering a target only ever explained the base `target(...)`
-    // signature, never the driver-specific keys actually in play.
-    if !targets.is_empty()
-        && let Some(driver) = target_driver_at(&index.source, byte_offset(&index.source, line, col))
-            .filter(|d| !d.is_empty())
+    // Hovering *inside* a `target(...)` whose driver resolves: append that
+    // driver's config-field docs — the same detail/doc a completion item for
+    // these keys would show. Hovering the callee token instead gets the whole
+    // signature narrowed to the driver (see `builtin_call_hover`), which is
+    // strictly better; this covers every other position in the call.
+    //
+    // The driver is resolved textually, like the matching completion, so this
+    // holds on a buffer that doesn't evaluate. Gating it on the call having
+    // produced targets would have meant the keys disappear the moment a typo
+    // breaks the file — exactly when they're being looked up.
+    if let Some(driver) = target_driver_at(&index.source, byte_offset(&index.source, line, col))
+        .filter(|d| !d.is_empty())
         && let Some(schema) = shared.engine.driver_schema(&driver)
         && !schema.fields.is_empty()
     {
@@ -448,6 +447,12 @@ fn enrich_hover(
         }
     }
 
+    // Nothing to say — leave the stock response alone rather than replacing it
+    // with an empty hover.
+    if md.is_empty() {
+        return;
+    }
+
     let hover = Hover {
         contents: HoverContents::Markup(MarkupContent {
             kind: MarkupKind::Markdown,
@@ -457,6 +462,46 @@ fn enrich_hover(
     };
     resp.result = Some(serde_json::to_value(hover).expect("serialize hover"));
     resp.error = None;
+}
+
+/// Hover markdown for the `target` / `provider_state` callee token under the
+/// cursor, or `None` when the cursor isn't on one.
+///
+/// The signature is narrowed to the call's own `driver = "…"` / `provider = "…"`
+/// whenever that name resolves to a schema, so the hover documents the keys this
+/// target actually accepts instead of a `**config` catch-all. The lookup is
+/// textual, like the matching completion and diagnostics, so it holds up on a
+/// buffer that doesn't evaluate.
+fn builtin_call_hover(source: &str, line: u32, col: u32, shared: &SharedState) -> Option<String> {
+    let offset = byte_offset(source, line, col);
+    let (name, open) = builtin_call_open_at(source, offset)?;
+    // The call's own argument list, not an enclosing one: the cursor is on the
+    // callee token, which sits *before* this call's `(`.
+    let args = call_args_from_open(source, open);
+    let selected = |key: &str| {
+        args.and_then(|a| kwarg_string(a, key))
+            .filter(|v| !v.is_empty())
+    };
+    Some(match name {
+        "provider_state" => {
+            let provider = selected("provider");
+            let schema = provider
+                .as_deref()
+                .and_then(|p| shared.engine.provider_state_schema(p).map(|s| (p, s)));
+            shared
+                .builtin_hovers
+                .provider_state(schema.as_ref().map(|(p, s)| (*p, s)))
+        }
+        _ => {
+            let driver = selected("driver");
+            let schema = driver
+                .as_deref()
+                .and_then(|d| shared.engine.driver_schema(d).map(|s| (d, s)));
+            shared
+                .builtin_hovers
+                .target(schema.as_ref().map(|(d, s)| (*d, s)))
+        }
+    })
 }
 
 /// Hover markdown for a provider-function reference under the cursor, or `None`
@@ -880,7 +925,14 @@ fn target_driver_at(source: &str, offset: usize) -> Option<String> {
 /// and nested calls are skipped so parens/quotes inside them don't confuse the
 /// scan.
 fn enclosing_call_args<'a>(name: &str, source: &'a str, offset: usize) -> Option<&'a str> {
-    let open = innermost_call_open(name, source, offset)?;
+    call_args_from_open(source, innermost_call_open(name, source, offset)?)
+}
+
+/// The argument list of the call whose `(` is at byte `open` — the text up to its
+/// matching `)`, or to the end of the source when that `)` hasn't been typed yet.
+/// String literals and nested calls are skipped so parens and quotes inside them
+/// don't confuse the scan.
+fn call_args_from_open(source: &str, open: usize) -> Option<&str> {
     let region_start = open + 1;
     let b = source.as_bytes();
     let mut depth = 0i32;
@@ -1033,10 +1085,13 @@ fn word_at_offset(source: &str, offset: usize) -> Option<&str> {
 }
 
 /// If the identifier covering `offset` is the callee name of a recognized builtin
-/// call — `target(` or `provider_state(` — return that name; `None` otherwise. The
-/// identifier must be immediately followed (modulo whitespace) by `(`, so a bare
-/// `target` used as a value isn't mistaken for the call. Purely textual.
-fn builtin_call_name_at(source: &str, offset: usize) -> Option<&str> {
+/// call — `target(` or `provider_state(` — return that name and the byte offset of
+/// the `(` that opens the call, so the caller can read the call's own arguments
+/// (which lie *after* the callee token the cursor is on). `None` otherwise.
+///
+/// The identifier must be immediately followed (modulo whitespace) by `(`, so a
+/// bare `target` used as a value isn't mistaken for the call. Purely textual.
+fn builtin_call_open_at(source: &str, offset: usize) -> Option<(&str, usize)> {
     let b = source.as_bytes();
     let is_ident = |c: u8| c.is_ascii_alphanumeric() || c == b'_';
     let offset = offset.min(b.len());
@@ -1061,7 +1116,7 @@ fn builtin_call_name_at(source: &str, offset: usize) -> Option<&str> {
     while b.get(k).copied().is_some_and(|c| c.is_ascii_whitespace()) {
         k += 1;
     }
-    (b.get(k) == Some(&b'(')).then_some(word)
+    (b.get(k) == Some(&b'(')).then_some((word, k))
 }
 
 fn field_item(name: &str, ty: &str, doc: String, ctx: &str, required: bool) -> CompletionItem {
@@ -1188,7 +1243,7 @@ fn enrich_completion(
 
 #[cfg(test)]
 mod tests {
-    use super::{builtin_call_name_at, find_symbol_def, pkg_of, result_points_to_other_file};
+    use super::{builtin_call_open_at, find_symbol_def, pkg_of, result_points_to_other_file};
     use std::path::Path;
 
     struct FakeEngine {
@@ -1283,7 +1338,7 @@ mod tests {
         };
         let doc_globals =
             crate::pluginbuildfile::run_file::build_globals(&registry).documentation();
-        let builtin_hovers = crate::pluginbuildfile::run_file::builtin_call_hovers(&doc_globals);
+        let builtin_hovers = crate::pluginbuildfile::run_file::BuiltinHovers::new(&doc_globals);
         let engine = Arc::new(FakeEngine {
             root: tmp.path().to_path_buf(),
             registry,
@@ -1473,8 +1528,9 @@ mod tests {
     #[test]
     fn hover_on_provider_state_callee_renders_signature() {
         // Hovering the `provider_state` name (not a field) shows the real
-        // signature, not the stock `def provider_state(*args, **kwargs)`.
-        let content = "provider_state(provider = \"go\")\n";
+        // signature, not the stock `def provider_state(*args, **kwargs)`. The
+        // provider doesn't resolve here, so the `**state` catch-all stands.
+        let content = "provider_state(provider = \"nope\")\n";
         let (shared, uri) = shared_with_index(content);
         // Cursor on the `provider_state` callee (0-based col 3).
         let md = hover_value(&shared, &uri, 0, 3).expect("hover");
@@ -1484,14 +1540,69 @@ mod tests {
     }
 
     #[test]
+    fn hover_on_provider_state_callee_narrows_to_the_selected_provider() {
+        let content = "provider_state(provider = \"go\")\n";
+        let (shared, uri) = shared_with_index(content);
+        let md = hover_value(&shared, &uri, 0, 3).expect("hover");
+        assert!(!md.contains("**state"), "catch-all replaced: {md}");
+        assert!(md.contains("go_codegen_root"), "names the field: {md}");
+        assert!(
+            md.contains("Mark this package as a Go codegen root."),
+            "shows the field doc: {md}"
+        );
+        assert!(md.contains("`go` provider"), "attributes the fields: {md}");
+    }
+
+    #[test]
     fn hover_on_target_callee_renders_signature() {
-        let content = "target(name = \"t\", driver = \"exec\")\n";
+        // No driver named, so nothing can narrow the config keys: the catch-all
+        // stands and the base args are all the hover can promise.
+        let content = "target(name = \"t\")\n";
         let (shared, uri) = shared_with_index(content);
         // Cursor on the `target` callee (0-based col 2).
         let md = hover_value(&shared, &uri, 0, 2).expect("hover");
         assert!(md.contains("name"), "names base arg: {md}");
         assert!(md.contains("**config"), "shows config kwargs: {md}");
         assert!(!md.contains("**kwargs"), "not the raw prototype: {md}");
+    }
+
+    #[test]
+    fn hover_on_target_callee_narrows_to_the_selected_driver() {
+        // The whole point: with `driver = "exec"` on the call, hovering `target`
+        // documents `exec`'s keys instead of an opaque `**config`.
+        let content = "target(name = \"t\", driver = \"exec\")\n";
+        let (shared, uri) = shared_with_index(content);
+        let md = hover_value(&shared, &uri, 0, 2).expect("hover");
+        assert!(!md.contains("**config"), "catch-all replaced: {md}");
+        assert!(md.contains("cmd"), "names the driver field: {md}");
+        assert!(
+            md.contains("Command line to run."),
+            "shows the field doc: {md}"
+        );
+        assert!(md.contains("`exec` driver"), "attributes the fields: {md}");
+        assert!(md.contains("name"), "keeps the base args: {md}");
+    }
+
+    #[test]
+    fn hover_on_target_callee_narrows_on_a_buffer_that_does_not_evaluate() {
+        // The driver is read textually, so the narrowed hover survives a buffer
+        // the engine would reject — which is when the reader needs it most.
+        let content = "target(name = \"t\", driver = \"exec\", bogus = undefined_symbol)\n";
+        let (shared, uri) = shared_with_index(content);
+        let md = hover_value(&shared, &uri, 0, 2).expect("hover");
+        assert!(md.contains("cmd"), "names the driver field: {md}");
+        assert!(md.contains("`exec` driver"), "attributes the fields: {md}");
+    }
+
+    #[test]
+    fn hover_on_target_callee_of_an_unknown_driver_keeps_the_catch_all() {
+        // An unresolvable driver is as unknowable as none at all: the hover must
+        // not claim a narrowed key set it can't back up.
+        let content = "target(name = \"t\", driver = \"nope\")\n";
+        let (shared, uri) = shared_with_index(content);
+        let md = hover_value(&shared, &uri, 0, 2).expect("hover");
+        assert!(md.contains("**config"), "catch-all stands: {md}");
+        assert!(!md.contains("driver's."), "no attribution line: {md}");
     }
 
     #[test]
@@ -1504,6 +1615,30 @@ mod tests {
         let md = hover_value(&shared, &uri, 0, col).expect("hover");
         assert!(md.contains("`exec` driver"), "names the driver: {md}");
         assert!(md.contains("cmd"), "shows the driver field: {md}");
+        assert!(
+            md.contains("Command line to run."),
+            "shows the field doc: {md}"
+        );
+    }
+
+    #[test]
+    fn hover_inside_target_shows_driver_fields_on_a_buffer_that_does_not_evaluate() {
+        // The driver reads textually, so the field docs must survive a buffer
+        // the engine rejects — the earlier gate on the call having produced
+        // targets took them away exactly when the keys were being looked up.
+        let content = "target(name = \"t\", driver = \"exec\", cmd = undefined_symbol)\n";
+        let (shared, uri) = shared_with_index(content);
+        assert!(
+            shared
+                .index(&uri)
+                .expect("index")
+                .targets_at(1, 1)
+                .is_none(),
+            "the buffer must not evaluate, or this proves nothing"
+        );
+        let col = content.find(')').unwrap() as u32;
+        let md = hover_value(&shared, &uri, 0, col).expect("hover");
+        assert!(md.contains("`exec` driver"), "names the driver: {md}");
         assert!(
             md.contains("Command line to run."),
             "shows the field doc: {md}"
@@ -1528,23 +1663,31 @@ mod tests {
 
     #[test]
     fn builtin_call_name_at_detects_callee_only() {
+        let name_at = |s, off| builtin_call_open_at(s, off).map(|(name, _)| name);
         // On the callee name immediately before `(`.
+        assert_eq!(name_at("target(name = \"t\")", 2), Some("target"));
         assert_eq!(
-            builtin_call_name_at("target(name = \"t\")", 2),
-            Some("target")
-        );
-        assert_eq!(
-            builtin_call_name_at("provider_state(provider = \"go\")", 3),
+            name_at("provider_state(provider = \"go\")", 3),
             Some("provider_state")
         );
         // Whitespace between name and `(` is tolerated.
-        assert_eq!(builtin_call_name_at("target  (x)", 2), Some("target"));
+        assert_eq!(name_at("target  (x)", 2), Some("target"));
         // A bare `target` not used as a call → None.
-        assert_eq!(builtin_call_name_at("x = target", 8), None);
+        assert_eq!(name_at("x = target", 8), None);
         // An unrelated identifier → None.
-        assert_eq!(builtin_call_name_at("glob(\"x\")", 1), None);
+        assert_eq!(name_at("glob(\"x\")", 1), None);
         // Inside the args, not on the callee → None.
-        assert_eq!(builtin_call_name_at("target(name = \"t\")", 9), None);
+        assert_eq!(name_at("target(name = \"t\")", 9), None);
+    }
+
+    #[test]
+    fn builtin_call_open_at_points_past_the_callee_token() {
+        // The reported offset is the call's own `(` — the args the hover reads
+        // start there, not at an enclosing call's.
+        let src = "target  (name = \"t\")";
+        let (_, open) = builtin_call_open_at(src, 2).expect("callee");
+        assert_eq!(open, src.find('(').unwrap());
+        assert_eq!(super::call_args_from_open(src, open), Some("name = \"t\""));
     }
 
     #[test]

--- a/crates/plugin-buildfile/src/pluginbuildfile/lsp/proxy.rs
+++ b/crates/plugin-buildfile/src/pluginbuildfile/lsp/proxy.rs
@@ -1579,8 +1579,17 @@ mod tests {
             md.contains("Command line to run."),
             "shows the field doc: {md}"
         );
-        assert!(md.contains("`exec` driver"), "attributes the fields: {md}");
+        // A blend, not a swap: `target`'s own spec-level fields stay, with their
+        // docs, and the closing line says which half is which.
         assert!(md.contains("name"), "keeps the base args: {md}");
+        assert!(
+            md.contains("Target name (required)."),
+            "keeps the base docs: {md}"
+        );
+        assert!(
+            md.contains("`target`'s own, then the `exec` driver's config"),
+            "attributes each half of the blend: {md}"
+        );
     }
 
     #[test]
@@ -1602,7 +1611,10 @@ mod tests {
         let (shared, uri) = shared_with_index(content);
         let md = hover_value(&shared, &uri, 0, 2).expect("hover");
         assert!(md.contains("**config"), "catch-all stands: {md}");
-        assert!(!md.contains("driver's."), "no attribution line: {md}");
+        assert!(
+            !md.contains("The fields above are"),
+            "no attribution line: {md}"
+        );
     }
 
     #[test]

--- a/crates/plugin-buildfile/src/pluginbuildfile/run_file.rs
+++ b/crates/plugin-buildfile/src/pluginbuildfile/run_file.rs
@@ -270,15 +270,19 @@ fn render_builtin_hover(
     }));
     let mut md = render_doc_item_no_link(name, &item);
 
+    // Say which half is which. The list above blends two sources — the
+    // builtin's own spec-level fields, then the selected schema's — and a
+    // reader who can't tell them apart can't tell what changes if they swap the
+    // driver.
     if let Some((schema_name, fields, kind, field_kind)) = schema {
         md.push_str("\n\n");
         if fields.is_empty() {
             md.push_str(&format!(
-                "*The `{schema_name}` {kind} takes no {field_kind} fields.*"
+                "*The fields above are `{name}`'s own; the `{schema_name}` {kind} takes no {field_kind}.*"
             ));
         } else {
             md.push_str(&format!(
-                "*The {field_kind} fields above are the `{schema_name}` {kind}'s.*"
+                "*The fields above are `{name}`'s own, then the `{schema_name}` {kind}'s {field_kind}.*"
             ));
         }
     }
@@ -1859,20 +1863,34 @@ mod tests {
         assert!(md.contains("Command line to run."), "field doc: {md}");
         assert!(md.contains("Echo the command."), "optional field doc: {md}");
         assert!(md.contains("verbose"), "optional field: {md}");
-        // The base args are still there — a driver narrows, it doesn't replace.
-        assert!(md.contains("name"), "keeps base args: {md}");
-        // And the reader can tell where `cmd` came from.
-        assert!(md.contains("`exec` driver"), "attributes the fields: {md}");
+        // A driver narrows the config keys; it never displaces `target`'s own
+        // spec-level fields. Every one of them is still there, documented.
+        for base in target_base_fields() {
+            assert!(
+                md.contains(&base.name),
+                "keeps base arg {}: {md}",
+                base.name
+            );
+            assert!(md.contains(&base.doc), "keeps base doc {}: {md}", base.name);
+        }
+        // Which half is which: the reader must be able to tell `name` (always
+        // there) from `cmd` (there because this target picked `exec`).
+        assert!(
+            md.contains("*The fields above are `target`'s own, then the `exec` driver's config.*"),
+            "attributes each half of the blend: {md}"
+        );
     }
 
     #[test]
     fn builtin_call_hovers_say_so_when_a_driver_takes_no_config() {
         // A config-less driver (`DriverSchema::default()`, what several real
-        // drivers return) must read as "no keys", not as a hover that broke.
+        // drivers return) must read as "no keys", not as a hover that broke —
+        // and must still show `target`'s own fields.
         let md = hovers().target(Some(("bare", &DriverSchema::default())));
         assert!(!md.contains("**config"), "catch-all replaced: {md}");
+        assert!(md.contains("name"), "keeps base args: {md}");
         assert!(
-            md.contains("`bare` driver takes no config fields"),
+            md.contains("`bare` driver takes no config"),
             "says the driver takes nothing: {md}"
         );
     }
@@ -1894,7 +1912,13 @@ mod tests {
             md.contains("Treat this package as a codegen root."),
             "field doc: {md}"
         );
-        assert!(md.contains("`go` provider"), "attributes the fields: {md}");
+        assert!(md.contains("provider"), "keeps the base arg: {md}");
+        assert!(
+            md.contains(
+                "*The fields above are `provider_state`'s own, then the `go` provider's state.*"
+            ),
+            "attributes each half of the blend: {md}"
+        );
     }
 
     #[test]

--- a/crates/plugin-buildfile/src/pluginbuildfile/run_file.rs
+++ b/crates/plugin-buildfile/src/pluginbuildfile/run_file.rs
@@ -6,8 +6,8 @@ use hcore::htvalue::signature::{FnSignature, ParamType};
 use hcore::htvalue::{self, parse_map_string_string, parse_map_string_strings, parse_strings};
 use hmodel::htaddr;
 use hmodel::htpkg::PkgBuf;
-use hplugin::driver::TargetAddr;
 use hplugin::driver::sandbox::{Dep, Env, EnvValue, Mode, Sandbox, Tool};
+use hplugin::driver::{DriverSchema, TargetAddr};
 use hplugin::provider::{
     Approval, FnArgs, FnCallContext, ProvenanceFrame, ProviderFn, ProviderFunctionRegistry,
 };
@@ -85,98 +85,204 @@ pub(crate) fn heph_core_members(globals_doc: &starlark::docs::DocModule) -> Vec<
         .collect()
 }
 
-/// Rendered hover markdown for the `target` and `provider_state` builtins, keyed
-/// by name. Both take a raw `args: &Arguments`, so the stock server can only
-/// render the meaningless `def name(*args, **kwargs)` prototype; we render a
-/// meaningful one — `target`'s recognized base arguments (from
-/// [`target_base_fields`], so the two never drift) plus a `**config` catch-all for
-/// driver fields, and `provider_state`'s `provider` plus a `**state` catch-all —
-/// while keeping each builtin's real docstring. Computed once at startup (the
-/// signatures are static); the proxy serves these when the callee name is hovered.
-pub(crate) fn builtin_call_hovers(
-    globals_doc: &starlark::docs::DocModule,
-) -> std::collections::HashMap<String, String> {
-    use starlark::docs::markdown::render_doc_item_no_link;
-    use starlark::docs::{
-        DocFunction, DocItem, DocMember, DocParam, DocParams, DocReturn, DocString,
-    };
-    use starlark::typing::Ty;
+/// Hover markdown for the `target` and `provider_state` builtins, rendered on
+/// demand so each prototype can be narrowed to what the call site selects.
+///
+/// Both builtins take a raw `args: &Arguments`, so the stock server can only
+/// render the meaningless `def name(*args, **kwargs)` prototype. We render a
+/// meaningful one instead: `target`'s recognized base arguments (from
+/// [`target_base_fields`], so the two never drift) and `provider_state`'s
+/// `provider`, keeping each builtin's real docstring.
+///
+/// The point of rendering per call rather than once at startup is the rest: when
+/// the call names a `driver` (or a `provider`) whose schema resolves, that
+/// schema's fields *replace* the `**config` / `**state` catch-all, each with its
+/// type, its required-ness and its doc. The hover then describes the keys this
+/// particular target accepts and nothing else — the generic prototype could only
+/// say "and some more keyword arguments". Only the docstrings are held here;
+/// rendering is a handful of allocations and runs once per hover.
+pub(crate) struct BuiltinHovers {
+    target_doc: Option<starlark::docs::DocString>,
+    provider_state_doc: Option<starlark::docs::DocString>,
+}
 
-    // The builtin's real docstring, pulled from the globals doc so it never drifts
-    // from the `#[starlark_module]` definition.
-    let docstring = |name: &str| -> Option<DocString> {
-        match globals_doc.members.get(name) {
+/// One schema field as the hover renderer needs it — the shape a driver's
+/// `DriverField` and a provider's `StateField` have in common.
+struct HoverField<'a> {
+    name: &'a str,
+    ty: &'a ParamType,
+    doc: &'a str,
+    required: bool,
+}
+
+impl BuiltinHovers {
+    pub(crate) fn new(globals_doc: &starlark::docs::DocModule) -> BuiltinHovers {
+        use starlark::docs::{DocItem, DocMember};
+        // The builtin's real docstring, pulled from the globals doc so it never
+        // drifts from the `#[starlark_module]` definition.
+        let docstring = |name: &str| match globals_doc.members.get(name) {
             Some(DocItem::Member(DocMember::Function(f))) => f.docs.clone(),
             _ => None,
+        };
+        BuiltinHovers {
+            target_doc: docstring("target"),
+            provider_state_doc: docstring("provider_state"),
         }
-    };
+    }
 
-    // One named parameter; `required` controls whether a `= None` default (the
-    // optional convention) is shown.
-    let param = |name: &str, ty: Ty, required: bool| DocParam {
-        name: name.to_string(),
-        docs: None,
-        typ: ty,
-        default_value: (!required).then(|| "None".to_string()),
-    };
-    // A `**name` catch-all of arbitrary type.
-    let kwargs = |name: &str| DocParam {
-        name: name.to_string(),
-        docs: None,
-        typ: Ty::any(),
-        default_value: None,
-    };
-    let render = |name: &str, params: DocParams, ret: Ty| {
-        let item = DocItem::Member(DocMember::Function(DocFunction {
-            docs: docstring(name),
-            params,
-            ret: DocReturn {
-                docs: None,
-                typ: ret,
-            },
-        }));
-        render_doc_item_no_link(name, &item)
-    };
-
-    let mut out = std::collections::HashMap::new();
-
-    // `target(name, driver, …, **config) -> str`. Base args come from the single
-    // source of truth shared with completion.
-    out.insert(
-        "target".to_string(),
-        render(
+    /// `target(name, driver, …, **config) -> str`, or — with `driver` resolved to
+    /// its schema — that driver's config fields in place of the catch-all.
+    pub(crate) fn target(&self, driver: Option<(&str, &DriverSchema)>) -> String {
+        let fields = driver.map(|(name, schema)| {
+            let fields: Vec<HoverField<'_>> = schema
+                .fields
+                .iter()
+                .map(|f| HoverField {
+                    name: &f.name,
+                    ty: &f.ty,
+                    doc: &f.doc,
+                    required: f.required,
+                })
+                .collect();
+            (name, fields, "driver", "config")
+        });
+        let base = target_base_fields();
+        let base: Vec<HoverField<'_>> = base
+            .iter()
+            .map(|f| HoverField {
+                name: &f.name,
+                ty: &f.ty,
+                doc: &f.doc,
+                required: f.required,
+            })
+            .collect();
+        render_builtin_hover(
             "target",
-            DocParams {
-                pos_only: Vec::new(),
-                pos_or_named: target_base_fields()
-                    .into_iter()
-                    .map(|f| param(&f.name, param_type_to_ty(&f.ty), f.required))
-                    .collect(),
-                args: None,
-                named_only: Vec::new(),
-                kwargs: Some(kwargs("config")),
-            },
-            Ty::string(),
-        ),
-    );
+            &self.target_doc,
+            &base,
+            fields
+                .as_ref()
+                .map(|(n, f, k, c)| (*n, f.as_slice(), *k, *c)),
+            "config",
+            starlark::typing::Ty::string(),
+        )
+    }
 
-    // `provider_state(provider, **state) -> None`.
-    out.insert(
-        "provider_state".to_string(),
-        render(
+    /// `provider_state(provider, **state) -> None`, narrowed the same way once
+    /// the named provider's state schema resolves.
+    pub(crate) fn provider_state(
+        &self,
+        provider: Option<(&str, &hplugin::provider::StateSchema)>,
+    ) -> String {
+        let fields = provider.map(|(name, schema)| {
+            let fields: Vec<HoverField<'_>> = schema
+                .fields
+                .iter()
+                .map(|f| HoverField {
+                    name: &f.name,
+                    ty: &f.ty,
+                    doc: &f.doc,
+                    required: f.required,
+                })
+                .collect();
+            (name, fields, "provider", "state")
+        });
+        let base = [HoverField {
+            name: "provider",
+            ty: &ParamType::String,
+            doc: "Provider whose state this sets.",
+            required: true,
+        }];
+        render_builtin_hover(
             "provider_state",
-            DocParams {
-                pos_only: Vec::new(),
-                pos_or_named: vec![param("provider", Ty::string(), true)],
-                args: None,
-                named_only: Vec::new(),
-                kwargs: Some(kwargs("state")),
-            },
-            Ty::none(),
-        ),
-    );
+            &self.provider_state_doc,
+            &base,
+            fields
+                .as_ref()
+                .map(|(n, f, k, c)| (*n, f.as_slice(), *k, *c)),
+            "state",
+            starlark::typing::Ty::none(),
+        )
+    }
+}
 
-    out
+/// Render one builtin's hover: its prototype, docstring, and a `#### Parameters`
+/// section for every field that documents itself.
+///
+/// `schema` is the resolved driver/provider — `(name, its fields, what it is,
+/// what the fields are called)`. Present, its fields take the place of the
+/// `**{catch_all}` parameter and a closing line attributes them, so a reader who
+/// wonders where `cmd` came from can see it. Absent, the catch-all stands: the
+/// remaining keys exist but nothing here knows them.
+fn render_builtin_hover(
+    name: &str,
+    docs: &Option<starlark::docs::DocString>,
+    base: &[HoverField<'_>],
+    schema: Option<(&str, &[HoverField<'_>], &str, &str)>,
+    catch_all: &str,
+    ret: starlark::typing::Ty,
+) -> String {
+    use starlark::docs::markdown::render_doc_item_no_link;
+    use starlark::docs::{
+        DocFunction, DocItem, DocMember, DocParam, DocParams, DocReturn, DocString, DocStringKind,
+    };
+
+    // `required` controls whether a `= None` default — the optional convention —
+    // is shown; the field's own doc becomes the parameter's, which is what puts
+    // it in the rendered `#### Parameters` list.
+    let param = |f: &HoverField<'_>| DocParam {
+        name: f.name.to_string(),
+        docs: DocString::from_docstring(DocStringKind::Starlark, f.doc),
+        typ: param_type_to_ty(f.ty),
+        default_value: (!f.required).then(|| "None".to_string()),
+    };
+
+    let params = DocParams {
+        pos_only: Vec::new(),
+        pos_or_named: Vec::new(),
+        args: None,
+        // Keyword-only, which is what these builtins actually are — they reject
+        // positional arguments outright. It also keeps the prototype well-formed
+        // once a schema is spliced in: a driver's required `cmd` lands after the
+        // optional base args, which reads as invalid syntax without the `*`.
+        named_only: base
+            .iter()
+            .chain(schema.iter().flat_map(|(_, fields, _, _)| fields.iter()))
+            .map(param)
+            .collect(),
+        // A `**name` catch-all of arbitrary type, only while the schema behind it
+        // is unknown.
+        kwargs: schema.is_none().then(|| DocParam {
+            name: catch_all.to_string(),
+            docs: None,
+            typ: starlark::typing::Ty::any(),
+            default_value: None,
+        }),
+    };
+
+    let item = DocItem::Member(DocMember::Function(DocFunction {
+        docs: docs.clone(),
+        params,
+        ret: DocReturn {
+            docs: None,
+            typ: ret,
+        },
+    }));
+    let mut md = render_doc_item_no_link(name, &item);
+
+    if let Some((schema_name, fields, kind, field_kind)) = schema {
+        md.push_str("\n\n");
+        if fields.is_empty() {
+            md.push_str(&format!(
+                "*The `{schema_name}` {kind} takes no {field_kind} fields.*"
+            ));
+        } else {
+            md.push_str(&format!(
+                "*The {field_kind} fields above are the `{schema_name}` {kind}'s.*"
+            ));
+        }
+    }
+    md
 }
 
 pub(crate) fn build_globals(registry: &ProviderFunctionRegistry) -> Globals {
@@ -1697,29 +1803,98 @@ mod tests {
     use std::fs;
     use tempfile::tempdir;
 
+    fn hovers() -> BuiltinHovers {
+        BuiltinHovers::new(&build_globals(&ProviderFunctionRegistry::default()).documentation())
+    }
+
     #[test]
     fn builtin_call_hovers_render_real_signatures() {
-        let doc = build_globals(&ProviderFunctionRegistry::default()).documentation();
-        let hovers = builtin_call_hovers(&doc);
+        let hovers = hovers();
 
-        let target = hovers.get("target").expect("target hover");
-        // Real args, the `**config` catch-all, and the address return — not the
-        // stock `def target(*args, **kwargs) -> None`.
+        // With nothing selected: real args, the `**config` catch-all, and the
+        // address return — not the stock `def target(*args, **kwargs) -> None`.
+        let target = hovers.target(None);
         assert!(target.contains("name"), "names base arg: {target}");
         assert!(target.contains("driver"), "names driver arg: {target}");
         assert!(target.contains("**config"), "shows config kwargs: {target}");
         assert!(!target.contains("**kwargs"), "no raw kwargs: {target}");
         // The real docstring carries through.
         assert!(target.contains("Declare a build target"), "doc: {target}");
+        // Base fields document themselves.
+        assert!(
+            target.contains("Target name (required)."),
+            "base field doc: {target}"
+        );
 
-        let ps = hovers.get("provider_state").expect("provider_state hover");
+        let ps = hovers.provider_state(None);
         assert!(ps.contains("provider"), "names provider arg: {ps}");
         assert!(ps.contains("**state"), "shows state kwargs: {ps}");
         assert!(!ps.contains("**kwargs"), "no raw kwargs: {ps}");
+    }
+
+    #[test]
+    fn builtin_call_hovers_narrow_to_the_selected_driver() {
+        let schema = DriverSchema {
+            fields: vec![
+                hplugin::driver::DriverField {
+                    name: "cmd".to_string(),
+                    ty: ParamType::String,
+                    doc: "Command line to run.".to_string(),
+                    required: true,
+                },
+                hplugin::driver::DriverField {
+                    name: "verbose".to_string(),
+                    ty: ParamType::Bool,
+                    doc: "Echo the command.".to_string(),
+                    required: false,
+                },
+            ],
+        };
+        let md = hovers().target(Some(("exec", &schema)));
+
+        // The driver's fields stand in for the catch-all, in the prototype and
+        // in the parameter docs, with required-ness carried across.
+        assert!(!md.contains("**config"), "catch-all replaced: {md}");
+        assert!(md.contains("cmd"), "prototype names the field: {md}");
+        assert!(md.contains("Command line to run."), "field doc: {md}");
+        assert!(md.contains("Echo the command."), "optional field doc: {md}");
+        assert!(md.contains("verbose"), "optional field: {md}");
+        // The base args are still there — a driver narrows, it doesn't replace.
+        assert!(md.contains("name"), "keeps base args: {md}");
+        // And the reader can tell where `cmd` came from.
+        assert!(md.contains("`exec` driver"), "attributes the fields: {md}");
+    }
+
+    #[test]
+    fn builtin_call_hovers_say_so_when_a_driver_takes_no_config() {
+        // A config-less driver (`DriverSchema::default()`, what several real
+        // drivers return) must read as "no keys", not as a hover that broke.
+        let md = hovers().target(Some(("bare", &DriverSchema::default())));
+        assert!(!md.contains("**config"), "catch-all replaced: {md}");
         assert!(
-            ps.contains("provider state") || ps.contains("provider"),
-            "doc: {ps}"
+            md.contains("`bare` driver takes no config fields"),
+            "says the driver takes nothing: {md}"
         );
+    }
+
+    #[test]
+    fn builtin_call_hovers_narrow_to_the_selected_provider() {
+        let schema = hplugin::provider::StateSchema {
+            fields: vec![hplugin::provider::StateField {
+                name: "go_codegen_root".to_string(),
+                ty: ParamType::Bool,
+                doc: "Treat this package as a codegen root.".to_string(),
+                required: false,
+            }],
+        };
+        let md = hovers().provider_state(Some(("go", &schema)));
+        assert!(!md.contains("**state"), "catch-all replaced: {md}");
+        assert!(md.contains("go_codegen_root"), "names the field: {md}");
+        assert!(
+            md.contains("Treat this package as a codegen root."),
+            "field doc: {md}"
+        );
+        assert!(md.contains("`go` provider"), "attributes the fields: {md}");
     }
 
     #[test]


### PR DESCRIPTION
Stacked on #315.

Hovering `target` rendered one static prototype — the base arguments plus an opaque `**config`. The keys that particular call accepts, the driver's, were the part worth reading, and the hover never said them. Same for `provider_state` and its `**state`.

### Now

The prototype renders per hover instead of once at startup, and the resolved schema's fields take the place of the catch-all:

```python
def target(
    *,
    name: str,
    driver: str = None,
    labels: str | list[str] = None,
    transitive: dict[str, list[str] | dict[str, list[str]]] = None,
    approval: bool | dict[str, bool | list[str]] = None,
    cmd: str,
    verbose: bool = None,
) -> str
```

> Declare a build target.
>
> #### Parameters
>
> * `name`: (required)
>
>   Target name (required).
>
> * `cmd`: (required)
>
>   Command line to run.
>
> …
>
> *The config fields above are the `exec` driver's.*

Three details that matter:

- **Attribution.** The closing line names the driver, so a reader who wonders where `cmd` came from can see it — and a driver with an empty schema says "the `bare` driver takes no config fields" rather than rendering as a hover that quietly broke.
- **Nothing resolvable → catch-all stands.** No driver, or one that isn't registered, keeps `**config`. The remaining keys exist; nothing here knows them, and the hover doesn't claim otherwise. Same rule the diagnostics already follow.
- **Keyword-only.** All params render after `*`, which is what these builtins are (they reject positional arguments outright) and what keeps the prototype well-formed once a driver's required `cmd` lands after the optional base args.

Base fields also carry their docs now — `target_base_fields` has always had them and the hover was dropping them.

### The eval gate is gone

The driver is read textually, like the matching completion and diagnostics, so the narrowed hover holds on a buffer that doesn't evaluate. The separate field list shown when hovering *inside* the call (rather than on the callee) was gated on that call having produced targets — i.e. on a successful eval — so a typo anywhere in the file took the keys away exactly when they were being looked up. Removed, same reasoning as #315.

### Tests

Ten, in `run_file` (rendering) and `proxy` (the hover path end to end):

- narrowing for a driver and for a provider, each asserting the catch-all is gone, the field and its doc are present, the base args survive, and the driver/provider is named;
- the config-less driver saying so;
- unresolvable driver → catch-all stands, no attribution line;
- the generic no-driver prototype (the pre-existing tests, retargeted at a call that names nothing resolvable — they used to assert `**config` on a call that named `exec`);
- narrowing on a buffer that doesn't evaluate, both on the callee and inside the call, the latter asserting the buffer really doesn't evaluate so it can't pass vacuously;
- `builtin_call_open_at` reporting the call's own `(`.

`lint` clean; `cargo test -p plugin-buildfile --lib` green (178).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MW1UarZmkF5NdVDnu8vsa4