### PR TITLE
perf(plugin-go): stop asking go list for test metadata nothing reads

### DIFF
--- a/crates/plugin-go/src/plugingo/driver_golist.rs
+++ b/crates/plugin-go/src/plugingo/driver_golist.rs
@@ -57,6 +57,10 @@ struct GoGolistSpec {
     build_tags: Vec<String>,
     /// `GOEXPERIMENT` values from the variant (sorted). Empty → unset.
     goexperiment: Vec<String>,
+    /// Pass `-test` to `go list` — needed only when the package has `_test.go`
+    /// files whose imports and embed patterns must be resolved. See
+    /// [`crate::plugingo::target_golist`] for who sets it.
+    with_test: bool,
     /// For thirdparty packages: the `download` target whose filtered outputs are
     /// staged into consumers' sandboxes.
     #[spec(ty = ParamType::String)]
@@ -107,6 +111,7 @@ struct GoGolistDef {
     go_version: String,
     build_tags: Vec<String>,
     goexperiment: Vec<String>,
+    with_test: bool,
     dep_inputs: Vec<Input>,
     /// For thirdparty packages: the `download` target whose filtered outputs
     /// will be staged into consumers' sandboxes. Threaded through so
@@ -136,6 +141,9 @@ impl Hash for GoGolistDef {
         self.go_version.hash(state);
         self.build_tags.hash(state);
         self.goexperiment.hash(state);
+        // Flips the `go list` command line, and with it which fields come back
+        // populated — so it must key the cache.
+        self.with_test.hash(state);
         self.dep_inputs.hash(state);
         self.thirdparty_download_addr.hash(state);
         self.firstparty.hash(state);
@@ -211,6 +219,7 @@ impl ManagedDriver for GoGolistDriver {
             go_version: spec.go_version,
             build_tags: spec.build_tags,
             goexperiment: spec.goexperiment,
+            with_test: spec.with_test,
             dep_inputs: dep_inputs.clone(),
             thirdparty_download_addr: spec.thirdparty_download_addr,
             firstparty: spec.firstparty,
@@ -391,26 +400,7 @@ impl ManagedDriver for GoGolistDriver {
             return Ok(ManagedRunResponse { artifacts: vec![] });
         }
 
-        let mut cmd_args = vec![
-            "list".to_string(),
-            GOLIST_JSON_FIELDS.to_string(),
-            "-e".to_string(),
-            // -test populates TestEmbedFiles / XTestEmbedFiles (and resolves test
-            // imports). Without it go list reports test embed patterns but never
-            // resolves them, so the test embedcfg path globs against an empty
-            // staged-file set. The flag also adds synthetic `pkg.test` / `pkg
-            // [pkg.test]` / `pkg_test [pkg.test]` entries — we discard them
-            // below and keep only the plain `pkg` entry.
-            "-test".to_string(),
-        ];
-
-        if !def.build_tags.is_empty() {
-            cmd_args.push(format!("-tags={}", def.build_tags.join(",")));
-        }
-
-        cmd_args.push(def.import_path.clone());
-
-        let args: Vec<OsString> = cmd_args.iter().map(OsString::from).collect();
+        let args: Vec<OsString> = golist_args(def).iter().map(OsString::from).collect();
         let env_pairs: Vec<(OsString, OsString)> = env
             .iter()
             .map(|(k, v)| (OsString::from(k), OsString::from(v)))
@@ -552,6 +542,44 @@ fn has_go_file(dir: &std::path::Path) -> anyhow::Result<bool> {
         }
     }
     Ok(false)
+}
+
+/// The `go list` command line for one package.
+///
+/// `-test` populates TestEmbedFiles / XTestEmbedFiles and resolves test imports.
+/// Without it `go list` reports test embed *patterns* but never resolves them,
+/// so the test embedcfg path would glob against an empty staged-file set. The
+/// flag also adds synthetic `pkg.test` / `pkg [pkg.test]` / `pkg_test [pkg.test]`
+/// entries, which `run` discards in favour of the plain `pkg` entry.
+///
+/// It is not free: it makes `go list` load the package a second time in its test
+/// configuration, pulling the test imports' own closure. Measured over 60 std
+/// packages listed one at a time against a *fresh shared* `GOCACHE` — i.e. what
+/// [`crate::plugingo::golist_gocache`] gives a cold run today — dropping `-test`
+/// took CPU from 3.72s to 2.58s (-31%) and wall from 1.89s to 1.69s (-11%).
+///
+/// The gap used to be far wider: before the shared `GOCACHE`, every sandbox
+/// re-warmed its own, and `-test` was ~3x the call. Sharing the cache absorbed
+/// most of that, so this is now a modest trim on the cold path and nothing at
+/// all on a full cache hit — do not quote it as a headline.
+///
+/// So the provider asks for it only where a test field can actually be read
+/// back — a first-party package with `_test.go` files on disk. std and
+/// thirdparty build no tests under heph and never pay it.
+fn golist_args(def: &GoGolistDef) -> Vec<String> {
+    let mut args = vec![
+        "list".to_string(),
+        GOLIST_JSON_FIELDS.to_string(),
+        "-e".to_string(),
+    ];
+    if def.with_test {
+        args.push("-test".to_string());
+    }
+    if !def.build_tags.is_empty() {
+        args.push(format!("-tags={}", def.build_tags.join(",")));
+    }
+    args.push(def.import_path.clone());
+    args
 }
 
 /// Strip every absolute path out of a `go list` package so the cached
@@ -924,6 +952,58 @@ mod tests {
             &p.content,
             Content::FilePath(s) if s == "package.bin"
         )));
