### PR TITLE
build(deps): pin crossterm to the EventStream wake-loss fix

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -991,7 +991,7 @@ checksum = "d0a5c400df2834b80a4c3327b3aad3a4c4cd4de0629063962b03235697506a28"
 [[package]]
 name = "crossterm"
 version = "0.29.0"
-source = "git+https://github.com/hephbuild/crossterm.git?branch=fixstderr#1ee8001cacd6b6a1dbf8eb0af1c47ec27dab9b84"
+source = "git+https://github.com/hephbuild/crossterm.git?branch=fix-eventstream-wake-loss#82a872c9db51c8956ecd0b1ef48a90275f796657"
 dependencies = [
  "bitflags 2.13.0",
  "crossterm_winapi",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -204,5 +204,5 @@ tempfile = "3"
 # replies from key events — see crates/tui/src/tui/input.rs. Avoids the
 # DSR-query / EventStream two-reader race.
 [patch.crates-io]
-crossterm = { git = "https://github.com/hephbuild/crossterm.git", branch = "fixstderr" }
+crossterm = { git = "https://github.com/hephbuild/crossterm.git", branch = "fix-eventstream-wake-loss" }
 


### PR DESCRIPTION
Takes [`hephbuild/crossterm@82a872c`](https://github.com/hephbuild/crossterm/commit/82a872c9db51c8956ecd0b1ef48a90275f796657) (branch `fix-eventstream-wake-loss`, one commit on top of `fixstderr`).

## The hang

The TUI drops its `EventStream` before a cursor-position query — a live stream's reader thread holds crossterm's *global* reader lock, so the query would block on it — and rebuilds the stream afterwards.

Dropping it only sets a shutdown flag and wakes the reader. If that wake was delivered in the same `poll` batch as terminal data, it was dropped on the floor: the token loop returned the parsed event and never acted on `WAKE_TOKEN`, and mio's waker is cleared by its own delivery (`EVFILT_USER` + `EV_CLEAR` on kqueue, edge-triggered `eventfd` on epoll), so nothing re-reports it. The reader then parked in `kevent` forever **holding the lock**, and every later crossterm call — the rebuild, the next `cursor::position` — queued behind it and never returned.

Diagnosed with `sample`:

```
main:   EventStream::default → RawMutex::lock_slow → cond_wait
reader: InternalEventReader::poll → try_read → kevent      ← holds the lock
```

## Why it matters beyond CI

This is not test-only. Every `heph run` of a single named target pauses and resumes the TUI around handing that target the terminal, so the same hang is reachable from an ordinary run on any terminal.

In CI it showed up as ~1% of pty runs hanging with the run's last byte an unanswered `\x1b[6n`, `open=0` from the stall watchdog, and the process never exiting — as `child did not exit within 180s` (`tui_pty`) and `heph did not exit after exit` (`shell_pty`).

## Verification

macOS, each iteration running `tui_pty` + `shell_pty`:

| | runs | hangs |
|---|---|---|
| before | ~365 | 4 |
| after | 494 | **0** |

At the prior ~1.1% rate, a clean 494 has about a 0.4% chance of being luck. `cargo metadata --locked` and a `--locked` release build both pass.

## Note on the lock

Edited to the new rev by hand rather than via `cargo update -p crossterm`, which also re-resolved `windows-sys` from 0.61.2 **down** to 0.60.2 — unrelated churn, and a downgrade, in what should be a one-line pin bump.

## Sequencing

Independent of #335/#336/#337 and mergeable in any order. The upstream crossterm rebase (32 commits ahead of `fixstderr`) is deliberately *not* bundled here — it does not fix this bug, and mixing it in would make this unreviewable. `014db9a` (drain stale cursor replies) is the one worth taking when that happens.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01C9WtkHVvtTGa4rpZjhADU6