### PR TITLE
refactor(engine): skip the transitive merge for deps that declare no sandbox

### DIFF
--- a/crates/e2e/tests/deps.rs
+++ b/crates/e2e/tests/deps.rs
@@ -246,6 +246,53 @@ target(
     Ok(())
 }
 
+// A dep that declares no transitive sandbox is skipped by the transitive
+// collector without disturbing the deps that do declare one.
+//
+// The collector numbers each merged sandbox by its position in the consumer's
+// runtime input list, and that number ends up in the merged tool/dep ids — so a
+// skip that renumbered would silently move def hashes and invalidate cached
+// artifacts. Here `plain` sorts before `carrier` in the consumer's inputs, so
+// `carrier`'s sandbox is *not* at position 0: if skipping `plain` shifted it,
+// or dropped it, `$SRC_HIDDEN` would not resolve.
+#[tokio::test]
+async fn test_transitive_survives_a_preceding_dep_without_one() -> anyhow::Result<()> {
+    let ws = Workspace::new();
+    ws.write_build_file(
+        "mixed",
+        r#"
+target(name = "hidden", driver = "bash", run = "printf hidden_value > $OUT", out = "h.txt")
+target(name = "plain", driver = "bash", run = "printf plain_value > $OUT", out = "p.txt")
+target(
+    name = "carrier",
+    driver = "bash",
+    run = "printf carrier_value > $OUT",
+    out = "c.txt",
+    transitive = {"deps": {"hidden": ["//mixed:hidden"]}},
+)
+target(
+    name = "consumer",
+    driver = "bash",
+    run = "printf '%s %s' \"$(cat $SRC_PLAIN)\" \"$(cat $SRC_HIDDEN)\" > $OUT",
+    out = "out.txt",
+    deps = {"plain": ["//mixed:plain"], "carrier": ["//mixed:carrier"]},
+)
+"#,
+    );
+
+    let result = ws.run("//mixed:consumer").await?;
+    let content = common::artifact_string(&result);
+    assert!(
+        content.contains("plain_value"),
+        "missing plain_value, got: {content:?}"
+    );
+    assert!(
+        content.contains("hidden_value"),
+        "transitive dep behind a non-transitive dep was dropped, got: {content:?}"
+    );
+    Ok(())
+}
+
 // Direct cycle A → B → A must be rejected
 #[tokio::test]
 async fn test_direct_cyclic_dep_detected() -> anyhow::Result<()> {

--- a/crates/engine/src/engine/result.rs
+++ b/crates/engine/src/engine/result.rs
@@ -3651,11 +3651,24 @@ impl Engine {
                             .await
                             .with_context(|| format!("get def for group: {:?}", input_ref))?;
                         dep_def.applied_transitive.clone()
+                    } else if spec.transitive.empty() {
+                        // Nothing to contribute. Checked before the clone because
+                        // `transitive` is an opt-in BUILD-file feature
+                        // (`target(..., transitive = {...})`) that most targets never
+                        // use — every Go target builds its spec with an empty one — so
+                        // this is the common case on every dependency edge in the
+                        // graph, which is the largest per-run count in the engine.
+                        // Merging an empty sandbox is a no-op, so skipping it here
+                        // reaches the same `sb` while dropping the clone and, below,
+                        // the `id` that only a merge would ever have read.
+                        None
                     } else {
                         Some(spec.transitive.clone())
                     };
 
                     if let Some(transitive) = transitive {
+                        // `hash_str` digests the whole addr and formats it, so build
+                        // the id only once something will actually merge under it.
                         let id = format!("_transitive_{}_{}", spec.addr.hash_str(), i);
                         anyhow::Ok(Some((id, transitive)))
                     } else {


### PR DESCRIPTION
`collect_transitive_deps` runs once per dependency edge, and for every edge
it unconditionally cloned the dep's `transitive` sandbox and built a merge
id:

    let id = format!("_transitive_{}_{}", spec.addr.hash_str(), i);

`hash_str` digests the whole addr (package, name, every arg) and formats the
result, so that line is a hash plus two String allocations. Both are dead
work whenever the sandbox is empty: `merge_sandbox` of an empty sandbox
iterates no tools, no deps, and extends `env` with nothing, so the id is
never read and `sb` is unchanged.

Empty is the common case, not the corner. `transitive` is an opt-in
BUILD-file feature (`target(..., transitive = {...})`); the Go plugin builds
every one of its specs with `..Default::default()`, so on a Go corpus
*every* edge paid for a merge that could not do anything.

Check `empty()` before the clone and build the id only when something will
merge under it. The group branch is untouched — `get_def_inner` already
stores `applied_transitive` as `None` when the aggregate is empty, so a
group's `Some` is never empty.

Merge ids stay byte-identical: `i` comes from `enumerate()` on the filtered
input list, evaluated before the skip, so skipping an empty dep cannot
renumber a non-empty one. That matters — those ids reach tool/dep ids in the
merged sandbox, which reach driver inputs and therefore def hashes. The new
e2e test pins it by putting a non-transitive dep ahead of a transitive one
and asserting the transitive dep still resolves.

Measured, not assumed: written expecting a hot-path win, it is not one.
Against a fully-cached 500-package Go corpus, 7 interleaved A/B reps put
this and the commit below it together inside noise (1.55s -> 1.55s wall),
and neither `hash_str` nor the sandbox clone charts in a release-build
profile. Landing it as dead-work removal, not as a speedup.

Co-Authored-By: Claude Opus 5 (1M context) <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01A9ACPrVo6RtSDYXzowsPT9

---

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>