### PR TITLE
fix(devenv): pick stat's syntax by which stat is on PATH, not by the OS

### DIFF
--- a/devenv.nix
+++ b/devenv.nix
@@ -287,8 +287,12 @@ in
       # branch's binary, and every assertion would still pass. Fingerprint the
       # artifacts around the copy so that becomes a loud failure instead of a
       # green run against the wrong bytes.
+      # Selected by which `stat` is on PATH, not by `$os`: the devenv shell puts
+      # GNU coreutils ahead of /usr/bin on macOS too, so keying this off `darwin`
+      # ran BSD syntax against GNU stat (`-f` there means "filesystem") and every
+      # local `e2e` on a Mac died before running a single test.
       fingerprint() {
-        if [ "$os" = "darwin" ]; then stat -f '%i %z %m' "$@"; else stat -c '%i %s %Y' "$@"; fi
+        stat -c '%i %s %Y' "$@" 2>/dev/null || stat -f '%i %z %m' "$@"
       }
       before="$(fingerprint "$out/heph" "$out/libplugin_go_cdylib.$ext" "$out/libplugin_gha_cdylib.$ext")"
 


### PR DESCRIPTION
`e2e`'s artifact fingerprint chose BSD `stat -f` whenever `$os` was darwin. But the devenv shell puts GNU coreutils ahead of `/usr/bin`, so on macOS that ran BSD syntax against GNU stat — where `-f` means "filesystem" — and the script died with

```
stat: cannot read file system information for '%i %z %m'
```

before running a single test. **Every local `e2e` on a Mac was broken.** CI never saw it because `HEPH_E2E_FROM=dist` skips that branch entirely.

Try the GNU spelling first and fall back to BSD, so the choice tracks the binary actually being invoked rather than an assumption about the platform. The concurrency guard the fingerprint exists for is unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01C9WtkHVvtTGa4rpZjhADU6