### PR TITLE
feat(bench): add JS/TS Tier B scenarios, go/js/both selector

### DIFF
--- a/.github/workflows/heph.yml
+++ b/.github/workflows/heph.yml
@@ -260,6 +260,7 @@ jobs:
           PLUGIN_GO_NAME="heph-go-plugin_${{ matrix.os }}_${{ matrix.arch }}.$ext"
           PLUGIN_GHA_NAME="heph-gha-plugin_${{ matrix.os }}_${{ matrix.arch }}.$ext"
           PLUGIN_OCI_NAME="heph-oci-plugin_${{ matrix.os }}_${{ matrix.arch }}.$ext"
+          PLUGIN_JS_NAME="heph-js-plugin_${{ matrix.os }}_${{ matrix.arch }}.$ext"
           # heph-bench: the perf-regression harness (`perfbench` job). Publishing
           # it as a release asset alongside `heph` itself means that job never
           # builds anything to compare a PR against its baseline — both the
@@ -277,6 +278,7 @@ jobs:
           echo "plugin_go_name=$PLUGIN_GO_NAME" >> $GITHUB_OUTPUT
           echo "plugin_gha_name=$PLUGIN_GHA_NAME" >> $GITHUB_OUTPUT
           echo "plugin_oci_name=$PLUGIN_OCI_NAME" >> $GITHUB_OUTPUT
+          echo "plugin_js_name=$PLUGIN_JS_NAME" >> $GITHUB_OUTPUT
           echo "bench_bin_name=$BENCH_BIN_NAME" >> $GITHUB_OUTPUT
           echo "debug_bin_name=$DEBUG_BIN_NAME" >> $GITHUB_OUTPUT
           OUT="$CARGO_TARGET_DIR/${{ matrix.target }}/release"
@@ -299,20 +301,21 @@ jobs:
           # share nearly the whole workspace dep graph, and under the release
           # profile (thin-LTO + opt-level=3) each artifact's final codegen/LTO pass
           # is heavy — splitting into separate `cargo build` calls serializes those
-          # three passes and pays cargo startup + freshness re-resolution each time.
+          # passes and pays cargo startup + freshness re-resolution each time.
           # A single invocation lets cargo's jobserver overlap them (one artifact's
           # link tail filling cores while the next codegens). `--bin heph` selects
-          # the binary; `--lib` adds every selected package's lib target — i.e. both
-          # cdylibs (heph's own lib is already built as the bin's dependency, so it
+          # the binary; `--lib` adds every selected package's lib target — i.e. every
+          # cdylib (heph's own lib is already built as the bin's dependency, so it
           # costs nothing extra). `heph-bench` links the same `heph` lib crate, so
           # adding it here is marginal — the expensive part (engine + deps) is
           # already being compiled for `heph` itself.
-          TARGETS="--bin heph --bin heph-bench --lib -p heph -p plugin-go-cdylib -p plugin-gha-cdylib -p plugin-oci-cdylib -p bench"
+          TARGETS="--bin heph --bin heph-bench --lib -p heph -p plugin-go-cdylib -p plugin-gha-cdylib -p plugin-oci-cdylib -p plugin-js-cdylib -p bench"
           if [ "${{ matrix.os }}" = "darwin" ]; then
             cargo build --release --locked --target ${{ matrix.target }} $TARGETS
             lib="$OUT/libplugin_go_cdylib.dylib"
             gha_lib="$OUT/libplugin_gha_cdylib.dylib"
             oci_lib="$OUT/libplugin_oci_cdylib.dylib"
+            js_lib="$OUT/libplugin_js_cdylib.dylib"
             # The nix toolchain hard-links libiconv against its /nix/store path,
             # which is absent on user machines (dyld aborts at launch). Rewrite
             # those load commands to the OS /usr/lib copies — for every artifact.
@@ -321,16 +324,19 @@ jobs:
             bash scripts/macos-portable.sh "$lib"
             bash scripts/macos-portable.sh "$gha_lib"
             bash scripts/macos-portable.sh "$oci_lib"
+            bash scripts/macos-portable.sh "$js_lib"
           else
             cargo zigbuild --release --locked --target ${{ matrix.target }} $TARGETS
             lib="$OUT/libplugin_go_cdylib.so"
             gha_lib="$OUT/libplugin_gha_cdylib.so"
             oci_lib="$OUT/libplugin_oci_cdylib.so"
+            js_lib="$OUT/libplugin_js_cdylib.so"
           fi
           cp "$OUT/heph-bench" $BENCH_BIN_NAME
           cp "$lib" $PLUGIN_GO_NAME
           cp "$gha_lib" $PLUGIN_GHA_NAME
           cp "$oci_lib" $PLUGIN_OCI_NAME
+          cp "$js_lib" $PLUGIN_JS_NAME
 
           # `heph` diverges into its two flavours from here — each stamped by
           # `patch-flavour.sh` with which one it is (`heph version` / self-upgrade
@@ -425,6 +431,12 @@ jobs:
           name: ${{steps.build.outputs.plugin_oci_name}}
           path: ${{steps.build.outputs.plugin_oci_name}}
 
+      - name: Upload js plugin artifact
+        uses: actions/upload-artifact@v6
+        with:
+          name: ${{steps.build.outputs.plugin_js_name}}
+          path: ${{steps.build.outputs.plugin_js_name}}
+
   upload_artifacts:
     name: Pre-release
     needs: [gen, govet, build]
@@ -449,8 +461,9 @@ jobs:
         uses: actions/download-artifact@v7
         with:
           # Matches the CLI, both release flavours (`heph_<os>_<arch>` std,
-          # `heph_debug_<os>_<arch>` debug) and the go plugin cdylib
-          # (`heph-go-plugin_<os>_<arch>.{so,dylib}`); excludes the `repo` source artifact.
+          # `heph_debug_<os>_<arch>` debug) and every plugin cdylib
+          # (`heph-{go,gha,oci,js}-plugin_<os>_<arch>.{so,dylib}`); excludes
+          # the `repo` source artifact.
           pattern: "heph*"
           path: dist
           merge-multiple: true
@@ -480,6 +493,17 @@ jobs:
               -prefix heph-gha-plugin -from-dir "$GITHUB_WORKSPACE/dist" -url-base "$BASE" \
               -out "$GITHUB_WORKSPACE/dist/heph-gha-plugin.json" )
           cat dist/heph-gha-plugin.json
+          # Deliberately NOT generating a heph-js-plugin.json here. The `build`
+          # job above now publishes the raw per-os/arch js plugin cdylib as a
+          # release asset (`heph-js-plugin_<os>_<arch>.{so,dylib}`) — needed so
+          # `perfbench`/`perf.yml` can download it for Tier B, same as go/gha.
+          # A public `plugins: - { identifier: { url: .../heph-js-plugin.json } }`
+          # manifest is a separate, larger decision (declaring the js plugin
+          # generally available to any real workspace, not just this bench
+          # pipeline's own locally-built manifest — see
+          # `crates/bench/src/dist.rs`'s `write_dist_config`, which builds its
+          # OWN manifest straight from the downloaded raw dylib and never reads
+          # this file). Left for a future PR to make explicitly.
           echo "manifest checksum: $(cat dist/heph-gha-plugin.json.sha256)"
           # The oci plugin (`docker_build` / `oci_pull` / `oci_push` / `oci_load`)
           # ships the same way — it is not compiled into the CLI.

--- a/.github/workflows/heph.yml
+++ b/.github/workflows/heph.yml
@@ -493,17 +493,6 @@ jobs:
               -prefix heph-gha-plugin -from-dir "$GITHUB_WORKSPACE/dist" -url-base "$BASE" \
               -out "$GITHUB_WORKSPACE/dist/heph-gha-plugin.json" )
           cat dist/heph-gha-plugin.json
-          # Deliberately NOT generating a heph-js-plugin.json here. The `build`
-          # job above now publishes the raw per-os/arch js plugin cdylib as a
-          # release asset (`heph-js-plugin_<os>_<arch>.{so,dylib}`) — needed so
-          # `perfbench`/`perf.yml` can download it for Tier B, same as go/gha.
-          # A public `plugins: - { identifier: { url: .../heph-js-plugin.json } }`
-          # manifest is a separate, larger decision (declaring the js plugin
-          # generally available to any real workspace, not just this bench
-          # pipeline's own locally-built manifest — see
-          # `crates/bench/src/dist.rs`'s `write_dist_config`, which builds its
-          # OWN manifest straight from the downloaded raw dylib and never reads
-          # this file). Left for a future PR to make explicitly.
           echo "manifest checksum: $(cat dist/heph-gha-plugin.json.sha256)"
           # The oci plugin (`docker_build` / `oci_pull` / `oci_push` / `oci_load`)
           # ships the same way — it is not compiled into the CLI.
@@ -512,6 +501,15 @@ jobs:
               -out "$GITHUB_WORKSPACE/dist/heph-oci-plugin.json" )
           cat dist/heph-oci-plugin.json
           echo "manifest checksum: $(cat dist/heph-oci-plugin.json.sha256)"
+          # The js plugin ships the same way: one manifest entry per
+          # per-os/arch cdylib in dist/, published as a release asset. A real
+          # workspace opts in the same way as go/gha:
+          # `plugins: - { identifier: { url: .../heph-js-plugin.json } }`.
+          ( cd tools/pluginmanifest && go run . -name js -version "$VERSION" \
+              -prefix heph-js-plugin -from-dir "$GITHUB_WORKSPACE/dist" -url-base "$BASE" \
+              -out "$GITHUB_WORKSPACE/dist/heph-js-plugin.json" )
+          cat dist/heph-js-plugin.json
+          echo "manifest checksum: $(cat dist/heph-js-plugin.json.sha256)"
 
       - name: Create Release in artifacts repo
         id: create_release

--- a/.github/workflows/perf.yml
+++ b/.github/workflows/perf.yml
@@ -108,6 +108,10 @@ jobs:
       PERFBENCH_LAYERS: "10"
       PERFBENCH_FAN_OUT: "4"
       PERFBENCH_GO_PACKAGES: "60"
+      # Same corpus size as go's — no measured reason yet to size the two
+      # differently, and keeping them equal makes go-vs-js deltas easier to
+      # read at a glance.
+      PERFBENCH_JS_PACKAGES: "60"
       # 3 was too few to tell signal from CI-runner noise (the first live
       # runs showed exactly that). Interleaving (see the run steps below)
       # fixes systematic drift between candidate/baseline; more reps is what
@@ -240,6 +244,21 @@ jobs:
             echo "no heph-bench asset in ${{ steps.baseline_release.outputs.version }} — predates publishing it, Tier A skipped"
             echo "bench_ok=false" >> "$GITHUB_OUTPUT"
           fi
+          # js plugin cdylib, fetched separately and best-effort for the same
+          # bootstrap reason as heph-bench above: baseline releases published
+          # before the bench js/go/both selector landed have no
+          # heph-js-plugin_<os>_<arch> asset at all, and that must not fail
+          # this whole step (go's Tier B comparison must still run).
+          if gh release download "${{ steps.baseline_release.outputs.version }}" \
+              --repo hephbuild/heph-artifacts-v1 \
+              --dir baseline-dist-raw \
+              --pattern "heph-js-plugin_${{ matrix.os }}_${{ matrix.arch }}.$ext"; then
+            cp "baseline-dist-raw/heph-js-plugin_${{ matrix.os }}_${{ matrix.arch }}.$ext" "baseline-dist/heph-js-plugin.$ext"
+            echo "js_ok=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "no heph-js-plugin asset in ${{ steps.baseline_release.outputs.version }} — predates publishing it, JS Tier B skipped"
+            echo "js_ok=false" >> "$GITHUB_OUTPUT"
+          fi
 
       - name: Download candidate (N) artifacts
         uses: actions/download-artifact@v7
