### PR TITLE
perf(cache): adopt a collected archive instead of copying it

### DIFF
--- a/crates/driver-support/src/driver_managed.rs
+++ b/crates/driver-support/src/driver_managed.rs
@@ -5,6 +5,7 @@ use hcore::hasync::{self, Cancellable};
 use hmodel::htaddr::Addr;
 use hplugin::driver::inputartifact;
 use hplugin::driver::outputartifact::Content::TarPath;
+use hplugin::driver::outputartifact::ContentPath;
 use hplugin::driver::targetdef::path::{self, Content};
 use hplugin::driver::{
     ApplyTransitiveRequest, ApplyTransitiveResponse, ConfigRequest, ConfigResponse, ParseRequest,
@@ -287,7 +288,9 @@ fn collect_outputs_inner(
             group: output.group.clone(),
             name: format!("{}.tar", output.group),
             r#type: outputartifact::Type::Output,
-            content: TarPath(tarpath.0),
+            // Owned: this tar exists only to be handed to the local cache, and
+            // the sandbox it lives in is torn down right after that write.
+            content: TarPath(ContentPath::owned(tarpath.0)),
             hashout: tarpath.1,
         });
     }
@@ -301,7 +304,7 @@ fn collect_outputs_inner(
             group: String::new(),
             name: "support.tar".to_string(),
             r#type: outputartifact::Type::SupportFile,
-            content: TarPath(tarpath),
+            content: TarPath(ContentPath::owned(tarpath)),
             hashout,
         });
     }

--- a/crates/engine/src/engine/local_cache.rs
+++ b/crates/engine/src/engine/local_cache.rs
@@ -268,6 +268,31 @@ pub trait LocalCache: Send + Sync {
     fn file_path(&self, _addr: &Addr, _hashin: &str, _name: &str) -> Option<std::path::PathBuf> {
         None
     }
+    /// Take `src` whole as the blob for `(addr, hashin, name)`, by moving the
+    /// file rather than reading it.
+    ///
+    /// `Ok(true)`: the blob is committed and `src` no longer exists. `Ok(false)`:
+    /// the backend declined and `src` is untouched — the caller streams it
+    /// through [`writer`](Self::writer) as it always did. Only a caller that owns
+    /// `src` outright may offer it (see
+    /// [`ContentPath::owned`](crate::engine::driver::outputartifact::ContentPath::owned)).
+    ///
+    /// **Defaults to declining, deliberately** — the opposite of
+    /// [`existence`](Self::existence). Declining costs a copy and nothing else,
+    /// so a backend that never overrides this is correct, just as fast as before,
+    /// and a decorator that forwards `writer` without forwarding this is
+    /// pessimal rather than wrong. Only a backend storing blobs as plain files
+    /// has anything to accept with, and even then only when `src` is on the same
+    /// filesystem — a cross-device rename is precisely what it declines on.
+    fn adopt_file(
+        &self,
+        _addr: &Addr,
+        _hashin: &str,
+        _name: &str,
+        _src: &std::path::Path,
+    ) -> anyhow::Result<bool> {
+        Ok(false)
+    }
 }
 
 #[derive(Debug, thiserror::Error)]
@@ -441,6 +466,54 @@ fn cache_entry_name(artifact: &outputartifact::OutputArtifact) -> String {
     }
 }
 
+/// Store a container (tar/cpio) the driver already wrote to disk, returning its
+/// size.
+///
+/// Packing an output wrote every collected byte once, into a file that is
+/// byte-for-byte the blob the cache is about to hold; streaming it in writes them
+/// all a second time, on the same filesystem, for the same content. When the
+/// producer hands the file over ([`ContentPath::owned`]) and the backend can take
+/// it whole, the file *becomes* the blob — one `rename(2)`, no bytes read, and
+/// nothing left for the sandbox teardown to delete.
+///
+/// Both halves are conditional on purpose: a container the producer still owns is
+/// copied (it must survive this call), and a backend that declines — sqlite,
+/// mem, or an FS store on the other side of an `EXDEV` — is copied into exactly
+/// as before. The size is read before either, so it is the file's own size on
+/// both paths.
+fn store_container(
+    cache: &dyn LocalCache,
+    addr: &Addr,
+    hashin: &str,
+    name: &str,
+    content: &outputartifact::ContentPath,
+    kind: &str,
+) -> anyhow::Result<u64> {
+    let src = std::path::Path::new(&content.path);
+    let size = std::fs::metadata(src)
+        .with_context(|| format!("stat {kind} artifact {}", content.path))?
+        .size();
+
+    if content.owned
+        && cache
+            .adopt_file(addr, hashin, name, src)
+            .with_context(|| format!("adopt {kind} artifact {} as {addr} {name}", content.path))?
+    {
+        return Ok(size);
+    }
+
+    let mut f =
+        File::open(src).with_context(|| format!("open {kind} artifact {}", content.path))?;
+    let mut w = cache
+        .writer(addr, hashin, name)
+        .with_context(|| format!("open cache writer for {addr} {name}"))?;
+    io::copy(&mut f, &mut w)
+        .with_context(|| format!("copy {kind} artifact {} into {addr} {name}", content.path))?;
+    w.commit()
+        .with_context(|| format!("commit {kind} artifact {addr} {name}"))?;
+    Ok(size)
+}
+
 impl Engine {
     pub async fn cache_artifact_locally(
         &self,
@@ -509,40 +582,14 @@ impl Engine {
                     })?;
                     (size, hartifactcontent::Type::Tar)
                 }
