### PR TITLE
feat(plugin-js): per-package ImportGraph cache, js_lint driver

### DIFF
--- a/crates/plugin-js-cdylib/src/lib.rs
+++ b/crates/plugin-js-cdylib/src/lib.rs
@@ -1,20 +1,23 @@
 //! The JS/TS plugin as a loadable cdylib behind the stable ABI.
 //!
-//! **M0-M4 scope**: exports the `js` provider (package discovery + pnpm/npm
+//! **M0-M5 scope**: exports the `js` provider (package discovery + pnpm/npm
 //! workspace-member resolution + lockfile-driven dependency wiring + oxc-based
 //! import-graph resolution), its `js_package_info` dependency-wiring driver,
 //! the hermetic `js_install` third-party fetch driver, the `js_typecheck`
 //! driver (M3 — `tsc --noEmit` per package, via a disclosed non-hermetic
 //! `tstool = "host"` toolchain; see `hplugin_js::pluginjs::driver_typecheck`
-//! module docs), and the `js_test` driver (M4 — one target per test file, via
+//! module docs), the `js_test` driver (M4 — one target per test file, via
 //! the configured `testrunner` (`vitest`/`jest`), same disclosed non-hermetic
 //! host-toolchain shape; see `hplugin_js::pluginjs::driver_test` module
+//! docs), and the `js_lint` driver (M5 — one target per package, via the
+//! configured `linter` (`oxlint`/`eslint`), same disclosed non-hermetic
+//! host-toolchain shape; see `hplugin_js::pluginjs::driver_lint` module
 //! docs). The host loads this with `hplugin_stabby::load_stable::load`,
 //! which verifies ABI compatibility via stabby's type reports before use.
 //! Calls then run in-process at native speed — no serialization on the hot
 //! path, no IPC.
 //!
-//! Linting, formatting, and bundling drivers are later milestones (see
+//! Formatting and bundling drivers are later milestones (see
 //! `ai-docs/js-plugin-plan.md`) and are not wired up here yet.
 //!
 //! Plugin-specific settings are read from the environment; only the