@@ -255,6 +274,11 @@ jobs:
           cp "candidate-dist-raw/heph_${{ matrix.os }}_${{ matrix.arch }}" candidate-dist/heph
           cp "candidate-dist-raw/heph-bench_${{ matrix.os }}_${{ matrix.arch }}" candidate-dist/heph-bench
           cp "candidate-dist-raw/heph-go-plugin_${{ matrix.os }}_${{ matrix.arch }}.$ext" "candidate-dist/heph-go-plugin.$ext"
+          # Candidate is always this same run's `build` job — no bootstrap gap
+          # like baseline's (see "Fetch baseline" above), so this is
+          # unconditional: the js plugin cdylib is always present here once
+          # the `build` job publishes it.
+          cp "candidate-dist-raw/heph-js-plugin_${{ matrix.os }}_${{ matrix.arch }}.$ext" "candidate-dist/heph-js-plugin.$ext"
           chmod +x candidate-dist/heph candidate-dist/heph-bench
 
       - name: Generate corpus
@@ -264,6 +288,7 @@ jobs:
             --targets "$PERFBENCH_TARGETS" --packages "$PERFBENCH_PACKAGES" \
             --layers "$PERFBENCH_LAYERS" --fan-out "$PERFBENCH_FAN_OUT" \
             --go-packages "$PERFBENCH_GO_PACKAGES" \
+            --js-packages "$PERFBENCH_JS_PACKAGES" \
             --out bench-corpus
 
       # `heph-bench run inprocess`/`run dist` are themselves the orchestrator
@@ -301,6 +326,41 @@ jobs:
               --out-candidate "candidate_dist_${scenario}.json" --out-baseline "baseline_dist_${scenario}.json"
           done
 
+      # Separate `--lang js` invocation (rather than folding into the go step
+      # above via `--lang both`) so `distjs` is its own tier below, gated on
+      # its own `js_ok` (baseline releases predating the js plugin cdylib
+      # must not sink the go comparison). The "Compare and report" jq merge
+      # below flattens `.scenarios[]` (not a hardcoded `[0]`) specifically so
+      # a future `--lang both` invocation — two `ScenarioResult`s per file —
+      # merges both instead of silently dropping the second.
+      #
+      # KNOWN GAP, disclosed rather than silently left: every generated js
+      # package always lists a `js_lint` target (`oxlint` by default) and,
+      # once it has a usable entry point, a `js_bundle` target (`esbuild`) —
+      # see `crates/plugin-js/src/pluginjs/provider.rs`'s `list()`. Neither
+      # tool is installed on these runners (no `setup-node`/`oxlint`/`esbuild`
+      # anywhere in this repo's workflows or `devenv.nix` as of this change),
+      # and this plugin has "no hermetic toolchain yet" for either (its own
+      # error message says so) — so this step will fail with "no oxlint/
+      # esbuild binary found" every run until a js toolchain is provisioned
+      # for CI. `continue-on-error: true` + "Compare and report"'s missing-
+      # file handling absorb that the same way a missing baseline artifact
+      # is absorbed elsewhere in this job: the `distjs` tier reports "no
+      # results", nothing else in this job is affected. Provisioning that
+      # toolchain is a separate, larger decision (which linter/bundler
+      # version, hermetic vs host) left for a follow-up.
+      - name: Time Tier B (dist) JS scenarios
+        if: steps.baseline_fetch.outputs.ok == 'true' && steps.baseline_fetch.outputs.js_ok == 'true'
+        continue-on-error: true
+        run: |
+          for scenario in cold full-hit incremental; do
+            ./candidate-dist/heph-bench run dist \
+              --candidate-dist candidate-dist --baseline-dist baseline-dist \
+              --corpus bench-corpus --scenario "$scenario" --warmup 1 --reps "$PERFBENCH_REPS" \
+              --lang js \
+              --out-candidate "candidate_distjs_${scenario}.json" --out-baseline "baseline_distjs_${scenario}.json"
+          done
+
       # Every scenario/tier combination is always attempted and reported —
       # `--allow-regression` keeps an individual `compare` call from ever
       # exiting non-zero, so one regression doesn't cut the table short. The
@@ -330,11 +390,15 @@ jobs:
               echo ""
               echo "_FAILED: no published release found for baseline \`${{ steps.base.outputs.sha }}\`_"
             else
-              for tier in inproc dist; do
+              for tier in inproc dist distjs; do
                 echo ""
                 echo "## Tier: $tier"
                 if [ "$tier" = "inproc" ] && [ "${{ steps.baseline_fetch.outputs.bench_ok }}" != "true" ]; then
                   echo "_skipped: baseline release predates publishing \`heph-bench\`_"
+                  continue
+                fi
+                if [ "$tier" = "distjs" ] && [ "${{ steps.baseline_fetch.outputs.js_ok }}" != "true" ]; then
+                  echo "_skipped: baseline release predates publishing the js plugin cdylib_"
                   continue
                 fi
                 base_files=()
@@ -351,8 +415,13 @@ jobs:
                   echo "_no results (run step failed — see logs)_"
                   continue
                 fi
-                jq -s '{tier: .[0].tier, scenarios: [.[].scenarios[0]]}' "${base_files[@]}" > "merged_baseline_${tier}.json"
-                jq -s '{tier: .[0].tier, scenarios: [.[].scenarios[0]]}' "${cand_files[@]}" > "merged_candidate_${tier}.json"
+                # `.scenarios[]`, not a hardcoded `.scenarios[0]`: a
+                # single-scenario result file (every tier today) still
+                # yields exactly one element, but a future `--lang both`
+                # result file (two `ScenarioResult`s per file) merges both
+                # instead of silently keeping only the first.
+                jq -s '{tier: .[0].tier, scenarios: [.[].scenarios[]]}' "${base_files[@]}" > "merged_baseline_${tier}.json"
+                jq -s '{tier: .[0].tier, scenarios: [.[].scenarios[]]}' "${cand_files[@]}" > "merged_candidate_${tier}.json"
                 "$BENCH" compare --baseline "merged_baseline_${tier}.json" --candidate "merged_candidate_${tier}.json" \
                   --thresholds "$GITHUB_WORKSPACE/.github/perfbench-thresholds.json" \
                   --json "verdicts/${tier}.json" \

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -370,7 +370,9 @@ dependencies = [
  "anyhow",
  "serde",
  "serde_json",
+ "serde_yaml",
  "tempfile",
+ "wax",
 ]
 
 [[package]]

--- a/crates/bench-corpus/Cargo.toml
+++ b/crates/bench-corpus/Cargo.toml
@@ -14,3 +14,11 @@ serde_json = "1.0"
 
 [dev-dependencies]
 tempfile = "3"
+# Test-only: parse the generated `pnpm-workspace.yaml` / match its globs
+# against generated package dirs using the exact crate+version
+# `crates/plugin-js/src/pluginjs/workspace.rs` uses, so the discoverability
+# assertion in `js_only_corpus_matches_manifest_and_workspace_shape` proves
+# something about the real provider's matching semantics, not a hand-rolled
+# approximation of them.
+serde_yaml = "0.9"
+wax = "0.7"

--- a/crates/bench-corpus/src/lib.rs
+++ b/crates/bench-corpus/src/lib.rs
@@ -1,11 +1,13 @@
 //! Deterministic synthetic-corpus generator for `heph-bench`.
 //!
 //! Produces a workspace tree of plain `bash`-driver targets arranged as a
-//! layered DAG (bounded fan-out, no cycles), plus an optional `go/` subtree
-//! of hermetic Go packages for scenarios that must cross the real
-//! plugin-cdylib seam. The go packages are discovered from `go.mod`; the only
-//! BUILD file written there declares the build variant, without which the go
-//! provider lists no build targets at all (see `write_go_variant_build`).
+//! layered DAG (bounded fan-out, no cycles), plus optional `go/` and `js/`
+//! subtrees for scenarios that must cross the real plugin-cdylib seam. The
+//! go packages are discovered from `go.mod`; the only BUILD file written
+//! there declares the build variant, without which the go provider lists no
+//! build targets at all (see `write_go_variant_build`). The js packages are
+//! a hermetic pnpm workspace, auto-discovered by the js provider with no
+//! BUILD file needed at all.
 //!
 //! Same seed + same params => byte-identical tree. A CI run generates the
 //! corpus once (from the PR-head generator) and points both the baseline and
@@ -67,6 +69,19 @@ pub struct CorpusParams {
     /// containing its `go.mod`). Defaults to the copy in this workspace via
     /// [`default_gorepogen_dir`].
     pub gorepogen_dir: PathBuf,
+    /// Number of JS/TS packages to generate under `js/` (Tier B, plugin-js).
+    /// 0 = no js subtree. Unlike `go_packages`, generation never shells out
+    /// to an external tool — see [`generate_js_tree`]'s doc comment for why
+    /// there is nothing external to resolve.
+    pub js_packages: usize,
+    /// Max nesting depth, in directories below `js/packages/`, a generated
+    /// package can sit at — mirrors `go_max_depth`'s role of bounding tree
+    /// shape, translated into `pnpm-workspace.yaml` glob patterns (one
+    /// literal `*` path segment per depth level: `packages/*`,
+    /// `packages/*/*`, ...) since pnpm globs don't cross directory
+    /// boundaries (see `crates/plugin-js/src/pluginjs/workspace.rs`'s
+    /// `resolve_members` doc comment).
+    pub js_max_depth: usize,
 }
 
 impl Default for CorpusParams {
@@ -80,6 +95,8 @@ impl Default for CorpusParams {
             go_packages: 0,
             go_max_depth: 4,
             gorepogen_dir: default_gorepogen_dir(),
+            js_packages: 0,
+            js_max_depth: 4,
         }
     }
 }