-                outputartifact::Content::TarPath(path) => {
-                    let mut f = File::open(path)
-                        .with_context(|| format!("open tar artifact {path}"))?;
-                    let size = f
-                        .metadata()
-                        .with_context(|| format!("stat tar artifact {path}"))?
-                        .size();
-                    let mut w = open_writer(&name)
-                        .with_context(|| format!("open cache writer for {addr} {name}"))?;
-                    io::copy(&mut f, &mut w).with_context(|| {
-                        format!("copy tar artifact {path} into {addr} {name}")
-                    })?;
-                    w.commit().with_context(|| {
-                        format!("commit tar artifact {addr} {name}")
-                    })?;
-                    (size, hartifactcontent::Type::Tar)
-                }
-                outputartifact::Content::CpioPath(path) => {
-                    let mut f = File::open(path)
-                        .with_context(|| format!("open cpio artifact {path}"))?;
-                    let size = f
-                        .metadata()
-                        .with_context(|| format!("stat cpio artifact {path}"))?
-                        .size();
-                    let mut w = open_writer(&name)
-                        .with_context(|| format!("open cache writer for {addr} {name}"))?;
-                    io::copy(&mut f, &mut w).with_context(|| {
-                        format!("copy cpio artifact {path} into {addr} {name}")
-                    })?;
-                    w.commit().with_context(|| {
-                        format!("commit cpio artifact {addr} {name}")
-                    })?;
-                    (size, hartifactcontent::Type::Cpio)
-                }
+                outputartifact::Content::TarPath(content) => (
+                    store_container(&*local_cache, &addr, &hashin, &name, content, "tar")?,
+                    hartifactcontent::Type::Tar,
+                ),
+                outputartifact::Content::CpioPath(content) => (
+                    store_container(&*local_cache, &addr, &hashin, &name, content, "cpio")?,
+                    hartifactcontent::Type::Cpio,
+                ),
             };
 
             let artifact_type = match artifact.r#type {
@@ -1102,6 +1149,22 @@ mod tests {
         (engine, dir)
     }
 
+    /// Engine whose durable cache spills to plain files above `threshold` bytes,
+    /// so a test can exercise the file-backed route (the only one that can adopt
+    /// an artifact file) without writing the 8 MiB the default would need.
+    fn test_engine_spilling_at(threshold: u64) -> (Engine, tempfile::TempDir) {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let engine = Engine::new(Config {
+            root: dir.path().to_path_buf(),
+            home_dir: std::path::PathBuf::new(),
+            parallelism: None,
+            spill_threshold_bytes: threshold,
+            ..Default::default()
+        })
+        .expect("engine");
+        (engine, dir)
+    }
+
     /// Engine wired to the remote cache at `remote_uri` (a `file://` dir shared
     /// across engines). Returns an `Arc` so the `self: &Arc<Self>` upload helper
     /// can be called.
@@ -1549,7 +1612,9 @@ mod tests {
             group: "out".to_string(),
             name: name.to_string(),
             r#type: outputartifact::Type::Output,
-            content: outputartifact::Content::TarPath(format!("/nonexistent/heph-{name}")),
+            content: outputartifact::Content::TarPath(outputartifact::ContentPath::owned(format!(
+                "/nonexistent/heph-{name}"
+            ))),
             hashout: format!("hashout-{name}"),
         };
         let Err(err) = engine
@@ -1709,7 +1774,9 @@ mod tests {
             group: "out".to_string(),
             name: "gone".to_string(),
             r#type: outputartifact::Type::Output,
-            content: outputartifact::Content::TarPath("/nonexistent/heph-test-tar".to_string()),
+            content: outputartifact::Content::TarPath(outputartifact::ContentPath::owned(
+                "/nonexistent/heph-test-tar",
+            )),
             hashout: "hashout-gone".to_string(),
         };
         let Err(err) = engine
@@ -1773,6 +1840,156 @@ mod tests {
             }),
             hashout: format!("hashout-{name}"),
         }
