### PR TITLE
test(bin-e2e): render the TUI where it is actually up, and answer every cursor query

### DIFF
--- a/crates/bin-e2e/tests/common/mod.rs
+++ b/crates/bin-e2e/tests/common/mod.rs
@@ -184,6 +184,58 @@ pub fn sha256_file(path: &Path) -> Result<String> {
     Ok(format!("sha256:{}", hex::encode(Sha256::digest(&bytes))))
 }
 
+/// CSI 6n — Device Status Report, "where is the cursor?".
+///
+/// A pty is a pipe: nothing on the master end answers queries. The inline
+/// viewport asks this while anchoring itself and **blocks until the terminal
+/// replies**, so a harness that only reads deadlocks the child. Every pty test
+/// therefore has to answer, and answer *every* occurrence — one missed query is
+/// a permanent hang of the run under test.
+pub const DSR_CURSOR: &[u8] = b"\x1b[6n";
+
+/// Reply a real terminal would give: cursor at row 1, column 1. The value only
+/// positions the inline viewport.
+pub const DSR_REPLY: &[u8] = b"\x1b[1;1R";
+
+/// Count the cursor-position queries in `tail`, and leave behind only what could
+/// still be the start of another.
+///
+/// `tail` carries bytes across pty reads because a query can straddle a chunk
+/// boundary. The rule both halves of that have to respect: consume through the
+/// end of the **last** complete query, then keep `DSR_CURSOR.len() - 1` trailing
+/// bytes so a straddling one is still assembled by the next read.
+///
+/// The earlier version cleared the whole tail whenever it matched, which is
+/// wrong precisely when two queries arrive close together — the viewport rebuild
+/// at resume and the one at teardown do exactly that. A chunk ending
+/// `…\x1b[6n…\x1b[6` answered the first query and then dropped the three bytes
+/// that begin the second, so the `n` opening the next chunk matched nothing, the
+/// second query was never answered, and heph blocked forever inside
+/// `Terminal::with_options` waiting for a reply that no longer had a sender.
+/// That surfaced as a `child did not exit within 180s` with the run's last byte
+/// being an unanswered `\x1b[6n` — a harness bug wearing the costume of a
+/// product hang.
+pub fn take_dsr_queries(tail: &mut Vec<u8>) -> usize {
+    let mut queries = 0;
+    let mut consumed = 0;
+    while let Some(pos) = tail
+        .get(consumed..)
+        .and_then(|rest| rest.windows(DSR_CURSOR.len()).position(|w| w == DSR_CURSOR))
+    {
+        consumed += pos + DSR_CURSOR.len();
+        queries += 1;
+    }
+    tail.drain(..consumed);
+    // Whatever is left held no complete query, so only a possible prefix of one
+    // is worth carrying.
+    let straddle = DSR_CURSOR.len() - 1;
+    if tail.len() > straddle {
+        let excess = tail.len() - straddle;
+        tail.drain(..excess);
+    }
+    queries
+}
+
 /// Host os/arch in the published-artifact spelling heph's manifest resolver
 /// matches on (`darwin`/`linux`, `amd64`/`arm64`).
 pub fn host_os_arch() -> (&'static str, &'static str) {
@@ -198,4 +250,49 @@ pub fn host_os_arch() -> (&'static str, &'static str) {
         "amd64"
     };
     (os, arch)
+}
+
+#[cfg(test)]
+mod dsr_tests {
+    use super::{DSR_CURSOR, take_dsr_queries};
+
+    /// The regression: a query that begins in the same chunk that ended a
+    /// previous one must survive into the next read.
+    #[test]
+    fn a_query_straddling_a_boundary_after_another_is_still_answered() {
+        let mut tail = b"\x1b[6nxx\x1b[6".to_vec();
+        assert_eq!(take_dsr_queries(&mut tail), 1, "the complete query");
+        tail.extend_from_slice(b"n");
+        assert_eq!(
+            take_dsr_queries(&mut tail),
+            1,
+            "the straddling query must be answered on the next read"
+        );
+    }
+
+    /// Several in one chunk are all counted, so all get answered.
+    #[test]
+    fn every_query_in_a_chunk_is_counted() {
+        let mut tail = b"a\x1b[6nb\x1b[6nc".to_vec();
+        assert_eq!(take_dsr_queries(&mut tail), 2);
+    }
+
+    /// A chunk with no query keeps only a possible prefix — the tail must not
+    /// grow without bound across a large transfer.
+    #[test]
+    fn a_miss_keeps_only_the_straddle_overlap() {
+        let mut tail = vec![b'x'; 100_000];
+        assert_eq!(take_dsr_queries(&mut tail), 0);
+        assert_eq!(tail.len(), DSR_CURSOR.len() - 1);
+    }
+
+    /// An answered query is never answered twice: replying to a stale one wakes
+    /// nothing and desynchronizes the next real reply.
+    #[test]
+    fn an_answered_query_is_not_seen_again() {
+        let mut tail = b"\x1b[6n".to_vec();
+        assert_eq!(take_dsr_queries(&mut tail), 1);
+        tail.extend_from_slice(b"plain output");
+        assert_eq!(take_dsr_queries(&mut tail), 0);
+    }
 }

