### PR TITLE
feat(plugin-js): js_test driver, per-test-file granularity

### DIFF
--- a/crates/plugin-js-cdylib/src/lib.rs
+++ b/crates/plugin-js-cdylib/src/lib.rs
@@ -1,24 +1,29 @@
 //! The JS/TS plugin as a loadable cdylib behind the stable ABI.
 //!
-//! **M0-M3 scope**: exports the `js` provider (package discovery + pnpm/npm
+//! **M0-M4 scope**: exports the `js` provider (package discovery + pnpm/npm
 //! workspace-member resolution + lockfile-driven dependency wiring + oxc-based
 //! import-graph resolution), its `js_package_info` dependency-wiring driver,
-//! the hermetic `js_install` third-party fetch driver, and the `js_typecheck`
+//! the hermetic `js_install` third-party fetch driver, the `js_typecheck`
 //! driver (M3 — `tsc --noEmit` per package, via a disclosed non-hermetic
 //! `tstool = "host"` toolchain; see `hplugin_js::pluginjs::driver_typecheck`
-//! module docs). The host loads this with `hplugin_stabby::load_stable::load`,
+//! module docs), and the `js_test` driver (M4 — one target per test file, via
+//! the configured `testrunner` (`vitest`/`jest`), same disclosed non-hermetic
+//! host-toolchain shape; see `hplugin_js::pluginjs::driver_test` module
+//! docs). The host loads this with `hplugin_stabby::load_stable::load`,
 //! which verifies ABI compatibility via stabby's type reports before use.
 //! Calls then run in-process at native speed — no serialization on the hot
 //! path, no IPC.
 //!
-//! Testing, linting, formatting, and bundling drivers are later milestones
-//! (see `ai-docs/js-plugin-plan.md`) and are not wired up here yet.
+//! Linting, formatting, and bundling drivers are later milestones (see
+//! `ai-docs/js-plugin-plan.md`) and are not wired up here yet.
 //!
 //! Plugin-specific settings are read from the environment; only the
 //! workspace root crosses in [`CreateConfig`].
 
 use hdriver_support::driver_managed::ManagedDriver;