+    }
+
+    /// A container artifact on disk, `owned` deciding whether the cache may
+    /// consume the file or has to copy out of it.
+    fn tar_artifact(
+        name: &str,
+        path: &std::path::Path,
+        owned: bool,
+    ) -> outputartifact::OutputArtifact {
+        let path = path.to_string_lossy().into_owned();
+        outputartifact::OutputArtifact {
+            group: "out".to_string(),
+            name: name.to_string(),
+            r#type: outputartifact::Type::Output,
+            content: outputartifact::Content::TarPath(if owned {
+                outputartifact::ContentPath::owned(path)
+            } else {
+                outputartifact::ContentPath::borrowed(path)
+            }),
+            hashout: format!("hashout-{name}"),
+        }
+    }
+
+    /// Collecting a target's outputs already wrote every byte once, into a tar
+    /// whose only purpose is this write — so the cache takes the file instead of
+    /// reading it back and writing a second, byte-identical copy. The revision
+    /// must be indistinguishable from the copied one: same bytes, same recorded
+    /// size, and no leftover in the sandbox for the teardown to sweep.
+    #[tokio::test]
+    async fn an_owned_container_is_moved_into_the_cache() {
+        let (engine, dir) = test_engine_spilling_at(64);
+        let ctoken = StdCancellationToken::new();
+        let addr = test_addr();
+
+        let src = dir.path().join("sandbox-collect").join("out.tar");
+        std::fs::create_dir_all(src.parent().expect("parent")).expect("mkdir");
+        let bytes = vec![7u8; 256];
+        std::fs::write(&src, &bytes).expect("write tar");
+
+        let arts = engine
+            .cache_locally(
+                &ctoken,
+                &addr,
+                "HASHIN_ADOPT",
+                vec![tar_artifact("out.tar", &src, true)],
+                false,
+            )
+            .await
+            .expect("cache_locally");
+
+        assert!(
+            !src.exists(),
+            "an owned container is handed over, not duplicated"
+        );
+        assert_eq!(arts[0].size, bytes.len() as u64);
+        assert_eq!(
+            drain_reader(
+                engine
+                    .local_cache
+                    .reader(&addr, "HASHIN_ADOPT", &arts[0].name)
+                    .expect("blob")
+                    .reader
+            ),
+            bytes,
+            "the adopted file is the blob"
+        );
+
+        let manifest = engine
+            .read_manifest(&addr, "HASHIN_ADOPT")
+            .expect("read manifest")
+            .expect("manifest committed");
+        assert_eq!(manifest.artifacts[0].size, bytes.len() as u64);
+    }
+
+    /// The move is gated on the producer handing the file over. A container it
+    /// still owns — anything reaching the engine across the plugin ABI, where
+    /// ownership does not travel — is copied and left exactly where it was.
+    #[tokio::test]
+    async fn a_borrowed_container_is_copied_and_left_alone() {
+        let (engine, dir) = test_engine_spilling_at(64);
+        let ctoken = StdCancellationToken::new();
+        let addr = test_addr();
+
+        let src = dir.path().join("kept.tar");
+        let bytes = vec![5u8; 256];
+        std::fs::write(&src, &bytes).expect("write tar");
+
+        let arts = engine
+            .cache_locally(
+                &ctoken,
+                &addr,
+                "HASHIN_COPY",
+                vec![tar_artifact("out.tar", &src, false)],
+                false,
+            )
+            .await
+            .expect("cache_locally");
+
+        assert_eq!(
+            std::fs::read(&src).expect("source survives"),
+            bytes,
+            "a borrowed container must outlive the write untouched"
+        );
+        assert_eq!(
+            drain_reader(
+                engine
+                    .local_cache
+                    .reader(&addr, "HASHIN_COPY", &arts[0].name)
+                    .expect("blob")
+                    .reader
+            ),
+            bytes
+        );
+    }
+
+    /// A container small enough to belong in sqlite is copied even when it is
+    /// offered: the backend declines, and declining must cost a copy rather than
+    /// the write. Same revision either way.
+    #[tokio::test]
+    async fn an_owned_container_below_the_spill_threshold_still_lands() {
+        let (engine, dir) = test_engine_spilling_at(64 * 1024);
+        let ctoken = StdCancellationToken::new();
+        let addr = test_addr();
+
+        let src = dir.path().join("small.tar");
+        let bytes = vec![3u8; 128];
+        std::fs::write(&src, &bytes).expect("write tar");
+
+        let arts = engine
+            .cache_locally(
+                &ctoken,
+                &addr,
+                "HASHIN_SMALL",
+                vec![tar_artifact("out.tar", &src, true)],
+                false,
+            )
+            .await
+            .expect("cache_locally");
+
+        assert_eq!(arts[0].size, bytes.len() as u64);
+        assert_eq!(
+            drain_reader(
+                engine
+                    .local_cache
+                    .reader(&addr, "HASHIN_SMALL", &arts[0].name)
+                    .expect("blob")
+                    .reader
+            ),
+            bytes
+        );
     }
 
     /// `duplicate_cache_revision` (the in_place fixpoint primitive) must copy both

--- a/crates/engine/src/engine/local_cache_fs.rs
+++ b/crates/engine/src/engine/local_cache_fs.rs
@@ -163,6 +163,36 @@ impl LocalCache for LocalCacheFS {
         }))
     }
 
