### PR TITLE
fix(engine): scope the package listing in the engine, not in each caller

### DIFF
--- a/crates/engine/src/engine/packages.rs
+++ b/crates/engine/src/engine/packages.rs
@@ -31,10 +31,31 @@ fn narrowing_prefix(m: &htmatcher::Matcher) -> PkgBuf {
 }
 
 impl Engine {
-    /// Every package matching `m`'s narrowing prefix, deduped, in an order that
+    /// Every package that can hold a match for `m`, deduped, in an order that
     /// does not depend on the order any provider returned: each provider's block
     /// is sorted, then the blocks are concatenated in provider-registration
     /// order.
+    ///
+    /// # Scope is the engine's guarantee, not the provider's
+    ///
+    /// [`ListPackagesRequest::prefix`] is a *hint*. Honoring it is an
+    /// optimization a provider may skip, and the buildfile provider does skip it
+    /// — one shared workspace walk serves both `list_packages` and the
+    /// `heph.core.packages()` builtin, which needs the whole list. So the prefix
+    /// narrows the *walk* where a provider bothers (plugin-go joins it onto the
+    /// search root), and the matcher narrows the *answer* here, for everyone.
+    ///
+    /// Leaving the second half to each caller did not hold: `query` and `states`
+    /// re-pruned, `EngineProviderExecutor::states_under` did not — so
+    /// `states_under("some/dir")` probed every package in the workspace, and a
+    /// probe is a whole-package Starlark evaluation. `heph inspect packages
+    /// //foo/...` and `heph tool build-fmt //foo/...` did not re-prune either,
+    /// and answered for the whole workspace. One filter here, at the only place
+    /// that sees both the matcher and the provider answers, is what makes a
+    /// scoped selector cost its scope — and `MatchNo` is the sound half of the
+    /// tri-state (see [`htmatcher::Matcher::matches_pkg`]): every arm that
+    /// cannot decide from the package path alone shrugs, so the filter is
+    /// over-inclusive by construction and can only cost time, never a result.
     ///
     /// The order is load-bearing, not cosmetic. It reaches a def hash by more
     /// than one route — `query` → `pluginquery`'s `deps` → `plugingroup` folds
@@ -159,11 +180,25 @@ impl Engine {
         // finished first.
         let mut seen: FxHashSet<String> = FxHashSet::default();
 
+        // A whole-graph selector rejects nothing, so skip the check rather than
+        // build a `PkgBuf` per package to be told so — `//...` is the single
+        // most common selector and the one with the most packages to say it
+        // about. Every other matcher pays one `PkgBuf` per *unique* package
+        // (after the dedup below), and saves a probe plus a `list` for each one
+        // it rejects.
+        let scoped = !matches!(m, htmatcher::Matcher::PackagePrefix(p) if p.is_empty());
+
         for pkgs in &per_provider {
             for p in pkgs.iter() {
-                if seen.insert(p.clone()) {
-                    all_packages.push(p.clone());
+                if !seen.insert(p.clone()) {
+                    continue;
                 }
+                if scoped
+                    && m.matches_pkg(&PkgBuf::from(p.as_str())) == htmatcher::MatchResult::MatchNo
+                {
+                    continue;
+                }
+                all_packages.push(p.clone());
             }
         }
 
@@ -612,6 +647,89 @@ mod tests {
         // land *after* `zeta`, so this is not one global sort). That composite
         // is the order that reaches a def hash.
         assert_eq!(pkgs, vec!["@heph/fs", "alpha", "zeta", "mid", "beta"]);
+        Ok(())
+    }
+
+    /// The listing is scoped by the *matcher*, not by whether the provider
+    /// honored `ListPackagesRequest::prefix` — `ListsPkgs` ignores it, exactly
+    /// like the buildfile provider (one shared workspace walk also serves
+    /// `heph.core.packages()`).
+    ///
+    /// Without this, every consumer had to re-prune, and the ones that forgot
+    /// answered for the whole workspace: `states_under("foo")` probed — i.e.
+    /// Starlark-evaluated — every package in the tree, and `heph inspect
+    /// packages //foo/...` printed all of them.
+    #[tokio::test]
+    async fn packages_scopes_the_listing_to_the_matcher() -> anyhow::Result<()> {
+        let root = tempfile::tempdir()?;
+        let mut engine = engine_with_builtins(&root)?;
+        engine.register_provider(move |_| {
+            Box::new(ListsPkgs::new(
+                "p1",
+                &["bar", "foo", "foo/deep", "foobar", "unrelated"],
+            ))
+        })?;
+        let engine = Arc::new(engine);
+        let rs = engine.new_state();
+
+        let pkgs: Vec<String> = engine
+            .packages(&Matcher::PackagePrefix(pkg("foo")), &rs)
+            .await?
+            .collect::<anyhow::Result<Vec<_>>>()?;
+
+        // `foobar` is not under `foo`: the prefix is a package prefix, not a
+        // string one. The built-in `fs` provider's `@heph/fs` is dropped too —
+        // it is out of scope like any other package.
+        assert_eq!(pkgs, vec!["foo".to_string(), "foo/deep".to_string()]);
+        Ok(())
+    }
+
+    /// The shape `heph run <label> //some/dir/...` parses to. The label arm can
+    /// never prune on a package path, but it must not *widen* the scan either:
+    /// `And` intersects, so the package arm still decides.
+    #[tokio::test]
+    async fn packages_scope_survives_an_unprunable_and_arm() -> anyhow::Result<()> {
+        let root = tempfile::tempdir()?;
+        let mut engine = engine_with_builtins(&root)?;
+        engine.register_provider(move |_| {
+            Box::new(ListsPkgs::new(
+                "p1",
+                &["bar", "foo", "foo/deep", "unrelated"],
+            ))
+        })?;
+        let engine = Arc::new(engine);
+        let rs = engine.new_state();
+
+        let m = Matcher::And(vec![
+            Matcher::Label("lint".to_string()),
+            Matcher::PackagePrefix(pkg("foo")),
+        ]);
+        let pkgs: Vec<String> = engine
+            .packages(&m, &rs)
+            .await?
+            .collect::<anyhow::Result<Vec<_>>>()?;
+
+        assert_eq!(pkgs, vec!["foo".to_string(), "foo/deep".to_string()]);
+        Ok(())
+    }
+
+    /// The other half of the same prune: an arm that cannot decide from the
+    /// package path shrugs, and a shrug keeps the package. Over-inclusive costs
+    /// time; dropping a package here would lose results outright.
+    #[tokio::test]
+    async fn packages_keeps_everything_for_an_unprunable_matcher() -> anyhow::Result<()> {
+        let root = tempfile::tempdir()?;
+        let mut engine = engine_with_builtins(&root)?;
+        engine.register_provider(move |_| Box::new(ListsPkgs::new("p1", &["bar", "foo"])))?;
+        let engine = Arc::new(engine);
+        let rs = engine.new_state();
+
+        let pkgs: Vec<String> = engine
+            .packages(&Matcher::Label("lint".to_string()), &rs)
+            .await?
+            .collect::<anyhow::Result<Vec<_>>>()?;
+
+        assert_eq!(pkgs, vec!["@heph/fs", "bar", "foo"]);
         Ok(())
     }
 

--- a/crates/engine/src/engine/query.rs
+++ b/crates/engine/src/engine/query.rs
@@ -114,26 +114,23 @@ impl Engine {
                 // to have each one bail. Ending the iterator makes the drain
                 // await only the <=K handles already spawned.
                 .take_while(enclose!((stop) move |_| !stop.load(std::sync::atomic::Ordering::Relaxed)))
-                .filter_map(|pkg_str| {
+                .map(|pkg_str| {
                 let pkg = PkgBuf::from(pkg_str);
 
-                // Prune before probing or listing. `list` is a whole-package
-                // Starlark evaluation for the buildfile provider, so without
-                // this a scoped query (`//foo/...`, `label(l) && //foo/...`,
-                // a bare `//foo:bar`) still pays to evaluate every BUILD file
-                // in the repo and then throws the results away at the addr
-                // check below. Providers are free to ignore `ListPackagesRequest::prefix`
-                // — most do — so the narrowing has to happen here too. Done
-                // before the stream so a pruned package never takes a slot.
-                if m.matches_pkg(&pkg) == MatchResult::MatchNo {
-                    return None;
-                }
-
+                // No package-scope prune here: `packages()` above already
+                // returns only packages `m` can match, whatever the provider
+                // did with `ListPackagesRequest::prefix`. That matters because
+                // `list` is a whole-package Starlark evaluation for the
+                // buildfile provider — a scoped selector (`//foo/...`,
+                // `label(l) && //foo/...`, a bare `//foo:bar`) must not pay to
+                // evaluate every BUILD file in the repo only to throw the
+                // results away at the addr check below.
+                //
                 // Spawned here rather than through a later `.map()`: handing the
                 // async block to a generic fn through a combinator makes its
                 // captured lifetimes late-bound and trips "implementation of
                 // `FnOnce` is not general enough".
-                Some(hcore::hmemoizer::spawn_with_cycle_ctx(enclose!((self => engine, rs, executor, stop) async move {
+                hcore::hmemoizer::spawn_with_cycle_ctx(enclose!((self => engine, rs, executor, stop) async move {
                     // An abandoned walk must not start evaluating packages it has
                     // not reached yet — that is what keeps the drains below (and
                     // in `Engine::result`) to a cheap poll per remaining package
@@ -174,7 +171,7 @@ impl Engine {
                     }
 
                     anyhow::Ok(candidates)
-                })))
+                }))
             }))
             // Each package runs as its own task, not merely as a future inside
             // `Buffered`. That is what makes the serial consumer below safe.

--- a/crates/engine/src/engine/result.rs
+++ b/crates/engine/src/engine/result.rs
@@ -331,18 +331,17 @@ impl ProviderExecutor for EngineProviderExecutor {
                 // <=K tasks already spawned instead of spawning one per remaining
                 // package — see `Engine::query`.
                 .take_while(enclose!((stop) move |_| !stop.load(std::sync::atomic::Ordering::Relaxed)))
-                .filter_map(|pkg_str| {
+                .map(|pkg_str| {
                 let pkg = PkgBuf::from(pkg_str.as_str());
 
-                // Same pruning as `Engine::query`: skip packages the matcher
-                // cannot select before paying for probe + list. Done here, off
-                // the buffered stream, so a pruned package costs no slot.
-                if m.matches_pkg(&pkg) == hmodel::htmatcher::MatchResult::MatchNo {
-                    return None;
-                }
-
+                // No package-scope prune here, same as `Engine::query`:
+                // `packages()` above already answers within `m`'s scope
+                // regardless of what the provider did with the prefix hint, so
+                // no package reaching this point can be rejected on its path
+                // alone.
+                //
                 // Spawned here, not through a later `.map()` — see `Engine::query`.
-                Some(hcore::hmemoizer::spawn_with_cycle_ctx(
+                hcore::hmemoizer::spawn_with_cycle_ctx(
                     enclose!((engine, rs, executor, stop, extra_skip) async move {
                         // See `Engine::query`: an abandoning walk stops evaluating
                         // packages it has not started, so the drain below costs a
@@ -392,7 +391,7 @@ impl ProviderExecutor for EngineProviderExecutor {
 
                         anyhow::Ok(candidates)
                     }),
-                ))
+                )
             }))
             // One task per package — see the long note in `Engine::query`: as
             // plain futures the `PKG_EVAL_SLOTS` permit holders would be
@@ -4511,6 +4510,125 @@ mod tests {
     /// the sum of every probe. plugin-go calls this for a whole module root
     /// before it can emit a single addr, so it sits on the critical path of a
     /// Go workspace's discovery.
+    /// `states_under(prefix)` means "the packages at or under `prefix`" — and a
+    /// probe is not cheap: `pluginbuildfile::probe` is `run_pkg`, a whole-package
+    /// Starlark evaluation holding a `PKG_EVAL_SLOTS` permit.
+    ///
+    /// It used to probe the *whole workspace* for any prefix. `list_packages`'s
+    /// prefix is only a hint — the buildfile provider ignores it, as the fake
+    /// here does — and this walk, unlike `Engine::query`, never re-pruned what
+    /// came back. plugin-go calls it once per first-party library package with
+    /// the module root, so a `heph run <label> //some/dir/...` in a workspace
+    /// with a root-level module paid a full-workspace evaluation per library.
+    /// `Engine::packages` now applies the matcher itself, which is what bounds
+    /// this to the subtree.
+    #[tokio::test]
+    async fn states_under_probes_only_packages_under_the_prefix() -> anyhow::Result<()> {
+        /// Records every package it is asked to probe; ignores the list prefix.
+        struct RecordingProbe {
+            pkgs: Vec<String>,
+            probed: SArc<std::sync::Mutex<Vec<String>>>,
+        }
+
+        impl crate::engine::provider::Provider for RecordingProbe {
+            fn config(&self, _req: ConfigRequest) -> anyhow::Result<ConfigResponse> {
+                Ok(ConfigResponse {
+                    name: "recording".to_string(),
+                })
+            }
+            fn list<'a>(
+                &'a self,
+                _req: ListRequest,
+                _ctoken: &'a (dyn Cancellable + Send + Sync),
+            ) -> BoxFuture<
+                'a,
+                anyhow::Result<Box<dyn Iterator<Item = anyhow::Result<ListResponse>> + Send>>,
+            > {
+                Box::pin(async { Ok(Box::new(std::iter::empty()) as Box<_>) })
+            }
+            fn list_packages<'a>(
+                &'a self,
+                _req: ListPackagesRequest,
+                _ctoken: &'a (dyn Cancellable + Send + Sync),
+            ) -> BoxFuture<
+                'a,
+                anyhow::Result<
+                    Box<dyn Iterator<Item = anyhow::Result<ListPackageResponse>> + Send>,
+                >,
+            > {
+                let items: Vec<anyhow::Result<ListPackageResponse>> = self
+                    .pkgs
+                    .iter()
+                    .map(|p| {
+                        Ok(ListPackageResponse {
+                            pkg: PkgBuf::from(p.as_str()),
+                        })
+                    })
+                    .collect();
+                Box::pin(async move { Ok(Box::new(items.into_iter()) as Box<_>) })
+            }
+            fn get<'a>(
+                &'a self,
+                _req: GetRequest,
+                _ctoken: &'a (dyn Cancellable + Send + Sync),
+            ) -> BoxFuture<'a, Result<GetResponse, GetError>> {
+                Box::pin(async { Err(GetError::NotFound) })
+            }
+            fn probe<'a>(
+                &'a self,
+                req: ProbeRequest,
+                _ctoken: &'a (dyn Cancellable + Send + Sync),
+            ) -> BoxFuture<'a, anyhow::Result<ProbeResponse>> {
+                let pkg = req.package.clone();
+                self.probed
+                    .lock()
+                    .expect("probed")
+                    .push(pkg.as_str().to_string());
+                Box::pin(async move {
+                    Ok(ProbeResponse {
+                        states: vec![State {
+                            package: pkg,
+                            provider: "recording".to_string(),
+                            state: Default::default(),
+                        }],
+                    })
+                })
+            }
+        }
+
+        let probed = SArc::new(std::sync::Mutex::new(Vec::new()));
+        let root = tempdir()?;
+        let mut engine = Engine::new(Config {
+            root: root.path().to_path_buf(),
+            home_dir: std::path::PathBuf::new(),
+            parallelism: None,
+            ..Default::default()
+        })?;
+        let pkgs: Vec<String> = ["bar", "foo", "foo/deep", "foobar", "unrelated"]
+            .iter()
+            .map(|s| s.to_string())
+            .collect();
+        engine.register_provider(enclose!((probed) move |_| Box::new(RecordingProbe {
+            pkgs: pkgs.clone(),
+            probed: SArc::clone(&probed),
+        })))?;
+        let engine = SArc::new(engine);
+        let rs = engine.new_state();
+
+        let states = states_under_of(&engine, &rs)
+            .states_under(&PkgBuf::from("foo"))
+            .await?;
+
+        let mut got = probed.lock().expect("probed").clone();
+        got.sort();
+        // `foobar` is not under `foo` — the scope is a package prefix, not a
+        // string one.
+        assert_eq!(got, vec!["foo".to_string(), "foo/deep".to_string()]);
+        let declared: Vec<&str> = states.iter().map(|s| s.package.as_str()).collect();
+        assert_eq!(declared, vec!["foo", "foo/deep"]);
+        Ok(())
+    }
+
     /// A failed `states_under` walk must stop probing.
     ///
     /// `Buffered` refills its queue from the underlying iterator on *every*

--- a/crates/engine/src/engine/states.rs
+++ b/crates/engine/src/engine/states.rs
@@ -4,7 +4,7 @@ use crate::engine::request_state::RequestState;
 use enclose::enclose;
 use futures::StreamExt;
 use futures::stream::FuturesOrdered;
-use hmodel::htmatcher::{MatchResult, Matcher};
+use hmodel::htmatcher::Matcher;
 use hmodel::htpkg::PkgBuf;
 use std::sync::Arc;
 
@@ -31,14 +31,6 @@ pub struct PackageStates {
     pub states: Vec<State>,
 }
 
-/// Whether `pkg` is selected by `m`. States are declared per package and carry
-/// no target name, so a matcher arm that needs one (`Label`, `TreeOutputTo`)
-/// can only shrug — those are treated as selecting the package, keeping the
-/// scan inclusive rather than silently dropping declarations.
-fn matches_package(m: &Matcher, pkg: &PkgBuf) -> bool {
-    m.matches_pkg(pkg) != MatchResult::MatchNo
-}
-
 impl Engine {
     /// Resolve the `provider_state(...)` declarations for every package matching `m`.
     ///
@@ -50,6 +42,12 @@ impl Engine {
     /// Packages are returned in lexical order, each with its states — including
     /// packages that have none, so callers can distinguish "no state here" from
     /// "package not matched".
+    ///
+    /// `packages()` already answers within `m`'s package scope, so there is no
+    /// second filter here. Its tri-state prune is the inclusive one this needs:
+    /// states are declared per package and carry no target name, so an arm that
+    /// needs one (`Label`, `TreeOutputTo`) shrugs rather than rejecting, and the
+    /// package is kept rather than silently dropping its declarations.
     pub async fn states(
         self: Arc<Self>,
         rs: Arc<RequestState>,
@@ -61,10 +59,7 @@ impl Engine {
             _ => {
                 let mut pkgs: Vec<PkgBuf> = Vec::new();
                 for p in self.packages(m, &rs).await? {
-                    let pkg = PkgBuf::from(p?.as_str());
-                    if matches_package(m, &pkg) {
-                        pkgs.push(pkg);
-                    }
+                    pkgs.push(PkgBuf::from(p?.as_str()));
                 }
                 pkgs.sort_by(|a, b| a.as_str().cmp(b.as_str()));
                 pkgs
@@ -318,11 +313,28 @@ mod tests {
         Ok(())
     }
 
-    #[test]
-    fn label_matcher_shrug_keeps_the_package() {
-        // A label says nothing about a package, and states have no target name
-        // to test it against — stay inclusive.
-        assert!(matches_package(&Matcher::Label("l".to_string()), &pkg("a")));
-        assert!(!matches_package(&Matcher::Package(pkg("b")), &pkg("a")));
+    /// A label says nothing about a package, and states carry no target name to
+    /// test it against, so every discovered package must survive the scan. The
+    /// scoping now happens inside `Engine::packages`, so this asserts the
+    /// inclusive half of that prune through the behavior rather than through the
+    /// local helper it replaced.
+    #[tokio::test]
+    async fn label_matcher_keeps_every_package() -> anyhow::Result<()> {
+        let engine = make_engine(&["p1"])?;
+        let rs = engine.new_state();
+
+        let out = engine
+            .states(
+                rs,
+                &Matcher::Label("l".to_string()),
+                &StatesOptions::default(),
+            )
+            .await?;
+
+        // `@heph/fs` comes from the always-on built-in provider; it is a package
+        // like any other and a label cannot rule it out either.
+        let scanned: Vec<&str> = out.iter().map(|ps| ps.package.as_str()).collect();
+        assert_eq!(scanned, vec!["@heph/fs", "a", "a/b", "other"]);
+        Ok(())
     }
 }

--- a/crates/model/src/htpkg/pkg.rs
+++ b/crates/model/src/htpkg/pkg.rs
@@ -21,12 +21,26 @@ impl PkgBuf {
         self.0.split('/').filter(|s| !s.is_empty())
     }
 
+    /// Whether this package is `prefix` or lives under it. The boundary check is
+    /// what makes it a *package* prefix rather than a string one: `a/b` is under
+    /// `a`, `ab` is not.
+    ///
+    /// Allocation-free on purpose — this is the predicate every package-scope
+    /// prune runs, once per package per walk (`Matcher::matches_pkg`) and once
+    /// per candidate (`matches_addr`), so the `format!("{p}/")` it used to build
+    /// was a heap allocation per call on the hottest filter in discovery.
     pub fn has_prefix(&self, prefix: &PkgBuf) -> bool {
         let p = prefix.as_str();
+        // The root package is everyone's prefix, and it is the one case with no
+        // separator to check for: `""` + `/` is not how `a` spells its path.
         if p.is_empty() {
             return true;
         }
-        self.0 == p || self.0.starts_with(&format!("{}/", p))
+        match self.0.strip_prefix(p) {
+            Some("") => true,
+            Some(rest) => rest.starts_with('/'),
+            None => false,
+        }
     }
 
     /// Iterator yielding this package, then each ancestor up to (and including)
@@ -178,6 +192,17 @@ mod tests {
     #[test]
     fn no_partial_component_match() {
         assert!(!pkg("foo/bar/baz").has_prefix(&pkg("foo/ba")));
+        // The sibling case a plain `starts_with` gets wrong, and the one a
+        // package-scope prune is asked about constantly: `//foo/...` must not
+        // pull in `foobar`.
+        assert!(!pkg("foobar").has_prefix(&pkg("foo")));
+        assert!(!pkg("foobar/deep").has_prefix(&pkg("foo")));
+    }
+
+    #[test]
+    fn shorter_than_prefix_is_not_a_match() {
+        assert!(!pkg("foo").has_prefix(&pkg("foo/bar")));
+        assert!(!pkg("").has_prefix(&pkg("foo")));
     }
 
     #[test]


### PR DESCRIPTION
`ListPackagesRequest::prefix` is a hint. Of every provider in the tree only plugin-go reads it — the buildfile provider ignores it, because the one sorted `PackageList` cell it would have to narrow also serves `heph.core.packages()`, which needs the whole workspace. So the prefix narrows the *walk* where a provider bothers, and nothing narrowed the *answer*: `Engine::packages` handed back every package the providers knew about and left it to each consumer to re-apply the matcher.

Three of six consumers didn't:

- **`EngineProviderExecutor::states_under(prefix)` probed every package in the workspace**, for any prefix. A probe is `pluginbuildfile::probe` — `run_pkg`, a whole-package Starlark evaluation holding a `PKG_EVAL_SLOTS` permit. plugin-go calls it once per first-party library package with the module root, so on a workspace with a root-level `go.mod` a scoped `heph r <label> //some/dir/...` paid a full-workspace evaluation per library.
- **`heph inspect packages //foo/...`** listed the whole workspace.
- **`heph tool build-fmt //foo/...`** formatted — i.e. wrote — BUILD files outside the requested scope.

## The change

`Engine::packages` applies `m.matches_pkg(..) != MatchNo` to the merged listing, so the returned set is matcher-scoped whatever the provider did with the prefix, and the hint goes back to being purely an optional walk optimization. `MatchNo` is the sound half of the tri-state — every arm that cannot decide from the package path alone shrugs — so the filter is over-inclusive by construction and can cost time, never a result. The whole-graph selector skips the check rather than build a `PkgBuf` per package to be told it rejects nothing.

The duplicated prunes in `Engine::query`, `EngineProviderExecutor::query` and `Engine::states` go with it: one place now sees both the matcher and the provider answers, instead of six places each remembering to.

`PkgBuf::has_prefix` stops building `format!("{p}/")` on every call while it is here. It is the predicate behind every package-scope prune (once per package per walk, once per candidate in `matches_addr`), and this change puts it on a noticeably hotter path.

## Hermeticity

**No def hash moves.** `states_under`'s only in-tree consumer already discarded the out-of-subtree states this stops collecting — plugin-go filters the result with `pkg_in_module` before `variant::universe_variants` — so the module universe, and the addr order it fixes, are byte-identical.

## Tests

Each one verified to fail against the unfixed engine:

- `packages_scopes_the_listing_to_the_matcher` — a provider that ignores the prefix, as the real ones do
- `packages_scope_survives_an_unprunable_and_arm` — the shape `heph r <label> //some/dir/...` parses to
- `packages_keeps_everything_for_an_unprunable_matcher` — the inclusive half of the prune
- `states_under_probes_only_packages_under_the_prefix`
- `has_prefix`'s sibling boundary — `//foo/...` must not pull in `foobar`

## Not in scope

The last O(whole tree) term for a scoped selector is the buildfile provider's own walk. Narrowing it needs a second, prefix-keyed cache alongside the full-list cell `heph.core.packages()` requires — a separate change, and unmeasured.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NKMLgDHgXcoNKEdQcXvq8k