@@ -116,6 +133,12 @@ pub struct CorpusManifest {
     /// The BUILD package directories that hold bash targets — the mutation
     /// unit for [`incrementalize`].
     pub bash_packages: Vec<String>,
+    /// Number of js packages generated under `js/` (0 if `js_packages == 0`).
+    pub js_package_count: usize,
+    /// Package-path prefix covering the generated js subtree (`"js"`), for a
+    /// `//js/...`-shaped build against a real pnpm workspace, dlopening the
+    /// real js plugin cdylib.
+    pub js_prefix: String,
 }
 
 struct Layered {
@@ -240,12 +263,21 @@ pub fn generate(params: &CorpusParams, root: &Path) -> Result<CorpusManifest> {
         0
     };
 
+    let js_package_count = if params.js_packages > 0 {
+        generate_js_tree(params, root)?;
+        params.js_packages
+    } else {
+        0
+    };
+
     let manifest = CorpusManifest {
         bash_addrs: g.addrs,
         bash_prefix: String::new(),
         go_package_count,
         go_prefix: "go".to_string(),
         bash_packages,
+        js_package_count,
+        js_prefix: "js".to_string(),
     };
     save_manifest(&manifest, root)?;
     Ok(manifest)
@@ -358,6 +390,174 @@ fn write_go_variant_build(go_root: &Path) -> Result<()> {
     Ok(())
 }
 
+/// A `js/` subtree the js provider auto-discovers via `pnpm-workspace.yaml` +
+/// each package's own `package.json` (no BUILD file) — generated directly in
+/// Rust rather than shelled out to an external tool, unlike
+/// [`generate_go_tree`]. There is nothing to resolve at generation (or
+/// measurement) time: the generated tree declares zero third-party npm
+/// dependencies — no `dependencies`/`devDependencies` entry names a real npm
+/// package at all — so every Tier B JS scenario stays fully offline (no
+/// `js_install` network fetch, no lockfile needed), the same "resolve once,
+/// up front" principle `generate_go_tree`'s `go mod tidy` establishes, just
+/// simpler here since there is nothing external at all. Cross-package edges
+/// are relative TypeScript `import` statements instead, so the module DAG is
+/// real without a package manager ever needing to resolve anything.
+///
+/// Package layout mirrors the bash-target DAG's own shape
+/// ([`layer_targets`]/[`generate`]): `params.layers` layers, each package
+/// depending on up to `params.fan_out` packages in the layer below (picked
+/// with the same [`Rng`] machinery), so js and bash corpora are structurally
+/// comparable at the same params. The RNG here is seeded independently of
+/// the bash-target loop's — `params.seed` XORed with a distinguishing
+/// constant, same convention [`incrementalize_go`] uses — so enabling or
+/// disabling `js_packages` never perturbs the bash (or go) output, and vice
+/// versa.
+///
+/// Chose `pnpm-workspace.yaml` over npm's `package.json` `"workspaces"`
+/// array (`crates/plugin-js/src/pluginjs/workspace.rs` supports both): pnpm
+/// needs no root `package.json` at all — the workspace-member glob list
+/// lives in its own file — one fewer file to generate, while still
+/// exercising the identical glob-based discovery path the npm branch would.
+fn generate_js_tree(params: &CorpusParams, root: &Path) -> Result<()> {
+    let js_root = root.join("js");
+    std::fs::create_dir_all(&js_root).context("create js/")?;
+
+    let layers = params.layers.max(1);
+    let max_depth = params.js_max_depth.max(1);
+    let n = params.js_packages;
+
+    // Independent of the bash-target loop's `rng` above — see doc comment.
+    let mut rng = Rng::new(params.seed ^ 0xBA5E_1000_ABCD_EF01);
+
+    // Layer and nesting depth are deterministic functions of the package
+    // index (not rng-drawn), so the tree's shape never shifts under however
+    // many `rng` draws the dep-picking loop below ends up making.
+    let mut by_layer: Vec<Vec<usize>> = vec![Vec::new(); layers];
+    let mut dirs: Vec<Vec<String>> = Vec::with_capacity(n);
+    for i in 0..n {
+        by_layer
+            .get_mut(i % layers)
+            .expect("i % layers is always < by_layer.len() == layers")
+            .push(i);
+
+        let depth = i % max_depth;
+        let mut comps = vec!["packages".to_string()];
+        for d in 0..depth {
+            comps.push(format!("grp{d}"));
+        }
+        comps.push(format!("pkg{i}"));
+        dirs.push(comps);
+    }
+
+    for i in 0..n {
+        let layer = i % layers;
+        let deps: Vec<usize> = if layer == 0 {
+            Vec::new()
+        } else {
+            let below = by_layer
+                .get(layer - 1)
+                .expect("layer > 0 here, so layer - 1 < layers == by_layer.len()");
+            let k = params.fan_out.min(below.len());
+            let mut picked = Vec::with_capacity(k);
+            for _ in 0..k {
+                let idx = *below
+                    .get(rng.below(below.len()))
+                    .expect("rng.below(below.len()) < below.len()");
+                if !picked.contains(&idx) {
+                    picked.push(idx);
+                }
+            }
+            picked
+        };
+
+        let dir_comps = dirs
+            .get(i)
+            .expect("i < n == dirs.len() by the loop bound above");
+        let pkg_dir = js_root.join(dir_comps.join("/"));
+        std::fs::create_dir_all(&pkg_dir)
+            .with_context(|| format!("create {}", pkg_dir.display()))?;
+
+        let package_json = serde_json::json!({
+            "name": format!("corpus-js-pkg{i}"),
+            "version": "0.0.0",
+            "main": "./index.ts",
+        });
+        std::fs::write(
+            pkg_dir.join("package.json"),
+            serde_json::to_vec_pretty(&package_json).context("encode package.json")?,
+        )
+        .with_context(|| format!("write {}/package.json", pkg_dir.display()))?;
+
+        let mut src = String::new();
+        for (n_dep, &dep) in deps.iter().enumerate() {
+            let dep_comps = dirs
+                .get(dep)
+                .expect("dep is a target index from by_layer, always < dirs.len()");
+            let import_path = relative_ts_import(dir_comps, dep_comps);
+            writeln!(
+                src,
+                "import {{ value as dep{n_dep} }} from \"{import_path}\";"
+            )
+            .context("format import")?;
+        }
+        // Same principle as the bash targets' `run` body: the module never
+        // reads a dep's real content, only imports its exported binding —
+        // dependency cost comes entirely from the import edges wiring the
+        // module graph (parse, resolve, first-party closure walk), not from
+        // any payload.
+        let value_expr = if deps.is_empty() {
+            format!("{i}")
+        } else {
+            let terms = (0..deps.len())
+                .map(|n_dep| format!("dep{n_dep}"))
+                .collect::<Vec<_>>()
+                .join(" + ");
+            format!("{i} + {terms}")
+        };
+        writeln!(src, "export const value: number = {value_expr};").context("format export")?;
+        std::fs::write(pkg_dir.join("index.ts"), src)
+            .with_context(|| format!("write {}/index.ts", pkg_dir.display()))?;
+    }
+
+    // One glob pattern per depth level actually reachable (0..max_depth): a
+    // literal `*` path segment per nesting level, matching pnpm's own
+    // non-crossing glob semantics (`packages/*` never matches
+    // `packages/grp0/pkg5` — see `workspace.rs`'s `resolve_members` doc
+    // comment) — every generated package is covered by exactly one line.
+    let mut yaml = String::from("packages:\n");
+    for d in 0..max_depth {
+        let mut pattern = String::from("packages");
+        for _ in 0..=d {
+            pattern.push_str("/*");
+        }
+        writeln!(yaml, "  - \"{pattern}\"").context("format pnpm-workspace.yaml pattern")?;
+    }
+    std::fs::write(js_root.join("pnpm-workspace.yaml"), yaml)
+        .context("write js/pnpm-workspace.yaml")?;
+
+    Ok(())
+}
+
+/// Relative TS import specifier from the package at `from_dir` to the
+/// package at `to_dir` (both directory-component lists relative to `js/`),
+/// pointing at the target's `index.ts` module (extension omitted — standard
+/// relative-import style). Always anchored (`./` or `../`), never a bare
+/// specifier, so it is never mistaken for a package-name import.
+fn relative_ts_import(from_dir: &[String], to_dir: &[String]) -> String {
+    let common = from_dir
+        .iter()
+        .zip(to_dir.iter())
+        .take_while(|(a, b)| a == b)
+        .count();
+    let mut parts: Vec<String> = (common..from_dir.len()).map(|_| "..".to_string()).collect();
+    parts.extend(to_dir.iter().skip(common).cloned());
+    if parts.first().map(String::as_str) != Some("..") {
+        parts.insert(0, ".".to_string());
+    }
+    parts.push("index".to_string());
+    parts.join("/")
+}
+
 /// `ceil(len * fraction)`, clamped to `len`. The f64->usize cast is provably
 /// non-negative (product of two non-negative factors, then `ceil`), but
 /// clippy's `cast_sign_loss` can't see that from the call site.
@@ -429,6 +629,53 @@ pub fn incrementalize_go(go_root: &Path, fraction: f64, seed: u64) -> Result<usi
     files.sort();
 
     let mut rng = Rng::new(seed ^ 0x0B0A_B0AB);
+    let n = fraction_count(files.len(), fraction);
+    let mut touched = std::collections::HashSet::new();
+    while touched.len() < n {
+        touched.insert(rng.below(files.len()));
+    }
+
+    for &idx in &touched {
+        let path = files
+            .get(idx)
+            .expect("idx drawn from files.len() in the loop above");
+        let mut src =
+            std::fs::read_to_string(path).with_context(|| format!("read {}", path.display()))?;
+        src.push_str(&format!("\n// bench-mutated seed={seed}\n"));
+        std::fs::write(path, src).with_context(|| format!("rewrite {}", path.display()))?;
+    }
+
+    Ok(touched.len())
+}
+
+fn collect_ts_files(dir: &Path, out: &mut Vec<PathBuf>) -> Result<()> {
+    if !dir.exists() {
+        return Ok(());
+    }
+    for entry in std::fs::read_dir(dir).with_context(|| format!("read dir {}", dir.display()))? {
+        let entry = entry.context("read dir entry")?;
+        let path = entry.path();
+        if entry.file_type().context("get file type")?.is_dir() {
+            collect_ts_files(&path, out)?;
+        } else if path.extension().and_then(|e| e.to_str()) == Some("ts") {
+            out.push(path);
+        }
+    }
+    Ok(())
+}
+
+/// Same idea as [`incrementalize_go`], for the js subtree: appends a
+/// trailing top-level statement (valid anywhere in a `.ts` module, changes
+/// nothing about the exported API) to a deterministic fraction of `.ts`
+/// files under `js_root`. Unlike Go there is no test-file convention to
+/// exclude — [`generate_js_tree`] never writes one — so, unlike
+/// [`incrementalize_go`], every `.ts` file found is eligible.
+pub fn incrementalize_js(js_root: &Path, fraction: f64, seed: u64) -> Result<usize> {
+    let mut files = Vec::new();
+    collect_ts_files(js_root, &mut files)?;
+    files.sort();
+
+    let mut rng = Rng::new(seed ^ 0xF00D_F00D_ABCD_1234);
     let n = fraction_count(files.len(), fraction);
     let mut touched = std::collections::HashSet::new();
     while touched.len() < n {
@@ -648,5 +895,250 @@ mod tests {
         let test_src = std::fs::read_to_string(go_root.join("pkg").join("f0_test.go"))
             .expect("read test file");
         assert_eq!(test_src, "package pkg\n", "test file must not be mutated");
+    }
+
+    /// Recursively collect `(path relative to `root`, contents)` under
+    /// `root`, sorted — used by the js-tree tests below the same way
+    /// `generate_is_deterministic`'s local `read_all` is used for the bash
+    /// tree, just recursive (js packages nest per `js_max_depth`).
+    fn read_all_recursive(root: &Path) -> Vec<(String, String)> {
+        fn walk(dir: &Path, root: &Path, out: &mut Vec<(String, String)>) {
+            let entries = std::fs::read_dir(dir).expect("read_dir");
+            for entry in entries {
+                let entry = entry.expect("dir entry");
+                let path = entry.path();
+                if path.is_dir() {
+                    walk(&path, root, out);
+                } else {
+                    let rel = path.strip_prefix(root).unwrap_or(&path);
+                    out.push((
+                        rel.to_string_lossy().into_owned(),
+                        std::fs::read_to_string(&path).expect("read file"),
+                    ));
+                }
+            }
+        }
+        let mut out = Vec::new();
+        walk(root, root, &mut out);
+        out.sort();
+        out
+    }
+
+    /// Recursively collect directories under `root` that contain their own
+    /// `package.json`, as paths relative to `root` — a minimal stand-in for
+    /// `collect_js_packages` (kept local to this test rather than depending
+    /// on the `plugin-js` crate, per this crate's existing "no plugin-crate
+    /// dependency" shape — see `generate_go_tree`'s doc comment).
+    fn discover_package_dirs(dir: &Path, root: &Path, out: &mut Vec<PathBuf>) {
+        if dir.join("package.json").is_file() {
+            out.push(dir.strip_prefix(root).unwrap_or(dir).to_path_buf());
+        }
+        let entries = std::fs::read_dir(dir).expect("read_dir");
+        for entry in entries {
+            let path = entry.expect("dir entry").path();
+            if path.is_dir() {
+                discover_package_dirs(&path, root, out);
+            }
+        }
+    }
+
+    #[test]
+    fn js_only_corpus_matches_manifest_and_workspace_shape() {
+        let params = CorpusParams {
+            seed: 5,
+            target_count: 20,
+            packages: 4,
+            layers: 3,
+            fan_out: 2,
+            js_packages: 12,
+            js_max_depth: 2,
+            ..Default::default()
+        };
+        let dir = tempfile::tempdir().expect("tempdir");
+        let manifest = generate(&params, dir.path()).expect("generate");
+
+        assert_eq!(manifest.js_package_count, 12);
+        assert_eq!(manifest.js_prefix, "js");
+        // go stays untouched: js_packages > 0 alone must not synthesize a go
+        // subtree or count.
+        assert_eq!(manifest.go_package_count, 0);
+        assert!(!dir.path().join("go").exists());
+
+        let js_root = dir.path().join("js");
+
+        // Shape assertion: parse the generated `pnpm-workspace.yaml` with the
+        // exact struct shape `workspace.rs::read_pnpm_workspace_globs` reads
+        // (a `packages: Vec<String>` list, see its test fixtures), then match
+        // every discovered package dir against those globs with the same
+        // `wax` crate/version the real provider matches with.
+        #[derive(serde::Deserialize)]
+        struct PnpmWorkspaceFile {
+            #[serde(default)]
+            packages: Vec<String>,
+        }
+        let raw = std::fs::read_to_string(js_root.join("pnpm-workspace.yaml"))
+            .expect("read pnpm-workspace.yaml");
+        let parsed: PnpmWorkspaceFile =
+            serde_yaml::from_str(&raw).expect("parse pnpm-workspace.yaml");
+        assert!(!parsed.packages.is_empty());
+
+        use wax::Program as _;
+        let globs: Vec<wax::Glob> = parsed
+            .packages
+            .iter()
+            .map(|p| wax::Glob::new(p).expect("valid glob"))
+            .collect();
+
+        let mut pkg_dirs = Vec::new();
+        discover_package_dirs(&js_root, &js_root, &mut pkg_dirs);
+        assert_eq!(
+            pkg_dirs.len(),
+            12,
+            "every generated package must be found on disk"
+        );
+
+        // js_max_depth == 2 must actually produce nesting beyond the flat
+        // `packages/pkgN` layer — otherwise this test would pass trivially
+        // with just one glob line.
+        assert!(
+            pkg_dirs.iter().any(|d| d.components().count() > 2),
+            "expected at least one package nested below packages/<name>"
+        );
+
+        for rel in &pkg_dirs {
+            assert!(
+                globs.iter().any(|g| g.is_match(rel.as_path())),
+                "{} matched by no pnpm-workspace.yaml glob",
+                rel.display()
+            );
+
+            let pj_raw = std::fs::read_to_string(js_root.join(rel).join("package.json"))
+                .expect("read package.json");
+            let pj: serde_json::Value = serde_json::from_str(&pj_raw).expect("parse package.json");
+            assert!(
+                pj.get("name").and_then(serde_json::Value::as_str).is_some(),
+                "{}: package.json missing name",
+                rel.display()
+            );
+            assert!(
+                pj.get("main").and_then(serde_json::Value::as_str).is_some(),
+                "{}: package.json missing main",
+                rel.display()
+            );
+            // Hermeticity: no entry may name a real npm package.
+            assert!(pj.get("dependencies").is_none());
+            assert!(pj.get("devDependencies").is_none());
+        }
+    }
+
+    #[test]
+    fn bash_and_go_output_unaffected_by_js_packages() {
+        let base = CorpusParams {
+            seed: 9,
+            target_count: 30,
+            packages: 6,
+            layers: 3,
+            fan_out: 2,
+            ..Default::default()
+        };
+        let without_js = base.clone();
+        let mut with_js = base;
+        with_js.js_packages = 8;
+        with_js.js_max_depth = 3;
+
+        let a = tempfile::tempdir().expect("tempdir");
+        let b = tempfile::tempdir().expect("tempdir");
+        let manifest_a = generate(&without_js, a.path()).expect("generate a");
+        let manifest_b = generate(&with_js, b.path()).expect("generate b");
+
+        assert_eq!(manifest_a.bash_addrs, manifest_b.bash_addrs);
+        assert_eq!(manifest_a.bash_packages, manifest_b.bash_packages);
+        for pkg in &manifest_a.bash_packages {
+            let src_a = std::fs::read_to_string(a.path().join(pkg).join("BUILD")).expect("read a");
+            let src_b = std::fs::read_to_string(b.path().join(pkg).join("BUILD")).expect("read b");
+            assert_eq!(
+                src_a, src_b,
+                "bash BUILD output for {pkg} must be unaffected by js_packages"
+            );
+        }
+
+        assert_eq!(manifest_a.js_package_count, 0);
+        assert_eq!(manifest_b.js_package_count, 8);
+    }
+
+    #[test]
+    fn js_tree_generation_is_deterministic() {
+        let params = CorpusParams {
+            seed: 77,
+            target_count: 10,
+            packages: 2,
+            layers: 2,
+            fan_out: 1,
+            js_packages: 15,
+            js_max_depth: 3,
+            ..Default::default()
+        };
+        let a = tempfile::tempdir().expect("tempdir");
+        let b = tempfile::tempdir().expect("tempdir");
+        generate(&params, a.path()).expect("generate a");
+        generate(&params, b.path()).expect("generate b");
+
+        let js_a = read_all_recursive(&a.path().join("js"));
+        let js_b = read_all_recursive(&b.path().join("js"));
+        assert!(!js_a.is_empty());
+        assert_eq!(js_a, js_b);
+    }
+
+    #[test]
+    fn incrementalize_js_touches_requested_fraction() {
+        let params = CorpusParams {
+            seed: 3,
+            target_count: 10,
+            packages: 2,
+            layers: 2,
+            fan_out: 1,
+            js_packages: 10,
+            js_max_depth: 2,
+            ..Default::default()
+        };
+        let dir = tempfile::tempdir().expect("tempdir");
+        generate(&params, dir.path()).expect("generate");
+        let js_root = dir.path().join("js");
+
+        let touched = incrementalize_js(&js_root, 0.3, 55).expect("incrementalize_js");
+        assert_eq!(touched, 3); // ceil(10 * 0.3), one index.ts per package
+
+        let mutated = read_all_recursive(&js_root)
+            .into_iter()
+            .filter(|(path, contents)| {
+                path.ends_with(".ts") && contents.contains("bench-mutated seed=55")
+            })
+            .count();
+        assert_eq!(mutated, 3);
+    }
+
+    // Ignored like `go_tree_produces_requested_package_count`: `go mod tidy`
+    // over gorepogen's output needs network. Extends that scenario to prove
+    // go and js subtrees coexist independently in one corpus.
+    #[test]
+    #[ignore = "needs network for `go mod tidy` on gorepogen's third-party imports"]
+    fn go_and_js_together_produce_both_independently() {
+        let params = CorpusParams {
+            seed: 3,
+            target_count: 30,
+            packages: 3,
+            layers: 3,
+            fan_out: 2,
+            go_packages: 5,
+            js_packages: 6,
+            js_max_depth: 2,
+            ..Default::default()
+        };
+        let dir = tempfile::tempdir().expect("tempdir");
+        let manifest = generate(&params, dir.path()).expect("generate");
+        assert_eq!(manifest.go_package_count, 5);
+        assert_eq!(manifest.js_package_count, 6);
+        assert!(dir.path().join("go/go.mod").is_file());
+        assert!(dir.path().join("js/pnpm-workspace.yaml").is_file());
     }
 }

--- a/crates/bench/src/dist.rs
+++ b/crates/bench/src/dist.rs
@@ -1,6 +1,7 @@
 //! Tier B: the real, prebuilt `heph` binary spawned as a child process,
-//! dlopening the real `go` plugin cdylib — the seam `crates/bin-e2e` exists
-//! to cover and an in-process test structurally cannot reach.
+//! dlopening the real per-language plugin cdylib(s) — the seam
+//! `crates/bin-e2e` exists to cover and an in-process test structurally
+//! cannot reach.
 //!
 //! Only prebuilt artifacts are used, located the same way
 //! `crates/bin-e2e/tests/common/mod.rs`'s `Dist` does: a normalized
@@ -12,6 +13,18 @@
 //! per-commit "subject" binary to keep a stable contract with. `prepare`/
 //! `measure_once` still split the same way as `inprocess`'s for a uniform
 //! orchestrator shape, not because a compatibility seam requires it here.
+//!
+//! **Languages**: [`GO`] and [`JS`] are the two [`Lang`]s this tier knows how
+//! to build — one `//<name>/...` corpus subtree, one plugin cdylib, one
+//! provider-level option a real workspace has no default for (mirrors the go
+//! provider's required `gotool`; see `Lang`'s doc). A caller picks one or
+//! both via the `langs` slice threaded through [`prepare`]/[`measure_once`];
+//! `crates/bench/src/main.rs`'s `--lang` flag is what turns that into a CLI
+//! selector. Each language selects its own targets its own way (see
+//! `Lang::label`'s doc): go carries a `go-build` label the provider stamps
+//! on every compile target; js has no such label mechanism, so it uses the
+//! `-e '<query>'` form instead. Both go through the same `matched_targets`
+//! safety net regardless of which form selected them.
 
 use anyhow::{Context, Result, bail};
 use bench_corpus::CorpusManifest;
@@ -36,7 +49,7 @@ impl Dist {
         if !heph.is_file() {
             bail!("{} does not contain a `heph` binary", dir.display());
         }
-        // Absolute: `build_go_tree` spawns `heph` with `current_dir(corpus)`,
+        // Absolute: `build_lang_tree` spawns `heph` with `current_dir(corpus)`,
         // so a relative `--dist` path (the common case — CI passes plain
         // `candidate-dist`) would silently resolve against the corpus dir
         // instead of the caller's cwd once that happens.
@@ -77,53 +90,129 @@ fn host_arch() -> &'static str {
     }
 }
 