+    /// Rename `src` over the destination — the same `rename(2)`, over the same
+    /// path, that [`AtomicFileWriter::commit`] ends every write with, minus the
+    /// byte copy that filled the temp file first. Same atomicity for a concurrent
+    /// reader, for the same reason.
+    ///
+    /// Declines rather than fails when the rename does not go through. The
+    /// ordinary case is `EXDEV` — `src` on another filesystem, which a sandbox
+    /// redirected through a FUSE mount always is — and there the copy the caller
+    /// falls back to is the only way to move the bytes at all. Anything else
+    /// (a vanished `src`, `EACCES`) fails the copy too, with an error that says
+    /// what it was doing; swallowing it here would only make the write succeed
+    /// where it should not.
+    fn adopt_file(&self, addr: &Addr, hashin: &str, name: &str, src: &Path) -> Result<bool> {
+        let dest = self.get_path(addr, hashin, name);
+        if let Some(parent) = dest.parent() {
+            fs::create_dir_all(parent)
+                .with_context(|| format!("Failed to create parent directories for: {:?}", dest))?;
+        }
+        match fs::rename(src, &dest) {
+            Ok(()) => Ok(true),
+            Err(e) => {
+                tracing::debug!(
+                    ?src, ?dest, error = %e,
+                    "cannot adopt cache blob by rename; falling back to a copy"
+                );
+                Ok(false)
+            }
+        }
+    }
+
     fn exists(&self, addr: &Addr, hashin: &str, name: &str) -> Result<bool> {
         let path = self.get_path(addr, hashin, name);
         Ok(path.exists())
@@ -415,6 +445,93 @@ mod tests {
             cache.file_path(&addr, "h", "out.tar").is_none(),
             "deleted blob must not keep answering with a path"
         );
+        Ok(())
+    }
+
+    /// Adoption is the write, minus the copy: the file *becomes* the blob. It
+    /// reads back as any other entry, it is where `file_path` says it is, and it
+    /// is gone from where it came — a caller that offers a file has handed it
+    /// over, and must not find it still sitting in its sandbox.
+    #[test]
+    fn adopt_file_moves_the_source_into_place() -> Result<()> {
+        let dir = tempdir()?;
+        let cache = LocalCacheFS::new(dir.path().join("cache"))?;
+        let addr = Addr::new(
+            hmodel::htpkg::PkgBuf::from("pkg"),
+            "t".to_string(),
+            Default::default(),
+        );
+
+        let src = dir.path().join("collected.tar");
+        std::fs::write(&src, b"packed bytes")?;
+
+        assert!(cache.adopt_file(&addr, "h", "out.tar", &src)?);
+        assert!(!src.exists(), "the adopted file is moved, not copied");
+
+        let mut got = String::new();
+        cache
+            .reader(&addr, "h", "out.tar")?
+            .reader
+            .read_to_string(&mut got)?;
+        assert_eq!(got, "packed bytes");
+        assert_eq!(
+            std::fs::read(cache.file_path(&addr, "h", "out.tar").expect("path"))?,
+            b"packed bytes",
+            "an adopted blob is a blob like any other"
+        );
+        Ok(())
+    }
+
+    /// A rename that cannot go through is a decline, not an error: the caller
+    /// still has the file and copies it instead. `EXDEV` is the real-world case
+    /// (a sandbox behind a FUSE mount); a vanished source stands in for it here,
+    /// since both arrive as a failed `rename(2)`.
+    #[test]
+    fn adopt_file_declines_when_the_rename_fails() -> Result<()> {
+        let dir = tempdir()?;
+        let cache = LocalCacheFS::new(dir.path().join("cache"))?;
+        let addr = Addr::new(
+            hmodel::htpkg::PkgBuf::from("pkg"),
+            "t".to_string(),
+            Default::default(),
+        );
+
+        assert!(!cache.adopt_file(&addr, "h", "out.tar", &dir.path().join("gone.tar"))?);
+        assert!(
+            !cache.exists(&addr, "h", "out.tar")?,
+            "a declined adoption commits nothing"
+        );
+        Ok(())
+    }
+
+    /// A blob written twice under one key resolves to the last write, adoption
+    /// included — the destination may already hold a complete file, and
+    /// `rename(2)` replacing it is what makes that atomic for a concurrent
+    /// reader.
+    #[test]
+    fn adopt_file_replaces_an_existing_blob() -> Result<()> {
+        let dir = tempdir()?;
+        let cache = LocalCacheFS::new(dir.path().join("cache"))?;
+        let addr = Addr::new(
+            hmodel::htpkg::PkgBuf::from("pkg"),
+            "t".to_string(),
+            Default::default(),
+        );
+
+        let mut w = cache.writer(&addr, "h", "out.tar")?;
+        w.write_all(b"first")?;
+        w.commit()?;
+
+        let src = dir.path().join("second.tar");
+        std::fs::write(&src, b"second")?;
+        assert!(cache.adopt_file(&addr, "h", "out.tar", &src)?);
+
+        let mut got = String::new();
+        cache
+            .reader(&addr, "h", "out.tar")?
+            .reader
+            .read_to_string(&mut got)?;
+        assert_eq!(got, "second");
         Ok(())
     }
 

