### PR TITLE
fix(pprof): walk frame pointers, not the unwinder, from the SIGPROF handler

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -3,4 +3,20 @@
 # cross-task wait-for cycle detection (see `src/hmemoizer/mod.rs`). Other
 # `tokio_unstable` APIs (Builder::name, runtime metrics, …) are not used by
 # this crate but become available when the flag is set.
-rustflags = ["--cfg", "tokio_unstable"]
+#
+# `-Cforce-frame-pointers=yes` keeps a frame record in every function so a stack
+# can be walked without the unwinder. Two things depend on it:
+#
+#   - `--pprof-cpu` walks the frame chain from its `SIGPROF` handler
+#     (`src/pprof_dump.rs`). The DWARF unwinder is not async-signal-safe and
+#     segfaulted the process it was profiling; a frame walk is the fix, and it
+#     produces garbage without frame pointers.
+#   - `samply` (the `perf-test` skill) unwinds by frame pointer first and only
+#     falls back to DWARF, which is slower and drops frames under a deep async
+#     stack.
+#
+# rustc omits frame pointers on both Linux targets at `opt-level > 0`;
+# aarch64-apple-darwin already forces them (the platform ABI requires it), so
+# this only changes the Linux builds. It costs one register and a
+# push/pop per call — the profilers stop lying in exchange.
+rustflags = ["--cfg", "tokio_unstable", "-Cforce-frame-pointers=yes"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -130,7 +130,12 @@ nom = { version = "8", default-features = false, features = ["std"] }
 anyhow = "1.0.102"
 memoize = "0.6.0"
 tokio = { version = "1.52.3", features = ["rt", "rt-multi-thread", "io-util", "io-std", "process", "macros", "sync", "signal", "fs", "test-util", "tracing", "net"] }
-pprof = { version = "0.15", features = ["prost-codec"] }
+# `frame-pointer` swaps pprof's stack walk from `_Unwind_Backtrace` (not
+# async-signal-safe — it faulted the process it was profiling) to a frame-pointer
+# chain walk that probes every address before dereferencing it. It needs the
+# frame pointers `-Cforce-frame-pointers=yes` in `.cargo/config.toml` emits; see
+# `src/pprof_dump.rs`.
+pprof = { version = "0.15", features = ["prost-codec", "frame-pointer"] }
 futures = "0.3.32"
 async-trait = "0.1.89"
 async-recursion = "1"

--- a/build.rs
+++ b/build.rs
@@ -10,6 +10,9 @@
 //! requires macFUSE present), so a null is never dereferenced.
 //!
 //! Linux FUSE is pure-Rust with no libfuse link, so nothing is emitted there.
+//!
+//! Also detects whether this build carries frame pointers, for `--pprof-cpu`
+//! (see [`frame_pointers`]).
 fn main() {
     println!("cargo::rerun-if-changed=build.rs");
     let macos = std::env::var("CARGO_CFG_TARGET_OS").as_deref() == Ok("macos");
@@ -18,4 +21,67 @@ fn main() {
     if macos && fuse {
         println!("cargo::rustc-link-arg=-weak-lfuse");
     }
+    frame_pointers();
+}
+
+/// Set `cfg(heph_frame_pointers)` when this build asks rustc to keep a frame
+/// record in every function.
+///
+/// `--pprof-cpu` walks that chain from its `SIGPROF` handler (`src/pprof_dump.rs`
+/// explains why it cannot use the unwinder). Without frame pointers the walk does
+/// not crash — it reads whatever the register happened to hold and reports a
+/// plausible-looking wrong stack. Nothing downstream can tell the difference, so
+/// the condition is detected here, at the only place that can see the flags, and
+/// `pprof_dump::start` refuses to profile without it rather than emitting
+/// fiction.
+///
+/// `.cargo/config.toml` sets the flag for every build in this workspace. An
+/// explicit `RUSTFLAGS` in the environment *replaces* that config (cargo does not
+/// merge them), which is exactly the case this has to catch — and the reason for
+/// a runtime refusal rather than a build failure: an unrelated
+/// `RUSTFLAGS=-Ctarget-cpu=native` should still build heph, just not silently
+/// turn its profiler into a random-stack generator.
+fn frame_pointers() {
+    println!("cargo::rustc-check-cfg=cfg(heph_frame_pointers)");
+    println!("cargo::rerun-if-env-changed=CARGO_ENCODED_RUSTFLAGS");
+    println!("cargo::rerun-if-env-changed=RUSTFLAGS");
+    // aarch64-apple-darwin keeps the frame record regardless of the flag — the
+    // platform ABI reserves x29 for it — so the guarantee holds there even if a
+    // build overrides RUSTFLAGS.
+    let apple_arm = std::env::var("CARGO_CFG_TARGET_OS").as_deref() == Ok("macos")
+        && std::env::var("CARGO_CFG_TARGET_ARCH").as_deref() == Ok("aarch64");
+    let flags = std::env::var("CARGO_ENCODED_RUSTFLAGS").unwrap_or_default();
+    if apple_arm || forces_frame_pointers(&flags) {
+        println!("cargo::rustc-cfg=heph_frame_pointers");
+    }
+}
+
+/// Whether `flags` (the `\u{1f}`-separated `CARGO_ENCODED_RUSTFLAGS`) turn
+/// `force-frame-pointers` on.
+///
+/// The option reaches rustc as `-Cforce-frame-pointers=yes`, as a bare
+/// `-Cforce-frame-pointers` (implicitly on), as `--codegen force-frame-pointers`
+/// in two tokens, and with `=no` to turn it back off — and the last spelling
+/// wins, so a later `=no` has to lose to nothing earlier.
+fn forces_frame_pointers(flags: &str) -> bool {
+    let mut on = false;
+    let mut tokens = flags.split('\u{1f}').filter(|t| !t.is_empty()).peekable();
+    while let Some(token) = tokens.next() {
+        // `-C opt` and `--codegen opt` put the option in the *next* token.
+        let opt = match token {
+            "-C" | "--codegen" => match tokens.next() {
+                Some(next) => next,
+                None => break,
+            },
+            _ => token
+                .strip_prefix("-C")
+                .or_else(|| token.strip_prefix("--codegen="))
+                .unwrap_or(""),
+        };
+        let Some(value) = opt.strip_prefix("force-frame-pointers") else {
+            continue;
+        };
+        on = matches!(value, "" | "=yes" | "=y" | "=on" | "=true");
+    }
+    on
 }

--- a/src/diag.rs
+++ b/src/diag.rs
@@ -2,8 +2,9 @@
 //!
 //! When a run hangs in a locked-down CI container, every external tool is blocked:
 //! ptrace is denied (no gdb/perf/`gcore`), the root fs is read-only (kernel core
-//! dumps are dropped), and pprof's sampler can segfault on a static binary. The
-//! one channel left is the process dumping its own stacks. A `SIGUSR1` handler
+//! dumps are dropped), and `--pprof-cpu` only samples a run it was passed on —
+//! which is never the run that turns out to hang. The one channel left is the
+//! process dumping its own stacks. A `SIGUSR1` handler
 //! appends the *signalled* thread's backtrace to a file, so signalling the busy
 //! thread reveals the loop — and a file beats stderr when hundreds of threads
 //! dump at once.

--- a/src/pprof_dump.rs
+++ b/src/pprof_dump.rs
@@ -7,6 +7,10 @@
 //! accumulated so far on `SIGUSR2`, so `kill -USR2 <pid>` snapshots a stuck
 //! process in place (to a writable tmpfs path). The filtered final report is
 //! still written at shutdown.
+//!
+//! Sampling happens in a `SIGPROF` handler, so how the stack is walked is a
+//! correctness question, not a quality one — [`start`] documents why this build
+//! walks frame pointers rather than calling the DWARF unwinder.
 
 use anyhow::Context;
 use std::path::{Path, PathBuf};
@@ -22,33 +26,27 @@ static SHUTDOWN: AtomicBool = AtomicBool::new(false);
 
 /// Sampling frequency, Hz.
 ///
-/// Every sample is a signal delivered to a running thread, and each one is a
-/// chance to interrupt somewhere the unwinder cannot walk (see
-/// [`UNWIND_BLOCKLIST`]). 1000 Hz across every thread of a wide build multiplied
-/// that exposure for resolution this diagnostic never needed: it exists to show
-/// *which loop* is burning a pegged worker, and a hang that has lasted minutes
-/// is not a signal 199 Hz can miss.
+/// Every sample is a signal delivered to a running thread, and the handler runs
+/// at whatever instruction it interrupted. 1000 Hz across every thread of a wide
+/// build bought resolution this diagnostic never needed: it exists to show *which
+/// loop* is burning a pegged worker, and a hang that has lasted minutes is not a
+/// signal 199 Hz can miss. The stack walk is signal-safe either way (see
+/// [`start`]) — this is about the per-sample cost heph pays while profiled, on
+/// every worker, not about containing a crash.
 const SAMPLE_HZ: libc::c_int = 199;
 
-/// Libraries the sampler must not unwind out of.
+/// Libraries the sampler must not walk into.
 ///
-/// `pprof` unwinds from inside its `SIGPROF` handler via the `backtrace` crate,
-/// i.e. `_Unwind_Backtrace`, which takes a global lock and is not
-/// async-signal-safe. Interrupt a thread that is already inside `libc`, the
-/// dynamic loader, or the unwinder itself, and walking that frame faults — which
-/// is how `--pprof-cpu` segfaulted the process it was meant to diagnose, within
-/// seconds of startup on a wide run.
+/// `pprof` resolves these names against the loaded shared objects, checks the
+/// interrupted PC *before* walking anything, and — because this build enables
+/// the `frame-pointer` tracer (see [`start`]) — checks every frame it reaches
+/// afterwards. A sample whose leaf lands in one of them is dropped whole; a walk
+/// that climbs into one stops there. That costs only frames attributable to the C
+/// library, which carry no information about heph's own hot loops.
 ///
-/// `pprof` resolves these names against the loaded shared objects and checks the
-/// interrupted PC *before* attempting any unwind, so a sample landing in one of
-/// them is dropped whole rather than walked. That costs only samples attributable
-/// to libc frames, which carry no information about heph's own hot loops.
-///
-/// Only the **leaf** PC is checked: the per-frame variant of this test is
-/// `#[cfg(feature = "frame-pointer")]` in pprof, and this build uses the
-/// `backtrace`/`_Unwind_Backtrace` tracer instead. So a sample that *starts* in
-/// heph code and walks up into libc is still unwound in full. This removes the
-/// dominant crash class, not the class — see the module TODO for the durable fix.
+/// This used to be the *entire* defence, back when the tracer was
+/// `_Unwind_Backtrace` and only the leaf PC could be tested — see [`start`] for
+/// why that was never sound and what replaced it.
 ///
 /// Matched as substrings against shared-object paths, and `str::contains` is
 /// **case-sensitive**: macOS ships `/usr/lib/libSystem.B.dylib`, which lowercase
@@ -95,9 +93,68 @@ impl Watcher {
     }
 }
 
+/// Whether this build keeps a frame record in every function, which is what the
+/// sampler's stack walk follows (see [`start`]). Set by `build.rs::frame_pointers`
+/// from the rustflags this build was compiled with.
+fn have_frame_pointers() -> bool {
+    cfg!(heph_frame_pointers)
+}
+
 /// Start CPU sampling plus the `SIGUSR2`-driven dump watcher, writing profiles to
 /// `path`. Call [`Watcher::shutdown`] at exit for the final report.
+///
+/// # How the stack is walked, and why it is not the unwinder
+///
+/// Every sample runs inside a `SIGPROF` handler, on whichever thread the kernel
+/// picked, at whatever instruction it happened to interrupt. The only code that
+/// may run there is async-signal-safe code — and `_Unwind_Backtrace`, which
+/// `pprof` uses by default (via the `backtrace` crate), is not. It takes
+/// libgcc's global `object_mutex`, re-enters `dl_iterate_phdr`, and reads
+/// loader state that the interrupted thread may have been halfway through
+/// mutating. Interrupt the wrong instruction and walking that stack faults —
+/// which is how `--pprof-cpu` segfaulted the very process it was asked to
+/// diagnose, within seconds of startup on a wide build.
+///
+/// [`UNWIND_BLOCKLIST`] was the first attempt at containing that: drop a sample
+/// whose *interrupted PC* is inside libc, the loader, or the unwinder. It is a
+/// heuristic on one address, and it left the class open — a sample that starts
+/// in heph code and climbs into libc was still handed to the unwinder in full,
+/// and heph is always in libc somewhere on some thread.
+///
+/// So the tracer itself is replaced: the `frame-pointer` feature makes `pprof`
+/// walk the frame-pointer chain instead. That walk cannot fault, by
+/// construction rather than by heuristic —
+///
+///   - it takes no lock and calls nothing in libc or the loader,
+///   - every candidate frame address is probed with a `write(2)` to a pipe
+///     (`EFAULT` ⇒ unreadable) *before* it is dereferenced, so a garbage frame
+///     pointer truncates the stack instead of segfaulting,
+///   - the chain must climb (a frame pointer below its predecessor ends the
+///     walk), so a corrupt chain cannot loop,
+///   - and [`UNWIND_BLOCKLIST`] is applied to every frame, not just the leaf.
+///
+/// It needs frame pointers to be there: `-Cforce-frame-pointers=yes` in
+/// `.cargo/config.toml` is what puts them there, and
+/// [`tests::this_build_has_frame_pointers`] fails if that flag is ever dropped —
+/// without it the walk does not crash, it silently reports garbage, which for a
+/// profiler is the worse outcome.
+///
+/// The cost is one frame of resolution: the walk starts at the return address in
+/// the innermost frame record, so the interrupted function is attributed to its
+/// caller. For "which loop is burning a pegged worker" — the question this flag
+/// exists to answer — the caller chain is what identifies the loop.
 pub fn start(path: PathBuf) -> anyhow::Result<Watcher> {
+    // A build without frame pointers cannot be sampled honestly: the walk reads
+    // whatever the register held and reports a stack that looks real. Refuse,
+    // rather than hand back fiction nobody can recognise as fiction.
+    if !have_frame_pointers() {
+        anyhow::bail!(
+            "this heph was built without frame pointers, so CPU profiles would report \
+             fabricated stacks; rebuild with `-Cforce-frame-pointers=yes` (the workspace \
+             `.cargo/config.toml` sets it — an explicit RUSTFLAGS replaces it)"
+        );
+    }
+
     // Fail here, where `main` already surfaces the error, rather than at dump
     // time where an unwritable path is a `warn!` the user may never see — by
     // which point they have re-run a multi-minute hang to get nothing. Probed by
@@ -317,15 +374,19 @@ mod tests {
     /// Both halves are load-bearing, and for opposite assertions:
     ///
     /// - The libc churn is the half that puts the sampler in front of the frames
-    ///   the blocklist exists for. The unwinder faults when it interrupts a thread
-    ///   already inside `malloc`, the dynamic loader or a syscall stub, so a pure
-    ///   integer loop — shallow stack, leaf PC in this binary — exercises
-    ///   precisely the case that never crashed. Note what this does *not* claim:
-    ///   the original segfault has not been shown to reproduce here on any
-    ///   supported target (blocklist off, it does not fire on darwin/arm64), so
+    ///   the blocklist exists for, and in front of the states the old unwinder-based
+    ///   tracer faulted in: a thread already inside `malloc`, the dynamic loader,
+    ///   or a syscall stub. A pure integer loop — shallow stack, leaf PC in this
+    ///   binary — exercises precisely the case that never crashed. Note what this
+    ///   does *not* claim: the original segfault has not been shown to reproduce
+    ///   here on any supported target (it fires on neither darwin/arm64 nor
+    ///   linux/arm64, blocklist off, under a 32-thread 20s hammer of concurrent
+    ///   `Backtrace::force_capture` + `dlopen`/`dlclose` + allocator churn), so
     ///   the first half of this test is "the process survives being profiled",
     ///   not a reproduction of the fault. That is why the churn is kept large
-    ///   rather than trimmed to whatever the second assertion needs.
+    ///   rather than trimmed to whatever the second assertion needs — and why the
+    ///   real fix was to stop calling the unwinder at all ([`start`]) rather than
+    ///   to keep widening a blocklist against a fault no test here can summon.
     /// - [`cpu_only`] is what the *profile has heph frames in it* assertion needs,
     ///   and it is not decoration. `pprof` drops a sample whose leaf PC is
     ///   blocklisted **by design**, so a workload built only from the first half
@@ -441,22 +502,54 @@ mod tests {
         UNWIND_BLOCKLIST.iter().any(|b| path.contains(b))
     }
 
+    /// This build must carry frame pointers, and heph must know that it does.
+    ///
+    /// The whole stack walk rests on it (see [`start`]), and both halves of the
+    /// wiring fail silently on their own. Drop `-Cforce-frame-pointers=yes` from
+    /// `.cargo/config.toml` and the frame chain becomes whatever the register
+    /// held; break `build.rs::frame_pointers` and the cfg goes missing while the
+    /// flag is still passed, which turns `--pprof-cpu` into a hard error on a
+    /// build that would have profiled perfectly well.
+    ///
+    /// Asserting the cfg rather than the codegen is deliberate: the test binary
+    /// is built at `opt-level = 0`, where rustc keeps frame pointers anyway, so a
+    /// test that walked its own frame chain would pass with the flag removed —
+    /// it could not fail. The cfg is the thing that actually tracks the flag.
+    ///
+    /// It is the **Linux** runs of this test that carry it. On
+    /// aarch64-apple-darwin the platform ABI reserves x29 for the frame record,
+    /// so `build.rs` sets the cfg unconditionally and this cannot go red — which
+    /// is why it must keep running on all three supported targets and not be
+    /// judged by a green macOS run.
+    #[test]
+    fn this_build_has_frame_pointers() {
+        assert!(
+            have_frame_pointers(),
+            "cfg(heph_frame_pointers) is unset: either `.cargo/config.toml` no longer \
+             passes -Cforce-frame-pointers=yes (CPU profiles would be fabricated), or \
+             build.rs stopped recognising the flag (--pprof-cpu now refuses to start)"
+        );
+    }
+
     /// The blocklist has to name the C library this process actually loaded, and
     /// must not name the main binary.
     ///
     /// Both halves are silent failures otherwise, which is what makes this the
     /// load-bearing test. `pprof` resolves these substrings against loaded shared
     /// objects **once**, at `start()`, and stores address ranges: match nothing
-    /// and `blocklist_segments` is empty, so the fix is a no-op and the sampler
-    /// goes back to faulting. Match the main binary and every heph frame is
-    /// dropped, so `--pprof-cpu` writes empty profiles forever — crashing
-    /// nothing, telling no one. `str::contains` is case-sensitive, which is how
+    /// and `blocklist_segments` is empty, so every profile fills up with C library
+    /// frames that say nothing about heph's own loops. Match the main binary and
+    /// every heph frame is dropped instead, so `--pprof-cpu` writes empty profiles
+    /// forever — telling no one. `str::contains` is case-sensitive, which is how
     /// `libSystem.B.dylib` slips past a lowercase entry.
     ///
+    /// Since the walk moved off the unwinder ([`start`]) an empty blocklist is no
+    /// longer a crash, only a worthless profile — which is why this stayed a test
+    /// of the *names* and did not become a test of survival.
+    ///
     /// A static build resolves `malloc` to the executable itself and fails here.
-    /// That is correct: the blocklist genuinely cannot work in that build, and
-    /// `src/diag.rs` already records that the sampler segfaults on static
-    /// binaries.
+    /// That is correct: the blocklist genuinely cannot distinguish the two in that
+    /// build.
     #[test]
     fn blocklist_covers_the_c_library_but_not_the_main_binary() {
         let libc_obj = owning_object(libc::malloc as *const std::ffi::c_void)
@@ -543,14 +636,16 @@ mod tests {
     ///
     /// Regression: `--pprof-cpu` segfaulted the process it was meant to diagnose,
     /// within seconds of startup on a wide run, because the `SIGPROF` handler
-    /// unwound through libc frames. A crash takes this whole test binary down —
+    /// called the DWARF unwinder. A crash takes this whole test binary down —
     /// that is the first half of the assertion, and it cannot be written any
     /// other way.
     ///
-    /// The second half guards the fix rather than the bug: an over-broad
-    /// [`UNWIND_BLOCKLIST`] (one matching the main binary) would drop every sample
-    /// and leave `--pprof-cpu` writing empty profiles forever, crashing nothing
-    /// and telling no one.
+    /// The second half guards the fix rather than the bug, and guards it against
+    /// two different silent failures now: an over-broad [`UNWIND_BLOCKLIST`] (one
+    /// matching the main binary) would drop every sample, and a frame-pointer walk
+    /// on a build without frame pointers would report stacks that never name this
+    /// binary's own functions. Either leaves `--pprof-cpu` producing nothing worth
+    /// reading while crashing nothing and telling no one.
     ///
     /// It asserts on [`cpu_only`] by name, not on "the profile is non-empty".
     /// Non-empty was the weaker *and* the flakier statement: with the whole burn


### PR DESCRIPTION
## What

`heph run lint //... --pprof-cpu=/tmp/cpu.prof` segfaults on Linux ~20s into the run — the profiler killing the process it was asked to diagnose.

#185 already hit this, lowered the sample rate to 199 Hz and added `UNWIND_BLOCKLIST`, and said in the same comment that it removes *the dominant crash class, not the class*, with a TODO for the durable fix. This is that fix.

## Why it crashes

`pprof`'s default tracer calls `_Unwind_Backtrace` from inside the `SIGPROF` handler. That takes libgcc's global `object_mutex`, re-enters `dl_iterate_phdr`, and reads loader state the interrupted thread may have been halfway through mutating — none of it async-signal-safe.

`UNWIND_BLOCKLIST` tests exactly one address, the interrupted PC. A sample whose leaf is in heph code but whose stack climbs into libc was still handed to the unwinder in full, and on a wide build heph is inside libc on *some* thread at all times. macOS is unaffected in practice because its unwinder lives in `libSystem`, which the blocklist always covers.

## The fix

Enable pprof's `frame-pointer` tracer. It cannot fault by construction rather than by heuristic:

- no locks, and nothing called in libc or the loader;
- every candidate frame address is probed with a `write(2)` to a pipe (`EFAULT` ⇒ unreadable) **before** it is dereferenced, so a garbage frame pointer truncates the stack instead of segfaulting;
- the chain must climb, so a corrupt chain cannot loop;
- `UNWIND_BLOCKLIST` is applied to **every** frame, not just the leaf.

It needs frame pointers, so `.cargo/config.toml` adds `-Cforce-frame-pointers=yes`. Without them the walk does not crash — it reports plausible, fabricated stacks, which is the worse failure — so `build.rs` detects the flag into `cfg(heph_frame_pointers)` and `pprof_dump::start` **refuses to profile** without it instead of emitting fiction.

Side benefit: samply (the `perf-test` skill) unwinds by frame pointer first and only falls back to DWARF, so its profiles of heph get more reliable too.

## Cost

- **One frame of resolution.** The walk starts at the return address in the innermost frame record, so the interrupted function is attributed to its caller. The caller chain is what answers "which loop is burning a pegged worker", which is the question this flag exists for.
- **Frame pointers in every build.** One register and a push/pop per call, on the Linux targets only (aarch64-apple-darwin already keeps the frame record — the platform ABI reserves x29 for it). Worth watching the perf job on this PR for the real number; I did not run `heph-bench` locally.

## Verification

- linux/arm64, 2800-target run under `--pprof-cpu`: no crash, 7.8s of samples, stacks 24+ frames deep running through tokio into heph's own poll chain (`go tool pprof -traces`).
- Dropping the flag from `RUSTFLAGS` on Linux turns `this_build_has_frame_pointers` red and makes `--pprof-cpu` refuse to start with a message naming the flag. Both halves checked.
- `cargo test --bin heph` green, `lint` green.

## What this PR does *not* claim

The original fault **did not reproduce locally** — not on darwin/arm64, not on linux/arm64 native, not on emulated linux/amd64, and not with the blocklist switched off under a 32-thread hammer of concurrent `Backtrace::force_capture` + `dlopen`/`dlclose` + allocator churn at up to 20 kHz. #185 recorded the same failure to reproduce. So this removes the unsafety rather than patching a captured trace: the handler no longer runs code that is unsafe to run there, whatever the exact instruction the signal landed on.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LfY4g55iZUmgqammq3qGag