+    }
+
+    fn def_with(with_test: bool, build_tags: Vec<String>) -> GoGolistDef {
+        GoGolistDef {
+            import_path: "example.com/mylib".to_string(),
+            goos: "linux".to_string(),
+            goarch: "amd64".to_string(),
+            go_version: crate::plugingo::toolchain::DEFAULT_GO_VERSION.to_string(),
+            build_tags,
+            goexperiment: vec![],
+            with_test,
+            dep_inputs: vec![],
+            thirdparty_download_addr: None,
+            firstparty: true,
+        }
+    }
+
+    #[test]
+    fn test_golist_args_omit_test_when_the_package_has_no_tests() {
+        let args = golist_args(&def_with(false, vec![]));
+        assert!(
+            !args.iter().any(|a| a == "-test"),
+            "a package with no test files must not pay for the test-config load: {args:?}"
+        );
+        // The rest of the command is unchanged — same field set, still -e, and
+        // the import path stays last.
+        assert!(args.iter().any(|a| a == "-e"));
+        assert_eq!(args.last().map(String::as_str), Some("example.com/mylib"));
+    }
+
+    #[test]
+    fn test_golist_args_keep_test_and_tags_together() {
+        let args = golist_args(&def_with(true, vec!["integration".to_string()]));
+        assert!(args.iter().any(|a| a == "-test"), "{args:?}");
+        assert!(args.iter().any(|a| a == "-tags=integration"), "{args:?}");
+        assert_eq!(args.last().map(String::as_str), Some("example.com/mylib"));
+    }
+
+    /// `with_test` changes which fields come back populated, so two otherwise
+    /// identical defs must not share a cache entry.
+    #[test]
+    fn test_with_test_keys_the_def_hash() {
+        let h = |d: &GoGolistDef| {
+            let mut hasher = Xxh3Default::new();
+            d.hash(&mut hasher);
+            hasher.finish()
+        };
+        assert_ne!(
+            h(&def_with(true, vec![])),
+            h(&def_with(false, vec![])),
+            "-test must key the golist cache"
+        );
     }
 
     #[test]