--- a/crates/engine/src/engine/local_cache_mem.rs
+++ b/crates/engine/src/engine/local_cache_mem.rs
@@ -93,6 +93,24 @@ impl LocalCache for LocalCacheMem {
         self.inner.writer(addr, hashin, name)
     }
 
+    /// Forwarded, so the tier below can still take the file — but only after the
+    /// same invalidation `writer` does, and at the same point: before the new
+    /// bytes land, so a reader arriving mid-adopt misses here and falls through
+    /// to the inner backend rather than being served the superseded copy. A
+    /// declined adoption evicted an entry the `writer` call right behind it would
+    /// have evicted anyway.
+    fn adopt_file(
+        &self,
+        addr: &Addr,
+        hashin: &str,
+        name: &str,
+        src: &std::path::Path,
+    ) -> Result<bool> {
+        let key = Self::key(addr, hashin, name);
+        self.cache.remove(&key);
+        self.inner.adopt_file(addr, hashin, name, src)
+    }
+
     fn exists(&self, addr: &Addr, hashin: &str, name: &str) -> Result<bool> {
         let key = Self::key(addr, hashin, name);
         // peek avoids bumping the cache recency for a presence check.
@@ -351,6 +369,39 @@ mod tests {
             .file_path(&addr, "h1", "out.tar")
             .expect("durable backend has a file for this blob");
         assert_eq!(std::fs::read(&path).expect("read"), b"blob bytes");
+    }
+
+    /// An adopted blob arrives without passing through `writer`, so this tier's
+    /// invalidation has to hang off `adopt_file` too. Miss it and a key that was
+    /// read once keeps serving the bytes it had before the rewrite, from memory,
+    /// for the life of the process.
+    #[test]
+    fn adopt_invalidates_the_resident_entry() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let inner = Arc::new(
+            crate::engine::local_cache_fs::LocalCacheFS::new(dir.path().join("blobs")).expect("fs"),
+        );
+        let dec = LocalCacheMem::new(inner, 1024, 64 * 1024);
+        let addr = make_addr();
+
+        write_blob(&dec, &addr, "out.tar", b"before");
+        // Read it in, so the stale bytes are resident and would shadow.
+        assert_eq!(
+            drain(dec.reader(&addr, "h1", "out.tar").expect("read").reader),
+            b"before"
+        );
+
+        let src = dir.path().join("after.tar");
+        std::fs::write(&src, b"after").expect("write src");
+        assert!(
+            dec.adopt_file(&addr, "h1", "out.tar", &src).expect("adopt"),
+            "the fs backend below takes the file"
+        );
+
+        assert_eq!(
+            drain(dec.reader(&addr, "h1", "out.tar").expect("read").reader),
+            b"after"
+        );
     }
 
     #[test]

--- a/crates/engine/src/engine/local_cache_spill.rs
+++ b/crates/engine/src/engine/local_cache_spill.rs
@@ -128,6 +128,51 @@ impl LocalCache for LocalCacheSpill {
         }))
     }
 
+    /// Adopt only what would have spilled anyway.
+    ///
+    /// The primary is sqlite — there is no file to rename into — so an adoption
+    /// can only land in the FS store, and routing a *small* artifact there
+    /// because it happened to arrive as a file would put it in a different
+    /// backend than the identical artifact packed from memory. Size decides,
+    /// against the same threshold and the same comparison [`SpillWriter`] uses,
+    /// so a blob's home does not depend on which way it was written.
+    fn adopt_file(
+        &self,
+        addr: &Addr,
+        hashin: &str,
+        name: &str,
+        src: &std::path::Path,
+    ) -> Result<bool> {
+        // The manifest is the GC index and always lives in the primary.
+        if Self::is_manifest(name) {
+            return Ok(false);
+        }
+        let size = std::fs::metadata(src)
+            .with_context(|| format!("stat {src:?} for adoption into {addr} {name}"))?
+            .len();
+        if size <= self.spill_threshold as u64 {
+            return Ok(false);
+        }
+        if !self.blobs.adopt_file(addr, hashin, name, src)? {
+            return Ok(false);
+        }
+        // The key now lives in the FS store, so drop anything the primary still
+        // holds for it — the same "exactly one backend" invariant `writer`
+        // maintains from the other side, seen from this one. The probe runs only
+        // for a genuinely large artifact, and finds nothing for the fresh
+        // revision that is the normal case.
+        if self
+            .primary
+            .exists_committed(addr, hashin, name)
+            .with_context(|| format!("probe primary for superseded blob {addr} {name}"))?
+        {
+            self.primary
+                .delete(addr, hashin, name)
+                .with_context(|| format!("drop stale primary blob for {addr} {name}"))?;
+        }
+        Ok(true)
+    }
+
     fn exists(&self, addr: &Addr, hashin: &str, name: &str) -> Result<bool> {
         Ok(self.primary.exists(addr, hashin, name)? || self.blobs.exists(addr, hashin, name)?)
     }
