### PR TITLE
perf(memoizer): answer run_pkg from a completed entry before building anything

### DIFF
--- a/crates/core/src/hmemoizer/mod.rs
+++ b/crates/core/src/hmemoizer/mod.rs
@@ -768,7 +768,15 @@ where
     /// *completed* (not in-flight, not absent). Lets a caller take a cheap path
     /// on a cache hit (e.g. registering a dep edge with `note_dep` instead of a
     /// full `result`) without disturbing the cache or deduping with in-flight work.
-    pub fn peek(&self, key: &K) -> Option<V> {
+    ///
+    /// Borrowed-key generic like `HashMap::get`: the hit path is the whole point
+    /// of this method, and making the caller mint an owned key to ask puts an
+    /// allocation back on it.
+    pub fn peek<Q>(&self, key: &Q) -> Option<V>
+    where
+        K: std::borrow::Borrow<Q>,
+        Q: std::hash::Hash + Eq + ?Sized,
+    {
         self.inner.peek(key)
     }
 

--- a/crates/core/src/hmemoizer/task_cell.rs
+++ b/crates/core/src/hmemoizer/task_cell.rs
@@ -361,7 +361,12 @@ where
             .unwrap_or_else(|e| e.into_inner())
     }
 
-    pub(crate) fn peek(&self, key: &K) -> Option<V> {
+    /// Borrowed-key generic like `HashMap::get`, so a hit needs no owned key.
+    pub(crate) fn peek<Q>(&self, key: &Q) -> Option<V>
+    where
+        K: std::borrow::Borrow<Q>,
+        Q: std::hash::Hash + Eq + ?Sized,
+    {
         self.cache_lock(key)
             .get(key)
             .and_then(|c| c.peek().cloned())

--- a/crates/plugin-buildfile/src/pluginbuildfile/run_file.rs
+++ b/crates/plugin-buildfile/src/pluginbuildfile/run_file.rs
@@ -1207,6 +1207,25 @@ fn pkg_eval_slots() -> usize {
 
 impl Provider {
     pub(crate) async fn run_pkg(&self, pkg: &str) -> anyhow::Result<Arc<RunResult>> {
+        // Answer a completed entry before building anything. Everything below
+        // this point exists only to construct the closure `once` runs on a
+        // *miss* — a `PathBuf` clone, a full clone of the function registry,
+        // five `Arc` bumps and a `String` — and it was all paid on every call,
+        // hit included.
+        //
+        // That is not a marginal saving here, because the call rate is not
+        // bounded by the number of packages. `probe` calls this for every
+        // package whose `provider_state` ancestry is consulted, and each
+        // top-level target with a `codegen = in_place` output re-runs its whole
+        // resolution under a *fresh* `RequestState` whose probe memo starts
+        // empty (`Engine::new_hash_only_state`). Measured on a fully cached
+        // `run lint //go/large/...` over 2000 Go packages: **12.27 million**
+        // calls, 11.4M of them from `probe` — against 13 BUILD files in the
+        // tree. The evaluation itself was already memoized; the preamble was
+        // not, and it was ~4% of the run's CPU.
+        if let Some(hit) = self.pkg_cache.peek(pkg) {
+            return hit.map_err(unwrap_arc_err);
+        }
         let key = pkg.to_string();
         let root = self.root.clone();
         let patterns = self.build_file_patterns.clone();


### PR DESCRIPTION
`Provider::run_pkg` memoized the Starlark evaluation but not the preamble that sets up the closure `once` would run on a **miss** — a `PathBuf` clone, a full clone of the function registry, five `Arc` bumps and a `String`. That ran on every call, hit included.

The call rate is not bounded by the number of BUILD files. `probe` calls this for every package whose `provider_state` ancestry is consulted, and each top-level target with a `codegen = in_place` output re-resolves under a fresh `RequestState` (`Engine::new_hash_only_state`) whose probe memo starts empty. Instrumented on a fully cached `run lint //go/large/...` over 2000 Go packages: **12,270,000 calls**, 11.4M of them from `probe`, against **13 BUILD files** in the tree.

`Memoizer::peek` becomes borrowed-key generic — like `HashMap::get`, and like `cache_lock` already is after #330 — so asking costs no allocation. The change is semantically inert: `pkg_cache` is already a process-lifetime memoizer, so peeking it only reorders the lookup ahead of work that was being thrown away.

## Measured

Interleaved A/B, host binary only, warmup discarded:

| workload | wall | CPU |
|---|---|---|
| `run lint` (in-place) | 47.69s → **47.10s** (−1.2%) | 417.5s → **411.4s** (−1.5%) |
| `run lint-check` (no in-place) | 9.07s → **8.98s** (−1.0%) | 16.0s → 15.9s |

Identical results on both (`done 26768, err 310, cache 11388 hit / 147 miss`).

## What was dropped, and why

A first version also cached the go provider's `list_packages` walk — called **17,791 times** across 6,115 prefixes on that run, the whole-tree prefix **1,831 times** — worth a further −5% wall. A hermeticity review of the design found the caching rule unsound rather than merely imperfect, so it is not here:

- Its justification ("an in-place write-back creates no directory and removes none") is **refuted by the code**: `materialize_codegen_tree` calls `create_dir_all` on that path, and `in_place_allows_net_new_files` proves net-new outputs are supported.
- Caching from the *second* sight of a prefix — which I chose to avoid a +3% cost on runs with no in-place targets — makes package membership depend on how many earlier requests happened to ask, i.e. **on thread scheduling**. Package membership feeds `pluginquery`'s deps and therefore a def hash. `PackageList` in the buildfile provider freezes on the *first* walk specifically to remove that non-determinism, and documents it; this reintroduced it.
- It also cached walk errors stickily, where the sibling provider deliberately does not — "a `readdir` failure is a transient environment fault, not a fact about the workspace".

## The repeat walks are a symptom

Measured with a throwaway build that skips the recheck when the target was a pure cache hit:

| fully cached `run lint //go/large/...` | wall | CPU |
|---|---|---|
| guard as today | 45.5s | 386s |
| guard skipped on pure cache hits | **8.8s** | **16.0s** |

8.8s is *below* the 9.3s an identical graph costs with no in-place targets at all. **The entire penalty is `check_in_place_inputs_unchanged` re-resolving 26,768 nodes, once per target, to answer a question about the handful of files that target is about to overwrite** — on targets that never executed and will write nothing.

That is the fix worth building, it does not need this cache, and it is not in this PR. Sketch: the guard's contract is "the files this target is about to overwrite still hold the bytes it hashed", which is O(files written) and derivable from `def.target.outputs` via `synthesized_fs_inputs` with no nested request at all — strictly more sensitive than today's check and strictly cheaper.

Stacked on #330.

🤖 Generated with [Claude Code](https://claude.com/claude-code)