### PR TITLE
fix(tui): let Ctrl-C cancel a run whose target holds the terminal

### DIFF
--- a/crates/bin-e2e/tests/tui_pty.rs
+++ b/crates/bin-e2e/tests/tui_pty.rs
@@ -135,8 +135,86 @@ fn no_tui_flag_wins_over_an_attached_terminal() {
     );
 }
 
+/// The named target announces itself, then sleeps far longer than the test can
+/// wait — so "the run ended" can only mean the Ctrl-C ended it. `cache = False`
+/// keeps a second run from short-circuiting to a cache hit.
+const SLEEPS_FOREVER: &str = concat!(
+    "target(name = \"slow\", driver = \"bash\", cache = False,",
+    " run = [\"echo e2e-running\", \"sleep 600\"])\n",
+);
+
+/// Ctrl-C must cancel a run whose *named* target holds the terminal.
+///
+/// Naming a single target hands it the terminal, which pauses the TUI for that
+/// target's entire runtime (see the `BUILD` const at the top of this file, which
+/// leans on the same behaviour for the opposite reason). That pause used to suppress the
+/// shutdown trigger wholesale, and the two producers fail in opposite
+/// directions: the TUI's key handler cannot see the press (the event stream is
+/// dropped while paused) and the kernel SIGINT — which the cooked-mode terminal
+/// does deliver — was thrown away by the suppression. So Ctrl-C was inert for
+/// the whole run, and so was the second-press abort behind it. Suppression is
+/// now scoped to a pause that hands the *keyboard* over (`--shell`,
+/// `PauseFor::Input`), and `shell_pty.rs` owns that side.
+///
+/// PTY-only by construction, twice over: the interactive backend engages only
+/// on a tty, and a Ctrl-C is only a SIGINT when it comes from a controlling
+/// terminal with a foreground process group. A linked test has neither, so it
+/// would pass on the broken code without executing any of it.
+#[test]
+fn ctrl_c_cancels_a_run_whose_target_holds_the_terminal() {
+    let dist = Dist::locate();
+    let ws = common::Workspace::new().expect("workspace");
+    ws.write("pkg/BUILD", SLEEPS_FOREVER).expect("write BUILD");
+
+    // 90s: long enough for a release binary to reach the target on a cold, busy
+    // runner, short enough that an ignored Ctrl-C fails the job rather than
+    // sitting on it for the full 600s sleep.
+    let session = run_in_pty_typing(
+        &dist,
+        ws.root(),
+        &["run", "//pkg:slow"],
+        Some(Interact {
+            marker: "e2e-running".to_string(),
+            send: vec![0x03],
+        }),
+        Duration::from_secs(90),
+    );
+
+    // Without this the test could pass on a run that died before it ever
+    // executed the target — no Ctrl-C sent, nothing about cancellation proved.
+    assert!(
+        session.sent_input,
+        "the target never reached its sleep, so no ctrl-c was ever sent\n{}",
+        session.report()
+    );
+    assert!(
+        !session.status_success,
+        "a cancelled run reported success\n{}",
+        session.report()
+    );
+
+    // Cancelling is not licence to wreck the terminal: the TUI resumes out of
+    // the pause on its way out, and must still hand the cursor back.
+    let hid = last_index(&session.raw, CURSOR_HIDE);
+    let shown = last_index(&session.raw, CURSOR_SHOW);
+    assert!(
+        hid.is_some(),
+        "TUI never hid the cursor\n{}",
+        session.report()
+    );
+    assert!(
+        shown > hid,
+        "cancelled run exited with the cursor still hidden\n{}",
+        session.report()
+    );
+}
+
 struct Session {
     status_success: bool,
+    /// Whether the [`Interact`] marker was ever seen, and so the keystroke sent.
+    /// Distinguishes "the run ignored Ctrl-C" from "the run never got far
+    /// enough to be sent one".
+    sent_input: bool,
     /// Every byte the child wrote to the pty.
     raw: Vec<u8>,
     /// Concatenation of the screen as rendered after each read — so an
@@ -156,6 +234,30 @@ impl Session {
 }
 
 fn run_in_pty(dist: &Dist, cwd: &std::path::Path, args: &[&str]) -> Session {
+    run_in_pty_typing(dist, cwd, args, None, DEADLINE)
+}
+
+/// Type something at the running child: once `marker` shows up in its output,
+/// `send` goes down the pty, once. The marker is what makes it a synchronisation
+/// point rather than a sleep — the keystroke lands when the run has actually
+/// reached the state under test.
+struct Interact {
+    marker: String,
+    send: Vec<u8>,
+}
+
+/// `run_in_pty`, plus the ability to type at the child and its own deadline.
+///
+/// The keystroke is written from the reader thread, which already owns the pty
+/// writer (it answers the TUI's cursor queries there) — a second handle would
+/// have to be split off `take_writer`, which hands out exactly one.
+fn run_in_pty_typing(
+    dist: &Dist,
+    cwd: &std::path::Path,
+    args: &[&str],
+    interact: Option<Interact>,
+    deadline: Duration,
+) -> Session {
     const ROWS: u16 = 40;
     const COLS: u16 = 140;
 
@@ -192,6 +294,8 @@ fn run_in_pty(dist: &Dist, cwd: &std::path::Path, args: &[&str]) -> Session {
     let mut writer = pair.master.take_writer().expect("take pty writer");
     let captured = Arc::new(Mutex::new((Vec::<u8>::new(), String::new())));
     let sink = Arc::clone(&captured);
+    let sent_input = Arc::new(std::sync::atomic::AtomicBool::new(false));
+    let sent_flag = Arc::clone(&sent_input);
     let pump = std::thread::spawn(move || {
         let mut parser = vt100::Parser::new(ROWS, COLS, 0);
         let mut buf = [0u8; 8192];
@@ -221,6 +325,16 @@ fn run_in_pty(dist: &Dist, cwd: &std::path::Path, args: &[&str]) -> Session {
                     guard.0.extend_from_slice(chunk);
                     guard.1.push_str(&screen);
                     guard.1.push('\n');
+
+                    // Marker matched against everything captured so far, not just
+                    // this chunk: a read boundary can land in the middle of it.
+                    if let Some(it) = interact.as_ref()
+                        && !sent_flag.load(std::sync::atomic::Ordering::Relaxed)
+                        && contains(&guard.0, it.marker.as_bytes())
+                    {
+                        sent_flag.store(true, std::sync::atomic::Ordering::Relaxed);
+                        drop(writer.write_all(&it.send).and_then(|()| writer.flush()));
+                    }
                 }
             }
         }
@@ -231,7 +345,7 @@ fn run_in_pty(dist: &Dist, cwd: &std::path::Path, args: &[&str]) -> Session {
         match child.try_wait().expect("wait on pty child") {
             Some(status) => break Some(status),
             None => {
-                if started.elapsed() > DEADLINE {
+                if started.elapsed() > deadline {
                     child.kill().expect("kill timed-out pty child");
                     break None;
                 }
@@ -249,12 +363,18 @@ fn run_in_pty(dist: &Dist, cwd: &std::path::Path, args: &[&str]) -> Session {
     let guard = captured.lock().expect("capture lock");
     let session = Session {
         status_success: status.is_some_and(|s| s.success()),
+        sent_input: sent_input.load(std::sync::atomic::Ordering::Relaxed),
         raw: guard.0.clone(),
         rendered: guard.1.clone(),
     };
     assert!(
         exited,
-        "child did not exit within {DEADLINE:?}\n{}",
+        "child did not exit within {deadline:?}{}\n{}",
+        if session.sent_input {
+            " — the input this test typed was delivered and ignored"
+        } else {
+            ""
+        },
         session.report()
     );
     session

--- a/crates/core/src/shutdown.rs
+++ b/crates/core/src/shutdown.rs
@@ -10,8 +10,13 @@ use tokio::sync::mpsc;
 /// listener and the TUI's Ctrl+C key handler call `trigger()` on this; a single
 /// consumer drives the shutdown state machine from the paired receiver.
 ///
-/// While `SuppressionHandle::set(true)` is in effect (e.g. the TUI is paused for
-/// an interactive prompt), `trigger()` silently drops presses.
+/// While `SuppressionHandle::set(true)` is in effect, `trigger()` silently drops
+/// presses — every press, including the second one that would otherwise abort.
+/// It is therefore for one situation only: the user is typing at something heph
+/// is hosting (`heph run --shell`) and the keystrokes are that session's, not
+/// heph's. Anything broader is a Ctrl-C that does nothing at all, since a TUI
+/// that has stepped aside is in cooked mode and the kernel SIGINT is then the
+/// only producer left.
 #[derive(Clone)]
 pub struct ShutdownTrigger {
     tx: mpsc::UnboundedSender<()>,

--- a/crates/tui/src/tui/app.rs
+++ b/crates/tui/src/tui/app.rs
@@ -9,8 +9,32 @@ use hcore::events::{BuildEvent, EventSender};
 type PendingCounter = std::sync::Arc<std::sync::atomic::AtomicUsize>;
 
 pub(crate) enum Control {
-    Pause(oneshot::Sender<()>),
+    Pause(oneshot::Sender<()>, PauseFor),
     Resume,
+}
+
+/// Why the TUI is stepping aside — which decides who owns Ctrl-C while it is
+/// down. The renderer leaves raw mode to pause, so the terminal starts
+/// generating SIGINT again the moment it does; this says what should happen to
+/// that press.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum PauseFor {
+    /// Something is *writing* to the cooked terminal — a diagnostic, a stdout
+    /// flush, or a target running with the terminal attached. Nobody is typing
+    /// at anything, so Ctrl-C still belongs to heph and must cancel the run.
+    Output,
+    /// The user is *typing* at something heph is hosting (`heph run --shell`).
+    /// Every keystroke, Ctrl-C included, belongs to that session — heph must
+    /// not read it as "cancel the build".
+    Input,
+}
+
+impl PauseFor {
+    /// Whether this pause hands keyboard input to something other than heph,
+    /// and so must suppress the shutdown trigger for its duration.
+    pub(crate) fn owns_input(self) -> bool {
+        matches!(self, Self::Input)
+    }
 }
 
 pub struct AppContext {
@@ -79,8 +103,11 @@ impl AppContext {
     /// drains pending log lines, restores the terminal, and switches the
     /// log sink to direct passthrough. On guard drop the renderer resumes.
     /// In CI mode this is a no-op.
+    ///
+    /// Pauses as [`PauseFor::Output`] — Ctrl-C stays heph's. Use
+    /// [`Pauser::pause_for`] to hand the keyboard over instead.
     pub async fn pause(&self) -> PauseGuard<'_> {
-        pause_inner(&self.control).await;
+        pause_inner(&self.control, PauseFor::Output).await;
         PauseGuard { ctx: self }
     }
 
@@ -110,8 +137,18 @@ pub struct Pauser {
 }
 
 impl Pauser {
+    /// Pause as [`PauseFor::Output`] — heph keeps Ctrl-C.
     pub async fn pause(&self) -> OwnedPauseGuard {
-        pause_inner(&self.control).await;
+        self.pause_for(PauseFor::Output).await
+    }
+
+    /// Pause, saying who owns the keyboard while the TUI is down. Only
+    /// [`PauseFor::Input`] suppresses the shutdown trigger, and only a caller
+    /// that is genuinely handing the user's keystrokes to something else
+    /// (`--shell`) may ask for it: a paused TUI is in cooked mode, so anything
+    /// else would silently eat the run's only Ctrl-C.
+    pub async fn pause_for(&self, kind: PauseFor) -> OwnedPauseGuard {
+        pause_inner(&self.control, kind).await;
         OwnedPauseGuard {
             control: self.control.clone(),
         }
@@ -128,10 +165,10 @@ impl Drop for OwnedPauseGuard {
     }
 }
 
-async fn pause_inner(control: &Option<mpsc::UnboundedSender<Control>>) {
+async fn pause_inner(control: &Option<mpsc::UnboundedSender<Control>>, kind: PauseFor) {
     if let Some(tx) = control {
         let (ack_tx, ack_rx) = oneshot::channel();
-        if tx.send(Control::Pause(ack_tx)).is_ok() {
+        if tx.send(Control::Pause(ack_tx, kind)).is_ok() {
             drop(ack_rx.await);
         }
     }

--- a/crates/tui/src/tui/backend/interactive.rs
+++ b/crates/tui/src/tui/backend/interactive.rs
@@ -149,12 +149,23 @@ pub async fn run<A: App + 'static>(
             }
             ctrl = control_rx.recv() => {
                 match ctrl {
-                    Some(Control::Pause(ack)) => {
+                    Some(Control::Pause(ack, kind)) => {
                         if !paused {
-                            // Suppress shutdown trigger before releasing raw mode so
-                            // a Ctrl+C delivered to the cooked-mode prompt can't
-                            // race past us and cancel engine work.
-                            suppression.set(true);
+                            // Leaving raw mode below re-arms the terminal's ISIG,
+                            // so from here until resume a Ctrl-C arrives as a real
+                            // SIGINT instead of a key event. Suppress the trigger
+                            // only when the pause is handing the keyboard to
+                            // something else (`--shell`) — that session's Ctrl-C is
+                            // not a request to cancel the build. For a plain pause
+                            // (a diagnostic, a stdout flush, a target running with
+                            // the terminal attached) the press is still heph's, and
+                            // suppressing it left `heph run //pkg:target` with no
+                            // working Ctrl-C at all for the whole of that target's
+                            // run: the key handler is not reading (the event stream
+                            // is dropped just below), so the kernel SIGINT was the
+                            // only surviving producer, and dropping it also put the
+                            // second-press abort out of reach.
+                            suppression.set(kind.owns_input());
                             // Drop the EventStream *before* `clear()`. `clear()`
                             // issues a cursor DSR query (`get_cursor_position`),
                             // which reads its reply through crossterm's single

--- a/crates/tui/src/tui/mod.rs
+++ b/crates/tui/src/tui/mod.rs
@@ -12,7 +12,7 @@ pub mod tty;
 
 use std::io::{self, IsTerminal};
 
-pub use app::{App, AppContext, CIAppView, PauseGuard, TUIAppView};
+pub use app::{App, AppContext, CIAppView, PauseFor, PauseGuard, TUIAppView};
 pub use approval::{ApprovalCenter, ApprovalNoticeView, ApprovalView};
 pub use log_sink::LogSink;
 pub use paused::paused;

--- a/scripts/macos-portable.sh
+++ b/scripts/macos-portable.sh
@@ -38,7 +38,13 @@ for dep in $nix_deps; do
   sys="/usr/lib/$base"
   # /usr/lib dylibs live in the dyld shared cache and may not exist as files,
   # so we can't stat them. dlopen is the reliable presence check.
-  if ! /usr/bin/python3 - "$sys" <<'PY'
+  #
+  # `env -u DEVELOPER_DIR`: /usr/bin/python3 is an xcrun shim that resolves the
+  # real tool under $DEVELOPER_DIR, and the devenv shell — the documented way to
+  # work in this repo — points that at the nix apple-sdk, which ships no python.
+  # Without this, `e2e` dies with a bare "error: tool 'python3' not found" on
+  # every macOS dev machine, at the staging step, after a full release build.
+  if ! env -u DEVELOPER_DIR /usr/bin/python3 - "$sys" <<'PY'
 import ctypes, sys
 try:
     ctypes.CDLL(sys.argv[1])

--- a/src/commands/bootstrap.rs
+++ b/src/commands/bootstrap.rs
@@ -52,9 +52,13 @@ pub fn block_on<F: Future>(fut: F) -> anyhow::Result<F::Output> {
 /// listener and the TUI's Ctrl+C key handler call `trigger()` on this; the
 /// state machine in `spawn_shutdown_handler` is the single consumer.
 ///
-/// While `SuppressionHandle::set(true)` is in effect (e.g. the TUI is paused
-/// for an interactive prompt), `trigger()` silently drops presses — neither
-/// kernel SIGINT nor TUI Ctrl+C cancels engine work in that window.
+/// While `SuppressionHandle::set(true)` is in effect — only while the TUI has
+/// handed the keyboard to a `--shell` session (`tui::PauseFor::Input`) —
+/// `trigger()` silently drops presses, so neither kernel SIGINT nor TUI Ctrl+C
+/// cancels engine work in that window. A pause that merely borrows the terminal
+/// for *output* (a diagnostic, a stdout flush, a target running with the
+/// terminal attached) must not suppress: the key handler is not reading while
+/// paused, so dropping the SIGINT too leaves the run with no Ctrl-C at all.
 // The shutdown signal types moved to `heph-core::shutdown` so the TUI can hold a
 // trigger without depending on this bin module; re-exported for existing callers.
 pub use hcore::shutdown::{ShutdownTrigger, SuppressionHandle};

--- a/src/commands/run.rs
+++ b/src/commands/run.rs
@@ -140,10 +140,21 @@ impl App for RunApp {
     async fn run(self, ctx: AppContext) -> anyhow::Result<()> {
         let interactive: Option<InteractiveWrapper> = if ctx.interactive() {
             let pauser = ctx.pauser();
+            // Who owns Ctrl-C while the target holds the terminal. `--shell` puts
+            // the user at a live shell inside the sandbox, and its keystrokes —
+            // Ctrl-C first among them — are for that session, so the trigger stays
+            // suppressed for its duration. A plain run is the opposite: nothing is
+            // reading the keyboard, the terminal is merely on loan for the target's
+            // output, and Ctrl-C must still cancel the run.
+            let pause_for = if self.args.shell.is_some() {
+                tui::PauseFor::Input
+            } else {
+                tui::PauseFor::Output
+            };
             Some(Arc::new(move |inner| {
                 let pauser = pauser.clone();
                 Box::pin(async move {
-                    let _guard = pauser.pause().await;
+                    let _guard = pauser.pause_for(pause_for).await;
                     // Source stdin from the client's /dev/tty via a TtyReader
                     // rather than tokio::io::stdin(): tokio's stdin spawns a
                     // global blocking thread parked on read(0, …) that cannot


### PR DESCRIPTION
## The bug

`heph run //pkg:target` did not respond to Ctrl-C at all — not slowly, not partially. Reported from a real OCI build that got slow and could not be stopped.

Naming a single target hands it the terminal, which pauses the TUI for that target's **entire run**. The pause set `SuppressionHandle(true)` unconditionally, and both Ctrl-C producers fail inside that window:

- the TUI's key handler cannot see the press — the `EventStream` is dropped while paused;
- the kernel SIGINT, which the now-cooked terminal *does* deliver and `spawn_sigint_producer` *does* receive, was thrown away by `ShutdownTrigger::trigger`'s suppression check.

The documented escape hatch died with it: the second-press abort (exit 130) counts presses behind the same gate, so it was unreachable too.

## The fix

Suppression now follows a `PauseFor` carried on the pause itself:

- **`PauseFor::Input`** — the pause hands over the *keyboard* (`--shell`). Keeps suppression: those keystrokes belong to that session, not to heph.
- **`PauseFor::Output`** — the pause merely borrows the terminal for *output* (a diagnostic, a stdout flush, a target running with the terminal attached). No suppression: the press is still heph's, and a paused TUI is in cooked mode, so the kernel SIGINT is the only producer left.

`--shell` behaviour is unchanged, and structurally safe either way — pluginexec re-enables raw mode for its pty relay, so Ctrl-C reaches the inner shell as a byte and never becomes a SIGINT for heph. `shell_pty.rs::ctrl_c_interrupts_foreground_child_not_the_session` owns that side.

## Evidence

Measured with a `pty.fork()` harness (a real controlling terminal — `subprocess` + `openpty` leaves the child without one, so the tty has no foreground process group to signal and the result is meaningless):

| run | pre-fix | post-fix |
|---|---|---|
| `heph run //sleep:s` (TUI) | alive 30s after Ctrl-C, SIGKILLed | **exits 0.0s after**, `rc=1` |
| `heph run -e '//sleep'` (TUI, no handoff) | exits 0.1s after | unchanged |
| `heph run //sleep:s --no-tui` | exits ~1s after SIGINT | unchanged |
| `heph run --shell //sleep:s` | session survives | **unchanged** — session survives |

## Tests

`tui_pty.rs` gains `ctrl_c_cancels_a_run_whose_target_holds_the_terminal`, plus harness support for typing at the child (`Interact`, keyed off a marker in the child's output rather than a sleep).

PTY-only twice over — the interactive backend engages only on a tty, and a Ctrl-C is only a SIGINT when it comes from a controlling terminal with a foreground process group — so a linked test would pass on the broken code without executing any of it.

Verified red against the pre-fix line (`suppression.set(true)`): `0 passed; 1 failed; 6 filtered out; finished in 90.11s` — it burns the whole deadline because the child never exits. Green with the fix, alongside the existing suite: `7 passed`.

## Also in here

One unrelated line in `scripts/macos-portable.sh`, which was **blocking**: inside the devenv shell `DEVELOPER_DIR` points at the nix apple-sdk, so the `/usr/bin/python3` xcrun shim dies with `error: tool 'python3' not found` — at the staging step, after a full release build, making `e2e` unrunnable on any macOS dev machine. Happy to split it out. `scripts/patch-flavour.sh` has the same latent issue (bare `python3`) but nothing local hits it, so it is left alone.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UFN3F1d1JHxeGGAkEEMgGu