@@ -418,6 +463,88 @@ mod tests {
         assert_eq!(read(&cache, &a, "large"), large);
         assert!(cache.exists(&a, "h", "small").expect("ex"));
         assert!(cache.exists(&a, "h", "large").expect("ex"));
+    }
+
+    /// Adoption follows the same routing as `writer`, on the same threshold: a
+    /// file large enough to spill is taken by the FS store (and is gone from
+    /// where it was), a small one is declined so the caller copies it into
+    /// sqlite. A blob's home must not depend on which way it was written.
+    #[test]
+    fn adopt_routes_on_the_same_threshold_as_writer() {
+        let dir = tempdir().expect("tempdir");
+        let (cache, sqlite, fs) = spill(dir.path(), 64);
+        let a = addr();
+
+        let small_src = dir.path().join("small.tar");
+        let large_src = dir.path().join("large.tar");
+        std::fs::write(&small_src, vec![1u8; 32]).expect("write small");
+        std::fs::write(&large_src, vec![2u8; 256]).expect("write large");
+
+        // Under the threshold: declined, and the file is left for the caller.
+        assert!(
+            !cache
+                .adopt_file(&a, "h", "small", &small_src)
+                .expect("adopt small"),
+            "a blob that belongs in sqlite must not be adopted onto the fs"
+        );
+        assert!(small_src.exists(), "a declined adoption leaves the source");
+
+        // Over it: taken, into the same backend `writer` would have spilled to.
+        assert!(
+            cache
+                .adopt_file(&a, "h", "large", &large_src)
+                .expect("adopt large"),
+            "a blob over the threshold is the fs store's to take"
+        );
+        assert!(!large_src.exists(), "an adopted file is moved, not copied");
+        assert!(fs.exists(&a, "h", "large").expect("ex"));
+        assert!(!sqlite.exists(&a, "h", "large").expect("ex"));
+        assert_eq!(read(&cache, &a, "large"), vec![2u8; 256]);
+    }
+
+    /// A rewrite by adoption leaves the key in exactly one backend, the same
+    /// invariant `writer` maintains from the other side: the earlier copy in the
+    /// primary has to go, or `reader` (primary first) and `file_path` (fs only)
+    /// answer with different bytes for one key.
+    #[test]
+    fn adopt_drops_a_superseded_primary_copy() {
+        let dir = tempdir().expect("tempdir");
+        let (cache, sqlite, fs) = spill(dir.path(), 64);
+        let a = addr();
+
+        // Landed in sqlite under a smaller threshold / an earlier, smaller build.
+        write(&cache, &a, "blob", &[9u8; 16]);
+        assert!(sqlite.exists(&a, "h", "blob").expect("ex"));
+
+        let src = dir.path().join("blob.tar");
+        std::fs::write(&src, vec![7u8; 256]).expect("write");
+        assert!(cache.adopt_file(&a, "h", "blob", &src).expect("adopt"));
+
+        assert!(fs.exists(&a, "h", "blob").expect("ex"));
+        assert!(
+            !sqlite.exists(&a, "h", "blob").expect("ex"),
+            "the superseded primary copy must be dropped"
+        );
+        assert_eq!(read(&cache, &a, "blob"), vec![7u8; 256]);
+        assert!(cache.file_path(&a, "h", "blob").is_some());
+    }
+
+    /// The manifest is the GC index and lives in the primary unconditionally —
+    /// size does not enter into it, so it is never adopted onto the filesystem.
+    #[test]
+    fn adopt_never_takes_the_manifest() {
+        let dir = tempdir().expect("tempdir");
+        let (cache, _sqlite, _fs) = spill(dir.path(), 64);
+        let a = addr();
+
+        let src = dir.path().join("manifest.bin");
+        std::fs::write(&src, vec![3u8; 256]).expect("write");
+
+        assert!(
+            !cache.adopt_file(&a, "h", MANIFEST_V1, &src).expect("adopt"),
+            "the manifest must stay in the primary whatever its size"
+        );
+        assert!(src.exists());
     }
 
     /// The direct-open fast path tracks the routing: a spilled blob is a real

--- a/crates/engine/src/engine/local_cache_tmp.rs
+++ b/crates/engine/src/engine/local_cache_tmp.rs
@@ -126,6 +126,22 @@ impl LocalCache for LocalCacheTmp {
         }))
     }
 
