### PR TITLE
perf(alloc): give the binary mimalloc — resolution is allocator-bound

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2160,6 +2160,7 @@ dependencies = [
  "lock",
  "mach2",
  "memoize",
+ "mimalloc",
  "minijinja",
  "model",
  "nom 8.0.0",
@@ -2740,6 +2741,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b6d2cec3eae94f9f509c767b45932f1ada8350c4bdb85af2fcab4a3c14807981"
 
 [[package]]
+name = "libmimalloc-sys"
+version = "0.1.49"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6a45a52f43e1c16f667ccfe4dd8c85b7f7c204fd5e3bf46c5b0db9a5c3c0b8e9"
+dependencies = [
+ "cc",
+]
+
+[[package]]
 name = "libsqlite3-sys"
 version = "0.37.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3015,6 +3025,15 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 1.0.109",
+]
+
+[[package]]
+name = "mimalloc"
+version = "0.1.52"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2d4139bb28d14ad1facf21d5eb8825051b326e172d216b39f6d31df53cc97862"
+dependencies = [
+ "libmimalloc-sys",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -173,6 +173,7 @@ crossbeam-channel = "0.5"
 quick_cache = "0.6"
 indexmap = "2"
 posthog-rs = "0.12.0"
+mimalloc = { version = "0.1", default-features = false }
 uuid = { version = "1.23.3", features = ["v4"] }
 object_store = { version = "0.13.2", features = ["aws", "gcp", "azure", "http", "tokio"] }
 url = "2.5.8"

--- a/src/main.rs
+++ b/src/main.rs
@@ -8,6 +8,13 @@ use tracing::error;
 use heph::diag;
 mod pprof_dump;
 
+/// Resolution is allocator-bound: a warm 85k-target `validate` spends ~15% of
+/// its on-CPU samples inside the platform allocator, spread across every worker
+/// thread. mimalloc's per-thread free lists take that traffic off the shared
+/// arena locks that libmalloc/glibc-malloc serialize on.
+#[global_allocator]
+static GLOBAL: mimalloc::MiMalloc = mimalloc::MiMalloc;
+
 #[derive(Parser)]
 #[command(name = "heph")]
 #[command(about = "An efficient build system", long_about = None)]


### PR DESCRIPTION
The largest single slice in a warm resolution profile is not heph code. It is the platform allocator.

On a warm 85k-target `validate //go/large/...` (gorepogen corpus, 2000 Go packages), ~15% of on-CPU samples sit inside `libsystem_malloc` and another ~10% in `_platform_memmove` — `malloc`/`free` traffic from every worker thread hitting the shared arena locks that libmalloc and glibc-malloc serialize on. mimalloc's per-thread free lists take that traffic off those locks.

## Measured

Interleaved A/B (never two blocks back to back — see `docs/CONCURRENCY_MEASUREMENTS.md`), same binary but for the allocator, 4 reps a side, one warmup discarded per side:

| | wall | CPU | peak RSS |
|---|---|---|---|
| **darwin/arm64**, 12 cores | 4.44s → **3.93s** (−11.5%) | 26.4s → **23.2s** (−12.1%) | 2.64 → 2.60 GB |
| **linux/arm64**, 11 cores | 7.61s → **4.21s** (−45%) | 28.2s → **19.4s** (−31%) | 2.83 → 3.15 GB (+11%) |

Run-to-run spread was under 3% on both hosts.

The Linux win is far bigger because glibc arena contention is what dominates there. That is also where the memory goes the other way: +11% peak RSS from mimalloc holding decommitted segments.

## The RSS trade was measured, not assumed

| config (linux/arm64) | wall | peak RSS |
|---|---|---|
| mimalloc defaults | 4.19s | 3.22 GB |
| `MIMALLOC_PURGE_DELAY=0` | 4.44s | 3.12 GB |
| `MIMALLOC_ARENA_EAGER_COMMIT=0` | 4.30s | 3.15 GB |
| both | 4.41s | 2.97 GB |

Tuning gives back ~5% of the wall time it just bought and still does not reach the baseline's 2.83 GB. Defaults win.

## Scope: host binary only

The plugin cdylibs statically link their own std and keep the system allocator. That is deliberate, not an oversight — two statically-linked mimalloc instances either side of the ABI seam are two heaps, and anything allocated on one side and freed on the other is corruption. The host's `#[global_allocator]` does not reach into a cdylib's crate graph, and the `mimalloc` crate is taken with `default-features = false`, so it does not interpose `malloc` globally either.

Verified end to end: the same corpus under both allocators reports an identical `done 18464, err 0, cache 6342 hit / 0 miss`.

Stacked on #324 (the numbers above are all post-#324 — this is a second, independent slice).

🤖 Generated with [Claude Code](https://claude.com/claude-code)