### PR TITLE
fix(tui,plugin-exec): stop the tty reader making stdout non-blocking, and stop discarding the output that cost

### DIFF
--- a/crates/engine/src/engine/result.rs
+++ b/crates/engine/src/engine/result.rs
@@ -1352,13 +1352,13 @@ impl Engine {
             // nesting depth.
             //
             // Sharing the terminal between siblings is not merely untidy: each
-            // member's wrapper builds its own `TtyReader` on fd 0, the first
-            // member to finish resumes the TUI (re-enabling raw mode and
-            // clearing Ctrl-C suppression) underneath its live siblings, and
-            // `TtyReader::drop` restores blocking mode on fd 0 while a sibling
-            // still drives it through `AsyncFd` — leaving a blocking `read(0)`
-            // on a tokio worker that the request's cancellation token cannot
-            // reach.
+            // member's wrapper builds its own `TtyReader`, so several readers
+            // race the same terminal input queue and a keystroke lands in
+            // whichever one the kernel picks; and the first member to finish
+            // resumes the TUI (re-enabling raw mode and clearing Ctrl-C
+            // suppression) underneath its live siblings — including the
+            // cursor-position query the resume re-anchor issues, whose reply a
+            // sibling's reader can swallow.
             if !has_single_member(&def.target_def.inputs) {
                 if opts.shell {
                     return Err(ShellNeedsSingleTarget::Group {

--- a/crates/plugin-exec/src/pluginexec/mod.rs
+++ b/crates/plugin-exec/src/pluginexec/mod.rs
@@ -384,6 +384,7 @@ async fn tee_stream(
     use tokio::io::{AsyncReadExt, AsyncWriteExt};
     let Some(mut source) = source else { return };
     let mut buf = vec![0u8; 8192];
+    let mut lost = SinkLoss::default();
     loop {
         match source.read(&mut buf).await {
             Ok(0) => break,
@@ -408,13 +409,65 @@ async fn tee_stream(
                     drop(g.write_all(slice));
                 }
                 if let Some(ref mut out) = sink {
-                    drop(out.write_all(slice).await);
+                    let wrote = out.write_all(slice).await;
                     // Flush immediately so interactive shells see each byte
                     // appear as it's typed (tokio::io::stdout is line-buffered
                     // when wired to a tty).
-                    drop(out.flush().await);
+                    let flushed = out.flush().await;
+                    // `tokio::io::stdout` buffers, so a rejected write usually
+                    // surfaces at the flush rather than at `write_all` — take
+                    // whichever failed.
+                    if let Err(e) = wrote.and(flushed) {
+                        lost.record(n, e);
+                    }
                 }
             }
+        }
+    }
+    lost.finish(addr, stream);
+}
+
+/// Output the sink refused, and why.
+///
+/// The sink write used to be `drop(out.write_all(..).await)`. When it failed,
+/// the target's output vanished from the user's terminal while `log.txt` kept
+/// every byte — the two disagreed and nothing anywhere said why. That is how a
+/// non-blocking stdout (see `tui::tty`, where the bug was) went unnoticed long
+/// enough to read as a flaky test: `EAGAIN` on a full terminal queue is a
+/// *silent* truncation, and it only shows up under output large enough to fill
+/// the queue.
+///
+/// Counting is per-chunk, not per-byte: `write_all` does not report how far it
+/// got before failing, so the whole chunk in flight is charged. The number is a
+/// floor on what the terminal missed, and is reported as such.
+#[derive(Default)]
+struct SinkLoss {
+    dropped_bytes: usize,
+    first: Option<std::io::Error>,
+}
+
+impl SinkLoss {
+    fn record(&mut self, chunk_len: usize, error: std::io::Error) {
+        self.dropped_bytes = self.dropped_bytes.saturating_add(chunk_len);
+        if self.first.is_none() {
+            self.first = Some(error);
+        }
+    }
+
+    /// Report once, at the end, rather than per failing chunk: the failure is
+    /// almost always the same error repeating for every chunk that follows, and
+    /// a warning per 8 KiB would bury the run's real output.
+    fn finish(self, addr: &str, stream: &str) {
+        if let Some(error) = self.first {
+            tracing::warn!(
+                addr,
+                stream,
+                dropped_bytes = self.dropped_bytes,
+                %error,
+                "heph could not write some of this target's output to the terminal, so at \
+                 least this many bytes of it were not shown. The full output is in the \
+                 target's log.txt"
+            );
         }
     }
 }
@@ -462,6 +515,7 @@ async fn tee_output<'io>(
     use tokio::io::AsyncWriteExt;
     let Some(mut reader) = reader else { return };
     let mut absorbed = SinkCost::default();
+    let (mut lost_stdout, mut lost_stderr) = (SinkLoss::default(), SinkLoss::default());
     loop {
         let (stream, chunk) = match reader.recv().await {
             Ok(Some(c)) => c,
@@ -495,10 +549,18 @@ async fn tee_output<'io>(
             proc_exec::StreamId::Stderr => stderr.as_mut(),
         };
         if let Some(out) = sink {
-            drop(out.write_all(&chunk).await);
+            let wrote = out.write_all(&chunk).await;
             // Flush immediately so an interactive consumer sees each chunk
             // as it appears rather than at process exit.
-            drop(out.flush().await);
+            let flushed = out.flush().await;
+            // Same silent-truncation trap as the PTY path — see [`SinkLoss`].
+            if let Err(e) = wrote.and(flushed) {
+                match stream {
+                    proc_exec::StreamId::Stdout => &mut lost_stdout,
+                    proc_exec::StreamId::Stderr => &mut lost_stderr,
+                }
+                .record(chunk.len(), e);
+            }
         }
         if absorbed.record(stream, started.elapsed()) {
             tracing::warn!(
@@ -511,6 +573,8 @@ async fn tee_output<'io>(
         }
     }
     absorbed.finish(addr);
+    lost_stdout.finish(addr, "stdout");
+    lost_stderr.finish(addr, "stderr");
 }
 
 /// Cumulative time a target spent blocked while heph wrote the target's own
@@ -1726,6 +1790,85 @@ mod tests {
     fn log_file(dir: &tempfile::TempDir) -> Arc<std::sync::Mutex<std::fs::File>> {
         let file = std::fs::File::create(dir.path().join("log.txt")).expect("create log file");
         Arc::new(std::sync::Mutex::new(file))
+    }
+
+    /// `AsyncWrite` double that swallows writes and then refuses to flush with
+    /// `WouldBlock` — the shape a *non-blocking* stdout takes once the
+    /// terminal's output queue fills. Refusing at the flush rather than the
+    /// write is not incidental: `tokio::io::stdout` buffers, so that is where
+    /// the real `EAGAIN` surfaced.
+    struct WouldBlockSink;
+
+    impl tokio::io::AsyncWrite for WouldBlockSink {
+        fn poll_write(
+            self: std::pin::Pin<&mut Self>,
+            _cx: &mut std::task::Context<'_>,
+            buf: &[u8],
+        ) -> std::task::Poll<std::io::Result<usize>> {
+            std::task::Poll::Ready(Ok(buf.len()))
+        }
+
+        fn poll_flush(
+            self: std::pin::Pin<&mut Self>,
+            _cx: &mut std::task::Context<'_>,
+        ) -> std::task::Poll<std::io::Result<()>> {
+            std::task::Poll::Ready(Err(std::io::Error::new(
+                std::io::ErrorKind::WouldBlock,
+                "synthetic EAGAIN",
+            )))
+        }
+
+        fn poll_shutdown(
+            self: std::pin::Pin<&mut Self>,
+            _cx: &mut std::task::Context<'_>,
+        ) -> std::task::Poll<std::io::Result<()>> {
+            std::task::Poll::Ready(Ok(()))
+        }
+    }
+
+    /// Output the terminal refuses must be *reported*, not discarded.
+    ///
+    /// This is the regression for a silent truncation: the sink write was
+    /// `drop(out.write_all(..).await)`, so when stdout was accidentally
+    /// non-blocking (see `tui::tty`) heph read the target's output, wrote every
+    /// byte to `log.txt`, and dropped an arbitrary tail of it on the way to the
+    /// terminal — with nothing logged, and the two records silently disagreeing.
+    /// A user's only symptom was output that stopped mid-stream.
+    #[tokio::test]
+    async fn tee_stream_reports_output_the_sink_refused() {
+        let (guard, log) = capture_tracing();
+        let tmp = tempfile::tempdir().expect("tempdir");
+        let bytes_read = std::sync::atomic::AtomicUsize::new(0);
+        let payload = vec![b'x'; 4096];
+        let mut sink = WouldBlockSink;
+
+        tee_stream(
+            Some(&payload[..]),
+            log_file(&tmp),
+            Some(&mut sink),
+            "//pkg:target",
+            "pty",
+            &bytes_read,
+        )
+        .await;
+        drop(guard);
+
+        let text = log.text();
+        assert!(
+            text.contains("could not write some of this target's output"),
+            "the refused output was not reported: {text}"
+        );
+        assert!(text.contains("//pkg:target"), "missing addr field: {text}");
+        // One 8 KiB read covers the whole payload, so the count is exact rather
+        // than merely a floor here.
+        assert!(
+            text.contains("dropped_bytes=4096"),
+            "missing or wrong dropped byte count: {text}"
+        );
+        assert!(
+            text.contains("synthetic EAGAIN"),
+            "missing underlying error: {text}"
+        );
     }
 
     #[tokio::test]

--- a/crates/tui/src/tui/tty.rs
+++ b/crates/tui/src/tui/tty.rs
@@ -8,56 +8,181 @@
 //!
 //! We cannot use `tokio::io::stdin()`: per tokio's docs, it spawns a global
 //! blocking thread parked on `read(0, …)` that cannot be cancelled, so
-//! runtime shutdown hangs until the user presses another key. Instead we
-//! put fd 0 into non-blocking mode and drive it via `tokio::io::unix::AsyncFd`.
-//! On drop we restore the original fd flags so the parent shell still sees
-//! a blocking stdin afterwards.
+//! runtime shutdown hangs until the user presses another key. Instead we drive
+//! the terminal through `tokio::io::unix::AsyncFd`, which needs the fd to be
+//! non-blocking.
 //!
-//! Important: this stomps on stdin shared with everything else in the
-//! process. Only construct one `TtyReader` at a time.
+//! # Why this reopens the terminal instead of flipping fd 0
+//!
+//! `O_NONBLOCK` is a property of the *open file description*, not of the file
+//! descriptor. A terminal is opened once and dup'd onto fds 0, 1 and 2, so all
+//! three normally share one description — and setting `O_NONBLOCK` on fd 0 sets
+//! it on **stdout and stderr too**.
+//!
+//! That is not academic. It is what made `heph run --shell` lose output: with
+//! stdout non-blocking, a write that filled the terminal's output queue
+//! returned `EAGAIN` instead of blocking, and the target's output was dropped
+//! on the floor — silently, and only once a command printed enough to fill the
+//! queue, which is why it read as a flaky test rather than as a bug.
+//!
+//! So when the fd is a terminal we open its device a second time and set
+//! `O_NONBLOCK` on *that* description, leaving the one stdout writes through
+//! untouched. Reads are equivalent: both descriptions refer to the same
+//! terminal, and the input queue is a property of the device.
+//!
+//! A non-terminal fd 0 (a pipe, a file) cannot be sharing a description with
+//! stdout, so there is nothing to protect and the fd is switched in place, with
+//! its original flags restored on drop.
+//!
+//! Still only one at a time. A private description stops this stomping on other
+//! *fds*, not on the terminal's single input queue: two live readers both
+//! consume from it and a keystroke lands in whichever the kernel picks. The
+//! engine is what guarantees one — at most one target per run gets the terminal
+//! (see `Engine::result`'s handling of `ResultOptions::interactive`).
 
 use std::io;
-use std::os::fd::{AsRawFd, RawFd};
+use std::os::fd::{AsRawFd, FromRawFd, OwnedFd, RawFd};
 use std::pin::Pin;
 use std::task::{Context, Poll};
 
 use tokio::io::unix::AsyncFd;
 use tokio::io::{AsyncRead, Interest, ReadBuf};
 
+/// Where a [`TtyReader`]'s bytes come from, and what cleanup it owes.
+enum Source {
+    /// A private second open of the same terminal. Closing it is the whole
+    /// cleanup — the caller's fds never saw a flag change.
+    Owned(OwnedFd),
+    /// The caller's own fd, switched to non-blocking in place because it is not
+    /// a terminal. `original_flags` goes back on drop.
+    Borrowed {
+        fd: RawFd,
+        original_flags: libc::c_int,
+    },
+}
+
+impl AsRawFd for Source {
+    fn as_raw_fd(&self) -> RawFd {
+        match self {
+            Self::Owned(fd) => fd.as_raw_fd(),
+            Self::Borrowed { fd, .. } => *fd,
+        }
+    }
+}
+
 pub struct TtyReader {
-    inner: AsyncFd<RawFd>,
-    original_flags: libc::c_int,
+    inner: AsyncFd<Source>,
 }
 
 impl TtyReader {
     pub fn from_stdin() -> io::Result<Self> {
-        let fd = io::stdin().as_raw_fd();
-        // SAFETY: F_GETFL/F_SETFL on stdin — they only read/write file status flags.
-        let original_flags = unsafe { libc::fcntl(fd, libc::F_GETFL) };
-        if original_flags < 0 {
-            return Err(io::Error::last_os_error());
-        }
-        // SAFETY: see above.
-        if unsafe { libc::fcntl(fd, libc::F_SETFL, original_flags | libc::O_NONBLOCK) } < 0 {
-            return Err(io::Error::last_os_error());
-        }
-        let inner = AsyncFd::with_interest(fd, Interest::READABLE).inspect_err(|_| {
-            // Restore the flags before bubbling the error.
-            // SAFETY: same fd, restoring its previous flags.
-            unsafe { libc::fcntl(fd, libc::F_SETFL, original_flags) };
-        })?;
-        Ok(Self {
-            inner,
-            original_flags,
-        })
+        Self::from_fd(io::stdin().as_raw_fd())
     }
+
+    /// Read the terminal (or pipe) behind `fd`.
+    ///
+    /// Takes the descriptor rather than reaching for `stdin()` so the
+    /// non-blocking policy above is testable against a pty pair, which is the
+    /// only shape in which the bug it exists for can be observed.
+    fn from_fd(fd: RawFd) -> io::Result<Self> {
+        let source = match reopen_terminal(fd) {
+            Some(owned) => Source::Owned(owned),
+            None => Source::Borrowed {
+                fd,
+                original_flags: set_nonblocking(fd)?,
+            },
+        };
+        let restore = restore_flags_of(&source);
+        AsyncFd::with_interest(source, Interest::READABLE)
+            .inspect_err(|_| restore())
+            .map(|inner| Self { inner })
+    }
+}
+
+/// The cleanup a `Source` owes, as a closure so the error path and `Drop` run
+/// the same thing.
+fn restore_flags_of(source: &Source) -> impl Fn() + use<> {
+    let borrowed = match *source {
+        Source::Borrowed { fd, original_flags } => Some((fd, original_flags)),
+        Source::Owned(_) => None,
+    };
+    move || {
+        if let Some((fd, flags)) = borrowed {
+            // SAFETY: the fd is the caller's and still valid — we never owned
+            // it, and only put back the flags it arrived with.
+            unsafe { libc::fcntl(fd, libc::F_SETFL, flags) };
+        }
+    }
+}
+
+/// Set `O_NONBLOCK` on `fd`, returning the flags it had before.
+fn set_nonblocking(fd: RawFd) -> io::Result<libc::c_int> {
+    // SAFETY: F_GETFL/F_SETFL on a valid fd only read/write file status flags.
+    let original_flags = unsafe { libc::fcntl(fd, libc::F_GETFL) };
+    if original_flags < 0 {
+        return Err(io::Error::last_os_error());
+    }
+    // SAFETY: see above.
+    if unsafe { libc::fcntl(fd, libc::F_SETFL, original_flags | libc::O_NONBLOCK) } < 0 {
+        return Err(io::Error::last_os_error());
+    }
+    Ok(original_flags)
+}
+
+/// Open a second, private description of the terminal `fd` refers to, already
+/// non-blocking. `None` when `fd` is not a terminal, or when the terminal
+/// cannot be reopened — both leave the caller to switch `fd` itself.
+///
+/// `O_NOCTTY` because acquiring a controlling terminal is emphatically not what
+/// this open is for.
+fn reopen_terminal(fd: RawFd) -> Option<OwnedFd> {
+    // SAFETY: isatty only inspects the fd.
+    if unsafe { libc::isatty(fd) } != 1 {
+        return None;
+    }
+    let mut name = [0 as libc::c_char; libc::PATH_MAX as usize];
+    // SAFETY: ttyname_r writes a NUL-terminated path into the buffer we own,
+    // bounded by the length we pass.
+    if unsafe { libc::ttyname_r(fd, name.as_mut_ptr(), name.len()) } != 0 {
+        return None;
+    }
+    // SAFETY: `open` reads the NUL-terminated path ttyname_r just wrote.
+    let opened = unsafe {
+        libc::open(
+            name.as_ptr(),
+            libc::O_RDONLY | libc::O_NONBLOCK | libc::O_NOCTTY,
+        )
+    };
+    if opened < 0 {
+        return None;
+    }
+    // SAFETY: `open` handed us ownership of this fd.
+    let owned = unsafe { OwnedFd::from_raw_fd(opened) };
+    // The name is resolved, then opened — two steps, so what came back is only
+    // *probably* the same terminal. Compare the device identity and fall back
+    // rather than read someone else's keystrokes.
+    same_char_device(fd, owned.as_raw_fd()).then_some(owned)
+}
+
+/// Whether two fds refer to the same character device.
+fn same_char_device(a: RawFd, b: RawFd) -> bool {
+    let is_char = |st: &libc::stat| st.st_mode & libc::S_IFMT == libc::S_IFCHR;
+    match (fstat(a), fstat(b)) {
+        (Some(a), Some(b)) => is_char(&a) && is_char(&b) && a.st_rdev == b.st_rdev,
+        _ => false,
+    }
+}
+
+fn fstat(fd: RawFd) -> Option<libc::stat> {
+    // SAFETY: fstat only writes the stat buffer we hand it.
+    let mut st = unsafe { std::mem::zeroed::<libc::stat>() };
+    // SAFETY: see above; fd is valid for the duration of the call.
+    (unsafe { libc::fstat(fd, &mut st) } == 0).then_some(st)
 }
 
 impl Drop for TtyReader {
     fn drop(&mut self) {
-        let fd = *self.inner.get_ref();
-        // SAFETY: fd still valid (we never owned it); restoring its prior flags.
-        unsafe { libc::fcntl(fd, libc::F_SETFL, self.original_flags) };
+        restore_flags_of(self.inner.get_ref())();
     }
 }
 
@@ -74,7 +199,7 @@ impl AsyncRead for TtyReader {
                 Poll::Pending => return Poll::Pending,
             };
             let res = guard.try_io(|inner| {
-                let fd = *inner.get_ref();
+                let fd = inner.get_ref().as_raw_fd();
                 let unfilled = buf.initialize_unfilled();
                 // SAFETY: fd valid, buf points to writable bytes.
                 let n = unsafe { libc::read(fd, unfilled.as_mut_ptr().cast(), unfilled.len()) };
@@ -93,5 +218,119 @@ impl AsyncRead for TtyReader {
                 Err(_would_block) => continue,
             }
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::io::Write as _;
+    use tokio::io::AsyncReadExt as _;
+
+    fn flags(fd: RawFd) -> libc::c_int {
+        // SAFETY: F_GETFL on a valid fd.
+        unsafe { libc::fcntl(fd, libc::F_GETFL) }
+    }
+
+    fn is_nonblocking(fd: RawFd) -> bool {
+        flags(fd) & libc::O_NONBLOCK != 0
+    }
+
+    /// `(master, slave)` of a fresh pty, both owned.
+    fn open_pty() -> (OwnedFd, OwnedFd) {
+        let mut master: libc::c_int = -1;
+        let mut slave: libc::c_int = -1;
+        // SAFETY: openpty writes the two fds we then take ownership of; the
+        // remaining pointers are NULL, documented as "use defaults".
+        let rc = unsafe {
+            libc::openpty(
+                &mut master,
+                &mut slave,
+                std::ptr::null_mut(),
+                std::ptr::null_mut(),
+                std::ptr::null_mut(),
+            )
+        };
+        assert_eq!(rc, 0, "openpty: {}", io::Error::last_os_error());
+        // SAFETY: openpty handed us ownership of the master fd.
+        let master = unsafe { OwnedFd::from_raw_fd(master) };
+        // SAFETY: and of the slave fd.
+        let slave = unsafe { OwnedFd::from_raw_fd(slave) };
+        (master, slave)
+    }
+
+    /// The regression, stated as the property that was violated: reading a
+    /// terminal must not turn the caller's descriptor non-blocking.
+    ///
+    /// Stdin, stdout and stderr share one open file description whenever the
+    /// terminal was opened once and dup'd — the ordinary case — and
+    /// `O_NONBLOCK` lives on the description. Setting it here therefore made
+    /// *writes to stdout* fail with `EAGAIN` once the terminal's output queue
+    /// filled, and `heph run --shell` dropped that output on the floor.
+    #[tokio::test]
+    async fn reading_a_terminal_leaves_the_callers_fd_blocking() {
+        let (_master, slave) = open_pty();
+        let fd = slave.as_raw_fd();
+        let before = flags(fd);
+        assert!(
+            !is_nonblocking(fd),
+            "precondition: a fresh pty slave is blocking"
+        );
+
+        let reader = TtyReader::from_fd(fd).expect("reader over a pty slave");
+        assert!(
+            !is_nonblocking(fd),
+            "the caller's fd (shared with stdout) was switched to non-blocking"
+        );
+        drop(reader);
+        assert_eq!(before, flags(fd), "the caller's fd was left modified");
+    }
+
+    /// …and it still reads what is typed. The point of the reopen is that it is
+    /// the *same* terminal, so bytes written to the master arrive.
+    #[tokio::test]
+    async fn a_terminal_reader_still_receives_input() {
+        let (master, slave) = open_pty();
+        let mut reader = TtyReader::from_fd(slave.as_raw_fd()).expect("reader over a pty slave");
+
+        let mut master_file = std::fs::File::from(master);
+        master_file.write_all(b"hi\n").expect("write to pty master");
+        master_file.flush().expect("flush pty master");
+
+        let mut buf = [0u8; 3];
+        reader.read_exact(&mut buf).await.expect("read from tty");
+        assert_eq!(&buf, b"hi\n");
+    }
+
+    /// A non-terminal stdin cannot be sharing a description with stdout, so it
+    /// takes the in-place path — and gets its flags back on drop.
+    #[tokio::test]
+    async fn a_pipe_is_switched_in_place_and_restored() {
+        let mut fds = [0 as libc::c_int; 2];
+        // SAFETY: pipe writes two fds into the array we own.
+        assert_eq!(unsafe { libc::pipe(fds.as_mut_ptr()) }, 0);
+        // SAFETY: pipe handed us ownership of the read end.
+        let read_end = unsafe { OwnedFd::from_raw_fd(fds[0]) };
+        // SAFETY: and of the write end.
+        let write_end = unsafe { OwnedFd::from_raw_fd(fds[1]) };
+        let fd = read_end.as_raw_fd();
+        let before = flags(fd);
+
+        let mut reader = TtyReader::from_fd(fd).expect("reader over a pipe");
+        assert!(
+            is_nonblocking(fd),
+            "a pipe has to be switched in place — there is no second open of it"
+        );
+
+        let mut writer = std::fs::File::from(write_end);
+        writer.write_all(b"ok").expect("write to pipe");
+        drop(writer);
+        let mut buf = Vec::new();
+        reader.read_to_end(&mut buf).await.expect("read pipe");
+        assert_eq!(buf, b"ok");
+
+        drop(reader);
+        assert_eq!(before, flags(fd), "the pipe's flags were not restored");
+        drop(read_end);
     }
 }


### PR DESCRIPTION
## The bug

`TtyReader::from_stdin` set `O_NONBLOCK` on fd 0. `O_NONBLOCK` lives on the open **file description**, not the descriptor, and a terminal is opened once then dup'd onto fds 0/1/2 — so this set it on **stdout and stderr too**.

With stdout non-blocking, a write that filled the terminal's output queue returned `EAGAIN` instead of blocking. `tee_stream` discarded that error (`drop(out.write_all(..).await)`), so the target's output was dropped on the floor — silently, only under enough output to fill the queue, and with `log.txt` still holding every byte so the two records disagreed with nothing to explain it.

Caught mid-failure, the numbers are unambiguous:

| | |
|---|---|
| `log.txt` | 909,767 bytes |
| heph's stdout offset | 762,249 bytes (frozen) |

It read everything and never wrote 147 KB of it. Instrumenting the swallowed error confirms the cause directly:

```
[sink flush err: Os { code: 35, kind: WouldBlock, message: "Resource temporarily unavailable" }]
```

This is user-facing, not a test artifact: `heph run --shell` loses output whenever a command prints enough.

## The fix

Both halves are needed — one caused it, the other hid it.

- **`TtyReader` reopens the terminal** by name (`ttyname_r` + `O_RDONLY|O_NONBLOCK|O_NOCTTY`) and puts `O_NONBLOCK` on that private description, leaving the one stdout writes through untouched. A non-terminal fd (pipe, file) cannot share a description with stdout, so it is still switched in place and restored on drop. Device identity is compared (`st_rdev`, both char devices) rather than trusting the name across the resolve→open gap.
- **`SinkLoss`** reports refused output on both the PTY and pipe paths instead of discarding it: the first error, plus a floor on how many bytes the terminal missed. Follows the precedent of #279.

## Why it matters

`exit_is_prompt_after_chatty_and_large_output` was four of the last five red master runs. #334 attributed it to the test harness's re-scanning cost and did not fix it — the run that landed it failed CI on two platforms.

## Verification

Matched soaks on macOS, each iteration running `tui_pty` + `shell_pty`:

| | runs | failures |
|---|---|---|
| master | 120 | 9 |
| this PR | 120 | **0** |

Cumulatively across all local runs: 13/250 before, 0/365 after.

Tests: three in `tty.rs` (one fails against the old code — it asserts the caller's fd is left blocking), one in `plugin-exec` driving a sink that refuses to flush with `WouldBlock`, which is the shape `tokio::io::stdout` surfaces `EAGAIN` in.

## Not fixed here

A rarer hang (~1% of local pty runs) remains and is unrelated: crossterm's dropped `EventStream` leaves its reader thread parked in a blocking `kevent` holding the global reader mutex, so the rebuild at resume deadlocks. Signature is an unanswered `\x1b[6n` as the run's last byte. Being investigated separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01C9WtkHVvtTGa4rpZjhADU6