+    /// Declines. This tier's whole point is to keep a throwaway entry in memory
+    /// and out of the durable store, and a file cannot be admitted to a map of
+    /// `Arc<[u8]>` without reading it — which is the copy adoption exists to
+    /// avoid. Forwarding to `durable` for the entries big enough to spill would
+    /// work, but it would put the admit/spill decision in a second place, free to
+    /// drift from [`TmpWriter`]'s. Uncacheable revisions keep the copy.
+    fn adopt_file(
+        &self,
+        _addr: &Addr,
+        _hashin: &str,
+        _name: &str,
+        _src: &std::path::Path,
+    ) -> Result<bool> {
+        Ok(false)
+    }
+
     fn exists(&self, addr: &Addr, hashin: &str, name: &str) -> Result<bool> {
         let key = Self::key(addr, hashin, name);
         if self.store.map.read().contains_key(&key) {

--- a/crates/plugin-abi/src/convert.rs
+++ b/crates/plugin-abi/src/convert.rs
@@ -722,7 +722,7 @@ pub fn target_def_from_pb(td: pb::TargetDef) -> anyhow::Result<TargetDef> {
 // ---- OutputArtifact (driver run outputs) ----
 
 use hplugin::driver::outputartifact::{
-    Content as OaContent, ContentFile, ContentRaw, OutputArtifact, Type as OaType,
+    Content as OaContent, ContentFile, ContentPath, ContentRaw, OutputArtifact, Type as OaType,
 };
 
 fn oa_type_to_pb(t: &OaType) -> pb::ArtifactType {
@@ -753,8 +753,8 @@ pub fn output_artifact_to_pb(oa: &OutputArtifact) -> pb::OutputArtifactRef {
             path: r.path.clone(),
             x: r.x,
         }),
-        OaContent::TarPath(p) => pb::output_artifact_ref::Content::TarPath(p.clone()),
-        OaContent::CpioPath(p) => pb::output_artifact_ref::Content::CpioPath(p.clone()),
+        OaContent::TarPath(p) => pb::output_artifact_ref::Content::TarPath(p.path.clone()),
+        OaContent::CpioPath(p) => pb::output_artifact_ref::Content::CpioPath(p.path.clone()),
     };
     pb::OutputArtifactRef {
         group: oa.group.clone(),
@@ -780,8 +780,15 @@ pub fn output_artifact_from_pb(oa: pb::OutputArtifactRef) -> OutputArtifact {
             path: r.path,
             x: r.x,
         }),
-        Some(pb::output_artifact_ref::Content::TarPath(p)) => OaContent::TarPath(p),
-        Some(pb::output_artifact_ref::Content::CpioPath(p)) => OaContent::CpioPath(p),
+        // Ownership does not cross the plugin ABI either (no proto field): the
+        // host copies an out-of-process driver's container and leaves the file
+        // where the driver put it. Safe default.
+        Some(pb::output_artifact_ref::Content::TarPath(p)) => {
+            OaContent::TarPath(ContentPath::borrowed(p))
+        }
+        Some(pb::output_artifact_ref::Content::CpioPath(p)) => {
+            OaContent::CpioPath(ContentPath::borrowed(p))
+        }
         None => OaContent::Raw(ContentRaw {
             data: vec![],
             path: String::new(),

--- a/crates/plugin-exec/src/pluginexec/mod.rs
+++ b/crates/plugin-exec/src/pluginexec/mod.rs
@@ -4078,7 +4078,9 @@ mod tests {
                         name: format!("{name}.tar"),
                         r#type: outputartifact::Type::Output,
                         content: outputartifact::Content::TarPath(
-                            tar_path.to_string_lossy().into_owned(),
+                            outputartifact::ContentPath::borrowed(
+                                tar_path.to_string_lossy().into_owned(),
+                            ),
                         ),
                         hashout: format!("h_{name}"),
                     }),

--- a/crates/plugin/src/driver.rs
+++ b/crates/plugin/src/driver.rs
@@ -816,12 +816,48 @@ pub mod outputartifact {
         pub passthrough: bool,
     }
 
+    /// A container (tar/cpio) the driver already wrote to disk.
+    #[derive(Clone, Debug)]
+    pub struct ContentPath {
+        pub path: String,
+        /// True when `path` is a temp file the driver produced *for* the local
+        /// cache and will never read again — a sandbox-collected output tar. The
+        /// cache write may then hand the file over whole (a rename, no bytes
+        /// copied) instead of streaming it, and `path` is gone once the write
+        /// returns.
+        ///
+        /// Leave false for anything the producer still owns: the engine copies
+        /// out of it and the file is untouched. Like
+        /// [`ContentFile::passthrough`], this does not cross the plugin ABI (no
+        /// proto field), so an out-of-process driver's containers are always
+        /// copied.
+        pub owned: bool,
+    }
+
+    impl ContentPath {
+        /// A file the engine may consume — see [`ContentPath::owned`].
+        pub fn owned(path: impl Into<String>) -> Self {
+            Self {
+                path: path.into(),
+                owned: true,
+            }
+        }
+
+        /// A file the producer keeps: the engine reads it and leaves it alone.
+        pub fn borrowed(path: impl Into<String>) -> Self {
+            Self {
+                path: path.into(),
+                owned: false,
+            }
+        }
+    }
+
     #[derive(Clone)]
     pub enum Content {
         File(ContentFile),
         Raw(ContentRaw),
-        TarPath(String),
-        CpioPath(String),
+        TarPath(ContentPath),
+        CpioPath(ContentPath),
     }
 
     #[derive(Clone)]
@@ -838,8 +874,8 @@ pub mod outputartifact {
             Ok(match &self.content {
                 Content::Raw(raw) => Box::new(io::Cursor::new(raw.data.clone())),
                 Content::File(file) => Box::new(File::open(&file.source_path)?),
-                Content::TarPath(path) => Box::new(File::open(path)?),
-                Content::CpioPath(path) => Box::new(File::open(path)?),
+                Content::TarPath(p) => Box::new(File::open(&p.path)?),
+                Content::CpioPath(p) => Box::new(File::open(&p.path)?),
             })
         }
 
@@ -859,8 +895,8 @@ pub mod outputartifact {
                         x: file.x,
                     },
                 }))),
