### PR TITLE
perf(plugin-go): keep generated testmain out of the remote cache

### DIFF
--- a/crates/plugin-go/src/plugingo/driver_testmain.rs
+++ b/crates/plugin-go/src/plugingo/driver_testmain.rs
@@ -179,7 +179,25 @@ impl ManagedDriver for GoTestmainDriver {
                 inputs,
                 outputs,
                 support_files: vec![],
-                cache: CacheConfig::on(true),
+                // Local cache only (`on(false)` = local on, remote off).
+                // Generating testmain.go is a scan of the package's test files
+                // plus a string build — microseconds, in-process, no subprocess.
+                //
+                // Opting out of the remote cache means this target executes
+                // whenever the local cache is cold, because a dependent needs
+                // its hashout and only a cache hit or a real run can produce
+                // one. That is the whole cost here, and it is bounded: the
+                // inputs are materialized either way — the provider reads the
+                // golist `package.bin` to build this spec at all, and the test
+                // sources are workspace files. Nothing is dragged in.
+                //
+                // This is exactly why `@heph/go/std/…:build_lib` keeps its
+                // remote cache despite being one `mv`: running *it* needs the
+                // whole `install|pkg` staged, so the same trade there would
+                // download all of std to learn a hash the remote manifest
+                // hands over for free. Cheap to run is not enough — the inputs
+                // have to already be there.
+                cache: CacheConfig::on(false),
                 pty: false,
                 hash,
                 transparent: false,
@@ -332,6 +350,20 @@ mod tests {
                 .any(|i| i.origin_id == "dep|golist|0"),
             "golist input must be present"
         );
+    }
+
+    /// Generating testmain.go is cheaper than fetching it, so the target stays
+    /// in the local cache and out of the remote one.
+    #[tokio::test]
+    async fn test_parse_keeps_testmain_out_of_the_remote_cache() {
+        let ct = noop_ctoken();
+        let req = make_parse_request("mypkg", "//mypkg:_golist|pkg");
+        let resp = driver().parse(req, &ct).await.unwrap();
+        assert!(
+            resp.target_def.cache.enabled,
+            "local cache must stay on — regenerating on every build is not the goal"
+        );
+        assert!(!resp.target_def.cache.remote_enabled);
     }
 
     #[tokio::test]

--- a/crates/plugin-go/src/plugingo/target_std.rs
+++ b/crates/plugin-go/src/plugingo/target_std.rs
@@ -167,7 +167,14 @@ pub fn build_spec(
             Value::List(vec![Value::String(out_file)]),
         )])),
     );
-
+    // NOTE: `build_lib` stays remote-cached even though running it is one `mv`.
+    // Cheap to run is not the same as cheap to *need*: a dependent needs this
+    // target's hashout to compute its own input hash, and a remote manifest
+    // carries that with no blob transfer at all. Opting out of the remote cache
+    // would mean the hashout could only come from executing, and executing needs
+    // `install|pkg` staged — so a build that is otherwise 100% remote hits would
+    // download the entire compiled std to learn a hash it can currently fetch
+    // for free.
     TargetSpec {
         addr,
         driver: "sh".to_string(),
@@ -325,6 +332,31 @@ mod tests {
             _ => panic!("deps must be map"),
         };
         assert!(!deps.contains_key(crate::plugingo::addr_util::GO_SDK_DEP_GROUP));
+    }
+
+    /// `build_lib` must stay remote-cacheable. Running it is one `mv`, which
+    /// makes opting out of the remote cache look free — it is not. A dependent
+    /// needs this target's hashout to compute its own input hash, and a remote
+    /// manifest carries hashouts with no blob transfer, whereas producing the
+    /// hashout locally means executing, and executing means `install|pkg` is
+    /// staged. Opting out would turn a free hash lookup into a download of the
+    /// entire compiled std on a build that is otherwise 100% cache hits.
+    #[test]
+    fn test_build_lib_stays_remote_cacheable() {
+        use hplugin::htspec::{FromSpecValue, TargetSpecCache};
+
+        let spec = build_spec(build_lib_addr(), "fmt", &test_factors(), &test_vref());
+        // An absent `cache` is both tiers on — the same default the driver applies.
+        let cache = match spec.config.get("cache") {
+            Some(v) => TargetSpecCache::from_spec_value(v).expect("`cache` must parse"),
+            None => TargetSpecCache::default(),
+        };
+        assert!(
+            cache.remote,
+            "std build_lib must stay remote-cacheable: a dependent reads its hashout \
+             from the remote manifest for free, and rebuilding it locally drags the \
+             whole `install` output down with it"
+        );
     }
 
     #[test]


### PR DESCRIPTION
Generating `testmain.go` is a scan of the package's test files plus a string build — microseconds, in-process, no subprocess. Fetching one is a manifest round trip plus a blob download, per test package, to avoid work the machine could have done in the meantime. It stays **locally** cached; only the remote tier is off.

Opting out means the target executes whenever the local cache is cold, because a dependent needs its hashout and only a cache hit or a real run produces one. That cost is bounded here: the inputs are materialized either way — the provider reads the golist `package.bin` to build this spec at all, and the test sources are workspace files. Nothing extra is dragged in.

### Why std `build_lib` is *not* included

The first version of this PR also opted `@heph/go/std/<import>:build_lib` out of the remote cache, on the grounds that running it is a single `mv`. That was wrong, and the reason is worth writing down:

A remote manifest carries every artifact's hashout with **no blob transfer** (`remote_cache.rs:15`), so a dependent gets `build_lib`'s hash for free today. Produce it locally instead and the hashout can only come from executing — and executing needs `install|pkg` staged. A build that is otherwise 100% remote hits would download the **entire compiled std** to learn a hash it can currently fetch for nothing.

Cheap to run is not the bar. The inputs have to already be there. That distinction is now a `NOTE` on the target and is frozen by `test_build_lib_stays_remote_cacheable`, because the `mv` makes the wrong call look obvious.

### Scope

The other trivially-cheap targets (`@heph/fs`, `group`, `text_file`, `host_bin`) are already `CacheConfig::off()`. Everything else in the go plugin — `install`, `_golist`, `go_compile`, the link steps, the thirdparty download, the SDK fetch — is real work worth a round trip, and each would drag its inputs in besides.

### Tests

- `test_parse_keeps_testmain_out_of_the_remote_cache` — remote off, local tier still on.
- `test_build_lib_stays_remote_cacheable` — the guardrail described above.
- Ran locally: `plugin` / `plugin-go` unit tests and `lint`, green.

`cache` is not part of `pluginexec`'s def hash, and this change touches no spec config anyway, so no existing cache entry is invalidated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019ob7Wy6mjtzr3pqK5EntYq