--- a/crates/bin-e2e/tests/shell_pty.rs
+++ b/crates/bin-e2e/tests/shell_pty.rs
@@ -28,8 +28,6 @@ use std::io::{Read, Write};
 use std::sync::{Arc, Mutex};
 use std::time::{Duration, Instant};
 
-const DSR_CURSOR: &[u8] = b"\x1b[6n";
-
 /// Generous: spawns a release binary plus an interactive bash child, on a
 /// shared CI runner.
 const DEADLINE: Duration = Duration::from_secs(60);
@@ -218,21 +216,11 @@ impl ShellSession {
                     Ok(n) => {
                         let Some(chunk) = buf.get(..n) else { break };
                         tail.extend_from_slice(chunk);
-                        let replies = tail
-                            .windows(DSR_CURSOR.len())
-                            .filter(|w| *w == DSR_CURSOR)
-                            .count();
-                        for _ in 0..replies {
+                        for _ in 0..common::take_dsr_queries(&mut tail) {
                             let mut w = dsr_writer.lock().expect("writer lock");
-                            if w.write_all(b"\x1b[1;1R").is_err() || w.flush().is_err() {
+                            if w.write_all(common::DSR_REPLY).is_err() || w.flush().is_err() {
                                 break;
                             }
-                        }
-                        if replies > 0 {
-                            tail.clear();
-                        } else if tail.len() > DSR_CURSOR.len() {
-                            let keep = tail.len() - (DSR_CURSOR.len() - 1);
-                            tail.drain(..keep);
                         }
                         sink.lock().expect("capture lock").extend_from_slice(chunk);
                     }

--- a/crates/bin-e2e/tests/tui_pty.rs
+++ b/crates/bin-e2e/tests/tui_pty.rs
@@ -17,18 +17,14 @@
 
 mod common;
 
-use common::Dist;
+// `DSR_CURSOR` is the cursor-position query. Only the interactive backend ever
+// issues one, which makes it the marker for "the TUI engaged"; answering every
+// occurrence is the harness's job — see `common::take_dsr_queries`.
+use common::{DSR_CURSOR, Dist};
 use portable_pty::{CommandBuilder, PtySize, native_pty_system};
 use std::io::{Read as _, Write as _};
 use std::sync::{Arc, Mutex};
 use std::time::{Duration, Instant};
-
-/// CSI 6n — Device Status Report, "where is the cursor?". The inline viewport
-/// needs the answer to know where to draw, and the child blocks until it gets
-/// one, so the harness must reply the way a real terminal would. Only the
-/// interactive backend ever asks, which also makes it the marker for "the TUI
-/// engaged".
-const DSR_CURSOR: &[u8] = b"\x1b[6n";
 
 /// CSI ?25l / ?25h — hide and show the cursor, around the TUI's lifetime.
 const CURSOR_HIDE: &[u8] = b"\x1b[?25l";
@@ -39,18 +35,35 @@ const CURSOR_SHOW: &[u8] = b"\x1b[?25h";
 /// rather than hang it.
 const DEADLINE: Duration = Duration::from_secs(180);
 
+/// The sleep is in a *dependency*, not in the target the command names, and
+/// that is the whole trick.
+///
+/// A run that names one target hands that target the terminal: the engine wraps
+/// its execution in the interactive wrapper, which **pauses the TUI for the
+/// target's entire runtime** so the target owns the terminal. So the box is only
+/// on screen before execution starts — and with the sleep in the named target
+/// itself, that window was "however long discovery, BUILD evaluation and hashing
+/// take", against an 80 ms frame tick. On a warm, fast runner that window closed
+/// before the first tick and the run drew *zero* frames: the terminal received a
+/// viewport, an immediate collapse, the target's own `e2e-ok`, and the final
+/// summary, with nothing rendered in between. That is the flake this shape
+/// removes, and it read as "the target never appeared" because the box carrying
+/// its name was never painted at all.
+///
+/// Dependencies never inherit the terminal (`ResultOptions::default()`), so
+/// while `//pkg:slow` runs the TUI stays up and ticking — a guaranteed second of
+/// frames, all of them carrying the run's label in the box footer.
+const BUILD: &str = concat!(
+    "target(name = \"slow\", driver = \"bash\", run = \"sleep 1\", cache = False)\n",
+    "target(name = \"ok\", driver = \"bash\", run = \"echo e2e-ok\", cache = False,",
+    " deps = {\"slow\": [\"//pkg:slow\"]})\n",
+);
+
 #[test]
 fn tui_renders_the_run_and_restores_the_terminal() {
     let dist = Dist::locate();
     let ws = common::Workspace::new().expect("workspace");
-    // The sleep guarantees the run is observable: without it the target can
-    // finish inside a single frame interval and the in-flight rendering this
-    // test is about never happens.
-    ws.write(
-        "pkg/BUILD",
-        "target(name = \"ok\", driver = \"bash\", run = \"sleep 1; echo e2e-ok\", cache = False)\n",
-    )
-    .expect("write BUILD");
+    ws.write("pkg/BUILD", BUILD).expect("write BUILD");
 
     let session = run_in_pty(&dist, ws.root(), &["run", "//pkg:ok"]);
 
@@ -64,16 +77,14 @@ fn tui_renders_the_run_and_restores_the_terminal() {
         "interactive TUI never engaged with a tty attached\n{}",
         session.report()
     );
-    // Raw bytes, not the vt100-rendered screen: `rendered` snapshots the
-    // screen once per pty `read()`, and on a loaded CI runner several ticks'
-    // worth of draws can land in one read before the pump thread gets
-    // scheduled — the in-progress frame is overwritten by the next one before
-    // it is ever sampled, even though it was genuinely painted. The address
-    // only ever reaches stderr as literal text drawn by the viewport (there is
-    // no other path that would write it), so its presence in the byte stream
-    // still proves it was rendered, just not caught at a read boundary.
+    // The vt100-rendered screens, not the raw bytes: this is the assertion the
+    // file exists for — that the viewport put the run into actual cells — and
+    // with the box up for the dependency's whole runtime there are frames enough
+    // to catch it at a read boundary. (It was weakened to a raw-byte scan when
+    // the box was only up for a race-length window; the fix for that was the
+    // window, not the assertion.)
     assert!(
-        contains(&session.raw, b"//pkg:ok"),
+        session.rendered.contains("//pkg:ok"),
         "the target never appeared in the rendered output\n{}",
         session.report()
     );
@@ -187,8 +198,9 @@ fn run_in_pty(dist: &Dist, cwd: &std::path::Path, args: &[&str]) -> Session {
         // A pty is a pipe, not a terminal: nothing on this end answers queries.
         // The TUI asks where the cursor is (DSR) while setting up its inline
         // viewport and blocks until the terminal replies, so a harness that only
-        // reads deadlocks the child. `tail` carries the last few bytes across
-        // reads in case a request straddles a chunk boundary.
+        // reads deadlocks the child. `tail` carries bytes across reads in case a
+        // request straddles a chunk boundary — see `take_dsr_queries`, which owns
+        // that rule and the boundary case it used to get wrong.
         let mut tail = Vec::<u8>::new();
         loop {
             match reader.read(&mut buf) {
@@ -198,24 +210,10 @@ fn run_in_pty(dist: &Dist, cwd: &std::path::Path, args: &[&str]) -> Session {
                     parser.process(chunk);
 
                     tail.extend_from_slice(chunk);
-                    let replies = tail
-                        .windows(DSR_CURSOR.len())
-                        .filter(|w| *w == DSR_CURSOR)
-                        .count();
-                    for _ in 0..replies {
-                        // Cursor at row 1, column 1 — the state a fresh terminal
-                        // is in. The value only positions the inline viewport.
-                        if writer.write_all(b"\x1b[1;1R").is_err() || writer.flush().is_err() {
+                    for _ in 0..common::take_dsr_queries(&mut tail) {
+                        if writer.write_all(common::DSR_REPLY).is_err() || writer.flush().is_err() {
                             break;
                         }
-                    }
-                    // Keep only enough tail to catch a split request, and drop
-                    // anything already answered.
-                    if replies > 0 {
-                        tail.clear();
-                    } else if tail.len() > DSR_CURSOR.len() {
-                        let keep = tail.len() - (DSR_CURSOR.len() - 1);
-                        tail.drain(..keep);
                     }
 
                     let screen = parser.screen().contents();


### PR DESCRIPTION
Two independent harness defects, both of which produce a flake that reads like a product failure.

## 1. The render assertion was a race

A run that names one target hands that target the terminal: the engine wraps its execution in the interactive wrapper, which **pauses the TUI for the target's entire runtime**. With the sleep inside the named target, the box was only on screen for however long discovery, BUILD evaluation and hashing took — against an 80 ms frame tick.

On a warm runner that window closed before the first tick and the run drew **zero frames**. The whole terminal transcript was: viewport, immediate collapse, the target's own `e2e-ok`, final summary — nothing rendered in between. It surfaced as "the target never appeared" because the addr only renders in the box *footer* under 5 s (`LONG_RUNNING_THRESHOLD_MS` gates the body rows), and the box carrying it was never painted at all.

Moving the sleep into a **dependency** fixes it by construction — dependencies never inherit the terminal (`ResultOptions::default()`), so the TUI stays up and ticking for the whole second. Measured: the addr lands in 15 sampled screens instead of 3-or-0.

That also lets the assertion go back to the vt100-rendered cells, which is what this file exists to check. The raw-byte scan added in #290 was a workaround for the race, not for the assertion.

## 2. The DSR responder dropped a straddling query

On a match it cleared the whole tail, so a chunk ending `…\x1b[6n…\x1b[6` answered the first query and threw away the three bytes that begin the second. The `n` opening the next chunk matched nothing, the query went unanswered, and heph blocked inside `Terminal::with_options` waiting for a reply that no longer had a sender — surfacing as `child did not exit within 180s`.

Two queries land close together at exactly one point: the viewport rebuild at resume and the one at teardown.

`take_dsr_queries` consumes through the end of the last complete query and keeps the `len-1` straddle overlap. It moved to `common/` because both pty files carried their own copy of the same wrong logic, and it is unit-tested without a pty, a child process, or a terminal.

## Merge order

Independent of #335, but `shell_pty` will keep flaking here until #335 lands — that's the `EAGAIN` bug, not this change. Worth merging #335 first.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01C9WtkHVvtTGa4rpZjhADU6