-use hplugin_js::pluginjs::{JsInstallDriver, JsPackageInfoDriver, JsTypecheckDriver, Provider};
+use hplugin_js::pluginjs::{
+    JsInstallDriver, JsPackageInfoDriver, JsTestDriver, JsTypecheckDriver, Provider,
+};
 use plugin_sdk::stabby::abi::{DynLogSink, DynSupervisor, NamedDriver, PluginComponents};
 use plugin_sdk::stabby::{
     create_config_from_bytes, install_log_sink, install_supervisor, make_dyn_managed_driver,
@@ -104,6 +109,15 @@ fn build(cfg: &[u8]) -> anyhow::Result<PluginComponents> {
     drivers.push(NamedDriver {
         name: "js_typecheck".into(),
         driver: make_dyn_managed_driver(typecheck),
+    });
+    // `js_test` (M4): runs the configured test runner (`vitest` default,
+    // `jest` alt) against one test file at a time — see
+    // `hplugin_js::pluginjs::driver_test` module docs, including its
+    // disclosed non-hermetic host-toolchain gap.
+    let test: Arc<dyn ManagedDriver> = Arc::new(JsTestDriver::new());
+    drivers.push(NamedDriver {
+        name: "js_test".into(),
+        driver: make_dyn_managed_driver(test),
     });
 
     Ok(PluginComponents {

--- a/crates/plugin-js/src/pluginjs/driver_test.rs
+++ b/crates/plugin-js/src/pluginjs/driver_test.rs
@@ -1,0 +1,886 @@
+//! `js_test` — runs the configured test runner (`vitest` default, `jest` alt)
+//! against **one test file at a time**.
+//!
+//! Per-test-file granularity is the stated differentiator this milestone
+//! exists to prove (`ai-docs/js-plugin-plan.md`'s "Caching / incrementality"
+//! section): "per-test-file targets using heph's own import graph — this is
+//! where an owned resolver beats every incumbent build system (Turborepo/Nx
+//! never get finer than package granularity for tasks)." One `js_test`
+//! target address exists per matched test file, distinguished by a `file`
+//! addr arg (see `provider.rs`'s `Provider::list`/`Provider::get` handling of
+//! [`crate::pluginjs::TEST_TARGET`]) — never a driver-per-tool name (the
+//! design doc's naming rule: one `js_test`, tool selected by the `testrunner`
+//! config option, never `js_test_vitest`/`js_test_jest`).
+//!
+//! ## Toolchain: `testrunner = "vitest"` (default) or `"jest"`, a disclosed
+//! ## non-hermetic escape hatch
+//!
+//! Exactly the same shape as `js_typecheck`'s `tstool = "host"` (see
+//! `driver_typecheck.rs`/`toolchain.rs` module docs): no hermetic Node/test-
+//! runner toolchain exists anywhere in this plugin yet, so `Provider::get`
+//! (`provider.rs::test_config`) resolves the configured runner's binary from
+//! the host (`toolchain::resolve_host_test_runner`:
+//! `<workspace_root>/node_modules/.bin/<vitest|jest>`, then `PATH`) and
+//! queries its `--version` once, threading both through this target's config
+//! for the driver to hash. Real, disclosed, not hidden — same class of gap as
+//! `driver_install.rs`'s `.npmrc`-auth gap.
+//!
+//! ## Inputs / cache key
+//!
+//! The test file itself, plus its full runtime-transitive closure within its
+//! owning package (`importgraph::build_test_closure` over
+//! `ImportGraph::runtime_edges` — see that function's doc for exactly what
+//! counts as "in the closure" vs. "one-hop external"), plus every third-party
+//! dependency that closure's own unresolved bare specifiers name (resolved
+//! via `deps::resolve_one_dependency`, the lockfile-driven mechanism — never
+//! by walking `oxc_resolver` paths against an ambient `node_modules`, see
+//! this crate's M3-review lesson recorded in `provider.rs`), plus the
+//! resolved test-runner config file, if any (`vitest.config.ts` /
+//! `jest.config.js` / `vite.config.ts`'s own `test: {...}` key / a jest
+//! project's `package.json` `"jest"` field, walked up the ancestor chain the
+//! same way a tsconfig is — see `importgraph::find_nearest_test_runner_config`
+//! / `importgraph::find_nearest_jest_package_json_config`), plus every
+//! additional file that config's own content names or imports, recursively
+//! (`importgraph::resolve_runner_config_referenced_files`), plus the queried
+//! runner version. See `provider.rs`'s `test_deps_config` for the pure,
+//! runner-free Input-scoping function this driver's `deps`/`test_file` config
+//! comes from — deliberately split out the same way `typecheck_deps_config`
+//! is, so the per-test-file scoping is unit-testable without a real
+//! `vitest`/`jest` binary (this is the task's "single most important test in
+//! this milestone").
+//!
+//! Beyond the declared `Input`s (content-hashed automatically by the
+//! engine), [`JsTestDef::hash`] additionally hashes `test_file` itself (so
+//! *which* test file this target is for is part of the key, not just its
+//! transitive content — two different test files with byte-identical
+//! closures must still be different cache entries), `runner_config_content`
+//! directly (same deliberate redundancy with its declared Input that
+//! `js_typecheck`'s `tsconfig_content` has — see that struct's doc), and
+//! `runner_version`. `runner_bin` (an absolute host path) is deliberately
+//! **excluded**, mirroring `tsc_bin`'s exclusion — see that field's doc in
+//! `driver_typecheck.rs` for the identical cache-portability rationale.
+//!
+//! **Known scope trim, disclosed rather than silent**: `build_test_closure`
+//! only recurses within the *owning package's* own import graph — a file
+//! reached one hop into a workspace-sibling package (or, absent
+//! `node_modules`, a third-party package) is declared as an `Input` but its
+//! own further imports are not followed (`importgraph.rs`'s `TestClosure`
+//! doc calls this "one-hop external", the identical trim
+//! `js_typecheck`'s type-edge handling already accepts). TODO M4+: recurse
+//! into a sibling package's own import graph once cross-package graph
+//! construction exists.
+//!
+//! **Known scope trim, disclosed rather than silent**: a resolved runner
+//! config's own `moduleNameMapper` (jest) / `resolve.alias` (vitest)
+//! mock-path values, and a custom `testEnvironment` module, are not
+//! extracted into the declared Input set (unlike `setupFiles`/
+//! `setupFilesAfterEnv`/`globalSetup`/`globalTeardown`, and a relative
+//! `import`/`require` of a shared base config — both of which *are* now
+//! resolved and declared, recursively; see
+//! `importgraph::resolve_runner_config_referenced_files`). A test reaching a
+//! first-party file only through a runner-specific alias that isn't also a
+//! tsconfig `paths` entry has that file silently missing from the declared
+//! Input set — editing it produces a stale cache hit. TODO M4+.
+//!
+//! ## Invocation shape
+//!
+//! Both runners are invoked from the sandboxed workspace root (`cwd =
+//! sandbox_ws_dir`), with the test file and (if any) runner config passed as
+//! absolute in-sandbox paths — mirroring `js_typecheck`'s `--project
+//! <tsconfig_abs>` shape, and avoiding the ambiguity of a config-relative or
+//! package-relative cwd in a monorepo where the config may live several
+//! directories up. `vitest` gets `run <file>` (the non-watch, CI-friendly
+//! subcommand — bare `vitest` defaults to interactive watch mode, which would
+//! hang forever under heph); `jest` gets `--runTestsByPath <file>` (an exact
+//! path match, not a `testPathPattern` regex, so the invocation can't
+//! accidentally pick up more than the one intended file). `PATH` is passed
+//! through to the child process — the same disclosed, minimal passthrough
+//! `js_typecheck`'s `run()` uses for its own `node`-shebang binaries, and for
+//! the identical reason (a `#!/usr/bin/env node`-shebang `vitest`/`jest`
+//! binary needs `node` reachable via `PATH`). `TZ=UTC` and `LANG=C.UTF-8`
+//! are additionally pinned (constants, not read from the host) rather than
+//! left ambient: absent both, Node/ICU falls back to the host's own
+//! timezone/locale, so a `Date`/`Intl`-sensitive test could otherwise pass on
+//! one machine and fail on another with a byte-identical cache key.
+//!
+//! ## Failure reporting
+//!
+//! A failing test is a plain, non-zero-exit driver failure with both stdout
+//! and stderr tails surfaced (`test_failure_detail`, identical shape to
+//! `driver_typecheck.rs`'s `tsc_failure_detail`) — the runner's actual
+//! output (assertion diffs, stack traces) must reach the user, never be
+//! swallowed into a bare "failed" with no detail.
+
+use anyhow::Context;
+use async_trait::async_trait;
+use hcore::debug_hash::DebugHasher;
+use hcore::hasync::Cancellable;
+use hdriver_support::driver_managed::{ManagedDriver, ManagedRunRequest, ManagedRunResponse};
+use hplugin::driver::targetdef::{CacheConfig, Input, InputMode, TargetDef};
+use hplugin::driver::{
+    ApplyTransitiveRequest, ApplyTransitiveResponse, ConfigRequest, ConfigResponse, ParseRequest,
+    ParseResponse, TargetAddr,
+};
+use hplugin::htspec::Spec;
+use hproc::proc_exec;
+use std::collections::HashMap;
+use std::ffi::OsString;
+use std::hash::{Hash, Hasher};
+use std::sync::Arc;
+use xxhash_rust::xxh3::Xxh3Default;
+
+use crate::pluginjs::toolchain;
+
+/// Config for a `js_test` target. Entirely engine-generated by the `js`
+/// provider's `Provider::get` (see `pluginjs::provider::Provider::test_config`)
+/// — never authored by hand in a BUILD file.
+#[derive(Spec)]
+struct JsTestSpec {
+    /// Which test runner this target invokes: `"vitest"` or `"jest"` (see
+    /// `toolchain::is_supported_testrunner`).
+    #[spec(required)]
+    testrunner: String,
+    /// Absolute host path to the resolved runner binary
+    /// (`toolchain::resolve_host_test_runner`). Deliberately **not** part of
+    /// `JsTestDef`'s hash — see that struct's `runner_bin` field doc.
+    #[spec(required)]
+    runner_bin: String,
+    /// The runner's own `--version` output, trimmed, queried once by
+    /// `Provider::get`. Hashed: a host runner upgrade/downgrade must bust the
+    /// cache.
+    #[spec(required)]
+    runner_version: String,
+    /// Workspace-root-relative path to the one test file this target runs.
+    /// Hashed (see module docs) and used by `run()` to build the runner
+    /// invocation's file argument.
+    #[spec(required)]
+    test_file: String,
+    /// Workspace-root-relative path to the resolved runner config
+    /// (`vitest.config.ts` / `jest.config.js`), or empty when none exists on
+    /// the ancestor chain.
+    runner_config_path: String,
+    /// The resolved runner config's own raw bytes, hashed directly — see
+    /// module docs' "Inputs / cache key" section for why this is not purely
+    /// redundant with the declared `"runner_config"` dep group.
+    runner_config_content: String,
+    /// Dependencies, grouped by name → target addresses: `""` = the test
+    /// file's own runtime-transitive first-party closure (always includes
+    /// the test file itself), `"external"` = every file that closure reaches
+    /// just outside its owning package (workspace sibling or third-party,
+    /// one-hop only) plus any lockfile-resolved third-party addr for an
+    /// import that never resolved on disk at all, `"runner_config"` = the
+    /// resolved runner config file, if any, plus every additional file its
+    /// own content names (`setupFiles`/`setupFilesAfterEnv`/`globalSetup`/
+    /// `globalTeardown`) or imports (a relative `import`/`require` of a
+    /// shared base config), recursively — see
+    /// `importgraph::resolve_runner_config_referenced_files` and module
+    /// docs' "Inputs / cache key" section.
+    deps: HashMap<String, Vec<String>>,
+}
+
+#[derive(Clone, serde::Serialize, serde::Deserialize)]
+struct JsTestDef {
+    testrunner: String,
+    runner_version: String,
+    test_file: String,
+    runner_config_path: String,
+    runner_config_content: String,
+    /// Absolute host runner path — carried through so `run()` can exec it,
+    /// but see `Hash` impl below: deliberately excluded from the cache key.
+    runner_bin: String,
+}
+
+/// Bump to invalidate every cached `js_test` result whenever the invocation
+/// shape (flags, runner-config-lookup rule, what counts as a hashed config
+/// field) changes in a way the declared `Input` content hash alone would not
+/// already capture.
+const JS_TEST_FORMAT_VERSION: u32 = 1;
+
+impl Hash for JsTestDef {
+    fn hash<H: Hasher>(&self, state: &mut H) {
+        JS_TEST_FORMAT_VERSION.hash(state);
+        self.testrunner.hash(state);
+        self.runner_version.hash(state);
+        self.test_file.hash(state);
+        self.runner_config_path.hash(state);
+        self.runner_config_content.hash(state);
+        // `runner_bin` is deliberately NOT hashed — an absolute host
+        // filesystem path that differs across machines/checkouts for the
+        // exact same effective toolchain; see `JsTypecheckDef::hash`'s
+        // identical `tsc_bin` exclusion for the full rationale.
+        //
+        // Source/closure file *content* arrives via declared `Input`s; the
+        // engine hashes that separately (architecture.md's "Automatic
+        // hashing"), so it is not duplicated here.
+    }
+}
+
+pub struct JsTestDriver;
+
+impl JsTestDriver {
+    pub fn new() -> Self {
+        Self
+    }
+}
+
+impl Default for JsTestDriver {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+#[async_trait]
+impl ManagedDriver for JsTestDriver {
+    fn config(&self, _req: ConfigRequest) -> anyhow::Result<ConfigResponse> {
+        Ok(ConfigResponse {
+            name: "js_test".to_string(),
+        })
+    }
+
+    fn schema(&self) -> hplugin::driver::DriverSchema {
+        JsTestSpec::schema()
+    }
+
+    async fn parse(
+        &self,
+        req: ParseRequest,
+        _ctoken: &(dyn Cancellable + Send + Sync),
+    ) -> anyhow::Result<ParseResponse> {
+        let addr = &req.target_spec.addr;
+        let pkg = addr.package.clone();
+        let spec = JsTestSpec::from(&req.target_spec.config).context("parse js_test config")?;
+
+        anyhow::ensure!(
+            toolchain::is_supported_testrunner(&spec.testrunner),
+            "js_test: unsupported testrunner {:?} for {} — expected \"vitest\" or \"jest\"",
+            spec.testrunner,
+            addr.format()
+        );
+
+        // Dep groups arrive from a HashMap — sort by group name so the
+        // resulting `inputs` (and thus anything order-sensitive downstream)
+        // is deterministic across parses, not HashMap-iteration order. Same
+        // regression class as `js_typecheck`/`js_package_info`'s own
+        // dep-input ordering.
+        let mut groups: Vec<(&String, &Vec<String>)> = spec.deps.iter().collect();
+        groups.sort_by_key(|(group, _)| *group);
+        let mut inputs: Vec<Input> = Vec::new();
+        for (group, addrs) in groups {
+            for (i, addr_str) in addrs.iter().enumerate() {
+                inputs.push(Input {
+                    r#ref: TargetAddr::parse(addr_str, &pkg)
+                        .with_context(|| format!("parse dep addr {addr_str}"))?,
+                    mode: InputMode::Standard,
+                    origin_id: format!("dep|{group}|{i}"),
+                    annotations: Default::default(),
+                    hashed: true,
+                    runtime: true,
+                });
+            }
+        }
+
+        let def = JsTestDef {
+            testrunner: spec.testrunner,
+            runner_version: spec.runner_version,
+            test_file: spec.test_file,
+            runner_config_path: spec.runner_config_path,
+            runner_config_content: spec.runner_config_content,
+            runner_bin: spec.runner_bin,
+        };
+
+        let hash = {
+            let mut h =
+                DebugHasher::new(Xxh3Default::new(), || format!("js_test_{}", addr.format()));
+            def.hash(&mut h);
+            format!("{:x}", h.finish()).into_bytes()
+        };
+
+        Ok(ParseResponse {
+            target_def: TargetDef {
+                addr: addr.clone(),
+                labels: req.target_spec.labels.clone(),
+                raw_def: Arc::new(def),
+                inputs,
+                // No output artifact: a `js_test` target's only observable
+                // effect is "did the test pass" — mirrors
+                // `js_typecheck`'s read-only, produces-nothing shape.
+                outputs: vec![],
+                support_files: vec![],
+                cache: CacheConfig::on(true),
+                pty: false,
+                hash,
+                transparent: false,
+            },
+        })
+    }
+
+    async fn apply_transitive(
+        &self,
+        req: ApplyTransitiveRequest,
+        _ctoken: &(dyn Cancellable + Send + Sync),
+    ) -> anyhow::Result<ApplyTransitiveResponse> {
+        Ok(ApplyTransitiveResponse {
+            target_def: req.target_def,
+        })
+    }
+
+    async fn run<'a, 'io>(
+        &self,
+        req: ManagedRunRequest<'a, 'io>,
+        ctoken: &(dyn Cancellable + Send + Sync),
+    ) -> anyhow::Result<ManagedRunResponse> {
+        let def = req.request.target.def_de::<JsTestDef>();
+        // Defense in depth: `Provider::get` already rejects an absolute or
+        // `..`-escaping `file`/`runner_config_path` before ever building this
+        // `TargetDef` (see `provider::reject_path_escape`'s doc — a
+        // code-quality review BLOCKER), but a cached `JsTestDef` read back
+        // from disk is untrusted input to this driver too, so the same check
+        // runs again here, before either ever reaches `sandbox_ws_dir.join`.
+        crate::pluginjs::provider::reject_path_escape("test_file", &def.test_file)
+            .context("validating cached js_test def before running")?;
+        if !def.runner_config_path.is_empty() {
+            crate::pluginjs::provider::reject_path_escape(
+                "runner_config_path",
+                &def.runner_config_path,
+            )
+            .context("validating cached js_test def before running")?;
+        }
+        let runner_bin = std::path::PathBuf::from(&def.runner_bin);
+        let test_file_abs = req.sandbox_ws_dir.join(&def.test_file);
+
+        // `testrunner = "vitest"/"jest"` are explicitly non-hermetic (see
+        // module docs): the resolved binary is very likely a
+        // `#!/usr/bin/env node` shebang script, so executing it needs `node`
+        // reachable via PATH — mirrors `js_typecheck::run`'s identical
+        // PATH-only passthrough and its own doc comment for why only `PATH`
+        // (not `HOME`/`TMPDIR`/etc.) is forwarded.
+        //
+        // `TZ`/`LANG` are pinned rather than left to the host's ambient
+        // configuration: absent both, Node/ICU falls back to the host's own
+        // timezone/locale (`/etc/localtime` etc.), so a `Date`/`Intl` test
+        // could legitimately pass on a `TZ=UTC` CI host and fail on a
+        // `TZ=America/Los_Angeles` laptop (or vice versa) while producing the
+        // byte-identical `JsTestDef` hash — a hermeticity M4 review finding.
+        // Pinning both makes the child's environment part of what the cache
+        // key actually reflects (identical on every host), rather than a
+        // silent, unhashed source of divergence.
+        let mut env: HashMap<String, String> = HashMap::new();
+        if let Ok(v) = std::env::var("PATH") {
+            env.insert("PATH".to_string(), v);
+        }
+        env.insert("TZ".to_string(), "UTC".to_string());
+        env.insert("LANG".to_string(), "C.UTF-8".to_string());
+
+        let mut args: Vec<OsString> = Vec::new();
+        match def.testrunner.as_str() {
+            toolchain::VITEST => {
+                // `run`, not bare `vitest`: bare `vitest` defaults to
+                // interactive watch mode, which would hang forever under
+                // heph (see module docs' "Invocation shape").
+                args.push(OsString::from("run"));
+                if !def.runner_config_path.is_empty() {
+                    args.push(OsString::from("--config"));
+                    args.push(
+                        req.sandbox_ws_dir
+                            .join(&def.runner_config_path)
+                            .into_os_string(),
+                    );
+                }
+                args.push(test_file_abs.into_os_string());
+            }
+            toolchain::JEST => {
+                if !def.runner_config_path.is_empty() {
+                    args.push(OsString::from("--config"));
+                    args.push(
+                        req.sandbox_ws_dir
+                            .join(&def.runner_config_path)
+                            .into_os_string(),
+                    );
+                }
+                // An exact path match, not a `testPathPattern` regex — see
+                // module docs' "Invocation shape".
+                args.push(OsString::from("--runTestsByPath"));
+                args.push(test_file_abs.into_os_string());
+            }
+            other => anyhow::bail!(
+                "js_test: unsupported testrunner {other:?} — expected \"vitest\" or \"jest\" \
+                 (this should have been rejected at parse() time)"
+            ),
+        }
+
+        self.exec_runner(&runner_bin, args, &env, &req.sandbox_ws_dir, ctoken)
+            .await?;
+
+        Ok(ManagedRunResponse { artifacts: vec![] })
+    }
+}
+
+impl JsTestDriver {
+    async fn exec_runner(
+        &self,
+        runner_bin: &std::path::Path,
+        args: Vec<OsString>,
+        env: &HashMap<String, String>,
+        cwd: &std::path::Path,
+        ctoken: &(dyn Cancellable + Send + Sync),
+    ) -> anyhow::Result<()> {
+        let env_pairs: Vec<(OsString, OsString)> = env
+            .iter()
+            .map(|(k, v)| (OsString::from(k), OsString::from(v)))
+            .collect();
+        let spec = proc_exec::Spec {
+            program: runner_bin.to_path_buf(),
+            args,
+            env: env_pairs,
+            cwd: cwd.to_path_buf(),
+            stdin: proc_exec::StdioSpec::Null,
+            stdout: proc_exec::StdioSpec::Piped,
+            stderr: proc_exec::StdioSpec::Piped,
+            setsid: false,
+            ctty: false,
+        };
+        let output = proc_exec::output(spec, ctoken)
+            .await
+            .with_context(|| format!("wait for test runner ({runner_bin:?})"))?;
+        if !output.status.success() {
+            let stdout = String::from_utf8_lossy(&output.stdout);
+            let stderr = String::from_utf8_lossy(&output.stderr);
+            anyhow::bail!(
+                "js_test failed ({}):\n{}",
+                output.status,
+                test_failure_detail(&stdout, &stderr)
+            );
+        }
+        Ok(())
+    }
+}
+
+/// Build the human-readable detail for a failed test-runner invocation —
+/// both stdout and stderr tails included, mirroring
+/// `driver_typecheck.rs`'s `tsc_failure_detail` for the identical reason: a
+/// failing test's actual output (assertion diffs, stack traces) must reach
+/// the user, never come back silently blank.
+fn test_failure_detail(stdout: &str, stderr: &str) -> String {
+    let stdout_tail = hplugin::error::last_n_lines(stdout.trim(), 60);
+    let stderr_tail = hplugin::error::last_n_lines(stderr.trim(), 60);
+    let mut detail = String::new();
+    if !stdout_tail.is_empty() {
+        detail.push_str("stdout:\n");
+        detail.push_str(&stdout_tail);
+    }
+    if !stderr_tail.is_empty() {
+        if !detail.is_empty() {
+            detail.push('\n');
+        }
+        detail.push_str("stderr:\n");
+        detail.push_str(&stderr_tail);
+    }
+    if detail.is_empty() {
+        "<no output on stdout or stderr>".to_string()
+    } else {
+        detail
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use hcore::hasync::StdCancellationToken;
+    use hcore::htvalue::Value;
+    use hmodel::htaddr::Addr;
+    use hmodel::htpkg::PkgBuf;
+    use hplugin::provider::TargetSpec;
+    use std::collections::HashMap;
+
+    fn driver() -> JsTestDriver {
+        JsTestDriver::new()
+    }
+
+    fn ctoken() -> StdCancellationToken {
+        StdCancellationToken::new()
+    }
+
+    fn config(extra: &[(&str, Value)]) -> HashMap<String, Value> {
+        let mut c: HashMap<String, Value> = HashMap::from([
+            (
+                "testrunner".to_string(),
+                Value::String("vitest".to_string()),
+            ),
+            (
+                "runner_bin".to_string(),
+                Value::String("/usr/bin/vitest".to_string()),
+            ),
+            (
+                "runner_version".to_string(),
+                Value::String("vitest/1.6.0".to_string()),
+            ),
+            (
+                "test_file".to_string(),
+                Value::String("packages/a/src/index.test.ts".to_string()),
+            ),
+            (
+                "runner_config_path".to_string(),
+                Value::String(String::new()),
+            ),
+            (
+                "runner_config_content".to_string(),
+                Value::String(String::new()),
+            ),
+        ]);
+        for (k, v) in extra {
+            c.insert((*k).to_string(), v.clone());
+        }
+        c
+    }
+
+    fn make_parse_request(extra: &[(&str, Value)]) -> ParseRequest {
+        ParseRequest {
+            request_id: "test".to_string(),
+            target_spec: Arc::new(TargetSpec {
+                addr: Addr::new(
+                    PkgBuf::from("packages/a"),
+                    "js_test".to_string(),
+                    std::collections::BTreeMap::from([(
+                        "file".to_string(),
+                        "packages/a/src/index.test.ts".to_string(),
+                    )]),
+                ),
+                driver: "js_test".to_string(),
+                config: config(extra),
+                ..Default::default()
+            }),
+        }
+    }
+
+    #[tokio::test]
+    async fn driver_name_is_js_test() {
+        let resp = driver().config(ConfigRequest {}).unwrap();
+        assert_eq!(resp.name, "js_test");
+    }
+
+    #[tokio::test]
+    async fn parse_missing_required_field_errors() {
+        let ct = ctoken();
+        let req = ParseRequest {
+            request_id: "test".to_string(),
+            target_spec: Arc::new(TargetSpec {
+                addr: Addr::new(
+                    PkgBuf::from("packages/a"),
+                    "js_test".to_string(),
+                    Default::default(),
+                ),
+                driver: "js_test".to_string(),
+                ..Default::default()
+            }),
+        };
+        assert!(driver().parse(req, &ct).await.is_err());
+    }
+
+    #[tokio::test]
+    async fn parse_rejects_unsupported_testrunner() {
+        let ct = ctoken();
+        let req = make_parse_request(&[("testrunner", Value::String("mocha".to_string()))]);
+        let err = driver()
+            .parse(req, &ct)
+            .await
+            .err()
+            .expect("an unsupported testrunner must fail parse");
+        assert!(format!("{err:#}").contains("mocha"));
+    }
+
+    #[tokio::test]
+    async fn parse_accepts_jest_as_well_as_vitest() {
+        let ct = ctoken();
+        let req = make_parse_request(&[("testrunner", Value::String("jest".to_string()))]);
+        driver()
+            .parse(req, &ct)
+            .await
+            .expect("jest must be accepted");
+    }
+
+    #[tokio::test]
+    async fn parse_hash_stable_across_identical_parses() {
+        let ct = ctoken();
+        let a = driver().parse(make_parse_request(&[]), &ct).await.unwrap();
+        let b = driver().parse(make_parse_request(&[]), &ct).await.unwrap();
+        assert_eq!(a.target_def.hash, b.target_def.hash);
+    }
+
+    /// Task requirement: a runner-version change must bust the cache.
+    #[tokio::test]
+    async fn parse_hash_changes_when_runner_version_changes() {
+        let ct = ctoken();
+        let a = driver().parse(make_parse_request(&[]), &ct).await.unwrap();
+        let b = driver()
+            .parse(
+                make_parse_request(&[(
+                    "runner_version",
+                    Value::String("vitest/2.0.0".to_string()),
+                )]),
+                &ct,
+            )
+            .await
+            .unwrap();
+        assert_ne!(a.target_def.hash, b.target_def.hash);
+    }
+
+    /// Task requirement: a different test file must be a different cache
+    /// entry, even holding everything else constant.
+    #[tokio::test]
+    async fn parse_hash_changes_when_test_file_changes() {
+        let ct = ctoken();
+        let a = driver().parse(make_parse_request(&[]), &ct).await.unwrap();
+        let b = driver()
+            .parse(
+                make_parse_request(&[(
+                    "test_file",
+                    Value::String("packages/a/src/other.test.ts".to_string()),
+                )]),
+                &ct,
+            )
+            .await
+            .unwrap();
+        assert_ne!(a.target_def.hash, b.target_def.hash);
+    }
+
+    /// Task requirement: a runner config content change must bust the cache.
+    #[tokio::test]
+    async fn parse_hash_changes_when_runner_config_content_changes() {
+        let ct = ctoken();
+        let a = driver().parse(make_parse_request(&[]), &ct).await.unwrap();
+        let b = driver()
+            .parse(
+                make_parse_request(&[(
+                    "runner_config_content",
+                    Value::String("export default { test: {} };".to_string()),
+                )]),
+                &ct,
+            )
+            .await
+            .unwrap();
+        assert_ne!(a.target_def.hash, b.target_def.hash);
+    }
+
+    /// `runner_bin` is an absolute host path — must NOT affect the cache key.
+    #[tokio::test]
+    async fn parse_hash_unaffected_by_runner_bin_path_difference() {
+        let ct = ctoken();
+        let a = driver().parse(make_parse_request(&[]), &ct).await.unwrap();
+        let b = driver()
+            .parse(
+                make_parse_request(&[(
+                    "runner_bin",
+                    Value::String("/home/someone/project/node_modules/.bin/vitest".to_string()),
+                )]),
+                &ct,
+            )
+            .await
+            .unwrap();
+        assert_eq!(
+            a.target_def.hash, b.target_def.hash,
+            "a different host runner path for the same effective toolchain must not bust the cache"
+        );
+    }
+
+    #[tokio::test]
+    async fn parse_no_outputs_and_caches_locally_and_remotely() {
+        let ct = ctoken();
+        let resp = driver().parse(make_parse_request(&[]), &ct).await.unwrap();
+        assert!(resp.target_def.outputs.is_empty());
+        assert!(resp.target_def.cache.enabled);
+        assert!(resp.target_def.cache.remote_enabled);
+    }
+
+    fn make_parse_request_with_deps(deps: Vec<(&str, Vec<&str>)>) -> ParseRequest {
+        let mut c = config(&[]);
+        let deps_map: HashMap<String, Value> = deps
+            .into_iter()
+            .map(|(k, vs)| {
+                (
+                    k.to_string(),
+                    Value::List(
+                        vs.into_iter()
+                            .map(|v| Value::String(v.to_string()))
+                            .collect(),
+                    ),
+                )
+            })
+            .collect();
+        c.insert("deps".to_string(), Value::Map(deps_map));
+        ParseRequest {
+            request_id: "test".to_string(),
+            target_spec: Arc::new(TargetSpec {
+                addr: Addr::new(
+                    PkgBuf::from("packages/a"),
+                    "js_test".to_string(),
+                    Default::default(),
+                ),
+                driver: "js_test".to_string(),
+                config: c,
+                ..Default::default()
+            }),
+        }
+    }
+
+    #[tokio::test]
+    async fn parse_deps_become_target_dep_inputs_ordered_by_group() {
+        let ct = ctoken();
+        let req = make_parse_request_with_deps(vec![
+            (
+                "external",
+                vec!["//@heph/fs:file@f=packages/b/src/index.ts"],
+            ),
+            ("", vec!["//@heph/fs:file@f=packages/a/src/index.test.ts"]),
+            ("runner_config", vec!["//@heph/fs:file@f=vitest.config.ts"]),
+        ]);
+        let resp = driver().parse(req, &ct).await.unwrap();
+        let origin_ids: Vec<&str> = resp
+            .target_def
+            .inputs
+            .iter()
+            .map(|i| i.origin_id.as_str())
+            .collect();
+        // Sorted group order: "" < "external" < "runner_config".
+        assert_eq!(
+            origin_ids,
+            vec!["dep||0", "dep|external|0", "dep|runner_config|0"]
+        );
+    }
+
+    // ---- run(): gated on a real vitest/jest binary being available in this devenv ----
+    //
+    // Everything above tests cache-key/Input-declaration behavior and needs no
+    // real test runner. These exercise the actual subprocess invocation and
+    // its success/failure surfacing (task requirement 5) — they require a
+    // real `vitest`/`jest` (checked via PATH / `node_modules/.bin` convention)
+    // and are #[ignore]d, with an honest message, when neither is present
+    // rather than silently skipping.
+
+    fn find_real_bin(name: &str) -> Option<std::path::PathBuf> {
+        let path = std::env::var_os("PATH")?;
+        for dir in std::env::split_paths(&path) {
+            let cand = dir.join(name);
+            if std::fs::metadata(&cand)
+                .map(|m| m.is_file())
+                .unwrap_or(false)
+            {
+                return Some(cand);
+            }
+        }
+        None
+    }
+
+    fn write(dir: &std::path::Path, rel: &str, contents: &str) {
+        let path = dir.join(rel);
+        if let Some(parent) = path.parent() {
+            std::fs::create_dir_all(parent).expect("create parent dir");
+        }
+        std::fs::write(path, contents).expect("write fixture file");
+    }
+
+    fn make_run_request<'a>(
+        target: &'a TargetDef,
+        request_id: &'a String,
+        ws_dir: std::path::PathBuf,
+        pkg_dir: std::path::PathBuf,
+        hashin: &'a str,
+    ) -> ManagedRunRequest<'a, 'a> {
+        use hplugin::driver::{RunInput, RunRequest};
+        ManagedRunRequest {
+            request: RunRequest {
+                request_id,
+                target,
+                tree_root_path: ws_dir.clone(),
+                inputs: Vec::<RunInput>::new(),
+                hashin,
+                stdin: None,
+                stdout: None,
+                stderr: None,
+                sandbox_dir: ws_dir.clone(),
+            },
+            sandbox_dir: ws_dir.clone(),
+            sandbox_ws_dir: ws_dir,
+            sandbox_pkg_dir: pkg_dir,
+            inputs: Vec::new(),
+        }
+    }
+
+    #[tokio::test]
+    #[ignore = "requires a real `vitest` on PATH — devenv.nix provisions no Node/vitest \
+                toolchain (see toolchain.rs module docs); run explicitly with \
+                `cargo test -- --ignored` on a host with vitest installed"]
+    async fn run_succeeds_on_a_passing_test_file() {
+        let vitest = find_real_bin("vitest").expect(
+            "this test is #[ignore]d precisely because vitest isn't guaranteed on PATH — it was \
+             run explicitly, so a missing vitest here is a real failure, not a skip",
+        );
+
+        let dir = tempfile::tempdir().expect("tempdir");
+        write(
+            dir.path(),
+            "packages/a/src/index.test.ts",
+            "import { expect, test } from 'vitest';\ntest('passes', () => { expect(1 + 1).toBe(2); });\n",
+        );
+
+        let ct = ctoken();
+        let req = make_parse_request(&[(
+            "runner_bin",
+            Value::String(vitest.to_string_lossy().into_owned()),
+        )]);
+        let parsed = driver().parse(req, &ct).await.unwrap();
+
+        let request_id = "test".to_string();
+        let run_req = make_run_request(
+            &parsed.target_def,
+            &request_id,
+            dir.path().to_path_buf(),
+            dir.path().join("packages/a"),
+            "deadbeef",
+        );
+        driver()
+            .run(run_req, &ct)
+            .await
+            .expect("a passing test file must succeed");
+    }
+
+    #[tokio::test]
+    #[ignore = "requires a real `vitest` on PATH — devenv.nix provisions no Node/vitest \
+                toolchain (see toolchain.rs module docs); run explicitly with \
+                `cargo test -- --ignored` on a host with vitest installed"]
+    async fn run_fails_and_surfaces_runner_output_on_a_real_failing_test() {
+        let vitest = find_real_bin("vitest").expect(
+            "this test is #[ignore]d precisely because vitest isn't guaranteed on PATH — it was \
+             run explicitly, so a missing vitest here is a real failure, not a skip",
+        );
+
+        let dir = tempfile::tempdir().expect("tempdir");
+        write(
+            dir.path(),
+            "packages/a/src/index.test.ts",
+            "import { expect, test } from 'vitest';\ntest('fails', () => { expect(1 + 1).toBe(3); });\n",
+        );
+
+        let ct = ctoken();
+        let req = make_parse_request(&[(
+            "runner_bin",
+            Value::String(vitest.to_string_lossy().into_owned()),
+        )]);
+        let parsed = driver().parse(req, &ct).await.unwrap();
+
+        let request_id = "test".to_string();
+        let run_req = make_run_request(
+            &parsed.target_def,
+            &request_id,
+            dir.path().to_path_buf(),
+            dir.path().join("packages/a"),
+            "deadbeef",
+        );
+        let err = driver()
+            .run(run_req, &ct)
+            .await
+            .err()
+            .expect("a real failing test must fail the driver, not succeed silently");
+        let msg = format!("{err:#}");
+        assert!(msg.contains("js_test failed"), "{msg}");
+    }
+}

--- a/crates/plugin-js/src/pluginjs/importgraph.rs
+++ b/crates/plugin-js/src/pluginjs/importgraph.rs
@@ -139,7 +139,12 @@ use crate::pluginjs::resolvers::{ResolveOutcome, Resolvers};
 use crate::pluginjs::{PACKAGE_JSON, is_skipped_dir_name};
 use anyhow::Context;
 use hwalk::{CachedWalker, EntryKind};
-use std::collections::{HashMap, HashSet};
+use oxc_allocator::Allocator;
+use oxc_ast::ast::{ArrayExpressionElement, Expression, PropertyKey};
+use oxc_ast_visit::{Visit, walk};
+use oxc_parser::Parser;
+use oxc_span::SourceType;
+use std::collections::{BTreeSet, HashMap, HashSet, VecDeque};
 use std::path::{Path, PathBuf};
 use std::sync::Mutex;
 use wax::{Glob, Program as _};
@@ -390,15 +395,83 @@ fn bare_specifier_guard(tsconfig: Option<&Path>) -> BareSpecifierGuard {
     BareSpecifierGuard::ExceptPatterns(paths.keys().cloned().collect())
 }
 
+/// Walk up from `pkg_dir` (inclusive) to `workspace_root`, returning the
+/// first directory's `candidates` entry (checked in order at each level)
+/// that exists as a file. Shared walk-up logic behind [`find_nearest_tsconfig`]
+/// and [`find_nearest_test_runner_config`] — `js_test`'s runner config
+/// (`vitest.config.ts` / `jest.config.js`) is walked up the same way a
+/// package's tsconfig is, per `ai-docs/js-plugin-plan.md`'s `js_test` milestone
+/// note.
+fn find_nearest_file(
+    workspace_root: &Path,
+    pkg_dir: &Path,
+    candidates: &[&str],
+) -> Option<PathBuf> {
+    let mut dir = pkg_dir;
+    loop {
+        for name in candidates {
+            let candidate = dir.join(name);
+            if candidate.is_file() {
+                return Some(candidate);
+            }
+        }
+        if dir == workspace_root {
+            return None;
+        }
+        match dir.parent() {
+            Some(parent) if parent.starts_with(workspace_root) || parent == workspace_root => {
+                dir = parent;
+            }
+            _ => return None,
+        }
+    }
+}
+
 /// Walk up from `pkg_dir` (inclusive) to `workspace_root` looking for the
 /// nearest `tsconfig.json` — used to configure `Resolvers`' `paths`/
 /// `baseUrl`/`extends` support. `None` if no workspace directory on that
 /// ancestor chain has one.
 pub fn find_nearest_tsconfig(workspace_root: &Path, pkg_dir: &Path) -> Option<PathBuf> {
+    find_nearest_file(workspace_root, pkg_dir, &["tsconfig.json"])
+}
+
+/// Walk up from `pkg_dir` (inclusive) to `workspace_root` looking for the
+/// nearest test-runner config file among `candidates` (e.g.
+/// `["vitest.config.ts", "vitest.config.js", ...]`) — the same ancestor walk
+/// [`find_nearest_tsconfig`] performs, generalized to whatever filenames the
+/// configured `testrunner` uses. `None` if no workspace directory on that
+/// ancestor chain has any of them.
+pub fn find_nearest_test_runner_config(
+    workspace_root: &Path,
+    pkg_dir: &Path,
+    candidates: &[&str],
+) -> Option<PathBuf> {
+    find_nearest_file(workspace_root, pkg_dir, candidates)
+}
+
+/// Walk up from `pkg_dir` (inclusive) to `workspace_root` looking for the
+/// nearest `package.json` whose own `"jest"` field is present — jest's other
+/// documented config location, alongside the dedicated `jest.config.*`
+/// filenames [`find_nearest_test_runner_config`] already checks. Called by
+/// `test_deps_config` only once none of those dedicated filenames are found
+/// on the same ancestor chain, matching jest's own precedence (a dedicated
+/// config file wins over the shared `package.json`). `None` if no ancestor's
+/// `package.json` carries a `"jest"` field (or fails to parse as JSON, or
+/// doesn't exist) — a hermeticity M4 review finding: this fallback was
+/// previously entirely absent, so a project configured this way had its real
+/// config invisible to the declared Input set and the cache key.
+pub fn find_nearest_jest_package_json_config(
+    workspace_root: &Path,
+    pkg_dir: &Path,
+) -> Option<PathBuf> {
     let mut dir = pkg_dir;
     loop {
-        let candidate = dir.join("tsconfig.json");
-        if candidate.is_file() {
+        let candidate = dir.join(PACKAGE_JSON);
+        if candidate.is_file()
+            && let Ok(text) = std::fs::read_to_string(&candidate)
+            && let Ok(value) = serde_json::from_str::<serde_json::Value>(&text)
+            && value.get("jest").is_some()
+        {
             return Some(candidate);
         }
         if dir == workspace_root {
@@ -409,6 +482,236 @@ pub fn find_nearest_tsconfig(workspace_root: &Path, pkg_dir: &Path) -> Option<Pa
                 dir = parent;
             }
             _ => return None,
+        }
+    }
+}
+
+/// Test-runner config keys whose value names one or more first-party files
+/// the real runner reads at test time, beyond the config file's own leaf
+/// bytes — `setupFiles`/`globalSetup`/`globalTeardown` (jest and vitest both
+/// support these); `setupFilesAfterEnv` is jest-only, harmless to also look
+/// for under vitest. See [`extract_runner_config_referenced_paths`] for the
+/// extraction itself, and this crate's M4 hermeticity-review note for why
+/// this exists: a `setupFiles` entry mutates real test behavior (mocks,
+/// globals) without touching the test file, its import closure, or the
+/// config's own leaf bytes' *meaning* to a casual diff reader — it must
+/// still bust the cache.
+///
+/// **Known scope trim, disclosed rather than silent**: `moduleNameMapper`
+/// (jest) / `resolve.alias` (vitest) mock-path values and a custom
+/// `testEnvironment` module are not extracted — the former's values commonly
+/// carry regex backreferences (`$1`) this static scan can't resolve without
+/// evaluating the mapping, and the latter is usually a package name, not a
+/// path. TODO M4+.
+const RUNNER_CONFIG_FILE_KEYS: &[&str] = &[
+    "setupFiles",
+    "setupFilesAfterEnv",
+    "globalSetup",
+    "globalTeardown",
+];
+
+/// Statically extract every string-literal value named by
+/// [`RUNNER_CONFIG_FILE_KEYS`] anywhere in `content` — a single string
+/// (`setupFiles: './setup.ts'`) or an array of strings (`setupFiles:
+/// ['./setup.ts']`). Deliberately not scoped to "the exported config
+/// object" specifically: this crate doesn't evaluate JS, so rather than
+/// trying to precisely locate the one object a `defineConfig(...)`/
+/// `module.exports = ...` call wraps (which can nest arbitrarily), it scans
+/// every object literal in the file. Over-inclusion (a same-named key that
+/// happens to appear elsewhere) costs one extra declared Input;
+/// under-inclusion is the actual hermeticity bug this exists to close, so
+/// the asymmetry is deliberate.
+///
+/// A config file that fails to parse (invalid syntax, or an extension this
+/// parser doesn't recognize) yields an empty list rather than an error — the
+/// leaf config's own raw bytes are already declared/hashed regardless of
+/// this scan's success (`test_deps_config`), so a parse failure here only
+/// means the extra references go undetected, not that the whole `js_test`
+/// target becomes unbuildable.
+fn extract_runner_config_referenced_paths(path: &Path, content: &str) -> Vec<String> {
+    let Ok(source_type) = SourceType::from_path(path) else {
+        return Vec::new();
+    };
+    let allocator = Allocator::default();
+    let ret = Parser::new(&allocator, content, source_type).parse();
+    if ret.panicked {
+        return Vec::new();
+    }
+    let mut visitor = RunnerConfigRefVisitor::default();
+    visitor.visit_program(&ret.program);
+    visitor.paths
+}
+
+#[derive(Default)]
+struct RunnerConfigRefVisitor {
+    paths: Vec<String>,
+}
+
+impl RunnerConfigRefVisitor {
+    fn push_value(&mut self, value: &Expression<'_>) {
+        match value {
+            Expression::StringLiteral(s) => self.paths.push(s.value.as_str().to_string()),
+            Expression::ArrayExpression(arr) => {
+                for el in &arr.elements {
+                    if let ArrayExpressionElement::StringLiteral(s) = el {
+                        self.paths.push(s.value.as_str().to_string());
+                    }
+                }
+            }
+            _ => {}
+        }
+    }
+}
+
+impl<'a> Visit<'a> for RunnerConfigRefVisitor {
+    fn visit_object_property(&mut self, it: &oxc_ast::ast::ObjectProperty<'a>) {
+        let key_name = match &it.key {
+            PropertyKey::StaticIdentifier(id) => Some(id.name.as_str()),
+            PropertyKey::StringLiteral(s) => Some(s.value.as_str()),
+            _ => None,
+        };
+        if key_name.is_some_and(|name| RUNNER_CONFIG_FILE_KEYS.contains(&name)) {
+            self.push_value(&it.value);
+        }
+        walk::walk_object_property(self, it);
+    }
+}
+
+/// Probe `candidate_no_ext` against Node/esbuild's common extension set for
+/// an extensionless specifier, then its own `index.*` if it names a
+/// directory — the same shape [`resolvers::Resolvers`] handles for real
+/// import resolution, kept separate and deliberately simpler here (no
+/// `package.json` `exports` map, no `tsconfig` `paths`) since a runner
+/// config's own referenced files are always plain relative paths in
+/// practice, never package-style specifiers.
+fn probe_first_party_path(candidate_no_ext: &Path) -> Option<PathBuf> {
+    const EXTS: &[&str] = &["", ".ts", ".tsx", ".js", ".jsx", ".mjs", ".cjs", ".json"];
+    for ext in EXTS {
+        let candidate = if ext.is_empty() {
+            candidate_no_ext.to_path_buf()
+        } else {
+            let mut s = candidate_no_ext.as_os_str().to_os_string();
+            s.push(ext);
+            PathBuf::from(s)
+        };
+        if candidate.is_file() {
+            return Some(candidate);
+        }
+    }
+    for index in &[
+        "index.ts",
+        "index.tsx",
+        "index.js",
+        "index.jsx",
+        "index.mjs",
+        "index.cjs",
+    ] {
+        let candidate = candidate_no_ext.join(index);
+        if candidate.is_file() {
+            return Some(candidate);
+        }
+    }
+    None
+}
+
+/// Resolve one `RUNNER_CONFIG_FILE_KEYS` value (`raw`) against `config_dir` —
+/// handling jest's `<rootDir>/...` token (approximated as `config_dir`,
+/// jest's own default when no explicit `rootDir` override exists) as well as
+/// a plain relative path. `None` for anything else (a bare module specifier
+/// naming a third-party setup package — not this scan's job; see
+/// [`RUNNER_CONFIG_FILE_KEYS`]'s doc).
+fn resolve_config_value_path(config_dir: &Path, raw: &str) -> Option<PathBuf> {
+    if let Some(rest) = raw.strip_prefix("<rootDir>") {
+        return probe_first_party_path(&config_dir.join(rest.trim_start_matches('/')));
+    }
+    if raw.starts_with("./") || raw.starts_with("../") {
+        return probe_first_party_path(&config_dir.join(raw));
+    }
+    None
+}
+
+/// Resolve one relative `import`/`require` specifier found *inside* a config
+/// file against that file's own directory. Deliberately only ever a relative
+/// specifier (`./...`/`../...`) — a bare specifier (`import { defineConfig }
+/// from 'vitest/config'`) names the config's own npm dependency, which is
+/// `js_install`'s concern, not this one-hop config-file scan's.
+fn resolve_config_import_specifier(config_dir: &Path, specifier: &str) -> Option<PathBuf> {
+    if !(specifier.starts_with("./") || specifier.starts_with("../")) {
+        return None;
+    }
+    probe_first_party_path(&config_dir.join(specifier))
+}
+
+/// Recursively resolve every additional first-party file a test-runner
+/// config's own content names or imports: [`RUNNER_CONFIG_FILE_KEYS`]
+/// entries, plus a relative `import`/`require` of a shared base config
+/// (`import base from '../../vitest.config.base'`) — which may itself name
+/// or import more, so each newly-resolved file is scanned the same way in
+/// turn. Bounded depth + a visited set guard against a cyclic/self-importing
+/// config; in practice a real config chain is one or two files deep.
+///
+/// **Known scope trim, disclosed rather than silent**: only a *relative*
+/// import/require inside the config file is followed — a shared base config
+/// pulled in via a bare package specifier (e.g. an internal
+/// `@myorg/test-config` package) is not, the same "third-party is
+/// `js_install`'s job" boundary `test_deps_config` draws elsewhere for the
+/// test file's own closure.
+pub fn resolve_runner_config_referenced_files(
+    config_path: &Path,
+    config_content: &str,
+) -> anyhow::Result<Vec<PathBuf>> {
+    const MAX_DEPTH: usize = 4;
+    let mut seen: HashSet<PathBuf> = HashSet::new();
+    let mut found: BTreeSet<PathBuf> = BTreeSet::new();
+    let mut queue: VecDeque<(PathBuf, String, usize)> = VecDeque::new();
+    seen.insert(config_path.to_path_buf());
+    queue.push_back((config_path.to_path_buf(), config_content.to_string(), 0));
+
+    while let Some((path, content, depth)) = queue.pop_front() {
+        if depth >= MAX_DEPTH {
+            continue;
+        }
+        let dir = path.parent().unwrap_or(Path::new(""));
+
+        for raw in extract_runner_config_referenced_paths(&path, &content) {
+            if let Some(resolved) = resolve_config_value_path(dir, &raw) {
+                enqueue_referenced_config_file(resolved, depth, &mut seen, &mut found, &mut queue);
+            }
+        }
+
+        // A config file with an unrecognized extension (e.g. `.json`, which
+        // `importparse::parse_file_imports` can't parse as a module) simply
+        // yields no import sites here — not an error, since `.json` config
+        // files (jest's `jest.config.json`) never `import` anything anyway.
+        if let Ok(imports) = importparse::parse_file_imports(&path, &content) {
+            for site in imports.sites {
+                if let Some(resolved) = resolve_config_import_specifier(dir, &site.specifier) {
+                    enqueue_referenced_config_file(
+                        resolved, depth, &mut seen, &mut found, &mut queue,
+                    );
+                }
+            }
+        }
+    }
+
+    Ok(found.into_iter().collect())
+}
+
+/// Record a newly-resolved referenced-config file (if not already seen) and
+/// queue it for its own scan one depth deeper — the shared "insert once,
+/// re-read, re-enqueue" step [`resolve_runner_config_referenced_files`]'s two
+/// call sites (config-value paths, config-file imports) both need.
+fn enqueue_referenced_config_file(
+    resolved: PathBuf,
+    depth: usize,
+    seen: &mut HashSet<PathBuf>,
+    found: &mut BTreeSet<PathBuf>,
+    queue: &mut VecDeque<(PathBuf, String, usize)>,
+) {
+    if seen.insert(resolved.clone()) {
+        found.insert(resolved.clone());
+        if let Ok(next_content) = std::fs::read_to_string(&resolved) {
+            queue.push_back((resolved, next_content, depth + 1));
         }
     }
 }
@@ -747,6 +1050,178 @@ pub fn package_source_files(
     let mut files = Vec::new();
     collect_source_files(walker, &pkg_dir, true, &mut files)?;
     Ok(files)
+}
+
+/// Every first-party source file directly owned by `pkg` (see
+/// [`package_source_files`]) whose path, relative to the package directory,
+/// matches at least one of `patterns` (wax glob syntax) — `js_test`'s
+/// per-test-file target discovery
+/// (`ai-docs/js-plugin-plan.md`'s `js_test` milestone: "one `js_test` target
+/// per test file", matched by a configurable glob).
+///
+/// Returned paths are workspace-root-relative strings, sorted, so target
+/// discovery is deterministic across filesystem-walk order/platform — same
+/// discipline as `resolve_members`/`typecheck_deps_config`'s own sorted
+/// output.
+pub fn discover_test_files(
+    walker: &CachedWalker,
+    workspace_root: &Path,
+    pkg: &str,
+    patterns: &[String],
+) -> anyhow::Result<Vec<String>> {
+    let pkg_dir = if pkg.is_empty() {
+        workspace_root.to_path_buf()
+    } else {
+        workspace_root.join(pkg)
+    };
+    let globs: Vec<Glob<'_>> = patterns
+        .iter()
+        .map(|p| Glob::new(p).with_context(|| format!("invalid js_test test_glob {p:?}")))
+        .collect::<anyhow::Result<_>>()?;
+
+    let files = package_source_files(walker, workspace_root, pkg)?;
+    let mut matched: Vec<String> = files
+        .into_iter()
+        .filter_map(|f| {
+            let rel = f.strip_prefix(&pkg_dir).unwrap_or(&f);
+            if globs.iter().any(|g| g.is_match(rel)) {
+                Some(
+                    f.strip_prefix(workspace_root)
+                        .unwrap_or(&f)
+                        .to_string_lossy()
+                        .replace('\\', "/"),
+                )
+            } else {
+                None
+            }
+        })
+        .collect();
+    matched.sort();
+    Ok(matched)
+}
+
+/// One test file's own runtime-transitive first-party closure within its
+/// owning package, plus everything it reaches just outside that boundary —
+/// see [`build_test_closure`].
+#[derive(Debug, Clone, Default)]
+pub struct TestClosure {
+    /// Workspace-relative paths of every first-party file, *within the same
+    /// package*, transitively reachable from the test file via
+    /// `ImportGraph::runtime_edges` — always includes the test file itself.
+    /// This is the per-test-file (not per-package) declared `Input` set that
+    /// is this milestone's stated differentiator over Turborepo/Nx (see
+    /// `ai-docs/js-plugin-plan.md`'s "Caching / incrementality" section).
+    pub files: BTreeSet<String>,
+    /// Workspace-relative paths of every file a closure member's own edge
+    /// resolved *outside* the owning package (a workspace sibling, or a
+    /// third-party package reached while `node_modules` happens to be
+    /// installed) — recorded but **not** recursed into further, the same
+    /// "one-hop" trim `js_typecheck`'s type-edge handling already accepts
+    /// (see `driver_typecheck.rs` module docs' "Known scope trims"). TODO
+    /// M4+: recurse into a workspace sibling's own import graph once
+    /// cross-package graph construction exists.
+    pub external_files: BTreeSet<String>,
+    /// Bare specifiers that never resolved on disk, restricted to sites
+    /// inside `files` — the ambient-`node_modules`-absent counterpart to
+    /// `external_files`, resolved by package name via
+    /// `deps::resolve_one_dependency` at the call site (see `provider.rs`'s
+    /// `test_deps_config`), mirroring `typecheck_deps_config`'s identical
+    /// on-demand third-party handling.
+    pub bare_specifiers: Vec<BareSpecifierSite>,
+}
+
+/// BFS `test_file_rel`'s own `ImportGraph::runtime_edges` closure, bounded to
+/// files first-party-owned by `pkg` (`canonical_workspace_root.join(pkg)`) —
+/// see [`TestClosure`]'s doc for exactly what counts as "in" vs. "one-hop
+/// external". `graph` must be `pkg`'s own whole-package import graph (as
+/// built by [`build_package_import_graph`]) — this never re-parses source
+/// itself, only walks the edges already resolved for `pkg`.
+///
+/// `canonical_workspace_root` must already be canonicalized (`edge.resolved`
+/// is realpath'd by `oxc_resolver` — see `check_phantom_dependencies`'s
+/// identical canonicalization requirement and its doc for why comparing
+/// against a non-canonical root silently breaks containment on a host where
+/// an ancestor of the workspace is itself a symlink).
+pub fn build_test_closure(
+    graph: &ImportGraph,
+    canonical_workspace_root: &Path,
+    pkg: &str,
+    test_file_rel: &str,
+) -> anyhow::Result<TestClosure> {
+    let pkg_dir = if pkg.is_empty() {
+        canonical_workspace_root.to_path_buf()
+    } else {
+        canonical_workspace_root.join(pkg)
+    };
+
+    let mut edges_by_file: HashMap<&str, Vec<&ResolvedEdge>> = HashMap::new();
+    for edge in &graph.runtime_edges {
+        edges_by_file
+            .entry(edge.file.as_str())
+            .or_default()
+            .push(edge);
+    }
+    let mut bare_by_file: HashMap<&str, Vec<&BareSpecifierSite>> = HashMap::new();
+    for site in &graph.unresolved_bare_specifiers {
+        bare_by_file
+            .entry(site.file.as_str())
+            .or_default()
+            .push(site);
+    }
+
+    let mut closure = TestClosure::default();
+    closure.files.insert(test_file_rel.to_string());
+    let mut queue: VecDeque<String> = VecDeque::new();
+    queue.push_back(test_file_rel.to_string());
+
+    while let Some(current) = queue.pop_front() {
+        if let Some(sites) = bare_by_file.get(current.as_str()) {
+            for site in sites {
+                closure.bare_specifiers.push((*site).clone());
+            }
+        }
+        let Some(edges) = edges_by_file.get(current.as_str()) else {
+            continue;
+        };
+        for edge in edges {
+            if edge.resolved.starts_with(&pkg_dir) {
+                let rel = edge
+                    .resolved
+                    .strip_prefix(canonical_workspace_root)
+                    .with_context(|| {
+                        format!(
+                            "js_test: {:?} resolved to {:?}, inside the package directory but \
+                             outside the canonicalized workspace root ({:?}) — cannot express it \
+                             as a declared js_test input",
+                            edge.file, edge.resolved, canonical_workspace_root
+                        )
+                    })?
+                    .to_string_lossy()
+                    .replace('\\', "/");
+                if closure.files.insert(rel.clone()) {
+                    queue.push_back(rel);
+                }
+            } else {
+                let rel = edge
+                    .resolved
+                    .strip_prefix(canonical_workspace_root)
+                    .with_context(|| {
+                        format!(
+                            "js_test: {:?} imports from {:?}, which resolved outside the \
+                             workspace root ({:?}) — cannot express it as a declared js_test \
+                             input (this typically means node_modules is a symlink to a global \
+                             store outside the workspace)",
+                            edge.file, edge.resolved, canonical_workspace_root
+                        )
+                    })?
+                    .to_string_lossy()
+                    .replace('\\', "/");
+                closure.external_files.insert(rel);
+            }
+        }
+    }
+
+    Ok(closure)
 }
 
 /// Build the import graph for every first-party source file directly owned
@@ -1574,5 +2049,438 @@ mod tests {
         let msg = format!("{err:#}");
         assert!(msg.contains("packages/a/src/index.ts"), "{msg}");
         assert!(msg.contains("escaped"), "{msg}");
+    }
+
+    // ---- js_test: discover_test_files / find_nearest_test_runner_config / build_test_closure ----
+
+    #[test]
+    fn discover_test_files_matches_configured_globs_only() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        write(dir.path(), "packages/a/package.json", r#"{"name":"a"}"#);
+        write(
+            dir.path(),
+            "packages/a/src/index.ts",
+            "export const x = 1;\n",
+        );
+        write(
+            dir.path(),
+            "packages/a/src/index.test.ts",
+            "import { x } from './index'; test('x', () => x);\n",
+        );
+        write(
+            dir.path(),
+            "packages/a/src/other.spec.tsx",
+            "test('y', () => 1);\n",
+        );
+
+        let patterns = vec![
+            "**/*.test.{ts,tsx,js,jsx}".to_string(),
+            "**/*.spec.{ts,tsx,js,jsx}".to_string(),
+        ];
+        let files =
+            discover_test_files(&walker(), dir.path(), "packages/a", &patterns).expect("discover");
+        assert_eq!(
+            files,
+            vec![
+                "packages/a/src/index.test.ts".to_string(),
+                "packages/a/src/other.spec.tsx".to_string(),
+            ]
+        );
+    }
+
+    #[test]
+    fn discover_test_files_empty_when_no_match() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        write(dir.path(), "packages/a/package.json", r#"{"name":"a"}"#);
+        write(
+            dir.path(),
+            "packages/a/src/index.ts",
+            "export const x = 1;\n",
+        );
+        let patterns = vec!["**/*.test.{ts,tsx,js,jsx}".to_string()];
+        let files =
+            discover_test_files(&walker(), dir.path(), "packages/a", &patterns).expect("discover");
+        assert!(files.is_empty());
+    }
+
+    #[test]
+    fn find_nearest_test_runner_config_walks_up_like_tsconfig() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        write(dir.path(), "vitest.config.ts", "export default {};\n");
+        write(dir.path(), "packages/a/package.json", r#"{"name":"a"}"#);
+        let found = find_nearest_test_runner_config(
+            dir.path(),
+            &dir.path().join("packages/a"),
+            &["vitest.config.ts", "vitest.config.js"],
+        )
+        .expect("found");
+        assert_eq!(found, dir.path().join("vitest.config.ts"));
+    }
+
+    #[test]
+    fn find_nearest_test_runner_config_none_when_absent() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        write(dir.path(), "packages/a/package.json", r#"{"name":"a"}"#);
+        assert!(
+            find_nearest_test_runner_config(
+                dir.path(),
+                &dir.path().join("packages/a"),
+                &["vitest.config.ts"],
+            )
+            .is_none()
+        );
+    }
+
+    #[test]
+    fn find_nearest_jest_package_json_config_walks_up_to_the_ancestor_that_has_it() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        write(
+            dir.path(),
+            "package.json",
+            r#"{"name":"root","jest":{"testEnvironment":"node"}}"#,
+        );
+        write(dir.path(), "packages/a/package.json", r#"{"name":"a"}"#);
+        let found =
+            find_nearest_jest_package_json_config(dir.path(), &dir.path().join("packages/a"))
+                .expect("found");
+        assert_eq!(found, dir.path().join("package.json"));
+    }
+
+    #[test]
+    fn find_nearest_jest_package_json_config_prefers_closest() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        write(
+            dir.path(),
+            "package.json",
+            r#"{"name":"root","jest":{"testEnvironment":"node"}}"#,
+        );
+        write(
+            dir.path(),
+            "packages/a/package.json",
+            r#"{"name":"a","jest":{"testEnvironment":"jsdom"}}"#,
+        );
+        let found =
+            find_nearest_jest_package_json_config(dir.path(), &dir.path().join("packages/a"))
+                .expect("found");
+        assert_eq!(found, dir.path().join("packages/a/package.json"));
+    }
+
+    #[test]
+    fn find_nearest_jest_package_json_config_none_without_a_jest_field() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        write(dir.path(), "package.json", r#"{"name":"root"}"#);
+        write(dir.path(), "packages/a/package.json", r#"{"name":"a"}"#);
+        assert!(
+            find_nearest_jest_package_json_config(dir.path(), &dir.path().join("packages/a"))
+                .is_none()
+        );
+    }
+
+    #[test]
+    fn extract_runner_config_referenced_paths_finds_single_string_and_array_values() {
+        let path = Path::new("vitest.config.ts");
+        let content = "export default { test: { \
+                        setupFiles: './single-setup.ts', \
+                        setupFilesAfterEnv: ['./after-env-1.ts', './after-env-2.ts'], \
+                        globalSetup: './global-setup.ts', \
+                        unrelatedKey: './not-collected.ts' \
+                        } };\n";
+        let mut found = extract_runner_config_referenced_paths(path, content);
+        found.sort();
+        assert_eq!(
+            found,
+            vec![
+                "./after-env-1.ts",
+                "./after-env-2.ts",
+                "./global-setup.ts",
+                "./single-setup.ts",
+            ]
+        );
+    }
+
+    #[test]
+    fn extract_runner_config_referenced_paths_empty_on_unparseable_content() {
+        let path = Path::new("jest.config.js");
+        let found = extract_runner_config_referenced_paths(path, "not valid js {{{");
+        assert!(found.is_empty(), "{found:?}");
+    }
+
+    #[test]
+    fn resolve_runner_config_referenced_files_resolves_root_dir_token_and_recurses_into_base_config()
+     {
+        let dir = tempfile::tempdir().expect("tempdir");
+        write(
+            dir.path(),
+            "vitest.config.base.ts",
+            "export default { test: { setupFiles: ['<rootDir>/base.setup.ts'] } };\n",
+        );
+        write(dir.path(), "base.setup.ts", "globalThis.__base = true;\n");
+        write(
+            dir.path(),
+            "vitest.config.ts",
+            "import base from './vitest.config.base';\n\
+             export default { ...base, test: { ...base.test, setupFiles: ['./leaf.setup.ts'] } };\n",
+        );
+        write(dir.path(), "leaf.setup.ts", "globalThis.__leaf = true;\n");
+
+        let config_path = dir.path().join("vitest.config.ts");
+        let content = std::fs::read_to_string(&config_path).expect("read fixture");
+        let mut refs = resolve_runner_config_referenced_files(&config_path, &content)
+            .expect("resolve referenced files");
+        refs.sort();
+
+        assert_eq!(
+            refs,
+            vec![
+                dir.path().join("base.setup.ts"),
+                dir.path().join("leaf.setup.ts"),
+                dir.path().join("vitest.config.base.ts"),
+            ]
+        );
+    }
+
+    #[test]
+    fn resolve_runner_config_referenced_files_empty_when_config_names_nothing() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let config_path = dir.path().join("vitest.config.ts");
+        let content = "export default { test: {} };\n";
+        write(dir.path(), "vitest.config.ts", content);
+        let refs = resolve_runner_config_referenced_files(&config_path, content)
+            .expect("resolve referenced files");
+        assert!(refs.is_empty(), "{refs:?}");
+    }
+
+    /// The single most important test in this milestone (per the task): the
+    /// closure for one test file must include only files transitively
+    /// reachable *from that file*, not every file in the package — an
+    /// unrelated sibling test file (and the source it alone imports) must
+    /// stay out of the closure entirely.
+    #[test]
+    fn build_test_closure_is_scoped_to_the_one_test_files_own_imports() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        write(dir.path(), "packages/a/package.json", r#"{"name":"a"}"#);
+        write(dir.path(), "packages/a/src/a.ts", "export const a = 1;\n");
+        write(dir.path(), "packages/a/src/b.ts", "export const b = 2;\n");
+        write(
+            dir.path(),
+            "packages/a/src/a.test.ts",
+            "import { a } from './a';\ntest('a', () => a);\n",
+        );
+        write(
+            dir.path(),
+            "packages/a/src/b.test.ts",
+            "import { b } from './b';\ntest('b', () => b);\n",
+        );
+
+        let resolvers = Resolvers::new(None);
+        let cache = ResolveCache::new();
+        let graph = build_package_import_graph(
+            &walker(),
+            dir.path(),
+            "packages/a",
+            &resolvers,
+            &cache,
+            None,
+        )
+        .expect("build graph");
+
+        let canonical_root = dir.path().canonicalize().expect("canonicalize");
+        let closure = build_test_closure(
+            &graph,
+            &canonical_root,
+            "packages/a",
+            "packages/a/src/a.test.ts",
+        )
+        .expect("build closure");
+
+        assert!(closure.files.contains("packages/a/src/a.test.ts"));
+        assert!(closure.files.contains("packages/a/src/a.ts"));
+        assert!(
+            !closure.files.contains("packages/a/src/b.ts"),
+            "b.ts is only imported by b.test.ts, never by a.test.ts: {:?}",
+            closure.files
+        );
+        assert!(
+            !closure.files.contains("packages/a/src/b.test.ts"),
+            "an unrelated sibling test file must never appear in a.test.ts's own closure: {:?}",
+            closure.files
+        );
+    }
+
+    /// A file reached transitively (test -> helper -> deep) must also be in
+    /// the closure, not just the test file's own direct imports.
+    #[test]
+    fn build_test_closure_follows_transitive_first_party_imports() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        write(dir.path(), "packages/a/package.json", r#"{"name":"a"}"#);
+        write(
+            dir.path(),
+            "packages/a/src/deep.ts",
+            "export const deep = 1;\n",
+        );
+        write(
+            dir.path(),
+            "packages/a/src/helper.ts",
+            "export { deep } from './deep';\n",
+        );
+        write(
+            dir.path(),
+            "packages/a/src/a.test.ts",
+            "import { deep } from './helper';\ntest('a', () => deep);\n",
+        );
+
+        let resolvers = Resolvers::new(None);
+        let cache = ResolveCache::new();
+        let graph = build_package_import_graph(
+            &walker(),
+            dir.path(),
+            "packages/a",
+            &resolvers,
+            &cache,
+            None,
+        )
+        .expect("build graph");
+
+        let canonical_root = dir.path().canonicalize().expect("canonicalize");
+        let closure = build_test_closure(
+            &graph,
+            &canonical_root,
+            "packages/a",
+            "packages/a/src/a.test.ts",
+        )
+        .expect("build closure");
+
+        assert!(closure.files.contains("packages/a/src/helper.ts"));
+        assert!(
+            closure.files.contains("packages/a/src/deep.ts"),
+            "a transitively-reached file must be in the closure: {:?}",
+            closure.files
+        );
+    }
+
+    /// An import that resolves outside the owning package (a workspace
+    /// sibling) lands in `external_files`, one-hop only — it is not itself
+    /// recursed into.
+    #[test]
+    fn build_test_closure_records_cross_package_import_as_external_one_hop() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        write(
+            dir.path(),
+            "packages/a/package.json",
+            r#"{"name":"a","dependencies":{"b":"workspace:*"}}"#,
+        );
+        write(
+            dir.path(),
+            "packages/a/src/a.test.ts",
+            "import { x } from '../../b/src/index';\ntest('a', () => x);\n",
+        );
+        write(dir.path(), "packages/b/package.json", r#"{"name":"b"}"#);
+        write(
+            dir.path(),
+            "packages/b/src/index.ts",
+            "export const x = 1;\n",
+        );
+
+        let resolvers = Resolvers::new(None);
+        let cache = ResolveCache::new();
+        let graph = build_package_import_graph(
+            &walker(),
+            dir.path(),
+            "packages/a",
+            &resolvers,
+            &cache,
+            None,
+        )
+        .expect("build graph");
+
+        let canonical_root = dir.path().canonicalize().expect("canonicalize");
+        let closure = build_test_closure(
+            &graph,
+            &canonical_root,
+            "packages/a",
+            "packages/a/src/a.test.ts",
+        )
+        .expect("build closure");
+
+        assert!(
+            closure.external_files.contains("packages/b/src/index.ts"),
+            "{:?}",
+            closure.external_files
+        );
+        assert!(!closure.files.contains("packages/b/src/index.ts"));
+    }
+
+    /// Pins the *boundary* of the accepted "one-hop external" trim (see this
+    /// module's `TestClosure` doc and `driver_test.rs`'s module docs): the
+    /// externally-reached file itself (`packages/b/src/index.ts`) is
+    /// declared, but its own further import (`packages/b/src/helper.ts`,
+    /// reached only because `index.ts` re-exports it — the common
+    /// barrel-file pattern) is not walked or declared anywhere, in either
+    /// `files` or `external_files`. A feature-quality M4 review flagged this
+    /// as untested: without this test, nothing pins *where* the accepted
+    /// trim stops, so a future change that accidentally started following
+    /// one more hop (or stopped following the first) would not be caught.
+    #[test]
+    fn build_test_closure_does_not_follow_the_cross_package_files_own_further_imports() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        write(
+            dir.path(),
+            "packages/a/package.json",
+            r#"{"name":"a","dependencies":{"b":"workspace:*"}}"#,
+        );
+        write(
+            dir.path(),
+            "packages/a/src/a.test.ts",
+            "import { x } from '../../b/src/index';\ntest('a', () => x);\n",
+        );
+        write(dir.path(), "packages/b/package.json", r#"{"name":"b"}"#);
+        // `index.ts` re-exports `helper.ts` — the common barrel-file
+        // pattern. A test reaching only `index.ts` directly must not also
+        // get `helper.ts`'s own content folded into its declared Input set.
+        write(
+            dir.path(),
+            "packages/b/src/index.ts",
+            "export { x } from './helper';\n",
+        );
+        write(
+            dir.path(),
+            "packages/b/src/helper.ts",
+            "export const x = 1;\n",
+        );
+
+        let resolvers = Resolvers::new(None);
+        let cache = ResolveCache::new();
+        let graph = build_package_import_graph(
+            &walker(),
+            dir.path(),
+            "packages/a",
+            &resolvers,
+            &cache,
+            None,
+        )
+        .expect("build graph");
+
+        let canonical_root = dir.path().canonicalize().expect("canonicalize");
+        let closure = build_test_closure(
+            &graph,
+            &canonical_root,
+            "packages/a",
+            "packages/a/src/a.test.ts",
+        )
+        .expect("build closure");
+
+        assert!(
+            closure.external_files.contains("packages/b/src/index.ts"),
+            "the one-hop external file itself must still be declared: {:?}",
+            closure.external_files
+        );
+        assert!(
+            !closure.external_files.contains("packages/b/src/helper.ts")
+                && !closure.files.contains("packages/b/src/helper.ts"),
+            "the externally-reached file's own further import must NOT be followed — this pins \
+             the accepted one-hop trim's boundary: files={:?} external_files={:?}",
+            closure.files,
+            closure.external_files
+        );
     }
 }

--- a/crates/plugin-js/src/pluginjs/mod.rs
+++ b/crates/plugin-js/src/pluginjs/mod.rs
@@ -3,6 +3,7 @@ mod conformance;
 mod deps;
 mod driver_install;
 mod driver_package_info;
+mod driver_test;
 mod driver_typecheck;
 mod importgraph;
 mod importparse;
@@ -17,6 +18,7 @@ mod workspace;
 
 pub use driver_install::JsInstallDriver;
 pub use driver_package_info::JsPackageInfoDriver;
+pub use driver_test::JsTestDriver;
 pub use driver_typecheck::JsTypecheckDriver;
 pub use provider::{Config, Provider};
 pub use workspace::{PkgManager, WorkspaceMember};
@@ -39,6 +41,12 @@ pub const PACKAGE_INFO_TARGET: &str = "package_info";
 /// nearest ancestor tsconfig's equivalent) over one package at a time. See
 /// `driver_typecheck.rs` module docs.
 pub const TYPECHECK_TARGET: &str = "js_typecheck";
+
+/// Target name of the M4 `js_test` target: runs the configured test runner
+/// (`vitest` default, `jest` alt) against one test file at a time — one
+/// target address per matched test file (distinguished by a `file` addr
+/// arg), never one per package. See `driver_test.rs` module docs.
+pub const TEST_TARGET: &str = "js_test";
 
 /// Directory names that are never a package boundary or workspace member,
 /// however deep they appear: `node_modules` is third-party/manager-owned

--- a/crates/plugin-js/src/pluginjs/provider.rs
+++ b/crates/plugin-js/src/pluginjs/provider.rs
@@ -1,8 +1,8 @@
 use crate::pluginjs::lockfile::{self, Lockfile, ResolvedGraph};
 use crate::pluginjs::workspace::{self, PkgManager, WorkspaceMember};
 use crate::pluginjs::{
-    PACKAGE_INFO_TARGET, PACKAGE_JSON, TYPECHECK_TARGET, deps, importgraph, is_skipped_dir_name,
-    package_json, platform, resolvers, thirdparty, toolchain,
+    PACKAGE_INFO_TARGET, PACKAGE_JSON, TEST_TARGET, TYPECHECK_TARGET, deps, importgraph,
+    is_skipped_dir_name, package_json, platform, resolvers, thirdparty, toolchain,
 };
 use anyhow::Context;
 use enclose::enclose;
@@ -22,6 +22,14 @@ use std::collections::{BTreeMap, HashMap};
 use std::path::{Path, PathBuf};
 use std::sync::Arc;
 use tokio::sync::OnceCell;
+
+/// Default `js_test` test-file globs, applied when the provider's
+/// `test_glob` option is absent — mirrors vitest's own default
+/// (`**/*.{test,spec}.?(c|m)[jt]s?(x)`) and jest's `**/?(*.)+(spec|test).[tj]s?(x)`
+/// convention (jest's separate `**/__tests__/**/*` convention is not matched
+/// — a disclosed scope trim, not silent; see `driver_test.rs` module docs).
+/// Matches this task's own example glob.
+const DEFAULT_TEST_GLOBS: &[&str] = &["**/*.test.{ts,tsx,js,jsx}", "**/*.spec.{ts,tsx,js,jsx}"];
 
 /// Provider construction config. See [`Provider::from_options`] for how each
 /// field is populated from the provider's `options:` map.
@@ -50,6 +58,15 @@ pub struct Config {
     /// working value — unlike `pkgmanager`, there is no genuine ambiguity to
     /// force an explicit choice over.
     pub tstool: String,
+    /// Which test runner `js_test` invokes — `"vitest"` (default) or
+    /// `"jest"`, per `ai-docs/js-plugin-plan.md`'s `js_test` row. Same
+    /// provider-level, host-toolchain shape as `tstool` — see
+    /// `toolchain::resolve_host_test_runner`.
+    pub testrunner: String,
+    /// Glob patterns (wax syntax) a package's own first-party source files
+    /// are matched against to discover `js_test` targets. Defaults to
+    /// [`DEFAULT_TEST_GLOBS`] when unset — see that constant's doc for why.
+    pub test_glob: Vec<String>,
 }
 
 impl Config {
@@ -60,6 +77,11 @@ impl Config {
             walker: Arc::new(CachedWalker::disabled()),
             allow_scripts: Vec::new(),
             tstool: toolchain::HOST.to_string(),
+            testrunner: toolchain::VITEST.to_string(),
+            test_glob: DEFAULT_TEST_GLOBS
+                .iter()
+                .map(|s| (*s).to_string())
+                .collect(),
         }
     }
 }
@@ -71,6 +93,8 @@ pub struct Provider {
     walker: Arc<CachedWalker>,
     allow_scripts: Vec<String>,
     tstool: String,
+    testrunner: String,
+    test_glob: Vec<String>,
     /// Lazily parsed lockfile (`None` when the workspace has none) and its
     /// derived [`ResolvedGraph`] — each `Provider::get` for a third-party
     /// `js_install` addr or a package's declared deps would otherwise
@@ -87,6 +111,14 @@ pub struct Provider {
     /// every single invocation, including a 100%-cache-hit run (M3 review
     /// finding).
     tsc_cache: OnceCell<Arc<(PathBuf, String)>>,
+    /// Lazily resolved host test-runner binary path + queried `--version`,
+    /// cached once for the `Provider`'s lifetime — same rationale as
+    /// `tsc_cache`: `test_config` runs once per `js_test` target (one per
+    /// test *file*, potentially many per package) per `Provider::get`, so
+    /// re-resolving and re-spawning `<runner> --version` per target would
+    /// scale a real subprocess cost with the number of test files, not just
+    /// packages.
+    testrunner_cache: OnceCell<Arc<(PathBuf, String)>>,
 }
 
 impl Provider {
@@ -108,7 +140,14 @@ impl Provider {
         hplugin::config::deny_unknown(
             "js provider",
             opts,
-            &["pkgmanager", "skip", "allow_scripts", "tstool"],
+            &[
+                "pkgmanager",
+                "skip",
+                "allow_scripts",
+                "tstool",
+                "testrunner",
+                "test_glob",
+            ],
         )?;
         let pkgmanager_str: String =
             hplugin::config::decode_opt(opts, "js provider", "pkgmanager")?.ok_or_else(|| {
@@ -134,6 +173,25 @@ impl Provider {
         let tstool: String = hplugin::config::decode_opt(opts, "js provider", "tstool")?
             .unwrap_or_else(|| toolchain::HOST.to_string());
 
+        // See `Config::testrunner`'s doc: defaults to the design doc's
+        // recommended default.
+        let testrunner: String = hplugin::config::decode_opt(opts, "js provider", "testrunner")?
+            .unwrap_or_else(|| toolchain::VITEST.to_string());
+        anyhow::ensure!(
+            toolchain::is_supported_testrunner(&testrunner),
+            "js provider: unsupported `testrunner` {testrunner:?} — expected \"vitest\" or \"jest\""
+        );
+
+        // See `DEFAULT_TEST_GLOBS`'s doc: defaults to vitest/jest's own
+        // conventions when unset.
+        let test_glob: Vec<String> = hplugin::config::decode_opt(opts, "js provider", "test_glob")?
+            .unwrap_or_else(|| {
+                DEFAULT_TEST_GLOBS
+                    .iter()
+                    .map(|s| (*s).to_string())
+                    .collect()
+            });
+
         Ok(Self::with_config(
             workspace_root,
             Config {
@@ -142,6 +200,8 @@ impl Provider {
                 walker,
                 allow_scripts,
                 tstool,
+                testrunner,
+                test_glob,
             },
         ))
     }
@@ -154,9 +214,12 @@ impl Provider {
             walker: config.walker,
             allow_scripts: config.allow_scripts,
             tstool: config.tstool,
+            testrunner: config.testrunner,
+            test_glob: config.test_glob,
             lockfile_cache: OnceCell::new(),
             resolved_graph_cache: OnceCell::new(),
             tsc_cache: OnceCell::new(),
+            testrunner_cache: OnceCell::new(),
         }
     }
 
@@ -267,6 +330,34 @@ impl Provider {
                     let tsc_version = toolchain::query_tsc_version(&tsc_bin)
                         .with_context(|| format!("querying {tsc_bin:?} --version"))?;
                     Ok(Arc::new((tsc_bin, tsc_version)))
+                })
+                .await
+            })
+            .await?;
+        Ok(Arc::clone(result))
+    }
+
+    /// The host test-runner binary path and its queried `--version`, resolved
+    /// once and cached for the `Provider`'s lifetime — see
+    /// [`Provider::testrunner_cache`]'s doc for why this matters.
+    async fn resolved_host_test_runner(&self) -> anyhow::Result<Arc<(PathBuf, String)>> {
+        let workspace_root = self.workspace_root.clone();
+        let testrunner = self.testrunner.clone();
+        let result = self
+            .testrunner_cache
+            .get_or_try_init(|| async move {
+                anyhow::ensure!(
+                    toolchain::is_supported_testrunner(&testrunner),
+                    "js provider: unsupported testrunner {testrunner:?} — only \"vitest\" or \
+                     \"jest\" is supported in this milestone; see pluginjs::toolchain module docs"
+                );
+                hcore::blocking::run(move || -> anyhow::Result<Arc<(PathBuf, String)>> {
+                    let runner_bin =
+                        toolchain::resolve_host_test_runner(&workspace_root, &testrunner)
+                            .context("resolving the js_test runner toolchain")?;
+                    let runner_version = toolchain::query_test_runner_version(&runner_bin)
+                        .with_context(|| format!("querying {runner_bin:?} --version"))?;
+                    Ok(Arc::new((runner_bin, runner_version)))
                 })
                 .await
             })
@@ -404,7 +495,14 @@ impl Provider {
     /// docs for why the version is queried here (spec-resolution time) and
     /// not deferred to the driver's `run()`.
     async fn typecheck_config(&self, pkg: &PkgBuf) -> anyhow::Result<HashMap<String, Value>> {
-        let (tsc_bin, tsc_version) = self.resolved_host_tsc().await?.as_ref().clone();
+        // Read straight out of the cached `Arc`'s fields rather than cloning
+        // the whole tuple: `tsc_bin` only ever ends up re-stringified via
+        // `to_string_lossy().into_owned()` below, so cloning the `PathBuf`
+        // first (via `.as_ref().clone()`) would allocate a copy that's
+        // immediately discarded.
+        let resolved_tsc = self.resolved_host_tsc().await?;
+        let tsc_bin = resolved_tsc.0.to_string_lossy().into_owned();
+        let tsc_version = resolved_tsc.1.clone();
         let lockfile = self.lockfile().await?;
         let resolved_graph = self.resolved_graph().await?;
         let workspace_root = self.workspace_root.clone();
@@ -456,15 +554,119 @@ impl Provider {
             .with_context(|| format!("building js_typecheck inputs for {pkg_str:?}"))?;
 
             let mut config: HashMap<String, Value> = HashMap::new();
-            config.insert(
-                "tsc_bin".to_string(),
-                Value::String(tsc_bin.to_string_lossy().into_owned()),
-            );
+            config.insert("tsc_bin".to_string(), Value::String(tsc_bin));
             config.insert("tsc_version".to_string(), Value::String(tsc_version));
             config.insert("tsconfig_path".to_string(), Value::String(tsconfig_path));
             config.insert(
                 "tsconfig_content".to_string(),
                 Value::String(tsconfig_content),
+            );
+            config.insert("deps".to_string(), Value::Map(deps));
+            Ok(config)
+        })
+        .await
+    }
+
+    /// Discover this package's own `js_test` test files (see
+    /// `importgraph::discover_test_files`), matched against the provider's
+    /// configured `test_glob`. Workspace-root-relative paths, sorted.
+    async fn discover_test_files(&self, pkg: &PkgBuf) -> anyhow::Result<Vec<String>> {
+        let workspace_root = self.workspace_root.clone();
+        let walker = Arc::clone(&self.walker);
+        let pkg_str = pkg.as_str().to_string();
+        let test_glob = self.test_glob.clone();
+        hcore::blocking::run(move || -> anyhow::Result<Vec<String>> {
+            importgraph::discover_test_files(&walker, &workspace_root, &pkg_str, &test_glob)
+        })
+        .await
+        .with_context(|| format!("discovering js_test targets for {}", pkg.as_str()))
+    }
+
+    /// Build the config for one `js_test` target (one test file): the host
+    /// runner toolchain resolution/version-query this milestone's disclosed
+    /// `testrunner`-is-host-resolved escape hatch requires (see
+    /// `toolchain.rs` module docs for why the version is queried here, at
+    /// spec-resolution time, rather than deferred to the driver's `run()`)
+    /// plus `test_deps_config`'s pure, runner-free Input-scoping.
+    async fn test_config(
+        &self,
+        pkg: &PkgBuf,
+        test_file_rel: &str,
+    ) -> anyhow::Result<HashMap<String, Value>> {
+        // See `typecheck_config`'s identical fix: read the cached `Arc`'s
+        // fields directly instead of cloning the whole tuple, since
+        // `runner_bin` only ever ends up re-stringified below.
+        let resolved_test_runner = self.resolved_host_test_runner().await?;
+        let runner_bin = resolved_test_runner.0.to_string_lossy().into_owned();
+        let runner_version = resolved_test_runner.1.clone();
+        let lockfile = self.lockfile().await?;
+        let resolved_graph = self.resolved_graph().await?;
+        let workspace_root = self.workspace_root.clone();
+        let walker = Arc::clone(&self.walker);
+        let skip = Arc::clone(&self.skip);
+        let pkgmanager = self.pkgmanager;
+        let testrunner = self.testrunner.clone();
+        let pkg_str = pkg.as_str().to_string();
+        let test_file_rel = test_file_rel.to_string();
+        let goos = platform::current_goos();
+        let goarch = platform::current_goarch();
+
+        hcore::blocking::run(move || -> anyhow::Result<HashMap<String, Value>> {
+            // Same workspace-member discovery `Provider::typecheck_config`
+            // does in its own blocking closure — needed here too so an
+            // import that never resolved on disk can still be attributed to
+            // a workspace sibling by name.
+            let patterns = match pkgmanager {
+                PkgManager::Npm => workspace::read_npm_workspace_globs(&workspace_root)?,
+                PkgManager::Pnpm => workspace::read_pnpm_workspace_globs(&workspace_root)?,
+            };
+            let member_addrs_by_name: BTreeMap<String, String> = if patterns.is_empty() {
+                BTreeMap::new()
+            } else {
+                let mut packages = Vec::new();
+                collect_js_packages(
+                    &walker,
+                    &workspace_root,
+                    &workspace_root,
+                    &skip,
+                    &mut packages,
+                );
+                let packages: Vec<PkgBuf> = packages.into_iter().collect::<anyhow::Result<_>>()?;
+                workspace::resolve_members(&workspace_root, &packages, &patterns)?
+                    .into_iter()
+                    .map(|m| (m.name, m.addr.format()))
+                    .collect()
+            };
+
+            let (deps, runner_config_path, runner_config_content) = test_deps_config(
+                &walker,
+                &workspace_root,
+                &pkg_str,
+                &test_file_rel,
+                lockfile.as_deref(),
+                resolved_graph.as_deref(),
+                &member_addrs_by_name,
+                &goos,
+                &goarch,
+                &testrunner,
+                runner_config_candidates(&testrunner)?,
+            )
+            .with_context(|| {
+                format!("building js_test inputs for {pkg_str:?} test file {test_file_rel:?}")
+            })?;
+
+            let mut config: HashMap<String, Value> = HashMap::new();
+            config.insert("testrunner".to_string(), Value::String(testrunner));
+            config.insert("runner_bin".to_string(), Value::String(runner_bin));
+            config.insert("runner_version".to_string(), Value::String(runner_version));
+            config.insert("test_file".to_string(), Value::String(test_file_rel));
+            config.insert(
+                "runner_config_path".to_string(),
+                Value::String(runner_config_path),
+            );
+            config.insert(
+                "runner_config_content".to_string(),
+                Value::String(runner_config_content),
             );
             config.insert("deps".to_string(), Value::Map(deps));
             Ok(config)
@@ -806,6 +1008,326 @@ fn typecheck_deps_config(
     Ok((deps, tsconfig_path_rel, tsconfig_content))
 }
 
+/// Candidate config filenames for `testrunner`'s ancestor-chain walk (see
+/// `importgraph::find_nearest_test_runner_config`) — every extension the
+/// runner itself accepts for its own config file. Errors on an unsupported
+/// `testrunner` rather than guessing — callers only ever reach this after
+/// `toolchain::is_supported_testrunner` has already validated it (see
+/// `Provider::resolved_host_test_runner`), so this should never actually
+/// trigger in practice, but a fallible return keeps that an enforced
+/// invariant rather than an assumed one.
+fn runner_config_candidates(testrunner: &str) -> anyhow::Result<&'static [&'static str]> {
+    match testrunner {
+        toolchain::VITEST => Ok(&[
+            "vitest.config.ts",
+            "vitest.config.js",
+            "vitest.config.mjs",
+            "vitest.config.cjs",
+            "vitest.config.mts",
+            "vitest.config.cts",
+            // Vitest's own documented fallback: a project that configures
+            // testing entirely under `vite.config.ts`'s `test: {...}` key,
+            // with no separate `vitest.config.*` file at all, is real and
+            // common (hermeticity M4 review) — checked after the dedicated
+            // filenames above, matching vitest's own precedence (dedicated
+            // config wins over the shared `vite.config.*`).
+            "vite.config.ts",
+            "vite.config.js",
+            "vite.config.mjs",
+            "vite.config.cjs",
+            "vite.config.mts",
+            "vite.config.cts",
+        ]),
+        toolchain::JEST => Ok(&[
+            "jest.config.js",
+            "jest.config.ts",
+            "jest.config.mjs",
+            "jest.config.cjs",
+            "jest.config.json",
+            // `package.json`'s own `"jest"` field (jest's other documented
+            // config location) is handled separately by
+            // `importgraph::find_nearest_jest_package_json_config` — checked
+            // by `test_deps_config` only once none of these dedicated
+            // filenames are found on the same ancestor chain.
+        ]),
+        other => anyhow::bail!(
+            "js_test: unsupported testrunner {other:?} — expected \"vitest\" or \"jest\" (should \
+             have been rejected earlier by toolchain::is_supported_testrunner)"
+        ),
+    }
+}
+
+/// Reject a `js_test` addr's `file` arg — or, defensively, a resolved
+/// `runner_config_path` read back out of a cached `JsTestDef` — that is
+/// anything other than a plain workspace-relative path: absolute, or
+/// `..`-escaping. `Path::join` silently *replaces* the base when the joined
+/// argument is absolute, so an unvalidated `file=/etc/passwd` addr would
+/// otherwise resolve to the literal host path in both `Provider::get`
+/// (`workspace_root.join(&test_file)`) and `driver_test.rs::run()`
+/// (`sandbox_ws_dir.join(&def.test_file)`) — a direct violation of
+/// architecture.md's target-isolation invariant ("It sees only its declared
+/// inputs; no ambient filesystem access"). Mirrors
+/// `hbuiltins::pluginfs::normalize_path`'s escape rejection (this crate
+/// cannot depend on `builtins`, and the fs-provider's own protection never
+/// fires here: `def.test_file` is a raw config string consumed directly, not
+/// a `fs:file` dep-group addr the engine resolves through it).
+pub(crate) fn reject_path_escape(field: &str, path: &str) -> anyhow::Result<()> {
+    anyhow::ensure!(
+        !Path::new(path).is_absolute(),
+        "js_test {field} {path:?} must be a workspace-relative path, not absolute"
+    );
+    anyhow::ensure!(
+        !path.split('/').any(|c| c == ".."),
+        "js_test {field} {path:?} must not contain a `..` path component"
+    );
+    Ok(())
+}
+
+/// A validated `test_file` must additionally live under the addressed
+/// package's own directory — otherwise `//packages/a:js_test@file=<path>`
+/// could address any other real, existing, non-test file anywhere in the
+/// workspace (e.g. a sibling package's source file never surfaced by
+/// `Provider::list`), confined to the workspace but still never a real
+/// `js_test` target. `package` empty means the root package (everything not
+/// already claimed by a nested `package.json` is "under" it).
+fn test_file_under_package(package: &str, test_file: &str) -> bool {
+    if package.is_empty() {
+        return true;
+    }
+    test_file
+        .strip_prefix(package)
+        .is_some_and(|rest| rest.starts_with('/'))
+}
+
+/// Build the `deps` map (`""` = the test file's own runtime-transitive
+/// first-party closure within its owning package —
+/// `importgraph::build_test_closure` over `ImportGraph::runtime_edges`,
+/// always including the test file itself; `"external"` = every file that
+/// closure reaches just outside the package boundary, one-hop only, plus a
+/// lockfile-resolved third-party addr for any closure member's unresolved
+/// bare specifier — the lockfile-driven `deps::resolve_one_dependency`
+/// mechanism, **never** by walking `oxc_resolver` paths against an ambient
+/// `node_modules` on disk: `Provider::get` always runs before `js_install`
+/// ever executes, so a fresh checkout has no `node_modules` at all, and an M3
+/// review caught exactly this mistake in an earlier draft of
+/// `typecheck_deps_config` — see that function's identical on-demand
+/// third-party handling for the precedent this mirrors; `"runner_config"` =
+/// the resolved test-runner config file, if any) plus that config's own
+/// workspace-relative path and raw content, for one `js_test` target.
+///
+/// Deliberately split out from [`Provider::test_config`] so it never touches
+/// the host test-runner toolchain — unit-testable without a real
+/// `vitest`/`jest` binary. This is the task's "single most important test in
+/// this milestone": proving per-test-file, not per-package, Input scoping —
+/// see this module's tests.
+///
+/// `pkg` is the package's workspace-relative path (`""` for the root);
+/// `test_file_rel` is the one test file's workspace-relative path.
+/// `lockfile`/`resolved_graph`/`member_addrs_by_name`/`goos`/`goarch` mirror
+/// `typecheck_deps_config`'s identically-named parameters.
+///
+/// **Known scope trim, disclosed rather than silent — and a real gap, not
+/// merely a narrower one**: the resolved tsconfig (used here only to
+/// configure `Resolvers`' `paths`/`baseUrl`/`extends` support so the import
+/// graph itself is built correctly) is not declared as its own `js_test`
+/// Input, nor hashed, the way `js_typecheck`'s `"tsconfig"`/`tsconfig_content`
+/// pair is. It is tempting to reason that `js_test` runs source directly
+/// (not through `tsc`) so this only affects import *resolution*, not
+/// behavior — but that reasoning is wrong: the recommended default runner,
+/// vitest, transforms TS via Vite's esbuild-based transform, which reads the
+/// nearest `tsconfig.json` itself at transform time for options
+/// (`jsx`/`jsxFactory`/`target`/`useDefineForClassFields`/
+/// `experimentalDecorators`) that change the *emitted, executed* JS — not
+/// just which file a specifier resolves to. Toggling one of those between
+/// two commits, with the resolved import/closure addr set unchanged, is
+/// silently invisible to this target's cache key today (M4 hermeticity
+/// review). Accepted as a known trim for this milestone rather than fixed —
+/// mirroring `js_typecheck`'s `tsconfig_content` fix is the natural
+/// follow-up. TODO M4+.
+#[expect(
+    clippy::too_many_arguments,
+    reason = "mirrors typecheck_deps_config's own lockfile/graph/member/platform parameter set, \
+              needed here too for the same on-demand third-party-input resolution, plus \
+              `testrunner` for the jest-package.json-field config fallback"
+)]
+fn test_deps_config(
+    walker: &CachedWalker,
+    workspace_root: &Path,
+    pkg: &str,
+    test_file_rel: &str,
+    lockfile: Option<&Lockfile>,
+    resolved_graph: Option<&ResolvedGraph>,
+    member_addrs_by_name: &BTreeMap<String, String>,
+    goos: &str,
+    goarch: &str,
+    testrunner: &str,
+    runner_config_candidates: &[&str],
+) -> anyhow::Result<(HashMap<String, Value>, String, String)> {
+    let pkg_dir = if pkg.is_empty() {
+        workspace_root.to_path_buf()
+    } else {
+        workspace_root.join(pkg)
+    };
+
+    let manifest = package_json::read_package_manifest(&pkg_dir.join(PACKAGE_JSON))
+        .with_context(|| format!("reading {pkg:?}'s package.json for js_test Input scoping"))?;
+
+    // See `typecheck_deps_config`'s identical canonicalization requirement:
+    // `edge.resolved`/`extends` targets are realpath'd, so every containment
+    // check must compare against a canonicalized `workspace_root`.
+    let canonical_root = workspace_root
+        .canonicalize()
+        .with_context(|| format!("canonicalize workspace root {workspace_root:?}"))?;
+
+    // Dedicated filenames first (`vitest.config.*`/`vite.config.*`, or
+    // `jest.config.*`); jest's other documented config location —
+    // `package.json`'s own `"jest"` field — is checked only once none of
+    // those are found on the same ancestor chain, matching jest's own
+    // precedence (hermeticity M4 review: this fallback was previously
+    // entirely missing, so a project configured this way got an unhashed
+    // `runner_config_path == ""` no matter what the real config said).
+    let runner_config = importgraph::find_nearest_test_runner_config(
+        workspace_root,
+        &pkg_dir,
+        runner_config_candidates,
+    )
+    .or_else(|| {
+        if testrunner == toolchain::JEST {
+            importgraph::find_nearest_jest_package_json_config(workspace_root, &pkg_dir)
+        } else {
+            None
+        }
+    });
+    let (runner_config_path_rel, runner_config_content) = match &runner_config {
+        Some(p) => {
+            let rel = p
+                .strip_prefix(workspace_root)
+                .unwrap_or(p)
+                .to_string_lossy()
+                .replace('\\', "/");
+            let content = std::fs::read_to_string(p)
+                .with_context(|| format!("reading test-runner config {p:?}"))?;
+            (rel, content)
+        }
+        None => (String::new(), String::new()),
+    };
+
+    // Additional files the resolved config's own content *names* or
+    // *imports* — `setupFiles`/`setupFilesAfterEnv`/`globalSetup`/
+    // `globalTeardown` entries, and a relative `import`/`require` of a
+    // shared base config — recursively, since a base config can itself name
+    // or import more (hermeticity M4 review BLOCKER: previously these were
+    // never discovered, declared, staged, or hashed at all, so e.g. editing
+    // a `setupFiles` target changed real test behavior — mocks, globals —
+    // without busting the cache for any `js_test` target that shared it).
+    // See `resolve_runner_config_referenced_files`'s doc for exactly what is
+    // (and, in the disclosed-trim sense, is not) followed.
+    let mut runner_config_ref_paths_rel: Vec<String> = Vec::new();
+    if let Some(p) = &runner_config {
+        let refs = importgraph::resolve_runner_config_referenced_files(p, &runner_config_content)
+            .with_context(|| {
+            format!("scanning test-runner config {p:?} for referenced files")
+        })?;
+        for f in refs {
+            runner_config_ref_paths_rel.push(
+                f.strip_prefix(workspace_root)
+                    .unwrap_or(&f)
+                    .to_string_lossy()
+                    .replace('\\', "/"),
+            );
+        }
+    }
+
+    let tsconfig = importgraph::find_nearest_tsconfig(workspace_root, &pkg_dir);
+    let import_resolvers = resolvers::Resolvers::new(tsconfig.as_deref());
+    let resolve_cache = importgraph::ResolveCache::new();
+    let graph = importgraph::build_package_import_graph(
+        walker,
+        workspace_root,
+        pkg,
+        &import_resolvers,
+        &resolve_cache,
+        tsconfig.as_deref(),
+    )
+    .with_context(|| format!("building import graph for {pkg:?}"))?;
+
+    // Phantom-dependency check: a workspace member requesting only `js_test`
+    // (never `js_package_info`/`js_typecheck`) must not skip it — same
+    // rationale `typecheck_deps_config` documents for its own identical call.
+    let declared_closure = importgraph::declared_closure(&manifest);
+    importgraph::check_phantom_dependencies(workspace_root, pkg, &graph, &declared_closure)
+        .with_context(|| {
+            format!("cross-checking {pkg:?}'s import graph against its declared dependencies")
+        })?;
+
+    let closure = importgraph::build_test_closure(&graph, &canonical_root, pkg, test_file_rel)
+        .with_context(|| {
+            format!("building test closure for {pkg:?}'s test file {test_file_rel:?}")
+        })?;
+
+    let mut deps: HashMap<String, Value> = HashMap::new();
+    deps.insert(
+        String::new(),
+        Value::List(
+            closure
+                .files
+                .iter()
+                .map(|p| Value::String(hbuiltins::pluginfs::file_addr(p).format()))
+                .collect(),
+        ),
+    );
+
+    let mut external_addrs: BTreeSet<String> = BTreeSet::new();
+    for f in &closure.external_files {
+        external_addrs.insert(hbuiltins::pluginfs::file_addr(f).format());
+    }
+    // Mirrors `typecheck_deps_config`'s identical on-demand third-party
+    // handling for an unresolved bare specifier: `check_phantom_dependencies`
+    // above already proved every one of these names is declared; a `None`
+    // here means it's a declared `optionalDependencies` entry that doesn't
+    // apply to this platform/lockfile state.
+    for site in &closure.bare_specifiers {
+        if let Some(addr) = deps::resolve_one_dependency(
+            pkg,
+            &site.package_name,
+            &manifest,
+            lockfile,
+            resolved_graph,
+            member_addrs_by_name,
+            goos,
+            goarch,
+        )
+        .with_context(|| {
+            format!(
+                "resolving {:?}'s unresolved import of `{}` for js_test",
+                site.file, site.package_name
+            )
+        })? {
+            external_addrs.insert(addr);
+        }
+    }
+    if !external_addrs.is_empty() {
+        deps.insert(
+            "external".to_string(),
+            Value::List(external_addrs.into_iter().map(Value::String).collect()),
+        );
+    }
+    if !runner_config_path_rel.is_empty() {
+        let mut runner_config_addrs = vec![Value::String(
+            hbuiltins::pluginfs::file_addr(&runner_config_path_rel).format(),
+        )];
+        for rel in &runner_config_ref_paths_rel {
+            runner_config_addrs.push(Value::String(hbuiltins::pluginfs::file_addr(rel).format()));
+        }
+        deps.insert(
+            "runner_config".to_string(),
+            Value::List(runner_config_addrs),
+        );
+    }
+
+    Ok((deps, runner_config_path_rel, runner_config_content))
+}
+
 /// The default npm registry tarball URL for a `(name, version)` — used when
 /// the lockfile doesn't record one directly (pnpm's common case for a plain
 /// registry dependency; npm's `package-lock.json` always records one, which
@@ -938,7 +1460,38 @@ impl ProviderTrait for Provider {
                 PACKAGE_INFO_TARGET.to_string(),
                 Default::default(),
             );
-            Ok(Box::new(std::iter::once(Ok(ListResponse { addr })))
+            let mut responses: Vec<anyhow::Result<ListResponse>> = vec![Ok(ListResponse { addr })];
+
+            // One `js_test` target per matched test file — the milestone's
+            // stated per-test-file (not per-package) granularity; see
+            // `driver_test.rs` module docs. Test discovery is an optional,
+            // additive listing on top of the always-present
+            // `PACKAGE_INFO_TARGET` entry above: a bad `test_glob` or an
+            // FS-walk error under this one package must not take
+            // `package_info` (and every other target kind that lives in this
+            // package) down with it, so a failure here is surfaced as its
+            // own per-entry error — mirroring `collect_js_packages`'s
+            // identical per-entry error handling — rather than propagated
+            // with `?`.
+            match self.discover_test_files(&req.package).await {
+                Ok(test_files) => {
+                    for file in test_files {
+                        let mut args = BTreeMap::new();
+                        args.insert("file".to_string(), file);
+                        responses.push(Ok(ListResponse {
+                            addr: Addr::new(req.package.clone(), TEST_TARGET.to_string(), args),
+                        }));
+                    }
+                }
+                Err(e) => {
+                    responses.push(Err(e.context(format!(
+                        "discovering js_test files for {}",
+                        req.package.as_str()
+                    ))));
+                }
+            }
+
+            Ok(Box::new(responses.into_iter())
                 as Box<
                     dyn Iterator<Item = anyhow::Result<ListResponse>> + Send,
                 >)
@@ -1037,6 +1590,69 @@ impl ProviderTrait for Provider {
                     target_spec: TargetSpec {
                         addr: req.addr.clone(),
                         driver: "js_typecheck".to_string(),
+                        config,
+                        labels: vec![],
+                        transitive: Default::default(),
+                        approval: Default::default(),
+                    },
+                });
+            }
+
+            // `js_test` is a third per-package-*file* target kind: one addr
+            // per matched test file, distinguished by the `file` addr arg —
+            // see `driver_test.rs` module docs. Checked before the
+            // `PACKAGE_INFO_TARGET` gate below for the same reason
+            // `TYPECHECK_TARGET` is.
+            if req.addr.name == TEST_TARGET {
+                if self
+                    .skip
+                    .prunes_package(&self.workspace_root, Path::new(req.addr.package.as_str()))
+                {
+                    return Err(GetError::NotFound);
+                }
+                let package_json = self
+                    .workspace_root
+                    .join(req.addr.package.as_str())
+                    .join(PACKAGE_JSON);
+                if !package_json.is_file() {
+                    return Err(GetError::NotFound);
+                }
+                let test_file = req.addr.args.get("file").cloned().ok_or_else(|| {
+                    GetError::Other(anyhow::anyhow!(
+                        "js_test addr {} is missing its required `file` arg",
+                        req.addr.format()
+                    ))
+                })?;
+                // Validated *before* ever touching the filesystem: an
+                // absolute or `..`-escaping `file` arg must never reach
+                // `workspace_root.join(...)` below — see `reject_path_escape`'s
+                // doc for why (a code-quality review BLOCKER — `Path::join`
+                // silently replaces the base for an absolute argument).
+                reject_path_escape("file arg", &test_file).map_err(GetError::Other)?;
+                if !test_file_under_package(req.addr.package.as_str(), &test_file) {
+                    return Err(GetError::Other(anyhow::anyhow!(
+                        "js_test addr {} names file {test_file:?} outside its own package {:?}",
+                        req.addr.format(),
+                        req.addr.package.as_str()
+                    )));
+                }
+                let test_file_abs = self.workspace_root.join(&test_file);
+                let is_file = hcore::blocking::run(enclose!((test_file_abs) move || {
+                    test_file_abs.is_file()
+                }))
+                .await;
+                if !is_file {
+                    return Err(GetError::NotFound);
+                }
+                let config = self
+                    .test_config(&req.addr.package, &test_file)
+                    .await
+                    .with_context(|| format!("resolving js_test config for {}", req.addr.format()))
+                    .map_err(GetError::Other)?;
+                return Ok(GetResponse {
+                    target_spec: TargetSpec {
+                        addr: req.addr.clone(),
+                        driver: "js_test".to_string(),
                         config,
                         labels: vec![],
                         transitive: Default::default(),
@@ -1698,6 +2314,8 @@ mod tests {
                 walker: Arc::new(CachedWalker::disabled()),
                 allow_scripts: vec!["native-thing".to_string()],
                 tstool: toolchain::HOST.to_string(),
+                testrunner: toolchain::VITEST.to_string(),
+                test_glob: Vec::new(),
             },
         );
 
@@ -2484,5 +3102,749 @@ mod tests {
             .expect("get js_typecheck target_spec");
         assert_eq!(resp.target_spec.driver, "js_typecheck");
         assert!(resp.target_spec.config.contains_key("tsc_version"));
+    }
+
+    // ---- js_test: test_deps_config Input scoping (no real vitest/jest needed) ----
+
+    /// `test_deps_config` with no lockfile/workspace-member context, matching
+    /// vitest's default config filenames — what most of these tests need,
+    /// since they exercise scoping behavior that doesn't touch an unresolved
+    /// third-party/sibling import.
+    fn call_test_deps_config(
+        walker: &CachedWalker,
+        workspace_root: &Path,
+        pkg: &str,
+        test_file_rel: &str,
+    ) -> anyhow::Result<(HashMap<String, Value>, String, String)> {
+        test_deps_config(
+            walker,
+            workspace_root,
+            pkg,
+            test_file_rel,
+            None,
+            None,
+            &BTreeMap::new(),
+            "linux",
+            "amd64",
+            toolchain::VITEST,
+            runner_config_candidates(toolchain::VITEST)?,
+        )
+    }
+
+    /// The single most important test in this milestone (per the task): two
+    /// test files in the *same package*, each importing a different sibling
+    /// source file, must get disjoint `""`-group Input sets — proving
+    /// per-test-file, not per-package, granularity. This is exactly what
+    /// Turborepo/Nx cannot do (package granularity only).
+    #[test]
+    fn test_deps_config_scopes_to_one_test_file_not_the_whole_package() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        write(dir.path(), "packages/a/package.json", r#"{"name": "a"}"#);
+        write(dir.path(), "packages/a/src/a.ts", "export const a = 1;\n");
+        write(dir.path(), "packages/a/src/b.ts", "export const b = 2;\n");
+        write(
+            dir.path(),
+            "packages/a/src/a.test.ts",
+            "import { a } from './a';\ntest('a', () => a);\n",
+        );
+        write(
+            dir.path(),
+            "packages/a/src/b.test.ts",
+            "import { b } from './b';\ntest('b', () => b);\n",
+        );
+
+        let walker = CachedWalker::disabled();
+        let (deps_a, _, _) = call_test_deps_config(
+            &walker,
+            dir.path(),
+            "packages/a",
+            "packages/a/src/a.test.ts",
+        )
+        .expect("build test deps config for a.test.ts");
+        let (deps_b, _, _) = call_test_deps_config(
+            &walker,
+            dir.path(),
+            "packages/a",
+            "packages/a/src/b.test.ts",
+        )
+        .expect("build test deps config for b.test.ts");
+
+        let src_a = dep_addrs(&deps_a, "");
+        let src_b = dep_addrs(&deps_b, "");
+
+        assert!(
+            src_a.iter().any(|a| a.contains("a.test.ts"))
+                && src_a.iter().any(|a| a.contains("src/a.ts")),
+            "{src_a:?}"
+        );
+        assert!(
+            !src_a
+                .iter()
+                .any(|a| a.contains("b.test.ts") || a.contains("src/b.ts")),
+            "a.test.ts's own closure must not include b.test.ts or b.ts: {src_a:?}"
+        );
+
+        assert!(
+            src_b.iter().any(|a| a.contains("b.test.ts"))
+                && src_b.iter().any(|a| a.contains("src/b.ts")),
+            "{src_b:?}"
+        );
+        assert!(
+            !src_b
+                .iter()
+                .any(|a| a.contains("a.test.ts") || a.contains("src/a.ts")),
+            "b.test.ts's own closure must not include a.test.ts or a.ts: {src_b:?}"
+        );
+    }
+
+    /// A file reached transitively (not just directly imported) must still
+    /// be declared — the closure follows the whole chain, not one hop.
+    #[test]
+    fn test_deps_config_includes_transitively_imported_file() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        write(dir.path(), "packages/a/package.json", r#"{"name": "a"}"#);
+        write(
+            dir.path(),
+            "packages/a/src/deep.ts",
+            "export const deep = 1;\n",
+        );
+        write(
+            dir.path(),
+            "packages/a/src/helper.ts",
+            "export { deep } from './deep';\n",
+        );
+        write(
+            dir.path(),
+            "packages/a/src/a.test.ts",
+            "import { deep } from './helper';\ntest('a', () => deep);\n",
+        );
+        // An unrelated workspace file elsewhere entirely — must not appear.
+        write(
+            dir.path(),
+            "packages/c/unrelated.ts",
+            "export const z = 1;\n",
+        );
+
+        let walker = CachedWalker::disabled();
+        let (deps, _, _) = call_test_deps_config(
+            &walker,
+            dir.path(),
+            "packages/a",
+            "packages/a/src/a.test.ts",
+        )
+        .expect("build test deps config");
+
+        let src_addrs = dep_addrs(&deps, "");
+        assert!(
+            src_addrs.iter().any(|a| a.contains("helper.ts")),
+            "{src_addrs:?}"
+        );
+        assert!(
+            src_addrs.iter().any(|a| a.contains("deep.ts")),
+            "a transitively-reached file must be declared: {src_addrs:?}"
+        );
+        assert!(
+            !src_addrs.iter().any(|a| a.contains("unrelated")),
+            "an unrelated workspace file must not be a declared input: {src_addrs:?}"
+        );
+    }
+
+    #[test]
+    fn test_deps_config_includes_runner_config_group_and_content_when_present() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        write(
+            dir.path(),
+            "vitest.config.ts",
+            "export default { test: {} };\n",
+        );
+        write(dir.path(), "packages/a/package.json", r#"{"name": "a"}"#);
+        write(
+            dir.path(),
+            "packages/a/src/a.test.ts",
+            "test('a', () => 1);\n",
+        );
+
+        let walker = CachedWalker::disabled();
+        let (deps, runner_config_path, runner_config_content) = call_test_deps_config(
+            &walker,
+            dir.path(),
+            "packages/a",
+            "packages/a/src/a.test.ts",
+        )
+        .expect("build test deps config");
+
+        assert_eq!(runner_config_path, "vitest.config.ts");
+        assert_eq!(runner_config_content, "export default { test: {} };\n");
+        let runner_config_addrs = dep_addrs(&deps, "runner_config");
+        assert_eq!(runner_config_addrs.len(), 1);
+        assert!(runner_config_addrs[0].contains("vitest.config.ts"));
+    }
+
+    #[test]
+    fn test_deps_config_no_runner_config_group_when_absent() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        write(dir.path(), "packages/a/package.json", r#"{"name": "a"}"#);
+        write(
+            dir.path(),
+            "packages/a/src/a.test.ts",
+            "test('a', () => 1);\n",
+        );
+
+        let walker = CachedWalker::disabled();
+        let (deps, runner_config_path, runner_config_content) = call_test_deps_config(
+            &walker,
+            dir.path(),
+            "packages/a",
+            "packages/a/src/a.test.ts",
+        )
+        .expect("build test deps config");
+
+        assert!(runner_config_path.is_empty());
+        assert!(runner_config_content.is_empty());
+        assert!(!deps.contains_key("runner_config"));
+    }
+
+    /// Same lesson as `typecheck_deps_config_declares_thirdparty_type_input_with_no_ambient_node_modules`:
+    /// an unresolved third-party import (no `node_modules` on disk at all)
+    /// must still be resolved to a `js_install` Input via the lockfile —
+    /// never by walking `oxc_resolver` paths against an absent ambient
+    /// `node_modules` (the M3-review lesson this task explicitly calls out).
+    #[test]
+    fn test_deps_config_declares_thirdparty_input_with_no_ambient_node_modules() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        write(
+            dir.path(),
+            "packages/a/package.json",
+            r#"{"name": "a", "devDependencies": {"lodash": "^4.17.21"}}"#,
+        );
+        write(
+            dir.path(),
+            "packages/a/src/a.test.ts",
+            "import _ from 'lodash';\ntest('a', () => _.identity(1));\n",
+        );
+        // Deliberately no `node_modules` anywhere in this fixture.
+
+        let lockfile = Lockfile::parse(
+            PkgManager::Npm,
+            r#"{
+                "packages": {
+                    "": {},
+                    "packages/a": { "name": "a" },
+                    "node_modules/lodash": {
+                        "version": "4.17.21",
+                        "integrity": "sha512-abc"
+                    }
+                }
+            }"#,
+        )
+        .expect("parse lockfile");
+        let resolved_graph = lockfile.resolved_graph();
+
+        let walker = CachedWalker::disabled();
+        let (deps, _, _) = test_deps_config(
+            &walker,
+            dir.path(),
+            "packages/a",
+            "packages/a/src/a.test.ts",
+            Some(&lockfile),
+            Some(&resolved_graph),
+            &BTreeMap::new(),
+            "linux",
+            "amd64",
+            toolchain::VITEST,
+            runner_config_candidates(toolchain::VITEST).expect("vitest is supported"),
+        )
+        .expect("build test deps config");
+
+        let external_addrs = dep_addrs(&deps, "external");
+        assert!(
+            external_addrs
+                .iter()
+                .any(|a| a.contains("lodash") && a.contains("js_install")),
+            "an unresolved third-party import must still declare a js_install Input even absent \
+             ambient node_modules: {external_addrs:?}"
+        );
+    }
+
+    #[test]
+    fn runner_config_candidates_covers_both_supported_runners() {
+        assert!(
+            runner_config_candidates(toolchain::VITEST)
+                .expect("vitest is supported")
+                .contains(&"vitest.config.ts")
+        );
+        assert!(
+            runner_config_candidates(toolchain::JEST)
+                .expect("jest is supported")
+                .contains(&"jest.config.js")
+        );
+    }
+
+    #[test]
+    fn runner_config_candidates_errors_on_unsupported_testrunner() {
+        runner_config_candidates("mocha").expect_err("mocha must not be supported");
+    }
+
+    // ---- Provider::list / Provider::get: js_test per-test-file target discovery ----
+
+    #[tokio::test]
+    async fn list_discovers_one_js_test_target_per_matched_test_file() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        write(dir.path(), "packages/a/package.json", r#"{"name": "a"}"#);
+        write(
+            dir.path(),
+            "packages/a/src/index.ts",
+            "export const x = 1;\n",
+        );
+        write(
+            dir.path(),
+            "packages/a/src/index.test.ts",
+            "test('x', () => 1);\n",
+        );
+        write(
+            dir.path(),
+            "packages/a/src/other.spec.ts",
+            "test('y', () => 1);\n",
+        );
+
+        let provider = Provider::new(dir.path().to_path_buf(), PkgManager::Npm);
+        let ct = ctoken();
+        let executor = Arc::new(NoopExecutor);
+        let iter = provider
+            .list(
+                ListRequest {
+                    request_id: "test".to_string(),
+                    package: PkgBuf::from("packages/a"),
+                    states: vec![],
+                    executor,
+                },
+                &ct,
+            )
+            .await
+            .expect("list");
+        let addrs: Vec<Addr> = iter.map(|r| r.expect("no per-entry error").addr).collect();
+
+        let test_addrs: Vec<&Addr> = addrs.iter().filter(|a| a.name == TEST_TARGET).collect();
+        assert_eq!(test_addrs.len(), 2, "{addrs:?}");
+        let files: Vec<&String> = test_addrs
+            .iter()
+            .filter_map(|a| a.args.get("file"))
+            .collect();
+        assert!(files.iter().any(|f| f.contains("index.test.ts")));
+        assert!(files.iter().any(|f| f.contains("other.spec.ts")));
+        // The package_info target must still be present too.
+        assert!(addrs.iter().any(|a| a.name == PACKAGE_INFO_TARGET));
+    }
+
+    #[tokio::test]
+    async fn get_js_test_not_found_for_nonexistent_file() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        write(dir.path(), "packages/a/package.json", r#"{"name": "a"}"#);
+
+        let provider = Provider::new(dir.path().to_path_buf(), PkgManager::Npm);
+        let ct = ctoken();
+        let executor = Arc::new(NoopExecutor);
+        let mut args = BTreeMap::new();
+        args.insert(
+            "file".to_string(),
+            "packages/a/src/does-not-exist.test.ts".to_string(),
+        );
+        let result = provider
+            .get(
+                GetRequest {
+                    request_id: "test".to_string(),
+                    addr: Addr::new(PkgBuf::from("packages/a"), TEST_TARGET.to_string(), args),
+                    states: vec![],
+                    executor,
+                },
+                &ct,
+            )
+            .await;
+        assert!(matches!(result, Err(GetError::NotFound)));
+    }
+
+    // ---- `js_test` addr `file` arg: path-escape / sandbox-isolation
+    // rejection (code-quality review BLOCKER) ----
+
+    #[test]
+    fn reject_path_escape_allows_plain_relative_path() {
+        reject_path_escape("file", "packages/a/src/index.test.ts")
+            .expect("plain workspace-relative path is fine");
+    }
+
+    #[test]
+    fn reject_path_escape_rejects_absolute_path() {
+        reject_path_escape("file", "/etc/passwd").expect_err("absolute path must be rejected");
+    }
+
+    #[test]
+    fn reject_path_escape_rejects_dotdot_escape_anywhere_in_the_path() {
+        reject_path_escape("file", "../../../../etc/passwd")
+            .expect_err("a leading `..` escape must be rejected");
+        reject_path_escape("file", "packages/a/../../../etc/passwd").expect_err(
+            "a `..` component anywhere in the path must be rejected, not just a leading one",
+        );
+    }
+
+    #[test]
+    fn test_file_under_package_confines_to_the_addressed_package() {
+        assert!(test_file_under_package(
+            "packages/a",
+            "packages/a/src/index.test.ts"
+        ));
+        assert!(!test_file_under_package(
+            "packages/a",
+            "packages/b/src/index.ts"
+        ));
+        // A sibling directory that merely shares a prefix with the package
+        // name must not be treated as "under" it.
+        assert!(!test_file_under_package(
+            "packages/a",
+            "packages/a-other/src/index.ts"
+        ));
+        assert!(test_file_under_package("", "packages/a/src/index.test.ts"));
+    }
+
+    #[tokio::test]
+    async fn get_js_test_rejects_absolute_file_arg() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        write(dir.path(), "packages/a/package.json", r#"{"name": "a"}"#);
+
+        let provider = Provider::new(dir.path().to_path_buf(), PkgManager::Npm);
+        let ct = ctoken();
+        let executor = Arc::new(NoopExecutor);
+        let mut args = BTreeMap::new();
+        args.insert("file".to_string(), "/etc/passwd".to_string());
+        let result = provider
+            .get(
+                GetRequest {
+                    request_id: "test".to_string(),
+                    addr: Addr::new(PkgBuf::from("packages/a"), TEST_TARGET.to_string(), args),
+                    states: vec![],
+                    executor,
+                },
+                &ct,
+            )
+            .await;
+        assert!(
+            matches!(result, Err(GetError::Other(_))),
+            "an absolute `file` arg must be rejected outright, never resolved against the real \
+             host filesystem via `Path::join`'s absolute-replaces-base semantics"
+        );
+    }
+
+    #[tokio::test]
+    async fn get_js_test_rejects_dotdot_escaping_file_arg() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        write(dir.path(), "packages/a/package.json", r#"{"name": "a"}"#);
+
+        let provider = Provider::new(dir.path().to_path_buf(), PkgManager::Npm);
+        let ct = ctoken();
+        let executor = Arc::new(NoopExecutor);
+        let mut args = BTreeMap::new();
+        args.insert(
+            "file".to_string(),
+            "packages/a/../../../../../../etc/passwd".to_string(),
+        );
+        let result = provider
+            .get(
+                GetRequest {
+                    request_id: "test".to_string(),
+                    addr: Addr::new(PkgBuf::from("packages/a"), TEST_TARGET.to_string(), args),
+                    states: vec![],
+                    executor,
+                },
+                &ct,
+            )
+            .await;
+        assert!(
+            matches!(result, Err(GetError::Other(_))),
+            "a `..`-escaping `file` arg must be rejected"
+        );
+    }
+
+    #[tokio::test]
+    async fn get_js_test_rejects_file_outside_addressed_package() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        write(dir.path(), "packages/a/package.json", r#"{"name": "a"}"#);
+        write(dir.path(), "packages/b/package.json", r#"{"name": "b"}"#);
+        write(
+            dir.path(),
+            "packages/b/src/index.ts",
+            "export const x = 1;\n",
+        );
+
+        let provider = Provider::new(dir.path().to_path_buf(), PkgManager::Npm);
+        let ct = ctoken();
+        let executor = Arc::new(NoopExecutor);
+        let mut args = BTreeMap::new();
+        args.insert("file".to_string(), "packages/b/src/index.ts".to_string());
+        let result = provider
+            .get(
+                GetRequest {
+                    request_id: "test".to_string(),
+                    addr: Addr::new(PkgBuf::from("packages/a"), TEST_TARGET.to_string(), args),
+                    states: vec![],
+                    executor,
+                },
+                &ct,
+            )
+            .await;
+        assert!(
+            matches!(result, Err(GetError::Other(_))),
+            "a real, existing file belonging to a different package must not be addressable as \
+             packages/a's own js_test target"
+        );
+    }
+
+    // ---- `Provider::from_options`: fail fast on an unsupported `testrunner`
+    // (feature-quality review) ----
+
+    #[test]
+    fn from_options_rejects_unsupported_testrunner() {
+        let mut opts: hplugin::config::Options = BTreeMap::new();
+        opts.insert(
+            "pkgmanager".to_string(),
+            serde_yaml::Value::String("npm".to_string()),
+        );
+        opts.insert(
+            "testrunner".to_string(),
+            serde_yaml::Value::String("mocha".to_string()),
+        );
+        let walker = Arc::new(CachedWalker::disabled());
+        let result =
+            Provider::from_options(PathBuf::from("/does-not-matter"), &[], &[], &opts, walker);
+        match result {
+            Err(err) => assert!(
+                err.to_string().contains("testrunner"),
+                "error should name the rejected option: {err}"
+            ),
+            Ok(_) => panic!(
+                "mocha is not a supported testrunner — Provider::from_options must fail fast at \
+                 construction time, not defer to Provider::get"
+            ),
+        }
+    }
+
+    // ---- hermeticity M4 review: `js_test`'s runner-config resolution/scoping ----
+
+    #[test]
+    fn runner_config_candidates_includes_vite_config_fallback_for_vitest() {
+        let candidates = runner_config_candidates(toolchain::VITEST).expect("vitest is supported");
+        assert!(
+            candidates.contains(&"vite.config.ts"),
+            "vitest's documented `vite.config.ts`-only fallback must be checked too: {candidates:?}"
+        );
+    }
+
+    #[test]
+    fn test_deps_config_falls_back_to_vite_config_when_no_dedicated_vitest_config() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        write(
+            dir.path(),
+            "vite.config.ts",
+            "export default { test: { environment: 'node' } };\n",
+        );
+        write(dir.path(), "packages/a/package.json", r#"{"name": "a"}"#);
+        write(
+            dir.path(),
+            "packages/a/src/a.test.ts",
+            "test('a', () => 1);\n",
+        );
+
+        let walker = CachedWalker::disabled();
+        let (_, runner_config_path, runner_config_content) = call_test_deps_config(
+            &walker,
+            dir.path(),
+            "packages/a",
+            "packages/a/src/a.test.ts",
+        )
+        .expect("build test deps config");
+
+        assert_eq!(runner_config_path, "vite.config.ts");
+        assert!(runner_config_content.contains("environment"));
+    }
+
+    #[test]
+    fn test_deps_config_falls_back_to_jest_field_in_package_json() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        write(
+            dir.path(),
+            "package.json",
+            r#"{"name": "root", "jest": {"testEnvironment": "node"}}"#,
+        );
+        write(dir.path(), "packages/a/package.json", r#"{"name": "a"}"#);
+        write(
+            dir.path(),
+            "packages/a/src/a.test.ts",
+            "test('a', () => 1);\n",
+        );
+
+        let walker = CachedWalker::disabled();
+        let (deps, runner_config_path, runner_config_content) = test_deps_config(
+            &walker,
+            dir.path(),
+            "packages/a",
+            "packages/a/src/a.test.ts",
+            None,
+            None,
+            &BTreeMap::new(),
+            "linux",
+            "amd64",
+            toolchain::JEST,
+            runner_config_candidates(toolchain::JEST).expect("jest is supported"),
+        )
+        .expect("build test deps config");
+
+        assert_eq!(runner_config_path, "package.json");
+        assert!(runner_config_content.contains("testEnvironment"));
+        let runner_config_addrs = dep_addrs(&deps, "runner_config");
+        assert_eq!(runner_config_addrs.len(), 1);
+        assert!(runner_config_addrs[0].contains("package.json"));
+    }
+
+    #[test]
+    fn test_deps_config_declares_setup_files_referenced_by_runner_config() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        write(
+            dir.path(),
+            "vitest.config.ts",
+            "export default { test: { setupFiles: ['./vitest.setup.ts'] } };\n",
+        );
+        write(
+            dir.path(),
+            "vitest.setup.ts",
+            "globalThis.__setup = true;\n",
+        );
+        write(dir.path(), "packages/a/package.json", r#"{"name": "a"}"#);
+        write(
+            dir.path(),
+            "packages/a/src/a.test.ts",
+            "test('a', () => 1);\n",
+        );
+
+        let walker = CachedWalker::disabled();
+        let (deps, _, _) = call_test_deps_config(
+            &walker,
+            dir.path(),
+            "packages/a",
+            "packages/a/src/a.test.ts",
+        )
+        .expect("build test deps config");
+
+        let runner_config_addrs = dep_addrs(&deps, "runner_config");
+        assert_eq!(runner_config_addrs.len(), 2, "{runner_config_addrs:?}");
+        assert!(
+            runner_config_addrs
+                .iter()
+                .any(|a| a.contains("vitest.config.ts"))
+        );
+        assert!(
+            runner_config_addrs
+                .iter()
+                .any(|a| a.contains("vitest.setup.ts")),
+            "a setupFiles-referenced file must be declared as its own Input too, or editing it \
+             would produce a stale cache hit: {runner_config_addrs:?}"
+        );
+    }
+
+    #[test]
+    fn test_deps_config_declares_base_config_reached_via_relative_import() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        write(
+            dir.path(),
+            "vitest.config.base.ts",
+            "export default { test: { globals: true } };\n",
+        );
+        write(
+            dir.path(),
+            "vitest.config.ts",
+            "import base from './vitest.config.base';\nexport default base;\n",
+        );
+        write(dir.path(), "packages/a/package.json", r#"{"name": "a"}"#);
+        write(
+            dir.path(),
+            "packages/a/src/a.test.ts",
+            "test('a', () => 1);\n",
+        );
+
+        let walker = CachedWalker::disabled();
+        let (deps, _, _) = call_test_deps_config(
+            &walker,
+            dir.path(),
+            "packages/a",
+            "packages/a/src/a.test.ts",
+        )
+        .expect("build test deps config");
+
+        let runner_config_addrs = dep_addrs(&deps, "runner_config");
+        assert!(
+            runner_config_addrs
+                .iter()
+                .any(|a| a.contains("vitest.config.base.ts")),
+            "a shared base config reached via a relative import inside the leaf config must be \
+             declared too: {runner_config_addrs:?}"
+        );
+    }
+
+    // ---- `Provider::get` end to end for `js_test` — gated on a real
+    // vitest/jest binary being available in this devenv (querying
+    // `--version` is unavoidably a real subprocess call), unlike the
+    // Input-scoping tests above.
+
+    fn find_real_bin_for_test(name: &str) -> Option<std::path::PathBuf> {
+        let path = std::env::var_os("PATH")?;
+        for dir in std::env::split_paths(&path) {
+            let cand = dir.join(name);
+            if std::fs::metadata(&cand)
+                .map(|m| m.is_file())
+                .unwrap_or(false)
+            {
+                return Some(cand);
+            }
+        }
+        None
+    }
+
+    #[tokio::test]
+    #[ignore = "requires a real `vitest` on PATH — devenv.nix provisions no Node/vitest \
+                toolchain (see toolchain.rs module docs); run explicitly with \
+                `cargo test -- --ignored` on a host with vitest installed"]
+    async fn get_resolves_js_test_target_end_to_end() {
+        find_real_bin_for_test("vitest").expect(
+            "this test is #[ignore]d precisely because vitest isn't guaranteed on PATH — it was \
+             run explicitly, so a missing vitest here is a real failure, not a skip",
+        );
+
+        let dir = tempfile::tempdir().expect("tempdir");
+        write(dir.path(), "packages/a/package.json", r#"{"name": "a"}"#);
+        write(
+            dir.path(),
+            "packages/a/src/index.test.ts",
+            "test('x', () => 1);\n",
+        );
+
+        let provider = Provider::new(dir.path().to_path_buf(), PkgManager::Npm);
+        let ct = ctoken();
+        let executor = Arc::new(NoopExecutor);
+        let mut args = BTreeMap::new();
+        args.insert(
+            "file".to_string(),
+            "packages/a/src/index.test.ts".to_string(),
+        );
+        let resp = provider
+            .get(
+                GetRequest {
+                    request_id: "test".to_string(),
+                    addr: Addr::new(PkgBuf::from("packages/a"), TEST_TARGET.to_string(), args),
+                    states: vec![],
+                    executor,
+                },
+                &ct,
+            )
+            .await
+            .expect("get js_test target_spec");
+        assert_eq!(resp.target_spec.driver, "js_test");
+        assert!(resp.target_spec.config.contains_key("runner_version"));
     }
 }

--- a/crates/plugin-js/src/pluginjs/toolchain.rs
+++ b/crates/plugin-js/src/pluginjs/toolchain.rs
@@ -60,38 +60,124 @@ pub fn is_host(spec: &str) -> bool {
     spec == HOST
 }
 
+/// `<workspace_root>/node_modules/.bin/<bin_name>` first, then the process's
+/// own `PATH` — the shared resolution order behind both [`resolve_host_tsc`]
+/// and `js_test`'s `testrunner` binary resolution (`resolve_host_test_runner`
+/// in this module). `None` when neither has it; each caller wraps that into
+/// its own error naming both places checked, per this milestone's explicit
+/// "do not silently assume the binary is on PATH" requirement.
+fn find_host_bin(workspace_root: &Path, bin_name: &str) -> Option<PathBuf> {
+    let local = workspace_root
+        .join("node_modules")
+        .join(".bin")
+        .join(bin_name);
+    if std::fs::metadata(&local)
+        .map(|m| m.is_file())
+        .unwrap_or(false)
+    {
+        return Some(local);
+    }
+
+    if let Some(path) = std::env::var_os("PATH") {
+        for dir in std::env::split_paths(&path) {
+            let cand = dir.join(bin_name);
+            if std::fs::metadata(&cand)
+                .map(|m| m.is_file())
+                .unwrap_or(false)
+            {
+                return Some(cand);
+            }
+        }
+    }
+    None
+}
+
 /// Resolve the `tsc` binary to run: `<workspace_root>/node_modules/.bin/tsc`
 /// first, then the process's own `PATH`. Fails loudly, naming both places
 /// checked, rather than silently assuming `tsc` is reachable — per this
 /// milestone's explicit "do not silently assume tsc is on PATH" requirement.
 pub(crate) fn resolve_host_tsc(workspace_root: &Path) -> anyhow::Result<PathBuf> {
     let local = workspace_root.join("node_modules").join(".bin").join("tsc");
-    if std::fs::metadata(&local)
-        .map(|m| m.is_file())
-        .unwrap_or(false)
-    {
-        return Ok(local);
-    }
+    find_host_bin(workspace_root, "tsc").ok_or_else(|| {
+        anyhow::anyhow!(
+            "js_typecheck: no `tsc` binary found at {local:?} or on PATH — install TypeScript \
+             (`npm install -D typescript` / `pnpm add -D typescript`) so `node_modules/.bin/tsc` \
+             exists, or make a `tsc` binary available on PATH. There is no hermetic TypeScript \
+             toolchain yet in this plugin — `tstool=\"host\"` (the only supported value in this \
+             milestone) requires one of those two to be reachable."
+        )
+    })
+}
 
-    if let Some(path) = std::env::var_os("PATH") {
-        for dir in std::env::split_paths(&path) {
-            let cand = dir.join("tsc");
-            if std::fs::metadata(&cand)
-                .map(|m| m.is_file())
-                .unwrap_or(false)
-            {
-                return Ok(cand);
-            }
-        }
-    }
+/// Sentinel `testrunner` values `js_test` accepts — see this module's
+/// `resolve_host_test_runner` doc and `driver_test.rs` module docs for the
+/// same disclosed non-hermetic-toolchain shape `tstool = "host"` already has.
+pub const VITEST: &str = "vitest";
+pub const JEST: &str = "jest";
 
-    anyhow::bail!(
-        "js_typecheck: no `tsc` binary found at {local:?} or on PATH — install TypeScript \
-         (`npm install -D typescript` / `pnpm add -D typescript`) so `node_modules/.bin/tsc` \
-         exists, or make a `tsc` binary available on PATH. There is no hermetic TypeScript \
-         toolchain yet in this plugin — `tstool=\"host\"` (the only supported value in this \
-         milestone) requires one of those two to be reachable."
-    )
+/// Whether `testrunner` names a supported test runner — the only two values
+/// `js_test` recognizes in this milestone (see `ai-docs/js-plugin-plan.md`'s
+/// `js_test` row: `testrunner` defaults to `vitest`, alt `jest`).
+pub fn is_supported_testrunner(testrunner: &str) -> bool {
+    testrunner == VITEST || testrunner == JEST
+}
+
+/// Resolve the configured `testrunner`'s binary:
+/// `<workspace_root>/node_modules/.bin/<vitest|jest>` first, then the
+/// process's own `PATH` — the same disclosed non-hermetic escape hatch
+/// `tstool = "host"` already has (see [`resolve_host_tsc`]), extended to
+/// `js_test`'s toolchain axis. Fails loudly, naming both places checked, when
+/// neither has it.
+pub(crate) fn resolve_host_test_runner(
+    workspace_root: &Path,
+    testrunner: &str,
+) -> anyhow::Result<PathBuf> {
+    anyhow::ensure!(
+        is_supported_testrunner(testrunner),
+        "js_test: unsupported testrunner {testrunner:?} — expected \"vitest\" or \"jest\""
+    );
+    let local = workspace_root
+        .join("node_modules")
+        .join(".bin")
+        .join(testrunner);
+    find_host_bin(workspace_root, testrunner).ok_or_else(|| {
+        anyhow::anyhow!(
+            "js_test: no `{testrunner}` binary found at {local:?} or on PATH — install it \
+             (`npm install -D {testrunner}` / `pnpm add -D {testrunner}`) so \
+             `node_modules/.bin/{testrunner}` exists, or make a `{testrunner}` binary available \
+             on PATH. There is no hermetic {testrunner} toolchain yet in this plugin — \
+             `testrunner=\"{testrunner}\"` requires one of those two to be reachable."
+        )
+    })
+}
+
+/// Query the resolved test runner's own `--version` output, trimmed —
+/// hashed into `JsTestDef` so a host runner upgrade/downgrade busts the
+/// cache, mirroring [`query_tsc_version`]'s "query once at `Provider::get`
+/// time, not `run()` time" rationale (see that function's doc): the
+/// driver's cache-key hash is computed in `parse()`, strictly before `run()`,
+/// so a version bump queried only inside `run()` would never bust a cache
+/// hit.
+pub(crate) fn query_test_runner_version(runner_bin: &Path) -> anyhow::Result<String> {
+    let out = std::process::Command::new(runner_bin)
+        .arg("--version")
+        .output()
+        .with_context(|| format!("run {runner_bin:?} --version"))?;
+    anyhow::ensure!(
+        out.status.success(),
+        "`{runner_bin:?} --version` failed ({}): {}",
+        out.status,
+        String::from_utf8_lossy(&out.stderr)
+    );
+    let version = String::from_utf8(out.stdout)
+        .with_context(|| format!("{runner_bin:?} --version output is not utf8"))?
+        .trim()
+        .to_string();
+    anyhow::ensure!(
+        !version.is_empty(),
+        "`{runner_bin:?} --version` returned empty output"
+    );
+    Ok(version)
 }
 
 /// Query `tsc --version`'s full trimmed output (e.g. `"Version 5.6.2"`) —
@@ -198,6 +284,92 @@ mod tests {
             std::fs::set_permissions(&fake_tsc, perms).expect("chmod");
         }
         let err = query_tsc_version(&fake_tsc).expect_err("nonzero exit must error");
+        assert!(format!("{err:#}").contains("failed"));
+    }
+
+    // ---- testrunner (js_test) ----
+
+    #[test]
+    fn is_supported_testrunner_recognizes_only_vitest_and_jest() {
+        assert!(is_supported_testrunner(VITEST));
+        assert!(is_supported_testrunner(JEST));
+        assert!(!is_supported_testrunner("mocha"));
+        assert!(!is_supported_testrunner(""));
+    }
+
+    #[test]
+    fn resolve_host_test_runner_rejects_unsupported_value() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let err = resolve_host_test_runner(dir.path(), "mocha")
+            .expect_err("unsupported testrunner must error");
+        assert!(format!("{err:#}").contains("mocha"));
+    }
+
+    #[test]
+    fn resolve_host_test_runner_prefers_local_node_modules_bin_over_path() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let local_bin_dir = dir.path().join("node_modules").join(".bin");
+        std::fs::create_dir_all(&local_bin_dir).expect("mkdir");
+        let local_vitest = local_bin_dir.join(VITEST);
+        std::fs::write(&local_vitest, b"#!/bin/sh\necho local\n").expect("write local vitest");
+
+        let found = resolve_host_test_runner(dir.path(), VITEST).expect("resolve");
+        assert_eq!(found, local_vitest);
+    }
+
+    #[test]
+    fn resolve_host_test_runner_errors_clearly_when_absent_everywhere() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let prior = std::env::var_os("PATH");
+        // SAFETY: test-only, single-threaded within this process for the
+        // duration of the mutation; restored immediately below.
+        unsafe { std::env::set_var("PATH", "") };
+        let result = resolve_host_test_runner(dir.path(), JEST);
+        match &prior {
+            // SAFETY: test-only, restoring the prior value we saved above.
+            Some(v) => unsafe { std::env::set_var("PATH", v) },
+            // SAFETY: test-only, restoring the prior (unset) state.
+            None => unsafe { std::env::remove_var("PATH") },
+        }
+        let err = result.expect_err("no jest anywhere must error, not silently succeed");
+        let msg = format!("{err:#}");
+        assert!(msg.contains("jest"), "{msg}");
+        assert!(msg.contains("PATH"), "{msg}");
+    }
+
+    #[test]
+    fn query_test_runner_version_reads_trimmed_stdout() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let fake_bin = dir.path().join("vitest");
+        std::fs::write(&fake_bin, "#!/bin/sh\necho 'vitest/1.6.0'\n").expect("write fake runner");
+        #[cfg(unix)]
+        {
+            use std::os::unix::fs::PermissionsExt;
+            let mut perms = std::fs::metadata(&fake_bin)
+                .expect("metadata")
+                .permissions();
+            perms.set_mode(0o755);
+            std::fs::set_permissions(&fake_bin, perms).expect("chmod");
+        }
+        let version = query_test_runner_version(&fake_bin).expect("query version");
+        assert_eq!(version, "vitest/1.6.0");
+    }
+
+    #[test]
+    fn query_test_runner_version_errors_on_nonzero_exit() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let fake_bin = dir.path().join("jest");
+        std::fs::write(&fake_bin, "#!/bin/sh\nexit 3\n").expect("write fake runner");
+        #[cfg(unix)]
+        {
+            use std::os::unix::fs::PermissionsExt;
+            let mut perms = std::fs::metadata(&fake_bin)
+                .expect("metadata")
+                .permissions();
+            perms.set_mode(0o755);
+            std::fs::set_permissions(&fake_bin, perms).expect("chmod");
+        }
+        let err = query_test_runner_version(&fake_bin).expect_err("nonzero exit must error");
         assert!(format!("{err:#}").contains("failed"));
     }
 }