-                Content::TarPath(path) => Box::new(hcore::hartifactcontent::tar::TarWalker::new(
-                    File::open(path)?,
+                Content::TarPath(p) => Box::new(hcore::hartifactcontent::tar::TarWalker::new(
+                    File::open(&p.path)?,
                 )?),
                 #[expect(clippy::unimplemented, reason = "cpio format is not yet implemented")]
                 Content::CpioPath(_) => unimplemented!("cpio is not implemented"),


### PR DESCRIPTION
## The double copy

A cache miss writes every collected byte twice.

`collect_outputs` packs a target's outputs into
`<sandbox>/heph-collect-artifacts/<hashin>-<group>.tar` (`driver_managed.rs`), and
`cache_artifact_locally` then `io::copy`s that file into the cache blob
(`local_cache.rs`) — a second full read and write, on the same filesystem,
producing a blob that is byte-for-byte the file it just read. The tar is then
deleted with the sandbox.

## The fix

Hand the file over instead of reading it back. `LocalCache::adopt_file` takes a
file whole for a key by moving it: one `rename(2)` — the same rename, over the
same destination path, that `AtomicFileWriter::commit` already ends every FS
write with, minus the byte copy that filled the temp first. Same atomicity for a
concurrent reader.

It defaults to declining. Declining costs a copy and never correctness, so a
backend that never overrides it is correct and exactly as fast as before; only
`LocalCacheFS` has a file to rename into and accepts.

Two gates, both deliberate:

**The producer must hand the file over.** `Content::TarPath`/`CpioPath` now carry
`ContentPath { path, owned }`. Only `collect_outputs` sets `owned`, because only
it produces a tar whose sole purpose is this write, into a sandbox torn down
right after. Ownership does not cross the plugin ABI (no proto field — same
treatment as `ContentFile::passthrough`), so an out-of-process driver's container
is copied and its file left exactly where it put it.

**The backend must have somewhere to put it.** `LocalCacheSpill` adopts only
above `spill_threshold`, against the same comparison `SpillWriter` uses, so a
blob's home does not depend on which way it was written — small artifacts still
land in sqlite where the mem tier serves them. It drops any superseded primary
copy afterwards, the "exactly one backend" invariant `writer` maintains seen from
the other side. A cross-device rename — a sandbox redirected through a FUSE
mount, the one case where `src` is never on the cache's filesystem — declines and
copies exactly as before.

`LocalCacheMem` forwards `adopt_file`, but only after the same invalidation it
does on `writer`: an adopted blob never passes through the writer, so without it
a key read once would keep serving pre-rewrite bytes from memory for the life of
the process. `LocalCacheTmp` declines — a file cannot be admitted to its
in-memory map without reading it, which is the copy adoption exists to avoid, and
duplicating its admit/spill decision here would leave it free to drift.

## Scope of the win

Artifacts over the 8 MiB spill threshold — the ones where a full extra
read+write actually costs something. Everything smaller takes the path it took
before, because its second write goes into sqlite, not onto the filesystem, and
routing it elsewhere would change where it lives rather than how it got there.

Still on the table, and not attempted here: the *first* copy. Packing straight
into the cache writer would remove the sandbox tar entirely, but collect is
driver-side and the cache is engine-side — a larger change than this one.

## Tests

- `local_cache_fs`: adoption moves the source into place and reads back as any
  other blob; a failed rename declines and commits nothing; adopting over an
  existing blob replaces it.
- `local_cache_spill`: routes on the same threshold as `writer` (small declined
  and left alone, large taken by the FS store); drops a superseded primary copy;
  never takes the manifest.
- `local_cache_mem`: adoption invalidates a resident entry, so the next read sees
  the new bytes.
- `local_cache` (engine): an owned container is moved in — source gone, blob and
  manifest size correct; a borrowed one is copied and left untouched; an owned
  one below the threshold still lands.

Full `tst` could not run locally — the machine's disk is full and the test
binaries fail to link with `ENOSPC`. The engine, driver-support, plugin and
plugin-abi unit suites pass (525 + 38 + 48), and `lint` is clean; CI covers the
rest.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XL1RfuZRoc2a2ujdpRxbxy