@@ -22,7 +25,7 @@
 
 use hdriver_support::driver_managed::ManagedDriver;
 use hplugin_js::pluginjs::{
-    JsInstallDriver, JsPackageInfoDriver, JsTestDriver, JsTypecheckDriver, Provider,
+    JsInstallDriver, JsLintDriver, JsPackageInfoDriver, JsTestDriver, JsTypecheckDriver, Provider,
 };
 use plugin_sdk::stabby::abi::{DynLogSink, DynSupervisor, NamedDriver, PluginComponents};
 use plugin_sdk::stabby::{
@@ -118,6 +121,15 @@ fn build(cfg: &[u8]) -> anyhow::Result<PluginComponents> {
     drivers.push(NamedDriver {
         name: "js_test".into(),
         driver: make_dyn_managed_driver(test),
+    });
+    // `js_lint` (M5): runs the configured linter (`oxlint` default, `eslint`
+    // alt) against one package at a time — see
+    // `hplugin_js::pluginjs::driver_lint` module docs, including its
+    // disclosed non-hermetic host-toolchain gap.
+    let lint: Arc<dyn ManagedDriver> = Arc::new(JsLintDriver::new());
+    drivers.push(NamedDriver {
+        name: "js_lint".into(),
+        driver: make_dyn_managed_driver(lint),
     });
 
     Ok(PluginComponents {

--- a/crates/plugin-js/src/pluginjs/driver_lint.rs
+++ b/crates/plugin-js/src/pluginjs/driver_lint.rs
@@ -1,0 +1,912 @@
+//! `js_lint` — runs a configured linter over one package at a time.
+//!
+//! One driver name, tool selected by config (`linter = "oxlint"` default,
+//! `"eslint"` alt) — matching the established naming rule this crate already
+//! follows for `js_test`'s `testrunner` axis: never a driver-per-tool
+//! (`js_lint_oxlint`/`js_lint_eslint`), see `ai-docs/js-plugin-plan.md`'s
+//! tool-selection table.
+//!
+//! ## Granularity: per-package, for both tools
+//!
+//! Per the design doc's "Caching / incrementality" section: oxlint (a fast,
+//! syntactic-rules-only linter, no cross-file type information) may be cheap
+//! enough that per-file caching isn't worth the bookkeeping; eslint's
+//! type-aware rules need the same tsconfig-derived type graph `js_typecheck`
+//! needs, which only exists at package granularity. Rather than having
+//! `linter` silently change what a `js_lint` addr even *means* (per-file for
+//! one tool, per-package for the other — which would also make switching
+//! `linter` a breaking addr-shape change for anything depending on a
+//! specific `js_lint` target), this driver is per-package for **both**
+//! tools, matching `js_typecheck`'s own granularity. This is the simpler,
+//! uniform answer and the one the design doc's own reasoning already points
+//! to for eslint; nothing about oxlint's speed argues *for* finer than
+//! per-package here, only that per-file wouldn't have been prohibitively
+//! expensive if chosen — so per-package is not just simpler but has no
+//! displaced correctness or performance win being left on the table.
+//!
+//! ## Toolchain: `linter = host`, the same disclosed non-hermetic escape
+//! ## hatch as `tstool`/`testrunner`
+//!
+//! No hermetic Node toolchain exists anywhere in this plugin yet.
+//! `Provider::get` (see `provider.rs::lint_config`) resolves the configured
+//! linter's binary from the host (`toolchain::resolve_host_linter`) and
+//! threads its absolute path plus its queried `--version` string through
+//! this target's config, queried once per `Provider` lifetime
+//! (`Provider::linter_cache`) rather than once per package — the exact
+//! per-call subprocess-spawn mistake the M4 review already caught once for
+//! `tsc`/the test runner, not to be repeated a third time here.
+//!
+//! ## Inputs / cache key
+//!
+//! `""` = the package's own first-party source files (no tsconfig
+//! `include`/`exclude` filtering — a linter reads raw source files directly,
+//! unlike `tsc`'s project-scoped compilation); `"config"` = the resolved
+//! linter config file, if any (`.oxlintrc.json` for oxlint; the modern flat
+//! `eslint.config.*` or a legacy `.eslintrc.*` for eslint, walked up the
+//! ancestor chain the same way `tsconfig.json`/test-runner configs are — see
+//! `provider.rs`'s `lint_config_candidates`). Deliberately **no**
+//! `package.json`-field fallback (`"oxlint"`/`"eslintConfig"`) — an earlier
+//! version had one, but neither tool actually reads a `package.json` that
+//! way when invoked with the `-c <path>` flag this driver always passes (a
+//! feature-quality M5 review finding); see
+//! `importgraph::find_nearest_package_json_field_config`'s doc.
+//!
+//! `"tsconfig"` (eslint type-aware rules only) = the tsconfig(s) named by
+//! every `parserOptions.project` occurrence (a multi-entry flat config can
+//! have more than one — every one is resolved, not just the first, per a
+//! code-quality M5 review finding) plus each one's whole `extends` chain,
+//! exactly the same Input/hash treatment `js_typecheck` gives its own
+//! tsconfig — **this is the specific gap named by the M5 task**: an eslint
+//! config with type-aware rules gets its type information from that tsconfig
+//! the same way `tsc` does, so a change anywhere in it (or its `extends`
+//! chain) must bust this target's cache the same way it busts
+//! `js_typecheck`'s, and M3/M4 already caught this exact class of miss (an
+//! under-declared dependency graph) for two other drivers; `"eslint_plugins"`
+//! (eslint only) = every `extends`/`plugins` entry that names an npm
+//! package, resolved through the lockfile (`deps::resolve_one_dependency`) —
+//! never treated as a raw filesystem path, the same M3/M4-review-class
+//! mistake named again here; `"config_refs"` (eslint only) = every
+//! *relative-path* shared config file the leaf config's own `extends`/
+//! `plugins` (legacy) or relative `import`/`require` (modern flat config)
+//! names — see `importgraph::resolve_eslint_config_referenced_files`'s doc
+//! for the hermeticity M5 review finding this closes (a shared base config
+//! edited without touching the leaf config previously left the cache key
+//! unchanged). See `provider.rs`'s `lint_deps_config` and its tests for the
+//! input-scoping proof, mirroring `typecheck_deps_config`'s role for
+//! `js_typecheck`.
+//!
+//! Beyond the declared `Input`s, [`JsLintDef::hash`] additionally hashes the
+//! resolved config's own content and (for eslint type-aware rules) the
+//! tsconfig chain's content directly, plus the queried `linter_version`
+//! string — the same deliberate redundancy `JsTypecheckDef::hash` already
+//! has with its own declared tsconfig Input, for the identical reason (the
+//! explicit hash keeps this target's cache-sensitivity independently
+//! verifiable at the `parse()` level without a full engine round-trip). Like
+//! `tsc_bin`, `linter_bin` (an absolute host path) is deliberately
+//! **excluded** — see that field's own doc comment.
+//!
+//! ## Failure reporting
+//!
+//! Both oxlint and eslint exit non-zero when they find lint errors (as
+//! opposed to `go_lint`'s `-json`-always-exits-0 analyze/gate split, which
+//! exists there to let facts propagate to dependents even when a package has
+//! findings — `js_lint` has no such fact-propagation concern, mirroring
+//! `js_typecheck`'s identical single-driver shape). A non-zero exit fails the
+//! driver with both stdout and stderr tails included: which files, which
+//! rules, and why is the whole point of a lint failure, so nothing here
+//! swallows the linter's own output — see [`lint_failure_detail`].
+
+use anyhow::Context;
+use async_trait::async_trait;
+use hcore::debug_hash::DebugHasher;
+use hcore::hasync::Cancellable;
+use hdriver_support::driver_managed::{ManagedDriver, ManagedRunRequest, ManagedRunResponse};
+use hplugin::driver::targetdef::{CacheConfig, Input, InputMode, TargetDef};
+use hplugin::driver::{
+    ApplyTransitiveRequest, ApplyTransitiveResponse, ConfigRequest, ConfigResponse, ParseRequest,
+    ParseResponse, TargetAddr,
+};
+use hplugin::htspec::Spec;
+use hproc::proc_exec;
+use std::collections::HashMap;
+use std::ffi::OsString;
+use std::hash::{Hash, Hasher};
+use std::io::BufRead;
+use std::sync::Arc;
+use xxhash_rust::xxh3::Xxh3Default;
+
+/// Config for a `js_lint` target. Entirely engine-generated by the `js`
+/// provider's `Provider::get` (see `pluginjs::provider::Provider::lint_config`)
+/// — never authored by hand in a BUILD file.
+#[derive(Spec)]
+struct JsLintSpec {
+    /// Which linter this target runs — `"oxlint"` or `"eslint"`. Not itself
+    /// used to pick the invocation shape at `run()` time beyond a `-c`
+    /// config flag both tools share; carried through mainly so a driver-side
+    /// bug surfaces as "ran the wrong linter" rather than silently assuming
+    /// one.
+    #[spec(required)]
+    linter: String,
+    /// Absolute host path to the resolved linter binary
+    /// (`toolchain::resolve_host_linter`). Deliberately **not** part of
+    /// `JsLintDef`'s hash — see that struct's `linter_bin` field doc.
+    #[spec(required)]
+    linter_bin: String,
+    /// `<linter> --version`'s trimmed output, queried once by `Provider::get`.
+    /// Hashed: a host linter upgrade/downgrade must bust the cache.
+    #[spec(required)]
+    linter_version: String,
+    /// Workspace-root-relative path to the resolved linter config, if any.
+    /// Empty when no config file was found anywhere on the ancestor chain
+    /// (the linter then runs with its own built-in defaults).
+    config_path: String,
+    /// The resolved config's own raw bytes, hashed directly — see module
+    /// docs' "Inputs / cache key" section for why this is not purely
+    /// redundant with the `"config"` dep group below.
+    config_content: String,
+    /// (eslint type-aware rules only) workspace-root-relative path to the
+    /// tsconfig named by `parserOptions.project` (the first one, when
+    /// multiple are configured). Empty for oxlint, and for an eslint config
+    /// with no type-aware rules configured.
+    tsconfig_path: String,
+    /// The resolved tsconfig's own raw bytes plus its whole `extends`
+    /// chain's, concatenated — see module docs' "Inputs / cache key" section
+    /// for why this is the specific gap the M5 task named.
+    tsconfig_content: String,
+    /// Dependencies, grouped by name → list of target addresses: `""` = the
+    /// package's own first-party source files, `"config"` = the resolved
+    /// linter config file (0 or 1 entries), `"tsconfig"` (eslint type-aware
+    /// only) = the tsconfig(s) plus their `extends` chain, `"eslint_plugins"`
+    /// (eslint only) = every `extends`/`plugins` npm package — see module
+    /// docs' "Inputs / cache key" section.
+    deps: HashMap<String, Vec<String>>,
+}
+
+#[derive(Clone, serde::Serialize, serde::Deserialize)]
+struct JsLintDef {
+    linter: String,
+    linter_version: String,
+    config_path: String,
+    config_content: String,
+    tsconfig_path: String,
+    tsconfig_content: String,
+    /// Absolute host linter path — carried through so `run()` can exec it,
+    /// but see `Hash` impl below: deliberately excluded from the cache key.
+    linter_bin: String,
+}
+
+/// Bump to invalidate every cached `js_lint` result whenever the invocation
+/// shape (flags, config-lookup rule, what counts as a hashed config field)
+/// changes in a way the declared `Input` content hash alone would not
+/// already capture.
+const JS_LINT_FORMAT_VERSION: u32 = 1;
+
+impl Hash for JsLintDef {
+    fn hash<H: Hasher>(&self, state: &mut H) {
+        JS_LINT_FORMAT_VERSION.hash(state);
+        self.linter.hash(state);
+        self.linter_version.hash(state);
+        self.config_path.hash(state);
+        self.config_content.hash(state);
+        self.tsconfig_path.hash(state);
+        self.tsconfig_content.hash(state);
+        // `linter_bin` is deliberately NOT hashed: it's an absolute host
+        // filesystem path that differs across machines/checkouts for the
+        // exact same effective toolchain — hashing it would needlessly
+        // break cache portability (including remote-cache sharing) for a
+        // toolchain that is otherwise identical. `linter_version` is the
+        // actual cache-relevant signal, mirroring `JsTypecheckDef`'s
+        // identical `tsc_bin` exclusion.
+        //
+        // Source/config file *content* arrives via declared `Input`s; the
+        // engine hashes that separately (architecture.md's "Automatic
+        // hashing"), so it is not duplicated here — same discipline as
+        // `JsTypecheckDef`.
+    }
+}
+
+pub struct JsLintDriver;
+
+impl JsLintDriver {
+    pub fn new() -> Self {
+        Self
+    }
+}
+
+impl Default for JsLintDriver {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+#[async_trait]
+impl ManagedDriver for JsLintDriver {
+    fn config(&self, _req: ConfigRequest) -> anyhow::Result<ConfigResponse> {
+        Ok(ConfigResponse {
+            name: "js_lint".to_string(),
+        })
+    }
+
+    fn schema(&self) -> hplugin::driver::DriverSchema {
+        JsLintSpec::schema()
+    }
+
+    async fn parse(
+        &self,
+        req: ParseRequest,
+        _ctoken: &(dyn Cancellable + Send + Sync),
+    ) -> anyhow::Result<ParseResponse> {
+        let addr = &req.target_spec.addr;
+        let pkg = addr.package.clone();
+        let spec = JsLintSpec::from(&req.target_spec.config).context("parse js_lint config")?;
+
+        // Dep groups arrive from a HashMap — sort by group name so the
+        // resulting `inputs` is deterministic across parses, not
+        // HashMap-iteration order. Same regression class as
+        // `driver_typecheck.rs`/`driver_test.rs`.
+        let mut groups: Vec<(&String, &Vec<String>)> = spec.deps.iter().collect();
+        groups.sort_by_key(|(group, _)| *group);
+        let mut inputs: Vec<Input> = Vec::new();
+        for (group, addrs) in groups {
+            for (i, addr_str) in addrs.iter().enumerate() {
+                inputs.push(Input {
+                    r#ref: TargetAddr::parse(addr_str, &pkg)
+                        .with_context(|| format!("parse dep addr {addr_str}"))?,
+                    mode: InputMode::Standard,
+                    origin_id: format!("dep|{group}|{i}"),
+                    annotations: Default::default(),
+                    hashed: true,
+                    runtime: true,
+                });
+            }
+        }
+
+        let def = JsLintDef {
+            linter: spec.linter,
+            linter_version: spec.linter_version,
+            config_path: spec.config_path,
+            config_content: spec.config_content,
+            tsconfig_path: spec.tsconfig_path,
+            tsconfig_content: spec.tsconfig_content,
+            linter_bin: spec.linter_bin,
+        };
+
+        let hash = {
+            let mut h =
+                DebugHasher::new(Xxh3Default::new(), || format!("js_lint_{}", addr.format()));
+            def.hash(&mut h);
+            format!("{:x}", h.finish()).into_bytes()
+        };
+
+        Ok(ParseResponse {
+            target_def: TargetDef {
+                addr: addr.clone(),
+                labels: req.target_spec.labels.clone(),
+                raw_def: Arc::new(def),
+                inputs,
+                // No output artifact: a `js_lint` target's only observable
+                // effect is "did it succeed" — mirrors `js_typecheck`'s
+                // identical read-only, produces-nothing shape.
+                outputs: vec![],
+                support_files: vec![],
+                cache: CacheConfig::on(true),
+                pty: false,
+                hash,
+                transparent: false,
+            },
+        })
+    }
+
+    async fn apply_transitive(
+        &self,
+        req: ApplyTransitiveRequest,
+        _ctoken: &(dyn Cancellable + Send + Sync),
+    ) -> anyhow::Result<ApplyTransitiveResponse> {
+        Ok(ApplyTransitiveResponse {
+            target_def: req.target_def,
+        })
+    }
+
+    async fn run<'a, 'io>(
+        &self,
+        req: ManagedRunRequest<'a, 'io>,
+        ctoken: &(dyn Cancellable + Send + Sync),
+    ) -> anyhow::Result<ManagedRunResponse> {
+        let def = req.request.target.def_de::<JsLintDef>();
+        let linter_bin = std::path::PathBuf::from(&def.linter_bin);
+
+        let srcs = self.group_staged_paths(&req, "");
+        if srcs.is_empty() {
+            // No first-party source files staged. Unlike `js_test` (which
+            // only ever lists a target for a file discovery actually found),
+            // `js_lint` is listed unconditionally for every package with a
+            // `package.json` (see `Provider::list`'s doc) — a very plausible
+            // case: the workspace-root `package.json`, a types-only
+            // re-export package, or a package mid-scaffolding. Hard-failing
+            // here (an earlier version did) made every such package's
+            // `js_lint` target permanently, unavoidably red with no way to
+            // opt out — a feature-quality M5 review finding. Nothing to
+            // lint, so succeed trivially, mirroring `js_typecheck`'s intent
+            // (not its letter — that guard only fires in its no-tsconfig
+            // fallback branch) of not hard-failing on an empty input set.
+            return Ok(ManagedRunResponse { artifacts: vec![] });
+        }
+
+        // `linter = "host"`-equivalent non-hermetic escape hatch (see module
+        // docs): the resolved binary is very likely a `#!/usr/bin/env node`
+        // shebang script (eslint always is; oxlint ships a native binary but
+        // its `node_modules/.bin` wrapper may still shell out), so executing
+        // it needs `node` reachable via PATH — mirrors `js_typecheck`'s
+        // identical PATH passthrough. Only `PATH` is forwarded.
+        let mut env: HashMap<String, String> = HashMap::new();
+        if let Ok(v) = std::env::var("PATH") {
+            env.insert("PATH".to_string(), v);
+        }
+
+        let mut args: Vec<OsString> = Vec::new();
+        if !def.config_path.is_empty() {
+            let config_abs = req.sandbox_ws_dir.join(&def.config_path);
+            args.push(OsString::from("-c"));
+            args.push(config_abs.into_os_string());
+        }
+        args.extend(srcs.into_iter().map(OsString::from));
+
+        self.exec_linter(&linter_bin, args, &env, &req.sandbox_ws_dir, ctoken)
+            .await?;
+
+        Ok(ManagedRunResponse { artifacts: vec![] })
+    }
+}
+
+impl JsLintDriver {
+    /// All staged file paths for the inputs in dep `group` (origin
+    /// `dep|group|*`). Mirrors `driver_typecheck.rs`/`driver_test.rs`'s
+    /// identically-named helper.
+    fn group_staged_paths(&self, req: &ManagedRunRequest<'_, '_>, group: &str) -> Vec<String> {
+        let prefix = format!("dep|{group}|");
+        let mut out: Vec<String> = Vec::new();
+        for m in &req.inputs {
+            if !m.input.origin_id.starts_with(&prefix) {
+                continue;
+            }
+            let Ok(list_path) = m.require_list_path() else {
+                continue;
+            };
+            if let Ok(f) = std::fs::File::open(list_path) {
+                for line in std::io::BufReader::new(f).lines().map_while(Result::ok) {
+                    if !line.is_empty() {
+                        out.push(line);
+                    }
+                }
+            }
+        }
+        out
+    }
+
+    async fn exec_linter(
+        &self,
+        linter_bin: &std::path::Path,
+        args: Vec<OsString>,
+        env: &HashMap<String, String>,
+        cwd: &std::path::Path,
+        ctoken: &(dyn Cancellable + Send + Sync),
+    ) -> anyhow::Result<()> {
+        let env_pairs: Vec<(OsString, OsString)> = env
+            .iter()
+            .map(|(k, v)| (OsString::from(k), OsString::from(v)))
+            .collect();
+        let spec = proc_exec::Spec {
+            program: linter_bin.to_path_buf(),
+            args,
+            env: env_pairs,
+            cwd: cwd.to_path_buf(),
+            stdin: proc_exec::StdioSpec::Null,
+            stdout: proc_exec::StdioSpec::Piped,
+            stderr: proc_exec::StdioSpec::Piped,
+            setsid: false,
+            ctty: false,
+        };
+        let output = proc_exec::output(spec, ctoken)
+            .await
+            .with_context(|| format!("wait for linter ({linter_bin:?})"))?;
+        if !output.status.success() {
+            let stdout = String::from_utf8_lossy(&output.stdout);
+            let stderr = String::from_utf8_lossy(&output.stderr);
+            anyhow::bail!(
+                "lint failed ({}):\n{}",
+                output.status,
+                lint_failure_detail(&stdout, &stderr)
+            );
+        }
+        Ok(())
+    }
+}
+
+/// Build the human-readable detail for a failed lint invocation. Both oxlint
+/// and eslint print findings to stdout by default; stderr is included too
+/// (a config/fatal error commonly lands there instead) — mirrors
+/// `driver_typecheck.rs`'s `tsc_failure_detail` for the identical reason: a
+/// tool whose failure output lands on either stream depending on the failure
+/// mode must never come back silently blank.
+fn lint_failure_detail(stdout: &str, stderr: &str) -> String {
+    let stdout_tail = hplugin::error::last_n_lines(stdout.trim(), 60);
+    let stderr_tail = hplugin::error::last_n_lines(stderr.trim(), 40);
+    let mut detail = String::new();
+    if !stdout_tail.is_empty() {
+        detail.push_str("stdout:\n");
+        detail.push_str(&stdout_tail);
+    }
+    if !stderr_tail.is_empty() {
+        if !detail.is_empty() {
+            detail.push('\n');
+        }
+        detail.push_str("stderr:\n");
+        detail.push_str(&stderr_tail);
+    }
+    if detail.is_empty() {
+        "<no output on stdout or stderr>".to_string()
+    } else {
+        detail
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use hcore::hasync::StdCancellationToken;
+    use hcore::htvalue::Value;
+    use hmodel::htaddr::Addr;
+    use hmodel::htpkg::PkgBuf;
+    use hplugin::provider::TargetSpec;
+    use std::collections::HashMap;
+
+    fn driver() -> JsLintDriver {
+        JsLintDriver::new()
+    }
+
+    fn ctoken() -> StdCancellationToken {
+        StdCancellationToken::new()
+    }
+
+    fn config(extra: &[(&str, Value)]) -> HashMap<String, Value> {
+        let mut c: HashMap<String, Value> = HashMap::from([
+            ("linter".to_string(), Value::String("oxlint".to_string())),
+            (
+                "linter_bin".to_string(),
+                Value::String("/usr/bin/oxlint".to_string()),
+            ),
+            (
+                "linter_version".to_string(),
+                Value::String("0.15.0".to_string()),
+            ),
+            (
+                "config_path".to_string(),
+                Value::String("packages/a/.oxlintrc.json".to_string()),
+            ),
+            (
+                "config_content".to_string(),
+                Value::String("{}".to_string()),
+            ),
+            ("tsconfig_path".to_string(), Value::String(String::new())),
+            ("tsconfig_content".to_string(), Value::String(String::new())),
+        ]);
+        for (k, v) in extra {
+            c.insert((*k).to_string(), v.clone());
+        }
+        c
+    }
+
+    fn make_parse_request(extra: &[(&str, Value)]) -> ParseRequest {
+        ParseRequest {
+            request_id: "test".to_string(),
+            target_spec: Arc::new(TargetSpec {
+                addr: Addr::new(
+                    PkgBuf::from("packages/a"),
+                    "js_lint".to_string(),
+                    Default::default(),
+                ),
+                driver: "js_lint".to_string(),
+                config: config(extra),
+                ..Default::default()
+            }),
+        }
+    }
+
+    #[tokio::test]
+    async fn driver_name_is_js_lint() {
+        let resp = driver().config(ConfigRequest {}).unwrap();
+        assert_eq!(resp.name, "js_lint");
+    }
+
+    #[tokio::test]
+    async fn parse_missing_required_field_errors() {
+        let ct = ctoken();
+        let req = ParseRequest {
+            request_id: "test".to_string(),
+            target_spec: Arc::new(TargetSpec {
+                addr: Addr::new(
+                    PkgBuf::from("packages/a"),
+                    "js_lint".to_string(),
+                    Default::default(),
+                ),
+                driver: "js_lint".to_string(),
+                ..Default::default()
+            }),
+        };
+        assert!(driver().parse(req, &ct).await.is_err());
+    }
+
+    #[tokio::test]
+    async fn parse_hash_stable_across_identical_parses() {
+        let ct = ctoken();
+        let a = driver().parse(make_parse_request(&[]), &ct).await.unwrap();
+        let b = driver().parse(make_parse_request(&[]), &ct).await.unwrap();
+        assert_eq!(a.target_def.hash, b.target_def.hash);
+    }
+
+    /// Task requirement: a linter *version* change must bust the cache.
+    #[tokio::test]
+    async fn parse_hash_changes_when_linter_version_changes() {
+        let ct = ctoken();
+        let a = driver().parse(make_parse_request(&[]), &ct).await.unwrap();
+        let b = driver()
+            .parse(
+                make_parse_request(&[("linter_version", Value::String("0.16.0".to_string()))]),
+                &ct,
+            )
+            .await
+            .unwrap();
+        assert_ne!(a.target_def.hash, b.target_def.hash);
+    }
+
+    /// Task requirement: the cache key changes when the resolved linter
+    /// config changes, and is stable when it does not.
+    #[tokio::test]
+    async fn parse_hash_changes_when_config_content_changes_and_stable_when_not() {
+        let ct = ctoken();
+        let a = driver().parse(make_parse_request(&[]), &ct).await.unwrap();
+        let b = driver().parse(make_parse_request(&[]), &ct).await.unwrap();
+        assert_eq!(
+            a.target_def.hash, b.target_def.hash,
+            "identical config content must hash identically"
+        );
+
+        let c = driver()
+            .parse(
+                make_parse_request(&[(
+                    "config_content",
+                    Value::String(r#"{"rules":{"no-console":"error"}}"#.to_string()),
+                )]),
+                &ct,
+            )
+            .await
+            .unwrap();
+        assert_ne!(
+            a.target_def.hash, c.target_def.hash,
+            "a changed lint config content must change the cache key"
+        );
+    }
+
+    /// Task requirement (the specific M5 gap): for eslint with type-aware
+    /// rules configured, the cache key changes when the tsconfig extends
+    /// chain changes — proxied here at the `parse()` level via
+    /// `tsconfig_content` exactly the way `driver_typecheck.rs`'s own
+    /// identical test proxies a tsconfig content change (the config-value's
+    /// derivation from the real extends chain is proven separately in
+    /// `provider.rs`'s `lint_deps_config` tests; this proves the *driver*
+    /// half — a changed `tsconfig_content` value actually reaches the hash).
+    #[tokio::test]
+    async fn parse_hash_changes_when_eslint_tsconfig_content_changes() {
+        let ct = ctoken();
+        let base = &[
+            ("linter", Value::String("eslint".to_string())),
+            (
+                "tsconfig_path",
+                Value::String("packages/a/tsconfig.json".to_string()),
+            ),
+            (
+                "tsconfig_content",
+                Value::String(r#"{"compilerOptions":{}}"#.to_string()),
+            ),
+        ];
+        let a = driver().parse(make_parse_request(base), &ct).await.unwrap();
+        let b = driver()
+            .parse(
+                make_parse_request(&[
+                    ("linter", Value::String("eslint".to_string())),
+                    (
+                        "tsconfig_path",
+                        Value::String("packages/a/tsconfig.json".to_string()),
+                    ),
+                    (
+                        // Simulates the extends chain changing (e.g. the
+                        // base tsconfig it extends flipping `strict`),
+                        // concatenated into `tsconfig_content` by
+                        // `lint_deps_config` the same way
+                        // `typecheck_deps_config` does for js_typecheck.
+                        "tsconfig_content",
+                        Value::String(
+                            r#"{"compilerOptions":{}}\n{"compilerOptions":{"strict":true}}"#
+                                .to_string(),
+                        ),
+                    ),
+                ]),
+                &ct,
+            )
+            .await
+            .unwrap();
+        assert_ne!(
+            a.target_def.hash, b.target_def.hash,
+            "an eslint type-aware tsconfig extends-chain content change must bust the cache"
+        );
+    }
+
+    /// `linter_bin` is an absolute host path — must NOT affect the cache key.
+    #[tokio::test]
+    async fn parse_hash_unaffected_by_linter_bin_path_difference() {
+        let ct = ctoken();
+        let a = driver().parse(make_parse_request(&[]), &ct).await.unwrap();
+        let b = driver()
+            .parse(
+                make_parse_request(&[(
+                    "linter_bin",
+                    Value::String("/home/someone/project/node_modules/.bin/oxlint".to_string()),
+                )]),
+                &ct,
+            )
+            .await
+            .unwrap();
+        assert_eq!(
+            a.target_def.hash, b.target_def.hash,
+            "a different host linter path for the same effective toolchain must not bust the cache"
+        );
+    }
+
+    #[tokio::test]
+    async fn parse_no_outputs_and_caches_locally_and_remotely() {
+        let ct = ctoken();
+        let resp = driver().parse(make_parse_request(&[]), &ct).await.unwrap();
+        assert!(resp.target_def.outputs.is_empty());
+        assert!(resp.target_def.cache.enabled);
+        assert!(resp.target_def.cache.remote_enabled);
+    }
+
+    fn make_parse_request_with_deps(deps: Vec<(&str, Vec<&str>)>) -> ParseRequest {
+        let mut c = config(&[]);
+        let deps_map: HashMap<String, Value> = deps
+            .into_iter()
+            .map(|(k, vs)| {
+                (
+                    k.to_string(),
+                    Value::List(
+                        vs.into_iter()
+                            .map(|v| Value::String(v.to_string()))
+                            .collect(),
+                    ),
+                )
+            })
+            .collect();
+        c.insert("deps".to_string(), Value::Map(deps_map));
+        ParseRequest {
+            request_id: "test".to_string(),
+            target_spec: Arc::new(TargetSpec {
+                addr: Addr::new(
+                    PkgBuf::from("packages/a"),
+                    "js_lint".to_string(),
+                    Default::default(),
+                ),
+                driver: "js_lint".to_string(),
+                config: c,
+                ..Default::default()
+            }),
+        }
+    }
+
+    #[tokio::test]
+    async fn parse_deps_become_target_dep_inputs_ordered_by_group() {
+        let ct = ctoken();
+        let req = make_parse_request_with_deps(vec![
+            (
+                "eslint_plugins",
+                vec!["//@heph/js/thirdparty/eslint-plugin-react@1.0.0:js_install"],
+            ),
+            ("", vec!["//@heph/fs:file@f=packages/a/src/index.ts"]),
+            (
+                "config",
+                vec!["//@heph/fs:file@f=packages/a/.oxlintrc.json"],
+            ),
+        ]);
+        let resp = driver().parse(req, &ct).await.unwrap();
+        let origin_ids: Vec<&str> = resp
+            .target_def
+            .inputs
+            .iter()
+            .map(|i| i.origin_id.as_str())
+            .collect();
+        // Sorted group order: "" < "config" < "eslint_plugins".
+        assert_eq!(
+            origin_ids,
+            vec!["dep||0", "dep|config|0", "dep|eslint_plugins|0"]
+        );
+    }
+
+    /// Task requirement (feature-quality M5 review finding): `js_lint` is
+    /// listed unconditionally for every package with a `package.json` — no
+    /// discovery gating the way `js_test`'s per-file glob has (see
+    /// `Provider::list`'s doc). A package with zero matched first-party
+    /// source files (the workspace-root `package.json`, a types-only
+    /// re-export package, a package mid-scaffolding) must not get a
+    /// permanently-failing target with no way to opt out. Needs no real
+    /// linter binary: with no staged `""`-group inputs, `run()` must take the
+    /// early no-op return before ever touching `linter_bin`.
+    #[tokio::test]
+    async fn run_noops_successfully_when_no_source_files_staged() {
+        let ct = ctoken();
+        let parsed = driver().parse(make_parse_request(&[]), &ct).await.unwrap();
+
+        let dir = tempfile::tempdir().expect("tempdir");
+        let request_id = "test".to_string();
+        let run_req = make_run_request(
+            &parsed.target_def,
+            &request_id,
+            dir.path().to_path_buf(),
+            dir.path().join("packages/a"),
+            "deadbeef",
+        );
+        let resp = driver()
+            .run(run_req, &ct)
+            .await
+            .expect("zero staged source files must no-op successfully, not hard-fail");
+        assert!(resp.artifacts.is_empty());
+    }
+
+    // ---- run(): gated on a real oxlint/eslint binary being available in
+    // this devenv ----
+    //
+    // Everything above tests cache-key/Input-declaration behavior and needs
+    // no real linter. These two exercise the actual subprocess invocation and
+    // its success/failure surfacing (task requirement 5) — they require a
+    // real `oxlint` (checked via PATH) and skip cleanly, with a clear
+    // message, when one isn't present, rather than failing the whole suite.
+
+    fn find_real_oxlint() -> Option<std::path::PathBuf> {
+        let path = std::env::var_os("PATH")?;
+        for dir in std::env::split_paths(&path) {
+            let cand = dir.join("oxlint");
+            if std::fs::metadata(&cand)
+                .map(|m| m.is_file())
+                .unwrap_or(false)
+            {
+                return Some(cand);
+            }
+        }
+        None
+    }
+
+    fn write(dir: &std::path::Path, rel: &str, contents: &str) {
+        let path = dir.join(rel);
+        if let Some(parent) = path.parent() {
+            std::fs::create_dir_all(parent).expect("create parent dir");
+        }
+        std::fs::write(path, contents).expect("write fixture file");
+    }
+
+    fn make_run_request<'a>(
+        target: &'a TargetDef,
+        request_id: &'a String,
+        ws_dir: std::path::PathBuf,
+        pkg_dir: std::path::PathBuf,
+        hashin: &'a str,
+    ) -> ManagedRunRequest<'a, 'a> {
+        use hplugin::driver::{RunInput, RunRequest};
+        ManagedRunRequest {
+            request: RunRequest {
+                request_id,
+                target,
+                tree_root_path: ws_dir.clone(),
+                inputs: Vec::<RunInput>::new(),
+                hashin,
+                stdin: None,
+                stdout: None,
+                stderr: None,
+                sandbox_dir: ws_dir.clone(),
+            },
+            sandbox_dir: ws_dir.clone(),
+            sandbox_ws_dir: ws_dir,
+            sandbox_pkg_dir: pkg_dir,
+            inputs: Vec::new(),
+        }
+    }
+
+    #[tokio::test]
+    #[ignore = "requires a real `oxlint` on PATH — devenv.nix provisions no Node/oxlint \
+                toolchain (see toolchain.rs module docs); run explicitly with \
+                `cargo test -- --ignored` on a host with oxlint installed"]
+    async fn run_succeeds_on_a_clean_package() {
+        let oxlint = find_real_oxlint().expect(
+            "this test is #[ignore]d precisely because `oxlint` isn't guaranteed on PATH — it \
+             was run explicitly, so a missing `oxlint` here is a real failure, not a skip",
+        );
+
+        let dir = tempfile::tempdir().expect("tempdir");
+        write(
+            dir.path(),
+            "packages/a/src/index.ts",
+            "export const x = 1;\n",
+        );
+
+        let ct = ctoken();
+        let req = make_parse_request(&[
+            (
+                "linter_bin",
+                Value::String(oxlint.to_string_lossy().into_owned()),
+            ),
+            ("config_path", Value::String(String::new())),
+            ("config_content", Value::String(String::new())),
+        ]);
+        let parsed = driver().parse(req, &ct).await.unwrap();
+
+        let request_id = "test".to_string();
+        let run_req = make_run_request(
+            &parsed.target_def,
+            &request_id,
+            dir.path().to_path_buf(),
+            dir.path().join("packages/a"),
+            "deadbeef",
+        );
+        driver()
+            .run(run_req, &ct)
+            .await
+            .expect("a clean package must lint successfully");
+    }
+
+    #[tokio::test]
+    #[ignore = "requires a real `oxlint` on PATH — devenv.nix provisions no Node/oxlint \
+                toolchain (see toolchain.rs module docs); run explicitly with \
+                `cargo test -- --ignored` on a host with oxlint installed"]
+    async fn run_fails_and_surfaces_lint_output_on_a_real_violation() {
+        let oxlint = find_real_oxlint().expect(
+            "this test is #[ignore]d precisely because `oxlint` isn't guaranteed on PATH — it \
+             was run explicitly, so a missing `oxlint` here is a real failure, not a skip",
+        );
+
+        let dir = tempfile::tempdir().expect("tempdir");
+        // `no-debugger` is one of oxlint's default-enabled correctness rules.
+        write(
+            dir.path(),
+            "packages/a/src/index.ts",
+            "debugger;\nexport const x = 1;\n",
+        );
+
+        let ct = ctoken();
+        let req = make_parse_request(&[
+            (
+                "linter_bin",
+                Value::String(oxlint.to_string_lossy().into_owned()),
+            ),
+            ("config_path", Value::String(String::new())),
+            ("config_content", Value::String(String::new())),
+        ]);
+        let parsed = driver().parse(req, &ct).await.unwrap();
+
+        let request_id = "test".to_string();
+        let run_req = make_run_request(
+            &parsed.target_def,
+            &request_id,
+            dir.path().to_path_buf(),
+            dir.path().join("packages/a"),
+            "deadbeef",
+        );
+        let err = driver()
+            .run(run_req, &ct)
+            .await
+            .err()
+            .expect("a real lint violation must fail the driver, not succeed silently");
+        let msg = format!("{err:#}");
+        assert!(msg.contains("lint failed"), "{msg}");
+        assert!(
+            msg.contains("no-debugger") || msg.contains("debugger"),
+            "the failure must name the violating rule/statement: {msg}"
+        );
+    }
+}

--- a/crates/plugin-js/src/pluginjs/importgraph.rs
+++ b/crates/plugin-js/src/pluginjs/importgraph.rs
@@ -449,6 +449,18 @@ pub fn find_nearest_test_runner_config(
     find_nearest_file(workspace_root, pkg_dir, candidates)
 }
 
+/// Same ancestor walk, generalized once more to `js_lint`'s linter config
+/// files (e.g. `[".oxlintrc.json"]` for oxlint, the flat/legacy `eslint.
+/// config.*`/`.eslintrc.*` candidate list for eslint) — see `driver_lint.rs`
+/// module docs.
+pub fn find_nearest_lint_config(
+    workspace_root: &Path,
+    pkg_dir: &Path,
+    candidates: &[&str],
+) -> Option<PathBuf> {
+    find_nearest_file(workspace_root, pkg_dir, candidates)
+}
+
 /// Walk up from `pkg_dir` (inclusive) to `workspace_root` looking for the
 /// nearest `package.json` whose own `"jest"` field is present — jest's other
 /// documented config location, alongside the dedicated `jest.config.*`
@@ -464,13 +476,42 @@ pub fn find_nearest_jest_package_json_config(
     workspace_root: &Path,
     pkg_dir: &Path,
 ) -> Option<PathBuf> {
+    find_nearest_package_json_field_config(workspace_root, pkg_dir, "jest")
+}
+
+/// **Deliberately no `js_lint` analog of this fallback for oxlint/eslint**:
+/// an earlier version of this module also walked up for a `package.json`
+/// `"oxlint"`/`"eslintConfig"` field the same way, on the theory that it
+/// mirrored jest's own `package.json`-field config location above. It didn't
+/// — a feature-quality M5 review caught that neither tool actually reads a
+/// `package.json` this way when invoked with `-c <that package.json>`:
+/// oxlint's documented auto-discovery is exactly `.oxlintrc.json` /
+/// `.oxlintrc.jsonc` / `oxlint.config.{ts,mts}`, nothing about a
+/// `package.json` field; eslint's `--config`/`-c` flag only accepts a real
+/// `eslint.config.*`/`.eslintrc.*` file; ESLint's real legacy
+/// `"eslintConfig"` field is picked up only by its own automatic cascading
+/// discovery when `--config` is *not* passed, which `js_lint`'s `-c`-always
+/// invocation shape (`driver_lint.rs::run`) never leaves room for. Passing
+/// `-c <package.json>` handed either tool a file shape it doesn't parse as
+/// config, so the fallback was removed rather than kept and made to somehow
+/// work — jest's own `package.json`-field fallback below is unaffected
+/// (jest's test-runner CLI has no equivalent single-`-c`-flag constraint).
+///
+/// Shared ancestor walk behind [`find_nearest_jest_package_json_config`]:
+/// walk up from `pkg_dir` (inclusive) to `workspace_root` for the nearest
+/// `package.json` that carries a top-level `field` key.
+fn find_nearest_package_json_field_config(
+    workspace_root: &Path,
+    pkg_dir: &Path,
+    field: &str,
+) -> Option<PathBuf> {
     let mut dir = pkg_dir;
     loop {
         let candidate = dir.join(PACKAGE_JSON);
         if candidate.is_file()
             && let Ok(text) = std::fs::read_to_string(&candidate)
             && let Ok(value) = serde_json::from_str::<serde_json::Value>(&text)
-            && value.get("jest").is_some()
+            && value.get(field).is_some()
         {
             return Some(candidate);
         }
@@ -713,6 +754,581 @@ fn enqueue_referenced_config_file(
         if let Ok(next_content) = std::fs::read_to_string(&resolved) {
             queue.push_back((resolved, next_content, depth + 1));
         }
+    }
+}
+
+/// Object property key naming `@typescript-eslint/parser`'s `project`
+/// option — present (under `parserOptions` in a legacy `.eslintrc.*`, or
+/// nested under `languageOptions.parserOptions` in a modern flat config)
+/// exactly when an eslint config turns on type-aware ("type-checked") rules.
+/// Scanned the same broadly-over-precisely way [`RUNNER_CONFIG_FILE_KEYS`] is
+/// (see that constant's doc for the rationale): a same-named key elsewhere in
+/// the file costs one extra declared/hashed Input (the tsconfig this function
+/// doesn't actually need), while missing a real one would silently drop the
+/// tsconfig extends chain from `js_lint`'s cache key for an eslint config
+/// that *does* type-check — see `driver_lint.rs` module docs for why this
+/// gap matters (an M3/M4-review-class mistake, called out again for this
+/// driver in the M5 task).
+const ESLINT_PROJECT_KEY: &str = "project";
+
+/// One `parserOptions.project` value found by [`detect_eslint_type_aware`].
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum EslintProjectOption {
+    /// `project: true` (or any value that isn't a string/array of strings,
+    /// e.g. a computed expression this static scan can't evaluate) —
+    /// `@typescript-eslint/parser`'s own documented "figure out the nearest
+    /// tsconfig yourself" shorthand. Carries no explicit path; the caller
+    /// falls back to [`find_nearest_tsconfig`].
+    AutoDetect,
+    /// One or more explicit tsconfig paths (relative to the config file's own
+    /// directory) — a bare string, or an array of strings
+    /// (`typescript-eslint` accepts either).
+    Paths(Vec<String>),
+}
+
+/// Whether `config_path`'s content configures eslint type-aware rules (one or
+/// more `parserOptions.project` entries — see [`ESLINT_PROJECT_KEY`]'s doc),
+/// and if so, which tsconfig(s) each names. An empty `Vec` means no `project`
+/// key was found anywhere in the file — not type-aware, so no
+/// tsconfig/extends-chain Input is needed for this `js_lint` target.
+///
+/// **Every** occurrence in the file is collected, not just the first: a flat
+/// config commonly has more than one — e.g. separate override blocks for
+/// `src/**` and `test/**`, each with its own `parserOptions.project` naming a
+/// different tsconfig (`tsconfig.json` vs `tsconfig.test.json`). Stopping at
+/// the first match (an earlier version of this function did) silently
+/// dropped every tsconfig named by a later entry from the declared Input
+/// set/cache key — a code-quality M5 review finding, the exact
+/// declared-Input-vs-real-tool-read mismatch class this crate's M3/M4
+/// reviews already caught twice for other drivers.
+///
+/// JSON/YAML (`.eslintrc.json`/`.yml`/`.yaml`, or the extensionless
+/// `.eslintrc`, itself JSON per eslint's own convention) is parsed as data
+/// and walked recursively for every `"project"` key at any depth. A JS/TS/mjs/cjs
+/// config (modern flat `eslint.config.*`, or a legacy `.eslintrc.js`) is
+/// parsed with `oxc_parser` and scanned for every object property named
+/// `project`, mirroring [`RunnerConfigRefVisitor`]'s shape. Either parse
+/// failing yields `Ok(vec![])` — the leaf config's own raw bytes are already a
+/// declared/hashed Input regardless (`lint_deps_config`), so a parse failure
+/// here only means a real type-aware config goes undetected, not that the
+/// whole `js_lint` target becomes unbuildable.
+pub fn detect_eslint_type_aware(
+    config_path: &Path,
+    content: &str,
+) -> anyhow::Result<Vec<EslintProjectOption>> {
+    let ext = config_path
+        .extension()
+        .and_then(|e| e.to_str())
+        .unwrap_or("");
+    match ext {
+        "json" | "yml" | "yaml" | "" => {
+            let value: serde_json::Value = if ext == "yml" || ext == "yaml" {
+                match serde_yaml::from_str(content) {
+                    Ok(v) => v,
+                    Err(_) => return Ok(Vec::new()),
+                }
+            } else {
+                match serde_json::from_str(content) {
+                    Ok(v) => v,
+                    Err(_) => return Ok(Vec::new()),
+                }
+            };
+            let mut found = Vec::new();
+            collect_project_keys(&value, &mut found);
+            Ok(found)
+        }
+        _ => {
+            let Ok(source_type) = SourceType::from_path(config_path) else {
+                return Ok(Vec::new());
+            };
+            let allocator = Allocator::default();
+            let ret = Parser::new(&allocator, content, source_type).parse();
+            if ret.panicked {
+                return Ok(Vec::new());
+            }
+            let mut visitor = EslintProjectVisitor::default();
+            visitor.visit_program(&ret.program);
+            Ok(visitor.found)
+        }
+    }
+}
+
+/// Recursively collect every `"project"` key found in a parsed JSON/YAML
+/// config value, at any depth — see [`detect_eslint_type_aware`]'s doc for
+/// why this is intentionally not scoped to exactly `parserOptions.project`,
+/// and for why every occurrence (not just the first) is collected.
+fn collect_project_keys(value: &serde_json::Value, out: &mut Vec<EslintProjectOption>) {
+    match value {
+        serde_json::Value::Object(map) => {
+            if let Some(v) = map.get(ESLINT_PROJECT_KEY) {
+                out.push(json_value_to_project_option(v));
+            }
+            for v in map.values() {
+                collect_project_keys(v, out);
+            }
+        }
+        serde_json::Value::Array(items) => {
+            for item in items {
+                collect_project_keys(item, out);
+            }
+        }
+        _ => {}
+    }
+}
+
+fn json_value_to_project_option(v: &serde_json::Value) -> EslintProjectOption {
+    match v {
+        serde_json::Value::String(s) => EslintProjectOption::Paths(vec![s.clone()]),
+        serde_json::Value::Array(items) => {
+            let paths: Vec<String> = items
+                .iter()
+                .filter_map(|i| i.as_str().map(str::to_string))
+                .collect();
+            if paths.is_empty() {
+                EslintProjectOption::AutoDetect
+            } else {
+                EslintProjectOption::Paths(paths)
+            }
+        }
+        _ => EslintProjectOption::AutoDetect,
+    }
+}
+
+/// Scans a parsed JS/TS eslint config's AST for every object property named
+/// [`ESLINT_PROJECT_KEY`] — the flat-config/legacy-JS-config counterpart to
+/// [`collect_project_keys`]'s JSON/YAML walk. Mirrors [`RunnerConfigRefVisitor`]'s
+/// shape (see that type's doc). Collects **every** occurrence, not just the
+/// first — see [`detect_eslint_type_aware`]'s doc for why a multi-entry flat
+/// config (separate `parserOptions.project` per override block) needs all of
+/// them.
+#[derive(Default)]
+struct EslintProjectVisitor {
+    found: Vec<EslintProjectOption>,
+}
+
+impl EslintProjectVisitor {
+    fn note(&mut self, value: &Expression<'_>) {
+        let option = match value {
+            Expression::StringLiteral(s) => {
+                EslintProjectOption::Paths(vec![s.value.as_str().to_string()])
+            }
+            Expression::ArrayExpression(arr) => {
+                let paths: Vec<String> = arr
+                    .elements
+                    .iter()
+                    .filter_map(|el| match el {
+                        ArrayExpressionElement::StringLiteral(s) => {
+                            Some(s.value.as_str().to_string())
+                        }
+                        _ => None,
+                    })
+                    .collect();
+                if paths.is_empty() {
+                    EslintProjectOption::AutoDetect
+                } else {
+                    EslintProjectOption::Paths(paths)
+                }
+            }
+            _ => EslintProjectOption::AutoDetect,
+        };
+        self.found.push(option);
+    }
+}
+
+impl<'a> Visit<'a> for EslintProjectVisitor {
+    fn visit_object_property(&mut self, it: &oxc_ast::ast::ObjectProperty<'a>) {
+        let key_name = match &it.key {
+            PropertyKey::StaticIdentifier(id) => Some(id.name.as_str()),
+            PropertyKey::StringLiteral(s) => Some(s.value.as_str()),
+            _ => None,
+        };
+        if key_name == Some(ESLINT_PROJECT_KEY) {
+            self.note(&it.value);
+        }
+        walk::walk_object_property(self, it);
+    }
+}
+
+/// Which `package.json` naming convention applies to a legacy eslint config's
+/// `extends`/`plugins` string entry — see [`eslint_module_name`]'s doc.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord)]
+pub enum EslintRefKind {
+    Extends,
+    Plugin,
+}
+
+const ESLINT_REF_KEYS: &[&str] = &["extends", "plugins"];
+
+/// Extract every npm package name a dedicated eslint config file's
+/// `extends`/`plugins` (legacy `.eslintrc.*`) or top-level bare
+/// `import`/`require` (modern flat `eslint.config.*`) references. See
+/// `driver_lint.rs`'s "Inputs / cache key" section for why these must be
+/// resolved via the lockfile (`deps::resolve_one_dependency`), never treated
+/// as raw filesystem paths — the exact M3/M4-review-class mistake named
+/// again for this driver.
+///
+/// The two config shapes are **not** interchangeable, and are dispatched by
+/// `config_path`'s own basename, not merely its extension (both can be a
+/// plain `.js` file): legacy config's `extends`/`plugins` are string/
+/// array-of-string values naming a package by eslint's own documented
+/// shorthand convention (`"airbnb"` → `eslint-config-airbnb`, `"react"` in
+/// `plugins` → `eslint-plugin-react`) — see [`eslint_module_name`], applied
+/// here. Modern flat config has no `extends` key at all (a shared config is
+/// spread into the exported array, e.g. `...tseslint.configs.recommended`)
+/// and its own `plugins` is an *object* mapping a plugin key to an
+/// already-`import`-ed module, not a string array — so for a flat config
+/// (`eslint.config.*`, detected by filename), this instead collects the
+/// file's own bare `import`/`require` specifiers verbatim: no naming-guess
+/// needed, since in that shape the specifier already *is* the real package
+/// name (`import reactHooks from 'eslint-plugin-react-hooks'`).
+///
+/// A relative-path `extends`/`plugins` entry (`"extends":
+/// "./base.eslintrc.json"`) names a local sibling config file, not an npm
+/// package — filtered out of this function's own result (below) and instead
+/// resolved as a declared first-party Input by
+/// [`resolve_eslint_config_referenced_files`], which also follows a modern
+/// flat config's own relative `import`/`require` of a shared base config.
+/// See that function's doc — this is `lint_deps_config`'s actual mechanism
+/// for both shapes; a hermeticity M5 review caught this doc previously
+/// claiming that mechanism already ran over the leaf config when it did not.
+pub fn extract_eslint_module_refs(
+    config_path: &Path,
+    content: &str,
+) -> anyhow::Result<Vec<String>> {
+    let basename = config_path
+        .file_name()
+        .and_then(|n| n.to_str())
+        .unwrap_or("");
+    if basename.starts_with("eslint.config") {
+        return extract_flat_config_bare_imports(config_path, content);
+    }
+
+    let ext = config_path
+        .extension()
+        .and_then(|e| e.to_str())
+        .unwrap_or("");
+    let raw_values: Vec<(&'static str, String)> = match ext {
+        "json" | "yml" | "yaml" | "" => {
+            let value: serde_json::Value = if ext == "yml" || ext == "yaml" {
+                match serde_yaml::from_str(content) {
+                    Ok(v) => v,
+                    Err(_) => return Ok(Vec::new()),
+                }
+            } else {
+                match serde_json::from_str(content) {
+                    Ok(v) => v,
+                    Err(_) => return Ok(Vec::new()),
+                }
+            };
+            let mut out = Vec::new();
+            collect_eslint_ref_values(&value, &mut out);
+            out
+        }
+        _ => {
+            let Ok(source_type) = SourceType::from_path(config_path) else {
+                return Ok(Vec::new());
+            };
+            let allocator = Allocator::default();
+            let ret = Parser::new(&allocator, content, source_type).parse();
+            if ret.panicked {
+                return Ok(Vec::new());
+            }
+            let mut visitor = EslintRefVisitor::default();
+            visitor.visit_program(&ret.program);
+            visitor.values
+        }
+    };
+
+    Ok(raw_values
+        .into_iter()
+        .filter_map(|(key, raw)| {
+            if raw.starts_with('.') || Path::new(&raw).is_absolute() {
+                return None;
+            }
+            if raw == "eslint:recommended" || raw == "eslint:all" {
+                return None;
+            }
+            let kind = if key == "plugins" {
+                EslintRefKind::Plugin
+            } else {
+                EslintRefKind::Extends
+            };
+            Some(eslint_module_name(&raw, kind))
+        })
+        .collect())
+}
+
+/// Recursively resolve every additional first-party file an eslint config's
+/// own content references beyond its own leaf bytes — the file-based
+/// counterpart to [`extract_eslint_module_refs`]'s npm-package resolution.
+/// Two shapes, both followed:
+///
+/// - A modern flat config's own relative `import`/`require` of a shared base
+///   config (`import base from './eslint-base.js'`) — reuses
+///   [`resolve_runner_config_referenced_files`]'s generic relative-import
+///   walk (recursive: a base config's own further relative imports are
+///   followed too).
+/// - A legacy config's relative `extends`/`plugins` string value
+///   (`"extends": "./base.eslintrc.json"`) — names a local sibling file, not
+///   an npm package (that half is [`extract_eslint_module_refs`]'s job), and
+///   is followed here the same recursive way, bounded by `MAX_DEPTH` and a
+///   `seen` set against a cyclic/self-extending config.
+///
+/// This closes the M5 hermeticity gap named in this crate's review history:
+/// editing only a shared base config (relative `extends`, or a flat config's
+/// relative import) previously left `js_lint`'s declared Input set/cache key
+/// unchanged, serving a stale cached result even though a fresh run of the
+/// real linter would pick up the edit. See `lint_deps_config`'s doc for how
+/// the result is declared/hashed.
+pub fn resolve_eslint_config_referenced_files(
+    config_path: &Path,
+    config_content: &str,
+) -> anyhow::Result<Vec<PathBuf>> {
+    let mut seen: HashSet<PathBuf> = HashSet::new();
+    let mut found: BTreeSet<PathBuf> = BTreeSet::new();
+    seen.insert(config_path.to_path_buf());
+
+    // Modern flat config's own relative `import`/`require` chain (recursive
+    // — `resolve_runner_config_referenced_files` already walks depth).
+    for f in resolve_runner_config_referenced_files(config_path, config_content)? {
+        if seen.insert(f.clone()) {
+            found.insert(f);
+        }
+    }
+
+    // Legacy config's relative `extends`/`plugins` string values, followed
+    // recursively (a base config can itself `extend` another).
+    const MAX_DEPTH: usize = 4;
+    let mut queue: VecDeque<(PathBuf, String, usize)> = VecDeque::new();
+    queue.push_back((config_path.to_path_buf(), config_content.to_string(), 0));
+    while let Some((path, content, depth)) = queue.pop_front() {
+        if depth >= MAX_DEPTH {
+            continue;
+        }
+        let dir = path.parent().unwrap_or(Path::new(""));
+        for raw in extract_eslint_relative_ref_values(&path, &content) {
+            let Some(resolved) = probe_first_party_path(&dir.join(&raw)) else {
+                continue;
+            };
+            if seen.insert(resolved.clone()) {
+                found.insert(resolved.clone());
+                if let Ok(next_content) = std::fs::read_to_string(&resolved) {
+                    queue.push_back((resolved, next_content, depth + 1));
+                }
+            }
+        }
+    }
+
+    Ok(found.into_iter().collect())
+}
+
+/// The legacy-config half of [`resolve_eslint_config_referenced_files`]:
+/// every raw `extends`/`plugins` value that looks like a relative filesystem
+/// path (starts with `.`), unfiltered otherwise — mirrors
+/// [`extract_eslint_module_refs`]'s own raw-value extraction (via the same
+/// [`collect_eslint_ref_values`]/[`EslintRefVisitor`]), just keeping the
+/// opposite half of that function's `raw.starts_with('.')` filter. Flat
+/// configs (`eslint.config.*`) have no `extends`/`plugins` string key at all
+/// (see `extract_eslint_module_refs`'s doc) — the relative-import chain
+/// [`resolve_runner_config_referenced_files`] already walks is that shape's
+/// equivalent, so this returns nothing for a flat config's own basename.
+fn extract_eslint_relative_ref_values(config_path: &Path, content: &str) -> Vec<String> {
+    let basename = config_path
+        .file_name()
+        .and_then(|n| n.to_str())
+        .unwrap_or("");
+    if basename.starts_with("eslint.config") {
+        return Vec::new();
+    }
+
+    let ext = config_path
+        .extension()
+        .and_then(|e| e.to_str())
+        .unwrap_or("");
+    let raw_values: Vec<(&'static str, String)> = match ext {
+        "json" | "yml" | "yaml" | "" => {
+            let value: serde_json::Value = if ext == "yml" || ext == "yaml" {
+                match serde_yaml::from_str(content) {
+                    Ok(v) => v,
+                    Err(_) => return Vec::new(),
+                }
+            } else {
+                match serde_json::from_str(content) {
+                    Ok(v) => v,
+                    Err(_) => return Vec::new(),
+                }
+            };
+            let mut out = Vec::new();
+            collect_eslint_ref_values(&value, &mut out);
+            out
+        }
+        _ => {
+            let Ok(source_type) = SourceType::from_path(config_path) else {
+                return Vec::new();
+            };
+            let allocator = Allocator::default();
+            let ret = Parser::new(&allocator, content, source_type).parse();
+            if ret.panicked {
+                return Vec::new();
+            }
+            let mut visitor = EslintRefVisitor::default();
+            visitor.visit_program(&ret.program);
+            visitor.values
+        }
+    };
+
+    raw_values
+        .into_iter()
+        .filter_map(|(_key, raw)| raw.starts_with('.').then_some(raw))
+        .collect()
+}
+
+/// The flat-config half of [`extract_eslint_module_refs`]: every bare (not
+/// relative, not absolute, not a Node builtin) `import`/`require` specifier
+/// the config file's own top level names, verbatim — see that function's
+/// doc for why no naming-convention guess is needed here. Reuses
+/// [`bare_specifier_package_name`] (the same bare-specifier→package-name
+/// extraction the hermetic phantom-dependency check uses) so a subpath
+/// import (`import foo from 'eslint-plugin-foo/configs/recommended'`) is
+/// correctly attributed to the `eslint-plugin-foo` package, not its full
+/// subpath.
+fn extract_flat_config_bare_imports(
+    config_path: &Path,
+    content: &str,
+) -> anyhow::Result<Vec<String>> {
+    let Ok(parsed) = importparse::parse_file_imports(config_path, content) else {
+        // A parse failure here only means these references go undetected —
+        // see `extract_eslint_module_refs`'s doc for the same "declared
+        // leaf-config bytes are hashed regardless" reasoning
+        // `detect_eslint_type_aware` already documents.
+        return Ok(Vec::new());
+    };
+    let mut names: BTreeSet<String> = BTreeSet::new();
+    for site in parsed.sites {
+        if let Some(name) = bare_specifier_package_name(&site.specifier) {
+            names.insert(name);
+        }
+    }
+    Ok(names.into_iter().collect())
+}
+
+fn collect_eslint_ref_values(value: &serde_json::Value, out: &mut Vec<(&'static str, String)>) {
+    match value {
+        serde_json::Value::Object(map) => {
+            for key in ESLINT_REF_KEYS {
+                if let Some(v) = map.get(*key) {
+                    push_string_or_array(key, v, out);
+                }
+            }
+            for v in map.values() {
+                collect_eslint_ref_values(v, out);
+            }
+        }
+        serde_json::Value::Array(items) => {
+            for v in items {
+                collect_eslint_ref_values(v, out);
+            }
+        }
+        _ => {}
+    }
+}
+
+fn push_string_or_array(
+    key: &'static str,
+    value: &serde_json::Value,
+    out: &mut Vec<(&'static str, String)>,
+) {
+    match value {
+        serde_json::Value::String(s) => out.push((key, s.clone())),
+        serde_json::Value::Array(items) => {
+            for i in items {
+                if let Some(s) = i.as_str() {
+                    out.push((key, s.to_string()));
+                }
+            }
+        }
+        _ => {}
+    }
+}
+
+/// Scans a parsed JS/TS eslint config's AST for an object property named
+/// `"extends"` or `"plugins"` — the flat-config/legacy-JS-config counterpart
+/// to [`collect_eslint_ref_values`]'s JSON/YAML walk. Mirrors
+/// [`RunnerConfigRefVisitor`]'s/[`EslintProjectVisitor`]'s shape.
+#[derive(Default)]
+struct EslintRefVisitor {
+    values: Vec<(&'static str, String)>,
+}
+
+impl EslintRefVisitor {
+    fn push_value(&mut self, key: &'static str, value: &Expression<'_>) {
+        match value {
+            Expression::StringLiteral(s) => self.values.push((key, s.value.as_str().to_string())),
+            Expression::ArrayExpression(arr) => {
+                for el in &arr.elements {
+                    if let ArrayExpressionElement::StringLiteral(s) = el {
+                        self.values.push((key, s.value.as_str().to_string()));
+                    }
+                }
+            }
+            _ => {}
+        }
+    }
+}
+
+impl<'a> Visit<'a> for EslintRefVisitor {
+    fn visit_object_property(&mut self, it: &oxc_ast::ast::ObjectProperty<'a>) {
+        let key_name = match &it.key {
+            PropertyKey::StaticIdentifier(id) => Some(id.name.as_str()),
+            PropertyKey::StringLiteral(s) => Some(s.value.as_str()),
+            _ => None,
+        };
+        let key = match key_name {
+            Some("extends") => Some("extends"),
+            Some("plugins") => Some("plugins"),
+            _ => None,
+        };
+        if let Some(key) = key {
+            self.push_value(key, &it.value);
+        }
+        walk::walk_object_property(self, it);
+    }
+}
+
+/// Map a raw `extends`/`plugins` string (already filtered to "names an npm
+/// package" by [`extract_eslint_module_refs`]) to the actual npm package
+/// name, per eslint's own documented shorthand-naming convention (a
+/// `"plugin:react/recommended"` `extends` entry names the `plugins` package
+/// `react` refers to, resolved recursively as [`EslintRefKind::Plugin`]).
+///
+/// Best-effort, not exhaustive: eslint itself resolves a shorthand name via
+/// `require.resolve` against a handful of candidate names in order; this
+/// picks the single most common one rather than replicating that whole
+/// fallback chain. A package published under a genuinely unconventional name
+/// would not be found this way — `deps::resolve_one_dependency`'s own "no
+/// lockfile resolution" error then names the *guessed* package, not the
+/// original config string, so this is a disclosed rough edge, not a silent
+/// one.
+pub fn eslint_module_name(raw: &str, kind: EslintRefKind) -> String {
+    if let Some(plugin_part) = raw.strip_prefix("plugin:") {
+        let name = plugin_part.split('/').next().unwrap_or(plugin_part);
+        return eslint_module_name(name, EslintRefKind::Plugin);
+    }
+    let (scoped_infix, bare_prefix) = match kind {
+        EslintRefKind::Extends => ("eslint-config", "eslint-config-"),
+        EslintRefKind::Plugin => ("eslint-plugin", "eslint-plugin-"),
+    };
+    if let Some(rest) = raw.strip_prefix('@') {
+        return match rest.split_once('/') {
+            None => format!("@{rest}/{scoped_infix}"),
+            Some((_scope, name)) if name.starts_with(scoped_infix) => raw.to_string(),
+            Some((scope, name)) => format!("@{scope}/{scoped_infix}-{name}"),
+        };
+    }
+    if raw.starts_with(bare_prefix) {
+        raw.to_string()
+    } else {
+        format!("{bare_prefix}{raw}")
     }
 }
 
@@ -2482,5 +3098,298 @@ mod tests {
             closure.files,
             closure.external_files
         );
+    }
+
+    // ---- find_nearest_lint_config ----
+
+    #[test]
+    fn find_nearest_lint_config_finds_dot_oxlintrc_at_package_dir() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        write(dir.path(), "packages/a/package.json", r#"{"name": "a"}"#);
+        write(dir.path(), "packages/a/.oxlintrc.json", "{}");
+        let found = find_nearest_lint_config(
+            dir.path(),
+            &dir.path().join("packages/a"),
+            &[".oxlintrc.json"],
+        )
+        .expect("find config");
+        assert_eq!(found, dir.path().join("packages/a/.oxlintrc.json"));
+    }
+
+    #[test]
+    fn find_nearest_lint_config_walks_up_to_workspace_root() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        write(dir.path(), "package.json", r#"{"name": "root"}"#);
+        write(dir.path(), ".oxlintrc.json", "{}");
+        write(dir.path(), "packages/a/package.json", r#"{"name": "a"}"#);
+        let found = find_nearest_lint_config(
+            dir.path(),
+            &dir.path().join("packages/a"),
+            &[".oxlintrc.json"],
+        )
+        .expect("find ancestor config");
+        assert_eq!(found, dir.path().join(".oxlintrc.json"));
+    }
+
+    // ---- detect_eslint_type_aware ----
+
+    #[test]
+    fn detect_eslint_type_aware_none_when_no_project_key() {
+        let result = detect_eslint_type_aware(
+            Path::new("eslint.config.js"),
+            "export default [{ rules: { semi: 'error' } }];",
+        )
+        .expect("scan config");
+        assert_eq!(result, Vec::new());
+    }
+
+    #[test]
+    fn detect_eslint_type_aware_flat_config_string_project() {
+        let content = r#"
+            export default [
+              {
+                languageOptions: {
+                  parserOptions: {
+                    project: './tsconfig.json',
+                  },
+                },
+              },
+            ];
+        "#;
+        let result =
+            detect_eslint_type_aware(Path::new("eslint.config.js"), content).expect("scan config");
+        assert_eq!(
+            result,
+            vec![EslintProjectOption::Paths(vec![
+                "./tsconfig.json".to_string()
+            ])]
+        );
+    }
+
+    #[test]
+    fn detect_eslint_type_aware_flat_config_boolean_project_is_auto_detect() {
+        let content = r#"
+            export default [
+              { languageOptions: { parserOptions: { project: true } } },
+            ];
+        "#;
+        let result =
+            detect_eslint_type_aware(Path::new("eslint.config.js"), content).expect("scan config");
+        assert_eq!(result, vec![EslintProjectOption::AutoDetect]);
+    }
+
+    #[test]
+    fn detect_eslint_type_aware_flat_config_array_of_projects() {
+        let content = r#"
+            export default [
+              {
+                languageOptions: {
+                  parserOptions: { project: ['./tsconfig.json', './tsconfig.test.json'] },
+                },
+              },
+            ];
+        "#;
+        let result =
+            detect_eslint_type_aware(Path::new("eslint.config.js"), content).expect("scan config");
+        assert_eq!(
+            result,
+            vec![EslintProjectOption::Paths(vec![
+                "./tsconfig.json".to_string(),
+                "./tsconfig.test.json".to_string()
+            ])]
+        );
+    }
+
+    /// **The specific code-quality M5 gap**: a multi-entry flat config
+    /// (separate override blocks, each with its own `parserOptions.project`)
+    /// must have every occurrence collected, not just the first.
+    #[test]
+    fn detect_eslint_type_aware_flat_config_multiple_entries_all_collected() {
+        let content = r#"
+            export default [
+              { files: ['src/**/*.ts'], languageOptions: { parserOptions: { project: './tsconfig.json' } } },
+              { files: ['test/**/*.ts'], languageOptions: { parserOptions: { project: './tsconfig.test.json' } } },
+            ];
+        "#;
+        let result =
+            detect_eslint_type_aware(Path::new("eslint.config.js"), content).expect("scan config");
+        assert_eq!(
+            result,
+            vec![
+                EslintProjectOption::Paths(vec!["./tsconfig.json".to_string()]),
+                EslintProjectOption::Paths(vec!["./tsconfig.test.json".to_string()]),
+            ],
+            "both override blocks' own `parserOptions.project` must be collected: {result:?}"
+        );
+    }
+
+    #[test]
+    fn detect_eslint_type_aware_legacy_json_config() {
+        let content = r#"{
+            "parserOptions": { "project": "./tsconfig.json" },
+            "extends": ["eslint:recommended"]
+        }"#;
+        let result =
+            detect_eslint_type_aware(Path::new(".eslintrc.json"), content).expect("scan config");
+        assert_eq!(
+            result,
+            vec![EslintProjectOption::Paths(vec![
+                "./tsconfig.json".to_string()
+            ])]
+        );
+    }
+
+    #[test]
+    fn detect_eslint_type_aware_legacy_yaml_config() {
+        let content = "parserOptions:\n  project: ./tsconfig.json\n";
+        let result =
+            detect_eslint_type_aware(Path::new(".eslintrc.yaml"), content).expect("scan config");
+        assert_eq!(
+            result,
+            vec![EslintProjectOption::Paths(vec![
+                "./tsconfig.json".to_string()
+            ])]
+        );
+    }
+
+    #[test]
+    fn detect_eslint_type_aware_legacy_json_no_project_is_none() {
+        let content = r#"{ "extends": ["eslint:recommended"] }"#;
+        let result =
+            detect_eslint_type_aware(Path::new(".eslintrc.json"), content).expect("scan config");
+        assert_eq!(result, Vec::new());
+    }
+
+    // ---- eslint_module_name ----
+
+    #[test]
+    fn eslint_module_name_maps_bare_extends_to_eslint_config_prefix() {
+        assert_eq!(
+            eslint_module_name("airbnb", EslintRefKind::Extends),
+            "eslint-config-airbnb"
+        );
+    }
+
+    #[test]
+    fn eslint_module_name_leaves_already_prefixed_extends_alone() {
+        assert_eq!(
+            eslint_module_name("eslint-config-airbnb", EslintRefKind::Extends),
+            "eslint-config-airbnb"
+        );
+    }
+
+    #[test]
+    fn eslint_module_name_maps_bare_plugin_to_eslint_plugin_prefix() {
+        assert_eq!(
+            eslint_module_name("react", EslintRefKind::Plugin),
+            "eslint-plugin-react"
+        );
+    }
+
+    #[test]
+    fn eslint_module_name_resolves_plugin_colon_extends_shorthand() {
+        assert_eq!(
+            eslint_module_name("plugin:react/recommended", EslintRefKind::Extends),
+            "eslint-plugin-react"
+        );
+    }
+
+    #[test]
+    fn eslint_module_name_maps_scoped_extends_and_plugins() {
+        assert_eq!(
+            eslint_module_name("@myorg/foo", EslintRefKind::Extends),
+            "@myorg/eslint-config-foo"
+        );
+        assert_eq!(
+            eslint_module_name("@myorg", EslintRefKind::Extends),
+            "@myorg/eslint-config"
+        );
+        assert_eq!(
+            eslint_module_name("@myorg/eslint-config-foo", EslintRefKind::Extends),
+            "@myorg/eslint-config-foo"
+        );
+        assert_eq!(
+            eslint_module_name("@myorg/foo", EslintRefKind::Plugin),
+            "@myorg/eslint-plugin-foo"
+        );
+    }
+
+    // ---- extract_eslint_module_refs ----
+
+    #[test]
+    fn extract_eslint_module_refs_flat_config_scans_bare_imports() {
+        // Real flat config has no `extends` key at all (a shared config is
+        // spread in) and `plugins` is an object of already-imported modules
+        // — the package names come from the file's own `import` specifiers.
+        let content = r#"
+            import js from '@eslint/js';
+            import reactHooks from 'eslint-plugin-react-hooks';
+            import './local-helper.js';
+            export default [
+              js.configs.recommended,
+              { plugins: { 'react-hooks': reactHooks } },
+            ];
+        "#;
+        let mut refs = extract_eslint_module_refs(Path::new("eslint.config.js"), content)
+            .expect("scan config");
+        refs.sort();
+        assert_eq!(
+            refs,
+            vec![
+                "@eslint/js".to_string(),
+                "eslint-plugin-react-hooks".to_string()
+            ]
+        );
+    }
+
+    #[test]
+    fn extract_eslint_module_refs_legacy_json_config() {
+        let content = r#"{
+            "extends": ["eslint:recommended", "airbnb"],
+            "plugins": ["react-hooks"]
+        }"#;
+        let mut refs =
+            extract_eslint_module_refs(Path::new(".eslintrc.json"), content).expect("scan config");
+        refs.sort();
+        // "eslint:recommended" is a built-in sentinel, filtered out; the
+        // rest are mapped through eslint's own naming convention.
+        assert_eq!(
+            refs,
+            vec![
+                "eslint-config-airbnb".to_string(),
+                "eslint-plugin-react-hooks".to_string(),
+            ]
+        );
+    }
+
+    #[test]
+    fn extract_eslint_module_refs_legacy_js_config_scans_extends_plugins_keys() {
+        // A legacy `.eslintrc.js`/`.cjs` is still JS-shaped, but (unlike flat
+        // config) genuinely does use `extends`/`plugins` string arrays —
+        // dispatched by basename, not extension.
+        let content = r#"
+            module.exports = {
+              extends: ['plugin:react/recommended'],
+              plugins: ['react-hooks'],
+            };
+        "#;
+        let mut refs =
+            extract_eslint_module_refs(Path::new(".eslintrc.js"), content).expect("scan config");
+        refs.sort();
+        assert_eq!(
+            refs,
+            vec![
+                "eslint-plugin-react".to_string(),
+                "eslint-plugin-react-hooks".to_string(),
+            ]
+        );
+    }
+
+    #[test]
+    fn extract_eslint_module_refs_skips_relative_paths() {
+        let content = r#"{ "extends": ["./base.eslintrc.json"] }"#;
+        let refs =
+            extract_eslint_module_refs(Path::new(".eslintrc.json"), content).expect("scan config");
+        assert!(refs.is_empty(), "{refs:?}");
     }
 }

--- a/crates/plugin-js/src/pluginjs/mod.rs
+++ b/crates/plugin-js/src/pluginjs/mod.rs
@@ -2,6 +2,7 @@
 mod conformance;
 mod deps;
 mod driver_install;
+mod driver_lint;
 mod driver_package_info;
 mod driver_test;
 mod driver_typecheck;
@@ -17,6 +18,7 @@ mod toolchain;
 mod workspace;
 
 pub use driver_install::JsInstallDriver;
+pub use driver_lint::JsLintDriver;
 pub use driver_package_info::JsPackageInfoDriver;
 pub use driver_test::JsTestDriver;
 pub use driver_typecheck::JsTypecheckDriver;
@@ -47,6 +49,12 @@ pub const TYPECHECK_TARGET: &str = "js_typecheck";
 /// target address per matched test file (distinguished by a `file` addr
 /// arg), never one per package. See `driver_test.rs` module docs.
 pub const TEST_TARGET: &str = "js_test";
+
+/// Target name of the M5 `js_lint` target: runs the configured linter
+/// (`oxlint` default, `eslint` alt) over one package at a time — per-package
+/// granularity, the same as `js_typecheck` (see `driver_lint.rs` module docs
+/// for why per-file caching isn't worth the bookkeeping here either).
+pub const LINT_TARGET: &str = "js_lint";
 
 /// Directory names that are never a package boundary or workspace member,
 /// however deep they appear: `node_modules` is third-party/manager-owned

--- a/crates/plugin-js/src/pluginjs/provider.rs
+++ b/crates/plugin-js/src/pluginjs/provider.rs
@@ -1,8 +1,8 @@
 use crate::pluginjs::lockfile::{self, Lockfile, ResolvedGraph};
 use crate::pluginjs::workspace::{self, PkgManager, WorkspaceMember};
 use crate::pluginjs::{
-    PACKAGE_INFO_TARGET, PACKAGE_JSON, TEST_TARGET, TYPECHECK_TARGET, deps, importgraph,
-    is_skipped_dir_name, package_json, platform, resolvers, thirdparty, toolchain,
+    LINT_TARGET, PACKAGE_INFO_TARGET, PACKAGE_JSON, TEST_TARGET, TYPECHECK_TARGET, deps,
+    importgraph, is_skipped_dir_name, package_json, platform, resolvers, thirdparty, toolchain,
 };
 use anyhow::Context;
 use enclose::enclose;
@@ -67,6 +67,11 @@ pub struct Config {
     /// are matched against to discover `js_test` targets. Defaults to
     /// [`DEFAULT_TEST_GLOBS`] when unset — see that constant's doc for why.
     pub test_glob: Vec<String>,
+    /// Which linter `js_lint` invokes — `"oxlint"` (default) or `"eslint"`,
+    /// per `ai-docs/js-plugin-plan.md`'s `js_lint` row. Same provider-level,
+    /// host-toolchain shape as `tstool`/`testrunner` — see
+    /// `toolchain::resolve_host_linter`.
+    pub linter: String,
 }
 
 impl Config {
@@ -82,6 +87,7 @@ impl Config {
                 .iter()
                 .map(|s| (*s).to_string())
                 .collect(),
+            linter: toolchain::OXLINT.to_string(),
         }
     }
 }
@@ -119,6 +125,58 @@ pub struct Provider {
     /// scale a real subprocess cost with the number of test files, not just
     /// packages.
     testrunner_cache: OnceCell<Arc<(PathBuf, String)>>,
+    /// Which linter `js_lint` invokes — see [`Config::linter`]'s doc.
+    linter: String,
+    /// Lazily resolved host linter binary path + queried `--version`, cached
+    /// once for the `Provider`'s lifetime — same rationale as
+    /// `tsc_cache`/`testrunner_cache`: `lint_config` runs once per `js_lint`
+    /// target (one per package) per `Provider::get`, so re-resolving and
+    /// re-spawning `<linter> --version` per package would scale a real
+    /// subprocess cost with package count, including a 100%-cache-hit run
+    /// (the same M3/M4-review-flagged mistake this milestone's task
+    /// explicitly calls out not to repeat).
+    linter_cache: OnceCell<Arc<(PathBuf, String)>>,
+    /// Workspace-member `{name -> addr}` map, resolved once and cached for
+    /// the `Provider`'s lifetime — same rationale as `tsc_cache`/
+    /// `testrunner_cache`/`linter_cache`: `deps_config`/`typecheck_config`/
+    /// `test_config`/`lint_config` each independently called
+    /// `member_addrs_by_name_blocking` (a full recursive workspace walk +
+    /// `package.json` parse of every package, plus a glob-match) from
+    /// scratch on every single call — for `test_config` that meant once
+    /// *per test file*. This is the identical "recompute-on-every-call"
+    /// shape `graph_cache` fixes for the import graph above, applied to
+    /// workspace-member discovery (feature-quality/code-quality M5 review
+    /// finding: fixing it for one O(P) walk while leaving an identically-
+    /// shaped one right next to it unfixed left O(P²) work on the table at
+    /// scale). Workspace membership can't change mid-`Provider`-lifetime any
+    /// more than the lockfile can, so a single cached value is correct for
+    /// every caller.
+    member_addrs_cache: OnceCell<Arc<BTreeMap<String, String>>>,
+    /// Per-package [`importgraph::ImportGraph`], parsed+resolved once per
+    /// package and cached for the `Provider`'s lifetime — see
+    /// [`Provider::import_graph`]'s doc for the M2/M4-review-flagged perf
+    /// issue this fixes: each of `deps_config`/`typecheck_config`/
+    /// `test_config` independently called
+    /// `importgraph::build_package_import_graph` (a full oxc_parser parse +
+    /// oxc_resolver resolve of every first-party file in the package) from
+    /// scratch on every single `Provider::get` call — for `js_test` this
+    /// meant once *per test file*, so a package with N source files and T
+    /// test files paid `2+T` full-package graph builds where 1 would do.
+    ///
+    /// Keyed per-package with an `Arc<OnceCell<_>>` per key rather than one
+    /// `Mutex` held across the build itself, so unrelated packages' builds
+    /// never serialize behind one lock — only concurrent `Provider::get`
+    /// calls for the *same* package coalesce onto one build, which is the
+    /// point.
+    graph_cache: tokio::sync::Mutex<HashMap<PkgBuf, Arc<OnceCell<Arc<importgraph::ImportGraph>>>>>,
+    /// Test-only: counts real `importgraph::build_package_import_graph`
+    /// invocations (cache misses), so a test can prove `graph_cache` actually
+    /// memoizes across independent callers rather than merely being
+    /// structurally present — see
+    /// `import_graph_is_shared_across_independent_callers` in this module's
+    /// tests.
+    #[cfg(test)]
+    graph_build_count: Arc<std::sync::atomic::AtomicUsize>,
 }
 
 impl Provider {
@@ -147,6 +205,7 @@ impl Provider {
                 "tstool",
                 "testrunner",
                 "test_glob",
+                "linter",
             ],
         )?;
         let pkgmanager_str: String =
@@ -192,6 +251,16 @@ impl Provider {
                     .collect()
             });
 
+        // See `Config::linter`'s doc: defaults to the design doc's
+        // recommended default (`oxlint`, the fast oxc-family syntactic
+        // linter; `eslint` is the alt for type-aware rules).
+        let linter: String = hplugin::config::decode_opt(opts, "js provider", "linter")?
+            .unwrap_or_else(|| toolchain::OXLINT.to_string());
+        anyhow::ensure!(
+            toolchain::is_supported_linter(&linter),
+            "js provider: unsupported `linter` {linter:?} — expected \"oxlint\" or \"eslint\""
+        );
+
         Ok(Self::with_config(
             workspace_root,
             Config {
@@ -202,6 +271,7 @@ impl Provider {
                 tstool,
                 testrunner,
                 test_glob,
+                linter,
             },
         ))
     }
@@ -220,6 +290,12 @@ impl Provider {
             resolved_graph_cache: OnceCell::new(),
             tsc_cache: OnceCell::new(),
             testrunner_cache: OnceCell::new(),
+            linter: config.linter,
+            linter_cache: OnceCell::new(),
+            member_addrs_cache: OnceCell::new(),
+            graph_cache: tokio::sync::Mutex::new(HashMap::new()),
+            #[cfg(test)]
+            graph_build_count: Arc::new(std::sync::atomic::AtomicUsize::new(0)),
         }
     }
 
@@ -365,6 +441,188 @@ impl Provider {
         Ok(Arc::clone(result))
     }
 
+    /// The host linter binary path and its queried `--version`, resolved once
+    /// and cached for the `Provider`'s lifetime — see
+    /// [`Provider::linter_cache`]'s doc for why this matters.
+    async fn resolved_host_linter(&self) -> anyhow::Result<Arc<(PathBuf, String)>> {
+        let workspace_root = self.workspace_root.clone();
+        let linter = self.linter.clone();
+        let result = self
+            .linter_cache
+            .get_or_try_init(|| async move {
+                anyhow::ensure!(
+                    toolchain::is_supported_linter(&linter),
+                    "js provider: unsupported linter {linter:?} — only \"oxlint\" or \"eslint\" \
+                     is supported in this milestone; see pluginjs::toolchain module docs"
+                );
+                hcore::blocking::run(move || -> anyhow::Result<Arc<(PathBuf, String)>> {
+                    let linter_bin = toolchain::resolve_host_linter(&workspace_root, &linter)
+                        .context("resolving the js_lint linter toolchain")?;
+                    let linter_version = toolchain::query_linter_version(&linter_bin)
+                        .with_context(|| format!("querying {linter_bin:?} --version"))?;
+                    Ok(Arc::new((linter_bin, linter_version)))
+                })
+                .await
+            })
+            .await?;
+        Ok(Arc::clone(result))
+    }
+
+    /// Workspace-member `{name -> addr}` map, resolved once and cached for
+    /// the `Provider`'s lifetime — see [`Provider::member_addrs_cache`]'s doc
+    /// for why this matters. Every one of `deps_config`/`typecheck_config`/
+    /// `test_config`/`lint_config` calls this instead of redoing the
+    /// discovery walk inside its own blocking closure.
+    async fn member_addrs_by_name(&self) -> anyhow::Result<Arc<BTreeMap<String, String>>> {
+        let workspace_root = self.workspace_root.clone();
+        let walker = Arc::clone(&self.walker);
+        let skip = Arc::clone(&self.skip);
+        let pkgmanager = self.pkgmanager;
+        let result = self
+            .member_addrs_cache
+            .get_or_try_init(|| async move {
+                hcore::blocking::run(move || -> anyhow::Result<Arc<BTreeMap<String, String>>> {
+                    member_addrs_by_name_blocking(&walker, &workspace_root, &skip, pkgmanager)
+                        .map(Arc::new)
+                })
+                .await
+            })
+            .await?;
+        Ok(Arc::clone(result))
+    }
+
+    /// Build the config for one `js_lint` target (one package): the host
+    /// linter toolchain resolution/version-query this milestone's disclosed
+    /// `linter`-is-host-resolved escape hatch requires (same shape as
+    /// `resolved_host_tsc`/`resolved_host_test_runner`) plus
+    /// `lint_deps_config`'s pure, linter-binary-free Input-scoping.
+    ///
+    /// Deliberately does **not** go through `Provider::import_graph`: unlike
+    /// `deps_config`/`typecheck_config`/`test_config`, a `js_lint` target's
+    /// Inputs are just the package's own first-party source files plus its
+    /// resolved linter config (and, for eslint type-aware rules, the
+    /// tsconfig/extends chain) — no cross-package import-graph edges are
+    /// needed to scope it (see `driver_lint.rs` module docs' "Inputs / cache
+    /// key" section). Skipping it here keeps `js_lint` from becoming a fifth
+    /// caller of the expensive parse+resolve path for no reason, on top of
+    /// the fix already applied to the other three.
+    async fn lint_config(&self, pkg: &PkgBuf) -> anyhow::Result<HashMap<String, Value>> {
+        let resolved_linter = self.resolved_host_linter().await?;
+        let linter_bin = resolved_linter.0.to_string_lossy().into_owned();
+        let linter_version = resolved_linter.1.clone();
+        let lockfile = self.lockfile().await?;
+        let resolved_graph = self.resolved_graph().await?;
+        let member_addrs_by_name = self.member_addrs_by_name().await?;
+        let workspace_root = self.workspace_root.clone();
+        let walker = Arc::clone(&self.walker);
+        let linter = self.linter.clone();
+        let pkg_str = pkg.as_str().to_string();
+        let goos = platform::current_goos();
+        let goarch = platform::current_goarch();
+
+        hcore::blocking::run(move || -> anyhow::Result<HashMap<String, Value>> {
+            let lint_deps = lint_deps_config(
+                &walker,
+                &workspace_root,
+                &pkg_str,
+                &linter,
+                lockfile.as_deref(),
+                resolved_graph.as_deref(),
+                &member_addrs_by_name,
+                &goos,
+                &goarch,
+            )
+            .with_context(|| format!("building js_lint inputs for {pkg_str:?}"))?;
+
+            let mut config: HashMap<String, Value> = HashMap::new();
+            config.insert("linter".to_string(), Value::String(linter));
+            config.insert("linter_bin".to_string(), Value::String(linter_bin));
+            config.insert("linter_version".to_string(), Value::String(linter_version));
+            config.insert(
+                "config_path".to_string(),
+                Value::String(lint_deps.config_path),
+            );
+            config.insert(
+                "config_content".to_string(),
+                Value::String(lint_deps.config_content),
+            );
+            config.insert(
+                "tsconfig_path".to_string(),
+                Value::String(lint_deps.tsconfig_path),
+            );
+            config.insert(
+                "tsconfig_content".to_string(),
+                Value::String(lint_deps.tsconfig_content),
+            );
+            config.insert("deps".to_string(), Value::Map(lint_deps.deps));
+            Ok(config)
+        })
+        .await
+    }
+
+    /// The package's [`importgraph::ImportGraph`], built once and cached for
+    /// the `Provider`'s lifetime — see [`Provider::graph_cache`]'s doc for why
+    /// this exists. `deps_config`, `typecheck_config` (via
+    /// `typecheck_deps_config`), and `test_config` (via `test_deps_config`,
+    /// once per test *file*) all go through this single entry point so a
+    /// package with N source files and T test files pays one full-package
+    /// graph build, not `2+T`.
+    ///
+    /// Locking: the outer `graph_cache` mutex is only held long enough to
+    /// get-or-insert this package's own `OnceCell` — the actual parse+resolve
+    /// work runs after it's released, inside that per-package cell's
+    /// `get_or_try_init`. Concurrent `Provider::get` calls for *different*
+    /// packages therefore never serialize behind one lock; concurrent calls
+    /// for the *same* package correctly coalesce onto one build via the cell,
+    /// the same shape `tsc_cache`/`testrunner_cache` already use for a single
+    /// (not per-key) value.
+    async fn import_graph(&self, pkg: &PkgBuf) -> anyhow::Result<Arc<importgraph::ImportGraph>> {
+        let cell = {
+            let mut cache = self.graph_cache.lock().await;
+            Arc::clone(
+                cache
+                    .entry(pkg.clone())
+                    .or_insert_with(|| Arc::new(OnceCell::new())),
+            )
+        };
+
+        let workspace_root = self.workspace_root.clone();
+        let walker = Arc::clone(&self.walker);
+        let pkg_str = pkg.as_str().to_string();
+        #[cfg(test)]
+        let build_count = Arc::clone(&self.graph_build_count);
+
+        let graph = cell
+            .get_or_try_init(|| async move {
+                hcore::blocking::run(move || -> anyhow::Result<Arc<importgraph::ImportGraph>> {
+                    #[cfg(test)]
+                    build_count.fetch_add(1, std::sync::atomic::Ordering::SeqCst);
+
+                    let pkg_dir = if pkg_str.is_empty() {
+                        workspace_root.clone()
+                    } else {
+                        workspace_root.join(&pkg_str)
+                    };
+                    let tsconfig = importgraph::find_nearest_tsconfig(&workspace_root, &pkg_dir);
+                    let import_resolvers = resolvers::Resolvers::new(tsconfig.as_deref());
+                    let resolve_cache = importgraph::ResolveCache::new();
+                    let graph = importgraph::build_package_import_graph(
+                        &walker,
+                        &workspace_root,
+                        &pkg_str,
+                        &import_resolvers,
+                        &resolve_cache,
+                        tsconfig.as_deref(),
+                    )
+                    .with_context(|| format!("building import graph for {pkg_str:?}"))?;
+                    Ok(Arc::new(graph))
+                })
+                .await
+            })
+            .await?;
+        Ok(Arc::clone(graph))
+    }
+
     /// Whether the provider's `allow_scripts` option permits `name@version`
     /// (or a bare `name` allowlist entry) to run lifecycle scripts.
     fn scripts_allowed_for(&self, name: &str, version: &str) -> bool {
@@ -392,10 +650,9 @@ impl Provider {
     async fn deps_config(&self, pkg: &PkgBuf) -> anyhow::Result<Value> {
         let lockfile = self.lockfile().await?;
         let resolved_graph = self.resolved_graph().await?;
+        let graph = self.import_graph(pkg).await?;
+        let member_addrs_by_name = self.member_addrs_by_name().await?;
         let workspace_root = self.workspace_root.clone();
-        let walker = Arc::clone(&self.walker);
-        let skip = Arc::clone(&self.skip);
-        let pkgmanager = self.pkgmanager;
         let pkg_str = pkg.as_str().to_string();
         let goos = platform::current_goos();
         let goarch = platform::current_goarch();
@@ -404,33 +661,6 @@ impl Provider {
             let package_json_path = workspace_root.join(&pkg_str).join(PACKAGE_JSON);
             let manifest = package_json::read_package_manifest(&package_json_path)
                 .with_context(|| format!("reading dependencies of {pkg_str:?}"))?;
-
-            // Workspace-member discovery, redone here rather than reusing
-            // `Provider::workspace_members` — this whole closure already
-            // runs on the blocking pool, so it calls the same free functions
-            // `workspace_members` itself calls rather than the `&self`
-            // method (which can't be moved into a `'static` blocking job).
-            let patterns = match pkgmanager {
-                PkgManager::Npm => workspace::read_npm_workspace_globs(&workspace_root)?,
-                PkgManager::Pnpm => workspace::read_pnpm_workspace_globs(&workspace_root)?,
-            };
-            let member_addrs_by_name: BTreeMap<String, String> = if patterns.is_empty() {
-                BTreeMap::new()
-            } else {
-                let mut packages = Vec::new();
-                collect_js_packages(
-                    &walker,
-                    &workspace_root,
-                    &workspace_root,
-                    &skip,
-                    &mut packages,
-                );
-                let packages: Vec<PkgBuf> = packages.into_iter().collect::<anyhow::Result<_>>()?;
-                workspace::resolve_members(&workspace_root, &packages, &patterns)?
-                    .into_iter()
-                    .map(|m| (m.name, m.addr.format()))
-                    .collect()
-            };
 
             let resolved = deps::resolve_package_deps(
                 &pkg_str,
@@ -444,20 +674,9 @@ impl Provider {
 
             // M2: cross-validate the declared-dependency wiring above against
             // the package's real import graph — see this method's doc
-            // comment and `importgraph.rs` module docs.
-            let tsconfig =
-                importgraph::find_nearest_tsconfig(&workspace_root, &workspace_root.join(&pkg_str));
-            let import_resolvers = resolvers::Resolvers::new(tsconfig.as_deref());
-            let resolve_cache = importgraph::ResolveCache::new();
-            let graph = importgraph::build_package_import_graph(
-                &walker,
-                &workspace_root,
-                &pkg_str,
-                &import_resolvers,
-                &resolve_cache,
-                tsconfig.as_deref(),
-            )
-            .with_context(|| format!("building import graph for {pkg_str:?}"))?;
+            // comment and `importgraph.rs` module docs. `graph` was already
+            // built (and cached) by `Provider::import_graph` before this
+            // closure was spawned.
             let declared_closure = importgraph::declared_closure(&manifest);
             importgraph::check_phantom_dependencies(
                 &workspace_root,
@@ -505,46 +724,20 @@ impl Provider {
         let tsc_version = resolved_tsc.1.clone();
         let lockfile = self.lockfile().await?;
         let resolved_graph = self.resolved_graph().await?;
+        let graph = self.import_graph(pkg).await?;
+        let member_addrs_by_name = self.member_addrs_by_name().await?;
         let workspace_root = self.workspace_root.clone();
         let walker = Arc::clone(&self.walker);
-        let skip = Arc::clone(&self.skip);
-        let pkgmanager = self.pkgmanager;
         let pkg_str = pkg.as_str().to_string();
         let goos = platform::current_goos();
         let goarch = platform::current_goarch();
 
         hcore::blocking::run(move || -> anyhow::Result<HashMap<String, Value>> {
-            // Same workspace-member discovery `Provider::deps_config` does
-            // in its own blocking closure — needed here too so an import
-            // that never resolved on disk (no ambient `node_modules`) can
-            // still be attributed to a workspace sibling by name (see
-            // `typecheck_deps_config`'s doc).
-            let patterns = match pkgmanager {
-                PkgManager::Npm => workspace::read_npm_workspace_globs(&workspace_root)?,
-                PkgManager::Pnpm => workspace::read_pnpm_workspace_globs(&workspace_root)?,
-            };
-            let member_addrs_by_name: BTreeMap<String, String> = if patterns.is_empty() {
-                BTreeMap::new()
-            } else {
-                let mut packages = Vec::new();
-                collect_js_packages(
-                    &walker,
-                    &workspace_root,
-                    &workspace_root,
-                    &skip,
-                    &mut packages,
-                );
-                let packages: Vec<PkgBuf> = packages.into_iter().collect::<anyhow::Result<_>>()?;
-                workspace::resolve_members(&workspace_root, &packages, &patterns)?
-                    .into_iter()
-                    .map(|m| (m.name, m.addr.format()))
-                    .collect()
-            };
-
             let (deps, tsconfig_path, tsconfig_content) = typecheck_deps_config(
                 &walker,
                 &workspace_root,
                 &pkg_str,
+                &graph,
                 lockfile.as_deref(),
                 resolved_graph.as_deref(),
                 &member_addrs_by_name,
@@ -601,10 +794,9 @@ impl Provider {
         let runner_version = resolved_test_runner.1.clone();
         let lockfile = self.lockfile().await?;
         let resolved_graph = self.resolved_graph().await?;
+        let graph = self.import_graph(pkg).await?;
+        let member_addrs_by_name = self.member_addrs_by_name().await?;
         let workspace_root = self.workspace_root.clone();
-        let walker = Arc::clone(&self.walker);
-        let skip = Arc::clone(&self.skip);
-        let pkgmanager = self.pkgmanager;
         let testrunner = self.testrunner.clone();
         let pkg_str = pkg.as_str().to_string();
         let test_file_rel = test_file_rel.to_string();
@@ -612,37 +804,11 @@ impl Provider {
         let goarch = platform::current_goarch();
 
         hcore::blocking::run(move || -> anyhow::Result<HashMap<String, Value>> {
-            // Same workspace-member discovery `Provider::typecheck_config`
-            // does in its own blocking closure — needed here too so an
-            // import that never resolved on disk can still be attributed to
-            // a workspace sibling by name.
-            let patterns = match pkgmanager {
-                PkgManager::Npm => workspace::read_npm_workspace_globs(&workspace_root)?,
-                PkgManager::Pnpm => workspace::read_pnpm_workspace_globs(&workspace_root)?,
-            };
-            let member_addrs_by_name: BTreeMap<String, String> = if patterns.is_empty() {
-                BTreeMap::new()
-            } else {
-                let mut packages = Vec::new();
-                collect_js_packages(
-                    &walker,
-                    &workspace_root,
-                    &workspace_root,
-                    &skip,
-                    &mut packages,
-                );
-                let packages: Vec<PkgBuf> = packages.into_iter().collect::<anyhow::Result<_>>()?;
-                workspace::resolve_members(&workspace_root, &packages, &patterns)?
-                    .into_iter()
-                    .map(|m| (m.name, m.addr.format()))
-                    .collect()
-            };
-
             let (deps, runner_config_path, runner_config_content) = test_deps_config(
-                &walker,
                 &workspace_root,
                 &pkg_str,
                 &test_file_rel,
+                &graph,
                 lockfile.as_deref(),
                 resolved_graph.as_deref(),
                 &member_addrs_by_name,
@@ -778,6 +944,9 @@ impl Provider {
 /// an Input set that might not match what `tsc --project` actually reads.
 ///
 /// `pkg` is the package's workspace-relative path (`""` for the root).
+/// `graph` is `pkg`'s [`importgraph::ImportGraph`] — built once by
+/// `Provider::import_graph` and shared with `deps_config`/`test_deps_config`
+/// rather than rebuilt here; see that method's doc for why.
 /// `lockfile`/`resolved_graph`/`member_addrs_by_name`/`goos`/`goarch` are
 /// only consulted when an import names a package that never resolved on
 /// disk — see above — and mirror the identically-named parameters
@@ -791,6 +960,7 @@ fn typecheck_deps_config(
     walker: &CachedWalker,
     workspace_root: &Path,
     pkg: &str,
+    graph: &importgraph::ImportGraph,
     lockfile: Option<&Lockfile>,
     resolved_graph: Option<&ResolvedGraph>,
     member_addrs_by_name: &BTreeMap<String, String>,
@@ -869,26 +1039,15 @@ fn typecheck_deps_config(
         }
     }
 
-    let import_resolvers = resolvers::Resolvers::new(tsconfig.as_deref());
-    let resolve_cache = importgraph::ResolveCache::new();
-    let graph = importgraph::build_package_import_graph(
-        walker,
-        workspace_root,
-        pkg,
-        &import_resolvers,
-        &resolve_cache,
-        tsconfig.as_deref(),
-    )
-    .with_context(|| format!("building import graph for {pkg:?}"))?;
-
     // Phantom-dependency check: `Provider::deps_config` (the `js_package_info`
     // target) already runs this, but a workspace member requesting only
     // `js_typecheck` (never `js_package_info`) must not skip it — this is
     // also what justifies treating every name reached below via
     // `member_addrs_by_name`/the lockfile as genuinely declared, rather than
-    // re-deriving that from scratch.
+    // re-deriving that from scratch. `graph` is the caller-supplied,
+    // `Provider::import_graph`-cached graph — see this function's doc.
     let declared_closure = importgraph::declared_closure(&manifest);
-    importgraph::check_phantom_dependencies(workspace_root, pkg, &graph, &declared_closure)
+    importgraph::check_phantom_dependencies(workspace_root, pkg, graph, &declared_closure)
         .with_context(|| {
             format!("cross-checking {pkg:?}'s import graph against its declared dependencies")
         })?;
@@ -1122,20 +1281,23 @@ fn test_file_under_package(package: &str, test_file: &str) -> bool {
 /// see this module's tests.
 ///
 /// `pkg` is the package's workspace-relative path (`""` for the root);
-/// `test_file_rel` is the one test file's workspace-relative path.
+/// `test_file_rel` is the one test file's workspace-relative path. `graph` is
+/// `pkg`'s [`importgraph::ImportGraph`] — built once by
+/// `Provider::import_graph` and shared with `deps_config`/`typecheck_config`
+/// rather than rebuilt here; see that method's doc for why.
 /// `lockfile`/`resolved_graph`/`member_addrs_by_name`/`goos`/`goarch` mirror
 /// `typecheck_deps_config`'s identically-named parameters.
 ///
 /// **Known scope trim, disclosed rather than silent — and a real gap, not
-/// merely a narrower one**: the resolved tsconfig (used here only to
-/// configure `Resolvers`' `paths`/`baseUrl`/`extends` support so the import
-/// graph itself is built correctly) is not declared as its own `js_test`
-/// Input, nor hashed, the way `js_typecheck`'s `"tsconfig"`/`tsconfig_content`
-/// pair is. It is tempting to reason that `js_test` runs source directly
-/// (not through `tsc`) so this only affects import *resolution*, not
-/// behavior — but that reasoning is wrong: the recommended default runner,
-/// vitest, transforms TS via Vite's esbuild-based transform, which reads the
-/// nearest `tsconfig.json` itself at transform time for options
+/// merely a narrower one**: the tsconfig that shaped how `graph` resolved
+/// `paths`/`baseUrl`/`extends`-aware specifiers is not declared as its own
+/// `js_test` Input, nor hashed, the way `js_typecheck`'s
+/// `"tsconfig"`/`tsconfig_content` pair is. It is tempting to reason that
+/// `js_test` runs source directly (not through `tsc`) so this only affects
+/// import *resolution*, not behavior — but that reasoning is wrong: the
+/// recommended default runner, vitest, transforms TS via Vite's
+/// esbuild-based transform, which reads the nearest `tsconfig.json` itself at
+/// transform time for options
 /// (`jsx`/`jsxFactory`/`target`/`useDefineForClassFields`/
 /// `experimentalDecorators`) that change the *emitted, executed* JS — not
 /// just which file a specifier resolves to. Toggling one of those between
@@ -1151,10 +1313,10 @@ fn test_file_under_package(package: &str, test_file: &str) -> bool {
               `testrunner` for the jest-package.json-field config fallback"
 )]
 fn test_deps_config(
-    walker: &CachedWalker,
     workspace_root: &Path,
     pkg: &str,
     test_file_rel: &str,
+    graph: &importgraph::ImportGraph,
     lockfile: Option<&Lockfile>,
     resolved_graph: Option<&ResolvedGraph>,
     member_addrs_by_name: &BTreeMap<String, String>,
@@ -1238,29 +1400,18 @@ fn test_deps_config(
         }
     }
 
-    let tsconfig = importgraph::find_nearest_tsconfig(workspace_root, &pkg_dir);
-    let import_resolvers = resolvers::Resolvers::new(tsconfig.as_deref());
-    let resolve_cache = importgraph::ResolveCache::new();
-    let graph = importgraph::build_package_import_graph(
-        walker,
-        workspace_root,
-        pkg,
-        &import_resolvers,
-        &resolve_cache,
-        tsconfig.as_deref(),
-    )
-    .with_context(|| format!("building import graph for {pkg:?}"))?;
-
     // Phantom-dependency check: a workspace member requesting only `js_test`
     // (never `js_package_info`/`js_typecheck`) must not skip it — same
     // rationale `typecheck_deps_config` documents for its own identical call.
+    // `graph` is the caller-supplied, `Provider::import_graph`-cached graph —
+    // see this function's doc.
     let declared_closure = importgraph::declared_closure(&manifest);
-    importgraph::check_phantom_dependencies(workspace_root, pkg, &graph, &declared_closure)
+    importgraph::check_phantom_dependencies(workspace_root, pkg, graph, &declared_closure)
         .with_context(|| {
             format!("cross-checking {pkg:?}'s import graph against its declared dependencies")
         })?;
 
-    let closure = importgraph::build_test_closure(&graph, &canonical_root, pkg, test_file_rel)
+    let closure = importgraph::build_test_closure(graph, &canonical_root, pkg, test_file_rel)
         .with_context(|| {
             format!("building test closure for {pkg:?}'s test file {test_file_rel:?}")
         })?;
@@ -1326,6 +1477,403 @@ fn test_deps_config(
     }
 
     Ok((deps, runner_config_path_rel, runner_config_content))
+}
+
+/// Candidate config filenames for `linter`'s ancestor-chain walk (see
+/// `importgraph::find_nearest_lint_config`). oxlint has exactly one
+/// dedicated config filename; eslint's list checks the modern flat-config
+/// filenames first (eslint 9's own default resolution order — a project
+/// with both a flat and a legacy config uses the flat one), falling back to
+/// every legacy `.eslintrc.*` extension eslint itself accepts. Errors on an
+/// unsupported `linter` rather than guessing — callers only ever reach this
+/// after `toolchain::is_supported_linter` has already validated it (see
+/// `Provider::resolved_host_linter`), so this should never actually trigger
+/// in practice, but a fallible return keeps that an enforced invariant
+/// rather than an assumed one.
+fn lint_config_candidates(linter: &str) -> anyhow::Result<&'static [&'static str]> {
+    match linter {
+        toolchain::OXLINT => Ok(&[".oxlintrc.json"]),
+        toolchain::ESLINT => Ok(&[
+            "eslint.config.js",
+            "eslint.config.mjs",
+            "eslint.config.cjs",
+            "eslint.config.ts",
+            "eslint.config.mts",
+            "eslint.config.cts",
+            ".eslintrc.js",
+            ".eslintrc.cjs",
+            ".eslintrc.yaml",
+            ".eslintrc.yml",
+            ".eslintrc.json",
+            ".eslintrc",
+        ]),
+        other => anyhow::bail!(
+            "js_lint: unsupported linter {other:?} — expected \"oxlint\" or \"eslint\" (should \
+             have been rejected earlier by toolchain::is_supported_linter)"
+        ),
+    }
+}
+
+/// Result of [`lint_deps_config`]: the `deps` map (see that function's doc)
+/// plus the resolved linter config's/tsconfig's own workspace-relative path
+/// and raw content, for a `js_lint` target. A plain tuple would work but
+/// clippy (rightly) flags a 5-element one as too easy to mis-order at the
+/// call site; a named struct makes each field self-documenting instead.
+///
+/// `Debug` is derived (code-quality M5 review NIT: most sibling internal
+/// state in this file derives it, and its absence made `{:?}`/`expect_err`
+/// in a test fail to compile) — private type, so this isn't a `rust.md`
+/// violation either way, just consistency.
+#[derive(Debug)]
+struct LintDepsConfig {
+    deps: HashMap<String, Value>,
+    config_path: String,
+    config_content: String,
+    tsconfig_path: String,
+    tsconfig_content: String,
+}
+
+/// Build the `deps` map (`""` = the package's own first-party source files
+/// (no tsconfig-`include`/`exclude` filtering — a linter operates on raw
+/// source files directly, unlike `tsc`'s project-scoped compilation);
+/// `"config"` = the resolved linter config file, if any; `"tsconfig"` =
+/// (eslint type-aware rules only) the tsconfig(s) named by
+/// `parserOptions.project` plus their whole `extends` chain, exactly the
+/// same Input/hash treatment `js_typecheck` gives its own tsconfig — see
+/// `driver_lint.rs` module docs' "Inputs / cache key" section, and this is
+/// the specific gap the M5 task calls out by name: a type-aware eslint
+/// config's type information comes from that tsconfig the same way `tsc`'s
+/// does, so a change to it (or anywhere in its `extends` chain) must bust
+/// this target's cache the same way it busts `js_typecheck`'s;
+/// `"eslint_plugins"` = (eslint only) every `extends`/`plugins` entry that
+/// names an npm package, resolved through the lockfile
+/// (`deps::resolve_one_dependency`) — never treated as a raw filesystem
+/// path, the exact M3/M4-review-class mistake this milestone's task named
+/// again for this driver) plus that config's own workspace-relative path and
+/// raw content, for one `js_lint` target.
+///
+/// Deliberately split out from [`Provider::lint_config`] so it never touches
+/// the host linter binary — unit-testable without a real `oxlint`/`eslint`
+/// installed, mirroring `typecheck_deps_config`/`test_deps_config`'s
+/// identical split for the identical reason.
+///
+/// `pkg` is the package's workspace-relative path (`""` for the root).
+/// `lockfile`/`resolved_graph`/`member_addrs_by_name`/`goos`/`goarch` mirror
+/// `typecheck_deps_config`'s identically-named parameters (only consulted
+/// for eslint's `extends`/`plugins` package resolution).
+///
+/// **Known scope trim, disclosed rather than silent**: a package's own
+/// ignore rules (`.eslintignore`, `.oxlintignore`, an `ignorePatterns` config
+/// field) are not applied when collecting the `""` source-file group — every
+/// first-party source file `importgraph::package_source_files` finds is
+/// declared, so an ignored file still costs a declared Input (over-inclusion,
+/// never a missed one). TODO M5+: fold ignore-pattern filtering in, mirroring
+/// `typecheck_deps_config`'s tsconfig-`include`/`exclude` treatment.
+#[expect(
+    clippy::too_many_arguments,
+    reason = "mirrors typecheck_deps_config's/test_deps_config's own lockfile/member/platform \
+              parameter set, needed here too for the same on-demand third-party-input \
+              resolution, plus `linter` to select the config-file search + eslint-only \
+              type-aware/extends handling"
+)]
+fn lint_deps_config(
+    walker: &CachedWalker,
+    workspace_root: &Path,
+    pkg: &str,
+    linter: &str,
+    lockfile: Option<&Lockfile>,
+    resolved_graph: Option<&ResolvedGraph>,
+    member_addrs_by_name: &BTreeMap<String, String>,
+    goos: &str,
+    goarch: &str,
+) -> anyhow::Result<LintDepsConfig> {
+    let pkg_dir = if pkg.is_empty() {
+        workspace_root.to_path_buf()
+    } else {
+        workspace_root.join(pkg)
+    };
+
+    let manifest = package_json::read_package_manifest(&pkg_dir.join(PACKAGE_JSON))
+        .with_context(|| format!("reading {pkg:?}'s package.json for js_lint Input scoping"))?;
+
+    // See `typecheck_deps_config`'s identical canonicalization requirement:
+    // `extends`-chain targets are realpath'd, so every containment check
+    // must compare against a canonicalized `workspace_root`.
+    let canonical_root = workspace_root
+        .canonicalize()
+        .with_context(|| format!("canonicalize workspace root {workspace_root:?}"))?;
+
+    let src_files = importgraph::package_source_files(walker, workspace_root, pkg)
+        .with_context(|| format!("collecting first-party source files for {pkg:?}"))?;
+    let mut src_rel: BTreeSet<String> = BTreeSet::new();
+    for f in &src_files {
+        let rel = f
+            .strip_prefix(workspace_root)
+            .unwrap_or(f)
+            .to_string_lossy()
+            .replace('\\', "/");
+        src_rel.insert(rel);
+    }
+
+    // Deliberately no `package.json`-field config fallback here: see
+    // `importgraph::find_nearest_package_json_field_config`'s doc for why an
+    // earlier version's oxlint/eslint fallback was removed rather than kept
+    // (a feature-quality M5 review finding — neither tool actually reads a
+    // `package.json` field when invoked with `-c <that package.json>`, the
+    // way `driver_lint.rs::run` always invokes them).
+    let candidates = lint_config_candidates(linter)?;
+    let config_path = importgraph::find_nearest_lint_config(workspace_root, &pkg_dir, candidates);
+
+    let mut deps: HashMap<String, Value> = HashMap::new();
+    deps.insert(
+        String::new(),
+        Value::List(
+            src_rel
+                .iter()
+                .map(|p| Value::String(hbuiltins::pluginfs::file_addr(p).format()))
+                .collect(),
+        ),
+    );
+
+    let (config_path_rel, config_content) = match &config_path {
+        Some(p) => {
+            let rel = p
+                .strip_prefix(workspace_root)
+                .unwrap_or(p)
+                .to_string_lossy()
+                .replace('\\', "/");
+            let content =
+                std::fs::read_to_string(p).with_context(|| format!("reading lint config {p:?}"))?;
+            (rel, content)
+        }
+        None => (String::new(), String::new()),
+    };
+
+    let mut tsconfig_rel: BTreeSet<String> = BTreeSet::new();
+    let mut tsconfig_path_rel = String::new();
+    let mut tsconfig_content = String::new();
+
+    if let Some(config_path) = &config_path {
+        // Invariant: `config_path_rel` is the relative path of a file that
+        // `find_nearest_lint_config` confirmed exists (see the `config_path`
+        // match above), so it is never empty here — no need to guard the
+        // insert (code-quality/feature-quality M5 review finding: an earlier
+        // `!config_path_rel.is_empty()` check was dead code with no test
+        // exercising the branch it guarded against).
+        debug_assert!(
+            !config_path_rel.is_empty(),
+            "config_path is Some, so config_path_rel must be a non-empty relative path"
+        );
+        deps.insert(
+            "config".to_string(),
+            Value::List(vec![Value::String(
+                hbuiltins::pluginfs::file_addr(&config_path_rel).format(),
+            )]),
+        );
+
+        if linter == toolchain::ESLINT {
+            // Type-aware rules: fold the tsconfig(s) named by every
+            // `parserOptions.project` occurrence plus their whole `extends`
+            // chain into the Input set/hash the same way `js_typecheck` does
+            // — see this function's doc. Every occurrence, not just the
+            // first, is resolved (code-quality M5 review finding): a
+            // multi-entry flat config (e.g. a separate override block per
+            // `src/**`/`test/**`, each with its own `parserOptions.project`)
+            // would otherwise have every tsconfig but the first silently
+            // invisible to the declared Input set/cache key.
+            let projects = importgraph::detect_eslint_type_aware(config_path, &config_content)
+                .with_context(|| format!("scanning {config_path:?} for parserOptions.project"))?;
+            if !projects.is_empty() {
+                let config_dir = config_path.parent().unwrap_or(config_path);
+                let mut project_paths: Vec<PathBuf> = Vec::new();
+                for project in &projects {
+                    match project {
+                        importgraph::EslintProjectOption::AutoDetect => {
+                            project_paths.extend(importgraph::find_nearest_tsconfig(
+                                workspace_root,
+                                &pkg_dir,
+                            ));
+                        }
+                        importgraph::EslintProjectOption::Paths(paths) => {
+                            project_paths.extend(paths.iter().map(|p| config_dir.join(p)));
+                        }
+                    }
+                }
+                anyhow::ensure!(
+                    !project_paths.is_empty(),
+                    "js_lint: {config_path:?} configures a type-aware `parserOptions.project`, \
+                     but no tsconfig could be found — `project: true` requires a tsconfig.json \
+                     somewhere on {pkg:?}'s ancestor chain"
+                );
+                for leaf in &project_paths {
+                    anyhow::ensure!(
+                        leaf.is_file(),
+                        "js_lint: {config_path:?} names tsconfig {leaf:?} via \
+                         `parserOptions.project`, but it does not exist"
+                    );
+                    // Canonicalize: `parserOptions.project` values commonly
+                    // carry a `./` prefix (`config_dir.join(p)` doesn't
+                    // normalize that away), and `resolve_tsconfig_extends_chain`'s
+                    // own ancestor paths are already realpath'd (see that
+                    // function's doc) — comparing/stripping against a
+                    // non-canonical leaf would otherwise produce a
+                    // `packages/a/./tsconfig.json`-shaped rel path instead of
+                    // the clean one `js_typecheck`'s identical treatment
+                    // produces.
+                    let leaf = leaf
+                        .canonicalize()
+                        .with_context(|| format!("canonicalize tsconfig {leaf:?}"))?;
+                    // Hard error (never a silent same-path fallback) on
+                    // workspace-root escape — a hermeticity + code-quality M5
+                    // review finding: an eslint config with
+                    // `parserOptions: { project: "/etc/hostname" }` (or any
+                    // `../`-heavy path) previously canonicalized successfully
+                    // and then had `strip_prefix(...).unwrap_or(&leaf)` fall
+                    // back to the raw absolute host path instead of erroring,
+                    // reading and hashing an arbitrary host file into
+                    // `js_lint`'s cache key. Mirrors this same file's
+                    // `types_addrs` cross-package-edge check just above and
+                    // `resolve_extends_specifier`'s `canonicalize_within` in
+                    // `importgraph.rs`, both of which hard-error rather than
+                    // fall back.
+                    let leaf_rel = leaf
+                        .strip_prefix(&canonical_root)
+                        .with_context(|| {
+                            format!(
+                                "js_lint: {config_path:?} names tsconfig {leaf:?} via \
+                                 `parserOptions.project`, which resolved outside the workspace \
+                                 root ({canonical_root:?}) — cannot express it as a declared \
+                                 js_lint input"
+                            )
+                        })?
+                        .to_string_lossy()
+                        .replace('\\', "/");
+                    if tsconfig_path_rel.is_empty() {
+                        tsconfig_path_rel.clone_from(&leaf_rel);
+                    }
+                    if tsconfig_rel.insert(leaf_rel) {
+                        let content = std::fs::read_to_string(&leaf)
+                            .with_context(|| format!("reading tsconfig {leaf:?}"))?;
+                        tsconfig_content.push('\n');
+                        tsconfig_content.push_str(&content);
+                    }
+                    let chain = importgraph::resolve_tsconfig_extends_chain(&canonical_root, &leaf)
+                        .with_context(|| {
+                            format!(
+                                "resolving tsconfig extends chain for {pkg:?}'s js_lint (via \
+                                 {config_path:?})"
+                            )
+                        })?;
+                    for ancestor in &chain {
+                        let rel = ancestor
+                            .strip_prefix(&canonical_root)
+                            .unwrap_or(ancestor)
+                            .to_string_lossy()
+                            .replace('\\', "/");
+                        if tsconfig_rel.insert(rel) {
+                            let content = std::fs::read_to_string(ancestor).with_context(|| {
+                                format!("reading extended tsconfig {ancestor:?}")
+                            })?;
+                            tsconfig_content.push('\n');
+                            tsconfig_content.push_str(&content);
+                        }
+                    }
+                }
+            }
+
+            // `extends`/`plugins` npm packages — resolved via the lockfile,
+            // never treated as raw filesystem paths (see
+            // `importgraph::extract_eslint_module_refs`'s doc).
+            let names = importgraph::extract_eslint_module_refs(config_path, &config_content)
+                .with_context(|| format!("scanning {config_path:?} for extends/plugins"))?;
+            let mut plugin_addrs: BTreeSet<String> = BTreeSet::new();
+            for name in names {
+                if let Some(addr) = deps::resolve_one_dependency(
+                    pkg,
+                    &name,
+                    &manifest,
+                    lockfile,
+                    resolved_graph,
+                    member_addrs_by_name,
+                    goos,
+                    goarch,
+                )
+                .with_context(|| format!("resolving eslint config package `{name}` for js_lint"))?
+                {
+                    plugin_addrs.insert(addr);
+                }
+            }
+            if !plugin_addrs.is_empty() {
+                deps.insert(
+                    "eslint_plugins".to_string(),
+                    Value::List(plugin_addrs.into_iter().map(Value::String).collect()),
+                );
+            }
+
+            // Relative-path shared eslint config files: a legacy config's own
+            // relative `extends`/`plugins` entry, or a modern flat config's
+            // relative `import`/`require` of a shared base config — both
+            // name a local sibling file rather than an npm package, and must
+            // be declared as Inputs the same way `test_deps_config` already
+            // does for a shared test-runner config (a hermeticity M5 review
+            // finding: editing only the referenced base config previously
+            // left `js_lint`'s cache key unchanged). See
+            // `importgraph::resolve_eslint_config_referenced_files`'s doc.
+            let referenced_configs =
+                importgraph::resolve_eslint_config_referenced_files(config_path, &config_content)
+                    .with_context(|| {
+                    format!("scanning {config_path:?} for referenced eslint config files")
+                })?;
+            let mut config_ref_addrs: BTreeSet<String> = BTreeSet::new();
+            for file in referenced_configs {
+                // Same hard-error-not-fallback containment discipline as the
+                // `parserOptions.project` leaf just above: a referenced
+                // config file that resolves outside the workspace root must
+                // never be silently read/hashed as an arbitrary host file.
+                let canonical_file = file
+                    .canonicalize()
+                    .with_context(|| format!("canonicalize referenced eslint config {file:?}"))?;
+                let rel = canonical_file
+                    .strip_prefix(&canonical_root)
+                    .with_context(|| {
+                        format!(
+                            "js_lint: {config_path:?} references {file:?}, which resolved \
+                             outside the workspace root ({canonical_root:?}) — cannot express \
+                             it as a declared js_lint input"
+                        )
+                    })?
+                    .to_string_lossy()
+                    .replace('\\', "/");
+                config_ref_addrs.insert(hbuiltins::pluginfs::file_addr(&rel).format());
+            }
+            if !config_ref_addrs.is_empty() {
+                deps.insert(
+                    "config_refs".to_string(),
+                    Value::List(config_ref_addrs.into_iter().map(Value::String).collect()),
+                );
+            }
+        }
+    }
+
+    if !tsconfig_rel.is_empty() {
+        deps.insert(
+            "tsconfig".to_string(),
+            Value::List(
+                tsconfig_rel
+                    .iter()
+                    .map(|p| Value::String(hbuiltins::pluginfs::file_addr(p).format()))
+                    .collect(),
+            ),
+        );
+    }
+
+    Ok(LintDepsConfig {
+        deps,
+        config_path: config_path_rel,
+        config_content,
+        tsconfig_path: tsconfig_path_rel,
+        tsconfig_content,
+    })
 }
 
 /// The default npm registry tarball URL for a `(name, version)` — used when
@@ -1415,6 +1963,40 @@ fn read_package_name_blocking(package_json: &Path) -> anyhow::Result<String> {
     workspace::read_package_name(package_json)
 }
 
+/// Resolve `member_addrs_by_name` (workspace-member package name →
+/// `package_info` target addr string) — the identical workspace-member
+/// discovery `Provider::deps_config`/`typecheck_config`/`test_config`/
+/// `lint_config` each need inside their own `hcore::blocking::run` closure,
+/// so an import that never resolved on disk can still be attributed to a
+/// workspace sibling by name. Factored out to a free function (not `&self`)
+/// for the same reason those closures already redo this discovery rather
+/// than call `Provider::workspace_members` directly: every call site already
+/// runs on the blocking pool, and `&self` can't be moved into a `'static`
+/// blocking job.
+fn member_addrs_by_name_blocking(
+    walker: &CachedWalker,
+    workspace_root: &Path,
+    skip: &Ignore,
+    pkgmanager: PkgManager,
+) -> anyhow::Result<BTreeMap<String, String>> {
+    let patterns = match pkgmanager {
+        PkgManager::Npm => workspace::read_npm_workspace_globs(workspace_root)?,
+        PkgManager::Pnpm => workspace::read_pnpm_workspace_globs(workspace_root)?,
+    };
+    if patterns.is_empty() {
+        return Ok(BTreeMap::new());
+    }
+    let mut packages = Vec::new();
+    collect_js_packages(walker, workspace_root, workspace_root, skip, &mut packages);
+    let packages: Vec<PkgBuf> = packages.into_iter().collect::<anyhow::Result<_>>()?;
+    Ok(
+        workspace::resolve_members(workspace_root, &packages, &patterns)?
+            .into_iter()
+            .map(|m| (m.name, m.addr.format()))
+            .collect(),
+    )
+}
+
 fn empty_list_responses() -> Box<dyn Iterator<Item = anyhow::Result<ListResponse>> + Send> {
     Box::new(std::iter::empty())
 }
@@ -1461,6 +2043,19 @@ impl ProviderTrait for Provider {
                 Default::default(),
             );
             let mut responses: Vec<anyhow::Result<ListResponse>> = vec![Ok(ListResponse { addr })];
+
+            // `js_lint` is a second per-package target kind alongside
+            // `package_info` — always present once the package exists (no
+            // additional discovery needed, unlike `js_test`'s per-file
+            // globbing), same as `js_typecheck` would be if it were listed
+            // here too.
+            responses.push(Ok(ListResponse {
+                addr: Addr::new(
+                    req.package.clone(),
+                    LINT_TARGET.to_string(),
+                    Default::default(),
+                ),
+            }));
 
             // One `js_test` target per matched test file — the milestone's
             // stated per-test-file (not per-package) granularity; see
@@ -1598,7 +2193,42 @@ impl ProviderTrait for Provider {
                 });
             }
 
-            // `js_test` is a third per-package-*file* target kind: one addr
+            // `js_lint` is a third per-package target kind alongside
+            // `package_info`/`js_typecheck`, checked before the
+            // `PACKAGE_INFO_TARGET` gate below for the same reason
+            // `TYPECHECK_TARGET` is.
+            if req.addr.name == LINT_TARGET {
+                if self
+                    .skip
+                    .prunes_package(&self.workspace_root, Path::new(req.addr.package.as_str()))
+                {
+                    return Err(GetError::NotFound);
+                }
+                let package_json = self
+                    .workspace_root
+                    .join(req.addr.package.as_str())
+                    .join(PACKAGE_JSON);
+                if !package_json.is_file() {
+                    return Err(GetError::NotFound);
+                }
+                let config = self
+                    .lint_config(&req.addr.package)
+                    .await
+                    .with_context(|| format!("resolving js_lint config for {}", req.addr.format()))
+                    .map_err(GetError::Other)?;
+                return Ok(GetResponse {
+                    target_spec: TargetSpec {
+                        addr: req.addr.clone(),
+                        driver: "js_lint".to_string(),
+                        config,
+                        labels: vec![],
+                        transitive: Default::default(),
+                        approval: Default::default(),
+                    },
+                });
+            }
+
+            // `js_test` is a fourth per-package-*file* target kind: one addr
             // per matched test file, distinguished by the `file` addr arg —
             // see `driver_test.rs` module docs. Checked before the
             // `PACKAGE_INFO_TARGET` gate below for the same reason
@@ -1781,6 +2411,187 @@ mod tests {
         dir
     }
 
+    // ---- graph_cache: Provider::import_graph memoization ----
+    //
+    // M2/M4 review-flagged perf issue: `deps_config`/`typecheck_config`/
+    // `test_config` each independently called
+    // `importgraph::build_package_import_graph` — a full oxc_parser parse +
+    // oxc_resolver resolve of every first-party file in the package — from
+    // scratch, on every single `Provider::get` call. `Provider::import_graph`
+    // fixes this with a per-package cache; these tests prove it actually
+    // memoizes (the same "prove it, don't just structurally add it" gap the
+    // M2 review flagged for `ResolveCache`), not merely that the type exists.
+
+    /// `deps_config` (the real, public, tsc/vitest-free entry point) followed
+    /// by a direct `Provider::import_graph` call — standing in for what
+    /// `typecheck_config`/`test_config` each do internally as the very first
+    /// thing they reach for the same package (see both methods' bodies) —
+    /// must build the underlying import graph exactly once between them.
+    ///
+    /// `typecheck_config`/`test_config` are not driven directly here because
+    /// both require a real host `tsc`/`vitest`/`jest` binary this environment
+    /// does not provision (see `get_resolves_js_typecheck_target_end_to_end`'s
+    /// `#[ignore]` for the identical reason); since both route through this
+    /// exact `import_graph` method before ever touching their own
+    /// tool-specific logic, proving the cache is shared here proves the fix
+    /// for all three real callers.
+    #[tokio::test]
+    async fn import_graph_is_shared_across_independent_callers() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        write(dir.path(), "packages/a/package.json", r#"{"name": "a"}"#);
+        write(
+            dir.path(),
+            "packages/a/src/index.ts",
+            "export const x = 1;\n",
+        );
+
+        let provider = Provider::new(dir.path().to_path_buf(), PkgManager::Npm);
+        let pkg = PkgBuf::from("packages/a");
+
+        provider
+            .deps_config(&pkg)
+            .await
+            .expect("deps_config for packages/a");
+        assert_eq!(
+            provider
+                .graph_build_count
+                .load(std::sync::atomic::Ordering::SeqCst),
+            1,
+            "deps_config's own import_graph call must have built the graph exactly once"
+        );
+
+        provider
+            .import_graph(&pkg)
+            .await
+            .expect("import_graph for packages/a");
+        assert_eq!(
+            provider
+                .graph_build_count
+                .load(std::sync::atomic::Ordering::SeqCst),
+            1,
+            "a second caller for the SAME package must hit the cache, not rebuild"
+        );
+    }
+
+    /// Different packages must not share one build slot — proving the cache
+    /// is keyed per-package rather than a single memo that would happen to
+    /// look "correct" for one caller. Also exercises that re-fetching an
+    /// already-cached package doesn't rebuild, independent of insertion order.
+    #[tokio::test]
+    async fn import_graph_is_not_shared_across_different_packages() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        write(dir.path(), "packages/a/package.json", r#"{"name": "a"}"#);
+        write(
+            dir.path(),
+            "packages/a/src/index.ts",
+            "export const x = 1;\n",
+        );
+        write(dir.path(), "packages/b/package.json", r#"{"name": "b"}"#);
+        write(
+            dir.path(),
+            "packages/b/src/index.ts",
+            "export const y = 2;\n",
+        );
+
+        let provider = Provider::new(dir.path().to_path_buf(), PkgManager::Npm);
+
+        provider
+            .import_graph(&PkgBuf::from("packages/a"))
+            .await
+            .expect("import_graph for packages/a");
+        provider
+            .import_graph(&PkgBuf::from("packages/b"))
+            .await
+            .expect("import_graph for packages/b");
+        assert_eq!(
+            provider
+                .graph_build_count
+                .load(std::sync::atomic::Ordering::SeqCst),
+            2,
+            "two different packages must each get their own build"
+        );
+
+        provider
+            .import_graph(&PkgBuf::from("packages/a"))
+            .await
+            .expect("import_graph for packages/a again");
+        assert_eq!(
+            provider
+                .graph_build_count
+                .load(std::sync::atomic::Ordering::SeqCst),
+            2,
+            "re-fetching an already-cached package must not rebuild"
+        );
+    }
+
+    /// The two tests above only ever `.await` one call before issuing the
+    /// next — they prove "a second *sequential* call for the same package
+    /// hits the cache," not "two *simultaneously racing* callers for the
+    /// same package coalesce onto one build," which is the actual property
+    /// `graph_cache`'s doc comment claims and every one of this crate's three
+    /// M5 reviews flagged as asserted-but-untested. Drive many concurrent
+    /// `import_graph` calls for the identical package via `join_all` and
+    /// assert exactly one build happened.
+    #[tokio::test]
+    async fn import_graph_concurrent_callers_for_the_same_package_coalesce_onto_one_build() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        write(dir.path(), "packages/a/package.json", r#"{"name": "a"}"#);
+        write(
+            dir.path(),
+            "packages/a/src/index.ts",
+            "export const x = 1;\n",
+        );
+
+        let provider = Provider::new(dir.path().to_path_buf(), PkgManager::Npm);
+        let pkg = PkgBuf::from("packages/a");
+
+        let futures = (0..16).map(|_| provider.import_graph(&pkg));
+        let results = futures::future::join_all(futures).await;
+        for r in results {
+            r.expect("concurrent import_graph call for packages/a");
+        }
+
+        assert_eq!(
+            provider
+                .graph_build_count
+                .load(std::sync::atomic::Ordering::SeqCst),
+            1,
+            "many callers racing the SAME package must single-flight onto exactly one build"
+        );
+    }
+
+    /// code-quality/feature-quality M5 review finding: `member_addrs_by_name_blocking`
+    /// (a full recursive workspace walk + `package.json` parse of every
+    /// package, plus a glob-match) was previously redone from scratch inside
+    /// each of `deps_config`/`typecheck_config`/`test_config`/`lint_config`'s
+    /// own blocking closure on every single call — the identical
+    /// "recompute-on-every-call" shape `graph_cache` fixes for the import
+    /// graph, left unfixed for workspace-member discovery. `member_addrs_cache`
+    /// backs `Provider::member_addrs_by_name` with a `tokio::sync::OnceCell`
+    /// exactly like `tsc_cache`/`testrunner_cache`/`linter_cache`; two calls
+    /// on the same `Provider` must return the identical cached `Arc`, not two
+    /// independently-built maps.
+    #[tokio::test]
+    async fn member_addrs_by_name_is_cached_across_calls_on_the_same_provider() {
+        let dir = pnpm_fixture();
+        let provider = Provider::new(dir.path().to_path_buf(), PkgManager::Pnpm);
+
+        let first = provider
+            .member_addrs_by_name()
+            .await
+            .expect("member_addrs_by_name first call");
+        let second = provider
+            .member_addrs_by_name()
+            .await
+            .expect("member_addrs_by_name second call");
+
+        assert!(
+            Arc::ptr_eq(&first, &second),
+            "a second call must reuse the cached Arc, not rebuild the workspace-member map"
+        );
+        assert!(!first.is_empty(), "sanity: the pnpm fixture has members");
+    }
+
     #[test]
     fn pnpm_workspace_members_excludes_node_modules() {
         let dir = pnpm_fixture();
@@ -1872,9 +2683,16 @@ mod tests {
             .await
             .expect("list");
         let addrs: Vec<Addr> = iter.map(|r| r.expect("no per-entry error").addr).collect();
-        assert_eq!(addrs.len(), 1);
+        // `package_info` + `js_lint` — see `Provider::list`'s doc for why
+        // `js_lint` is listed unconditionally alongside `package_info` (no
+        // `js_test`-style per-file discovery needed for it).
+        assert_eq!(addrs.len(), 2);
         assert_eq!(addrs[0].name, PACKAGE_INFO_TARGET);
         assert_eq!(addrs[0].package.as_str(), "packages/a");
+        assert!(
+            addrs.iter().any(|a| a.name == LINT_TARGET),
+            "js_lint must be listed alongside package_info: {addrs:?}"
+        );
     }
 
     #[tokio::test]
@@ -2316,6 +3134,7 @@ mod tests {
                 tstool: toolchain::HOST.to_string(),
                 testrunner: toolchain::VITEST.to_string(),
                 test_glob: Vec::new(),
+                linter: toolchain::OXLINT.to_string(),
             },
         );
 
@@ -2620,6 +3439,36 @@ mod tests {
         }
     }
 
+    /// Build the same [`importgraph::ImportGraph`] `Provider::import_graph`
+    /// would, for tests that call `typecheck_deps_config`/`test_deps_config`
+    /// directly against a bare fixture rather than through a `Provider` (and
+    /// therefore without its per-package cache — these tests exercise the
+    /// pure Input-scoping logic, not the cache itself; the cache has its own
+    /// dedicated tests, see `import_graph_is_shared_across_independent_callers`).
+    fn build_graph_for_test(
+        walker: &CachedWalker,
+        workspace_root: &Path,
+        pkg: &str,
+    ) -> importgraph::ImportGraph {
+        let pkg_dir = if pkg.is_empty() {
+            workspace_root.to_path_buf()
+        } else {
+            workspace_root.join(pkg)
+        };
+        let tsconfig = importgraph::find_nearest_tsconfig(workspace_root, &pkg_dir);
+        let import_resolvers = resolvers::Resolvers::new(tsconfig.as_deref());
+        let resolve_cache = importgraph::ResolveCache::new();
+        importgraph::build_package_import_graph(
+            walker,
+            workspace_root,
+            pkg,
+            &import_resolvers,
+            &resolve_cache,
+            tsconfig.as_deref(),
+        )
+        .expect("build import graph for test")
+    }
+
     /// `typecheck_deps_config` with no lockfile/workspace-member context —
     /// what most of these tests need, since they exercise scoping behavior
     /// that doesn't touch an unresolved third-party/sibling import.
@@ -2628,10 +3477,12 @@ mod tests {
         workspace_root: &Path,
         pkg: &str,
     ) -> anyhow::Result<(HashMap<String, Value>, String, String)> {
+        let graph = build_graph_for_test(walker, workspace_root, pkg);
         typecheck_deps_config(
             walker,
             workspace_root,
             pkg,
+            &graph,
             None,
             None,
             &BTreeMap::new(),
@@ -2917,10 +3768,12 @@ mod tests {
         let resolved_graph = lockfile.resolved_graph();
 
         let walker = CachedWalker::disabled();
+        let graph = build_graph_for_test(&walker, dir.path(), "packages/a");
         let (deps, _tsconfig_path, _tsconfig_content) = typecheck_deps_config(
             &walker,
             dir.path(),
             "packages/a",
+            &graph,
             Some(&lockfile),
             Some(&resolved_graph),
             &BTreeMap::new(),
@@ -3116,11 +3969,12 @@ mod tests {
         pkg: &str,
         test_file_rel: &str,
     ) -> anyhow::Result<(HashMap<String, Value>, String, String)> {
+        let graph = build_graph_for_test(walker, workspace_root, pkg);
         test_deps_config(
-            walker,
             workspace_root,
             pkg,
             test_file_rel,
+            &graph,
             None,
             None,
             &BTreeMap::new(),
@@ -3341,11 +4195,12 @@ mod tests {
         let resolved_graph = lockfile.resolved_graph();
 
         let walker = CachedWalker::disabled();
+        let graph = build_graph_for_test(&walker, dir.path(), "packages/a");
         let (deps, _, _) = test_deps_config(
-            &walker,
             dir.path(),
             "packages/a",
             "packages/a/src/a.test.ts",
+            &graph,
             Some(&lockfile),
             Some(&resolved_graph),
             &BTreeMap::new(),
@@ -3681,11 +4536,12 @@ mod tests {
         );
 
         let walker = CachedWalker::disabled();
+        let graph = build_graph_for_test(&walker, dir.path(), "packages/a");
         let (deps, runner_config_path, runner_config_content) = test_deps_config(
-            &walker,
             dir.path(),
             "packages/a",
             "packages/a/src/a.test.ts",
+            &graph,
             None,
             None,
             &BTreeMap::new(),
@@ -3785,6 +4641,560 @@ mod tests {
             "a shared base config reached via a relative import inside the leaf config must be \
              declared too: {runner_config_addrs:?}"
         );
+    }
+
+    // ---- js_lint: lint_deps_config Input scoping (no real oxlint/eslint
+    // needed) ----
+
+    /// `lint_deps_config` with no lockfile/workspace-member context — what
+    /// most of these tests need, since they exercise scoping behavior that
+    /// doesn't touch an unresolved eslint `extends`/`plugins` package.
+    fn call_lint_deps_config(
+        walker: &CachedWalker,
+        workspace_root: &Path,
+        pkg: &str,
+        linter: &str,
+    ) -> anyhow::Result<LintDepsConfig> {
+        lint_deps_config(
+            walker,
+            workspace_root,
+            pkg,
+            linter,
+            None,
+            None,
+            &BTreeMap::new(),
+            "linux",
+            "amd64",
+        )
+    }
+
+    #[test]
+    fn lint_deps_config_declares_first_party_source_files() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        write(dir.path(), "packages/a/package.json", r#"{"name": "a"}"#);
+        write(
+            dir.path(),
+            "packages/a/src/index.ts",
+            "export const x = 1;\n",
+        );
+        // An unrelated file elsewhere in the workspace must NOT appear —
+        // proving per-package, not workspace-wide, scoping.
+        write(
+            dir.path(),
+            "packages/b/unrelated.ts",
+            "export const unrelated = 1;\n",
+        );
+
+        let walker = CachedWalker::disabled();
+        let result = call_lint_deps_config(&walker, dir.path(), "packages/a", toolchain::OXLINT)
+            .expect("build lint deps config");
+
+        let src_addrs = dep_addrs(&result.deps, "");
+        assert_eq!(src_addrs.len(), 1, "{src_addrs:?}");
+        assert!(src_addrs[0].contains("packages/a/src/index.ts"));
+        assert!(!src_addrs.iter().any(|a| a.contains("unrelated")));
+    }
+
+    #[test]
+    fn lint_deps_config_oxlint_includes_config_group_and_content_when_present() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        write(dir.path(), "packages/a/package.json", r#"{"name": "a"}"#);
+        write(
+            dir.path(),
+            "packages/a/.oxlintrc.json",
+            r#"{"rules":{"no-console":"error"}}"#,
+        );
+        write(
+            dir.path(),
+            "packages/a/src/index.ts",
+            "export const x = 1;\n",
+        );
+
+        let walker = CachedWalker::disabled();
+        let result = call_lint_deps_config(&walker, dir.path(), "packages/a", toolchain::OXLINT)
+            .expect("build lint deps config");
+
+        assert_eq!(result.config_path, "packages/a/.oxlintrc.json");
+        assert_eq!(result.config_content, r#"{"rules":{"no-console":"error"}}"#);
+        let config_addrs = dep_addrs(&result.deps, "config");
+        assert_eq!(config_addrs.len(), 1);
+        assert!(config_addrs[0].contains("packages/a/.oxlintrc.json"));
+        // oxlint has no type-aware rules — no tsconfig group at all.
+        assert!(!result.deps.contains_key("tsconfig"));
+        assert!(result.tsconfig_path.is_empty());
+    }
+
+    #[test]
+    fn lint_deps_config_oxlint_no_config_group_when_absent() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        write(dir.path(), "packages/a/package.json", r#"{"name": "a"}"#);
+        write(
+            dir.path(),
+            "packages/a/src/index.ts",
+            "export const x = 1;\n",
+        );
+
+        let walker = CachedWalker::disabled();
+        let result = call_lint_deps_config(&walker, dir.path(), "packages/a", toolchain::OXLINT)
+            .expect("build lint deps config");
+
+        assert!(result.config_path.is_empty());
+        assert!(result.config_content.is_empty());
+        assert!(!result.deps.contains_key("config"));
+    }
+
+    /// Feature-quality M5 review finding: an earlier version fell back to a
+    /// `package.json`'s own `"oxlint"`/`"eslintConfig"` field when no
+    /// dedicated config file was found, then passed that `package.json`
+    /// straight to `-c` — a shape neither tool actually reads that way (see
+    /// `importgraph::find_nearest_package_json_field_config`'s doc). No
+    /// dedicated `.oxlintrc.json` here, so `js_lint` must run with no config
+    /// at all rather than fabricating one from the `"oxlint"` field.
+    #[test]
+    fn lint_deps_config_oxlint_has_no_package_json_field_fallback() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        write(
+            dir.path(),
+            "packages/a/package.json",
+            r#"{"name": "a", "oxlint": {"rules": {"no-console": "error"}}}"#,
+        );
+        write(
+            dir.path(),
+            "packages/a/src/index.ts",
+            "export const x = 1;\n",
+        );
+
+        let walker = CachedWalker::disabled();
+        let result = call_lint_deps_config(&walker, dir.path(), "packages/a", toolchain::OXLINT)
+            .expect("build lint deps config");
+
+        assert!(result.config_path.is_empty());
+        assert!(result.config_content.is_empty());
+        assert!(!result.deps.contains_key("config"));
+    }
+
+    /// Same as above, for eslint's `"eslintConfig"` field.
+    #[test]
+    fn lint_deps_config_eslint_has_no_package_json_field_fallback() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        write(
+            dir.path(),
+            "packages/a/package.json",
+            r#"{"name": "a", "eslintConfig": {"rules": {"no-console": "error"}}}"#,
+        );
+        write(
+            dir.path(),
+            "packages/a/src/index.ts",
+            "export const x = 1;\n",
+        );
+
+        let walker = CachedWalker::disabled();
+        let result = call_lint_deps_config(&walker, dir.path(), "packages/a", toolchain::ESLINT)
+            .expect("build lint deps config");
+
+        assert!(result.config_path.is_empty());
+        assert!(result.config_content.is_empty());
+        assert!(!result.deps.contains_key("config"));
+    }
+
+    /// **The specific M5 gap**: an eslint config with type-aware rules
+    /// configured (`parserOptions.project`) must declare/hash the tsconfig
+    /// AND its whole `extends` chain, exactly like `js_typecheck` — proven
+    /// the same way `typecheck_deps_config_declares_and_hashes_tsconfig_extends_chain`
+    /// proves it for `js_typecheck`: editing only the extends-chain
+    /// ancestor (leaf byte-identical) must change the hashed content.
+    #[test]
+    fn lint_deps_config_eslint_type_aware_declares_and_hashes_tsconfig_extends_chain() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        write(
+            dir.path(),
+            "tsconfig.base.json",
+            r#"{"compilerOptions":{"strict":false}}"#,
+        );
+        write(
+            dir.path(),
+            "packages/a/tsconfig.json",
+            r#"{"extends":"../../tsconfig.base.json"}"#,
+        );
+        write(dir.path(), "packages/a/package.json", r#"{"name": "a"}"#);
+        write(
+            dir.path(),
+            "packages/a/src/index.ts",
+            "export const x = 1;\n",
+        );
+        write(
+            dir.path(),
+            "packages/a/eslint.config.js",
+            "export default [{ languageOptions: { parserOptions: { project: \
+             './tsconfig.json' } } }];\n",
+        );
+
+        let walker = CachedWalker::disabled();
+        let result = call_lint_deps_config(&walker, dir.path(), "packages/a", toolchain::ESLINT)
+            .expect("build lint deps config");
+
+        assert_eq!(result.tsconfig_path, "packages/a/tsconfig.json");
+        let tsconfig_addrs = dep_addrs(&result.deps, "tsconfig");
+        assert_eq!(tsconfig_addrs.len(), 2, "{tsconfig_addrs:?}");
+        assert!(
+            tsconfig_addrs
+                .iter()
+                .any(|a| a.contains("packages/a/tsconfig.json"))
+        );
+        assert!(
+            tsconfig_addrs
+                .iter()
+                .any(|a| a.contains("tsconfig.base.json")),
+            "the extends-chain ancestor must be a declared Input too: {tsconfig_addrs:?}"
+        );
+        assert!(
+            result.tsconfig_content.contains("strict"),
+            "the extended base config's content must be folded into the hashed content: {:?}",
+            result.tsconfig_content
+        );
+
+        // Editing only the base config (leaf byte-identical) must change the
+        // hashed content — the actual cache-soundness claim, not just "the
+        // file is listed".
+        write(
+            dir.path(),
+            "tsconfig.base.json",
+            r#"{"compilerOptions":{"strict":true}}"#,
+        );
+        let result2 = call_lint_deps_config(&walker, dir.path(), "packages/a", toolchain::ESLINT)
+            .expect("build lint deps config after editing the base config");
+        assert_ne!(
+            result.tsconfig_content, result2.tsconfig_content,
+            "editing only the extended base config must change the hashed tsconfig content"
+        );
+    }
+
+    #[test]
+    fn lint_deps_config_eslint_not_type_aware_when_no_project_key() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        write(dir.path(), "packages/a/package.json", r#"{"name": "a"}"#);
+        write(
+            dir.path(),
+            "packages/a/src/index.ts",
+            "export const x = 1;\n",
+        );
+        write(
+            dir.path(),
+            "packages/a/eslint.config.js",
+            "export default [{ rules: { semi: 'error' } }];\n",
+        );
+
+        let walker = CachedWalker::disabled();
+        let result = call_lint_deps_config(&walker, dir.path(), "packages/a", toolchain::ESLINT)
+            .expect("build lint deps config");
+
+        assert!(result.tsconfig_path.is_empty());
+        assert!(result.tsconfig_content.is_empty());
+        assert!(!result.deps.contains_key("tsconfig"));
+    }
+
+    /// `extends`/`plugins` npm packages must resolve via the lockfile
+    /// (`deps::resolve_one_dependency`), not be silently dropped or treated
+    /// as filesystem paths.
+    #[test]
+    fn lint_deps_config_eslint_extends_plugins_resolved_via_lockfile() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        write(
+            dir.path(),
+            "packages/a/package.json",
+            r#"{"name": "a", "devDependencies": {"eslint-plugin-react-hooks": "^4.0.0"}}"#,
+        );
+        write(
+            dir.path(),
+            "packages/a/src/index.ts",
+            "export const x = 1;\n",
+        );
+        write(
+            dir.path(),
+            "packages/a/eslint.config.js",
+            "import reactHooks from 'eslint-plugin-react-hooks';\nexport default [{ plugins: \
+             { 'react-hooks': reactHooks } }];\n",
+        );
+
+        let lockfile = Lockfile::parse(
+            PkgManager::Npm,
+            r#"{
+                "packages": {
+                    "": {},
+                    "packages/a": { "name": "a" },
+                    "node_modules/eslint-plugin-react-hooks": {
+                        "version": "4.6.0",
+                        "integrity": "sha512-abc"
+                    }
+                }
+            }"#,
+        )
+        .expect("parse lockfile");
+        let resolved_graph = lockfile.resolved_graph();
+
+        let walker = CachedWalker::disabled();
+        let result = lint_deps_config(
+            &walker,
+            dir.path(),
+            "packages/a",
+            toolchain::ESLINT,
+            Some(&lockfile),
+            Some(&resolved_graph),
+            &BTreeMap::new(),
+            "linux",
+            "amd64",
+        )
+        .expect("build lint deps config");
+
+        let plugin_addrs = dep_addrs(&result.deps, "eslint_plugins");
+        assert!(
+            plugin_addrs
+                .iter()
+                .any(|a| a.contains("eslint-plugin-react-hooks") && a.contains("js_install")),
+            "an eslint config's `plugins` import must resolve to a js_install Input via the \
+             lockfile: {plugin_addrs:?}"
+        );
+    }
+
+    /// Code-quality M5 review finding: a multi-entry flat config (separate
+    /// override blocks, each with its own `parserOptions.project`) must have
+    /// **every** named tsconfig declared/hashed, not just the first. Before
+    /// the fix, `detect_eslint_type_aware` stopped at the first match, so
+    /// `tsconfig.test.json` here was invisible to the declared Input set.
+    #[test]
+    fn lint_deps_config_eslint_multi_entry_project_all_resolved() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        write(
+            dir.path(),
+            "packages/a/tsconfig.json",
+            r#"{"compilerOptions":{}}"#,
+        );
+        write(
+            dir.path(),
+            "packages/a/tsconfig.test.json",
+            r#"{"compilerOptions":{"types":["jest"]}}"#,
+        );
+        write(dir.path(), "packages/a/package.json", r#"{"name": "a"}"#);
+        write(
+            dir.path(),
+            "packages/a/src/index.ts",
+            "export const x = 1;\n",
+        );
+        write(
+            dir.path(),
+            "packages/a/eslint.config.js",
+            "export default [\n\
+             { files: ['src/**/*.ts'], languageOptions: { parserOptions: { project: \
+             './tsconfig.json' } } },\n\
+             { files: ['test/**/*.ts'], languageOptions: { parserOptions: { project: \
+             './tsconfig.test.json' } } },\n\
+             ];\n",
+        );
+
+        let walker = CachedWalker::disabled();
+        let result = call_lint_deps_config(&walker, dir.path(), "packages/a", toolchain::ESLINT)
+            .expect("build lint deps config");
+
+        let tsconfig_addrs = dep_addrs(&result.deps, "tsconfig");
+        assert!(
+            tsconfig_addrs
+                .iter()
+                .any(|a| a.contains("packages/a/tsconfig.json")),
+            "{tsconfig_addrs:?}"
+        );
+        assert!(
+            tsconfig_addrs
+                .iter()
+                .any(|a| a.contains("packages/a/tsconfig.test.json")),
+            "the second override block's own tsconfig must also be a declared Input, not just \
+             the first entry's: {tsconfig_addrs:?}"
+        );
+        assert!(
+            result.tsconfig_content.contains("jest"),
+            "the second tsconfig's content must be folded into the hashed content: {:?}",
+            result.tsconfig_content
+        );
+    }
+
+    /// Hermeticity + code-quality M5 review finding: a `parserOptions.project`
+    /// value that resolves outside the workspace root must hard-error, never
+    /// silently fall back to reading/hashing the arbitrary absolute host
+    /// path. `config_dir.join(absolute_path)` yields `absolute_path` verbatim
+    /// (`Path::join`'s documented behavior), so an absolute-path
+    /// `parserOptions.project` is the simplest deterministic repro of the
+    /// escape without relying on a specific number of `..` segments.
+    #[test]
+    fn lint_deps_config_eslint_parser_options_project_outside_workspace_root_errors() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let outside = tempfile::tempdir().expect("outside tempdir");
+        write(outside.path(), "tsconfig.json", r#"{"compilerOptions":{}}"#);
+        let outside_tsconfig = outside
+            .path()
+            .join("tsconfig.json")
+            .to_string_lossy()
+            .replace('\\', "/");
+
+        write(dir.path(), "packages/a/package.json", r#"{"name": "a"}"#);
+        write(
+            dir.path(),
+            "packages/a/src/index.ts",
+            "export const x = 1;\n",
+        );
+        write(
+            dir.path(),
+            "packages/a/eslint.config.js",
+            &format!(
+                "export default [{{ languageOptions: {{ parserOptions: {{ project: {:?} }} }} \
+                 }}];\n",
+                outside_tsconfig
+            ),
+        );
+
+        let walker = CachedWalker::disabled();
+        let err = call_lint_deps_config(&walker, dir.path(), "packages/a", toolchain::ESLINT)
+            .expect_err(
+                "a parserOptions.project resolving outside the workspace root must be a hard \
+                 error, not a silent same-path fallback",
+            );
+        let msg = format!("{err:#}");
+        assert!(
+            msg.contains("outside the workspace root"),
+            "error must name the actual failure, not just \"not found\": {msg}"
+        );
+    }
+
+    /// Hermeticity M5 review finding: a legacy eslint config's own relative
+    /// `extends` entry (`"extends": "./base.eslintrc.json"`) names a local
+    /// sibling config file, not an npm package — it must be declared as an
+    /// Input the same way `test_deps_config` already does for a shared
+    /// test-runner config, so editing only the base config busts the cache.
+    #[test]
+    fn lint_deps_config_eslint_legacy_relative_extends_declared_as_input() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        write(
+            dir.path(),
+            "packages/a/base.eslintrc.json",
+            r#"{"rules":{"no-console":"error"}}"#,
+        );
+        write(
+            dir.path(),
+            "packages/a/.eslintrc.json",
+            r#"{"extends":"./base.eslintrc.json"}"#,
+        );
+        write(dir.path(), "packages/a/package.json", r#"{"name": "a"}"#);
+        write(
+            dir.path(),
+            "packages/a/src/index.ts",
+            "export const x = 1;\n",
+        );
+
+        let walker = CachedWalker::disabled();
+        let result = call_lint_deps_config(&walker, dir.path(), "packages/a", toolchain::ESLINT)
+            .expect("build lint deps config");
+
+        let ref_addrs = dep_addrs(&result.deps, "config_refs");
+        assert!(
+            ref_addrs
+                .iter()
+                .any(|a| a.contains("packages/a/base.eslintrc.json")),
+            "a legacy config's relative `extends` must be a declared js_lint Input: {ref_addrs:?}"
+        );
+    }
+
+    /// Same gap, for a modern flat config's own relative `import`/`require`
+    /// of a shared base config.
+    #[test]
+    fn lint_deps_config_eslint_flat_config_relative_import_declared_as_input() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        write(
+            dir.path(),
+            "packages/a/eslint-base.js",
+            "export default [{ rules: { 'no-console': 'error' } }];\n",
+        );
+        write(
+            dir.path(),
+            "packages/a/eslint.config.js",
+            "import base from './eslint-base.js';\nexport default [...base];\n",
+        );
+        write(dir.path(), "packages/a/package.json", r#"{"name": "a"}"#);
+        write(
+            dir.path(),
+            "packages/a/src/index.ts",
+            "export const x = 1;\n",
+        );
+
+        let walker = CachedWalker::disabled();
+        let result = call_lint_deps_config(&walker, dir.path(), "packages/a", toolchain::ESLINT)
+            .expect("build lint deps config");
+
+        let ref_addrs = dep_addrs(&result.deps, "config_refs");
+        assert!(
+            ref_addrs
+                .iter()
+                .any(|a| a.contains("packages/a/eslint-base.js")),
+            "a flat config's relative import of a shared base config must be a declared js_lint \
+             Input: {ref_addrs:?}"
+        );
+    }
+
+    // ---- `Provider::get` end to end for `js_lint` — gated on a real
+    // oxlint binary being available in this devenv (querying `--version` is
+    // unavoidably a real subprocess call), unlike the Input-scoping tests
+    // above.
+
+    fn find_real_oxlint_for_test() -> Option<std::path::PathBuf> {
+        let path = std::env::var_os("PATH")?;
+        for dir in std::env::split_paths(&path) {
+            let cand = dir.join("oxlint");
+            if std::fs::metadata(&cand)
+                .map(|m| m.is_file())
+                .unwrap_or(false)
+            {
+                return Some(cand);
+            }
+        }
+        None
+    }
+
+    #[tokio::test]
+    #[ignore = "requires a real `oxlint` on PATH — devenv.nix provisions no Node/oxlint \
+                toolchain (see toolchain.rs module docs); run explicitly with \
+                `cargo test -- --ignored` on a host with oxlint installed"]
+    async fn get_resolves_js_lint_target_end_to_end() {
+        find_real_oxlint_for_test().expect(
+            "this test is #[ignore]d precisely because `oxlint` isn't guaranteed on PATH — it \
+             was run explicitly, so a missing `oxlint` here is a real failure, not a skip",
+        );
+
+        let dir = tempfile::tempdir().expect("tempdir");
+        write(dir.path(), "packages/a/package.json", r#"{"name": "a"}"#);
+        write(
+            dir.path(),
+            "packages/a/src/index.ts",
+            "export const x = 1;\n",
+        );
+
+        let provider = Provider::new(dir.path().to_path_buf(), PkgManager::Npm);
+        let ct = ctoken();
+        let executor = Arc::new(NoopExecutor);
+        let resp = provider
+            .get(
+                GetRequest {
+                    request_id: "test".to_string(),
+                    addr: Addr::new(
+                        PkgBuf::from("packages/a"),
+                        LINT_TARGET.to_string(),
+                        Default::default(),
+                    ),
+                    states: vec![],
+                    executor,
+                },
+                &ct,
+            )
+            .await
+            .expect("get js_lint target_spec");
+        assert_eq!(resp.target_spec.driver, "js_lint");
+        assert!(resp.target_spec.config.contains_key("linter_version"));
     }
 
     // ---- `Provider::get` end to end for `js_test` — gated on a real

--- a/crates/plugin-js/src/pluginjs/toolchain.rs
+++ b/crates/plugin-js/src/pluginjs/toolchain.rs
@@ -151,6 +151,72 @@ pub(crate) fn resolve_host_test_runner(
     })
 }
 
+/// Sentinel `linter` values `js_lint` accepts — see this module's
+/// `resolve_host_linter` doc and `driver_lint.rs` module docs for the same
+/// disclosed non-hermetic-toolchain shape `tstool = "host"`/`testrunner`
+/// already have. Mirrors `ai-docs/js-plugin-plan.md`'s `js_lint` row:
+/// `linter` defaults to `oxlint`, alt `eslint` (for type-aware rules).
+pub const OXLINT: &str = "oxlint";
+pub const ESLINT: &str = "eslint";
+
+/// Whether `linter` names a supported linter — the only two values `js_lint`
+/// recognizes in this milestone.
+pub fn is_supported_linter(linter: &str) -> bool {
+    linter == OXLINT || linter == ESLINT
+}
+
+/// Resolve the configured `linter`'s binary:
+/// `<workspace_root>/node_modules/.bin/<oxlint|eslint>` first, then the
+/// process's own `PATH` — the same disclosed non-hermetic escape hatch
+/// `tstool = "host"`/`testrunner` already have (see [`resolve_host_tsc`]),
+/// extended to `js_lint`'s toolchain axis. Fails loudly, naming both places
+/// checked, when neither has it.
+pub(crate) fn resolve_host_linter(workspace_root: &Path, linter: &str) -> anyhow::Result<PathBuf> {
+    anyhow::ensure!(
+        is_supported_linter(linter),
+        "js_lint: unsupported linter {linter:?} — expected \"oxlint\" or \"eslint\""
+    );
+    let local = workspace_root
+        .join("node_modules")
+        .join(".bin")
+        .join(linter);
+    find_host_bin(workspace_root, linter).ok_or_else(|| {
+        anyhow::anyhow!(
+            "js_lint: no `{linter}` binary found at {local:?} or on PATH — install it (`npm \
+             install -D {linter}` / `pnpm add -D {linter}`) so `node_modules/.bin/{linter}` \
+             exists, or make a `{linter}` binary available on PATH. There is no hermetic \
+             {linter} toolchain yet in this plugin — `linter=\"{linter}\"` requires one of those \
+             two to be reachable."
+        )
+    })
+}
+
+/// Query the resolved linter's own `--version` output, trimmed — hashed into
+/// `JsLintDef` so a host linter upgrade/downgrade busts the cache, mirroring
+/// [`query_tsc_version`]/[`query_test_runner_version`]'s identical "query
+/// once at `Provider::get` time, not `run()` time" rationale.
+pub(crate) fn query_linter_version(linter_bin: &Path) -> anyhow::Result<String> {
+    let out = std::process::Command::new(linter_bin)
+        .arg("--version")
+        .output()
+        .with_context(|| format!("run {linter_bin:?} --version"))?;
+    anyhow::ensure!(
+        out.status.success(),
+        "`{linter_bin:?} --version` failed ({}): {}",
+        out.status,
+        String::from_utf8_lossy(&out.stderr)
+    );
+    let version = String::from_utf8(out.stdout)
+        .with_context(|| format!("{linter_bin:?} --version output is not utf8"))?
+        .trim()
+        .to_string();
+    anyhow::ensure!(
+        !version.is_empty(),
+        "`{linter_bin:?} --version` returned empty output"
+    );
+    Ok(version)
+}
+
 /// Query the resolved test runner's own `--version` output, trimmed —
 /// hashed into `JsTestDef` so a host runner upgrade/downgrade busts the
 /// cache, mirroring [`query_tsc_version`]'s "query once at `Provider::get`
@@ -370,6 +436,92 @@ mod tests {
             std::fs::set_permissions(&fake_bin, perms).expect("chmod");
         }
         let err = query_test_runner_version(&fake_bin).expect_err("nonzero exit must error");
+        assert!(format!("{err:#}").contains("failed"));
+    }
+
+    // ---- linter (js_lint) ----
+
+    #[test]
+    fn is_supported_linter_recognizes_only_oxlint_and_eslint() {
+        assert!(is_supported_linter(OXLINT));
+        assert!(is_supported_linter(ESLINT));
+        assert!(!is_supported_linter("standard"));
+        assert!(!is_supported_linter(""));
+    }
+
+    #[test]
+    fn resolve_host_linter_rejects_unsupported_value() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let err =
+            resolve_host_linter(dir.path(), "standard").expect_err("unsupported linter must error");
+        assert!(format!("{err:#}").contains("standard"));
+    }
+
+    #[test]
+    fn resolve_host_linter_prefers_local_node_modules_bin_over_path() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let local_bin_dir = dir.path().join("node_modules").join(".bin");
+        std::fs::create_dir_all(&local_bin_dir).expect("mkdir");
+        let local_oxlint = local_bin_dir.join(OXLINT);
+        std::fs::write(&local_oxlint, b"#!/bin/sh\necho local\n").expect("write local oxlint");
+
+        let found = resolve_host_linter(dir.path(), OXLINT).expect("resolve");
+        assert_eq!(found, local_oxlint);
+    }
+
+    #[test]
+    fn resolve_host_linter_errors_clearly_when_absent_everywhere() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let prior = std::env::var_os("PATH");
+        // SAFETY: test-only, single-threaded within this process for the
+        // duration of the mutation; restored immediately below.
+        unsafe { std::env::set_var("PATH", "") };
+        let result = resolve_host_linter(dir.path(), ESLINT);
+        match &prior {
+            // SAFETY: test-only, restoring the prior value we saved above.
+            Some(v) => unsafe { std::env::set_var("PATH", v) },
+            // SAFETY: test-only, restoring the prior (unset) state.
+            None => unsafe { std::env::remove_var("PATH") },
+        }
+        let err = result.expect_err("no eslint anywhere must error, not silently succeed");
+        let msg = format!("{err:#}");
+        assert!(msg.contains("eslint"), "{msg}");
+        assert!(msg.contains("PATH"), "{msg}");
+    }
+
+    #[test]
+    fn query_linter_version_reads_trimmed_stdout() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let fake_bin = dir.path().join("oxlint");
+        std::fs::write(&fake_bin, "#!/bin/sh\necho '0.15.0'\n").expect("write fake linter");
+        #[cfg(unix)]
+        {
+            use std::os::unix::fs::PermissionsExt;
+            let mut perms = std::fs::metadata(&fake_bin)
+                .expect("metadata")
+                .permissions();
+            perms.set_mode(0o755);
+            std::fs::set_permissions(&fake_bin, perms).expect("chmod");
+        }
+        let version = query_linter_version(&fake_bin).expect("query version");
+        assert_eq!(version, "0.15.0");
+    }
+
+    #[test]
+    fn query_linter_version_errors_on_nonzero_exit() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let fake_bin = dir.path().join("eslint");
+        std::fs::write(&fake_bin, "#!/bin/sh\nexit 2\n").expect("write fake linter");
+        #[cfg(unix)]
+        {
+            use std::os::unix::fs::PermissionsExt;
+            let mut perms = std::fs::metadata(&fake_bin)
+                .expect("metadata")
+                .permissions();
+            perms.set_mode(0o755);
+            std::fs::set_permissions(&fake_bin, perms).expect("chmod");
+        }
+        let err = query_linter_version(&fake_bin).expect_err("nonzero exit must error");
         assert!(format!("{err:#}").contains("failed"));
     }
 }


### PR DESCRIPTION
M5 of the JS/TS heph plugin plan (part 5/6 of the stack).

**Perf fix (prerequisite)**: deps_config, typecheck_config, and test_config each rebuilt the whole package's ImportGraph from scratch on every Provider::get call — for js_test, once per test file. Flagged independently by both the M2 and M4 reviews and deferred twice. Added a per-package memoized cache (keyed OnceCell behind a Mutex whose critical section is just the get-or-insert, so unrelated packages never serialize behind one lock) shared by all import-graph consumers, plus a call-count test proving it actually memoizes. Also added the equivalent cache for workspace-member discovery.

**js_lint**: cacheable per-package target, oxlint default + eslint (with type-aware parserOptions.project support) via a single linter config option. Reuses the lockfile-driven third-party resolution and tsconfig-extends-chain handling already established for js_typecheck/js_test.

Reviewed by feature-quality/code-quality/hermeticity — five BLOCKERs found and fixed: a fabricated package.json-config fallback that doesn't match how oxlint/eslint actually discover config; an unconditional hard-fail on packages with zero lintable source files; only the first parserOptions.project entry in a multi-entry eslint config being tracked; **another real workspace escape** — an unvalidated parserOptions.project path letting a repo-controlled eslint config make heph read and hash an arbitrary host file (e.g. /etc/hostname) with no workspace-containment check, now a hard error instead of a silent fallback; and eslint configs' own relative-path extends/imports going untracked.

Explicitly deferred: converging the several OnceCell-based caches onto the repo's hmemoizer primitive for panic containment across the ABI seam; a same-package concurrent-race test for the new cache; no bin-e2e coverage for any JS driver's dlopen/ABI-crossing seam yet.

## Test plan
- [x] cargo build -p plugin-js -p plugin-js-cdylib
- [x] cargo test -p plugin-js
- [x] cargo clippy -p plugin-js -p plugin-js-cdylib --all-targets -- -D warnings
- [x] cargo fmt --check -p plugin-js -p plugin-js-cdylib

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>