--- a/crates/plugin-go/src/plugingo/provider.rs
+++ b/crates/plugin-go/src/plugingo/provider.rs
@@ -2485,6 +2485,13 @@ impl ProviderInner {
                 // so `go list` can resolve //go:embed patterns into EmbedFiles, and
                 // shared with the downstream `embed` target.
                 let extra_src_addrs = compute_pkg_src_addrs(pkg, states)?;
+                // `-test` is only worth its cost where a test field can be read
+                // back. Codegen can produce a `_test.go` that isn't on disk when
+                // the spec is built, so any package with a codegen/extra source
+                // lane keeps the flag unconditionally — the on-disk scan is
+                // authoritative only for a package whose sources are all static.
+                let has_test_files =
+                    !extra_src_addrs.is_empty() || self.package_has_test_files_on_disk(pkg);
                 target_golist::build_spec_firstparty(
                     addr,
                     import_path,
@@ -2494,6 +2501,7 @@ impl ProviderInner {
                     &go_src_glob_addr,
                     None,
                     &extra_src_addrs,
+                    has_test_files,
                 )?
             }
             GoPackageKind::ThirdParty {
@@ -2794,6 +2802,30 @@ impl ProviderInner {
     /// own output. Files reached through a `.heph*` cache dir are skipped for the
     /// same reason they are in the fs provider — they are engine artifacts, not
     /// source.
+    /// Whether the package directory holds any `_test.go` file, read through the
+    /// shared walk cache so an unchanged tree costs no `readdir`. Drives the
+    /// `-test` decision for a first-party `_golist` (see
+    /// [`target_golist::build_spec_firstparty`]).
+    ///
+    /// Errors are absorbed as `true`: a directory we cannot list is the case
+    /// where guessing wrong is expensive (an unresolved test embed is a build
+    /// failure, a redundant `-test` is only slow), and the read that matters —
+    /// `go list`'s own — reports the real error a moment later.
+    fn package_has_test_files_on_disk(&self, pkg: &str) -> bool {
+        let dir = if pkg.is_empty() {
+            self.workspace_root.clone()
+        } else {
+            self.workspace_root.join(pkg)
+        };
+        match self.walker.read_dir(&dir) {
+            Ok(listing) => listing
+                .entries
+                .iter()
+                .any(|e| e.kind == EntryKind::File && e.name.ends_with("_test.go")),
+            Err(_) => true,
+        }
+    }
+
     fn package_go_files_on_disk(&self, pkg: &str) -> anyhow::Result<Vec<String>> {
         let dir = if pkg.is_empty() {
             self.workspace_root.clone()
@@ -3167,6 +3199,9 @@ impl ProviderInner {
                             &go_mod.requires,
                             &go_mod.module_path,
                             &module_root,
+                            // The transitive walk recurses on the sub-imports —
+                            // this is the one caller that needs them.
+                            true,
                         )
                         .await?;
 
@@ -3274,6 +3309,9 @@ impl ProviderInner {
                 go_mod_requires,
                 workspace_module_path,
                 module_root,
+                // Direct-libs lane: `_sub` is dropped below, so don't pay to
+                // produce it (see `resolve_import`).
+                false,
             )
         }))
         .await?;
@@ -3287,6 +3325,22 @@ impl ProviderInner {
     }
 
     /// Resolve one import path: returns `(import_path, Option<lib Addr>, sub_imports)`.
+    ///
+    /// `need_sub_imports` is the caller's declaration that it will actually read
+    /// the third element. Only the transitive walk ([`Self::import_closure`])
+    /// does; the direct-libs lane drops it on the floor. For a **stdlib** import
+    /// the sub-imports are the *sole* reason to touch `_golist` — the lib addr is
+    /// derived syntactically by [`encode_stdlib`] — so resolving one there costs a
+    /// full `executor.result()` (and, cold, a sandboxed `go list`) per std package
+    /// per importer for a value that is then discarded. First-party/thirdparty
+    /// still read it unconditionally: the read doubles as the
+    /// no-buildable-files probe that decides whether the dep is emitted at all
+    /// (see the `NoGoFilesError` arm below), and their `_golist` is needed by the
+    /// dep's own `build_lib` regardless, so it is shared rather than extra.
+    #[expect(
+        clippy::too_many_arguments,
+        reason = "all parameters are required, no natural grouping"
+    )]
     async fn resolve_import(
         &self,
         executor: Arc<dyn ProviderExecutor>,
@@ -3295,12 +3349,16 @@ impl ProviderInner {
         go_mod_requires: &[(String, String)],
         workspace_module_path: &str,
         module_root: &Path,
+        need_sub_imports: bool,
     ) -> anyhow::Result<(String, Option<Addr>, Vec<String>)> {
         let is_workspace_module = !workspace_module_path.is_empty()
             && (import_path == workspace_module_path
                 || import_path.starts_with(&format!("{}/", workspace_module_path)));
         if !is_workspace_module && is_stdlib_import_path(import_path) {
             let addr = encode_stdlib(import_path, vref);
+            if !need_sub_imports {
+                return Ok((import_path.to_string(), Some(addr), vec![]));
+            }
             let golist_addr = Addr::new(
                 hmodel::htpkg::PkgBuf::from(format!("@heph/go/std/{}", import_path)),
                 "_golist".to_string(),
@@ -4439,6 +4497,121 @@ golang.org/x/oauth2 v0.0.0-20200107190931-bf48bf16ab8d h1:pE8b58s1HRDMi8RDc79m0H
             .await
             .unwrap();
         assert_eq!(resp.target_spec.driver, "go_compile");
+    }
+
+    /// Records every addr handed to `ProviderExecutor::result`.
+    struct RecordingExecutor {
+        inner: Arc<dyn ProviderExecutor>,
+        seen: Arc<parking_lot::Mutex<Vec<String>>>,
+    }
+
+    impl ProviderExecutor for RecordingExecutor {
+        fn result<'a>(&'a self, addr: &'a Addr) -> BoxFuture<'a, anyhow::Result<Arc<EResult>>> {
+            self.seen.lock().push(addr.format());
+            self.inner.result(addr)
+        }
+        fn states_under<'a>(
+            &'a self,
+            prefix: &'a hmodel::htpkg::PkgBuf,
+        ) -> BoxFuture<'a, anyhow::Result<Vec<State>>> {
+            self.inner.states_under(prefix)
+        }
+        fn query<'a>(
+            &'a self,
+            m: &'a hmodel::htmatcher::Matcher,
+            extra_skip: &'a [String],
+        ) -> BoxFuture<'a, anyhow::Result<Vec<Addr>>> {
+            self.inner.query(m, extra_skip)
+        }
+    }
+
+    fn recording_get(
+        p: &Provider,
+        addr: Addr,
+    ) -> (
+        impl std::future::Future<Output = Result<GetResponse, GetError>> + use<'_>,
+        Arc<parking_lot::Mutex<Vec<String>>>,
+    ) {
+        let workspace = p.inner.workspace_root.clone();
+        let seen = Arc::new(parking_lot::Mutex::new(Vec::new()));
+        let executor: Arc<dyn ProviderExecutor> = Arc::new(RecordingExecutor {
+            inner: test_executor(&workspace),
+            seen: Arc::clone(&seen),
+        });
+        let req = GetRequest {
+            request_id: "test".to_string(),
+            addr,
+            states: vec![host_variant_state()],
+            executor,
+        };
+        (
+            async move {
+                let ctoken = StdCancellationToken::new();
+                p.get(req, &ctoken).await
+            },
+            seen,
+        )
+    }
+
+    fn std_golist_reads(seen: &Arc<parking_lot::Mutex<Vec<String>>>) -> Vec<String> {
+        seen.lock()
+            .iter()
+            .filter(|a| a.starts_with("//@heph/go/std/") && a.contains(":_golist"))
+            .cloned()
+            .collect()
+    }
+
+    /// A stdlib import's `build_lib` addr is derived syntactically
+    /// (`encode_stdlib`), so on the direct-libs lane its `_golist` is read for
+    /// exactly one thing — the sub-imports — which `collect_libs_inner` then
+    /// discards. That made every `build_lib` in the tree force an
+    /// `executor.result()` (cold: a sandboxed `go list`) per std package it
+    /// directly imports, for a value nobody reads.
+    #[tokio::test]
+    async fn build_lib_does_not_resolve_stdlib_golist_for_direct_deps() {
+        require_go!();
+        let sandbox = copy_fixture("with_dep");
+        let p = Provider::new(sandbox.path().to_path_buf(), test_runtime()).unwrap();
+
+        // `lib` imports `fmt` and nothing else.
+        let (fut, seen) = recording_get(&p, make_addr("lib", "build_lib"));
+        let resp = fut.await.unwrap();
+        assert_eq!(resp.target_spec.driver, "go_compile");
+
+        assert!(
+            std_golist_reads(&seen).is_empty(),
+            "build_lib must not resolve a stdlib _golist: {:?}",
+            std_golist_reads(&seen)
+        );
+
+        // ...and the dep is still wired, so this isn't passing by resolving nothing.
+        let deps = match resp.target_spec.config.get("deps").unwrap() {
+            Value::Map(m) => m,
+            _ => panic!("expected deps map"),
+        };
+        assert!(
+            deps.keys().any(|k| k.contains("fmt")),
+            "lib build_lib must still link against fmt: {:?}",
+            deps.keys().collect::<Vec<_>>()
+        );
+    }
+
+    /// The counterpart: the transitive walk really does need the sub-imports to
+    /// recurse, so `build` must still read them. Guards against "optimizing" the
+    /// read away wholesale and silently truncating the link closure.
+    #[tokio::test]
+    async fn build_still_resolves_stdlib_golist_for_the_transitive_closure() {
+        require_go!();
+        let sandbox = copy_fixture("with_dep");
+        let p = Provider::new(sandbox.path().to_path_buf(), test_runtime()).unwrap();
+
+        let (fut, seen) = recording_get(&p, make_addr("cmd", "build"));
+        fut.await.unwrap();
+
+        assert!(
+            !std_golist_reads(&seen).is_empty(),
+            "build's transitive closure must still walk stdlib _golist"
+        );
     }
 
     #[tokio::test]

