### PR TITLE
fix(run): fail when the selector matched nothing instead of exiting 0

### DIFF
--- a/src/commands/errors.rs
+++ b/src/commands/errors.rs
@@ -221,6 +221,30 @@ pub fn fold_batch(
     .into())
 }
 
+/// Reject a run whose selector chose nothing.
+///
+/// `heph run //pkg:gone` already exits 1 — the addr arm resolves the addr and
+/// gets `TargetNotFound`. Only the *selector* arm was silent: a label no target
+/// carries, an unbuilt variant, or a scope that misses the tree produced an
+/// empty batch with no errors, which folded to `Ok` and exited 0. A run that
+/// built nothing is indistinguishable from a run that had nothing to do, which
+/// is how a CI job goes green having done no work.
+///
+/// Scoped to `run`. A `query` that matches nothing is a legitimate answer, and
+/// `validate` over an empty scope has nothing to prove.
+pub fn require_non_empty(
+    results: Vec<Arc<crate::engine::EResult>>,
+) -> anyhow::Result<Vec<Arc<crate::engine::EResult>>> {
+    if results.is_empty() {
+        anyhow::bail!(
+            "no targets matched — nothing was run.\n\
+             Check the selector with `heph query -e '<expr>'`; a label that no target \
+             carries, or a package matcher outside the workspace, matches nothing."
+        );
+    }
+    Ok(results)
+}
+
 macro_rules! finalize {
     ($ctx:expr, $rs:expr, $res:expr $(,)?) => {
         $crate::commands::errors::finalize!($ctx, $rs, $res, _ => { Ok(()) })
@@ -592,6 +616,39 @@ mod tests {
     /// Keep-going failures inside an `Ok` batch must fold into `res` — the
     /// registry normally duplicates them, but an unrecorded class (the
     /// silent-exit-0 lint incident) must still fail the run.
+    #[test]
+    fn empty_result_set_is_a_failed_run() {
+        // The bug: a selector matching nothing folded to `Ok(vec![])` and exited
+        // 0, so a typo'd label or an out-of-scope matcher "succeeded" having
+        // built nothing.
+        let err = require_non_empty(vec![]).err().expect("empty must fail");
+        let rendered = format!("{err:#}");
+        assert!(
+            rendered.contains("no targets matched"),
+            "the message must say nothing ran, got: {rendered}"
+        );
+        assert!(
+            rendered.contains("heph query"),
+            "and point at how to debug the selector, got: {rendered}"
+        );
+    }
+
+    #[test]
+    fn a_non_empty_result_set_passes_through_untouched() {
+        let batch = crate::engine::BatchResult {
+            ok: vec![],
+            errors: vec![],
+        };
+        // Guard the shape rather than the emptiness: `fold_batch` on a clean
+        // batch is `Ok`, and only `require_non_empty` decides emptiness — so a
+        // future change that makes `fold_batch` itself reject empty would be
+        // caught here as a double rejection.
+        assert!(
+            fold_batch(batch).is_ok(),
+            "fold_batch must not judge emptiness"
+        );
+    }
+
     #[test]
     fn fold_batch_surfaces_keep_going_errors() {
         let batch = crate::engine::BatchResult {

--- a/src/commands/run.rs
+++ b/src/commands/run.rs
@@ -220,7 +220,10 @@ impl App for RunApp {
                 // NOT `.map(|batch| batch.ok)`: keep-going failures ride
                 // inside the Ok and must fold into `res`, or an error the
                 // registry didn't record exits 0 in silence. See `fold_batch`.
-                .and_then(crate::commands::errors::fold_batch),
+                .and_then(crate::commands::errors::fold_batch)
+                // A selector that chose nothing is a failed run, not a
+                // successful empty one — see `require_non_empty`.
+                .and_then(crate::commands::errors::require_non_empty),
         };
 
         // On success print `--cat-out` / `--list-out`; failures/cancellation are


### PR DESCRIPTION
`heph run` with a selector that chose no targets built nothing and exited 0.
A typo'd label, a variant that is not declared, or a scope that misses the
tree all produced an empty batch with no errors, which folded to `Ok` and
reported success.

The addr arm was never affected — `heph run //pkg:gone` resolves the addr,
gets `TargetNotFound`, and exits 1. Only the *selector* arm was silent, so
the two disagreed about the same mistake depending on how it was spelled.

This is the failure mode that is worst in CI, because a run that built
nothing is indistinguishable from a run that had nothing to do. The repo has
already been bitten by the same shape elsewhere: `heph-bench`'s Tier B
scenario matched zero targets without a declared variant and still exited 0,
so it measured nothing while looking green (fixed separately in #348), and
`CLAUDE.md` warns about exactly this for `e2e` — "a run that tested nothing
is indistinguishable from a run that passed".

Reject an empty result set in `require_non_empty`, with a message that says
nothing ran and points at `heph query -e '<expr>'` to debug the selector.

Scoped deliberately to `run`. A `query` that matches nothing is a legitimate
answer, and `validate` over an empty scope has nothing to prove — neither
changes.

**This changes a CLI exit code**, so it is a compatibility-relevant change: a
caller that today invokes `heph run <label> //...` on a tree where the label
legitimately matches nothing goes from 0 to 1. That is the point of the fix,
but it is the kind of thing that surfaces in someone's CI. If a repo turns
out to need "empty is fine", the follow-up is an explicit opt-out flag rather
than restoring a silent pass.

Verified by hand on the example workspace: `-e //nonexistent/...` and
`nosuchlabel //...` now exit 1 with the message; `-e //hello/...` and
`//hello:hello` still exit 0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01A9ACPrVo6RtSDYXzowsPT9