### PR TITLE
feat(plugin-gha): rewrite the CI report for 20k-target runs

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3901,6 +3901,7 @@ dependencies = [
  "core",
  "plugin",
  "reqwest",
+ "rustc-hash",
  "serde_json",
  "serde_yaml",
  "tempfile",

--- a/crates/plugin-gha/Cargo.toml
+++ b/crates/plugin-gha/Cargo.toml
@@ -17,6 +17,10 @@ tracing = "0.1"
 # the other crates' reqwest config.
 reqwest = { version = "0.13", default-features = false, features = ["blocking", "rustls", "json"] }
 serde_json = "1"
+# Hash maps on the event-drain path. `BTreeSet<String>` costs O(log n) string
+# comparisons per insert, each walking a long shared `//deep/package/…` prefix
+# before diverging; FxHash hashes the bytes once.
+rustc-hash = "2"
 
 [dev-dependencies]
 tempfile = "3"

--- a/crates/plugin-gha/src/lib.rs
+++ b/crates/plugin-gha/src/lib.rs
@@ -1,7 +1,19 @@
 //! A GitHub Actions hook: folds the engine's build-event stream into a status
-//! tally (done/total, built, cached, failed, slow targets) and surfaces it two
-//! ways. Published out-of-process as a cdylib (see `plugin-gha-cdylib`) and
-//! enabled via a config `plugins:` entry.
+//! [`Tally`] and surfaces it two ways. Published out-of-process as a cdylib (see
+//! `plugin-gha-cdylib`) and enabled via a config `plugins:` entry.
+//!
+//! The design, and the reasoning behind it, is `docs/GHA_REPORTING.md`. The two
+//! things to know before editing:
+//!
+//! - **The live comment and the final summary are different products**, with
+//!   separate renderers ([`render::render_live`] / [`render::render_final`]). One
+//!   renderer serving both is what made the summary ship a "slow targets" table
+//!   that was structurally near-empty — it reported *currently-running* targets
+//!   at the moment everything had finished.
+//! - **A CI run has ~20k targets.** Nothing retained may be proportional to the
+//!   graph, and nothing rendered may be a per-target list. See [`tally`].
+//!
+//! Surfaces:
 //!
 //! - **Live**, while the job runs: a **sticky PR comment** whose body is PATCHed on
 //!   a timer. `$GITHUB_STEP_SUMMARY` is rendered by GitHub *only* when the step
@@ -12,243 +24,25 @@
 //!   section, so a job's earlier steps' results are preserved, not overwritten. The
 //!   comment also records the workflow run id, so a *new* run's first step resets
 //!   the body instead of stacking its sections on the previous build's.
-//! - **At the end**: the full markdown is written once to `$GITHUB_STEP_SUMMARY`.
+//! - **At the end**: the final report is appended once to `$GITHUB_STEP_SUMMARY`.
 //!
-//! The aggregation is intentionally self-contained (a small [`Tally`]) rather than
-//! reusing the TUI's `BuildState`: the renderer's aggregator is coupled to ratatui
-//! and lives in the (terminal) `tui` crate, and a hook only needs a handful of
-//! counts plus the in-flight set for slow detection.
+//! The aggregation is intentionally self-contained rather than reusing the TUI's
+//! `BuildState`: that aggregator is coupled to ratatui and lives in the
+//! (terminal) `tui` crate.
 
-use std::collections::{BTreeMap, BTreeSet};
+mod render;
+mod tally;
+
 use std::path::PathBuf;
 use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::{Arc, Mutex};
 use std::time::Duration;
 
-use hcore::events::{BuildEvent, BuildEventKind, now_unix_ms};
+use hcore::events::{BuildEvent, now_unix_ms};
 use hplugin::config::{Options, decode_opt, deny_unknown};
 use hplugin::hook::Hook;
 
-/// A target executing longer than this (ms) is surfaced in the "slow targets"
-/// section of the summary.
-const SLOW_THRESHOLD_MS: u64 = 10_000;
-
-/// `$GITHUB_STEP_SUMMARY` is capped at 1 MiB by GitHub. The header is tiny and
-/// fixed; the only unbounded sections are the slow + failed lists, so they are
-/// truncated to the slowest / first N (with a "…and X more" line) to keep every
-/// snapshot well under the limit.
-const MAX_SLOW_ROWS: usize = 20;
-const MAX_FAILED_ROWS: usize = 50;
-
-/// One long-running phase a target can currently be in. A target is slow because
-/// of a *single* active phase (it executes, or pulls from cache, or writes cache —
-/// not several at once), so the summary names which one.
-#[derive(Clone, Copy)]
-enum Phase {
-    Execute,
-    CachePull,
-    LocalCacheWrite,
-    RemoteCacheWrite,
-}
-
-impl Phase {
-    fn label(self) -> &'static str {
-        match self {
-            Phase::Execute => "execute",
-            Phase::CachePull => "cache pull",
-            Phase::LocalCacheWrite => "cache write",
-            Phase::RemoteCacheWrite => "remote cache write",
-        }
-    }
-}
-
-/// The folded build status. Only what the summary renders: matched/finished sets
-/// for progress, cache-hit + built counts, the failure list, and the in-flight
-/// active phase per target for slow detection.
-#[derive(Default)]
-struct Tally {
-    matched: BTreeSet<String>,
-    matched_complete: bool,
-    /// Set once the build's event stream closes (`on_close`). The build is over,
-    /// so the status must settle: ✅ unless something failed. Without this the
-    /// emoji stays ⏳ whenever `done` never reaches `total` — e.g. transparent
-    /// group targets are matched but emit no `ResultEnd`, so they never finish.
-    closed: bool,
-    finished: BTreeSet<String>,
-    built: usize,
-    cache_hit: BTreeSet<String>,
-    failed: Vec<(String, Option<String>)>,
-    /// addr -> (active phase, its start timestamp). Set on a phase `*Start`,
-    /// cleared on the matching `*End`; the remaining entries are the targets
-    /// currently inside a phase (one phase each).
-    running: BTreeMap<String, (Phase, u64)>,
-}
-
-impl Tally {
-    fn apply(&mut self, ev: &BuildEvent) {
-        match &ev.kind {
-            BuildEventKind::Matched { addrs, complete } => {
-                for a in addrs {
-                    self.matched.insert(a.clone());
-                }
-                if *complete {
-                    self.matched_complete = true;
-                }
-            }
-            BuildEventKind::ResultEnd { addr, error } => {
-                self.finished.insert(addr.clone());
-                if let Some(e) = error {
-                    self.failed.push((addr.clone(), Some(e.clone())));
-                }
-            }
-            BuildEventKind::ExecuteStart { addr, .. } => {
-                self.running
-                    .insert(addr.clone(), (Phase::Execute, ev.at_unix_ms));
-                // A target that executes is not a cached target, even when it was
-                // announced as a hit first: the engine decides a hit from the
-                // revision's manifest, and a manifest can outlive its blobs (GC,
-                // an object-store lifecycle rule, or blobs never pulled on a run
-                // that is now offline), in which case it rebuilds. Retract the
-                // hit, or the summary counts the same addr under both "built" and
-                // "cached" and the two can sum past the target count.
-                self.cache_hit.remove(addr);
-            }
-            BuildEventKind::ExecuteEnd { addr, error } => {
-                self.running.remove(addr);
-                if error.is_none() {
-                    self.built += 1;
-                }
-            }
-            BuildEventKind::RemoteCacheReadStart { addr } => {
-                self.running
-                    .insert(addr.clone(), (Phase::CachePull, ev.at_unix_ms));
-            }
-            BuildEventKind::LocalCacheWriteStart { addr } => {
-                self.running
-                    .insert(addr.clone(), (Phase::LocalCacheWrite, ev.at_unix_ms));
-            }
-            BuildEventKind::RemoteCacheWriteStart { addr } => {
-                self.running
-                    .insert(addr.clone(), (Phase::RemoteCacheWrite, ev.at_unix_ms));
-            }
-            BuildEventKind::RemoteCacheReadEnd { addr, .. }
-            | BuildEventKind::LocalCacheWriteEnd { addr, .. }
-            | BuildEventKind::RemoteCacheWriteEnd { addr, .. } => {
-                self.running.remove(addr);
-            }
-            BuildEventKind::LocalCacheHit { addr } | BuildEventKind::RemoteCacheHit { addr } => {
-                self.cache_hit.insert(addr.clone());
-            }
-            _ => {}
-        }
-    }
-
-    /// `(done, total)` over the matched top-level set: done = matched targets that
-    /// have finished. `total` is provisional until the matcher resolves.
-    fn progress(&self) -> (usize, usize) {
-        let done = self
-            .matched
-            .iter()
-            .filter(|a| self.finished.contains(*a))
-            .count();
-        (done, self.matched.len())
-    }
-
-    fn cached_count(&self) -> usize {
-        self.matched
-            .iter()
-            .filter(|a| self.cache_hit.contains(*a))
-            .count()
-    }
-
-    /// Targets stuck in a single phase past [`SLOW_THRESHOLD_MS`], slowest first.
-    /// Each carries the phase label so the summary shows *what* is slow.
-    fn slow(&self, now_ms: u64) -> Vec<(String, &'static str, u64)> {
-        let mut slow: Vec<(String, &'static str, u64)> = self
-            .running
-            .iter()
-            .filter_map(|(addr, (phase, start))| {
-                let elapsed = now_ms.saturating_sub(*start);
-                (elapsed >= SLOW_THRESHOLD_MS).then(|| (addr.clone(), phase.label(), elapsed))
-            })
-            .collect();
-        // Slowest first.
-        slow.sort_by_key(|(_, _, elapsed)| std::cmp::Reverse(*elapsed));
-        slow
-    }
-
-    /// A status emoji reflecting whether *this invocation* is still running: ⏳
-    /// until its event stream closes, then ✅ (or ❌ if anything failed). Progress
-    /// counts (`done`/`total`) drive the targets line, not this — a matched
-    /// transparent group emits no `ResultEnd`, so `done == total` is unreliable as
-    /// a "finished" signal; the stream closing is the authoritative one.
-    fn status_emoji(&self) -> &'static str {
-        if !self.closed {
-            "⏳"
-        } else if self.failed.is_empty() {
-            "✅"
-        } else {
-            "❌"
-        }
-    }
-
-    /// Render the GitHub-Actions markdown for the current tally. `heading` is the
-    /// H2 title (the heph command being run).
-    fn render_markdown(&self, now_ms: u64, heading: &str) -> String {
-        let (done, total) = self.progress();
-        let total_str = if self.matched_complete {
-            total.to_string()
-        } else {
-            format!("~{total}")
-        };
-        let mut out = String::new();
-        // Heading leads with the invocation status emoji.
-        out.push_str(&format!("## {} {heading}\n\n", self.status_emoji()));
-        out.push_str(&format!(
-            "**Targets:** {done} / {total_str} &nbsp;•&nbsp; **built:** {} &nbsp;•&nbsp; **cached:** {} &nbsp;•&nbsp; **failed:** {}\n",
-            self.built,
-            self.cached_count(),
-            self.failed.len(),
-        ));
-
-        let slow = self.slow(now_ms);
-        if !slow.is_empty() {
-            // Collapsible: slow targets are noise most of the time, expanded on demand.
-            // The blank line after </summary> is required for the table to render.
-            out.push_str(&format!(
-                "\n<details><summary>🐢 Slow targets ({})</summary>\n\n| target | phase | running for |\n| --- | --- | --- |\n",
-                slow.len(),
-            ));
-            for (addr, phase, elapsed) in slow.iter().take(MAX_SLOW_ROWS) {
-                out.push_str(&format!("| `{addr}` | {phase} | {}s |\n", elapsed / 1000));
-            }
-            if slow.len() > MAX_SLOW_ROWS {
-                out.push_str(&format!("\n…and {} more\n", slow.len() - MAX_SLOW_ROWS));
-            }
-            out.push_str("</details>\n");
-        }
-
-        if !self.failed.is_empty() {
-            out.push_str("\n### Failed\n\n");
-            for (addr, err) in self.failed.iter().take(MAX_FAILED_ROWS) {
-                match err {
-                    Some(e) => out.push_str(&format!(
-                        "- `{addr}` — {}\n",
-                        e.lines().next().unwrap_or("")
-                    )),
-                    None => out.push_str(&format!("- `{addr}`\n")),
-                }
-            }
-            if self.failed.len() > MAX_FAILED_ROWS {
-                out.push_str(&format!(
-                    "\n…and {} more\n",
-                    self.failed.len() - MAX_FAILED_ROWS
-                ));
-            }
-        }
-        out
-    }
-}
+use crate::tally::Tally;
 
 /// Scopes the sticky comment to one per job: the Actions job id (`GITHUB_JOB`) when
 /// present, else the heph command (so local / non-Actions runs still get a stable
@@ -259,6 +53,73 @@ fn comment_key(command: &str, job: Option<String>) -> String {
         None if command.is_empty() => "heph".to_string(),
         None => command.to_string(),
     }
+}
+
+/// Longest command label rendered into a public comment.
+const MAX_COMMAND_LABEL: usize = 120;
+
+/// A safe label for the heph command being run, for the comment heading and the
+/// section key.
+///
+/// **Never the raw argv.** The comment is public on the PR, and joining
+/// `std::env::args()` publishes every flag — including any `--define`/`--env`
+/// carrying a secret.
+///
+/// This is an **allowlist, not a blocklist**: only the subcommand and things
+/// that look like target selectors (`//…`, `:…`, `…`) are kept. A blocklist that
+/// tried to pair flags with their values would have to know which flags are
+/// boolean — get that wrong in one direction and a selector is dropped, wrong in
+/// the other and a secret is published. Recognising the two shapes worth showing
+/// cannot leak a `--define` value, because a secret does not look like a target.
+fn command_label() -> String {
+    command_label_from(std::env::args().skip(1))
+}
+
+/// The filtering behind [`command_label`], over a supplied argument list so it
+/// can be tested without depending on how the test harness was invoked.
+fn command_label_from(args: impl Iterator<Item = String>) -> String {
+    let mut parts: Vec<String> = Vec::new();
+    let mut have_subcommand = false;
+    for arg in args {
+        if arg.starts_with('-') {
+            continue;
+        }
+        let is_selector = arg.starts_with("//") || arg.starts_with(':') || arg == "...";
+        if is_selector {
+            parts.push(arg);
+            continue;
+        }
+        // The first bare word is the subcommand (`run`, `query`, …). Later bare
+        // words are flag values and are dropped.
+        if !have_subcommand {
+            have_subcommand = true;
+            parts.push(arg);
+        }
+    }
+    let joined = parts.join(" ");
+    if joined.chars().count() <= MAX_COMMAND_LABEL {
+        return joined;
+    }
+    joined
+        .chars()
+        .take(MAX_COMMAND_LABEL)
+        .chain(std::iter::once('…'))
+        .collect()
+}
+
+/// A link to the current workflow run, when the Actions env provides one.
+fn run_url_from_env() -> Option<String> {
+    let server = std::env::var("GITHUB_SERVER_URL")
+        .ok()
+        .filter(|s| !s.is_empty())
+        .unwrap_or_else(|| "https://github.com".to_string());
+    let repo = std::env::var("GITHUB_REPOSITORY")
+        .ok()
+        .filter(|s| !s.is_empty())?;
+    let run = std::env::var("GITHUB_RUN_ID")
+        .ok()
+        .filter(|s| !s.is_empty())?;
+    Some(format!("{server}/{repo}/actions/runs/{run}"))
 }
 
 /// Shared GitHub REST auth/version headers.
