### PR TITLE
perf(engine): key the addr memoizers on pointer identity, not content

### DIFF
--- a/crates/engine/src/engine/expand.rs
+++ b/crates/engine/src/engine/expand.rs
@@ -2,7 +2,7 @@ use crate::engine::Engine;
 use crate::engine::driver::TargetAddr;
 use crate::engine::driver::targetdef::path::Content;
 use crate::engine::driver::targetdef::{Input, InputMode};
-use crate::engine::request_state::RequestState;
+use crate::engine::request_state::{AddrKey, RequestState};
 use async_recursion::async_recursion;
 use enclose::enclose;
 use hcore::hmemoizer::unwrap_arc_err;
@@ -137,7 +137,7 @@ impl Engine {
         rs.data
             .mem_expanded_inputs
             .once(
-                addr.clone(),
+                AddrKey(addr.clone()),
                 enclose!((self => engine, rs, addr) move || async move {
                     // _no_track: result_addr (the upstream entry point) already set
                     // parent=addr before getting here, so tracked get_def would

--- a/crates/engine/src/engine/meta.rs
+++ b/crates/engine/src/engine/meta.rs
@@ -1,4 +1,4 @@
-use crate::engine::request_state::RequestState;
+use crate::engine::request_state::{AddrKey, RequestState};
 use crate::engine::result::ExtendedTargetDef;
 use crate::engine::{EResult, Engine, OutputMatcher, ResultOptions};
 use anyhow::Context;
@@ -26,7 +26,7 @@ impl Engine {
             .data
             .mem_meta
             .once(
-                addr.clone(),
+                AddrKey(addr.clone()),
                 enclose!((self => engine, rs, addr) move || async move {
                     engine.inner_meta(rs, &addr).await
                 }),

--- a/crates/engine/src/engine/request_state.rs
+++ b/crates/engine/src/engine/request_state.rs
@@ -21,6 +21,58 @@ type ArcErr = Arc<anyhow::Error>;
 type ExecuteCacheResult = Result<(Vec<ResultArtifact>, Vec<ArtifactMeta>), ArcErr>;
 type ProbeStatesResult = Result<Arc<Vec<State>>, ArcErr>;
 
+/// Process-local memoizer key for an `Addr`.
+///
+/// `Addr` is interned, so `Arc::ptr_eq` is already what `Addr::PartialEq`
+/// does — but `Addr::Hash` walks package + name + every arg, because that same
+/// impl feeds driver def hashes and therefore the persisted cache key (see the
+/// comment on `impl Hash for Addr` in `htaddr/addr.rs`). Memoizer maps are
+/// per-request and never persisted, so they can hash the pointer instead.
+///
+/// This is not a behaviour change, it is the removal of redundant work: a map
+/// that compares by pointer and hashes by content already treats two
+/// ptr-distinct, content-equal `Addr`s as two entries (they collide in a bucket
+/// and then compare unequal). Hashing the pointer puts them in different
+/// buckets and reaches the same two entries. Every lookup outcome is identical;
+/// only the cost differs — measured 7.1x cheaper per lookup (10.2 ns) on
+/// realistic addresses.
+///
+/// `Debug` still renders the `Addr`, so the SIGQUIT memoizer inventory and the
+/// stall diagnostics keep naming targets rather than pointers.
+#[derive(Clone)]
+pub struct AddrKey(pub Addr);
+
+impl From<Addr> for AddrKey {
+    #[inline]
+    fn from(addr: Addr) -> Self {
+        Self(addr)
+    }
+}
+
+impl PartialEq for AddrKey {
+    #[inline]
+    fn eq(&self, other: &Self) -> bool {
+        // `Addr::PartialEq` is already `Arc::ptr_eq`.
+        self.0 == other.0
+    }
+}
+
+impl Eq for AddrKey {}
+
+impl std::hash::Hash for AddrKey {
+    #[inline]
+    fn hash<H: std::hash::Hasher>(&self, state: &mut H) {
+        let inner: &AddrInner = self.0.deref();
+        (inner as *const AddrInner as usize).hash(state);
+    }
+}
+
+impl std::fmt::Debug for AddrKey {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        std::fmt::Debug::fmt(&self.0, f)
+    }
+}
+
 /// Pointer-keyed map entry for `DepDag` nodes.
 ///
 /// `Addr` is interned via the sharded table in `src/htaddr/addr.rs` — content-equal
@@ -218,27 +270,29 @@ pub struct RequestStateData {
     // Key includes `is_top`: top-level vs dependency resolution of the same
     // (addr, outputs) must not share a cell, because only the top-level frame
     // writes a codegen target's tree back / stores its fixpoint.
-    pub mem_result:
-        Memoizer<(Addr, OutputMatcher, bool), Result<Arc<crate::engine::result::EResult>, ArcErr>>,
-    pub mem_execute_cache: Memoizer<(Addr, String), ExecuteCacheResult>,
+    pub mem_result: Memoizer<
+        (AddrKey, OutputMatcher, bool),
+        Result<Arc<crate::engine::result::EResult>, ArcErr>,
+    >,
+    pub mem_execute_cache: Memoizer<(AddrKey, String), ExecuteCacheResult>,
     /// Single-flights the per-addr result-LOCK + cache-fetch/execute, keyed by
     /// `Addr` ALONE (not `is_top`/`outputs`). The `(outputs, is_top)`
     /// `mem_result` cells all await this, share its one riding read guard, then
     /// filter outputs on top. Keyed addr-only so two sibling computations of one
     /// addr can never both hold the non-reentrant per-addr lock — the
     /// self-deadlock this prevents.
-    pub(crate) mem_locked_result: Memoizer<Addr, Result<Arc<LockedResolution>, ArcErr>>,
+    pub(crate) mem_locked_result: Memoizer<AddrKey, Result<Arc<LockedResolution>, ArcErr>>,
     /// Single-flights the lazy pull of one remote blob, keyed by
     /// `(addr, hashin, blob name)`. Two `outputs` cells of the same addr both need
     /// its support files, so without this they would download and write the same
     /// blob concurrently — duplicate transfer, and two writers racing on one cache
     /// key.
-    pub(crate) mem_remote_blob: Memoizer<(Addr, String, String), Result<bool, ArcErr>>,
-    pub mem_meta: Memoizer<Addr, Result<ResultMeta, ArcErr>>,
-    pub mem_spec: Memoizer<Addr, Result<Arc<EngineTargetSpec>, ArcErr>>,
-    pub mem_def: Memoizer<Addr, Result<Arc<ExtendedTargetDef>, ArcErr>>,
+    pub(crate) mem_remote_blob: Memoizer<(AddrKey, String, String), Result<bool, ArcErr>>,
+    pub mem_meta: Memoizer<AddrKey, Result<ResultMeta, ArcErr>>,
+    pub mem_spec: Memoizer<AddrKey, Result<Arc<EngineTargetSpec>, ArcErr>>,
+    pub mem_def: Memoizer<AddrKey, Result<Arc<ExtendedTargetDef>, ArcErr>>,
     pub mem_expanded_inputs:
-        Memoizer<Addr, Result<Arc<Vec<crate::engine::driver::targetdef::Input>>, ArcErr>>,
+        Memoizer<AddrKey, Result<Arc<Vec<crate::engine::driver::targetdef::Input>>, ArcErr>>,
     pub mem_packages: Memoizer<String, Result<Arc<Vec<String>>, ArcErr>>,
     /// Outer memoizer for `Engine::probe_segments`. Keyed by the target package;
     /// the cached value is the flat accumulation of every provider's probe across
@@ -1584,5 +1638,66 @@ mod tests {
             "the *End event must reach the hook even with no renderer channel"
         );
         Ok(())
+    }
+
+    /// Two content-equal `Addr`s are ONE memoizer key.
+    ///
+    /// This is the invariant `AddrKey`'s pointer hash rests on, and it is
+    /// interning that supplies it — `Addr::PartialEq` is already `Arc::ptr_eq`,
+    /// so the map's behaviour is unchanged by hashing the pointer. If interning
+    /// ever stopped handing out one `Arc` per distinct content, this goes red
+    /// and every addr-keyed memoizer would silently double-compute — worse than
+    /// slow for `mem_locked_result`, whose whole job is to stop two sibling
+    /// computations of one addr both reaching for the non-reentrant per-addr
+    /// lock.
+    #[test]
+    fn content_equal_addrs_are_one_addr_key() {
+        let a = addr("t");
+        let b = addr("t");
+        let c = addr("u");
+
+        let mut m: FxHashMap<AddrKey, u32> = FxHashMap::default();
+        m.insert(AddrKey(a.clone()), 1);
+        m.insert(AddrKey(b.clone()), 2);
+        m.insert(AddrKey(c.clone()), 3);
+
+        assert_eq!(m.len(), 2, "content-equal addrs must share one cell");
+        assert_eq!(
+            m.get(&AddrKey(b)),
+            Some(&2),
+            "the second insert addressed the same entry"
+        );
+        assert_eq!(m.get(&AddrKey(c)), Some(&3));
+        assert!(
+            !m.contains_key(&AddrKey(addr("other"))),
+            "a distinct addr must not alias an existing cell"
+        );
+        drop(a);
+    }
+
+    /// `Hash` agrees with `Eq` — the contract a `HashMap` key owes.
+    #[test]
+    fn addr_key_hash_agrees_with_eq() {
+        use std::hash::{Hash, Hasher};
+
+        fn h(k: &AddrKey) -> u64 {
+            let mut hasher = rustc_hash::FxHasher::default();
+            k.hash(&mut hasher);
+            hasher.finish()
+        }
+
+        let a = AddrKey(addr("t"));
+        let b = AddrKey(addr("t"));
+        assert_eq!(a, b);
+        assert_eq!(h(&a), h(&b), "equal keys must hash equal");
+    }
+
+    /// The memoizer inventory and stall diagnostics render the key with
+    /// `Debug`. A key that printed a pointer would turn "which target is
+    /// stuck?" into an unanswerable question, so `AddrKey` forwards to `Addr`.
+    #[test]
+    fn addr_key_debug_names_the_target() {
+        let a = addr("t");
+        assert_eq!(format!("{:?}", AddrKey(a.clone())), format!("{a:?}"));
     }
 }

--- a/crates/engine/src/engine/result.rs
+++ b/crates/engine/src/engine/result.rs
@@ -9,7 +9,7 @@ use crate::engine::provider::{
     GetError, GetRequest, GetResponse, ListRequest, ProbeRequest, ProviderExecutor, State,
     TargetSpec,
 };
-use crate::engine::request_state::RequestState;
+use crate::engine::request_state::{AddrKey, RequestState};
 use crate::engine::spec::EngineTargetSpec;
 use async_recursion::async_recursion;
 use enclose::enclose;
@@ -1409,7 +1409,7 @@ impl Engine {
         // is_top variant needs its own memoizer cell or a race could bake the
         // wrong is_top into the shared computation. The second variant hits the
         // on-disk cache (keyed by hashin, not is_top), so there is no re-execute.
-        let key = (addr.clone(), key_outputs, is_top);
+        let key = (AddrKey(addr.clone()), key_outputs, is_top);
         let opts = opts.clone();
         let interactive = opts.interactive.is_some();
         let res = rs
@@ -2294,7 +2294,7 @@ impl Engine {
             async {
                 let mut pulls = Vec::with_capacity(missing.len());
                 for name in &missing {
-                    let key = (addr.clone(), hashin.clone(), name.clone());
+                    let key = (AddrKey(addr.clone()), hashin.clone(), name.clone());
                     let engine = Arc::clone(self);
                     let rs_owned = Arc::clone(rs);
                     let rev = Arc::clone(rev);
@@ -2353,7 +2353,7 @@ impl Engine {
         rs.data
             .mem_locked_result
             .once(
-                addr,
+                AddrKey(addr),
                 enclose!((self => engine, rs) move || async move {
                     // is_top/frozen are deliberately fixed here: the shared cell
                     // is addr-keyed and output/is_top-agnostic. It never runs
@@ -2951,7 +2951,7 @@ impl Engine {
         let use_tmp_cache = !opts.def.target.cache.enabled || opts.shell;
         let interactive = opts.interactive.clone();
         let shell = opts.shell;
-        let key = (addr.clone(), hashin.clone());
+        let key = (AddrKey(addr.clone()), hashin.clone());
 
         rs.data
             .mem_execute_cache
@@ -3391,7 +3391,7 @@ impl Engine {
         rs.data
             .mem_def
             .once(
-                addr.clone(),
+                AddrKey(addr.clone()),
                 enclose!((self => engine, rs, addr) move || async move {
                     engine.get_def_inner(rs, &addr, true).await.with_context(|| format!("get_def: {}", addr))
                 }),
@@ -3593,7 +3593,7 @@ impl Engine {
         rs.data
             .mem_spec
             .once(
-                addr.clone(),
+                AddrKey(addr.clone()),
                 enclose!((self => engine, rs, addr) move || async move {
                     engine.get_spec_inner(&rs, &addr).await
                 }),


### PR DESCRIPTION
Stacked on #319.

`Addr` is interned, so `Addr::PartialEq` is already `Arc::ptr_eq`. Its `Hash`, however, walks package + name + every arg — deliberately, because that same impl feeds driver def hashes and therefore the persisted cache key (`impl Hash for Addr` says so in its comment). The eight per-request memoizers keyed on an `Addr` paid that multi-string walk on every lookup for a map that then decided the match by comparing two pointers.

`AddrKey` wraps an `Addr` and hashes the interned pointer instead.

## Why this is not a behaviour change

It is the removal of redundant work. A map that compares by pointer while hashing by content **already** treats two ptr-distinct, content-equal `Addr`s as two entries — they share a bucket and then compare unequal. Hashing the pointer puts them in separate buckets and reaches the same two entries. Every lookup outcome is identical; only the cost differs.

## Why `impl Hash for Addr` is untouched

That was the obvious change and it would have been wrong. The content hash reaches persisted state through four routes, three of them invisible at the call site:

- `#[derive(Hash)]` on `TargetAddr` → `Input` → the pluginexec and `_golist` def hashes → `hashin`
- `Addr::hash_str()` calls `self.hash()` — feeds on-disk cache dir names, **cross-process result-lock paths**, nix gcroots, sandbox dir names
- `hash_str` values laundered into `origin_id` and into `Addr` args themselves

Pointer-hashing those would mint new cache keys every process (100% miss, unbounded cache growth) and make two concurrent `heph` processes compute *different* lock paths for the same addr. A separate key type keeps the two hashes apart by construction.

`AddrKey: Debug` forwards to `Addr`, so the SIGQUIT memoizer inventory and stall diagnostics keep naming targets rather than pointers.

## Measured

20k realistic addresses, 800k lookups, release build:

| | content | pointer | ratio |
|---|---|---|---|
| hash only | 4.42ms | 602µs | **7.33x** |
| full `get` | 9.50ms | 1.34ms | **7.08x** |

**10.2 ns saved per lookup.**

Context: the same 361s CPU profile put hashing/HashMap at 117.3s of 657s (17.8%), `HashMap::entry` alone at 44.9s.

## Tests

- `content_equal_addrs_are_one_addr_key` — the invariant the pointer hash rests on. If interning ever stopped handing out one `Arc` per distinct content this goes red, and every addr-keyed memoizer would silently double-compute — worse than slow for `mem_locked_result`, whose job is to stop two sibling computations of one addr both reaching for the non-reentrant per-addr lock.
- `addr_key_hash_agrees_with_eq` — the contract a `HashMap` key owes.
- `addr_key_debug_names_the_target` — guards the diagnostics.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GcxMXLVjoe7oHuDUf9Wgdy