### PR TITLE
fix(validate): stop running speculative query walks concurrently

### DIFF
--- a/crates/engine/src/engine/request_state.rs
+++ b/crates/engine/src/engine/request_state.rs
@@ -14,6 +14,7 @@ use parking_lot::Mutex;
 use rustc_hash::{FxHashMap, FxHashSet};
 use std::collections::HashSet;
 use std::ops::Deref;
+use std::sync::atomic::Ordering;
 use std::sync::{Arc, Weak};
 use std::time::Duration;
 
@@ -267,6 +268,9 @@ pub struct RequestStateData {
     pub request_id: String,
     pub ctoken: StdCancellationToken,
     pub dep_dag: Mutex<DepDag>,
+    /// Speculative `RequestState`s alive on this request — see
+    /// [`RequestState::speculative_live`].
+    speculative_live: std::sync::atomic::AtomicUsize,
     // Key includes `is_top`: top-level vs dependency resolution of the same
     // (addr, outputs) must not share a cell, because only the top-level frame
     // writes a codegen target's tree back / stores its fixpoint.
@@ -790,6 +794,7 @@ impl RequestState {
     ///
     /// [`track_dep`]: RequestState::track_dep
     pub fn speculative(&self) -> Arc<RequestState> {
+        self.data.speculative_live.fetch_add(1, Ordering::AcqRel);
         Arc::new(RequestState {
             data: Arc::clone(&self.data),
             parent: self.parent.clone(),
@@ -797,6 +802,18 @@ impl RequestState {
             crumbs: self.crumbs.clone(),
             speculative: true,
         })
+    }
+
+    /// How many speculative states are alive on this request right now.
+    ///
+    /// The invariant `Engine::query`'s `MatchShrug` arm depends on is "at most
+    /// one speculative chain at a time", and until this counter it was enforced
+    /// only by the shape of the code — a walk's arm sits in the consumer of its
+    /// own fan-out, so *that* walk cannot overlap itself. Nothing stopped two
+    /// walks on one request from overlapping each other, and nothing could
+    /// observe it when they did. Now a test can.
+    pub fn speculative_live(&self) -> usize {
+        self.data.speculative_live.load(Ordering::Acquire)
     }
 
     /// Record that the current `parent` depends on `addr`, returning a
@@ -843,6 +860,17 @@ impl RequestStateData {
             // A closed receiver (consumer gone) is expected; events are
             // best-effort, so dropping the send result is intentional.
             drop(tx.send(event));
+        }
+    }
+}
+
+impl Drop for RequestState {
+    fn drop(&mut self) {
+        // Only speculative states counted up, so only they count down. A
+        // non-speculative state pays one predictable branch here; there is no
+        // atomic on that path.
+        if self.speculative {
+            self.data.speculative_live.fetch_sub(1, Ordering::AcqRel);
         }
     }
 }
@@ -957,6 +985,7 @@ impl Engine {
             request_id: request_id.clone(),
             ctoken: StdCancellationToken::new(),
             dep_dag: Mutex::new(DepDag::new()),
+            speculative_live: std::sync::atomic::AtomicUsize::new(0),
             mem_execute_cache: Memoizer::with_tag_task("execute_cache", self.runtime.clone()),
             mem_locked_result: Memoizer::with_tag_task("locked_result", self.runtime.clone()),
             mem_remote_blob: Memoizer::with_tag_task("remote_blob", self.runtime.clone()),
@@ -1213,6 +1242,54 @@ mod tests {
             0,
             "no slot may be left outstanding when the engine is gone"
         );
+        Ok(())
+    }
+
+    /// Speculative states are counted while alive, so "at most one speculative
+    /// chain at a time" is observable rather than merely structural.
+    ///
+    /// `Engine::query`'s `MatchShrug` arm resolves candidates on a speculative
+    /// state whose cycle check walks per-chain breadcrumbs instead of the shared
+    /// `DepDag` — sound only one chain at a time. A walk guarantees that against
+    /// itself; nothing guaranteed it *between* walks on one request, and nothing
+    /// could see it. `heph validate` awaits its three walks one at a time for
+    /// exactly this reason (`src/commands/validate.rs`).
+    #[test]
+    fn speculative_states_are_counted_while_alive() -> anyhow::Result<()> {
+        let (_dir, engine) = test_engine()?;
+        let root = engine.new_state();
+        assert_eq!(root.speculative_live(), 0, "no chain to begin with");
+
+        {
+            let a = root.speculative();
+            assert_eq!(root.speculative_live(), 1);
+            {
+                // Two at once is the hazard the counter exists to expose.
+                let b = root.speculative();
+                assert_eq!(
+                    root.speculative_live(),
+                    2,
+                    "overlapping chains must be visible, not silent"
+                );
+                drop(b);
+            }
+            assert_eq!(root.speculative_live(), 1, "the inner chain released");
+            drop(a);
+        }
+        assert_eq!(root.speculative_live(), 0, "every chain released");
+
+        // Sequential use — what `validate` now does — never exceeds one.
+        for _ in 0..3 {
+            let s = root.speculative();
+            assert_eq!(root.speculative_live(), 1);
+            drop(s);
+        }
+        assert_eq!(root.speculative_live(), 0);
+
+        // A non-speculative child is not counted; only the shrug arm's states are.
+        let child = root.with_parent(addr("a"));
+        assert_eq!(root.speculative_live(), 0, "ordinary states are not chains");
+        drop(child);
         Ok(())
     }
 

--- a/src/commands/validate.rs
+++ b/src/commands/validate.rs
@@ -68,9 +68,41 @@ impl App for ValidateApp {
 
         let out = BufferedStdout::new(&ctx);
         let res: anyhow::Result<()> = async {
+            // Each check runs to completion before the next begins, and that is
+            // a correctness requirement rather than a style choice.
+            //
+            // Each drives its own `Engine::query` walk, and a walk's
+            // `MatchShrug` arm resolves candidates on a *speculative*
+            // `RequestState` whose cycle check walks per-chain breadcrumbs
+            // instead of the shared `DepDag`. That is sound only while one such
+            // chain exists at a time — a guarantee `Engine::query` makes *per
+            // walk* (its arm sits in the consumer of its own fan-out) and
+            // therefore cannot make across walks. `Engine::query`'s own comment
+            // names this command as the way the guarantee gets broken.
+            //
+            // Two chains at once are mutually invisible, and both consequences
+            // reach a build definition: `mem_spec`/`mem_def` are shared and keyed
+            // by addr, so whichever chain creates the cell decides which provider
+            // resolved the addr — and `hashin` folds `def.driver`, so the race
+            // picks the cache key. And two chains that resolve each other close a
+            // cycle neither can see, which hangs where the serial path reported an
+            // error. Both are reachable here: unscoped, checks 2 and 3 run the
+            // *same* `TreeOutputTo("")` matcher, which shrugs at the addr *and*
+            // the spec level, so both walks drive `get_spec` and `get_def`
+            // speculatively over the whole workspace.
+            //
+            // Serialising costs much less than three times one walk: the three
+            // share this request's memoizers, so the second and third walk hit
+            // cells the first already filled. It is the *speculative chains* that
+            // must not overlap, not the work they memoize.
+            //
+            // Every result is bound rather than `?`-propagated, so a failing
+            // check never short-circuits the others and `finish` reports all of
+            // them at once.
+
             // 1. Link every in-scope target: parse + resolve its runtime inputs.
             //    No execution — proves the graph is well-formed.
-            let link_fut = enclose!((engine, rs, matcher) async move {
+            let link_res: anyhow::Result<()> = async {
                 let addrs: Vec<Addr> = Arc::clone(&engine)
                     .query(rs.clone(), &matcher)
                     .try_collect()
@@ -100,22 +132,23 @@ impl App for ValidateApp {
                     })
                 });
                 // Always aggregate: validate reports every broken target, not
-                // just the first one to fail.
+                // just the first one to fail. This fan-out is genuinely
+                // concurrent and stays so — it resolves real deps on `rs`, not
+                // speculative candidates, so it starts no chain.
                 crate::engine::fanout::join_all_failable(futs, false).await?;
-                Ok::<(), anyhow::Error>(())
-            });
+                Ok(())
+            }
+            .await;
 
             // 2. Detect overlapping `codegen = copy` outputs.