@@ -583,7 +444,7 @@ impl CommentClient {
 
 struct Inner {
     tally: Mutex<Tally>,
-    /// The summary H2 + comment heading: `heph: <command>`.
+    /// The summary H2 + comment heading: `heph <command>`.
     title: String,
     /// Final step-summary path; `None` disables the end-of-run file write.
     summary_path: Option<PathBuf>,
@@ -592,27 +453,72 @@ struct Inner {
     comment: Option<CommentClient>,
     /// Set by `on_close` so the live-update thread exits.
     stop: AtomicBool,
+    /// Threshold for "running longest" rows and lock-wait notices.
+    slow_after_ms: u64,
+    /// Whether this invocation stops at the first failure. Reported, never set:
+    /// a reporter that changes which targets execute is the wrong shape.
+    fail_fast: bool,
+    /// Link to the workflow run, when the Actions env provides one.
+    run_url: Option<String>,
 }
 
 impl Inner {
-    /// The full status markdown for the current tally.
-    fn render_markdown(&self) -> String {
-        let tally = self.tally.lock().unwrap_or_else(|e| e.into_inner());
-        tally.render_markdown(now_unix_ms(), &self.title)
+    fn ctx(&self) -> render::RenderCtx<'_> {
+        render::RenderCtx {
+            heading: &self.title,
+            now_ms: now_unix_ms(),
+            slow_after_ms: self.slow_after_ms,
+            run_url: self.run_url.as_deref(),
+            fail_fast: self.fail_fast,
+        }
     }
 
-    /// Write the full markdown to the step-summary file once, at the end of the
-    /// run. Atomic (temp + rename) so a reader never sees a half-written file.
+    /// The live comment body for the current tally.
+    ///
+    /// Budgeted well under GitHub's 65,536-character comment cap: this is one
+    /// section inside a body shared with every other heph step in the job, and
+    /// `assemble_body` concatenates them all.
+    fn render_live(&self) -> String {
+        let tally = self.tally.lock().unwrap_or_else(|e| e.into_inner());
+        render::render_live(&tally, &self.ctx(), render::LIVE_SECTION_BUDGET)
+    }
+
+    /// The end-of-run report for `$GITHUB_STEP_SUMMARY`.
+    fn render_final(&self) -> String {
+        let tally = self.tally.lock().unwrap_or_else(|e| e.into_inner());
+        render::render_final(&tally, &self.ctx(), render::SUMMARY_BUDGET)
+    }
+
+    /// Append the final report to the step-summary file.
+    ///
+    /// **Append, not replace.** `$GITHUB_STEP_SUMMARY` is a per-step append
+    /// target (the documented usage is `echo >> $GITHUB_STEP_SUMMARY`), so the
+    /// previous write-then-rename destroyed anything an earlier command in the
+    /// same step had written — including a user's own summary lines.
+    ///
+    /// Both failure paths are logged. The previous form,
+    /// `if write().is_ok() && let Err(e) = rename()`, short-circuited on a failed
+    /// *write*, so a full disk or a permissions error produced no summary and no
+    /// warning either.
     fn write_summary(&self) {
         let Some(path) = &self.summary_path else {
             return;
         };
-        let markdown = self.render_markdown();
-        let tmp = path.with_extension("heph-tmp");
-        if std::fs::write(&tmp, markdown.as_bytes()).is_ok()
-            && let Err(e) = std::fs::rename(&tmp, path)
-        {
-            tracing::warn!("failed to write step summary: {e}");
+        let markdown = self.render_final();
+        let opened = std::fs::OpenOptions::new()
+            .create(true)
+            .append(true)
+            .open(path);
+        match opened {
+            Ok(mut f) => {
+                use std::io::Write;
+                if let Err(e) = f.write_all(markdown.as_bytes()) {
+                    tracing::warn!(path = %path.display(), "writing step summary failed: {e}");
+                }
+            }
+            Err(e) => {
+                tracing::warn!(path = %path.display(), "opening step summary failed: {e}");
+            }
         }
     }
 }
@@ -626,16 +532,23 @@ impl GhaHook {
     /// Build from the plugin's `options:` map. Options (all optional):
     /// `refreshSecs` (live PR-comment PATCH interval, default 30), `summaryPath`
     /// (final step-summary file, default `$GITHUB_STEP_SUMMARY`), `tokenEnv` (name
-    /// of the env var holding the API token, default `GITHUB_TOKEN`). Spawns the
-    /// live-update thread when a PR comment can be created.
+    /// of the env var holding the API token, default `GITHUB_TOKEN`),
+    /// `slowAfterSecs` (how long a target must run before it is surfaced,
+    /// default 30). Spawns the live-update thread when a PR comment can be
+    /// created.
     pub fn from_options(opts: &Options) -> anyhow::Result<Self> {
         deny_unknown(
             "gha hook",
             opts,
-            &["refreshSecs", "summaryPath", "tokenEnv"],
+            &["refreshSecs", "summaryPath", "tokenEnv", "slowAfterSecs"],
         )?;
         tracing::info!("gha hook loaded");
         let refresh_secs: u64 = decode_opt(opts, "gha hook", "refreshSecs")?
+            .unwrap_or(30)
+            .max(1);
+        // 30s, not the previous hardcoded 10s: with a 30-second refresh, a 10s
+        // threshold lists half of a cold build as "slow".
+        let slow_after_secs: u64 = decode_opt(opts, "gha hook", "slowAfterSecs")?
             .unwrap_or(30)
             .max(1);
         let summary_path = decode_opt::<String>(opts, "gha hook", "summaryPath")?
@@ -647,14 +560,15 @@ impl GhaHook {
                  no step summary will be written"
             );
         }
-        // The plugin shares the heph process, so its args ARE the heph command:
-        // skip the binary (argv[0]) and join the rest, e.g. `run //foo:bar`.
-        let command = std::env::args().skip(1).collect::<Vec<_>>().join(" ");
+        // The plugin shares the heph process, so its args ARE the heph command.
+        let command = command_label();
         let title = if command.is_empty() {
             "heph".to_string()
         } else {
-            format!("heph: {command}")
+            format!("heph {command}")
         };
+        let fail_fast = std::env::args().any(|a| a == "--fail-fast" || a == "--ff");
+        let run_url = run_url_from_env();
 
         let token_env = decode_opt::<String>(opts, "gha hook", "tokenEnv")?;
         // One sticky PR comment per job (keyed by GITHUB_JOB, command as fallback);
@@ -680,6 +594,9 @@ impl GhaHook {
             summary_path,
             comment,
             stop: AtomicBool::new(false),
+            slow_after_ms: slow_after_secs.saturating_mul(1000),
+            fail_fast,
+            run_url,
         });
 
         // Live updates run only when a comment is configured. A plain thread (no
@@ -690,7 +607,7 @@ impl GhaHook {
             let t = Arc::clone(&inner);
             std::thread::spawn(move || {
                 if let Some(c) = &t.comment {
-                    c.sync(t.render_markdown());
+                    c.sync(t.render_live());
                 }
                 while !t.stop.load(Ordering::Acquire) {
                     std::thread::sleep(Duration::from_secs(refresh_secs));
@@ -698,7 +615,7 @@ impl GhaHook {
                         break;
                     }
                     if let Some(c) = &t.comment {
-                        c.sync(t.render_markdown());
+                        c.sync(t.render_live());
                     }
                 }
             });
@@ -731,9 +648,9 @@ impl Hook for GhaHook {
             .tally
             .lock()
             .unwrap_or_else(|e| e.into_inner())
-            .closed = true;
+            .set_closed();
         if let Some(c) = &self.inner.comment {
-            c.sync(self.inner.render_markdown());
+            c.sync(self.inner.render_live());
         }
         self.inner.write_summary();
     }
@@ -742,243 +659,13 @@ impl Hook for GhaHook {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use hcore::events::BuildEventKind;
 
     fn ev(at: u64, kind: BuildEventKind) -> BuildEvent {
         BuildEvent {
             at_unix_ms: at,
             kind,
         }
-    }
-
-    fn scripted() -> Tally {
-        let mut t = Tally::default();
-        t.apply(&ev(
-            0,
-            BuildEventKind::Matched {
-                addrs: vec!["//a:x".into(), "//a:y".into(), "//a:z".into()],
-                complete: true,
-            },
-        ));
-        // x: built
-        t.apply(&ev(
-            10,
-            BuildEventKind::ExecuteStart {
-                addr: "//a:x".into(),
-                driver: "exec".into(),
-                cache: true,
-            },
-        ));
-        t.apply(&ev(
-            20,
-            BuildEventKind::ExecuteEnd {
-                addr: "//a:x".into(),
-                error: None,
-            },
-        ));
-        t.apply(&ev(
-            20,
-            BuildEventKind::ResultEnd {
-                addr: "//a:x".into(),
-                error: None,
-            },
-        ));
-        // y: cache hit, finished
-        t.apply(&ev(
-            15,
-            BuildEventKind::LocalCacheHit {
-                addr: "//a:y".into(),
-            },
-        ));
-        t.apply(&ev(
-            15,
-            BuildEventKind::ResultEnd {
-                addr: "//a:y".into(),
-                error: None,
-            },
-        ));
-        // z: started long ago, still running (slow), then a separate failure
-        t.apply(&ev(
-            0,
-            BuildEventKind::ExecuteStart {
-                addr: "//a:z".into(),
-                driver: "exec".into(),
-                cache: false,
-            },
-        ));
-        t.apply(&ev(
-            30,
-            BuildEventKind::ResultEnd {
-                addr: "//a:w".into(),
-                error: Some("boom".into()),
-            },
-        ));
-        t
-    }
-
-    #[test]
-    fn markdown_reports_counts_slow_and_failures() {
-        let mut t = scripted();
-        // The build has ended (stream closed) with a failure recorded.
-        t.closed = true;
-        // now far enough past //a:z's start to mark it slow.
-        let md = t.render_markdown(SLOW_THRESHOLD_MS + 5_000, "heph: test");
-
-        // The H2 is the heph command, led by a status emoji (❌ — there's a failure).
-        assert!(md.contains("## ❌ heph: test"), "command heading: {md}");
-        // 2 of 3 matched finished (x, y); w finished but isn't in the matched set.
-        assert!(md.contains("2 / 3"), "progress: {md}");
-        assert!(md.contains("**built:** 1"), "built: {md}");
-        assert!(md.contains("**cached:** 1"), "cached: {md}");
-        assert!(md.contains("**failed:** 1"), "failed: {md}");
-        // //a:z is still running past the threshold — in the collapsible.
-        assert!(
-            md.contains("<details><summary>🐢 Slow targets (1)</summary>"),
-            "slow collapsible: {md}"
-        );
-        assert!(md.contains("</details>"), "collapsible closed: {md}");
-        assert!(md.contains("//a:z"), "slow target listed: {md}");
-        // failure surfaced with its message.
-        assert!(md.contains("### Failed"), "failed section: {md}");
-        assert!(
-            md.contains("//a:w") && md.contains("boom"),
-            "failure detail: {md}"
-        );
-    }
-
-    #[test]
-    fn cached_count_includes_remote_hits() {
-        let mut t = Tally::default();
-        t.apply(&ev(
-            0,
-            BuildEventKind::Matched {
-                addrs: vec!["//a:local".into(), "//a:remote".into()],
-                complete: true,
-            },
-        ));
-        // One local hit and one remote hit — both are cache hits.
-        t.apply(&ev(
-            1,
-            BuildEventKind::LocalCacheHit {
-                addr: "//a:local".into(),
-            },
-        ));
-        t.apply(&ev(
-            2,
-            BuildEventKind::RemoteCacheHit {
-                addr: "//a:remote".into(),
-            },
-        ));
-        assert_eq!(t.cached_count(), 2, "remote hit must count as cached");
-    }
-
-    #[test]
-    fn status_emoji_tracks_invocation_outcome() {
-        let mut t = Tally::default();
-        t.apply(&ev(
-            0,
-            BuildEventKind::Matched {
-                addrs: vec!["//a:x".into()],
-                complete: true,
-            },
-        ));
-        // Stream still open → running, regardless of how much has finished.
-        assert_eq!(t.status_emoji(), "⏳");
-        assert!(
-            t.render_markdown(0, "heph: test")
-                .contains("## ⏳ heph: test")
-        );
-        t.apply(&ev(
-            1,
-            BuildEventKind::ResultEnd {
-                addr: "//a:x".into(),
-                error: None,
-            },
-        ));
-        assert_eq!(
-            t.status_emoji(),
-            "⏳",
-            "still running until the stream closes"
-        );
-
-        // Stream closes with no failure → success.
-        t.closed = true;
-        assert_eq!(t.status_emoji(), "✅");
-
-        // A failure flips a closed invocation to failed.
-        t.apply(&ev(
-            2,
-            BuildEventKind::ResultEnd {
-                addr: "//a:x".into(),
-                error: Some("boom".into()),
-            },
-        ));
-        assert_eq!(t.status_emoji(), "❌");
-    }
-
-    #[test]
-    fn slow_target_names_its_active_phase() {
-        let mut t = Tally::default();
-        // Stuck pulling from the remote cache (not executing).
-        t.apply(&ev(
-            0,
-            BuildEventKind::RemoteCacheReadStart {
-                addr: "//a:p".into(),
-            },
-        ));
-        let md = t.render_markdown(SLOW_THRESHOLD_MS + 1, "heph: test");
-        assert!(md.contains("//a:p"), "slow target listed: {md}");
-        assert!(md.contains("cache pull"), "phase labelled: {md}");
-        assert!(md.contains("| phase |"), "phase column header: {md}");
-
-        // Its end clears it — no longer slow.
-        t.apply(&ev(
-            0,
-            BuildEventKind::RemoteCacheReadEnd {
-                addr: "//a:p".into(),
-                error: None,
-            },
-        ));
-        assert!(
-            !t.render_markdown(SLOW_THRESHOLD_MS + 1, "heph: test")
-                .contains("### Slow"),
-            "cleared on phase end"
-        );
-    }
-
-    #[test]
-    fn slow_list_capped_to_top_n() {
-        let mut t = Tally::default();
-        // Many concurrent long-running targets; the slowest started earliest.
-        for i in 0..(MAX_SLOW_ROWS + 5) {
-            t.apply(&ev(
-                i as u64,
-                BuildEventKind::ExecuteStart {
-                    addr: format!("//a:t{i}"),
-                    driver: "exec".into(),
-                    cache: false,
-                },
-            ));
-        }
-        let md = t.render_markdown(1_000_000, "heph: test");
-        let rows = md.matches("| `//a:t").count();
-        assert_eq!(rows, MAX_SLOW_ROWS, "slow rows capped: {rows}");
-        assert!(md.contains("…and 5 more"), "overflow line: {md}");
-    }
-
-    #[test]
-    fn provisional_total_until_matcher_complete() {
-        let mut t = Tally::default();
-        t.apply(&ev(
-            0,
-            BuildEventKind::Matched {
-                addrs: vec!["//a:x".into()],
-                complete: false,
-            },
-        ));
-        assert!(
-            t.render_markdown(0, "heph: test").contains("~1"),
-            "provisional total"
-        );
     }
 
     #[test]
@@ -1067,34 +754,6 @@ mod tests {
     }
 
     #[test]
-    fn status_settles_to_success_when_stream_closes() {
-        let mut t = Tally::default();
-        // Matched a target that never finishes (e.g. a transparent group emits no
-        // ResultEnd), and the matcher set was never marked complete.
-        t.apply(&ev(
-            0,
-            BuildEventKind::Matched {
-                addrs: vec!["//a:grp".into()],
-                complete: false,
-            },
-        ));
-        assert_eq!(t.status_emoji(), "⏳", "still running before close");
-
-        // Stream closes: build is over, nothing failed → success, not stuck ⏳.
-        t.closed = true;
-        assert_eq!(t.status_emoji(), "✅");
-        assert!(
-            t.render_markdown(0, "heph: test")
-                .contains("## ✅ heph: test"),
-            "checkbox in final render"
-        );
-
-        // A failure still wins over the closed-success default.
-        t.failed.push(("//a:grp".into(), Some("boom".into())));
-        assert_eq!(t.status_emoji(), "❌");
-    }
-
-    #[test]
     fn pr_number_extracted_from_event_and_ref() {
         let payload = serde_json::json!({ "pull_request": { "number": 122 } }).to_string();
         assert_eq!(pr_number_from_json(payload.as_bytes()), Some(122));
@@ -1105,22 +764,32 @@ mod tests {
         assert_eq!(pr_number_from_ref("refs/heads/main"), None);
     }
 
-    #[test]
-    fn on_close_writes_final_summary_to_path() {
-        let dir = tempfile::tempdir().expect("tempdir");
-        let path = dir.path().join("summary.md");
+    fn hook_writing_to(path: &std::path::Path) -> GhaHook {
         let opts: Options = [(
             "summaryPath".to_string(),
             serde_yaml::Value::String(path.to_string_lossy().into_owned()),
         )]
         .into_iter()
         .collect();
-        let hook = GhaHook::from_options(&opts).expect("hook");
+        GhaHook::from_options(&opts).expect("hook")
+    }
+
+    #[test]
+    fn on_close_writes_final_summary_to_path() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let path = dir.path().join("summary.md");
+        let hook = hook_writing_to(&path);
         hook.on_event(&ev(
             0,
             BuildEventKind::Matched {
                 addrs: vec!["//a:x".into()],
                 complete: true,
+            },
+        ));
+        hook.on_event(&ev(
+            0,
+            BuildEventKind::LocalCacheHit {
+                addr: "//a:x".into(),
             },
         ));
         hook.on_event(&ev(
@@ -1133,6 +802,90 @@ mod tests {
         hook.on_close();
 
         let written = std::fs::read_to_string(&path).expect("summary written");
-        assert!(written.contains("1 / 1"), "final summary: {written}");
+        assert!(written.contains("✅"), "final summary: {written}");
+        assert!(
+            written.contains("nothing executed"),
+            "all-cached one-liner: {written}"
+        );
+    }
+
+    #[test]
+    fn step_summary_is_appended_not_clobbered() {
+        // `$GITHUB_STEP_SUMMARY` is a per-step *append* target. The previous
+        // write-then-rename destroyed whatever an earlier command in the same
+        // step had written there.
+        let dir = tempfile::tempdir().expect("tempdir");
+        let path = dir.path().join("summary.md");
+        std::fs::write(&path, "## Set up by an earlier step\n").expect("seed");
+
+        let hook = hook_writing_to(&path);
+        hook.on_event(&ev(
+            0,
+            BuildEventKind::Matched {
+                addrs: vec!["//a:x".into()],
+                complete: true,
+            },
+        ));
+        hook.on_close();
+
+        let written = std::fs::read_to_string(&path).expect("summary written");
+        assert!(
+            written.contains("Set up by an earlier step"),
+            "pre-existing content preserved: {written}"
+        );
+        assert!(
+            written.contains("heph"),
+            "heph's report appended: {written}"
+        );
+    }
+
+    #[test]
+    fn a_failed_summary_write_is_logged_not_swallowed() {
+        // The path is a directory, so opening it for append fails. The old code
+        // short-circuited on a failed write and logged nothing at all; this must
+        // at minimum not panic and not create a file.
+        let dir = tempfile::tempdir().expect("tempdir");
+        let path = dir.path().join("a-directory");
+        std::fs::create_dir(&path).expect("mkdir");
+
+        let hook = hook_writing_to(&path);
+        hook.on_close();
+
+        assert!(path.is_dir(), "still a directory, nothing clobbered");
+    }
+
+    #[test]
+    fn command_label_drops_flags_and_their_values() {
+        // The comment is public on the PR: a `--define`/`--env` carrying a secret
+        // must never reach it.
+        assert_eq!(label_from(&["run", "//foo:bar"]), "run //foo:bar");
+        assert_eq!(
+            label_from(&["run", "--define", "TOKEN=hunter2", "//foo:bar"]),
+            "run //foo:bar"
+        );
+        assert_eq!(
+            label_from(&["run", "--env=SECRET=hunter2", "//foo:bar"]),
+            "run //foo:bar"
+        );
+        // A boolean flag must not swallow the selector that follows it.
+        assert_eq!(label_from(&["run", "--ff", "//a:b"]), "run //a:b");
+        // A flag value that is a bare word is dropped, not mistaken for a target.
+        assert_eq!(
+            label_from(&["run", "--token", "hunter2", "//a:b"]),
+            "run //a:b"
+        );
+        assert_eq!(label_from(&["query", "..."]), "query ...");
+        // Over-long labels are capped rather than published whole.
+        let long: Vec<String> = (0..100).map(|i| format!("//pkg{i}:target")).collect();
+        let refs: Vec<&str> = long.iter().map(String::as_str).collect();
+        let out = label_from(&refs);
+        assert!(
+            out.chars().count() <= MAX_COMMAND_LABEL + 1,
+            "capped: {out}"
+        );
+    }
+
+    fn label_from(args: &[&str]) -> String {
+        command_label_from(args.iter().map(|s| (*s).to_string()))
     }
 }

--- a/crates/plugin-gha/src/lib.rs
+++ b/crates/plugin-gha/src/lib.rs
@@ -455,9 +455,6 @@ struct Inner {
     stop: AtomicBool,
     /// Threshold for "running longest" rows and lock-wait notices.
     slow_after_ms: u64,
-    /// Whether this invocation stops at the first failure. Reported, never set:
-    /// a reporter that changes which targets execute is the wrong shape.
-    fail_fast: bool,
     /// Link to the workflow run, when the Actions env provides one.
     run_url: Option<String>,
 }
@@ -469,7 +466,6 @@ impl Inner {
             now_ms: now_unix_ms(),
             slow_after_ms: self.slow_after_ms,
             run_url: self.run_url.as_deref(),
-            fail_fast: self.fail_fast,
         }
     }
 
@@ -567,7 +563,6 @@ impl GhaHook {
         } else {
             format!("heph {command}")
         };
-        let fail_fast = std::env::args().any(|a| a == "--fail-fast" || a == "--ff");
         let run_url = run_url_from_env();
 
         let token_env = decode_opt::<String>(opts, "gha hook", "tokenEnv")?;
@@ -595,7 +590,6 @@ impl GhaHook {
             comment,
             stop: AtomicBool::new(false),
             slow_after_ms: slow_after_secs.saturating_mul(1000),
-            fail_fast,
             run_url,
         });
 

--- a/crates/plugin-gha/src/render.rs
+++ b/crates/plugin-gha/src/render.rs
@@ -207,7 +207,6 @@ pub(crate) struct RenderCtx<'a> {
     pub slow_after_ms: u64,
     /// A link to the workflow run, when one can be built from the environment.
     pub run_url: Option<&'a str>,
-    pub fail_fast: bool,
 }
 
 fn counts_line(t: &Tally, c: &Counters) -> String {
@@ -299,13 +298,6 @@ pub(crate) fn render_live(t: &Tally, ctx: &RenderCtx<'_>, budget: usize) -> Stri
             "↑ {} cache uploads in flight (background)\n",
             fmt_count(t.background_ops())
         ));
-    }
-
-    if ctx.fail_fast && c.roots_total > 0 {
-        b.push(
-            "\n> [!WARNING]\n> Stopped at the first failure (`--fail-fast`) — \
-             remaining targets were not attempted.\n",
-        );
     }
 
     push_lock_waits(&mut b, t, ctx);
@@ -696,7 +688,6 @@ mod tests {
             now_ms,
             slow_after_ms: 30_000,
             run_url: None,
-            fail_fast: false,
         }
     }
 
@@ -1070,17 +1061,6 @@ mod tests {
         assert_eq!(fmt_count(4_117), "4,117");
         assert_eq!(fmt_count(20_140), "20,140");
         assert_eq!(fmt_count(7), "7");
-    }
-
-    #[test]
-    fn fail_fast_mode_is_disclosed() {
-        // Otherwise a one-failure report reads as "one thing is broken" when the
-        // truth is "we stopped looking".
-        let t = build(20_000, 1, 0);
-        let mut c = ctx("heph run //...", 9_000);
-        c.fail_fast = true;
-        let md = render_live(&t, &c, COMMENT_LIMIT);
-        assert!(md.contains("Stopped at the first failure"), "{md}");
     }
 
     /// Prints the rendered views for eyeballing against the mockups in

--- a/crates/plugin-gha/src/render.rs
+++ b/crates/plugin-gha/src/render.rs
@@ -1,0 +1,1142 @@
+//! Markdown renderers for the GitHub Actions hook.
+//!
+//! Two renderers, not one, because the live comment and the final step summary
+//! are different products (see `docs/GHA_REPORTING.md` §2):
+//!
+//! - [`render_live`] answers *pass? stuck? how long? is it mine?* for someone
+//!   glancing at a PR comment on a phone. ≤8 lines, failures first, no wide
+//!   tables, and it self-dates so a stale comment is distinguishable from a slow
+//!   build.
+//! - [`render_final`] answers *what broke and why, how long, what did cache do*
+//!   for someone debugging a red build, and for an agent deciding what to do
+//!   next.
+//!
+//! Reusing one renderer for both is what made the old summary ship a
+//! "slow targets" table that was structurally near-empty: it reported
+//! *currently-running* targets at the moment everything had finished.
+//!
+//! # Byte budgets
+//!
+//! Every render takes a **byte budget** and is guaranteed not to exceed it.
+//! This is a correctness requirement, not tidiness: GitHub caps an issue comment
+//! at 65,536 characters, and over that it answers 422 — which the old code
+//! turned into a `tracing::warn!` nobody reads, leaving the comment frozen at its
+//! last good body for the rest of the job. It broke exactly when the report
+//! mattered most, because the thing that blew the budget was having many
+//! failures.
+//!
+//! Row *counts* are not a budget: a failure message is
+//! `format!("{e:#}")` over an anyhow chain, which is the whole cause chain on one
+//! line, unbounded in width. So every variable-length field is capped in
+//! characters, sections are emitted in priority order, and anything dropped says
+//! so.
+
+use crate::tally::{Counters, Tally};
+
+/// GitHub's hard cap on an issue-comment body.
+pub(crate) const COMMENT_LIMIT: usize = 65_536;
+
+/// GitHub's hard cap on `$GITHUB_STEP_SUMMARY`. Rendered with headroom.
+pub(crate) const SUMMARY_BUDGET: usize = 900 * 1024;
+
+/// Budget for **one step's section** of the shared comment.
+///
+/// A job's comment holds a section per heph step, all concatenated by
+/// `assemble_body`, plus the hidden markers. Budgeting a single section at the
+/// full comment limit would let one step consume the whole body and 422 the
+/// next; a quarter leaves room for several steps and the markers.
+pub(crate) const LIVE_SECTION_BUDGET: usize = COMMENT_LIMIT / 4;
+
+/// Longest single failure message rendered. The full text is in the job log and
+/// the JSON document; the report is an index, not a transcript.
+const MAX_MSG_CHARS: usize = 200;
+
+/// Longest addr rendered inline.
+const MAX_ADDR_CHARS: usize = 128;
+
+/// Live view: sample sizes. Small on purpose — on a phone the count is the
+/// signal and the rows are the illustration.
+const LIVE_RUNNING_ROWS: usize = 6;
+const LIVE_LOCK_ROWS: usize = 3;
+const LIVE_ROOT_ROWS: usize = 5;
+/// Log-tail lines shown live, for the first root only.
+const LIVE_LOG_LINES: usize = 5;
+const LIVE_LOG_BYTES: usize = 1024;
+
+/// Final view: table sizes.
+const FINAL_SLOWEST_ROWS: usize = 20;
+const FINAL_PKG_ROWS: usize = 15;
+
+/// A `String` that will not grow past a byte budget.
+///
+/// Sections push into it and check the return value: a section that does not fit
+/// is skipped whole rather than half-written, so the output is never a truncated
+/// table row or an unterminated `<details>`.
+pub(crate) struct Budgeted {
+    out: String,
+    budget: usize,
+    truncated: bool,
+}
+
+impl Budgeted {
+    pub(crate) fn new(budget: usize) -> Self {
+        Self {
+            out: String::new(),
+            budget,
+            truncated: false,
+        }
+    }
+
+    /// Push if it fits. Returns whether it was written.
+    fn push(&mut self, s: &str) -> bool {
+        // Reserve room for the truncation notice so it can always be appended.
+        const RESERVE: usize = 64;
+        if self
+            .out
+            .len()
+            .saturating_add(s.len())
+            .saturating_add(RESERVE)
+            > self.budget
+        {
+            self.truncated = true;
+            return false;
+        }
+        self.out.push_str(s);
+        true
+    }
+
+    pub(crate) fn finish(mut self) -> String {
+        if self.truncated {
+            self.out.push_str("\n_…output truncated to fit._\n");
+        }
+        self.out
+    }
+}
+
+/// Truncate to at most `max` characters, on a character boundary, with an
+/// ellipsis when anything was dropped.
+///
+/// Character-counting rather than byte-slicing is required, not stylistic: an
+/// addr or an error message can contain multi-byte UTF-8, and a byte-index slice
+/// through one is a panic. The workspace also denies raw string slicing for
+/// exactly this reason.
+fn truncate_chars(s: &str, max: usize) -> String {
+    let mut out = String::new();
+    for (i, c) in s.chars().enumerate() {
+        if i >= max {
+            out.push('…');
+            return out;
+        }
+        out.push(c);
+    }
+    out
+}
+
+/// Collapse a message to its first line, capped. `format!("{e:#}")` puts the
+/// whole anyhow chain on one line, so this is a width cap, not a line cap.
+fn one_line(msg: &str, max: usize) -> String {
+    let first = msg.lines().next().unwrap_or("");
+    truncate_chars(first.trim(), max)
+}
+
+fn addr_cell(addr: &str) -> String {
+    truncate_chars(addr, MAX_ADDR_CHARS)
+}
+
+/// `4m12s`, `58s`, `1h04m`.
+pub(crate) fn fmt_duration(ms: u64) -> String {
+    let secs = ms / 1000;
+    if secs < 60 {
+        return format!("{secs}s");
+    }
+    if secs < 3_600 {
+        return format!("{}m{:02}s", secs / 60, secs % 60);
+    }
+    format!("{}h{:02}m", secs / 3_600, (secs % 3_600) / 60)
+}
+
+/// `1,412` — thousands separators, because the difference between 4117 and 41171
+/// is not scannable at a glance and these numbers are read at a glance.
+fn fmt_count(n: usize) -> String {
+    let s = n.to_string();
+    let mut out = String::new();
+    let len = s.chars().count();
+    for (i, c) in s.chars().enumerate() {
+        if i > 0 && (len - i).is_multiple_of(3) {
+            out.push(',');
+        }
+        out.push(c);
+    }
+    out
+}
+
+/// A 20-cell progress bar. Unicode blocks rather than an image: a badge would be
+/// an external HTTP dependency inside a build report.
+fn progress_bar(done: usize, total: usize) -> String {
+    const CELLS: usize = 20;
+    if total == 0 {
+        return "░".repeat(CELLS);
+    }
+    let filled = (done.saturating_mul(CELLS))
+        .saturating_div(total)
+        .min(CELLS);
+    let mut s = String::with_capacity(CELLS * 3);
+    for i in 0..CELLS {
+        s.push(if i < filled { '█' } else { '░' });
+    }
+    s
+}
+
+/// `updated 14:02:11Z`, quantized to 5-second granularity.
+///
+/// Quantization is what makes unchanged-body suppression possible at all: an
+/// unquantized clock changes every render, so every timer tick would PATCH even
+/// when nothing about the build changed.
+pub(crate) fn fmt_clock(unix_ms: u64) -> String {
+    let secs = (unix_ms / 1000) / 5 * 5;
+    let h = (secs / 3600) % 24;
+    let m = (secs / 60) % 60;
+    let s = secs % 60;
+    format!("{h:02}:{m:02}:{s:02}Z")
+}
+
+/// Inputs both renderers share.
+pub(crate) struct RenderCtx<'a> {
+    pub heading: &'a str,
+    pub now_ms: u64,
+    pub slow_after_ms: u64,
+    /// A link to the workflow run, when one can be built from the environment.
+    pub run_url: Option<&'a str>,
+    pub fail_fast: bool,
+}
+
+fn counts_line(t: &Tally, c: &Counters) -> String {
+    let (done, total, complete) = t.progress();
+    let total_str = if complete {
+        fmt_count(total)
+    } else {
+        format!("~{}", fmt_count(total))
+    };
+    format!(
+        "**{} / {}** done · {} cached · {} executed · **{} failed**\n",
+        fmt_count(done),
+        total_str,
+        fmt_count(c.cached()),
+        fmt_count(c.executed),
+        fmt_count(c.roots_total),
+    )
+}
+
+/// Render the **live** view — the sticky PR comment while the build runs.
+///
+/// Ordering is most-alarming-first: failures come above the counts, because they
+/// are the reason anyone opens the comment. Only *root* failures are listed;
+/// collateral is a number. At 20k targets one broken leaf can block thousands of
+/// targets, and rendering a row each would push the actual cause off the bottom
+/// of a phone screen.
+pub(crate) fn render_live(t: &Tally, ctx: &RenderCtx<'_>, budget: usize) -> String {
+    let mut b = Budgeted::new(budget);
+    let c = t.counters();
+    let elapsed = t.elapsed_ms(ctx.now_ms);
+
+    let status = if c.roots_total > 0 {
+        format!(
+            "## ❌ {} · **{} failed**{} · still running ({})\n\n",
+            ctx.heading,
+            fmt_count(c.roots_total),
+            if c.blocked > 0 {
+                format!(" (+{} blocked)", fmt_count(c.blocked))
+            } else {
+                String::new()
+            },
+            fmt_duration(elapsed),
+        )
+    } else {
+        format!(
+            "## {} {} · {}\n\n",
+            t.status_emoji(),
+            ctx.heading,
+            fmt_duration(elapsed)
+        )
+    };
+    b.push(&status);
+
+    // Failures first.
+    if c.roots_total > 0 {
+        push_live_failures(&mut b, t, &c);
+    }
+
+    // Counts + the freshness clock.
+    b.push(&counts_line(t, &c));
+    let (done, total, _) = t.progress();
+    let workers = if t.max_workers() > 0 {
+        format!(
+            " · {}/{} workers busy",
+            fmt_count(t.active_foreground().min(t.max_workers())),
+            fmt_count(t.max_workers())
+        )
+    } else {
+        String::new()
+    };
+    let pct = if total > 0 {
+        done.saturating_mul(100).saturating_div(total)
+    } else {
+        0
+    };
+    b.push(&format!(
+        "`{}` {}%{} · updated {}\n",
+        progress_bar(done, total),
+        pct,
+        workers,
+        fmt_clock(ctx.now_ms),
+    ));
+
+    if t.background_ops() > 0 {
+        // One aggregate row, never per-target: `RemoteCacheWriteStart` fires
+        // before the upload semaphore is acquired, so at 20k targets this is
+        // ~20k entries with 16 actually uploading.
+        b.push(&format!(
+            "↑ {} cache uploads in flight (background)\n",
+            fmt_count(t.background_ops())
+        ));
+    }
+
+    if ctx.fail_fast && c.roots_total > 0 {
+        b.push(
+            "\n> [!WARNING]\n> Stopped at the first failure (`--fail-fast`) — \
+             remaining targets were not attempted.\n",
+        );
+    }
+
+    push_lock_waits(&mut b, t, ctx);
+    push_running_longest(&mut b, t, ctx);
+
+    if c.roots_total > 0 {
+        b.push("\n_Build continues — remaining targets still running._\n");
+    }
+
+    b.finish()
+}
+
+fn push_live_failures(b: &mut Budgeted, t: &Tally, c: &Counters) {
+    let roots = t.roots();
+    let mut alert = format!(
+        "> [!CAUTION]\n> **{} root failure{}**",
+        fmt_count(c.roots_total),
+        if c.roots_total == 1 { "" } else { "s" }
+    );
+    if c.blocked > 0 {
+        alert.push_str(&format!(
+            " — {} targets blocked downstream",
+            fmt_count(c.blocked)
+        ));
+    }
+    alert.push_str(".\n\n");
+    b.push(&alert);
+
+    for (i, r) in roots.iter().take(LIVE_ROOT_ROWS).enumerate() {
+        let dur = r
+            .duration_ms
+            .map(|d| format!(", after {}", fmt_duration(d)))
+            .unwrap_or_default();
+        let mut section = format!(
+            "### `{}` — failed{}\n\n{}\n",
+            addr_cell(&r.addr),
+            dur,
+            one_line(&r.message, MAX_MSG_CHARS)
+        );
+        // Only the first root gets a log tail live: mid-build the reader is
+        // answering "is this mine?", and one error answers that where ten don't.
+        if i == 0
+            && let Some(tail) = live_log_tail(&r.message)
+        {
+            section.push_str(&format!("\n```\n{tail}\n```\n"));
+        }
+        section.push_str(&format!("\nReproduce: `heph run {}`\n", addr_cell(&r.addr)));
+        if r.blocked > 0 {
+            section.push_str(&format!(
+                "**{} targets blocked** — {}\n",
+                fmt_count(r.blocked),
+                pkg_rollup(r, 3)
+            ));
+        }
+        section.push('\n');
+        if !b.push(&section) {
+            break;
+        }
+    }
+    if c.roots_total > roots.len() {
+        b.push(&format!(
+            "…and {} more root failures.\n\n",
+            fmt_count(c.roots_total.saturating_sub(roots.len()))
+        ));
+    }
+}
+
+/// The log tail is not on the event stream yet (`docs/GHA_REPORTING.md` §7.1), so
+/// live rendering has only the flattened cause chain to work with. Returns
+/// `None` until `ResultEnd` carries a real tail — better nothing than a fake
+/// code block containing the same sentence already printed above it.
+fn live_log_tail(_message: &str) -> Option<String> {
+    let _ = (LIVE_LOG_LINES, LIVE_LOG_BYTES);
+    None
+}
+
+fn pkg_rollup(r: &crate::tally::RootFailure, limit: usize) -> String {
+    let mut v: Vec<(&str, usize)> = r
+        .blocked_by_pkg
+        .iter()
+        .map(|(k, n)| (k.as_ref(), *n))
+        .collect();
+    v.sort_by(|a, b| b.1.cmp(&a.1).then_with(|| a.0.cmp(b.0)));
+    let shown: Vec<String> = v
+        .iter()
+        .take(limit)
+        .map(|(p, n)| {
+            format!(
+                "`{}` ({})",
+                truncate_chars(p, MAX_ADDR_CHARS),
+                fmt_count(*n)
+            )
+        })
+        .collect();
+    let mut s = shown.join(", ");
+    if v.len() > limit {
+        s.push_str(&format!(
+            ", …{} more packages",
+            v.len().saturating_sub(limit)
+        ));
+    }
+    s
+}
+
+fn push_lock_waits(b: &mut Budgeted, t: &Tally, ctx: &RenderCtx<'_>) {
+    let (waits, total) = t.lock_waits(ctx.now_ms, ctx.slow_after_ms, LIVE_LOCK_ROWS);
+    if waits.is_empty() {
+        return;
+    }
+    b.push(&format!(
+        "\n> [!WARNING]\n> {} target{} waiting on the result lock — \
+         another heph process holds it.\n\n",
+        fmt_count(total),
+        if total == 1 { "" } else { "s" }
+    ));
+    b.push("| target | held by | waiting |\n| --- | --- | --- |\n");
+    for w in &waits {
+        let holder = match w.holder_pid {
+            Some(pid) => format!("pid {pid}"),
+            None => "unknown".to_string(),
+        };
+        let row = format!(
+            "| `{}` | {} | {} |\n",
+            addr_cell(&w.addr),
+            holder,
+            fmt_duration(ctx.now_ms.saturating_sub(w.since_ms))
+        );
+        if !b.push(&row) {
+            break;
+        }
+    }
+}
+
+fn push_running_longest(b: &mut Budgeted, t: &Tally, ctx: &RenderCtx<'_>) {
+    let (rows, total) = t.running_longest(ctx.now_ms, ctx.slow_after_ms, LIVE_RUNNING_ROWS);
+    if rows.is_empty() {
+        return;
+    }
+    // The count is the honest signal; the rows are a sample. At 20k targets
+    // "218 over 30s" is the fact — listing 218 is not an option.
+    b.push(&format!(
+        "\n<details><summary>Running longest ({} of {} over {})</summary>\n\n\
+         | target | phase | for |\n| --- | --- | --- |\n",
+        rows.len(),
+        fmt_count(total),
+        fmt_duration(ctx.slow_after_ms),
+    ));
+    for (addr, phase, elapsed) in &rows {
+        let row = format!(
+            "| `{}` | {} | {} |\n",
+            addr_cell(addr),
+            phase,
+            fmt_duration(*elapsed)
+        );
+        if !b.push(&row) {
+            break;
+        }
+    }
+    b.push("\n</details>\n");
+}
+
+/// Render the **final** view — written once to `$GITHUB_STEP_SUMMARY`.
+///
+/// Not the live view at `t = end`: it reports what *happened* (durations, cache
+/// outcome, what broke) rather than what is *happening* (currently-running
+/// targets, which at close is by definition almost nothing).
+pub(crate) fn render_final(t: &Tally, ctx: &RenderCtx<'_>, budget: usize) -> String {
+    let mut b = Budgeted::new(budget);
+    let c = t.counters();
+    let elapsed = t.elapsed_ms(ctx.now_ms);
+    let (_, total, _) = t.progress();
+
+    if c.roots_total > 0 {
+        b.push(&format!(
+            "## ❌ {} — {} of {} targets failed in {}\n\n",
+            ctx.heading,
+            fmt_count(c.roots_total),
+            fmt_count(total),
+            fmt_duration(elapsed)
+        ));
+        let mut alert = format!(
+            "> [!CAUTION]\n> **{} root failure{}**",
+            fmt_count(c.roots_total),
+            if c.roots_total == 1 { "" } else { "s" }
+        );
+        if c.blocked > 0 {
+            alert.push_str(&format!(
+                ", {} targets blocked downstream",
+                fmt_count(c.blocked)
+            ));
+        }
+        alert.push_str(".\n\n");
+        b.push(&alert);
+        push_final_failures(&mut b, t, &c);
+    } else if c.executed == 0 && c.cached() > 0 {
+        // All-cached: one line earns the whole report.
+        b.push(&format!(
+            "## ✅ {} — {} · {}/{} targets, nothing executed\n\n",
+            ctx.heading,
+            fmt_duration(elapsed),
+            fmt_count(c.cached()),
+            fmt_count(total)
+        ));
+        b.push(&format!(
+            "{} cache hits ({} local, {} remote)\n",
+            fmt_count(c.cached()),
+            fmt_count(c.cached_local),
+            fmt_count(c.cached_remote)
+        ));
+        return b.finish();
+    } else {
+        b.push(&format!(
+            "## ✅ {} — {}\n\n",
+            ctx.heading,
+            fmt_duration(elapsed)
+        ));
+    }
+
+    push_summary_table(&mut b, t, &c);
+    push_zero_hit_diagnosis(&mut b, &c);
+    push_slowest(&mut b, t);
+    push_miss_rollup(&mut b, t, &c);
+
+    if let Some(url) = ctx.run_url {
+        b.push(&format!("\n[Full log]({url})\n"));
+    }
+    b.finish()
+}
+
+fn push_summary_table(b: &mut Budgeted, t: &Tally, c: &Counters) {
+    let (done, total, _) = t.progress();
+    let mut s = String::from("| | |\n| --- | --- |\n");
+    s.push_str(&format!(
+        "| targets | {} matched · {} ok · {} failed |\n",
+        fmt_count(total),
+        fmt_count(done.saturating_sub(c.roots_total.min(done))),
+        fmt_count(c.roots_total)
+    ));
+    match c.hit_rate() {
+        Some(rate) => s.push_str(&format!(
+            "| cache | {} hits ({} local, {} remote) · **{:.1}% hit rate** · {} misses |\n",
+            fmt_count(c.cached()),
+            fmt_count(c.cached_local),
+            fmt_count(c.cached_remote),
+            rate * 100.0,
+            fmt_count(c.misses())
+        )),
+        // Never render "0%" for a cache that was never consulted.
+        None => s.push_str("| cache | not consulted |\n"),
+    }
+    s.push_str(&format!(
+        "| executed | {} targets |\n",
+        fmt_count(c.executed)
+    ));
+    if c.blocked > 0 {
+        s.push_str(&format!(
+            "| blocked | {} targets downstream of a failure |\n",
+            fmt_count(c.blocked)
+        ));
+    }
+    s.push('\n');
+    b.push(&s);
+}
+
+/// The "why did I get no cache hits" sentence.
+///
+/// Deliberately prose naming the dominant cause rather than a number: `0 cached`
+/// sends someone to Slack. The precise reason needs `MissReason` on the miss
+/// events (`docs/GHA_REPORTING.md` §7.2); until then this says what *is* known
+/// and points at the command that answers the rest.
+fn push_zero_hit_diagnosis(b: &mut Budgeted, c: &Counters) {
+    if c.cached() > 0 || c.misses() == 0 {
+        return;
+    }
+    b.push(&format!(
+        "\n> [!WARNING]\n> **0 of {} targets hit cache.** Every consulted target missed.\n\
+         > Inspect one to see what changed: `heph inspect hashin <target>`\n\n",
+        fmt_count(c.misses())
+    ));
+}
+
+fn push_final_failures(b: &mut Budgeted, t: &Tally, c: &Counters) {
+    for r in t.roots() {
+        let mut s = format!("### `{}`\n\n", addr_cell(&r.addr));
+        // A target that failed before it started executing has neither. Omit the
+        // line rather than rendering a lone `unknown`.
+        let mut meta: Vec<String> = Vec::new();
+        if let Some(d) = r.driver.as_deref() {
+            meta.push(format!("`{d}`"));
+        }
+        if let Some(d) = r.duration_ms {
+            meta.push(format!("executed {}", fmt_duration(d)));
+        }
+        if !meta.is_empty() {
+            s.push_str(&format!("{}\n\n", meta.join(" · ")));
+        }
+        s.push_str(&format!("{}\n\n", one_line(&r.message, MAX_MSG_CHARS)));
+        s.push_str(&format!("Reproduce: `heph run {}`\n", addr_cell(&r.addr)));
+        if r.blocked > 0 {
+            s.push_str(&format!(
+                "\n**{} targets blocked downstream** — {}\n",
+                fmt_count(r.blocked),
+                pkg_rollup(r, 5)
+            ));
+        }
+        s.push('\n');
+        if !b.push(&s) {
+            break;
+        }
+    }
+    let shown = t.roots().len();
+    if c.roots_total > shown {
+        b.push(&format!(
+            "…and {} more root failures.\n\n",
+            fmt_count(c.roots_total.saturating_sub(shown))
+        ));
+    }
+}
+
+fn push_slowest(b: &mut Budgeted, t: &Tally) {
+    let slowest = t.slowest();
+    if slowest.is_empty() {
+        return;
+    }
+    b.push(&format!(
+        "<details><summary>Slowest {} executed targets</summary>\n\n\
+         | target | driver | duration |\n| --- | --- | --- |\n",
+        slowest.len().min(FINAL_SLOWEST_ROWS)
+    ));
+    for cmp in slowest.iter().take(FINAL_SLOWEST_ROWS) {
+        let row = format!(
+            "| `{}` | {} | {} |\n",
+            addr_cell(&cmp.addr),
+            cmp.driver.as_deref().unwrap_or("—"),
+            fmt_duration(cmp.duration_ms)
+        );
+        if !b.push(&row) {
+            break;
+        }
+    }
+    b.push("\n</details>\n\n");
+}
+
+fn push_miss_rollup(b: &mut Budgeted, t: &Tally, c: &Counters) {
+    let (rows, total_pkgs) = t.misses_by_package(FINAL_PKG_ROWS);
+    if rows.is_empty() {
+        return;
+    }
+    // At 20k targets a per-target miss list is unreadable, and the interesting
+    // fact — that the misses are concentrated in a couple of packages — only
+    // exists at the package level.
+    b.push(&format!(
+        "<details><summary>Cache misses by package ({} across {} packages)</summary>\n\n\
+         | package | misses |\n| --- | --- |\n",
+        fmt_count(c.misses()),
+        fmt_count(total_pkgs)
+    ));
+    for (pkg, n) in &rows {
+        let row = format!("| `{}` | {} |\n", addr_cell(pkg), fmt_count(*n));
+        if !b.push(&row) {
+            break;
+        }
+    }
+    if total_pkgs > rows.len() {
+        b.push(&format!(
+            "\n_…and {} more packages._\n",
+            fmt_count(total_pkgs.saturating_sub(rows.len()))
+        ));
+    }
+    b.push("\n</details>\n\n");
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use hcore::events::{BuildEvent, BuildEventKind};
+
+    fn ev(at: u64, kind: BuildEventKind) -> BuildEvent {
+        BuildEvent {
+            at_unix_ms: at,
+            kind,
+        }
+    }
+
+    fn ctx<'a>(heading: &'a str, now_ms: u64) -> RenderCtx<'a> {
+        RenderCtx {
+            heading,
+            now_ms,
+            slow_after_ms: 30_000,
+            run_url: None,
+            fail_fast: false,
+        }
+    }
+
+    /// A build with `matched` top-level targets, `failing` root failures, and
+    /// `blocked` collateral failures under the first root.
+    fn build(matched: usize, failing: usize, blocked: usize) -> Tally {
+        let mut t = Tally::default();
+        t.apply(&ev(0, BuildEventKind::MaxWorkers { count: 64 }));
+        t.apply(&ev(
+            0,
+            BuildEventKind::Matched {
+                addrs: (0..matched)
+                    .map(|i| format!("//pkg{}:t{i}", i % 50))
+                    .collect(),
+                complete: true,
+            },
+        ));
+        for i in 0..failing {
+            t.apply(&ev(
+                1_000,
+                BuildEventKind::ResultEnd {
+                    addr: format!("//root{i}:broken"),
+                    error: Some(format!(
+                        "execute //root{i}:broken: process exited with status 1"
+                    )),
+                },
+            ));
+        }
+        for i in 0..blocked {
+            t.apply(&ev(
+                2_000,
+                BuildEventKind::ResultEnd {
+                    addr: format!("//services/api:t{i}"),
+                    error: Some(
+                        "result //services/api:t: dependency failed (root: //root0:broken)".into(),
+                    ),
+                },
+            ));
+        }
+        t
+    }
+
+    #[test]
+    fn live_view_at_20k_targets_stays_small() {
+        // The whole point of the live view: it must be readable on a phone
+        // regardless of graph size.
+        let mut t = build(20_000, 0, 0);
+        for i in 0..500 {
+            t.apply(&ev(
+                0,
+                BuildEventKind::ExecuteStart {
+                    addr: format!("//pkg{}:running{i}", i % 50),
+                    driver: "exec".into(),
+                    cache: false,
+                },
+            ));
+        }
+        let md = render_live(&t, &ctx("heph run //...", 600_000), COMMENT_LIMIT);
+        assert!(
+            md.len() < 2_000,
+            "live view stays small: {} bytes",
+            md.len()
+        );
+        assert!(md.contains("20,000"), "total shown with separators: {md}");
+        assert!(
+            md.contains("of 500 over 30s"),
+            "honest count, sampled rows: {md}"
+        );
+        assert_eq!(
+            md.matches("| `//pkg").count(),
+            LIVE_RUNNING_ROWS,
+            "running rows capped: {md}"
+        );
+    }
+
+    #[test]
+    fn live_view_puts_failures_above_the_counts() {
+        let t = build(20_000, 2, 4_117);
+        let md = render_live(&t, &ctx("heph run //...", 120_000), COMMENT_LIMIT);
+        let alert = md.find("[!CAUTION]").expect("alert present");
+        let counts = md.find("done ·").expect("counts present");
+        assert!(alert < counts, "failures come first: {md}");
+        assert!(md.contains("**2 failed** (+4,117 blocked)"), "{md}");
+    }
+
+    #[test]
+    fn a_huge_collateral_cone_renders_no_per_target_rows() {
+        // One broken leaf under 4,117 dependents. The old renderer produced a row
+        // per failure; this must produce two root sections and a count.
+        let t = build(20_000, 2, 4_117);
+        let md = render_live(&t, &ctx("heph run //...", 120_000), COMMENT_LIMIT);
+        assert!(
+            !md.contains("dependency failed"),
+            "collateral is never listed: {md}"
+        );
+        assert_eq!(md.matches("### `//root").count(), 2, "two roots: {md}");
+        assert!(
+            md.contains("**4,109 targets blocked**") || md.contains("4,117 blocked"),
+            "collateral counted: {md}"
+        );
+        assert!(
+            md.contains("`//services/api`"),
+            "blocked rolled up by package: {md}"
+        );
+    }
+
+    #[test]
+    fn budget_is_never_exceeded_by_pathological_failures() {
+        // 200 roots, each with a 4 KB single-line message — the case that froze
+        // the old comment at a silent 422.
+        let mut t = Tally::default();
+        t.apply(&ev(
+            0,
+            BuildEventKind::Matched {
+                addrs: vec!["//a:x".into()],
+                complete: true,
+            },
+        ));
+        let huge = "x".repeat(4096);
+        for i in 0..200 {
+            t.apply(&ev(
+                1_000,
+                BuildEventKind::ResultEnd {
+                    addr: format!("//pkg{i}:broken"),
+                    error: Some(format!("execute failed: {huge}")),
+                },
+            ));
+        }
+        t.set_closed();
+
+        for budget in [COMMENT_LIMIT, 4_096, 512] {
+            let live = render_live(&t, &ctx("heph run //...", 9_000), budget);
+            assert!(
+                live.len() <= budget,
+                "live over budget {budget}: {}",
+                live.len()
+            );
+            let fin = render_final(&t, &ctx("heph run //...", 9_000), budget);
+            assert!(
+                fin.len() <= budget,
+                "final over budget {budget}: {}",
+                fin.len()
+            );
+        }
+    }
+
+    #[test]
+    fn an_unbounded_message_is_capped_in_width() {
+        let mut t = Tally::default();
+        t.apply(&ev(
+            1_000,
+            BuildEventKind::ResultEnd {
+                addr: "//a:x".into(),
+                // `format!("{e:#}")` puts the whole chain on ONE line, so a line
+                // cap alone would not bound this.
+                error: Some("y".repeat(10_000)),
+            },
+        ));
+        let md = render_live(&t, &ctx("heph run //...", 9_000), COMMENT_LIMIT);
+        assert!(md.len() < 1_500, "width-capped: {} bytes", md.len());
+        assert!(md.contains('…'), "truncation is visible: {md}");
+    }
+
+    #[test]
+    fn multibyte_messages_and_addrs_do_not_panic() {
+        let mut t = Tally::default();
+        t.apply(&ev(
+            1_000,
+            BuildEventKind::ResultEnd {
+                addr: format!("//パッケージ:{}", "名前".repeat(200)),
+                error: Some("エラー".repeat(500)),
+            },
+        ));
+        let md = render_live(&t, &ctx("heph run //...", 9_000), COMMENT_LIMIT);
+        assert!(md.contains("//パッケージ"), "rendered: {md}");
+    }
+
+    #[test]
+    fn truncation_is_always_announced() {
+        let t = build(20_000, 50, 10_000);
+        let md = render_final(&t, &ctx("heph run //...", 120_000), 700);
+        assert!(md.len() <= 700);
+        assert!(
+            md.contains("truncated"),
+            "silent truncation is the same bug class as the silent 422: {md}"
+        );
+    }
+
+    #[test]
+    fn all_cached_final_is_one_line() {
+        let mut t = Tally::default();
+        t.apply(&ev(
+            0,
+            BuildEventKind::Matched {
+                addrs: (0..20_000).map(|i| format!("//pkg:t{i}")).collect(),
+                complete: true,
+            },
+        ));
+        for i in 0..20_000 {
+            t.apply(&ev(
+                1,
+                BuildEventKind::LocalCacheHit {
+                    addr: format!("//pkg:t{i}"),
+                },
+            ));
+            t.apply(&ev(
+                2,
+                BuildEventKind::ResultEnd {
+                    addr: format!("//pkg:t{i}"),
+                    error: None,
+                },
+            ));
+        }
+        t.set_closed();
+        let md = render_final(&t, &ctx("heph run //...", 41_000), SUMMARY_BUDGET);
+        assert!(md.contains("nothing executed"), "{md}");
+        assert!(md.contains("20,000 cache hits"), "{md}");
+        assert!(md.len() < 300, "one line, not a wall: {} bytes", md.len());
+    }
+
+    #[test]
+    fn final_view_reports_what_happened_not_what_is_running() {
+        // The old renderer showed *currently running* targets in the final
+        // summary, which at close is by definition almost empty.
+        let mut t = Tally::default();
+        t.apply(&ev(
+            0,
+            BuildEventKind::Matched {
+                addrs: vec!["//a:slow".into()],
+                complete: true,
+            },
+        ));
+        t.apply(&ev(
+            0,
+            BuildEventKind::ExecuteStart {
+                addr: "//a:slow".into(),
+                driver: "exec".into(),
+                cache: false,
+            },
+        ));
+        t.apply(&ev(
+            0,
+            BuildEventKind::LocalCacheMiss {
+                addr: "//a:slow".into(),
+            },
+        ));
+        t.apply(&ev(
+            252_000,
+            BuildEventKind::ExecuteEnd {
+                addr: "//a:slow".into(),
+                error: None,
+            },
+        ));
+        t.apply(&ev(
+            252_000,
+            BuildEventKind::ResultEnd {
+                addr: "//a:slow".into(),
+                error: None,
+            },
+        ));
+        t.set_closed();
+
+        let md = render_final(&t, &ctx("heph run //...", 999_000), SUMMARY_BUDGET);
+        assert!(md.contains("Slowest"), "durations reported: {md}");
+        assert!(md.contains("4m12s"), "the actual duration: {md}");
+        assert!(
+            !md.contains("Running longest"),
+            "no live-state section in the final view: {md}"
+        );
+        assert!(md.contains("Cache misses by package"), "rollup: {md}");
+    }
+
+    #[test]
+    fn zero_hit_rate_is_diagnosed_not_just_reported() {
+        let mut t = Tally::default();
+        t.apply(&ev(
+            0,
+            BuildEventKind::Matched {
+                addrs: vec!["//a:x".into()],
+                complete: true,
+            },
+        ));
+        for i in 0..500 {
+            t.apply(&ev(
+                0,
+                BuildEventKind::LocalCacheMiss {
+                    addr: format!("//pkg:t{i}"),
+                },
+            ));
+        }
+        t.set_closed();
+        let md = render_final(&t, &ctx("heph run //...", 9_000), SUMMARY_BUDGET);
+        assert!(md.contains("0 of 500 targets hit cache"), "{md}");
+        assert!(
+            md.contains("heph inspect hashin"),
+            "points at the next command: {md}"
+        );
+    }
+
+    #[test]
+    fn cache_never_consulted_does_not_render_zero_percent() {
+        let mut t = Tally::default();
+        t.apply(&ev(
+            0,
+            BuildEventKind::Matched {
+                addrs: vec!["//a:x".into()],
+                complete: true,
+            },
+        ));
+        t.apply(&ev(
+            5,
+            BuildEventKind::ResultEnd {
+                addr: "//a:x".into(),
+                error: None,
+            },
+        ));
+        t.set_closed();
+        let md = render_final(&t, &ctx("heph run //...", 9_000), SUMMARY_BUDGET);
+        assert!(md.contains("not consulted"), "{md}");
+        assert!(!md.contains("0.0% hit rate"), "0% would be a lie: {md}");
+    }
+
+    #[test]
+    fn background_uploads_render_as_one_aggregate_line() {
+        let mut t = build(20_000, 0, 0);
+        for i in 0..5_000 {
+            t.apply(&ev(
+                0,
+                BuildEventKind::RemoteCacheWriteStart {
+                    addr: format!("//pkg:t{i}"),
+                },
+            ));
+        }
+        let md = render_live(&t, &ctx("heph run //...", 600_000), COMMENT_LIMIT);
+        assert!(md.contains("↑ 5,000 cache uploads in flight"), "{md}");
+        assert!(
+            !md.contains("remote cache write |"),
+            "never per-target rows: {md}"
+        );
+    }
+
+    #[test]
+    fn lock_waits_are_surfaced_with_their_holder() {
+        let mut t = build(100, 0, 0);
+        t.apply(&ev(
+            0,
+            BuildEventKind::ResultLockWaitStart {
+                addr: "//a:x".into(),
+                holder_pid: Some(4412),
+            },
+        ));
+        let md = render_live(&t, &ctx("heph run //...", 600_000), COMMENT_LIMIT);
+        assert!(md.contains("waiting on the result lock"), "{md}");
+        assert!(md.contains("pid 4412"), "{md}");
+    }
+
+    #[test]
+    fn clock_is_quantized_so_suppression_can_fire() {
+        // An unquantized clock changes on every render, so every tick would PATCH
+        // even when nothing about the build changed.
+        assert_eq!(fmt_clock(1_000 * (14 * 3600 + 2 * 60 + 11)), "14:02:10Z");
+        assert_eq!(fmt_clock(1_000 * (14 * 3600 + 2 * 60 + 14)), "14:02:10Z");
+        assert_eq!(fmt_clock(1_000 * (14 * 3600 + 2 * 60 + 15)), "14:02:15Z");
+    }
+
+    #[test]
+    fn duration_and_count_formatting() {
+        assert_eq!(fmt_duration(8_200), "8s");
+        assert_eq!(fmt_duration(252_000), "4m12s");
+        assert_eq!(fmt_duration(3_930_000), "1h05m");
+        assert_eq!(fmt_count(4_117), "4,117");
+        assert_eq!(fmt_count(20_140), "20,140");
+        assert_eq!(fmt_count(7), "7");
+    }
+
+    #[test]
+    fn fail_fast_mode_is_disclosed() {
+        // Otherwise a one-failure report reads as "one thing is broken" when the
+        // truth is "we stopped looking".
+        let t = build(20_000, 1, 0);
+        let mut c = ctx("heph run //...", 9_000);
+        c.fail_fast = true;
+        let md = render_live(&t, &c, COMMENT_LIMIT);
+        assert!(md.contains("Stopped at the first failure"), "{md}");
+    }
+
+    /// Prints the rendered views for eyeballing against the mockups in
+    /// `docs/GHA_REPORTING.md`. Ignored: it asserts nothing, it is a way to look
+    /// at the output.
+    ///
+    /// `cargo test -p plugin-gha preview -- --ignored --nocapture`
+    #[test]
+    #[ignore = "prints output for human review; asserts nothing"]
+    fn preview() {
+        let mut t = build(20_000, 0, 0);
+        for i in 0..218 {
+            t.apply(&ev(
+                i,
+                BuildEventKind::ExecuteStart {
+                    addr: format!("//services/api:image{i}"),
+                    driver: "exec".into(),
+                    cache: false,
+                },
+            ));
+        }
+        for i in 0..8_412 {
+            t.apply(&ev(
+                1,
+                BuildEventKind::LocalCacheHit {
+                    addr: format!("//pkg{}:t{i}", i % 50),
+                },
+            ));
+            t.apply(&ev(
+                2,
+                BuildEventKind::ResultEnd {
+                    addr: format!("//pkg{}:t{i}", i % 50),
+                    error: None,
+                },
+            ));
+        }
+        t.apply(&ev(0, BuildEventKind::MaxWorkers { count: 64 }));
+        println!("\n===== LIVE, healthy =====\n");
+        println!(
+            "{}",
+            render_live(&t, &ctx("run //...", 374_000), COMMENT_LIMIT)
+        );
+
+        let t2 = build(20_000, 2, 4_117);
+        println!("\n===== LIVE, cone expanding =====\n");
+        println!(
+            "{}",
+            render_live(&t2, &ctx("run //...", 182_000), COMMENT_LIMIT)
+        );
+
+        let mut t3 = build(20_000, 2, 4_117);
+        t3.set_closed();
+        println!("\n===== FINAL, failed =====\n");
+        println!(
+            "{}",
+            render_final(&t3, &ctx("run //...", 468_000), SUMMARY_BUDGET)
+        );
+    }
+}