### PR DESCRIPTION
M4 of the JS/TS heph plugin plan (part 4/6 of the stack).

A cacheable js_test ManagedDriver with one target per test file (vitest default, jest alt via a single testrunner config option), fed by the M2/M3 import graph — the differentiator over Turborepo/Nx, which never get finer than per-package task caching.

- Per-test-file Input scoping: the test file's own runtime-transitive closure (BFS over ImportGraph::runtime_edges, bounded to the owning package), third-party deps resolved via the same lockfile-driven mechanism js_install/js_typecheck use, and the resolved test-runner config.
- Runner-config discovery covers vitest's own fallback (vite.config.*) and jest's package.json "jest" field, not just the dedicated config filenames.

Reviewed by feature-quality/code-quality/hermeticity. Three BLOCKERs found and fixed: **a real sandbox escape** — a js_test addr's `file=` argument accepted an absolute path or a `..`-escape with no validation, letting a target read/exec outside the workspace and sandbox entirely (fixed at both Provider::get and defensively again in the driver's run()); vitest/jest config-referenced files (setupFiles, globalSetup, a shared base config) were untracked, so editing one didn't bust the cache of every dependent test; and the primary runner-config file itself could go undiscovered for vite.config.\*/package.json-jest-field layouts. Each has a regression test.

Explicitly deferred: per-test-file Provider::get rebuilding the whole package's import graph from scratch (fixed later in the stack); the cross-package one-hop trim risking a stale test-pass cache hit for a barrel-file re-export; test-runner-specific alias resolution.

## Test plan
- [x] cargo build -p plugin-js -p plugin-js-cdylib
- [x] cargo test -p plugin-js
- [x] cargo clippy -p plugin-js -p plugin-js-cdylib --all-targets -- -D warnings
- [x] cargo fmt --check -p plugin-js -p plugin-js-cdylib

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>