-            let overlap_fut = enclose!((engine, rs) async move {
-                Arc::clone(&engine)
-                    .codegen_copy_overlaps(rs.clone(), &overlap_matcher)
-                    .await
-            });
+            let overlap_res = Arc::clone(&engine)
+                .codegen_copy_overlaps(rs.clone(), &overlap_matcher)
+                .await;
 
             // 3. Verify `.gitignore` is up to date (whole-workspace runs only).
-            let gitignore_fut = enclose!((engine, rs) async move {
+            let gitignore_res: anyhow::Result<bool> = async {
                 if scoped {
-                    return Ok::<bool, anyhow::Error>(false);
+                    return Ok(false);
                 }
                 let entries = Arc::clone(&engine)
                     .codegen_copy_gitignore_patterns(
@@ -131,13 +164,8 @@ impl App for ValidateApp {
                 };
                 let want = gitignore::render(&existing, &entries);
                 Ok(want != existing) // true = stale
-            });
-
-            // `join!` (not `try_join!`) so a failing check never short-circuits
-            // the others — every check runs to completion and `finish` reports
-            // all of their failures at once.
-            let (link_res, overlap_res, gitignore_res) =
-                tokio::join!(link_fut, overlap_fut, gitignore_fut);
+            }
+            .await;
 
             let overlap_res = overlap_res.map(|overlaps| {
                 overlaps


### PR DESCRIPTION
`heph validate` ran its three checks under `tokio::join!`, and each drives
its own `Engine::query` walk against the same `RequestState`. A walk's
`MatchShrug` arm resolves candidates on a *speculative* `RequestState` whose
cycle check walks per-chain breadcrumbs instead of the shared `DepDag`,
which is sound only while one such chain exists at a time.

`Engine::query` guarantees that per walk — its arm sits in the consumer of
its own fan-out, so a walk cannot overlap itself — and says so, naming this
command as the place the guarantee does not hold:

    The guarantee is per **walk**, not per engine: `heph validate` runs
    three `Engine::query` walks concurrently on one `RequestState`
    (`src/commands/validate.rs`), two of them with `TreeOutputTo`, so
    speculative chains from different walks can still overlap.

Both consequences reach a build definition. `mem_spec`/`mem_def` are shared
and keyed by addr, and `get_spec_inner` skips a provider whose `get` cycles
and falls through to the next — so whichever chain creates the cell decides
which provider resolved the addr, and `hashin` folds `def.driver`. The race
picks the cache key. And two chains that resolve each other close a cycle
neither can see, hanging where the serial path reported an error.

It is reachable, not theoretical: unscoped, `overlap_fut` and
`gitignore_fut` run the *same* `TreeOutputTo("")` matcher, which shrugs at
the addr *and* the spec level, so both walks drive `get_spec` and `get_def`
speculatively across the whole workspace.

Await the three one at a time. Every result is still collected rather than
`?`-propagated, so a failing check does not suppress the others and `finish`
still reports all of them at once — the property the `join!` was there for,
already covered by `reports_every_problem_not_just_the_first`.

Cost is well under three walks: they share this request's memoizers, so the
second and third hit cells the first filled. It is the speculative *chains*
that must not overlap, not the work they memoize.

The invariant was enforced only by the shape of the code and nothing could
observe a violation, which is how this survived. `RequestState::speculative`
now counts live chains and `speculative_live()` exposes the count, so
`speculative_states_are_counted_while_alive` can pin it. Non-speculative
states pay one branch on drop and no atomic.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01A9ACPrVo6RtSDYXzowsPT9