--- a/crates/plugin-gha/src/tally.rs
+++ b/crates/plugin-gha/src/tally.rs
@@ -1,0 +1,1148 @@
+//! Build-status aggregation for the GitHub Actions hook.
+//!
+//! Folds the engine's [`BuildEvent`] stream into the handful of facts the two
+//! renderers need. The shape is driven by one constraint: **a CI run has ~20k
+//! targets**, so nothing retained here may be proportional to the graph and
+//! nothing rendered from it may be a per-target list.
+//!
+//! The rules that follow from that, and the reasons they are not negotiable:
+//!
+//! - **One record per *in-flight* target**, dropped at `ResultEnd`. The previous
+//!   design kept `finished` and `cache_hit` as graph-wide `BTreeSet<String>`s but
+//!   only ever read them as `matched ∩ …`, retaining ~16 MB at 100k targets of
+//!   which ~90% was never read. The TUI reached the same conclusion after
+//!   measuring (`crates/tui/src/tui/progress.rs:668`): fold at both edges, keep
+//!   no history.
+//! - **Counters, not sets**, for everything whose only use is a number.
+//! - **Failures are tracked by *root*.** One broken leaf under 20k dependents
+//!   produces 20k `ResultEnd`s carrying `dependency failed (root: …)`; counting
+//!   them individually renders `failed: 20001` and buries the actual cause. Each
+//!   collateral failure increments its root's `blocked` count and a per-package
+//!   tally instead of allocating a row.
+//! - **Slowest-completed is a bounded top-N heap**, never a map. Retaining a
+//!   duration per completed target costs ~118 B each — ~2.4 MB at 20k, ~12 MB at
+//!   100k — for a list that only ever shows 20 rows.
+//! - **The addr `String` is allocated once**, into a `Box<str>` key on first
+//!   sight; every later event for that target is a lookup and a field write.
+
+use std::cmp::Reverse;
+use std::collections::BinaryHeap;
+
+use hcore::events::{BuildEvent, BuildEventKind};
+use rustc_hash::FxHashMap;
+
+/// How many completed targets to retain for the "slowest" table. The heap is
+/// capped at this, so the memory is constant regardless of graph size.
+pub(crate) const SLOWEST_KEPT: usize = 20;
+
+/// Root failures retained with full detail. Beyond this only the count is kept —
+/// a build with 200 independent breakages is a catastrophe whose report is the
+/// count, not the list.
+pub(crate) const ROOTS_KEPT: usize = 10;
+
+/// One long-running phase a target can be in. A target is slow because of a
+/// *single* active phase, so the report names which one.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub(crate) enum Phase {
+    Execute,
+    CachePull,
+    LocalCacheWrite,
+    RemoteCacheWrite,
+}
+
+impl Phase {
+    pub(crate) fn label(self) -> &'static str {
+        match self {
+            Phase::Execute => "execute",
+            Phase::CachePull => "cache pull",
+            Phase::LocalCacheWrite => "cache write",
+            Phase::RemoteCacheWrite => "remote cache write",
+        }
+    }
+
+    /// Runs on a background task *after* the build's critical path, so it is
+    /// never the reason a build feels stuck and must not appear in the live
+    /// "running longest" table.
+    ///
+    /// This matters more than it looks: `RemoteCacheWriteStart` is emitted
+    /// *before* the upload semaphore is acquired (deliberately — a queued push
+    /// should still render as in-flight, see
+    /// `crates/engine/src/engine/remote_cache.rs:1643`) and there are only
+    /// [16 slots](`MAX_CONCURRENT_UPLOADS`). At 20k targets that means ~20k
+    /// entries in flight with 16 actually uploading, so per-target rows would
+    /// flood the table with targets that are queued, not slow.
+    fn is_background(self) -> bool {
+        matches!(self, Phase::RemoteCacheWrite)
+    }
+}
+
+/// Which cache answered. Kept per in-flight target so a hit can be *un-counted*
+/// off the right counter when the target turns out to rebuild.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub(crate) enum CacheHitKind {
+    Local,
+    Remote,
+}
+
+/// State for a target that is currently in flight. Dropped at `ResultEnd`.
+#[derive(Debug, Default)]
+struct TargetRec {
+    /// First event seen for this target, used as its duration origin.
+    started_ms: u64,
+    /// The active phase and when it began, or `None` between phases.
+    phase: Option<(Phase, u64)>,
+    driver: Option<Box<str>>,
+    /// The cache that answered, if any — retracted when the target executes.
+    cache: Option<CacheHitKind>,
+    /// Whether this target actually ran. A later cache hit must not count a
+    /// target that already executed.
+    executed: bool,
+}
+
+/// A completed target retained for the "slowest" table.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) struct Completed {
+    pub duration_ms: u64,
+    pub addr: String,
+    pub driver: Option<String>,
+}
+
+// Ordered by duration, then addr, so the heap is deterministic and two runs
+// produce diffable output.
+impl Ord for Completed {
+    fn cmp(&self, other: &Self) -> std::cmp::Ordering {
+        self.duration_ms
+            .cmp(&other.duration_ms)
+            .then_with(|| other.addr.cmp(&self.addr))
+    }
+}
+impl PartialOrd for Completed {
+    fn partial_cmp(&self, other: &Self) -> Option<std::cmp::Ordering> {
+        Some(self.cmp(other))
+    }
+}
+
+/// A failure that is *not* downstream of another failure — the thing a human has
+/// to fix. Collateral failures are folded into `blocked` / `blocked_by_pkg`.
+#[derive(Debug, Clone, Default)]
+pub(crate) struct RootFailure {
+    pub addr: String,
+    pub message: String,
+    pub driver: Option<String>,
+    pub duration_ms: Option<u64>,
+    /// Targets that failed solely because this one did.
+    pub blocked: usize,
+    /// Where those blocked targets live, for the rollup line. Bounded by package
+    /// count (~1–3k), not target count.
+    pub blocked_by_pkg: FxHashMap<Box<str>, usize>,
+}
+
+/// A target waiting on the per-addr result lock — the "is it stuck?" signal.
+#[derive(Debug, Clone)]
+pub(crate) struct LockWait {
+    pub addr: String,
+    pub since_ms: u64,
+    pub holder_pid: Option<u32>,
+}
+
+#[derive(Debug, Default, Clone, Copy)]
+pub(crate) struct Counters {
+    pub executed: usize,
+    pub cached_local: usize,
+    pub cached_remote: usize,
+    pub miss_local: usize,
+    pub miss_remote: usize,
+    /// Collateral failures across all roots, including those beyond `ROOTS_KEPT`.
+    pub blocked: usize,
+    /// Root failures seen, including those beyond `ROOTS_KEPT`.
+    pub roots_total: usize,
+}
+
+impl Counters {
+    pub(crate) fn cached(&self) -> usize {
+        self.cached_local.saturating_add(self.cached_remote)
+    }
+
+    pub(crate) fn misses(&self) -> usize {
+        self.miss_local.saturating_add(self.miss_remote)
+    }
+
+    /// Hit rate over targets the cache was actually consulted for. `None` when it
+    /// was never consulted — rendering `0%` there would be a lie.
+    pub(crate) fn hit_rate(&self) -> Option<f64> {
+        let considered = self.cached().saturating_add(self.misses());
+        (considered > 0).then(|| self.cached() as f64 / considered as f64)
+    }
+}
+
+/// The folded build status.
+#[derive(Debug, Default)]
+pub(crate) struct Tally {
+    /// Top-level matched targets → whether they have finished. Bounded by what
+    /// the user selected, not by the graph, and it is the only exact membership
+    /// set retained.
+    matched: FxHashMap<Box<str>, bool>,
+    matched_done: usize,
+    matched_complete: bool,
+
+    /// In-flight targets only. Dropped at `ResultEnd`.
+    live: FxHashMap<Box<str>, TargetRec>,
+
+    /// Targets currently waiting on the result lock. Bounded by concurrency.
+    lock_waits: FxHashMap<Box<str>, LockWait>,
+
+    /// In-flight background cache uploads, rendered as one aggregate row rather
+    /// than thousands of per-target ones. See [`Phase::is_background`].
+    background_ops: usize,
+
+    counters: Counters,
+
+    /// Roots in first-seen order — never re-sorted, so consecutive renders differ
+    /// by appends only and an agent diffing two fetches sees "one new root"
+    /// rather than a reshuffled list.
+    roots: Vec<RootFailure>,
+    root_index: FxHashMap<Box<str>, usize>,
+
+    /// Min-heap of the [`SLOWEST_KEPT`] longest completed targets.
+    slowest: BinaryHeap<Reverse<Completed>>,
+
+    /// Cache misses per package, for the rollup that replaces a per-target list.
+    misses_by_pkg: FxHashMap<Box<str>, usize>,
+
+    max_workers: usize,
+    first_event_ms: Option<u64>,
+    last_event_ms: u64,
+
+    /// Set once the event stream closes. The build is over, so the status must
+    /// settle: progress counts are not a reliable "finished" signal because a
+    /// matched transparent group emits no `ResultEnd`.
+    closed: bool,
+}
+
+/// Extract the root addr from a collateral failure's message.
+///
+/// **Interim.** `UpstreamFailed` renders as `dependency failed (root: //x:y)`
+/// (`crates/plugin/src/error.rs:201`) and `ResultEnd.error` is the whole cause
+/// chain flattened by `format!("{e:#}")`, so sniffing the string is the only way
+/// to tell collateral from root damage today. This is replaced by a structured
+/// `upstream_of` field on `ResultEnd`; see `docs/GHA_REPORTING.md` §7.1.
+fn parse_upstream_root(message: &str) -> Option<&str> {
+    const OPEN: &str = "dependency failed (root: ";
+    let i = message.find(OPEN)?;
+    let after = message.get(i.checked_add(OPEN.len())?..)?;
+    let end = after.find(')')?;
+    after.get(..end)
+}
+
+/// The package part of `//pkg/sub:name`, or the whole addr if it has no `:`.
+fn package_of(addr: &str) -> &str {
+    match addr.rfind(':') {
+        Some(i) => addr.get(..i).unwrap_or(addr),
+        None => addr,
+    }
+}
+
+impl Tally {
+    /// Fold one event.
+    ///
+    /// This runs on the plugin's event-drain thread for every event — ~160k times
+    /// on a 20k-target build — so it must stay allocation-light. In particular it
+    /// must never `format!`, and must never allocate a package `String` per
+    /// event (hence `get_mut`-then-`insert` on the package maps).
+    pub(crate) fn apply(&mut self, ev: &BuildEvent) {
+        self.first_event_ms.get_or_insert(ev.at_unix_ms);
+        self.last_event_ms = self.last_event_ms.max(ev.at_unix_ms);
+
+        // Exhaustive on purpose: a new `BuildEventKind` must be a compile error
+        // here, not a silent drop. The previous `_ => {}` swallowed six kinds,
+        // four of which this renderer wants.
+        match &ev.kind {
+            BuildEventKind::MaxWorkers { count } => self.max_workers = *count,
+
+            BuildEventKind::Matched { addrs, complete } => {
+                for a in addrs {
+                    // Allocate the key only for genuinely new addrs — `Matched`
+                    // arrives incrementally and can repeat an addr.
+                    if !self.matched.contains_key(a.as_str()) {
+                        self.matched.insert(a.as_str().into(), false);
+                    }
+                }
+                if *complete {
+                    self.matched_complete = true;
+                }
+            }
+
+            BuildEventKind::ResultStart { addr } => {
+                self.ensure(addr, ev.at_unix_ms);
+            }
+
+            BuildEventKind::ResultEnd { addr, error } => {
+                self.finish(addr, error.as_deref(), ev.at_unix_ms);
+            }
+
+            BuildEventKind::ExecuteStart { addr, driver, .. } => {
+                let at = ev.at_unix_ms;
+                self.ensure(addr, at);
+                let mut retract = None;
+                if let Some(rec) = self.live.get_mut(addr.as_str()) {
+                    rec.phase = Some((Phase::Execute, at));
+                    rec.executed = true;
+                    if rec.driver.is_none() {
+                        rec.driver = Some(driver.as_str().into());
+                    }
+                    // A target that executes is not a cached target, even when a
+                    // hit was announced first: the engine decides a hit from the
+                    // revision's manifest, and a manifest can outlive its blobs
+                    // (GC, a lifecycle rule, or blobs never pulled on a run that
+                    // is now offline), in which case it rebuilds. Retract the hit
+                    // off the counter it was put on, or "executed + cached" can
+                    // sum past the target count.
+                    retract = rec.cache.take();
+                }
+                match retract {
+                    Some(CacheHitKind::Local) => {
+                        self.counters.cached_local = self.counters.cached_local.saturating_sub(1);
+                    }
+                    Some(CacheHitKind::Remote) => {
+                        self.counters.cached_remote = self.counters.cached_remote.saturating_sub(1);
+                    }
+                    None => {}
+                }
+            }
+
+            BuildEventKind::ExecuteEnd { addr, error } => {
+                self.clear_phase(addr);
+                if error.is_none() {
+                    self.counters.executed = self.counters.executed.saturating_add(1);
+                }
+            }
+
+            BuildEventKind::RemoteCacheReadStart { addr } => {
+                self.start_phase(addr, Phase::CachePull, ev.at_unix_ms);
+            }
+            BuildEventKind::LocalCacheWriteStart { addr } => {
+                self.start_phase(addr, Phase::LocalCacheWrite, ev.at_unix_ms);
+            }
+            BuildEventKind::RemoteCacheWriteStart { addr } => {
+                self.start_phase(addr, Phase::RemoteCacheWrite, ev.at_unix_ms);
+            }
+            BuildEventKind::RemoteCacheReadEnd { addr, .. }
+            | BuildEventKind::LocalCacheWriteEnd { addr, .. }
+            | BuildEventKind::RemoteCacheWriteEnd { addr, .. } => {
+                self.clear_phase(addr);
+            }
+
+            BuildEventKind::LocalCacheHit { addr } => {
+                self.hit(addr, ev.at_unix_ms, CacheHitKind::Local)
+            }
+            BuildEventKind::RemoteCacheHit { addr } => {
+                self.hit(addr, ev.at_unix_ms, CacheHitKind::Remote)
+            }
+
+            BuildEventKind::LocalCacheMiss { addr } => {
+                self.counters.miss_local = self.counters.miss_local.saturating_add(1);
+                self.bump_pkg_miss(addr);
+            }
+            BuildEventKind::RemoteCacheMiss { .. } => {
+                // Counted, but not rolled up by package: a remote miss almost
+                // always accompanies the local miss already counted above, and
+                // double-counting the package would overstate the rollup.
+                self.counters.miss_remote = self.counters.miss_remote.saturating_add(1);
+            }
+
+            BuildEventKind::ResultLockWaitStart { addr, holder_pid } => {
+                self.lock_waits.insert(
+                    addr.as_str().into(),
+                    LockWait {
+                        addr: addr.clone(),
+                        since_ms: ev.at_unix_ms,
+                        holder_pid: *holder_pid,
+                    },
+                );
+            }
+            BuildEventKind::ResultLockWaitEnd { addr } => {
+                self.lock_waits.remove(addr.as_str());
+            }
+
+            // Emitted only by `heph tool gc` / `clean`, which this hook does not
+            // report on — those commands have their own output.
+            BuildEventKind::GcTargetSwept { .. } => {}
+        }
+    }
+
+    /// Ensure a record exists for `addr`, allocating the `Box<str>` key only on
+    /// first sight.
+    ///
+    /// Deliberately does *not* return `&mut TargetRec`: doing so needs either a
+    /// conditional-return borrow that current borrowck rejects, or `entry()`,
+    /// which takes an owned key and would therefore allocate on every one of
+    /// ~160k events. Callers pair this with `live.get_mut`. Two hashes on the hit
+    /// path is far cheaper than one allocation.
+    fn ensure(&mut self, addr: &str, at: u64) {
+        if !self.live.contains_key(addr) {
+            self.live.insert(
+                addr.into(),
+                TargetRec {
+                    started_ms: at,
+                    ..TargetRec::default()
+                },
+            );
+        }
+    }
+
+    fn start_phase(&mut self, addr: &str, phase: Phase, at: u64) {
+        if phase.is_background() {
+            self.background_ops = self.background_ops.saturating_add(1);
+        }
+        self.ensure(addr, at);
+        if let Some(rec) = self.live.get_mut(addr) {
+            rec.phase = Some((phase, at));
+        }
+    }
+
+    fn clear_phase(&mut self, addr: &str) {
+        if let Some(rec) = self.live.get_mut(addr)
+            && let Some((phase, _)) = rec.phase.take()
+            && phase.is_background()
+        {
+            self.background_ops = self.background_ops.saturating_sub(1);
+        }
+    }
+
+    fn hit(&mut self, addr: &str, at: u64, kind: CacheHitKind) {
+        self.ensure(addr, at);
+        // A hit arriving *after* the target executed (possible: the result
+        // memoizer keys on `(addr, outputs, is_top)`, so a second variant can hit
+        // the local cache the first variant just populated) must not count the
+        // same addr as both executed and cached.
+        match self.live.get_mut(addr) {
+            Some(rec) if rec.executed || rec.cache.is_some() => return,
+            Some(rec) => rec.cache = Some(kind),
+            None => return,
+        }
+        match kind {
+            CacheHitKind::Local => {
+                self.counters.cached_local = self.counters.cached_local.saturating_add(1)
+            }
+            CacheHitKind::Remote => {
+                self.counters.cached_remote = self.counters.cached_remote.saturating_add(1)
+            }
+        }
+    }
+
+    fn bump_pkg_miss(&mut self, addr: &str) {
+        let pkg = package_of(addr);
+        // `get_mut` first so the package key is allocated only on first sight —
+        // otherwise this allocates a `String` on every one of ~160k events.
+        if let Some(n) = self.misses_by_pkg.get_mut(pkg) {
+            *n = n.saturating_add(1);
+            return;
+        }
+        self.misses_by_pkg.insert(pkg.into(), 1);
+    }
+
+    fn finish(&mut self, addr: &str, error: Option<&str>, at: u64) {
+        let rec = self.live.remove(addr);
+
+        // Progress is over the matched top-level set, deduped: the memoizer can
+        // emit several `ResultEnd`s for one addr, and `done` must never exceed
+        // `total`.
+        if let Some(done) = self.matched.get_mut(addr)
+            && !*done
+        {
+            *done = true;
+            self.matched_done = self.matched_done.saturating_add(1);
+        }
+
+        if let Some(rec) = &rec
+            && error.is_none()
+            && rec.executed
+        {
+            let duration_ms = at.saturating_sub(rec.started_ms);
+            self.push_slowest(Completed {
+                duration_ms,
+                addr: addr.to_string(),
+                driver: rec.driver.as_deref().map(str::to_string),
+            });
+        }
+
+        let Some(message) = error else { return };
+
+        if let Some(root) = parse_upstream_root(message) {
+            self.record_collateral(root, addr);
+            return;
+        }
+        self.record_root(addr, message, rec.as_ref(), at);
+    }
+
+    fn push_slowest(&mut self, c: Completed) {
+        if self.slowest.len() < SLOWEST_KEPT {
+            self.slowest.push(Reverse(c));
+            return;
+        }
+        // Replace the smallest if this one is longer. `peek` on a min-heap of
+        // `Reverse` yields the shortest retained duration.
+        if let Some(Reverse(min)) = self.slowest.peek()
+            && c.duration_ms > min.duration_ms
+        {
+            self.slowest.pop();
+            self.slowest.push(Reverse(c));
+        }
+    }
+
+    fn record_root(&mut self, addr: &str, message: &str, rec: Option<&TargetRec>, at: u64) {
+        self.counters.roots_total = self.counters.roots_total.saturating_add(1);
+        if self.root_index.contains_key(addr) {
+            // Deduped: one addr can produce several `ResultEnd`s.
+            self.counters.roots_total = self.counters.roots_total.saturating_sub(1);
+            return;
+        }
+        if self.roots.len() >= ROOTS_KEPT {
+            // Beyond the cap only the count is kept.
+            return;
+        }
+        self.root_index.insert(addr.into(), self.roots.len());
+        self.roots.push(RootFailure {
+            addr: addr.to_string(),
+            message: message.to_string(),
+            driver: rec.and_then(|r| r.driver.as_deref().map(str::to_string)),
+            duration_ms: rec.map(|r| at.saturating_sub(r.started_ms)),
+            blocked: 0,
+            blocked_by_pkg: FxHashMap::default(),
+        });
+    }
+
+    fn record_collateral(&mut self, root: &str, blocked_addr: &str) {
+        self.counters.blocked = self.counters.blocked.saturating_add(1);
+        let Some(&idx) = self.root_index.get(root) else {
+            // The root is beyond `ROOTS_KEPT`, or its own `ResultEnd` has not
+            // arrived yet. The global `blocked` counter above still reflects it.
+            return;
+        };
+        let Some(rf) = self.roots.get_mut(idx) else {
+            return;
+        };
+        rf.blocked = rf.blocked.saturating_add(1);
+        let pkg = package_of(blocked_addr);
+        if let Some(n) = rf.blocked_by_pkg.get_mut(pkg) {
+            *n = n.saturating_add(1);
+            return;
+        }
+        rf.blocked_by_pkg.insert(pkg.into(), 1);
+    }
+
+    pub(crate) fn set_closed(&mut self) {
+        self.closed = true;
+    }
+
+    pub(crate) fn counters(&self) -> Counters {
+        self.counters
+    }
+
+    pub(crate) fn roots(&self) -> &[RootFailure] {
+        &self.roots
+    }
+
+    pub(crate) fn max_workers(&self) -> usize {
+        self.max_workers
+    }
+
+    /// Targets currently inside a *foreground* phase — the denominator for
+    /// "workers busy". Background cache uploads are excluded; they are not
+    /// occupying a worker slot the build is waiting on.
+    pub(crate) fn active_foreground(&self) -> usize {
+        self.live
+            .values()
+            .filter(|r| r.phase.is_some_and(|(p, _)| !p.is_background()))
+            .count()
+    }
+
+    pub(crate) fn background_ops(&self) -> usize {
+        self.background_ops
+    }
+
+    /// `(done, total, total_is_final)` over the matched top-level set.
+    pub(crate) fn progress(&self) -> (usize, usize, bool) {
+        (self.matched_done, self.matched.len(), self.matched_complete)
+    }
+
+    /// Elapsed across the observed event stream. Named "build time" rather than
+    /// wall time: the first event is not process start, so this excludes startup
+    /// and matcher resolution before the first emit.
+    pub(crate) fn elapsed_ms(&self, now_ms: u64) -> u64 {
+        let Some(first) = self.first_event_ms else {
+            return 0;
+        };
+        let end = if self.closed {
+            self.last_event_ms
+        } else {
+            now_ms.max(self.last_event_ms)
+        };
+        end.saturating_sub(first)
+    }
+
+    /// Foreground targets past `threshold_ms` in their current phase, longest
+    /// first, capped at `limit`. Returns `(rows, total_over_threshold)` so the
+    /// renderer can show a sample and an honest count.
+    ///
+    /// Scans only the in-flight map and never sorts more than `limit` rows: at
+    /// 20k targets the previous implementation cloned and sorted every entry past
+    /// the threshold on every 30-second render.
+    pub(crate) fn running_longest(
+        &self,
+        now_ms: u64,
+        threshold_ms: u64,
+        limit: usize,
+    ) -> (Vec<(String, &'static str, u64)>, usize) {
+        let mut total = 0usize;
+        let mut heap: BinaryHeap<Reverse<(u64, &str, &'static str)>> = BinaryHeap::new();
+        for (addr, rec) in &self.live {
+            let Some((phase, since)) = rec.phase else {
+                continue;
+            };
+            if phase.is_background() {
+                continue;
+            }
+            let elapsed = now_ms.saturating_sub(since);
+            if elapsed < threshold_ms {
+                continue;
+            }
+            total = total.saturating_add(1);
+            if heap.len() < limit {
+                heap.push(Reverse((elapsed, addr, phase.label())));
+            } else if let Some(Reverse((min, _, _))) = heap.peek()
+                && elapsed > *min
+            {
+                heap.pop();
+                heap.push(Reverse((elapsed, addr, phase.label())));
+            }
+        }
+        let mut rows: Vec<(String, &'static str, u64)> = heap
+            .into_iter()
+            .map(|Reverse((elapsed, addr, phase))| (addr.to_string(), phase, elapsed))
+            .collect();
+        rows.sort_by_key(|(addr, _, elapsed)| (Reverse(*elapsed), addr.clone()));
+        (rows, total)
+    }
+
+    /// Lock waits past `threshold_ms`, longest first, capped at `limit`.
+    pub(crate) fn lock_waits(
+        &self,
+        now_ms: u64,
+        threshold_ms: u64,
+        limit: usize,
+    ) -> (Vec<LockWait>, usize) {
+        let mut all: Vec<LockWait> = self
+            .lock_waits
+            .values()
+            .filter(|w| now_ms.saturating_sub(w.since_ms) >= threshold_ms)
+            .cloned()
+            .collect();
+        let total = all.len();
+        all.sort_by_key(|w| (w.since_ms, w.addr.clone()));
+        all.truncate(limit);
+        (all, total)
+    }
+
+    /// The retained slowest completed targets, longest first.
+    pub(crate) fn slowest(&self) -> Vec<Completed> {
+        let mut v: Vec<Completed> = self.slowest.iter().map(|Reverse(c)| c.clone()).collect();
+        v.sort_by(|a, b| b.cmp(a));
+        v
+    }
+
+    /// Cache misses per package, most first, capped at `limit`. Returns the rows
+    /// and the total package count.
+    pub(crate) fn misses_by_package(&self, limit: usize) -> (Vec<(String, usize)>, usize) {
+        let total = self.misses_by_pkg.len();
+        let mut v: Vec<(String, usize)> = self
+            .misses_by_pkg
+            .iter()
+            .map(|(k, n)| (k.to_string(), *n))
+            .collect();
+        v.sort_by(|a, b| b.1.cmp(&a.1).then_with(|| a.0.cmp(&b.0)));
+        v.truncate(limit);
+        (v, total)
+    }
+
+    /// ⏳ until the stream closes, then ✅ or ❌. Progress counts do not drive
+    /// this: a matched transparent group emits no `ResultEnd`, so `done == total`
+    /// is unreliable as a "finished" signal — the stream closing is the
+    /// authoritative one.
+    pub(crate) fn status_emoji(&self) -> &'static str {
+        if !self.closed {
+            if self.counters.roots_total > 0 {
+                "❌"
+            } else {
+                "⏳"
+            }
+        } else if self.counters.roots_total == 0 {
+            "✅"
+        } else {
+            "❌"
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn ev(at: u64, kind: BuildEventKind) -> BuildEvent {
+        BuildEvent {
+            at_unix_ms: at,
+            kind,
+        }
+    }
+
+    fn matched(t: &mut Tally, addrs: &[&str], complete: bool) {
+        t.apply(&ev(
+            0,
+            BuildEventKind::Matched {
+                addrs: addrs.iter().map(|s| (*s).to_string()).collect(),
+                complete,
+            },
+        ));
+    }
+
+    fn exec(t: &mut Tally, addr: &str, start: u64, end: u64) {
+        t.apply(&ev(
+            start,
+            BuildEventKind::ExecuteStart {
+                addr: addr.into(),
+                driver: "exec".into(),
+                cache: false,
+            },
+        ));
+        t.apply(&ev(
+            end,
+            BuildEventKind::ExecuteEnd {
+                addr: addr.into(),
+                error: None,
+            },
+        ));
+        t.apply(&ev(
+            end,
+            BuildEventKind::ResultEnd {
+                addr: addr.into(),
+                error: None,
+            },
+        ));
+    }
+
+    #[test]
+    fn collateral_failures_fold_into_their_root() {
+        // One broken leaf under 4k dependents must render as ONE failure with a
+        // blocked count — not 4001 failures. This is the 20k-scale case.
+        let mut t = Tally::default();
+        t.apply(&ev(
+            10,
+            BuildEventKind::ResultEnd {
+                addr: "//base:proto".into(),
+                error: Some("execute //base:proto: process exited with status 1".into()),
+            },
+        ));
+        for i in 0..4_000 {
+            t.apply(&ev(
+                20,
+                BuildEventKind::ResultEnd {
+                    addr: format!("//services/api:t{i}"),
+                    error: Some(
+                        "result //services/api:t: dependency failed (root: //base:proto)".into(),
+                    ),
+                },
+            ));
+        }
+
+        let c = t.counters();
+        assert_eq!(c.roots_total, 1, "one root failure, not 4001");
+        assert_eq!(c.blocked, 4_000, "collateral counted, not listed");
+        assert_eq!(t.roots().len(), 1);
+        let root = t.roots().first().expect("root");
+        assert_eq!(root.addr, "//base:proto");
+        assert_eq!(root.blocked, 4_000);
+        assert_eq!(
+            root.blocked_by_pkg.get("//services/api").copied(),
+            Some(4_000),
+            "blocked targets rolled up by package"
+        );
+    }
+
+    #[test]
+    fn duplicate_result_end_is_not_double_counted() {
+        // The result memoizer keys on `(addr, outputs, is_top)`, so one addr can
+        // emit several `ResultEnd`s.
+        let mut t = Tally::default();
+        matched(&mut t, &["//a:x"], true);
+        for _ in 0..3 {
+            t.apply(&ev(
+                5,
+                BuildEventKind::ResultEnd {
+                    addr: "//a:x".into(),
+                    error: Some("boom".into()),
+                },
+            ));
+        }
+        assert_eq!(t.counters().roots_total, 1, "root deduped by addr");
+        assert_eq!(t.roots().len(), 1);
+        let (done, total, _) = t.progress();
+        assert_eq!((done, total), (1, 1), "done must never exceed total");
+    }
+
+    #[test]
+    fn cache_hit_is_retracted_when_the_target_rebuilds() {
+        // A manifest can outlive its blobs, so an announced hit can still rebuild.
+        let mut t = Tally::default();
+        t.apply(&ev(
+            1,
+            BuildEventKind::LocalCacheHit {
+                addr: "//a:x".into(),
+            },
+        ));
+        assert_eq!(t.counters().cached(), 1);
+        t.apply(&ev(
+            2,
+            BuildEventKind::ExecuteStart {
+                addr: "//a:x".into(),
+                driver: "exec".into(),
+                cache: false,
+            },
+        ));
+        assert_eq!(t.counters().cached(), 0, "hit retracted off its counter");
+        t.apply(&ev(
+            3,
+            BuildEventKind::ExecuteEnd {
+                addr: "//a:x".into(),
+                error: None,
+            },
+        ));
+        let c = t.counters();
+        assert_eq!(c.executed, 1);
+        assert_eq!(
+            c.executed + c.cached(),
+            1,
+            "executed + cached must not exceed the target count"
+        );
+    }
+
+    #[test]
+    fn cache_hit_after_execute_does_not_double_count() {
+        // The reverse order: a second memoizer variant hits the cache the first
+        // just populated.
+        let mut t = Tally::default();
+        t.apply(&ev(
+            1,
+            BuildEventKind::ExecuteStart {
+                addr: "//a:x".into(),
+                driver: "exec".into(),
+                cache: false,
+            },
+        ));
+        t.apply(&ev(
+            2,
+            BuildEventKind::ExecuteEnd {
+                addr: "//a:x".into(),
+                error: None,
+            },
+        ));
+        t.apply(&ev(
+            3,
+            BuildEventKind::LocalCacheHit {
+                addr: "//a:x".into(),
+            },
+        ));
+        let c = t.counters();
+        assert_eq!(c.cached(), 0, "an executed target is not also cached");
+        assert_eq!(c.executed, 1);
+    }
+
+    #[test]
+    fn local_and_remote_hits_are_counted_separately() {
+        let mut t = Tally::default();
+        t.apply(&ev(
+            1,
+            BuildEventKind::LocalCacheHit {
+                addr: "//a:l".into(),
+            },
+        ));
+        t.apply(&ev(
+            2,
+            BuildEventKind::RemoteCacheHit {
+                addr: "//a:r".into(),
+            },
+        ));
+        let c = t.counters();
+        assert_eq!((c.cached_local, c.cached_remote), (1, 1));
+        assert_eq!(c.cached(), 2);
+    }
+
+    #[test]
+    fn queued_uploads_never_appear_as_slow_targets() {
+        // `RemoteCacheWriteStart` fires before the upload semaphore is acquired,
+        // so at 20k targets ~20k are "in flight" with 16 uploading. They must be
+        // one aggregate number, never per-target rows.
+        let mut t = Tally::default();
+        for i in 0..5_000 {
+            t.apply(&ev(
+                0,
+                BuildEventKind::RemoteCacheWriteStart {
+                    addr: format!("//a:t{i}"),
+                },
+            ));
+        }
+        let (rows, total) = t.running_longest(600_000, 30_000, 6);
+        assert!(rows.is_empty(), "background uploads are not slow targets");
+        assert_eq!(total, 0);
+        assert_eq!(t.background_ops(), 5_000, "surfaced as one aggregate count");
+        assert_eq!(t.active_foreground(), 0, "not occupying worker slots");
+    }
+
+    #[test]
+    fn running_longest_samples_without_sorting_everything() {
+        let mut t = Tally::default();
+        // 500 concurrently-executing targets, all past the threshold; the ones
+        // that started earliest are the slowest.
+        for i in 0..500u64 {
+            t.apply(&ev(
+                i,
+                BuildEventKind::ExecuteStart {
+                    addr: format!("//a:t{i}"),
+                    driver: "exec".into(),
+                    cache: false,
+                },
+            ));
+        }
+        let (rows, total) = t.running_longest(100_000, 30_000, 6);
+        assert_eq!(rows.len(), 6, "sample capped");
+        assert_eq!(total, 500, "but the true count is reported");
+        // Longest first, and the longest is the earliest-started.
+        assert_eq!(rows.first().map(|r| r.0.as_str()), Some("//a:t0"));
+        assert!(
+            rows.windows(2).all(|w| w[0].2 >= w[1].2),
+            "rows ordered longest-first"
+        );
+    }
+
+    #[test]
+    fn slowest_completed_is_bounded_and_keeps_the_longest() {
+        let mut t = Tally::default();
+        // 1000 completions of increasing duration; only the top 20 are retained.
+        for i in 0..1_000u64 {
+            exec(&mut t, &format!("//a:t{i}"), 0, i);
+        }
+        let slowest = t.slowest();
+        assert_eq!(slowest.len(), SLOWEST_KEPT, "heap bounded");
+        assert_eq!(
+            slowest.first().map(|c| c.duration_ms),
+            Some(999),
+            "longest first"
+        );
+        assert_eq!(
+            slowest.last().map(|c| c.duration_ms),
+            Some(980),
+            "keeps the longest, not the first seen"
+        );
+        assert!(
+            slowest
+                .windows(2)
+                .all(|w| w[0].duration_ms >= w[1].duration_ms),
+            "ordered"
+        );
+    }
+
+    #[test]
+    fn progress_counts_only_matched_targets() {
+        let mut t = Tally::default();
+        matched(&mut t, &["//a:x", "//a:y"], true);
+        // A dependency finishes — not matched, so it moves no progress.
+        exec(&mut t, "//dep:d", 0, 5);
+        let (done, total, complete) = t.progress();
+        assert_eq!((done, total, complete), (0, 2, true));
+        exec(&mut t, "//a:x", 0, 5);
+        assert_eq!(t.progress().0, 1);
+    }
+
+    #[test]
+    fn counters_are_graph_wide() {
+        // Decision recorded in docs/GHA_REPORTING.md §13.4: `executed` and
+        // `cached` both count the whole graph, so the two are reconcilable
+        // against each other even though progress is matched-only.
+        let mut t = Tally::default();
+        matched(&mut t, &["//a:top"], true);
+        exec(&mut t, "//dep:one", 0, 1);
+        exec(&mut t, "//dep:two", 0, 1);
+        exec(&mut t, "//a:top", 0, 2);
+        assert_eq!(t.counters().executed, 3, "dependencies included");
+        assert_eq!(t.progress(), (1, 1, true), "progress stays matched-only");
+    }
+
+    #[test]
+    fn misses_roll_up_by_package() {
+        let mut t = Tally::default();
+        for i in 0..30 {
+            t.apply(&ev(
+                0,
+                BuildEventKind::LocalCacheMiss {
+                    addr: format!("//services/api:t{i}"),
+                },
+            ));
+        }
+        for i in 0..10 {
+            t.apply(&ev(
+                0,
+                BuildEventKind::LocalCacheMiss {
+                    addr: format!("//web:t{i}"),
+                },
+            ));
+        }
+        let (rows, total_pkgs) = t.misses_by_package(10);
+        assert_eq!(total_pkgs, 2);
+        assert_eq!(
+            rows.first().map(|(p, n)| (p.as_str(), *n)),
+            Some(("//services/api", 30)),
+            "most misses first"
+        );
+        assert_eq!(t.counters().misses(), 40);
+    }
+
+    #[test]
+    fn hit_rate_is_none_when_the_cache_was_never_consulted() {
+        let t = Tally::default();
+        assert!(t.counters().hit_rate().is_none(), "0% would be a lie");
+        let mut t = Tally::default();
+        t.apply(&ev(
+            0,
+            BuildEventKind::LocalCacheHit {
+                addr: "//a:x".into(),
+            },
+        ));
+        t.apply(&ev(
+            0,
+            BuildEventKind::LocalCacheMiss {
+                addr: "//a:y".into(),
+            },
+        ));
+        assert_eq!(t.counters().hit_rate(), Some(0.5));
+    }
+
+    #[test]
+    fn lock_waits_surface_with_their_holder() {
+        let mut t = Tally::default();
+        t.apply(&ev(
+            0,
+            BuildEventKind::ResultLockWaitStart {
+                addr: "//a:x".into(),
+                holder_pid: Some(4412),
+            },
+        ));
+        let (waits, total) = t.lock_waits(60_000, 30_000, 5);
+        assert_eq!(total, 1);
+        assert_eq!(waits.first().and_then(|w| w.holder_pid), Some(4412));
+        t.apply(&ev(
+            0,
+            BuildEventKind::ResultLockWaitEnd {
+                addr: "//a:x".into(),
+            },
+        ));
+        assert_eq!(t.lock_waits(60_000, 30_000, 5).1, 0, "cleared on end");
+    }
+
+    #[test]
+    fn status_settles_when_the_stream_closes() {
+        let mut t = Tally::default();
+        // A matched transparent group emits no `ResultEnd`, so `done == total`
+        // can never be reached; the stream closing is the authoritative signal.
+        matched(&mut t, &["//a:grp"], false);
+        assert_eq!(t.status_emoji(), "⏳");
+        t.set_closed();
+        assert_eq!(t.status_emoji(), "✅");
+    }
+
+    #[test]
+    fn a_failure_shows_as_failed_while_still_running() {
+        // Diagnosing before the end is the point: the status must go red the
+        // moment a root failure lands, not at close.
+        let mut t = Tally::default();
+        matched(&mut t, &["//a:x", "//a:y"], true);
+        assert_eq!(t.status_emoji(), "⏳");
+        t.apply(&ev(
+            5,
+            BuildEventKind::ResultEnd {
+                addr: "//a:x".into(),
+                error: Some("boom".into()),
+            },
+        ));
+        assert_eq!(t.status_emoji(), "❌", "red before the build finishes");
+    }
+
+    #[test]
+    fn roots_are_capped_but_still_counted() {
+        let mut t = Tally::default();
+        for i in 0..200 {
+            t.apply(&ev(
+                0,
+                BuildEventKind::ResultEnd {
+                    addr: format!("//a:t{i}"),
+                    error: Some("boom".into()),
+                },
+            ));
+        }
+        assert_eq!(t.roots().len(), ROOTS_KEPT, "detail capped");
+        assert_eq!(t.counters().roots_total, 200, "count is exact");
+    }
+
+    #[test]
+    fn roots_keep_first_seen_order() {
+        // Consecutive renders must differ by appends only, so an agent diffing
+        // two fetches sees "one new root" rather than a reshuffle.
+        let mut t = Tally::default();
+        for addr in ["//c:z", "//a:x", "//b:y"] {
+            t.apply(&ev(
+                0,
+                BuildEventKind::ResultEnd {
+                    addr: addr.into(),
+                    error: Some("boom".into()),
+                },
+            ));
+        }
+        let order: Vec<&str> = t.roots().iter().map(|r| r.addr.as_str()).collect();
+        assert_eq!(order, vec!["//c:z", "//a:x", "//b:y"], "not re-sorted");
+    }
+
+    #[test]
+    fn upstream_root_parsing() {
+        assert_eq!(
+            parse_upstream_root("result //a:b: dependency failed (root: //base:proto)"),
+            Some("//base:proto")
+        );
+        assert_eq!(parse_upstream_root("process exited with status 1"), None);
+        // Malformed: no closing paren.
+        assert_eq!(parse_upstream_root("dependency failed (root: //a:b"), None);
+    }
+
+    #[test]
+    fn package_derivation() {
+        assert_eq!(package_of("//services/api:test"), "//services/api");
+        assert_eq!(package_of("//:root"), "//");
+        // No colon at all — the whole thing is the package rather than a panic.
+        assert_eq!(package_of("//services/api"), "//services/api");
+    }
+
+    #[test]
+    fn elapsed_is_bounded_by_the_stream_once_closed() {
+        let mut t = Tally::default();
+        t.apply(&ev(1_000, BuildEventKind::MaxWorkers { count: 16 }));
+        t.apply(&ev(
+            5_000,
+            BuildEventKind::ResultEnd {
+                addr: "//a:x".into(),
+                error: None,
+            },
+        ));
+        // Still running: elapsed tracks now.
+        assert_eq!(t.elapsed_ms(9_000), 8_000);
+        t.set_closed();
+        // Closed: elapsed freezes at the last event, not at render time.
+        assert_eq!(t.elapsed_ms(999_000), 4_000);
+    }
+}

--- a/crates/tui/src/tui/progress.rs
+++ b/crates/tui/src/tui/progress.rs
@@ -714,7 +714,7 @@ pub struct BuildState {
     done: Vec<String>,
     /// Targets whose driver actually ran to success (`ExecuteEnd` with no error).
     /// Distinct from `completed`, which includes cache hits that never executed.
-    built: usize,
+    executed: usize,
     local_hits: usize,
     local_misses: usize,
     remote_hits: usize,
@@ -757,7 +757,7 @@ pub struct Counts {
     /// The denominator, bound to the [`ViewMode::Matched`] tab and `~`-prefixed
     /// while the matcher is still streaming. `None` before any `Matched` event,
     /// where the segment reads `{done} done` with no denominator (and `done` is
-    /// the built count, not a matched count).
+    /// the executed count, not a matched count).
     pub total: Option<String>,
     /// Cache hits in scope, e.g. `"3 cached"`.
     pub cached: String,
@@ -910,7 +910,7 @@ impl BuildState {
                 self.open_ops.remove(addr);
             }
             // The op timeline (folded above) tracks Execute's duration; here we
-            // keep only the `built` counter side effect on a successful end.
+            // keep only the `executed` counter side effect on a successful end.
             //
             // A target that executes is not a cached target — even if it was
             // announced as a hit first. The engine decides a hit from the
@@ -918,13 +918,13 @@ impl BuildState {
             // turn out to be unreadable (GC'd, expired on a shared cache, or
             // simply never pulled and the remote is now unreachable) and the
             // target is rebuilt. Retract the hit here rather than counting the
-            // same addr as both cached and built, which would let "built + cached"
+            // same addr as both cached and executed, which would let "executed + cached"
             // exceed the number of targets — and, on an offline run over a
             // remote-mirrored cache, report a full rebuild as "N cached".
             BuildEventKind::ExecuteStart { addr, .. } => self.retract_cache_hit(addr),
             BuildEventKind::ExecuteEnd { error, .. } => {
                 if error.is_none() {
-                    self.built += 1;
+                    self.executed += 1;
                 }
             }
             BuildEventKind::LocalCacheHit { addr } => {
@@ -1089,7 +1089,7 @@ impl BuildState {
                     let tilde = if complete { "" } else { "~" };
                     (done.to_string(), Some(format!("{tilde}{total}")))
                 }
-                None => (self.built.to_string(), None),
+                None => (self.executed.to_string(), None),
             },
         };
         Counts {
@@ -1452,7 +1452,7 @@ impl ProgressHeader for BuildHeader {
         // The done segment `X / Y done` splits into two independent tabs: `X`
         // (the finished count → Done view) and `Y` (the matched total → Matched
         // view). The connective ` / ` and trailing ` done` are inert text. Before
-        // any `Matched` event there is no denominator, so it reads `{built} done`
+        // any `Matched` event there is no denominator, so it reads `{executed} done`
         // with only the Done tab.
         let mut done_parts = vec![HeaderPart::tab(ViewMode::Done, done)];
         match total {
@@ -2047,7 +2047,7 @@ impl TUIAppView for TuiProgressView {
     /// Layout (top to bottom), a rounded box sized to `height` rows (one third of
     /// the terminal, see [`rows_for_height`]), with a dim help row pinned beneath:
     /// ```text
-    /// ╭─ heph · N built · N cached · N running · N failed ──── <workers> ─╮
+    /// ╭─ 1m05s · D / N done · N cached · N failed ──────────── <workers> ─╮
     ///   <slow rows + lock waits, scrollable>
     /// ╰─── <label> ───────────────────────────────────────────────────────╯
     ///   ↑/↓ scroll
@@ -2633,7 +2633,7 @@ mod tests {
     /// its blobs — a local GC, an expiry rule on a shared cache, or blobs that
     /// were never pulled and a remote that is now unreachable. It announces the
     /// hit, discovers the bytes are unreadable, and rebuilds. Counting both would
-    /// let "built + cached" exceed the number of targets, and would report a
+    /// let "executed + cached" exceed the number of targets, and would report a
     /// fully-offline rebuild of the whole graph as "N cached" — the header would
     /// say the opposite of what happened.
     #[test]
@@ -2671,9 +2671,9 @@ mod tests {
             (1, 1),
             "and counted as the miss it turned out to be"
         );
-        assert_eq!(s.built, 2);
+        assert_eq!(s.executed, 2);
         // Through the header's own accessors, not the raw counters: these are the
-        // numbers the user reads, and the point is that `built + cached` (2 + 1)
+        // numbers the user reads, and the point is that `executed + cached` (2 + 1)
         // does not exceed the three targets seen.
         assert_eq!(
             s.cached_count(CountScope::All),
@@ -2707,7 +2707,7 @@ mod tests {
         s.apply(&ev(2, execute_end("//a:fresh")));
         assert_eq!((s.local_hits, s.remote_hits), (0, 0));
         assert_eq!((s.local_misses, s.remote_misses), (0, 0));
-        assert_eq!(s.built, 1);
+        assert_eq!(s.executed, 1);
     }
 
     #[test]
@@ -3168,7 +3168,7 @@ mod tests {
         // frame precisely so the header does not re-derive them.
         let mut s = BuildState::new();
 
-        // Before any Matched event: the done segment falls back to `{built} done`
+        // Before any Matched event: the done segment falls back to `{executed} done`
         // with no denominator, and cached falls back to raw hit counts.
         s.apply(&ev(0, execute_start("//a:built")));
         s.apply(&ev(1, execute_end("//a:built")));

--- a/docs/GHA_REPORTING.md
+++ b/docs/GHA_REPORTING.md
@@ -1,0 +1,842 @@
+# GitHub Actions reporting — design
+
+Status: **design, not yet implemented.** Reviewed by `product-vision` and `feature-quality`.
+
+Scope: what `crates/plugin-gha` renders, and the event-stream changes that reporting needs.
+Not in scope: the sticky-comment transport (found-or-create, per-step sections, run markers) —
+that plumbing is sound and is kept.
+
+---
+
+## 1. The design constraint that drives everything: 20,000 targets
+
+A real CI run has **20k targets**. Every number below is sized against that, not against the
+120-target examples that make mockups readable.
+
+At 20k targets:
+
+| Quantity | Magnitude | Consequence |
+|---|---|---|
+| Events on the stream | ~160k (`~8/target`, measured — `crates/engine/src/engine/diag.rs:21`) | `on_event` must be allocation-light; nothing per-event may `format!` |
+| Matched top-level set | up to 20k addrs | a full addr list is never renderable; every list is top-N |
+| In-flight set (`running`) | **up to 20k**, not 16 — see §1.1 | the "slow" table must be filtered by *phase*, not just elapsed |
+| Failure cone | up to ~20k rows from **one** broken leaf | per-target failure rows are unbounded; roots-only is mandatory |
+| Packages | ~1–3k | package rollups are bounded and become the *primary* aggregation |
+| Retained addr strings | ~16 MB today (§6) | current design retains the whole graph to answer questions about the matched subset |
+
+**The rule this produces: no rendered section may be proportional to target count.** Every list is
+top-N with an explicit overflow line, every aggregation is by package or by root, and the only
+unbounded thing allowed to grow is a counter.
+
+### 1.1 The in-flight set is not bounded by worker count
+
+`RemoteCacheWriteStart` is emitted **before** the upload semaphore is acquired — deliberately, so a
+queued push still renders as an in-flight `↑` op (`crates/engine/src/engine/remote_cache.rs:1643`).
+`MAX_CONCURRENT_UPLOADS` is 16 (`remote_cache.rs:112`).
+
+So on a 20k-target cold build, at the moment the build finishes executing, `running` can hold
+**~20k `RemoteCacheWrite` entries of which 16 are actually uploading.** Today `Tally::slow()`
+clones every entry past the 10s threshold into a `Vec<(String, _, _)>` and sorts it — on every
+30-second render. That is ~20k `String` clones and an O(n log n) sort, producing a "slow targets"
+table listing thousands of targets that are not slow, they are queued.
+
+Requirements that follow:
+
+- **Cap the slow scan.** Maintain a bounded top-N (N=20) by start time rather than scanning and
+  sorting the whole map per render.
+- **Distinguish queued from active.** A queued upload is not a slow target. Either the engine
+  emits the slot acquisition (`RemoteCacheWriteQueued` → `…Start`), or the hook renders remote
+  writes as one aggregate row (`↑ 1,412 uploads queued, 16 active`) and never as per-target rows.
+  The aggregate row is preferred: it needs no event change and is the more useful fact.
+- **Never render remote-cache-write rows in the live "longest running" table.** They are after the
+  critical path and the user cannot act on them.
+
+---
+
+## 2. Two products, one event stream
+
+The single biggest structural fault today is one `render_markdown` serving both surfaces.
+
+| | **Live PR comment** | **Final step summary** |
+|---|---|---|
+| Read by | a human, on a phone, ~3s, repeatedly | someone debugging a red build; an agent deciding what's next |
+| Question answered | *pass? stuck? how long? is it mine?* | *what broke and why, how long, what did cache do* |
+| Shape | ≤8 lines, failures first, ≤3-column tables | tables, log tails, one diagram |
+| Budget | 65,536 chars, **shared with every other step's section** | 1 MiB |
+| Cost per render | one authenticated API write | one file write, free |
+| Diagrams | **never** (mermaid does not render in the GitHub mobile app) | yes, one |
+| Cadence | timer + out-of-band on failure | once |
+
+`render_live()` and `render_final()` are separate functions with separate budgets. The final view
+is not "the live view at t=end" — that is why today's summary ships a "slow targets" table that is
+structurally near-empty, since it reports *currently-running* targets at the moment everything has
+finished.
+
+---
+
+## 3. What the hook throws away today
+
+`Tally::apply` has a `_ => {}` arm (`crates/plugin-gha/src/lib.rs:142`). Silently dropped:
+
+- `MaxWorkers` — worker saturation, the "is it stuck vs busy" signal
+- `ResultLockWaitStart { holder_pid }` / `End` — the other half of that signal
+- `LocalCacheMiss`, `RemoteCacheMiss` — the entire denominator of the hit rate
+- `ResultStart` — per-target start time
+- `GcTargetSwept`
+
+And every `at_unix_ms` on every event, so **no duration of any kind survives**. The TUI
+(`crates/tui/src/tui/progress.rs`) consumes all of it. The CI reader — who has *less* context than
+the terminal user, not more — currently gets strictly less information.
+
+**Requirement: `Tally::apply` matches exhaustively**, with an explicit no-op arm and a one-line
+reason for each ignored kind, so a new `BuildEventKind` is a compile error here rather than a
+silent drop.
+
+---
+
+## 4. Live view
+
+### 4.1 Healthy, 20k targets
+
+```markdown
+## ⏳ heph run //... · 6m12s
+
+**8,412 / 20,140** done · 7,901 cached · **0 failed**
+`████████░░░░░░░░░░░░` 42% · 64/64 workers busy · updated 14:02:11Z
+
+<details><summary>Running longest (6 of 218 over 30s)</summary>
+
+| target | phase | for |
+| --- | --- | --- |
+| `//services/api:image` | execute | 4m02s |
+| `//web:bundle` | execute | 3m48s |
+| `//go/pkg/db:test` | execute | 2m11s |
+| `//services/auth:image` | execute | 1m52s |
+| `//tools/proto:gen` | execute | 1m40s |
+| `//web:typecheck` | execute | 1m31s |
+
+</details>
+```
+
+Notes at scale:
+
+- `6 of 218 over 30s` — the count is the honest signal; the rows are the sample. Never list 218.
+- `64/64 workers busy` distinguishes *slow* from *wedged*, and is free (`MaxWorkers` + the
+  in-flight count).
+- `updated …Z` is load-bearing: without it a ⏳ comment is indistinguishable from a comment whose
+  runner was OOM-killed 20 minutes ago.
+- The threshold is `slowAfterSecs`, default **30** (today's hardcoded 10s lists half a cold build).
+
+### 4.2 Stuck
+
+```markdown
+## ⏳ heph run //... · 14m40s — **no progress for 8m**
+
+**8,412 / 20,140** done · 7,901 cached · 0 failed
+`████████░░░░░░░░░░░░` 42% · **0/64 workers busy** · updated 14:09:37Z
+
+> [!WARNING]
+> 3 targets waiting on the result lock — another heph process holds it.
+
+| target | phase | for |
+| --- | --- | --- |
+| `//services/api:image` | 🔒 locked (pid 4412) | 8m01s |
+| `//web:bundle` | 🔒 locked (holder unknown) | 7m58s |
+```
+
+Every input here is already on the stream and discarded today. Idle workers plus a lock notice is
+the difference between waiting and hitting cancel.
+
+### 4.3 First failure — flushed out-of-band, comment reposted so it notifies
+
+````markdown
+## ❌ heph run //... · **1 failed** · still running (2m14s)
+
+> [!CAUTION]
+> **`//services/api:test` failed** — exit 1, after 34s.
+
+```
+--- FAIL: TestCreateUser (0.03s)
+    user_test.go:88: want status 201, got 500
+    user_test.go:91: body: {"error":"nil pointer"}
+FAIL
+```
+
+Reproduce: `heph run //services/api:test`
+
+---
+8,412 / 20,140 done · 7,901 cached · 64/64 workers busy · updated 14:02:14Z
+_Build continues — `--fail-fast` is off, remaining targets still running._
+````
+
+`updated 14:02:14Z` off the 30-second grid is the visible proof the out-of-band flush fired.
+
+### 4.4 Cone expanding — the 20k case
+
+One broken leaf can block ~20k targets. Rendering per-target rows is not an option.
+
+````markdown
+## ❌ heph run //... · **2 failed** (+4,117 blocked) · still running (7m02s)
+
+> [!CAUTION]
+> **2 root failures.** 4,117 targets blocked downstream.
+
+### `//base:proto` — exit 1, after 3s
+
+```
+proto/api.proto:41:3: "UserId" is not defined.
+```
+
+Reproduce: `heph run //base:proto`
+**4,109 targets blocked** — `//services` (2,204), `//web` (1,012), `//go/pkg` (893)
+
+### `//web:lint` — exit 2, after 4s
+`src/app.tsx:12:3  error  'foo' is defined but never used`
+**8 targets blocked** — `//web` (8)
+
+---
+11,204 / 20,140 done · 7,901 cached · 61/64 workers busy · updated 14:07:02Z
+````
+
+Rules:
+
+1. **A `ResultEnd` carrying `upstream_of: Some(root)` never renders a row.** It increments a
+   counter attributed to its root, and a per-package tally under that root.
+2. **Roots render in first-seen order, never re-sorted**, so consecutive PATCH bodies differ by
+   appends only and an agent diffing two fetches sees "one new root", not a reshuffle.
+3. **Log tail: 5 lines, first root only**, ~1 KiB cap. Mid-build the reader is answering "is this
+   mine?" — one error answers that, ten don't.
+4. Roots are themselves capped (10) with `…and N more root failures`.
+
+Without rule 1, this same moment renders 4,117 rows of `dependency failed` and the actual proto
+error is off the bottom of a phone screen.
+
+### 4.5 Fail-fast mode
+
+`--fail-fast` is opt-in (`src/commands/global.rs:67`), so keep-going is the default. When it *is*
+on, a one-failure report reads as "one thing is broken" when the truth is "we stopped looking":
+
+```markdown
+> [!WARNING]
+> Stopped at the first failure (`--fail-fast`) — 11,728 targets not attempted.
+```
+
+**The hook must never set or influence `fail_fast`.** A reporter that changes which targets execute
+is the wrong shape; the same command with and without a `plugins:` entry must run the same targets.
+Report the mode, don't set it.
+
+### 4.6 Completion — collapse asymmetrically
+
+- **Success** → one line. The PR timeline must not carry a green wall of tables forever.
+  ```markdown
+  ✅ **run //...** — 20,140 targets, 19,802 cached, 6m41s. [Full report](…#step-summary)
+  ```
+- **Failure** → stays expanded. It is the artifact people link in Slack.
+
+---
+
+## 5. Final view (step summary)
+
+### 5.1 Success, all cached
+
+```markdown
+## ✅ heph run //... — 41s · 20,140/20,140 targets, nothing executed
+
+20,140 cache hits (19,988 local, 152 remote) · 1.2 GiB pulled
+```
+
+### 5.2 Success, real work, 20k targets
+
+````markdown
+## ✅ heph run //... — 12m04s
+
+| | |
+| --- | --- |
+| targets | 20,140 matched · 20,140 ok · 0 failed |
+| cache | 19,802 hits (19,650 local, 152 remote) · **98.3% hit rate** · 338 misses |
+| executed | 338 targets · 3h11m of execute time over 64 workers |
+| remote cache | pulled 1.2 GiB (2m01s) · pushed 240 MiB (48s, 1,412 queued) |
+| drivers | exec 201 · go 128 · sh 9 |
+
+<details><summary>Slowest 20 of 338 executed</summary>
+
+| target | driver | execute | cache write | total |
+| --- | --- | --- | --- | --- |
+| `//services/api:image` | exec | 4m12s | 4s | 4m16s |
+| `//web:bundle` | exec | 3m48s | 2s | 3m50s |
+
+</details>
+
+<details><summary>Cache misses by package (338 across 47 packages)</summary>
+
+| package | misses | executed |
+| --- | --- | --- |
+| `//services/api` | 94 | 41m12s |
+| `//web` | 71 | 22m18s |
+
+_…and 45 more packages._
+
+</details>
+
+<details><summary>Timeline — 12m04s, 64 workers, showing the 20 longest of 338 executed</summary>
+
+> The last **4m02s** was `//services/api:image` running alone — it is the long pole.
+
+```mermaid
+gantt
+    title Run timeline
+    dateFormat x
+    axisFormat %M:%S
+    todayMarker off
+
+    section run
+    matching       :0, 31000
+    executing      :31000, 692000
+    cache upload   :692000, 724000
+
+    section longest targets
+    services/api·image :440000, 692000
+    web·bundle         :210000, 438000
+    go/pkg/db·test     :120000, 305000
+```
+
+</details>
+````
+
+At 20k the **package rollup is the primary aggregation** — a per-target list of 338 misses is
+already unreadable, and the interesting fact ("the misses are concentrated in two packages") only
+exists at the package level.
+
+### 5.3 Failure
+
+````markdown
+## ❌ heph run //... — 2 of 20,140 targets failed in 7m48s
+
+> [!CAUTION]
+> **2 root failures**, 4,117 targets blocked downstream. 15,921 ok.
+
+### `//base:proto`
+`exec` · executed 3s · exit status 1
+
+```
+proto/api.proto:41:3: "UserId" is not defined.
+proto/api.proto:52:3: "UserId" is not defined.
+```
+
+Reproduce: `heph run //base:proto`
+
+**4,109 targets blocked downstream** — `//services` (2,204), `//web` (1,012), `//go/pkg` (893)
+
+### `//web:lint`
+`exec` · executed 4s · exit status 2
+
+```
+src/app.tsx:12:3  error  'foo' is defined but never used
+```
+
+Reproduce: `heph run //web:lint`
+
+---
+15,921 ok · 15,802 cached · [full log](https://github.com/o/r/actions/runs/123456)
+````
+
+### 5.4 Frozen-check failure
+
+`FrozenCheckError` carries its diff as structured data (`crates/plugin/src/error.rs:273`;
+`src/commands/errors.rs:121` already renders it in a dedicated box). A ```` ```diff ```` fence gets
+GitHub's `+`/`-` colouring free, on a failure mode that is *entirely* about reading a diff.
+
+````markdown
+### `//proto:gen`
+`exec` · frozen check failed — generated output differs from tree
+
+```diff
+--- proto/api.pb.go (tree)
++++ proto/api.pb.go (generated)
+@@ -41,6 +41,7 @@
+ type User struct {
+   Id    string
++  Email string
+ }
+```
+
+Reproduce: `heph run //proto:gen` (without `--frozen`)
+````
+
+### 5.5 Zero cache hits — the diagnosability case
+
+Today no heph surface can answer "why did I miss", because `LocalCacheMiss { addr }` is a bare
+addr. With §7's `MissReason`:
+
+```markdown
+## ✅ heph run //... — 47m21s · **0 of 20,140 targets hit cache**
+
+> [!WARNING]
+> **19,984 misses were `definition changed`** — a BUILD file or tool version in the dependency
+> closure differs from the last cached run. 156 were `never built here`.
+> Remote cache: configured (`s3://ci-cache`), reachable, 0 hits, 19,984 misses.
+>
+> Inspect one: `heph inspect hashin //services/api:test`
+```
+
+The three things that make this work, all design-time:
+
+1. Miss reasons are **counted and the dominant one named in prose**, not tabulated.
+2. The remote cache states whether it was **configured and reachable** — "0 remote hits" is
+   otherwise ambiguous between "no remote cache" and "the remote cache is broken", and those page
+   different people.
+3. **The next command is printed.** `heph inspect hashin` already exists; extend the surface the
+   user has rather than inventing an `--explain` nobody discovers.
+
+---
+
+## 6. Data structures and cost at 20k
+
+### 6.1 What it costs today
+
+`Tally` holds `matched`, `finished`, `cache_hit` as `BTreeSet<String>` and `failed` as an unbounded
+`Vec`. `finished` and `cache_hit` accumulate over the **whole graph** but are only ever read as
+`matched ∩ …` (`lib.rs:148-162`).
+
+At ~80-100 B per retained addr, a 100k-target graph with 10k matched retains ~16 MB of which ~90%
+is never read. At 20k targets it is ~3-4 MB, still mostly dead. `BTreeSet<String>` also costs
+O(log n) **string comparisons** per insert, each walking a long shared `//deep/package/...` prefix
+before diverging.
+
+### 6.2 Target design
+
+One record per target, dropped at `ResultEnd`; counters folded at both edges (the rule the TUI
+already adopted at `progress.rs:668-676` after measuring 21–24 ms per frame of rescans at 100k):
+
+```rust
+struct TargetRec {
+    started_ms: u64,
+    phase: Option<(Phase, u64)>,
+    driver: Option<Box<str>>,
+    cache: Option<CacheHitKind>,   // Local | Remote — needed to un-count on retraction
+}
+
+struct Tally {
+    live: FxHashMap<Box<str>, TargetRec>,   // in-flight only; dropped at ResultEnd
+    seen: FxHashSet<u64>,                    // addr hashes, 8 B, for late-Matched dedup
+    slowest: BoundedHeap<Completed, 20>,     // top-N by duration, ~6 KB constant
+    roots: Vec<RootFailure>,                 // capped at 10 rendered, counted beyond
+    by_package: FxHashMap<Box<str>, PkgTally>,
+    counters: Counters,                      // executed, cached_local, cached_remote, misses…
+}
+```
+
+Result: **~5 MB at 100k targets, less than the ~16 MB today, with strictly more output.**
+
+Allocation: the addr `String` is already allocated by the plugin seam's JSON decode
+(`crates/plugin-sdk/src/serve.rs:1404`) — the hook cannot avoid that. But the hook's *own*
+3–4 clones per target (`matched`, `finished`, `cache_hit`, `running`) collapse to **one**
+`Box<str>` on first sight; every later event is a lookup and a field write. At 20k targets that is
+~80k → ~20k allocations.
+
+**Package-key rule:** derive as `&addr[..addr.rfind(':')]`, `get_mut` first, `insert(pkg.to_string())`
+only on miss. Otherwise a package `String` is allocated on every one of the ~160k events.
+
+### 6.3 Cost verdict per feature
+
+| Feature | Verdict | Note |
+|---|---|---|
+| Total build time | cheap | fold `min`/`max` of `at_unix_ms`. Call it "build time" — the first event is not process start |
+| Driver mix | cheap | `ExecuteStart.driver`; ≤20 entries |
+| Hit rate, local vs remote | cheap | misses are free today (dropped); needs `CacheHitKind` to un-count on retraction |
+| Lock waits, worker saturation | cheap | bounded by concurrency |
+| Package rollups | cheap | bounded by ~1–3k packages; obeys the key rule above |
+| Top-N slowest completed | cheap | bounded heap, ~6 KB |
+| **Per-target duration map** | **needs a cap** | ~118 B/target retained forever → ~2.4 MB at 20k, ~12 MB at 100k. Use the heap, never a map |
+| **Critical path** | **don't build** | `BuildEventKind` carries no dependency edges. Adding them multiplies per-event JSON by fan-out for *every* hook. Ship "top-N slowest" and name it that |
+| Previous-run delta | cheap if capped | stash ≤512 B of JSON in a hidden marker; `fetch_existing` already returns the body and the code currently discards the prior run's content (`lib.rs:534`) |
+
+Two things not to ship: a **critical path** without real edge data, and a **"cache saved 4m"**
+number without recorded prior execute durations. Both are plausible-looking fabrications that
+discredit every other number on the page.
+
+---
+
+## 7. Event-stream changes
+
+Each must earn its place for the TUI and telemetry too, not only for this hook — the host
+serde-JSON-encodes **every event per registered hook** at the emit chokepoint
+(`crates/plugin-stabby/src/load_stable.rs:826`), so every added field is paid ~160k times.
+
+### 7.1 `ResultEnd` carries structured failure detail — **the blocking change**
+
+Today `error: Option<String>` is `format!("{e:#}")` (`crates/engine/src/engine/event.rs:64`) — the
+whole anyhow chain on one line. `e.lines().next()` therefore yields the entire chain, unbounded in
+width, and for the common case renders `execute //x:test: process exited with status 1`, which says
+nothing.
+
+```rust
+ResultEnd { addr: String, error: Option<TargetError> }
+
+struct TargetError {
+    message: String,               // unchanged semantics: `{e:#}`
+    upstream_of: Option<String>,   // collateral: this failed because `root` did
+    exit_code: Option<i32>,
+    log_tail: Option<LogTail>,     // already captured at result.rs:1182, already bounded
+}
+```
+
+`log_tail` attaches only to failing results, so a green 20k build pays nothing. `upstream_of` is
+free — the engine constructs `UpstreamFailed { root }` at that exact site
+(`crates/plugin/src/error.rs:195`).
+
+This gates the live *and* final failure views. **Consult `compatibility` before the shape is
+fixed**: it is a stream-format change and telemetry reads the field.
+
+### 7.2 `MissReason` on cache-miss events + one-shot `CacheConfig`
+
+```rust
+LocalCacheMiss { addr: String, reason: MissReason }
+
+enum MissReason { NoEntry, InputsChanged, DefChanged, BlobsMissing, Disabled }
+```
+
+Plus a one-shot `CacheConfig { local, remote: Vec<String>, read_only, forced_miss }` alongside
+`MaxWorkers`. Coarse is fine — the point is turning a dead end into a direction.
+
+### 7.3 Bytes on remote-cache span ends
+
+`RemoteCacheReadEnd { addr, bytes, error }`, same for write. Two fields on events that already
+exist, only on cache-touching targets.
+
+### 7.4 Not now
+
+- **`parent` on `ResultStart`** — the only honest basis for a critical path. Defer with the
+  critical path itself.
+- **Driver-emitted structured diagnostics** (`file`, `line`, `col`, `severity`). This is what
+  unlocks `file=`/`line=` annotations and permalink embedding. It is a `Driver` surface change and
+  belongs to its own design, not smuggled in here.
+
+---
+
+## 8. Reaching the developer
+
+GitHub **does not notify on comment edits**, only on creation. A build that goes red at minute 2 of
+40 silently updates a comment nobody is looking at. Two channels, different jobs:
+
+### 8.1 Annotations — the live channel (MUST)
+
+`::error::` workflow commands stream to the run page *while the job runs*, appear inline in the job
+log at the point of failure, cost **zero API calls**, and are immune to rate limits. Nothing else in
+Actions has all four properties.
+
+```
+::error title=heph //base:proto::exit 1: proto/api.proto:41:3: "UserId" is not defined.
+```
+
+**Target-level only in v1 — no `file=`/`line=`.** heph cannot produce them: `TargetFailure` carries
+addr + log tail + cause chain and nothing else. Do **not** regex `file:line` out of the log tail in
+the hook; that is a zoo of per-language heuristics living in a reporter, producing wrong
+annotations on the PR diff. Gate `file=`/`line=` on §7.4's driver diagnostics.
+
+**Cap annotations at the root count** (GitHub renders ~10 per step in the UI anyway). Never emit one
+per collateral failure — at 20k that is 4,117 annotations.
+
+### 8.2 Comment cadence and the repost
+
+- Timer: `refreshSecs`, default 30.
+- **Out-of-band flush on the first failure, then on each new *root* failure, floored at 10s.**
+  Below the floor, set a dirty flag and let the next tick carry it. Collateral never flushes. Cost
+  is bounded by *breakage count*, not target count.
+- **On the running→failed transition, delete and re-post the comment once**, guarded by the
+  existing `run_marker` so a re-run doesn't re-notify off stale state. Net comment count on the PR
+  is unchanged; the state change generates exactly one notification; everything after is a PATCH.
+- Suppress PATCHes whose *semantic* body is unchanged. Quantize the `updated` clock to 5s so this
+  can actually fire.
+- Honour `Retry-After`; back off the refresh interval as the build ages (15s → 30s → 60s).
+
+Rate-limit context: GitHub's secondary limit on content-generating requests is ~80/min and ~500/hr
+per token. 120 PATCHes/hr/step × 8 matrix legs × 3 heph steps = 2,880/hr → throttled, then a
+`tracing::warn!` nobody reads and a comment that silently stops updating.
+
+---
+
+## 9. Byte budgets and truncation
+
+**Today over 65,536 chars: GitHub 422s, `error_for_status` turns it into a warn (`lib.rs:579`), and
+the comment freezes at its last good body for the rest of the job — every later tick 422s
+identically.** It breaks exactly when the report matters most.
+
+`MAX_FAILED_ROWS = 50` is a *row* count while each row's width is unbounded (see §7.1). 50 rows ×
+~1.3 KB already exceeds the cap from a single step's section, and `assemble_body` concatenates
+**every step's** section.
+
+The bounded design:
+
+1. **Budget in bytes, top-down.** `render_live(now, budget)` / `render_final(now, budget)`.
+2. **Two budgets.** Summary ~900 KiB (headroom under 1 MiB). Comment = `65,536 −
+   markers − other steps' sections`, computed at assemble time.
+3. **Cap each row's width**, not just the count: `MAX_FAILURE_MSG = 200` chars on the message line.
+4. Truncate at a `char_indices` boundary, never a byte index.
+5. **`assemble_body` enforces the hard cap last**, dropping the oldest foreign sections with an
+   explicit `…earlier steps trimmed` line. A comment that keeps updating beats one that is complete
+   and frozen.
+6. **Every truncation is visible** (`…and N more`, `…message truncated`). Silent truncation is the
+   same class of bug as the silent 422.
+7. **Treat a 422 as a bug signal, not a transient**: log the body length, then PATCH a minimal
+   fallback body (header + counts) so the comment degrades to the essential numbers rather than
+   freezing.
+
+---
+
+## 10. Visual vocabulary
+
+### 10.1 The one diagram: a gantt, step summary only
+
+Ship exactly one, in `$GITHUB_STEP_SUMMARY`, **never in the PR comment** — mermaid does not render
+reliably in the GitHub mobile app, and the phone reader is the live view's entire justification.
+
+A sorted duration table structurally cannot show what the gantt shows: **overlap** (338 targets
+summing to 3h11m over 64 workers is either great or terrible), **the tail** (the last 4m02s was one
+target alone — the most actionable CI perf fact there is), **idle gaps**, and **serialization**.
+
+Rules:
+
+- **Caps: 20 target rows + 4 phase rows.** Selected as the *longest*, and say so:
+  `showing the 20 longest of 338 executed`.
+- **Fallback is the sorted table**, which is built anyway. The diagram is **strictly additive** —
+  never the sole source of any number.
+- **Skip it entirely** under 3 executed targets or a 10s run.
+- **Never ship a diagram whose finding isn't also stated in a sentence** above it. The diagram makes
+  the finding credible; the sentence makes it reachable.
+
+**The landmine: mermaid gantt uses `:` as its field separator, and every heph addr contains one.**
+`//services/api:test` as a task label breaks the parse and renders as an error box. Sanitize —
+strip `//`, replace `:` with `·`, strip any remaining `:`/`,`/`;` — and keep the real addr in the
+adjacent table. This needs a specific test: a colon in a target name is not an edge case, it is
+every target.
+
+### 10.2 GFM features worth taking
+
+| Feature | Use |
+|---|---|
+| `> [!CAUTION]` | failed. Coloured, icon'd, mobile-native, and still plain markdown so an agent parses it as a state marker |
+| `> [!WARNING]` | stopped at first failure; 0 cache hits; lock waits |
+| `> [!NOTE]` | informational only |
+| `<details open>` | **first root failure only.** `open` on a long list defeats the phone case it serves |
+| ```` ```diff ```` | frozen-check diffs (§5.4) — the one syntax-highlighted fence worth having |
+| Plain fences | log tails. Highlighting mixed compiler/test output as `console` buys a coloured prompt character and invites language-guessing, which is the driver's job if it is anyone's |
+
+Three alert levels is the whole vocabulary anyone can hold; leave `TIP`/`IMPORTANT` alone.
+
+### 10.3 Rejected — and why, so it stays rejected
+
+| Proposal | Why not |
+|---|---|
+| shields.io / any badge | External HTTP dep in a build report, camo-cached unpredictably, breaks on GHES and private repos, encodes one number a word already carries |
+| Inline `<svg>` | Stripped by GitHub's sanitizer along with its whole subtree. SVG only works as a hosted `<img>`, which needs an upload and a network dependency |
+| Any `<img>`, incl. a self-hosted chart renderer | Upload + network, camo-caches unpredictably, breaks on GHES/private, invisible to agents |
+| Mermaid `pie` of cache hit rate | A two-slice pie is the textbook chart that loses to a percentage. `98.3% hit rate` is smaller, sharper, greppable |
+| Mermaid flowchart of the failure cone | Star topology in the common case — one hub, N spokes — conveys exactly the fan-out count, which the sentence already gives. `heph inspect revdeps` owns this question |
+| Mermaid dependency graph of the build | Unreadable above ~30 nodes; duplicates `heph inspect deps` badly |
+| Any mermaid in the PR comment | Doesn't render in the mobile app; eats the 65,536-char budget |
+| ASCII bar charts beyond the one progress bar | A per-package bar chart is a table that lost its alignment |
+| Emoji beyond ⏳ ✅ ❌ | Those three encode state; 🐢🚀🔥 encode mood, and an agent must learn them for nothing |
+| `#step:<n>:<line>` deep links | Three fragile lookups (jobs API, step index, log line) for a slightly better link. Link to the run |
+| Nested collapsibles > 1 level | Two taps is one too many, and it breaks mermaid rendering in some clients |
+| Live-view tables wider than 3 columns | Wrap into mush on a phone |
+
+**The rule underneath:** a visual earns its place only when it makes a *finding* legible that prose
+can't — and even then it ships alongside the sentence, never instead of it.
+
+---
+
+## 11. Agent-consumable surfaces
+
+An autonomous agent reads this to decide what to do next. Markdown-scraping a table and getting one
+line of a colon-joined chain serves it badly. Three surfaces, in priority order:
+
+1. **`GITHUB_OUTPUT`** — GHA-native, free, no parsing, no rate limit:
+   `heph_status=failed`, `heph_failed=2`, `heph_blocked=4117`, `heph_elapsed_ms=468000`,
+   `heph_cache_hit_rate=0.983`, `heph_json_path=…`
+2. **`jsonPath`** — a file the agent reads directly:
+
+```json
+{
+  "schema": "heph.gha/1",
+  "status": "failed",
+  "command": "run //...",
+  "elapsed_ms": 468000,
+  "fail_fast": false,
+  "targets": { "matched": 20140, "done": 15923, "failed": 2, "blocked": 4117,
+               "cached": 15802, "executed": 338 },
+  "cache": {
+    "local_hits": 15650, "remote_hits": 152, "misses": 338, "hit_rate": 0.983,
+    "miss_reasons": { "inputs_changed": 320, "no_entry": 18 },
+    "remote": { "configured": true, "reachable": true, "endpoints": ["s3://ci-cache"],
+                "bytes_pulled": 1288490188 }
+  },
+  "failures": [
+    { "addr": "//base:proto", "driver": "exec", "duration_ms": 3000, "exit_code": 1,
+      "upstream_of": null, "blocked_count": 4109,
+      "message": "process exited with status 1",
+      "log_tail": ["proto/api.proto:41:3: \"UserId\" is not defined."] }
+  ],
+  "slowest": [ { "addr": "//services/api:image", "driver": "exec", "duration_ms": 252000 } ]
+}
+```
+
+3. **`<!-- heph:json {...} -->`** in the comment body, for an agent that fetches the comment via the
+   API and has no filesystem access. The marker machinery already exists.
+
+Stability rules: **field names never change within a schema version**; `failures` and `slowest` are
+**deterministically sorted** (duration desc, then addr) so two runs diff cleanly; **collateral
+failures never appear in `failures`** — they are `blocked_count` on their root.
+
+### 11.1 The embedded JSON is a *different, hard-capped* document
+
+The JSON above is the **file** form. It is unbounded by design — 338 `slowest` entries and full log
+tails are fine in a file nothing limits.
+
+**The embedded `<!-- heph:json -->` form must never be that document.** It lives inside a body that
+GitHub caps at 65,536 characters (and, for the summary, 1 MiB) — a budget already shared with the
+header, the failure boxes, and *every other step's section in the same job*. At 20k targets a naive
+embed of the full document is tens of KiB on its own and would consume the entire comment.
+
+Rules, all enforced in code and covered by tests:
+
+1. **`EMBEDDED_JSON_MAX = 2048` bytes, hard.** The compact form carries counters, status, elapsed,
+   cache summary, and **only the root failure addrs** — no log tails, no `slowest`, no
+   `miss_reasons` breakdown, no package rollups.
+2. **It is budgeted *first*, not last.** The embed is reserved out of the byte budget before any
+   prose is rendered, because a truncated *fact* is recoverable for a human but a truncated *JSON
+   document is unparseable* — a half-written object breaks the agent that depends on it.
+3. **If the compact form still exceeds 2048 bytes** (many roots), drop root addrs oldest-first
+   until it fits, and record what was dropped **inside the JSON** so the agent knows it is reading a
+   truncated view:
+   ```json
+   {"schema":"heph.gha/1","status":"failed","truncated":true,"failures_omitted":37,
+    "elapsed_ms":468000,"targets":{"matched":20140,"failed":41,"blocked":4117},
+    "json_path":"/home/runner/work/_temp/heph-summary.json"}
+   ```
+4. **`truncated` and `json_path` are mandatory fields**, always present. `truncated: false` on the
+   happy path. `json_path` is how an agent that hits a truncated embed finds the complete document —
+   without it, truncation is a dead end.
+5. **Serialize compactly** (no pretty-printing) and **never let a log tail, an error message, or an
+   addr reach the embed unbounded** — addrs are capped at 128 chars each.
+6. **The embed is emitted once, in the final render only.** Live PATCHes carry no JSON: it would
+   burn budget on every tick to describe a state that is still changing, and an agent polling a
+   running build should read `GITHUB_OUTPUT` or the file.
+
+Test: at 20k targets with 200 root failures and 4 KB messages, assert the rendered body is
+≤ 65,536 bytes, the embedded JSON **parses**, `truncated` is `true`, and `json_path` is present.
+
+---
+
+## 12. Config surface
+
+Current: `refreshSecs`, `summaryPath`, `tokenEnv`. Keep the names and the camelCase.
+
+| Option | Default | Why |
+|---|---|---|
+| `comment` | `onFailureOrSlow` | `always`/`never`/`onFailure`/`onFailureOrSlow`. A 3-second all-cached step must not post. The single biggest spam fix |
+| `commentKey` | `$GITHUB_JOB` + leg discriminator | Fixes the matrix collision (§13) |
+| `slowAfterSecs` | `30` | Both the "running longest" threshold and the `onFailureOrSlow` gate. One knob |
+| `jsonPath` | unset | The agent surface |
+| `annotations` | `true` | `::error::` workflow commands |
+| `detail` | `auto` | `compact`/`full`/`auto` (compact on success, full on failure) |
+| `logTailLines` | follows the engine's `log_tail_lines` | Not a second independent number |
+
+`summaryPath` keeps its name but changes semantics to **append**, matching GitHub's contract.
+
+---
+
+## 13. Inherited bugs — fix as the foundation
+
+| # | Bug | Location |
+|---|---|---|
+| 1 | **Matrix legs collide.** `GITHUB_JOB` is the workflow-file job id, identical across legs. All legs race `fetch_existing`, all find nothing, all POST → duplicate comments; then each caches `sections` once at first sync and never re-reads, so legs permanently erase each other. This repo's own `test` job has three legs. **More urgent with §8.2's repost: a keying bug amplifies from clobbered sections to duplicate notifications** | `lib.rs:256`, `:663` |
+| 2 | **`failed` counts the collateral cone and double-counts.** Unguarded `Vec` push; every dependent gets a `ResultEnd` carrying `dependency failed (root: …)`. One broken leaf under 20k dependents renders `failed: 20001`. The memoizer keys on `(addr, outputs, is_top)` so one addr can emit several `ResultEnd`s — the TUI guards with a set, this doesn't | `lib.rs:98-103` |
+| 3 | **No byte budget** → silent 422 → the comment freezes (§9) | `lib.rs:231-248`, `:386-399` |
+| 4 | **`executed` and `cached` have different denominators.** `built` increments on every `ExecuteEnd` graph-wide; `cached_count()` counts `matched ∩ cache_hit`. **Decision: graph-wide for both**, so the two are reconcilable | `lib.rs:116-121`, `:157-162` |
+| 5 | **Step summary clobbered; failed write silent.** `fs::write` + `rename` destroys anything written earlier in the same step. `if write().is_ok() && let Err(e) = rename()` short-circuits, so a failed *write* logs nothing. Fixed temp path collides between concurrent processes | `lib.rs:606-617` |
+| 6 | **Raw argv in a public comment** — any `--define`/`--env` carrying a secret is published. Unbounded length | `lib.rs:652` |
+| 7 | **The live thread can overwrite the final comment.** It renders (releasing the tally lock) *before* taking the comment lock; if `on_close` lands in that window the stale "⏳" body PATCHes over the final one, permanently | `lib.rs:695-703`, `:724-739` |
+| 8 | **No request deadline.** `fetch_existing` walks up to 10 pages at reqwest's 30s default; a first sync landing in `on_close` can block ~300s, and the host awaits `Hook::drain` before exit | `lib.rs:482-521` |
+| 9 | **`parse_sections` mis-parses content containing its own delimiters**, and the section key is the unbounded raw command — a key containing `" -->"` appends a new section every step until the body hits the cap. Hash the key | `lib.rs:343-371` |
+| 10 | **`_ => {}` drops six event kinds silently** (§3) | `lib.rs:142` |
+
+---
+
+## 14. Test plan
+
+`crates/plugin-gha` `#[cfg(test)]` — everything below is provable in-process:
+
+- **Byte-budget truncation at both limits**, adversarial: 500 failures × 4 KB single-line messages;
+  3k packages; a 3 KB section key. Assert `body.len() <= 65_536`, the first root survives, and the
+  truncation marker is present.
+- **20k-scale folding**: 20k `Matched` + a 4k-deep collateral cone renders roots-only, `blocked`
+  counts correctly, and no per-target row appears.
+- **`CommentClient` against a loopback server** — needs the seam refactor below. Create-then-PATCH
+  uses the returned id; adopt with matching run id preserves other steps' sections; different run
+  id resets; 422 leaves state consistent; 404 mid-run doesn't wedge; `on_close` returns within its
+  deadline against a server that never responds.
+- **`write_summary`**: pre-existing content preserved; a failed write is logged; concurrent temp
+  files don't collide.
+- **Gantt label sanitization**: a target addr's `:` never reaches the mermaid block.
+- **`parse_sections`** adversarial bodies: delimiters in content, `" -->"` in the key, newline in
+  the key, empty body, container marker only.
+- **Failure dedup**: a duplicate `ResultEnd` for one addr adds no row.
+- **Out-of-band flush**: first failure flushes; a collateral failure does not; two roots within the
+  10s floor coalesce.
+
+**Blocking refactor: the HTTP layer has no test seam.** `from_env` reads process env directly
+(`lib.rs:442`), so nothing can construct a `CommentClient` in a test without mutating global env.
+Split `CommentClient::new(CommentConfig { … })` from a thin `from_env` adapter. Use the loopback
+pattern already in `crates/e2e/tests/http_fetch.rs:17-41` (std `TcpListener` on `127.0.0.1:0`, no
+new dependency).
+
+**Test-isolation defect today:** `on_close_writes_final_summary_to_path` (`lib.rs:1109`) constructs
+the real `GhaHook`, which calls `CommentClient::from_env`. Under Actions `GITHUB_REPOSITORY` and
+`GITHUB_REF` are always set; only the absence of `GITHUB_TOKEN` from the `test` job's env stops it
+spawning a live thread and POSTing onto the PR under test. That is an undeclared ambient invariant,
+and it means the shipped branch (comment enabled) is the one never exercised.
+
+`crates/e2e` — one test: run a real build with the hook registered and `summaryPath` in a
+`TempDir`; assert the summary's counts match what the engine actually did, including a cache hit and
+a failure. Every existing test hand-scripts the event stream and would keep passing if the engine's
+event semantics changed.
+
+`crates/bin-e2e` — **nothing new.** `shipped_gha_cdylib_loads` already covers the only qualifying
+seam. Do not put summary-content assertions there.
+
+---
+
+## 15. Sequencing
+
+1. **Rendering, keying, and the test seam — no engine changes.** Bugs 1, 3, 4, 5, 6, 7, 8, 9, 10;
+   split `render_live`/`render_final`; elapsed + `updated …Z`; `executed` rename across both
+   surfaces; `comment: onFailureOrSlow`; drop the t=0 sync; byte budgets. This alone fixes the live
+   view and every comment bug.
+2. **`ResultEnd` structured failure detail** (§7.1) — gates live failure diagnosis, the highest-value
+   item. Consult `compatibility` on the shape first.
+3. **Annotations, out-of-band flush, the failure repost** (§8) — early diagnosis reaches a human.
+4. **`MissReason` + `CacheConfig`** (§7.2), the prose diagnosis, `jsonPath` / `GITHUB_OUTPUT`.
+5. **Final-view richness**: durations, package rollups, local/remote split, the gantt.
+
+---
+
+## 16. Open decisions
+
+- **The matrix comment key.** Fold a leg discriminator into `commentKey` (runner os/arch, or the
+  matrix context passed as an option), or re-read the body and merge before each PATCH at one extra
+  GET per tick? Per `CLAUDE.md`, a per-platform behavioural difference is the user's call, and this
+  one is now urgent (§13.1).
+- **`upstream_of` on the wire** — `compatibility` must rule on whether changing
+  `ResultEnd.error` from `Option<String>` to a struct needs a version bump or a compatibility
+  shim, given telemetry reads the field.
+
+### Settled
+
+- `built` → **`executed`**, in both the GHA output and the TUI (the `BuildState::built` field, the
+  fallback render at `progress.rs:1092`, and the stale doc comment at `progress.rs:2050` that
+  advertises a header the code no longer produces).
+- Counts are **graph-wide**, not matched-only.
+- `comment` defaults to **`onFailureOrSlow`**.
+- Diagrams: **one gantt, step summary only.** No SVG, no badges, no cone flowchart.
+- The hook **never** influences `fail_fast`; it reports the mode.

--- a/docs/GHA_REPORTING.md
+++ b/docs/GHA_REPORTING.md
@@ -470,14 +470,16 @@ whole anyhow chain on one line. `e.lines().next()` therefore yields the entire c
 width, and for the common case renders `execute //x:test: process exited with status 1`, which says
 nothing.
 
-```rust
-ResultEnd { addr: String, error: Option<TargetError> }
+**Approved shape — sibling fields, `error` untouched.** `compatibility` reviewed this and rejected
+retyping `error` to a struct. Add fields alongside it instead:
 
-struct TargetError {
-    message: String,               // unchanged semantics: `{e:#}`
-    upstream_of: Option<String>,   // collateral: this failed because `root` did
-    exit_code: Option<i32>,
-    log_tail: Option<LogTail>,     // already captured at result.rs:1182, already bounded
+```rust
+ResultEnd {
+    addr: String,
+    error: Option<String>,                          // unchanged type AND semantics: still `{e:#}`
+    #[serde(default)] upstream_of: Option<String>,  // collateral: this failed because `root` did
+    #[serde(default)] exit_code: Option<i32>,
+    #[serde(default)] log_tail: Option<LogTailData>,
 }
 ```
 
@@ -485,8 +487,67 @@ struct TargetError {
 free — the engine constructs `UpstreamFailed { root }` at that exact site
 (`crates/plugin/src/error.rs:195`).
 
-This gates the live *and* final failure views. **Consult `compatibility` before the shape is
-fixed**: it is a stream-format change and telemetry reads the field.
+### Why retyping `error` was rejected
+
+`BuildEvent` is **already a live cross-process, cross-artifact boundary**, not the hypothetical one
+the module doc implies. `StableRemoteHook` serde-JSON-encodes every event to out-of-process hooks
+(`crates/plugin-stabby/src/load_stable.rs:826`), and `plugin-gha-cdylib` ships as its own release
+artifact pinned by manifest URL independently of the `heph` binary — so host/plugin version skew is
+a normal reachable state.
+
+A skewed pair still loads at `dlopen` (stabby's structural check covers only the
+`StreamItem { item: SVec<u8> }` envelope, which doesn't change). The break happens later, and the
+failure mode is the worst available:
+
+```rust
+// crates/plugin-sdk/src/serve.rs
+Body::StreamItem(si) => serde_json::from_slice(&si.item).ok(),   // decode failure -> None
+...
+match decode_event_frame(&bytes) {
+    Some(ev) => hook.on_event(&ev),
+    None => break,                                                // ends the WHOLE stream
+}
+}
+hook.on_close();                                                  // hook thinks the build ended fine
+```
+
+**One undecodable frame silently truncates that hook's entire event stream**, and `on_close` then
+fires as if the build had finished normally. No error surfaces anywhere. Worse, it is conditional
+on a *failure* occurring — a green build with a skewed pair looks perfectly healthy, so it passes
+every smoke test and breaks in the field on exactly the red builds this feature exists to diagnose.
+
+The sibling shape is additive in both directions:
+
+| | Result |
+|---|---|
+| old host → new plugin | keys absent; `#[serde(default)]` fills `None`; decodes fine, no richer detail |
+| new host → old plugin | serde ignores unknown fields (no `deny_unknown_fields` on the enum); decodes fine, zero regression |
+| matched | full detail |
+
+`#[serde(default)]` is load-bearing, not decoration: a bare `Option<T>` field is **not**
+absent-tolerant under `serde_derive` — a missing key is an error without it.
+
+### Two constraints on the shape
+
+- **`LogTail` cannot be used directly.** It lives in `crates/plugin/src/error.rs`, derives only
+  `Debug, Clone, PartialEq, Eq` (no serde), and `crates/plugin` depends on `crates/core` — not the
+  reverse. `hcore::events` is deliberately the lowest crate. So either define a small serde mirror
+  in `hcore::events` (`text`, `start_line`) and convert at the emit site, or move the plain-data
+  part of `LogTail` down into `hcore` and re-export it from `crates/plugin`.
+- **The doc previously claimed telemetry reads this field.** It doesn't —
+  `collector.rs::observe_event` only counts variant occurrences, it never inspects `.error`. The
+  real exposure is the out-of-process hook seam above.
+
+### Two follow-ups this surfaced (not part of the reporting work)
+
+1. **`crates/core/src/events.rs` is in no ABI watch set.** `scripts/abi-check.sh` guards
+   `crates/plugin-stabby/src/abi.rs` as a hard path and `proto/plugin/v1` as a warn-only glob;
+   `events.rs` crosses the same dlopen'd seam and produces **zero** CI signal. Nothing forces a
+   change here to be reviewed as a wire change, so this class of break will recur.
+2. **Adding a `BuildEventKind` variant has the same failure characteristic.** The enum is
+   `#[serde(tag = "type")]`; an old plugin meeting an unknown tag fails to decode and truncates its
+   stream by the same path. A `#[serde(other)] Unknown` catch-all variant would make unknown kinds
+   skippable rather than fatal. Pre-existing fragility, worth its own fix.
 
 ### 7.2 `MissReason` on cache-miss events + one-shot `CacheConfig`
 
@@ -827,12 +888,18 @@ seam. Do not put summary-content assertions there.
   matrix context passed as an option), or re-read the body and merge before each PATCH at one extra
   GET per tick? Per `CLAUDE.md`, a per-platform behavioural difference is the user's call, and this
   one is now urgent (§13.1).
-- **`upstream_of` on the wire** — `compatibility` must rule on whether changing
-  `ResultEnd.error` from `Option<String>` to a struct needs a version bump or a compatibility
-  shim, given telemetry reads the field.
+- **Where the `LogTail` plain data lives** — a serde mirror in `hcore::events`, or move
+  `LogTail`'s data part down into `hcore` and re-export it from `crates/plugin`? Either satisfies
+  the layering; §7.1 does not pick one.
+- **Whether the two follow-ups in §7.1 are taken now or tracked** — adding `events.rs` to
+  `abi-check.sh`, and the `#[serde(other)] Unknown` catch-all variant. Both are pre-existing
+  fragility this work surfaced rather than caused.
 
 ### Settled
 
+- **`ResultEnd` gains sibling `#[serde(default)]` fields; `error` keeps its type.** Ruled by
+  `compatibility` (§7.1) — retyping it would silently truncate a skewed plugin's whole event
+  stream, and only on builds that fail.
 - `built` → **`executed`**, in both the GHA output and the TUI (the `BuildState::built` field, the
   fallback render at `progress.rs:1092`, and the stale doc comment at `progress.rs:2050` that
   advertises a header the code no longer produces).


### PR DESCRIPTION
Rewrites what the GitHub Actions hook reports. The plumbing (sticky comment, per-step sections, run markers, cdylib seam) is kept; what it *renders* was a placeholder.

Design doc: `docs/GHA_REPORTING.md` — reviewed by `product-vision` and `feature-quality`, and sized throughout against a **20k-target** CI run, which is what forces most of the decisions.

## The problem

`Tally::apply` had a `_ => {}` arm that silently dropped `MaxWorkers`, `ResultLockWait*`, both cache-miss kinds and `ResultStart`, and discarded every `at_unix_ms` — so **no duration of any kind survived**. The TUI consumes all of it. The person watching CI from a phone got strictly less than the person at the terminal, and the same block was rendered for both the live comment and the final summary.

## What changed

**Aggregation** — one record per *in-flight* target, dropped at `ResultEnd`; counters folded at both edges; failures tracked by root with per-package collateral rollups; slowest-completed as a bounded top-N heap. Exhaustive match on `BuildEventKind` so a new kind can't be silently dropped again.

**Rendering** — split into `render_live` (failures first, roots only, elapsed + a quantized `updated …Z` clock, worker saturation, lock waits) and `render_final` (what *happened*: hit rate split local/remote, slowest targets, package rollups). Both take a byte budget and cannot exceed it.

## Bugs fixed along the way

| | |
|---|---|
| `failed: 20001` from one broken leaf | Every dependent gets a `ResultEnd` carrying `dependency failed (root: …)`. Collateral is now counted, not listed, and the root is never absent from the report. Roots deduped by addr (the memoizer emits several `ResultEnd`s per addr). |
| Silent 422 froze the comment | `MAX_FAILED_ROWS` was a *row* count while each message is `format!("{e:#}")` — the whole anyhow chain on one line, unbounded in width. Many failures blew the 65,536-char cap, GitHub 422'd, and the comment froze at its last good body for the rest of the job. Now byte-budgeted, with every truncation announced. |
| Thousands of "slow" queued uploads | `RemoteCacheWriteStart` fires *before* the 16-slot upload semaphore, so at 20k targets ~20k are in flight with 16 uploading. `slow()` cloned and sorted all of them every 30s. Now one aggregate line, never per-target rows. |
| `$GITHUB_STEP_SUMMARY` clobbered | It's a per-step *append* target; write-then-rename destroyed anything an earlier command in the same step wrote. Also `if write().is_ok() && let Err(e) = rename()` swallowed a failed write entirely — no summary, no warning. |
| Secrets in a public comment | The heading was raw argv, publishing every flag including any `--define`/`--env` carrying a secret. Now an allowlist: subcommand plus target selectors. |
| `built`/`cached` didn't reconcile | Different denominators. Both are graph-wide now; progress stays matched-only. Also renamed `built` → `executed` across the GHA output *and* the TUI, matching the engine's own vocabulary. |

## Memory

The rewrite makes the hook **cheaper** than before: `finished`/`cache_hit` were graph-wide `BTreeSet<String>`s read only as `matched ∩ …`, retaining ~16 MB at 100k targets of which ~90% was never read. Now ~5 MB, with strictly more output.

## Tests

44 in `plugin-gha`, including the 20k-scale cases: a 4,117-target collateral cone rendering two root sections and no per-target rows; 200 roots × 4 KB messages staying inside every budget; 5,000 queued uploads producing zero slow rows; multibyte addrs and messages not panicking. `cargo test -p plugin-gha preview -- --ignored --nocapture` prints the rendered views for eyeballing.

## Still to come (design doc §15)

Not in this PR: the `ResultEnd` structured failure detail (`exit_code`/`log_tail`/`upstream_of`) that gates live failure diagnosis and needs a `compatibility` ruling; `::error::` annotations; the out-of-band flush and failure repost; `MissReason`; the bounded JSON surfaces; the matrix comment-key fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QdtQoQV7ptcJzoiUgXJvJv