### PR TITLE
fix(diag): stop SIGQUIT deadlocking the process it is diagnosing

### DIFF
--- a/crates/core/src/hmemoizer/mod.rs
+++ b/crates/core/src/hmemoizer/mod.rs
@@ -8,7 +8,7 @@ use std::future::Future;
 use std::hash::{Hash, Hasher};
 use std::sync::Arc;
 use std::sync::atomic::{AtomicU64, Ordering};
-use std::sync::{Mutex, OnceLock, PoisonError};
+use std::sync::{Mutex, OnceLock};
 use std::time::Duration;
 use xxhash_rust::xxh3::Xxh3Default;
 
@@ -249,11 +249,26 @@ fn format_phases() -> String {
 /// every other test in the binary also locks, permanently, for the rest of
 /// the process.
 fn format_phases_from(m: &Mutex<HashMap<u64, &'static str>>) -> String {
+    // `try_lock`, for the same reason `TaskSource::collect` uses it: never block
+    // a diagnostic dump on the process being dumped. With `HEPH_PHASE_TRACE=1`
+    // this mutex is touched by every invocation on every phase transition, and
+    // std's `Mutex` is not fair — a blocking `lock()` here can be starved by a
+    // busy engine for as long as the engine stays busy, which turns "dump the
+    // state" into "hang the dumper" on exactly the run someone is trying to
+    // diagnose.
+    //
     // A panic while some other caller held this lock (mid `set_phase` or
     // `clear_phase`) must not turn this diagnostic dump into a second panic —
     // recover the guard rather than propagating the poison, same as
     // `ApprovalCenter::lock`.
-    let map = m.lock().unwrap_or_else(PoisonError::into_inner);
+    let map = match m.try_lock() {
+        Ok(g) => g,
+        Err(std::sync::TryLockError::Poisoned(e)) => e.into_inner(),
+        Err(std::sync::TryLockError::WouldBlock) => {
+            return "  (not sampled — the phase map was busy; the engine is still running)"
+                .to_string();
+        }
+    };
     if map.is_empty() {
         return "  (none)".to_string();
     }
@@ -870,9 +885,21 @@ fn format_wait_graph() -> String {
 /// [`format_phases_from`]: so a test can poison a private `Mutex` instead of
 /// the process-wide static.
 fn format_wait_graph_from(m: &Mutex<WaitGraph>) -> String {
+    // `try_lock` — see `format_phases_from` for why a diagnostic must never
+    // block on the process it is diagnosing. `HEPH_DEBUG_MEMOIZER_CYCLE=1`
+    // makes this mutex hot on every `once()`, so a blocking `lock()` is
+    // starvable by a busy engine.
+    //
     // Recover a poisoned guard instead of panicking a second time — see
     // `format_phases`.
-    let wg = m.lock().unwrap_or_else(PoisonError::into_inner);
+    let wg = match m.try_lock() {
+        Ok(g) => g,
+        Err(std::sync::TryLockError::Poisoned(e)) => e.into_inner(),
+        Err(std::sync::TryLockError::WouldBlock) => {
+            return "  (not sampled — the wait-for graph was busy; the engine is still running)"
+                .to_string();
+        }
+    };
     let mut out = String::new();
     if wg.cells.is_empty() && wg.waiting.is_empty() {
         out.push_str("  (empty)");
@@ -2117,6 +2144,44 @@ mod tests {
     /// real `phases()` static would poison it for every other test in this
     /// binary for the rest of the process (a `Mutex`'s poison never clears),
     /// not just this one.
+    /// A held lock must not block the dump.
+    ///
+    /// `TaskSource::collect` states the rule — "never block a diagnostic dump on
+    /// the process being dumped" — and takes its map with `try_lock`. These two
+    /// sections did not, and they are the ones gated behind `HEPH_PHASE_TRACE=1`
+    /// and `HEPH_DEBUG_MEMOIZER_CYCLE=1`, which are precisely the flags that make
+    /// these mutexes hot: every phase transition and every `once()` respectively.
+    /// std's `Mutex` is not fair, so a blocking `lock()` here is starvable by a
+    /// busy engine for as long as it stays busy — turning "dump the state" into
+    /// "hang the dumper" on the exact run someone is trying to diagnose.
+    ///
+    /// Deterministic without a second thread: `try_lock` on a mutex this thread
+    /// already holds returns `WouldBlock` (std's `Mutex` is not reentrant), so
+    /// the guard below reproduces contention exactly.
+    #[test]
+    fn format_phases_does_not_block_on_a_held_lock() {
+        let m: Mutex<HashMap<u64, &'static str>> = Mutex::new(HashMap::new());
+        let _held = m.lock().expect("hold the lock");
+        let text = format_phases_from(&m);
+        assert!(
+            text.contains("not sampled"),
+            "a busy phase map must yield a note, not block: {text}"
+        );
+    }
+
+    /// Same as `format_phases_does_not_block_on_a_held_lock`, for the
+    /// wait-for-graph lock.
+    #[test]
+    fn format_wait_graph_does_not_block_on_a_held_lock() {
+        let m: Mutex<WaitGraph> = Mutex::new(WaitGraph::new());
+        let _held = m.lock().expect("hold the lock");
+        let text = format_wait_graph_from(&m);
+        assert!(
+            text.contains("not sampled"),
+            "a busy wait-for graph must yield a note, not block: {text}"
+        );
+    }
+
     #[test]
     fn format_phases_recovers_from_a_poisoned_lock() {
         let m: Mutex<HashMap<u64, &'static str>> = Mutex::new(HashMap::new());

--- a/crates/engine/src/engine/diag.rs
+++ b/crates/engine/src/engine/diag.rs
@@ -1061,9 +1061,15 @@ pub fn render_stall(r: &StallReport) -> String {
     // it is exactly what cannot help — the TUI clears ISIG, so the terminal
     // never raises SIGINT. Name the escalation that does work, here, where it is
     // read, rather than leaving it to be rediscovered per incident.
+    // Names the inventory and *not* the backtraces: `--diag-backtrace` is off by
+    // default because capturing a stack from a signal handler calls the unwinder
+    // and the allocator, and a thread interrupted inside `malloc` deadlocks the
+    // whole process (`src/diag.rs`). This line is read by someone whose build is
+    // already in trouble — pointing them at the half that can wedge it is the one
+    // thing it must not do.
     out.push_str(&format!(
-        "\n  Still stuck? `kill -QUIT {}` writes every thread's backtrace plus the\n  \
-         full in-flight inventory next to this file; it does not kill the process.\n",
+        "\n  Still stuck? `kill -QUIT {}` writes the full in-flight inventory next\n  \
+         to this file; it does not kill the process.\n",
         std::process::id()
     ));
 
@@ -1992,6 +1998,13 @@ mod tests {
     /// A frozen TUI swallows Ctrl-C (raw mode clears ISIG), so the paragraph must
     /// name the escalation that does work instead of leaving it to be
     /// rediscovered per incident.
+    ///
+    /// And it must name the *safe* escalation. `SIGQUIT` used to dump every
+    /// thread's stack unconditionally, which calls the unwinder and the allocator
+    /// from a signal handler and deadlocks a process interrupted inside `malloc`
+    /// (`src/diag.rs`). This paragraph is read by someone whose build is already
+    /// in trouble; advertising the half that can wedge it is the one thing it
+    /// must not do, and the claim went stale silently when the default changed.
     #[test]
     fn the_paragraph_names_the_next_step() {
         let s = state();
@@ -2001,6 +2014,16 @@ mod tests {
         assert!(
             text.contains(&std::process::id().to_string()),
             "the pid must be filled in, not left as a placeholder: {text}"
+        );
+        assert!(
+            text.contains("in-flight inventory"),
+            "the paragraph must name what the dump actually produces: {text}"
+        );
+        assert!(
+            !text.contains("backtrace"),
+            "the paragraph must not promise thread backtraces: they are behind \
+             --diag-backtrace precisely because that path can deadlock the \
+             process this reader is trying to rescue: {text}"
         );
     }
 

--- a/src/commands/global.rs
+++ b/src/commands/global.rs
@@ -43,6 +43,21 @@ pub struct GlobalOptions {
         global = true
     )]
     pub stall_notice: std::time::Duration,
+    /// Also dump every thread's backtrace on `SIGQUIT`. Can deadlock the process
+    ///
+    /// `SIGQUIT` always writes the in-flight report (what work is open and what
+    /// it is waiting on), which is the half that names the stuck work and is
+    /// written by an ordinary thread. This flag adds per-thread backtraces,
+    /// which are captured *inside a signal handler* — that calls the DWARF
+    /// unwinder and the allocator, neither of which is async-signal-safe. A
+    /// thread interrupted inside `malloc` re-enters it from its own handler and
+    /// deadlocks holding the arena lock, taking the whole process with it.
+    ///
+    /// Off by default because that outcome is the opposite of what a hang
+    /// diagnostic is for. Turn it on only when the in-flight report was not
+    /// enough, on a run you are willing to lose.
+    #[arg(long = "diag-backtrace", global = true)]
+    pub diag_backtrace: bool,
     /// Disable the interactive TUI (force CI/log-only output)
     #[arg(long = "no-tui", global = true)]
     pub no_tui: bool,

--- a/src/diag.rs
+++ b/src/diag.rs
@@ -1,31 +1,55 @@
-//! On-demand thread backtraces for diagnosing hangs. Always installed.
+//! On-demand in-flight state for diagnosing hangs. Always installed.
 //!
 //! When a run hangs in a locked-down CI container, every external tool is blocked:
 //! ptrace is denied (no gdb/perf/`gcore`), the root fs is read-only (kernel core
 //! dumps are dropped), and `--pprof-cpu` only samples a run it was passed on —
 //! which is never the run that turns out to hang. The one channel left is the
-//! process dumping its own stacks. A `SIGUSR1` handler
-//! appends the *signalled* thread's backtrace to a file, so signalling the busy
-//! thread reveals the loop — and a file beats stderr when hundreds of threads
-//! dump at once.
+//! process reporting on itself.
 //!
-//! Dump every thread of a stuck process by sending it `SIGQUIT` — which is
-//! `Ctrl-\\` at the terminal, so a human staring at a frozen TUI needs no
-//! forethought, no flag, and no recipe:
+//! Dump a stuck process by sending it `SIGQUIT` — which is `Ctrl-\\` at the
+//! terminal, so a human staring at a frozen TUI needs no forethought, no flag,
+//! and no recipe:
 //! ```sh
 //! kill -QUIT <pid>          # or just press Ctrl-\\
-//! cat .heph3/diag/dump-<pid>.txt
+//! cat <home>/diag/dump-<pid>.txt
 //! ```
 //! `SIGQUIT` follows the Go/JVM convention and, unlike `SIGUSR1`, is not already
-//! taken here (`SIGUSR2` belongs to the pprof sampler). The handler dumps and
-//! continues; it never terminates the process.
+//! taken here (`SIGUSR2` belongs to the pprof sampler). The handler sets one
+//! atomic and returns; the work happens on the sweeper thread, and the process
+//! keeps running.
 //!
-//! The handler is not strictly async-signal-safe (capturing a backtrace
-//! allocates), but it targets a CPU-bound hang, where the interrupted thread is
-//! looping in compute rather than inside the allocator — a pragmatic trade for a
-//! diagnostic that is off unless `--diag-backtrace` is passed. Backtraces resolve
-//! to function names only when the binary keeps its symbol table
-//! (`strip = "debuginfo"`, not `strip = true`).
+//! # What the dump contains, and why backtraces are opt-in
+//!
+//! By default: the **in-flight report** — every memoized computation that is
+//! open, how long it has been open, and what it is waiting on. It is produced by
+//! [`write_inventory`] on an ordinary thread, allocating and locking normally,
+//! and it is the half that names the stuck work. See [`inventory_report`].
+//!
+//! With `--diag-backtrace`: every thread's stack too. That half is captured
+//! *inside a signal handler* ([`on_dump_signal`]), which calls
+//! `Backtrace::force_capture` — the DWARF unwinder, which takes libgcc's global
+//! `object_mutex` and re-enters `dl_iterate_phdr` — and then `format!`, which
+//! allocates. Neither is async-signal-safe.
+//!
+//! This used to be unconditional, on the reasoning that it "targets a CPU-bound
+//! hang, where the interrupted thread is looping in compute rather than inside
+//! the allocator". That premise does not hold for this engine: a real run
+//! measured ~11% of its CPU in drop glue alone, so at any instant some worker is
+//! very likely inside `malloc`. Signal *that* thread and its handler re-enters
+//! the allocator, deadlocks on the arena lock it already holds, and never
+//! returns — so every other thread blocks on the same lock and the process
+//! freezes with all threads at 0% CPU. Observed in practice, on the very
+//! workload someone reached for `SIGQUIT` to diagnose.
+//!
+//! Serialising the sweep does not fix it (and the cap and inter-thread gap below
+//! were never able to): the deadlock needs only *one* thread interrupted in the
+//! wrong place, not two overlapping. The same class of bug made `--pprof-cpu`
+//! segfault the process it was diagnosing, fixed there by walking frame pointers
+//! instead of calling the unwinder. Doing that here would make the backtrace
+//! half safe as well; until then it is behind a flag that says what it costs.
+//!
+//! Backtraces resolve to function names only when the binary keeps its symbol
+//! table (the `debug` release flavour; the stripped `std` one yields addresses).
 
 use std::backtrace::Backtrace;
 use std::ffi::CString;
@@ -37,14 +61,23 @@ use tracing::warn;
 /// File descriptor the handler appends dumps to; `-1` until [`install`] opens it.
 static DIAG_FD: AtomicI32 = AtomicI32::new(-1);
 
-/// Install the `SIGQUIT` → backtrace-to-file handler. Called unconditionally at
-/// startup.
+/// Whether this run also dumps per-thread backtraces. Set once by [`install`]
+/// from `--diag-backtrace`; read by [`sweep`]. See the module docs for why the
+/// backtrace half can deadlock the process and the in-flight report cannot.
+static BACKTRACES: AtomicBool = AtomicBool::new(false);
+
+/// Install the `SIGQUIT` → dump handler. Called unconditionally at startup.
 ///
 /// Unconditionally, because the opt-in version could not work: nobody passes a
 /// diagnostic flag on the run they do not yet know will hang, and on a process
 /// started without it `SIGQUIT` defaults to *terminating* — so reaching for the
 /// dump would kill the build being inspected. The cost is one `signal(2)`.
-pub fn install() {
+///
+/// `backtraces` gates only the *contents*, never the handler: `SIGQUIT` always
+/// writes the in-flight report, so the always-on guarantee above still holds for
+/// the half that is safe to produce.
+pub fn install(backtraces: bool) {
+    BACKTRACES.store(backtraces, Ordering::Relaxed);
     let handler = on_sigquit as extern "C" fn(libc::c_int);
     // SAFETY: the handler only stores to an `AtomicBool` (async-signal-safe);
     // installed once at startup before the runtime matters.
@@ -107,13 +140,10 @@ fn dump_path() -> std::path::PathBuf {
 
 /// Poll for a requested dump and perform the sweep off the signal handler.
 ///
-/// The sweep must not run *in* the handler: capturing a backtrace allocates and
-/// takes the unwinder's global lock, and signalling every thread at once puts all
-/// of them inside `_Unwind_Backtrace` together — one interrupted mid-`malloc`
-/// then re-enters the allocator from its handler. That is the same class of bug
-/// that made `--pprof-cpu` segfault the process it was diagnosing, and heph runs
-/// a lot of threads (tokio workers, the blocking pool, tokio's own blocking pool,
-/// the sandbox cleaner). So: serial, with a gap, and capped.
+/// The sweep must not run *in* the handler: it opens files, allocates, and takes
+/// locks. Doing it on a plain thread is also what keeps the default path — the
+/// in-flight report — entirely free of the re-entrancy hazard that put
+/// `--diag-backtrace` behind a flag (module docs).
 fn spawn_sweeper() {
     static ONCE: Once = Once::new();
     ONCE.call_once(|| {
@@ -166,18 +196,35 @@ fn sweep() {
     }
     DIAG_FD.store(fd, Ordering::Relaxed);
 
-    let handler = on_dump_signal as extern "C" fn(libc::c_int);
-    // SAFETY: installed before any thread is signalled below.
-    unsafe {
-        libc::signal(DUMP_SIGNAL, handler as libc::sighandler_t);
-    }
-
-    let n = sweep_threads();
+    // Opt-in, and deliberately *before* the inventory: the backtrace half is the
+    // half that can wedge the process (module docs), so if it does, the reader
+    // still gets a file whose contents show how far it got.
+    let n = if BACKTRACES.load(Ordering::Relaxed) {
+        let handler = on_dump_signal as extern "C" fn(libc::c_int);
+        // SAFETY: installed before any thread is signalled below.
+        unsafe {
+            libc::signal(DUMP_SIGNAL, handler as libc::sighandler_t);
+        }
+        sweep_threads()
+    } else {
+        0
+    };
     write_inventory(fd);
     // `warn!`, not `info!`: someone pressed `Ctrl-\` on a frozen build and the one
     // thing they need back is where the dump went. At `info!` that line sits in
     // the same stream as ordinary build chatter and scrolls past unread.
-    warn!(threads = n, path = %path.display(), "Wrote thread backtraces");
+    //
+    // Naming the flag matters as much as the path: a reader who needed stacks and
+    // got none has no other way to learn they were available.
+    if n == 0 {
+        warn!(
+            path = %path.display(),
+            "Wrote in-flight report (no thread backtraces; pass --diag-backtrace to add them, \
+             at the risk of deadlocking the process)"
+        );
+    } else {
+        warn!(threads = n, path = %path.display(), "Wrote thread backtraces and in-flight report");
+    }
 }
 
 /// Append the parked-future state to the dump, after the thread backtraces.
@@ -353,6 +400,73 @@ mod tests {
         // Unset in a test process, so both must self-describe.
         assert!(text.contains("HEPH_DEBUG_MEMOIZER_CYCLE"), "{text}");
         assert!(text.contains("HEPH_PHASE_TRACE"), "{text}");
+    }
+
+    /// `SIGQUIT` writes the in-flight report and installs **no** signal handler
+    /// unless `--diag-backtrace` asked for one.
+    ///
+    /// The handler is the hazard: it captures a backtrace (DWARF unwinder) and
+    /// `format!`s it (allocator) from inside a signal, so a thread interrupted
+    /// in `malloc` deadlocks the process — observed on a real run, which is how
+    /// this default came to be. Asserting on `SIGUSR1`'s disposition rather than
+    /// on the file contents is deliberate: "no backtrace text appeared" would
+    /// also pass on a build where the sweep ran and simply found nothing, while
+    /// a handler still installed is the actual footgun.
+    ///
+    /// Only the *off* path is exercised end to end. Driving the on path here
+    /// would signal every thread of the test binary — i.e. reproduce the
+    /// deadlock this test exists because of. For the same reason the flag round
+    /// trip is asserted *inside* this test rather than beside it: `BACKTRACES`
+    /// is process-global, and a sibling test setting it to `true` in parallel
+    /// with the `sweep()` below is exactly that reproduction, by accident.
+    #[test]
+    fn a_dump_installs_no_handler_unless_backtraces_were_asked_for() {
+        fn sigusr1_disposition() -> libc::sighandler_t {
+            // SAFETY: all-zero is a valid initial `sigaction`; it is only an
+            // out-param here.
+            let mut old: libc::sigaction = unsafe { std::mem::zeroed() };
+            // SAFETY: a null `act` queries the disposition without installing
+            // anything; `old` is a valid out-param `sigaction` only writes to.
+            unsafe {
+                libc::sigaction(DUMP_SIGNAL, std::ptr::null(), &mut old);
+            }
+            old.sa_sigaction
+        }
+
+        // The flag reaches the sweeper. Without this the gate below could be
+        // wired to a constant and still pass.
+        install(true);
+        assert!(BACKTRACES.load(Ordering::Relaxed));
+        install(false);
+        assert!(!BACKTRACES.load(Ordering::Relaxed));
+
+        let before = sigusr1_disposition();
+
+        let dir = tempfile::tempdir().expect("tempdir");
+        set_dump_dir(dir.path());
+        let path = dump_path();
+        assert!(
+            path.starts_with(dir.path()),
+            "DUMP_DIR is a OnceLock and something set it first, so this test would \
+             write into the working tree instead of {dir:?}: {path:?}"
+        );
+
+        sweep();
+
+        assert_eq!(
+            sigusr1_disposition(),
+            before,
+            "the default dump installed a handler for signal {DUMP_SIGNAL}; that is \
+             the path that deadlocks a process interrupted inside the allocator"
+        );
+
+        // The half that is always safe to produce must still be there — the
+        // point of the gate is to keep it, not to make SIGQUIT do nothing.
+        let text = std::fs::read_to_string(&path).expect("dump written");
+        assert!(
+            text.contains("in-flight inventory"),
+            "the default dump must still carry the in-flight report: {text}"
+        );
     }
 
     /// The dump lands at an absolute path.

--- a/src/diag.rs
+++ b/src/diag.rs
@@ -154,7 +154,7 @@ fn spawn_sweeper() {
                     loop {
                         std::thread::sleep(std::time::Duration::from_millis(200));
                         if DUMP_REQUESTED.swap(false, Ordering::Relaxed) {
-                            sweep();
+                            sweep(&dump_path());
                         }
                     }
                 }),
@@ -170,8 +170,14 @@ const MAX_THREADS: usize = 256;
 /// Pause between signalling successive threads.
 const THREAD_GAP: std::time::Duration = std::time::Duration::from_millis(2);
 
-fn sweep() {
-    let path = dump_path();
+/// Write a dump to `path`.
+///
+/// The path is a parameter rather than read from [`dump_path`] inside: that
+/// reads a process-global `OnceLock`, so a test wanting its own file had to set
+/// the global and thereby decide where *every other* test in the binary thought
+/// dumps went. That is what it did — silently, ordering-dependent, green
+/// locally and red on CI.
+fn sweep(path: &std::path::Path) {
     if let Some(dir) = path.parent() {
         drop(std::fs::create_dir_all(dir));
     }
@@ -442,16 +448,14 @@ mod tests {
 
         let before = sigusr1_disposition();
 
+        // Its own path, never `set_dump_dir`: that writes a process-global
+        // `OnceLock`, so this test would decide where every *other* test in the
+        // binary thinks dumps go — which is exactly how it broke
+        // `the_dump_path_is_absolute`, ordering-dependent and only on CI.
         let dir = tempfile::tempdir().expect("tempdir");
-        set_dump_dir(dir.path());
-        let path = dump_path();
-        assert!(
-            path.starts_with(dir.path()),
-            "DUMP_DIR is a OnceLock and something set it first, so this test would \
-             write into the working tree instead of {dir:?}: {path:?}"
-        );
+        let path = dir.path().join("dump.txt");
 
-        sweep();
+        sweep(&path);
 
         assert_eq!(
             sigusr1_disposition(),

--- a/src/main.rs
+++ b/src/main.rs
@@ -118,7 +118,7 @@ fn main() -> ExitCode {
     // did not anticipate — you would have to have passed a flag on the run that
     // is already stuck. Costs one `signal(2)` at startup; the file is opened
     // lazily inside the handler.
-    diag::install();
+    diag::install(cli.global.diag_backtrace);
 
     // When `--pprof-cpu` is set, start the sampler + `SIGUSR2` dump watcher.
     let pprof_watcher = match cli.global.pprof_cpu.clone() {


### PR DESCRIPTION
Sending `SIGQUIT` to a real run froze heph solid — every thread at 0% CPU, TUI dead, build unrecoverable. The tool built to diagnose hangs was causing one.

## Cause

`on_dump_signal` (`src/diag.rs`) runs **inside a signal handler** and calls:

- `Backtrace::force_capture()` — the DWARF unwinder, which takes libgcc's global `object_mutex` and re-enters `dl_iterate_phdr`
- `format!(…)` — which allocates

Neither is async-signal-safe. A thread interrupted inside `malloc` re-enters the allocator from its own handler, deadlocks on the arena lock it already holds, and never returns. Every other thread then blocks on that same lock.

The old comment justified this as *"a pragmatic trade"* on the grounds that it *"targets a CPU-bound hang, where the interrupted thread is looping in compute rather than inside the allocator"*. That premise doesn't hold for this engine: a CPU profile of a real run puts **~11% of its time in drop glue alone**, so at any instant some worker is very likely inside the allocator. With 12–16 threads signalled, hitting one is near-certain rather than unlucky.

Serialising the sweep never mitigated it either — the `MAX_THREADS` cap and the 2ms inter-thread gap address *two* threads unwinding at once, but the deadlock needs only **one** thread interrupted in the wrong place.

## Fix

The backtrace half moves behind `--diag-backtrace`, off by default.

`SIGQUIT` still works unconditionally and still writes the **in-flight report** — every open computation, how long it has been open, and what it is waiting on. That half is produced by an ordinary thread with no re-entrancy hazard, and it is the one this file already documents as mattering:

> Thread backtraces alone answered "every thread is idle" on a wedged run — true, and useless. The inventory is the half that names the stuck work.

The `warn!` line names the flag, so a reader who wanted stacks and got none learns they exist rather than concluding the dump is broken.

This is the same defect class as #318, which took the SIGPROF sampler off `_Unwind_Backtrace` for exactly this reason. Walking frame pointers here too would make the backtrace half *safe* rather than merely gated — worth doing, but a much larger change; until then the flag states what it costs.

## Test

`a_dump_installs_no_handler_unless_backtraces_were_asked_for` asserts on `SIGUSR1`'s **disposition** after a default dump, not on the absence of backtrace text — an empty sweep would satisfy the latter, while a handler still installed is the actual footgun. It also asserts the in-flight report is still written, since the point of the gate is to keep that half, not to make `SIGQUIT` do nothing.

Only the *off* path runs end to end: driving the on path in-process would signal every thread of the test binary — i.e. reproduce the deadlock. The flag round trip is asserted inside that same test because `BACKTRACES` is process-global, and a parallel sibling test setting it would be that reproduction by accident.

## Compatibility

Additive CLI flag, default `false`. The only behaviour change to an existing invocation is that `SIGQUIT` no longer emits thread backtraces unless asked — which is the fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GcxMXLVjoe7oHuDUf9Wgdy