-/// Write the go-plugin manifest + a `.hephconfig` pointing at it, into
-/// `corpus` — a real config a real `heph` invocation loads, forcing the
-/// dlopen + ABI-negotiation + checksum-verify path. `corpus` must already be
-/// absolute (see `Dist::locate`'s comment for why).
-fn write_go_config(corpus: &Path, dist: &Dist) -> Result<()> {
-    let dylib = dist.plugin("go");
-    if !dylib.is_file() {
-        bail!(
-            "missing {} — the dist dir must contain the go plugin cdylib \
-             (heph-go-plugin.{DYLIB_EXT}), not just the `heph` binary",
-            dylib.display()
-        );
-    }
-    let manifest_path = corpus.join("heph-go-plugin.json");
-    let sum = sha256_file(&dylib)?;
-    let doc = serde_json::json!({
-        "name": "go",
-        "version": "bench",
-        "artifacts": [{
-            "os": host_os(),
-            "arch": host_arch(),
-            "path": dylib,
-            "checksum": sum,
-        }],
-    });
-    std::fs::write(&manifest_path, serde_json::to_vec_pretty(&doc)?)
-        .with_context(|| format!("write {}", manifest_path.display()))?;
+/// A language Tier B knows how to build: `name` doubles as the plugin
+/// identity (`heph-<name>-plugin.<ext>`) *and* the corpus subtree / target
+/// prefix (`//<name>/...`) — true for both `go/` and `js/`, the only two
+/// today, and simpler than carrying two separate fields that would always
+/// agree in practice.
+///
+/// Deliberately data, not a `match` on a `&str` language tag scattered
+/// across this module — adding a third language means adding one more
+/// `const`, not hunting down every place a go-vs-js branch was hand-written.
+#[derive(Debug)]
+pub struct Lang {
+    pub name: &'static str,
+    /// The provider's `options:` fragment this language's plugin requires
+    /// with no default — mirrors the go provider's `gotool` option (see
+    /// `write_dist_config`'s doc comment) and the js provider's `pkgmanager`
+    /// option (`crates/plugin-js/src/pluginjs/provider.rs`: "required — set
+    /// it to \"npm\" or \"pnpm\"", no genuine default to pick for a real
+    /// workspace).
+    provider_options: &'static str,
+    /// The label this language's *compile* targets carry, if any — go's
+    /// `go-build` label (`crates/plugin-go/src/plugingo/driver_compile.rs`
+    /// et al.) lets target selection use the fast `heph r <label>
+    /// //go/...` two-positional-arg form (`label(go-build) && //go/...`).
+    /// `None` means the provider has no such label (the js provider stamps
+    /// none), so `build_lang_tree` falls back to the `-e '<query>'` form
+    /// instead — see that function's doc for why the *other* two-positional
+    /// form (`heph r build //<lang>/...`) is never correct for either case.
+    label: Option<&'static str>,
+    /// Pulls this language's generated package count out of a
+    /// [`CorpusManifest`] — `measure_once`'s "nothing for Tier B to build"
+    /// bail needs this per language, same pattern as the original go-only
+    /// `measure_once`'s `manifest.go_package_count == 0` check.
+    package_count: fn(&CorpusManifest) -> usize,
+    /// Mutates a fraction of this language's corpus subtree for the
+    /// `Incremental` scenario — `bench_corpus::incrementalize_go` /
+    /// `incrementalize_js`.
+    incrementalize: fn(&Path, f64, u64) -> anyhow::Result<usize>,
+}
 
-    // `gotool: host` — the go provider requires an explicit choice (host /
-    // pinned version / a toolchain-producing target) and has no default.
+pub const GO: Lang = Lang {
+    name: "go",
     // `host` uses the Go `actions/setup-go` already installed for
     // `tools/gorepogen`, so this stays offline and pays no extra hermetic-
     // SDK download — same choice `bin-e2e`'s own go-plugin fixture makes,
     // and for the same reason.
+    provider_options: "gotool: \"host\"",
+    // NOT `build` — that is a *target name* in the go provider, not a
+    // label, and the bare `//pkg:build` magic group only resolves for a
+    // `package main`, which this corpus has none of. `go-build` is the real
+    // label the go provider's compile targets (`build_lib`, `build_test`,
+    // `build_xtest`, ...) carry.
+    label: Some("go-build"),
+    package_count: |m| m.go_package_count,
+    incrementalize: bench_corpus::incrementalize_go,
+};
+
+pub const JS: Lang = Lang {
+    name: "js",
+    // pnpm is the package-manager convention `bench_corpus::generate_js_tree`
+    // writes (`js/pnpm-workspace.yaml`) — must match, or the js provider
+    // discovers no workspace members at all.
+    provider_options: "pkgmanager: \"pnpm\"",
+    // The js provider stamps no bench-specific label on its targets, so
+    // there's nothing to select by — `build_lang_tree` uses the `-e` query
+    // form for this language instead.
+    label: None,
+    package_count: |m| m.js_package_count,
+    incrementalize: bench_corpus::incrementalize_js,
+};
+
+/// Write every one of `langs`' plugin manifest + a single `.hephconfig`
+/// covering all of them, into `corpus` — a real config a real `heph`
+/// invocation loads, forcing the dlopen + ABI-negotiation + checksum-verify
+/// path for each. `corpus` must already be absolute (see `Dist::locate`'s
+/// comment for why).
+fn write_dist_config(corpus: &Path, dist: &Dist, langs: &[&Lang]) -> Result<()> {
     // `sh` is not optional: the go provider's stdlib `build_lib` targets are
     // sh-driven, so without it every first-party compile fails at
-    // `//@heph/go/std/...: driver not found: sh`. It went unnoticed while this
-    // scenario matched zero targets and therefore never resolved a std dep.
-    let config = format!(
+    // `//@heph/go/std/...: driver not found: sh`. It went unnoticed while
+    // this scenario matched zero targets and therefore never resolved a std
+    // dep. Registered unconditionally (js-only runs pay nothing for an
+    // unused builtin) rather than only when `GO` is among `langs`, so this
+    // preamble doesn't itself need a language branch.
+    let mut config = String::from(
         "plugins:\n  \
          - builtin: buildfile\n    options:\n      patterns:\n        - BUILD\n  \
          - builtin: exec\n  \
          - builtin: bash\n  \
-         - builtin: sh\n  \
-         - path: {}\n    options:\n      gotool: \"host\"\n",
-        manifest_path.display()
+         - builtin: sh\n",
     );
+
+    for lang in langs {
+        let dylib = dist.plugin(lang.name);
+        if !dylib.is_file() {
+            bail!(
+                "missing {} — the dist dir must contain the {n} plugin cdylib \
+                 (heph-{n}-plugin.{DYLIB_EXT}), not just the `heph` binary",
+                dylib.display(),
+                n = lang.name,
+            );
+        }
+        let manifest_path = corpus.join(format!("heph-{}-plugin.json", lang.name));
+        let sum = sha256_file(&dylib)?;
+        let doc = serde_json::json!({
+            "name": lang.name,
+            "version": "bench",
+            "artifacts": [{
+                "os": host_os(),
+                "arch": host_arch(),
+                "path": dylib,
+                "checksum": sum,
+            }],
+        });
+        std::fs::write(&manifest_path, serde_json::to_vec_pretty(&doc)?)
+            .with_context(|| format!("write {}", manifest_path.display()))?;
+
+        config.push_str(&format!(
+            "  - path: {}\n    options:\n      {}\n",
+            manifest_path.display(),
+            lang.provider_options,
+        ));
+    }
+
     std::fs::write(corpus.join(".hephconfig"), config).context("write .hephconfig")
 }
 
@@ -156,12 +245,6 @@ fn wipe_cache(corpus: &Path) -> Result<()> {
     Ok(())
 }
 
-/// The label carried by the go plugin's compile targets (`build_lib`,
-/// `build_test`, `build_xtest`). NOT `build` — that is a *target name* in the go
-/// provider, not a label, and the bare `//pkg:build` magic group only resolves
-/// for a `package main`, which this corpus has none of.
-const GO_BUILD_LABEL: &str = "go-build";
-
 /// Number of targets `heph` reported matching, parsed from its `matched N
 /// targets` line. `None` if no such line was emitted.
 fn matched_targets(stderr: &str) -> Option<u64> {
@@ -170,11 +253,24 @@ fn matched_targets(stderr: &str) -> Option<u64> {
     digits.parse().ok()
 }
 
-fn build_go_tree(dist: &Dist, corpus: &Path) -> Result<f64> {
+fn build_lang_tree(dist: &Dist, corpus: &Path, lang: &Lang) -> Result<f64> {
     let home = tempfile::tempdir().context("create HOME tempdir")?;
+    let target = format!("//{}/...", lang.name);
     let start = Instant::now();
+    // NOT `["r", "build", &target]` for either selection form: with two
+    // positional args, `heph r`'s arg1/arg2 form treats arg1 as a *label*,
+    // ANDed with arg2's package matcher (`src/commands/utils.rs::
+    // matcher_from_args`) — `label(build) && //<lang>/...` matches nothing
+    // (no BUILD file/provider sets a `build` label) and exits 0 having built
+    // zero targets. Two real forms select something: `lang`'s own label
+    // (`label(go-build) && //go/...`) when one exists, or the `-e` query
+    // form when it doesn't.
+    let args: Vec<&str> = match lang.label {
+        Some(label) => vec!["r", label, &target],
+        None => vec!["r", "-e", &target],
+    };
     let out = Command::new(dist.heph())
-        .args(["r", GO_BUILD_LABEL, "//go/..."])
+        .args(&args)
         .current_dir(corpus)
         .env("HOME", home.path())
         .env("HEPH_CWD", corpus)
@@ -182,82 +278,118 @@ fn build_go_tree(dist: &Dist, corpus: &Path) -> Result<f64> {
         .env("HEPH_DISABLE_TELEMETRY", "1")
         .stdin(Stdio::null())
         .output()
-        .context("spawn heph r go-build //go/...")?;
+        .with_context(|| format!("spawn heph {}", args.join(" ")))?;
     let stderr =
         String::from_utf8_lossy(&out.stdout).into_owned() + &String::from_utf8_lossy(&out.stderr);
     if !out.status.success() {
         bail!(
-            "heph r {GO_BUILD_LABEL} //go/... failed: status {}\n--- output ---\n{}",
+            "heph {} failed: status {}\n--- output ---\n{}",
+            args.join(" "),
             out.status,
             stderr,
         );
     }
-    // A selection that matches nothing still exits 0, so without this a broken
-    // corpus or a renamed label reads as a passing — and very fast — benchmark.
-    // That is not hypothetical: this scenario spent its whole life matching zero
-    // targets and timing only package discovery.
+    // A selection that matches nothing still exits 0, so without this a
+    // broken corpus, a renamed label, or a wrong query reads as a passing —
+    // and very fast — benchmark. Not hypothetical: the go scenario spent
+    // its whole life matching zero targets and timing only package
+    // discovery before this check existed.
     match matched_targets(&stderr) {
         Some(0) | None => bail!(
-            "heph r {GO_BUILD_LABEL} //go/... matched no targets — the corpus built nothing, so \
-             this measures package discovery, not a build. Check that the corpus declares a go \
-             variant and that `{GO_BUILD_LABEL}` is still the compile targets' label.\n\
-             --- output ---\n{stderr}",
+            "heph {} matched no targets — the {} corpus subtree built nothing, so this \
+             measures package discovery, not a build.\n--- output ---\n{stderr}",
+            args.join(" "),
+            lang.name,
         ),
         Some(_) => {}
     }
     Ok(start.elapsed().as_secs_f64() * 1000.0)
 }
 
-/// `corpus` must already be absolute (canonicalize before calling — see
-/// `write_go_config`'s comment on why a relative path breaks once `heph`
-/// runs with `current_dir(corpus)`).
-pub fn prepare(dist_dir: &Path, corpus: &Path, scenario: Scenario) -> Result<()> {
-    let dist = Dist::locate(dist_dir)?;
-    write_go_config(corpus, &dist)?;
-    match scenario {
-        Scenario::Cold | Scenario::FullHit | Scenario::Incremental => {
-            wipe_cache(corpus)?;
-            build_go_tree(&dist, corpus)?;
+/// Bails loudly, naming the missing language, if any of `langs` has no
+/// generated corpus subtree — shared by `prepare` and `measure_once` so
+/// requesting an ungenerated language fails the same way (and this early)
+/// regardless of which one is called first.
+fn require_langs_generated(manifest: &CorpusManifest, langs: &[&Lang]) -> Result<()> {
+    for lang in langs {
+        if (lang.package_count)(manifest) == 0 {
+            bail!(
+                "corpus has no {n}/ subtree (generate with --{n}-packages > 0) — nothing for Tier B to build",
+                n = lang.name
+            );
         }
     }
     Ok(())
 }
 
-/// One measured rep. `mutate_seed` only matters for `Incremental` (ignored
-/// otherwise) — the caller must vary it across repeated calls against the
-/// same corpus, or every call mutates the same files again. `corpus` must
-/// already be absolute, same as `prepare`.
+/// `corpus` must already be absolute (canonicalize before calling — see
+/// `write_dist_config`'s comment on why a relative path breaks once `heph`
+/// runs with `current_dir(corpus)`). `langs` is the full set of languages
+/// this run measures — every one of them gets a plugin entry in the written
+/// `.hephconfig` and a throwaway warmup build.
+pub fn prepare(
+    dist_dir: &Path,
+    corpus: &Path,
+    manifest: &CorpusManifest,
+    scenario: Scenario,
+    langs: &[&Lang],
+) -> Result<()> {
+    require_langs_generated(manifest, langs)?;
+    let dist = Dist::locate(dist_dir)?;
+    write_dist_config(corpus, &dist, langs)?;
+    match scenario {
+        Scenario::Cold | Scenario::FullHit | Scenario::Incremental => {
+            wipe_cache(corpus)?;
+            for lang in langs {
+                build_lang_tree(&dist, corpus, lang)?;
+            }
+        }
+    }
+    Ok(())
+}
+
+/// One measured rep, across every language in `langs` — returned as
+/// `(lang.name, elapsed_ms)` pairs, one per input language, **in the same
+/// order `langs` was given** (callers rely on this to zip results back onto
+/// their own per-language accumulators without a lookup). `mutate_seed` only
+/// matters for `Incremental` (ignored otherwise) — the caller must vary it
+/// across repeated calls against the same corpus, or every call mutates the
+/// same files again. `corpus` must already be absolute, same as `prepare`.
 pub fn measure_once(
     dist_dir: &Path,
     corpus: &Path,
     manifest: &CorpusManifest,
     scenario: Scenario,
     mutate_seed: u64,
-) -> Result<f64> {
-    if manifest.go_package_count == 0 {
-        bail!(
-            "corpus has no go/ subtree (generate with --go-packages > 0) — nothing for Tier B to build"
-        );
-    }
+    langs: &[&Lang],
+) -> Result<Vec<(&'static str, f64)>> {
+    require_langs_generated(manifest, langs)?;
     let dist = Dist::locate(dist_dir)?;
-    write_go_config(corpus, &dist)?;
+    write_dist_config(corpus, &dist, langs)?;
 
     if let Scenario::Cold = scenario {
         wipe_cache(corpus)?;
     }
     if let Scenario::Incremental = scenario {
-        // Mutates the go/ subtree being built here, not the bash pkgN
-        // packages `bench_corpus::incrementalize` touches — Tier B only
-        // builds `//go/...`.
-        bench_corpus::incrementalize_go(&corpus.join("go"), 0.01, 0xDEC1 ^ mutate_seed)
-            .context("mutate go corpus for incremental scenario")?;
+        // Mutates each language's own subtree being built here, not the bash
+        // pkgN packages `bench_corpus::incrementalize` touches — Tier B only
+        // builds `//<lang>/...` trees.
+        for lang in langs {
+            (lang.incrementalize)(&corpus.join(lang.name), 0.01, 0xDEC1 ^ mutate_seed)
+                .with_context(|| format!("mutate {} corpus for incremental scenario", lang.name))?;
+        }
     }
-    build_go_tree(&dist, corpus)
+
+    let mut results = Vec::with_capacity(langs.len());
+    for lang in langs {
+        results.push((lang.name, build_lang_tree(&dist, corpus, lang)?));
+    }
+    Ok(results)
 }
 
 #[cfg(test)]
 mod tests {
-    use super::matched_targets;
+    use super::*;
 
     #[test]
     fn reads_the_match_count_heph_reports() {
@@ -276,5 +408,243 @@ mod tests {
     #[test]
     fn absent_line_is_none() {
         assert_eq!(matched_targets("no such line here\n"), None);
+    }
+
+    /// `write_dist_config` with a single language must produce the exact
+    /// same base `plugins:` preamble the original go-only implementation
+    /// did (plus `builtin: sh`, which every language now shares) — a
+    /// regression here silently breaks `.hephconfig` for every existing
+    /// `run dist` caller (bare `--lang go`, today's default).
+    #[test]
+    fn write_dist_config_go_only_matches_legacy_shape() {
+        let dist_dir = tempfile::tempdir().expect("dist tempdir");
+        let corpus_dir = tempfile::tempdir().expect("corpus tempdir");
+        std::fs::write(dist_dir.path().join("heph"), b"fake").expect("write fake heph");
+        std::fs::write(
+            dist_dir.path().join(format!("heph-go-plugin.{DYLIB_EXT}")),
+            b"fake dylib bytes",
+        )
+        .expect("write fake go dylib");
+
+        let dist = Dist::locate(dist_dir.path()).expect("locate dist");
+        write_dist_config(corpus_dir.path(), &dist, &[&GO]).expect("write config");
+
+        let config = std::fs::read_to_string(corpus_dir.path().join(".hephconfig"))
+            .expect("read .hephconfig");
+        assert!(config.contains("builtin: buildfile"));
+        assert!(config.contains("builtin: exec"));
+        assert!(config.contains("builtin: bash"));
+        assert!(config.contains("builtin: sh"));
+        assert!(config.contains("heph-go-plugin.json"));
+        assert!(config.contains("gotool: \"host\""));
+        assert!(
+            !config.contains("pkgmanager"),
+            "go-only config must not mention js's pkgmanager option: {config}"
+        );
+
+        let manifest: serde_json::Value = serde_json::from_slice(
+            &std::fs::read(corpus_dir.path().join("heph-go-plugin.json"))
+                .expect("read go manifest"),
+        )
+        .expect("parse go manifest");
+        assert_eq!(manifest["name"], "go");
+    }
+
+    /// `--lang both`'s config must declare BOTH plugins in one file — this
+    /// is what lets a single `heph r` process see both `//go/...` and
+    /// `//js/...` targets without a second dlopen pass.
+    #[test]
+    fn write_dist_config_both_langs_declares_both_plugins() {
+        let dist_dir = tempfile::tempdir().expect("dist tempdir");
+        let corpus_dir = tempfile::tempdir().expect("corpus tempdir");
+        std::fs::write(dist_dir.path().join("heph"), b"fake").expect("write fake heph");
+        std::fs::write(
+            dist_dir.path().join(format!("heph-go-plugin.{DYLIB_EXT}")),
+            b"fake go dylib bytes",
+        )
+        .expect("write fake go dylib");
+        std::fs::write(
+            dist_dir.path().join(format!("heph-js-plugin.{DYLIB_EXT}")),
+            b"fake js dylib bytes",
+        )
+        .expect("write fake js dylib");
+
+        let dist = Dist::locate(dist_dir.path()).expect("locate dist");
+        write_dist_config(corpus_dir.path(), &dist, &[&GO, &JS]).expect("write config");
+
+        let config = std::fs::read_to_string(corpus_dir.path().join(".hephconfig"))
+            .expect("read .hephconfig");
+        assert!(config.contains("heph-go-plugin.json"));
+        assert!(config.contains("heph-js-plugin.json"));
+        assert!(config.contains("gotool: \"host\""));
+        assert!(config.contains("pkgmanager: \"pnpm\""));
+    }
+
+    /// A missing js dylib must bail with a js-specific message, not a
+    /// generic or go-flavored one — this is the loud-failure path an
+    /// operator staging an incomplete dist directory hits.
+    #[test]
+    fn write_dist_config_missing_js_dylib_bails_naming_js() {
+        let dist_dir = tempfile::tempdir().expect("dist tempdir");
+        let corpus_dir = tempfile::tempdir().expect("corpus tempdir");
+        std::fs::write(dist_dir.path().join("heph"), b"fake").expect("write fake heph");
+        // No heph-js-plugin.<ext> written.
+
+        let dist = Dist::locate(dist_dir.path()).expect("locate dist");
+        let err = write_dist_config(corpus_dir.path(), &dist, &[&JS]).expect_err("must bail");
+        let msg = format!("{err:#}");
+        assert!(msg.contains("js plugin cdylib"), "{msg}");
+        assert!(msg.contains("heph-js-plugin"), "{msg}");
+    }
+
+    /// `measure_once` must bail loudly, and name the missing language, when
+    /// asked for a language whose corpus subtree was never generated —
+    /// mirrors the original go-only "nothing for Tier B to build" bail.
+    #[test]
+    fn measure_once_bails_naming_missing_language_subtree() {
+        let dist_dir = tempfile::tempdir().expect("dist tempdir");
+        let corpus_dir = tempfile::tempdir().expect("corpus tempdir");
+        std::fs::write(dist_dir.path().join("heph"), b"fake").expect("write fake heph");
+        std::fs::write(
+            dist_dir.path().join(format!("heph-js-plugin.{DYLIB_EXT}")),
+            b"fake js dylib bytes",
+        )
+        .expect("write fake js dylib");
+
+        let manifest = CorpusManifest {
+            bash_addrs: Vec::new(),
+            bash_prefix: String::new(),
+            bash_packages: Vec::new(),
+            go_package_count: 0,
+            go_prefix: "go".to_string(),
+            js_package_count: 0,
+            js_prefix: "js".to_string(),
+        };
+
+        let err = measure_once(
+            dist_dir.path(),
+            corpus_dir.path(),
+            &manifest,
+            Scenario::Cold,
+            0,
+            &[&JS],
+        )
+        .expect_err("must bail — js_package_count is 0");
+        let msg = format!("{err:#}");
+        assert!(msg.contains("js/"), "{msg}");
+        assert!(msg.contains("--js-packages"), "{msg}");
+    }
+
+    /// Locates the real `heph` binary this workspace produces for the
+    /// current (non-release) profile, building it on demand if the profile
+    /// directory this test binary itself was built into doesn't have one
+    /// yet — e.g. a scoped `cargo test -p bench` run that never asked for
+    /// the root package's bin target.
+    ///
+    /// `crates/bench` only depends on the `heph` *library* (for Tier A,
+    /// in-process); nothing in a plain `cargo test -p bench` build graph
+    /// forces the `heph` *binary* target to exist, so `build_lang_tree`
+    /// (Tier B) has no artifact to spawn without this.
+    fn locate_or_build_dev_heph() -> PathBuf {
+        let mut profile_dir = std::env::current_exe().expect("current_exe (test binary path)");
+        profile_dir.pop();
+        if profile_dir.ends_with("deps") {
+            profile_dir.pop();
+        }
+        let bin_name = if cfg!(windows) { "heph.exe" } else { "heph" };
+        let candidate = profile_dir.join(bin_name);
+        if !candidate.is_file() {
+            let workspace_root = Path::new(env!("CARGO_MANIFEST_DIR"))
+                .join("../..")
+                .canonicalize()
+                .expect("canonicalize workspace root (crates/bench/../..)");
+            let mut cmd = Command::new(env!("CARGO"));
+            cmd.args(["build", "--locked", "-p", "heph", "--bin", "heph"])
+                .current_dir(&workspace_root);
+            if profile_dir.ends_with("release") {
+                cmd.arg("--release");
+            }
+            let status = cmd
+                .status()
+                .expect("spawn `cargo build -p heph --bin heph`");
+            assert!(
+                status.success(),
+                "cargo build -p heph --bin heph failed with {status}"
+            );
+        }
+        assert!(
+            candidate.is_file(),
+            "expected a `heph` binary at {} after building it — the assumption that this \
+             test binary's profile dir ({}) matches where `cargo build -p heph --bin heph` \
+             places its output may not hold here",
+            candidate.display(),
+            profile_dir.display(),
+        );
+        candidate
+    }
+
+    /// End-to-end proof that `build_lang_tree` actually selects and runs
+    /// real targets against the real `heph` binary — not just that it
+    /// constructs a config file and exits 0. This is the regression test
+    /// for the "matched zero targets, exits 0 anyway" bug class this
+    /// module's whole `matched_targets` mechanism exists to catch: covers
+    /// the `label: None` (query-form) branch, since a fixture `bash` target
+    /// carries no bench-specific label to select by.
+    #[test]
+    fn build_lang_tree_runs_real_targets_not_zero() {
+        let heph_bin = locate_or_build_dev_heph();
+
+        let dist_dir = tempfile::tempdir().expect("dist tempdir");
+        std::fs::copy(&heph_bin, dist_dir.path().join("heph")).expect("copy heph binary");
+        let dist = Dist::locate(dist_dir.path()).expect("locate dist");
+
+        let corpus_dir = tempfile::tempdir().expect("corpus tempdir");
+        let corpus = corpus_dir
+            .path()
+            .canonicalize()
+            .expect("canonicalize corpus dir");
+        std::fs::write(
+            corpus.join(".hephconfig"),
+            "plugins:\n  \
+             - builtin: buildfile\n    options:\n      patterns:\n        - BUILD\n  \
+             - builtin: bash\n",
+        )
+        .expect("write .hephconfig");
+
+        // A fixture "language" subtree — same `//<name>/...` shape `Lang`
+        // uses, just with a plain bash target instead of a real go/js
+        // provider, so this test needs no plugin cdylib.
+        let pkg_dir = corpus.join("testlang");
+        std::fs::create_dir_all(&pkg_dir).expect("create testlang/ package dir");
+        std::fs::write(
+            pkg_dir.join("BUILD"),
+            "target(\n    \
+             name = \"t0\",\n    \
+             driver = \"bash\",\n    \
+             run = \"echo hi > $OUT\",\n    \
+             out = \"t0.out\",\n\
+             )\n",
+        )
+        .expect("write BUILD");
+
+        let test_lang = Lang {
+            name: "testlang",
+            provider_options: "",
+            label: None,
+            package_count: |_| 1,
+            incrementalize: |_, _, _| Ok(0),
+        };
+
+        let elapsed_ms = build_lang_tree(&dist, &corpus, &test_lang).expect("build_lang_tree");
+        assert!(
+            elapsed_ms >= 0.0,
+            "elapsed_ms must be a real, non-negative measurement"
+        );
+        assert!(
+            cache_dir(&corpus).is_dir(),
+            "a real build must populate {} — the label-matcher bug this test guards against \
+             matches zero targets and never touches the cache at all",
+            cache_dir(&corpus).display(),
+        );
     }
 }

--- a/crates/bench/src/main.rs
+++ b/crates/bench/src/main.rs
@@ -49,11 +49,16 @@ struct GenerateArgs {
     layers: usize,
     #[arg(long, default_value_t = 3)]
     fan_out: usize,
-    /// 0 = no go/ subtree (Tier B scenarios need this > 0).
+    /// 0 = no go/ subtree (Tier B `--lang go`/`both` scenarios need this > 0).
     #[arg(long, default_value_t = 0)]
     go_packages: usize,
     #[arg(long, default_value_t = 4)]
     go_max_depth: usize,
+    /// 0 = no js/ subtree (Tier B `--lang js`/`both` scenarios need this > 0).
+    #[arg(long, default_value_t = 0)]
+    js_packages: usize,
+    #[arg(long, default_value_t = 4)]
+    js_max_depth: usize,
     #[arg(long)]
     out: PathBuf,
 }
@@ -128,7 +133,7 @@ struct RunInprocessArgs {
     out_baseline: PathBuf,
 }
 
-/// Unlike Tier A, `heph`/the go plugin are already prebuilt artifacts on
+/// Unlike Tier A, `heph`/the plugin cdylibs are already prebuilt artifacts on
 /// both sides and the code driving them (`dist::prepare`/`measure_once`) is
 /// always the current checkout's own — there is no per-commit "subject"
 /// binary to keep compatible here, so this calls into that module directly
@@ -147,6 +152,12 @@ struct RunDistArgs {
     corpus: PathBuf,
     #[arg(long, value_enum)]
     scenario: dist::Scenario,
+    /// Which language(s)' plugin cdylib to build+time. Defaults to `go` —
+    /// the only language Tier B measured before this flag existed, so an
+    /// existing caller that never passes `--lang` (CI's `perf.yml` today)
+    /// keeps building and reporting exactly what it always has.
+    #[arg(long, value_enum, default_value_t = LangArg::Go)]
+    lang: LangArg,
     #[arg(long, default_value_t = 1)]
     warmup: usize,
     #[arg(long, default_value_t = 3)]
@@ -155,6 +166,48 @@ struct RunDistArgs {
     out_candidate: PathBuf,
     #[arg(long)]
     out_baseline: PathBuf,
+}
+
+/// `run dist`'s language selector. `Both` measures `go` and `js` in the same
+/// invocation — one `.hephconfig` with both plugins loaded, two separately
+/// timed `heph r -e '//<lang>/...'` calls per rep — and reports each as its
+/// own [`ScenarioResult`] rather than summing/averaging them together (see
+/// `write_dist_results`).
+///
+/// Caveat: because `Both` shares one `.hephconfig` declaring both plugins,
+/// each language's timed build also pays the *other* language's plugin
+/// dlopen + ABI-negotiation + checksum-verify cost as fixed per-process
+/// overhead — a `--lang both` js number is not apples-to-apples with a
+/// solo `--lang js` run (what CI's `distjs` tier actually uses today). Not
+/// exercised by CI (`perf.yml` never passes `--lang both`), so this is
+/// latent, not live; fixing it for real would mean writing a separate
+/// single-plugin `.hephconfig` per language even under `Both`, which isn't
+/// done here.
+#[derive(Clone, Copy, Debug, PartialEq, Eq, ValueEnum)]
+enum LangArg {
+    Go,
+    Js,
+    Both,
+}
+
+impl LangArg {
+    fn langs(self) -> Vec<&'static dist::Lang> {
+        match self {
+            LangArg::Go => vec![&dist::GO],
+            LangArg::Js => vec![&dist::JS],
+            LangArg::Both => vec![&dist::GO, &dist::JS],
+        }
+    }
+}
+
+impl std::fmt::Display for LangArg {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.write_str(match self {
+            LangArg::Go => "go",
+            LangArg::Js => "js",
+            LangArg::Both => "both",
+        })
+    }
 }
 
 #[derive(Args)]
@@ -220,14 +273,17 @@ fn run_corpus(args: GenerateArgs) -> Result<()> {
         fan_out: args.fan_out,
         go_packages: args.go_packages,
         go_max_depth: args.go_max_depth,
+        js_packages: args.js_packages,
+        js_max_depth: args.js_max_depth,
         ..Default::default()
     };
     let manifest = bench_corpus::generate(&params, &args.out).context("generate corpus")?;
     println!(
-        "generated {} bash targets across {} packages, {} go packages, at {}",
+        "generated {} bash targets across {} packages, {} go packages, {} js packages, at {}",
         manifest.bash_addrs.len(),
         manifest.bash_packages.len(),
         manifest.go_package_count,
+        manifest.js_package_count,
         args.out.display()
     );
     Ok(())
@@ -369,14 +425,12 @@ async fn run_inprocess_both(args: RunInprocessArgs) -> Result<()> {
     write_results(
         &args.out_candidate,
         "inprocess",
-        args.scenario.name(),
-        candidate_ms,
+        vec![(args.scenario.name().to_string(), candidate_ms)],
     )?;
     write_results(
         &args.out_baseline,
         "inprocess",
-        args.scenario.name(),
-        baseline_ms,
+        vec![(args.scenario.name().to_string(), baseline_ms)],
     )?;
     Ok(())
 }
@@ -384,6 +438,13 @@ async fn run_inprocess_both(args: RunInprocessArgs) -> Result<()> {
 /// Same interleaving shape as `run_inprocess_both`, calling straight into
 /// `dist::prepare`/`measure_once` (no subprocess spawn of `heph-bench`
 /// itself needed — see `RunDistArgs`'s doc comment for why).
+///
+/// `--lang both` measures both languages inside the same interleaved
+/// candidate/baseline loop rather than running two separate passes: each
+/// `measure_once` call already builds every requested language's tree back
+/// to back for one side, so interleaving stays per-*rep*, not per-language —
+/// a systematic drift across the rep still lands on both sides symmetrically
+/// for both languages, not just the first one measured.
 fn run_dist_both(args: RunDistArgs) -> Result<()> {
     let corpus = args
         .corpus
@@ -391,56 +452,110 @@ fn run_dist_both(args: RunDistArgs) -> Result<()> {
         .with_context(|| format!("canonicalize {}", args.corpus.display()))?;
     let manifest = bench_corpus::load_manifest(&corpus)
         .context("load corpus manifest (run `corpus` first)")?;
+    let langs = args.lang.langs();
 
     for _ in 0..args.warmup {
-        dist::prepare(&args.candidate_dist, &corpus, args.scenario).context("prepare candidate")?;
-        dist::prepare(&args.baseline_dist, &corpus, args.scenario).context("prepare baseline")?;
+        dist::prepare(
+            &args.candidate_dist,
+            &corpus,
+            &manifest,
+            args.scenario,
+            &langs,
+        )
+        .context("prepare candidate")?;
+        dist::prepare(
+            &args.baseline_dist,
+            &corpus,
+            &manifest,
+            args.scenario,
+            &langs,
+        )
+        .context("prepare baseline")?;
     }
 
-    let mut candidate_ms = Vec::with_capacity(args.reps);
-    let mut baseline_ms = Vec::with_capacity(args.reps);
+    // Indexed the same as `langs` — `dist::measure_once` returns its
+    // per-language results in that exact order (see its doc comment), so
+    // these accumulate without a name lookup.
+    let mut candidate_ms: Vec<Vec<f64>> = langs
+        .iter()
+        .map(|_| Vec::with_capacity(args.reps))
+        .collect();
+    let mut baseline_ms: Vec<Vec<f64>> = langs
+        .iter()
+        .map(|_| Vec::with_capacity(args.reps))
+        .collect();
     for i in 0..args.reps {
         let seed = i as u64;
-        candidate_ms.push(
-            dist::measure_once(
-                &args.candidate_dist,
-                &corpus,
-                &manifest,
-                args.scenario,
-                seed,
-            )
-            .context("measure candidate")?,
-        );
-        baseline_ms.push(
-            dist::measure_once(&args.baseline_dist, &corpus, &manifest, args.scenario, seed)
-                .context("measure baseline")?,
-        );
+        let cand = dist::measure_once(
+            &args.candidate_dist,
+            &corpus,
+            &manifest,
+            args.scenario,
+            seed,
+            &langs,
+        )
+        .context("measure candidate")?;
+        for (slot, (_, ms)) in candidate_ms.iter_mut().zip(cand) {
+            slot.push(ms);
+        }
+        let base = dist::measure_once(
+            &args.baseline_dist,
+            &corpus,
+            &manifest,
+            args.scenario,
+            seed,
+            &langs,
+        )
+        .context("measure baseline")?;
+        for (slot, (_, ms)) in baseline_ms.iter_mut().zip(base) {
+            slot.push(ms);
+        }
     }
 
-    write_results(
-        &args.out_candidate,
-        "dist",
-        args.scenario.name(),
-        candidate_ms,
-    )?;
-    write_results(
-        &args.out_baseline,
-        "dist",
-        args.scenario.name(),
-        baseline_ms,
-    )?;
+    write_dist_results(&args.out_candidate, args.scenario, &langs, candidate_ms)?;
+    write_dist_results(&args.out_baseline, args.scenario, &langs, baseline_ms)?;
     Ok(())
 }
 
-fn write_results(out: &Path, tier: &str, scenario: &str, wall_ms: Vec<f64>) -> Result<()> {
-    let mean = wall_ms.iter().sum::<f64>() / wall_ms.len().max(1) as f64;
-    println!("{scenario}: {} reps, {mean:.1}ms mean", wall_ms.len());
+/// `--lang go` (the default) or `--lang js` alone reports the bare scenario
+/// name (`"cold"`, unchanged from before this flag existed — see
+/// `RunDistArgs::lang`'s doc comment on why that matters for an existing
+/// caller). `--lang both` reports two scenario rows, `"<scenario>-go"` and
+/// `"<scenario>-js"`, so a regression in one language is never averaged away
+/// by the other — see `crates/bench/src/timing.rs`'s `RunResults` doc: it
+/// already carries a `Vec<ScenarioResult>` for exactly this.
+fn write_dist_results(
+    out: &Path,
+    scenario: dist::Scenario,
+    langs: &[&dist::Lang],
+    wall_ms_by_lang: Vec<Vec<f64>>,
+) -> Result<()> {
+    let scenarios = langs
+        .iter()
+        .zip(wall_ms_by_lang)
+        .map(|(lang, wall_ms)| {
+            let name = if langs.len() == 1 {
+                scenario.name().to_string()
+            } else {
+                format!("{}-{}", scenario.name(), lang.name)
+            };
+            (name, wall_ms)
+        })
+        .collect();
+    write_results(out, "dist", scenarios)
+}
+
+fn write_results(out: &Path, tier: &str, scenarios: Vec<(String, Vec<f64>)>) -> Result<()> {
+    for (scenario, wall_ms) in &scenarios {
+        let mean = wall_ms.iter().sum::<f64>() / wall_ms.len().max(1) as f64;
+        println!("{scenario}: {} reps, {mean:.1}ms mean", wall_ms.len());
+    }
     let results = RunResults {
         tier: tier.to_string(),
-        scenarios: vec![ScenarioResult {
-            scenario: scenario.to_string(),
-            wall_ms,
-        }],
+        scenarios: scenarios
+            .into_iter()
+            .map(|(scenario, wall_ms)| ScenarioResult { scenario, wall_ms })
+            .collect(),
     };
     let bytes = serde_json::to_vec_pretty(&results).context("encode results")?;
     std::fs::write(out, bytes).with_context(|| format!("write {}", out.display()))
@@ -474,4 +589,114 @@ fn run_compare(args: CompareArgs) -> Result<()> {
         anyhow::bail!("regression detected — see table above");
     }
     Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// `--lang go` (the default, and the only case `run dist` measured
+    /// before `--lang` existed) must keep reporting the bare scenario name —
+    /// a caller (CI's `perf.yml`) reading `"cold"`/`"full-hit"`/etc out of
+    /// the result JSON, or matching thresholds keyed by those bare names,
+    /// must see byte-identical scenario names whether or not `--lang` is
+    /// ever passed.
+    #[test]
+    fn write_dist_results_single_lang_keeps_bare_scenario_name() {
+        let out = tempfile::NamedTempFile::new().expect("tempfile");
+        write_dist_results(
+            out.path(),
+            dist::Scenario::Cold,
+            &[&dist::GO],
+            vec![vec![12.0, 14.0]],
+        )
+        .expect("write_dist_results");
+
+        let results: RunResults =
+            serde_json::from_slice(&std::fs::read(out.path()).expect("read results"))
+                .expect("parse results");
+        assert_eq!(results.scenarios.len(), 1);
+        assert_eq!(results.scenarios[0].scenario, "cold");
+        assert_eq!(results.scenarios[0].wall_ms, vec![12.0, 14.0]);
+    }
+
+    /// `--lang both` must report go and js as two DISTINCT scenario rows,
+    /// each carrying only its own language's wall-clock samples — never
+    /// summed or averaged into one number (see `RunDistArgs::lang`'s doc
+    /// comment and this crate's `timing.rs`). A regression that only exists
+    /// on one side would be invisible if the two got merged.
+    #[test]
+    fn write_dist_results_both_langs_reports_two_distinct_scenarios_never_merged() {
+        let out = tempfile::NamedTempFile::new().expect("tempfile");
+        write_dist_results(
+            out.path(),
+            dist::Scenario::FullHit,
+            &[&dist::GO, &dist::JS],
+            vec![vec![100.0, 110.0], vec![5.0, 6.0]],
+        )
+        .expect("write_dist_results");
+
+        let results: RunResults =
+            serde_json::from_slice(&std::fs::read(out.path()).expect("read results"))
+                .expect("parse results");
+        assert_eq!(results.scenarios.len(), 2);
+        assert_eq!(results.scenarios[0].scenario, "full-hit-go");
+        assert_eq!(results.scenarios[0].wall_ms, vec![100.0, 110.0]);
+        assert_eq!(results.scenarios[1].scenario, "full-hit-js");
+        assert_eq!(results.scenarios[1].wall_ms, vec![5.0, 6.0]);
+    }
+
+    #[test]
+    fn lang_arg_selects_expected_lang_set() {
+        assert_eq!(LangArg::Go.langs().len(), 1);
+        assert_eq!(LangArg::Go.langs()[0].name, "go");
+        assert_eq!(LangArg::Js.langs().len(), 1);
+        assert_eq!(LangArg::Js.langs()[0].name, "js");
+        let both: Vec<&str> = LangArg::Both.langs().iter().map(|l| l.name).collect();
+        assert_eq!(both, vec!["go", "js"]);
+    }
+
+    /// `heph-bench corpus --js-packages N` must actually reach
+    /// `bench_corpus::generate`'s `js_packages` param — this is the CLI
+    /// wiring gap this task found (the corpus subcommand's `GenerateArgs`
+    /// had no `--js-packages`/`--js-max-depth` flags at all before this
+    /// change, even though `bench_corpus::CorpusParams` already supported
+    /// them). Goes through `Cli::try_parse_from` → `run_corpus`, the real
+    /// CLI→`CorpusParams` mapping, not a hand-built `CorpusParams` — a
+    /// regression that drops `args.js_packages`/`args.js_max_depth` from
+    /// `run_corpus`'s field mapping (main.rs) would still leave a
+    /// hand-built `CorpusParams` test green, which is exactly what this
+    /// test replaces. `--go-packages` is left at 0 so this test needs no
+    /// network (go corpus generation shells out to `go mod tidy`).
+    #[test]
+    fn generate_args_wires_js_packages_into_corpus_params() {
+        let out = tempfile::tempdir().expect("tempdir");
+        let cli = Cli::try_parse_from([
+            "heph-bench",
+            "corpus",
+            "--targets",
+            "20",
+            "--packages",
+            "4",
+            "--layers",
+            "2",
+            "--fan-out",
+            "2",
+            "--js-packages",
+            "6",
+            "--js-max-depth",
+            "2",
+            "--out",
+            out.path().to_str().expect("tempdir path is utf8"),
+        ])
+        .expect("parse `heph-bench corpus --js-packages 6 ...`");
+        let Cmd::Corpus(args) = cli.cmd else {
+            panic!("expected Cmd::Corpus, got a different subcommand");
+        };
+        run_corpus(args).expect("run_corpus");
+
+        let manifest = bench_corpus::load_manifest(out.path()).expect("load generated manifest");
+        assert_eq!(manifest.js_package_count, 6);
+        assert_eq!(manifest.go_package_count, 0, "go_packages defaulted to 0");
+    }
 }

--- a/devenv.nix
+++ b/devenv.nix
@@ -236,6 +236,16 @@ in
   #   e2e                      # build them from this tree (local default)
   #   HEPH_E2E_FROM=dist e2e   # use an already-downloaded set (CI)
   #
+  # Deliberately does NOT build/stage `plugin-js-cdylib` here (as of the
+  # bench js/go/both selector work): every artifact this script stages is
+  # named because `crates/bin-e2e/tests/plugin_dylib.rs` actually dlopens it
+  # (`shipped_go_cdylib_loads` / `shipped_gha_cdylib_loads`) — there is no
+  # equivalent js test yet. Adding it here would build an artifact `e2e`
+  # never exercises, purely for its own build-time cost. `qualityCrates`
+  # above already lints/fmts `plugin-js-cdylib` without `e2e` testing it —
+  # same asymmetry, same reason. Revisit once a `shipped_js_cdylib_loads`
+  # test exists; add both together.
+  #
   # Both branches converge on the same normalized layout, so the tests never
   # learn which one ran. Extra args pass through to cargo test (e.g.
   # `e2e tui_pty -- --nocapture`).


### PR DESCRIPTION
Part 7/7 of the stack — extends `heph-bench` to measure the new plugin-js the same way it already measures plugin-go, generalizes Tier B (`dist.rs`) across languages instead of duplicating the go-specific path, and publishes the js plugin as a real, generally-installable artifact — same as go/gha.

## What's here

- **`crates/bench-corpus`**: `generate_js_tree` produces a synthetic, network-free pnpm workspace (zero third-party deps by design — no js_install fetch, no lockfile, fully hermetic) with the same layered-DAG shape the bash and go generators already use. Wired via `js_packages`/`js_max_depth`, mirroring `go_packages`/`go_max_depth` exactly — `0` (the default) is a no-op, so existing callers get byte-identical output.
- **`crates/bench`**: `dist.rs` rewritten around a `Lang` abstraction (GO/JS consts: name, provider-option fragment, package-count accessor, incrementalize fn) instead of two near-duplicate go/js code paths. `run dist --lang go|js|both` (default `go`, preserving existing-caller behavior exactly — byte-identical `.hephconfig`/scenario names to the pre-existing code path). `both` reports each language as its own distinct `ScenarioResult` (`<scenario>-go`/`<scenario>-js`) — never silently summed/averaged.
- The `corpus` CLI subcommand was missing `--js-packages`/`--js-max-depth` entirely (bench-corpus's library supported them, main.rs never exposed them) — added, mirroring `--go-packages`/`--go-max-depth`.

## A real pre-existing bug, found while mirroring the go path for js

Tier B's `heph r build //<lang>/...` invocation is the two-positional-arg form, which parses as `label("build") && //<lang>/...` — no BUILD file in the corpus sets that label, so it has **always matched zero targets and exited 0, silently measuring an empty build**. This affected the existing go benchmark too, not just the new js one — it predates this PR entirely, just surfaced while faithfully mirroring the path. Fixed to the query form (`heph r -e '//<lang>/...'`), verified against a real binary (built a fixture, confirmed the old form reports \"matched 0 targets\" and the new one actually executes targets), with a regression test that fails if the matcher regresses back to the broken form.

## Artifact pipeline — js is now published like go/gha

`plugin-js-cdylib` is built and published by `heph.yml`'s `build` job alongside `plugin-go-cdylib`/`plugin-gha-cdylib`, in the same pre-release artifact bundle, **and** `upload_artifacts` now generates a public `heph-js-plugin.json` manifest via `tools/pluginmanifest`, exactly the same way go/gha do (per-os/arch checksum entries, URL-base pointing at the release, a `.sha256` sidecar for the manifest itself). A real workspace can now opt in the same way as go/gha:

```yaml
plugins:
  - path: .heph3/heph-js-plugin.json   # or a url: pointing at the published release asset
```

`crates/bench/src/dist.rs`'s `write_dist_config` is unaffected — it still builds its own local manifest straight from the downloaded raw dylib and never reads the published one; the two are independent consumers of the same underlying cdylib asset.

`devenv.nix`'s `e2e` script still deliberately does **not** build `plugin-js-cdylib` locally — there is no `shipped_js_cdylib_loads` bin-e2e test yet to justify the build cost, mirroring the existing lint-but-don't-e2e-test asymmetry already in place for this crate. That's a narrower, still-open gap than manifest publishing and unaffected by this update.

## Known, disclosed gap

No `oxlint`/`esbuild` toolchain is provisioned on any CI runner yet, so `perf.yml`'s new JS Tier B comparison step will report \"no results\" until one is. The target-matcher fix above makes that failure mode honest (a real attempt, a real failure) rather than the previous silent zero-targets false success. Provisioning a JS toolchain for CI (host vs. hermetic, which versions) is a separate follow-up decision, not made here.

## Test plan
- [x] `cargo build -p bench -p bench-corpus`
- [x] `cargo test -p bench -p bench-corpus` (14 + 8 passed, 2 pre-existing network-gated ignored)
- [x] `cargo clippy -p bench -p bench-corpus --all-targets -- -D warnings` (clean)
- [x] `cargo fmt --check -p bench -p bench-corpus`
- [x] `cargo build --release -p plugin-js-cdylib` (the artifact this whole change assumes exists)
- [x] Workflow YAML (`heph.yml`, `perf.yml`) parses
- [ ] CI (`tst`, `lint`) on this PR

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>