--- a/crates/plugin-go/src/plugingo/target_golist.rs
+++ b/crates/plugin-go/src/plugingo/target_golist.rs
@@ -18,6 +18,7 @@ pub fn build_spec_firstparty(
     go_src_addr: &Addr,
     go_src_query_addr: Option<&Addr>,
     non_go_src_addrs: &[String],
+    has_test_files: bool,
 ) -> anyhow::Result<TargetSpec> {
     let mut srcfiles: Vec<String> = vec![go_src_addr.format()];
     if let Some(q) = go_src_query_addr {
@@ -33,6 +34,11 @@ pub fn build_spec_firstparty(
             ("modfiles", &[go_mod_addr.format()][..]),
             ("srcfiles", &srcfiles),
         ],
+        // `-test` is what resolves TestEmbedFiles/XTestEmbedFiles and the test
+        // import sets. A package with no `_test.go` on disk has none of those,
+        // so the flag would only buy `go list` a second (test-variant) package
+        // load for fields that come back empty either way.
+        has_test_files,
     )?;
     // Only a first-party package has its `.go` sources staged into the sandbox
     // (as `srcfiles` deps, codegen included). That is what lets the driver
@@ -48,7 +54,10 @@ pub fn build_spec_stdlib(
     factors: &Factors,
     go_version: &str,
 ) -> anyhow::Result<TargetSpec> {
-    build_spec_inner(addr, import_path, factors, go_version, &[])
+    // std ships `_test.go` files, but heph never builds std's tests: `list`
+    // emits only `_golist`/`build_lib` for a Stdlib package. Loading the test
+    // variants is pure cost.
+    build_spec_inner(addr, import_path, factors, go_version, &[], false)
 }
 
 pub fn build_spec_thirdparty(
@@ -65,6 +74,9 @@ pub fn build_spec_thirdparty(
         factors,
         go_version,
         &[("modfiles", &[go_mod_addr.format()][..])],
+        // Same as stdlib: `list` emits no test targets for a ThirdParty
+        // package, so nothing downstream can read a test field.
+        false,
     )?;
     // Threaded through to the driver so `resolve_package_addrs` can emit
     // `download`-filter refs for thirdparty per-file addresses. NOT a runtime
@@ -82,6 +94,7 @@ fn build_spec_inner(
     factors: &Factors,
     go_version: &str,
     extra_deps: &[(&str, &[String])],
+    with_test: bool,
 ) -> anyhow::Result<TargetSpec> {
     let mut deps: HashMap<String, Value> = HashMap::new();
     for (group, dep_addrs) in extra_deps {
@@ -112,6 +125,9 @@ fn build_spec_inner(
         "go_version".to_string(),
         Value::String(go_version.to_string()),
     );
+    // Whether `go list` gets `-test`. Carried in the config (not inferred in the
+    // driver) so it reaches the def hash — flipping it changes the artifact.
+    config.insert("with_test".to_string(), Value::Bool(with_test));
     if !factors.build_tags.is_empty() {
         config.insert(
             "build_tags".to_string(),
@@ -209,6 +225,7 @@ mod tests {
             &go_src_addr(),
             None,
             &[],
+            true,
         )
         .unwrap();
         assert_eq!(spec.driver, "go_golist");
@@ -225,6 +242,7 @@ mod tests {
             &go_src_addr(),
             None,
             &[],
+            true,
         )
         .unwrap();
         let out = match spec.config.get("out").unwrap() {
@@ -246,6 +264,7 @@ mod tests {
             &go_src_addr(),
             None,
             &[],
+            true,
         )
         .unwrap();
         assert!(
@@ -268,6 +287,7 @@ mod tests {
             &go_src_addr(),
             None,
             &[],
+            true,
         )
         .unwrap();
         assert!(matches!(
@@ -306,6 +326,62 @@ mod tests {
         );
     }
 
+    /// `-test` makes `go list` load the package a second time in its test
+    /// configuration (~31% of the call's CPU on a shared `GOCACHE`; see
+    /// `driver_golist::golist_args`). std and thirdparty never build tests under
+    /// heph — `Provider::list` emits no test target for either — so nothing can
+    /// read a test field back and the flag must stay off.
+    #[test]
+    fn test_stdlib_and_thirdparty_never_ask_for_test_metadata() {
+        let std = build_spec_stdlib(test_addr(), "fmt", &test_factors(), V).unwrap();
+        assert_eq!(
+            std.config.get("with_test"),
+            Some(&Value::Bool(false)),
+            "stdlib _golist must not pay for -test"
+        );
+
+        let tp = build_spec_thirdparty(
+            test_addr(),
+            "github.com/foo/bar",
+            &test_factors(),
+            V,
+            &go_mod_addr(),
+            &tp_download_addr(),
+        )
+        .unwrap();
+        assert_eq!(
+            tp.config.get("with_test"),
+            Some(&Value::Bool(false)),
+            "thirdparty _golist must not pay for -test"
+        );
+    }
+
+    /// First-party carries the caller's on-disk verdict through verbatim: a
+    /// package with `_test.go` files still needs `-test` to resolve
+    /// TestEmbedFiles/XTestEmbedFiles, one without has nothing to resolve.
+    #[test]
+    fn test_firstparty_with_test_follows_has_test_files() {
+        for has_tests in [true, false] {
+            let spec = build_spec_firstparty(
+                test_addr(),
+                "example.com/mylib",
+                &test_factors(),
+                V,
+                &go_mod_addr(),
+                &go_src_addr(),
+                None,
+                &[],
+                has_tests,
+            )
+            .unwrap();
+            assert_eq!(
+                spec.config.get("with_test"),
+                Some(&Value::Bool(has_tests)),
+                "with_test must mirror has_test_files ({has_tests})"
+            );
+        }
+    }
+
     #[test]
     fn test_config_no_run_key() {
         let spec = build_spec_firstparty(
@@ -317,6 +393,7 @@ mod tests {
             &go_src_addr(),
             None,
             &[],
+            true,
         )
         .unwrap();
         assert!(!spec.config.contains_key("run"), "spec must not have 'run'");
@@ -341,6 +418,7 @@ mod tests {
             &go_src_addr(),
             None,
             &[],
+            true,
         )
         .unwrap();
         if let Some(Value::Map(deps)) = spec.config.get("deps") {
@@ -359,6 +437,7 @@ mod tests {
             &go_src_addr(),
             None,
             &[],
+            true,
         )
         .unwrap();
         let deps = match spec.config.get("deps").unwrap() {


### PR DESCRIPTION
Two independent trims to the golist layer, both about not producing values no consumer can read.

## `-test` only where a test field can be read back

`-test` makes `go list` load the package a second time in its test configuration, pulling the test imports' own closure. It is now requested only where something downstream can actually read a test field:

- **stdlib / thirdparty: never.** `Provider::list` emits no test target for either kind, so `TestGoFiles`/`TestEmbedFiles` are unreachable by construction.
- **first-party: only if the directory holds a `_test.go`**, read through the shared walk cache (free on an unchanged tree).
- A package with a codegen source lane keeps the flag unconditionally — a generated `_test.go` is not on disk when the spec is built.

`with_test` is carried in the spec config, not inferred in the driver, so it reaches the def hash: flipping it changes which fields come back populated, and must not share a cache entry.

## `resolve_import` stops producing sub-imports the caller discards

Only the transitive walk reads the third element of `resolve_import`; the direct-libs lane drops it on the floor. For a **stdlib** import those sub-imports are the *sole* reason to touch `_golist` at all — the lib addr comes from `encode_stdlib` syntactically — so the direct lane was forcing a full `executor.result()` per std package per importer for a value it then threw away.

First-party/thirdparty still read it unconditionally: there the read doubles as the no-buildable-files probe that decides whether the dep is emitted, and their `_golist` is needed by the dep's own `build_lib` regardless.

## Measurements, including the ones that came out flat

600-package synthetic Go corpus (81 thirdparty, 185 stdlib in the closure), `gotool: host`, release binaries, interleaved A/B.

| | base | this PR |
|---|---|---|
| stdlib `_golist` executed (`test = False`) | 61 | **0** |
| total golist executed (`test = False`) | 1542 | **1481** |
| `go list` CPU, 60 std pkgs, fresh shared GOCACHE | 3.72 s | **2.58 s** (-31%) |
| full-cache-hit wall, `r go-build //go/...` | 873 ms | 862 ms (noise) |

**Neither change moves full-cache-hit wall time.** `-test` costs nothing on a cache hit, and the stdlib skip is masked whenever test targets are in the selection, because `build_test` takes the transitive lane regardless. This is a cold/incremental-path change; the commit body and the doc comments both say so.

Also worth recording: the pre-#344 framing of `-test` as a ~3x win was measured against a **cold per-sandbox GOCACHE**. The shared GOCACHE absorbed most of it, and the doc comment on `golist_args` now carries the current number plus an explicit note not to quote it as a headline.

## Tests

- `test_stdlib_and_thirdparty_never_ask_for_test_metadata` / `test_firstparty_with_test_follows_has_test_files` — the spec-side gate
- `test_golist_args_omit_test_when_the_package_has_no_tests` / `..._keep_test_and_tags_together` — the command line (extracted `golist_args` so it is testable without a sandbox)
- `test_with_test_keys_the_def_hash` — two otherwise identical defs must not share a cache entry
- `build_lib_does_not_resolve_stdlib_golist_for_direct_deps` — asserts zero `//@heph/go/std/*:_golist` resolutions while still linking `fmt`
- `build_still_resolves_stdlib_golist_for_the_transitive_closure` — the guard against "optimizing" the read away wholesale and silently truncating the link closure

`plugin-go` 423 passed, `plugingo-e2e` 30 passed (real Go builds), `lint` clean.

`golist_args` uses the `GOLIST_JSON_FIELDS` constant from #344 rather than re-inlining the field list, so the two call sites cannot drift apart and quietly stop sharing GOCACHE entries.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01A6RCELnJQkR8KmBxuo54NJ