### PR TITLE
feat(events): carry structured failure detail on ResultEnd

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -861,6 +861,7 @@ dependencies = [
  "libc",
  "rustc-hash",
  "serde",
+ "serde_json",
  "stacker",
  "tar",
  "tempfile",

--- a/crates/core/Cargo.toml
+++ b/crates/core/Cargo.toml
@@ -21,3 +21,6 @@ tracing = "0.1"
 
 [dev-dependencies]
 tempfile = "3"
+# The build-event stream is a live JSON wire format to out-of-process hooks; its
+# cross-version decode behaviour is tested against real JSON frames.
+serde_json = "1"

--- a/crates/core/src/events.rs
+++ b/crates/core/src/events.rs
@@ -2,12 +2,44 @@
 //! the TUI + telemetry. Shared here (the lowest crate) so neither consumer needs
 //! to depend on the engine.
 //!
-//! Events are serde-serializable and transport-ready for a future client/server
-//! process split. They carry the target address as a `String` (`//pkg:name`),
-//! never the internal `Arc`-backed `Addr`. The server (engine) stamps every event
-//! with a wall-clock timestamp at emit time (`at_unix_ms`). The `emit_scope`
-//! helper that pairs Start/End events lives in the engine (it needs the engine's
-//! `RequestState`).
+//! Events are serde-serializable. They carry the target address as a `String`
+//! (`//pkg:name`), never the internal `Arc`-backed `Addr`. The server (engine)
+//! stamps every event with a wall-clock timestamp at emit time (`at_unix_ms`).
+//! The `emit_scope` helper that pairs Start/End events lives in the engine (it
+//! needs the engine's `RequestState`).
+//!
+//! # This is a live wire format
+//!
+//! Not a "future" one. `StableRemoteHook` serde-JSON-encodes **every** event
+//! across the plugin seam to out-of-process hooks
+//! (`crates/plugin-stabby/src/load_stable.rs`), and a plugin cdylib such as
+//! `plugin-gha-cdylib` ships as its own release artifact, pinned by manifest URL
+//! independently of which `heph` binary the user runs. **Host/plugin version
+//! skew is therefore a normal, reachable state**, and a skewed pair still loads
+//! successfully at `dlopen` — the ABI check covers the `StreamItem` envelope,
+//! not this payload.
+//!
+//! The decode path has **no slack**: a frame that fails to deserialize is
+//! treated as end-of-stream by the plugin SDK's pull loop, which then calls
+//! `on_close()`. A single undecodable event silently truncates that hook's whole
+//! stream while the hook believes the build finished normally.
+//!
+//! So, when changing anything here:
+//!
+//! - **Never change an existing field's type or remove one.** Add new fields
+//!   alongside, each `#[serde(default)]` — a bare `Option<T>` is *not*
+//!   absent-tolerant under `serde_derive`; a missing key is an error without it.
+//!   Unknown fields are already ignored on the way in (no
+//!   `deny_unknown_fields`), so new-host → old-plugin is safe.
+//! - **New variants are safe** only because of [`BuildEventKind::Unknown`]'s
+//!   `#[serde(other)]`. Do not remove it.
+//! - **Renaming a variant is a break**, not a refactor: the name *is* the `type`
+//!   tag on the wire. An old consumer decodes the renamed variant as `Unknown`
+//!   and silently loses that event — it degrades rather than truncating the
+//!   stream, which is survivable but is still a loss. `RequestConfig` was renamed
+//!   from `MaxWorkers` deliberately, pre-1.0, with that cost accepted.
+//!
+//! `scripts/abi-check.sh` watches this file and will flag changes for review.
 
 use serde::{Deserialize, Serialize};
 
@@ -21,12 +53,32 @@ pub struct BuildEvent {
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(tag = "type")]
 pub enum BuildEventKind {
-    /// Declares the engine's worker capacity (the `result` semaphore size) for
-    /// this request. Emitted once at the start of a `result` batch so the client
-    /// can render a fixed worker-slot indicator. `count` is the maximum number of
-    /// targets that can execute concurrently.
-    MaxWorkers {
-        count: usize,
+    /// Declares how this request is configured. Emitted once at the start of a
+    /// `result` batch.
+    ///
+    /// This is the one-shot "here is how the build is set up" announcement, and
+    /// the home for anything a consumer would otherwise have to *discover* about
+    /// the run. It was `MaxWorkers { count }` until it grew a second field and
+    /// the name started lying; further request-level configuration (which caches
+    /// are wired up, whether they are read-only) belongs here rather than in new
+    /// variants.
+    RequestConfig {
+        /// The maximum number of targets that can execute concurrently (the
+        /// `result` semaphore size). Lets a client render a fixed worker-slot
+        /// indicator.
+        max_workers: usize,
+        /// Whether this request stops at the first target failure.
+        ///
+        /// On the stream because a consumer must not have to guess it. The GHA
+        /// hook previously scanned `std::env::args()` for `--fail-fast`, which is
+        /// wrong twice over: a plugin is handed what it needs rather than reading
+        /// the ambient environment — it may not even share the host's process —
+        /// and a naive argv scan false-positives on a flag *value* that happens
+        /// to look like the flag (`--define X=--ff`).
+        ///
+        /// It matters to a report because a one-failure summary under fail-fast
+        /// reads as "one thing is broken" when the truth is "we stopped looking".
+        fail_fast: bool,
     },
     /// Incremental notice of matched top-level targets. `addrs` are newly
     /// matched addresses to add to the set; `complete` is false while the
@@ -41,7 +93,30 @@ pub enum BuildEventKind {
     },
     ResultEnd {
         addr: String,
+        /// The failure, flattened by `format!("{e:#}")` — the whole cause chain
+        /// on one line. Unchanged in type and meaning; the fields below add
+        /// structure alongside it rather than replacing it, because retyping
+        /// this field would break a version-skewed plugin (see the module docs).
         error: Option<String>,
+        /// Set when this target failed *only* because a dependency did, naming
+        /// the root. Lets a consumer separate the one thing a human has to fix
+        /// from the collateral cone — which at 20k targets can be thousands of
+        /// targets reporting the same underlying failure.
+        #[serde(default)]
+        upstream_of: Option<String>,
+        /// The process's exit status as the OS reported it (e.g. `exit status:
+        /// 1`), when the failure was a subprocess.
+        ///
+        /// A string, not an `i32`, because a string is what the engine actually
+        /// has: `ProcessFailed::status` is already formatted. Parsing an integer
+        /// back out of it in a consumer would be the same guesswork this field
+        /// exists to remove.
+        #[serde(default)]
+        exit_status: Option<String>,
+        /// The last lines of the target's process log. Only ever attached to a
+        /// failing result, so a green build pays nothing for it.
+        #[serde(default)]
+        log_tail: Option<LogTailData>,
     },
     ExecuteStart {
         addr: String,
@@ -121,15 +196,154 @@ pub enum BuildEventKind {
         revisions_removed: usize,
         bytes_removed: u64,
     },
+    /// An event kind this build of the consumer does not know.
+    ///
+    /// **Load-bearing for cross-version safety, not a placeholder.** Events ride
+    /// to out-of-process hooks as serde-JSON, and a plugin cdylib ships as its
+    /// own release artifact pinned independently of the `heph` binary — so a
+    /// consumer meeting an event kind newer than itself is a reachable state.
+    ///
+    /// Without this catch-all, that event fails to deserialize, and the plugin
+    /// SDK's pull loop treats a decode failure as end-of-stream
+    /// (`crates/plugin-sdk/src/serve.rs`: `decode_event_frame(..)` → `None` →
+    /// `break`) and then calls `on_close()`. One unknown event would silently
+    /// truncate that hook's **entire** stream while the hook believed the build
+    /// had ended normally — no error surfaced anywhere.
+    ///
+    /// `#[serde(other)]` makes the unknown kind decode to this variant instead,
+    /// so consumers skip it and keep receiving everything after it.
+    #[serde(other)]
+    Unknown,
+}
+
+/// A bounded slice of a target's process log, carried on the event stream.
+///
+/// A mirror of `hplugin::error::LogTail` rather than that type itself: it has no
+/// serde derives, and `crates/plugin` depends on this crate, not the reverse.
+/// `hcore` is deliberately the lowest crate so the TUI and telemetry need no
+/// engine or plugin dependency to read events.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct LogTailData {
+    pub text: String,
+    /// 1-based line number of `text`'s first line within the full log, so a
+    /// renderer can show true file positions rather than renumbering from 1.
+    pub start_line: usize,
 }
 
 pub type EventSender = tokio::sync::mpsc::UnboundedSender<BuildEvent>;
 pub type EventReceiver = tokio::sync::mpsc::UnboundedReceiver<BuildEvent>;
 
-/// Wall-clock milliseconds since the Unix epoch. Stamped once at emit time.
 pub fn now_unix_ms() -> u64 {
     std::time::SystemTime::now()
         .duration_since(std::time::UNIX_EPOCH)
         .map(|d| d.as_millis() as u64)
         .unwrap_or(0)
+}
+
+/// Wall-clock milliseconds since the Unix epoch. Stamped once at emit time.
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// A frame from a host *older* than this build: the sibling fields are absent
+    /// from the JSON entirely.
+    ///
+    /// This must decode. Without `#[serde(default)]` on each new field, a missing
+    /// key is a hard error — a bare `Option<T>` is not absent-tolerant under
+    /// `serde_derive` — and the plugin SDK treats a decode error as end-of-stream,
+    /// silently truncating everything after it.
+    #[test]
+    fn old_host_frame_decodes_against_new_fields() {
+        let old = r#"{"at_unix_ms":1,"kind":{"type":"ResultEnd","addr":"//a:x","error":"boom"}}"#;
+        let ev: BuildEvent = serde_json::from_str(old).expect("old frame must decode");
+        match ev.kind {
+            BuildEventKind::ResultEnd {
+                addr,
+                error,
+                upstream_of,
+                exit_status,
+                log_tail,
+            } => {
+                assert_eq!(addr, "//a:x");
+                assert_eq!(error.as_deref(), Some("boom"));
+                assert_eq!(upstream_of, None);
+                assert_eq!(exit_status, None);
+                assert_eq!(log_tail, None);
+            }
+            other => panic!("wrong variant: {other:?}"),
+        }
+    }
+
+    /// A frame from a host *newer* than this build: it carries fields this build
+    /// has never heard of. Serde ignores unknown fields by default, and nothing
+    /// here sets `deny_unknown_fields` — adding it would break this.
+    #[test]
+    fn newer_host_frame_with_unknown_fields_decodes() {
+        let newer = r#"{"at_unix_ms":1,"kind":{"type":"ResultEnd","addr":"//a:x",
+            "error":null,"upstream_of":null,"exit_status":null,"log_tail":null,
+            "some_field_from_the_future":{"nested":true}}}"#;
+        let ev: BuildEvent = serde_json::from_str(newer).expect("unknown fields are ignored");
+        assert!(matches!(ev.kind, BuildEventKind::ResultEnd { .. }));
+    }
+
+    /// An event *kind* from a newer host. Without `Unknown`'s `#[serde(other)]`
+    /// this fails to deserialize, and one such event silently ends the whole
+    /// stream for an out-of-process hook while it believes the build finished.
+    #[test]
+    fn unknown_event_kind_decodes_instead_of_ending_the_stream() {
+        let future = r#"{"at_unix_ms":1,"kind":{"type":"SomethingInventedLater","x":1}}"#;
+        let ev: BuildEvent = serde_json::from_str(future).expect("unknown kind must not be fatal");
+        assert!(matches!(ev.kind, BuildEventKind::Unknown));
+    }
+
+    /// A whole stream survives an unknown kind in the middle — the property that
+    /// actually matters, since the failure mode is truncation, not one lost event.
+    #[test]
+    fn a_stream_continues_past_an_unknown_kind() {
+        let frames = [
+            r#"{"at_unix_ms":1,"kind":{"type":"RequestConfig","max_workers":8,"fail_fast":false}}"#,
+            r#"{"at_unix_ms":2,"kind":{"type":"FutureKind","whatever":true}}"#,
+            r#"{"at_unix_ms":3,"kind":{"type":"ResultEnd","addr":"//a:x","error":null}}"#,
+        ];
+        let decoded: Vec<BuildEvent> = frames
+            .iter()
+            .map(|f| serde_json::from_str(f).expect("every frame decodes"))
+            .collect();
+        assert_eq!(decoded.len(), 3);
+        assert!(matches!(decoded[1].kind, BuildEventKind::Unknown));
+        assert!(matches!(decoded[2].kind, BuildEventKind::ResultEnd { .. }));
+    }
+
+    /// New fields round-trip when both sides know them.
+    #[test]
+    fn structured_failure_detail_round_trips() {
+        let ev = BuildEvent {
+            at_unix_ms: 7,
+            kind: BuildEventKind::ResultEnd {
+                addr: "//a:x".into(),
+                error: Some("target failed".into()),
+                upstream_of: Some("//base:proto".into()),
+                exit_status: Some("exit status: 1".into()),
+                log_tail: Some(LogTailData {
+                    text: "FAIL".into(),
+                    start_line: 88,
+                }),
+            },
+        };
+        let json = serde_json::to_string(&ev).expect("encode");
+        let back: BuildEvent = serde_json::from_str(&json).expect("decode");
+        match back.kind {
+            BuildEventKind::ResultEnd {
+                upstream_of,
+                exit_status,
+                log_tail,
+                ..
+            } => {
+                assert_eq!(upstream_of.as_deref(), Some("//base:proto"));
+                assert_eq!(exit_status.as_deref(), Some("exit status: 1"));
+                assert_eq!(log_tail.map(|l| l.start_line), Some(88));
+            }
+            other => panic!("wrong variant: {other:?}"),
+        }
+    }
 }

--- a/crates/engine/src/engine/diag.rs
+++ b/crates/engine/src/engine/diag.rs
@@ -811,7 +811,7 @@ impl hplugin::hook::Hook for DiagHook {
         let now = s.now_ms();
         match &ev.kind {
             BuildEventKind::ResultStart { addr } => s.op_start(Op::Result, addr, now),
-            BuildEventKind::ResultEnd { addr, error } => {
+            BuildEventKind::ResultEnd { addr, error, .. } => {
                 s.op_end(Op::Result, addr, now);
                 s.done.fetch_add(1, Ordering::Relaxed);
                 if error.is_some() {
@@ -2362,6 +2362,9 @@ mod tests {
         h.on_event(&ev(BuildEventKind::ResultEnd {
             addr: "//a:b".into(),
             error: Some("boom".into()),
+            upstream_of: None,
+            exit_status: None,
+            log_tail: None,
         }));
         assert_eq!(s.open_count(Op::Result), 0);
         assert_eq!((s.done(), s.failed()), (1, 1));

--- a/crates/engine/src/engine/engine.rs
+++ b/crates/engine/src/engine/engine.rs
@@ -94,7 +94,7 @@ pub struct Engine {
     pub(crate) runtime: tokio::runtime::Handle,
     pub(crate) result_permits: Arc<crate::engine::worker_pool::WorkerPool>,
     /// Maximum concurrent executes (the `result_permits` capacity). Cached
-    /// here so it can be announced to clients via a `MaxWorkers` build event
+    /// here so it can be announced to clients via a `RequestConfig` build event
     /// without reaching into the semaphore (whose live `available_permits` only
     /// reflects the *free* count, not the configured max).
     pub(crate) max_workers: usize,

--- a/crates/engine/src/engine/event.rs
+++ b/crates/engine/src/engine/event.rs
@@ -23,10 +23,73 @@ pub use hcore::events::{BuildEvent, BuildEventKind, EventReceiver, EventSender, 
 /// event fans out to registered hooks too — an out-of-process hook (e.g. the GHA
 /// status plugin) must see `ResultEnd`/`ExecuteEnd`, or every count it tallies
 /// against paired scopes reads zero.
+/// What a failing scope knows about its failure, beyond the flattened message.
+///
+/// Extracted once at the emit site by downcasting, so consumers never have to
+/// re-derive it from prose. Before this existed the GHA reporter told a root
+/// failure from collateral damage by searching the message for
+/// `"dependency failed (root: …)"` — a string sniff of a `Display` impl, which
+/// breaks the moment that wording changes.
+#[derive(Debug, Default, Clone)]
+pub struct ErrorDetail {
+    /// `format!("{e:#}")` — the whole cause chain on one line.
+    pub message: String,
+    /// The root, when this target failed only because a dependency did.
+    pub upstream_of: Option<String>,
+    /// The subprocess's exit status as the OS reported it.
+    pub exit_status: Option<String>,
+    pub log_tail: Option<hcore::events::LogTailData>,
+}
+
+impl ErrorDetail {
+    /// Pull the structured detail out of an error chain.
+    ///
+    /// Every field is optional because every one of them is genuinely absent for
+    /// some failures: a target can fail before it ever starts a process, and an
+    /// internal engine error is neither upstream damage nor a subprocess.
+    pub fn from_error(e: &anyhow::Error) -> Self {
+        use hplugin::error::{ProcessFailed, TargetFailure, UpstreamFailed};
+        let mut d = Self {
+            message: format!("{e:#}"),
+            ..Self::default()
+        };
+        for cause in e.chain() {
+            if d.upstream_of.is_none()
+                && let Some(u) = cause.downcast_ref::<UpstreamFailed>()
+            {
+                d.upstream_of = Some(u.root.format());
+            }
+            if d.exit_status.is_none()
+                && let Some(p) = cause.downcast_ref::<ProcessFailed>()
+            {
+                d.exit_status = Some(p.status.clone());
+            }
+            if d.log_tail.is_none()
+                && let Some(t) = cause.downcast_ref::<TargetFailure>()
+                && let Some(tail) = &t.log_tail
+            {
+                d.log_tail = Some(hcore::events::LogTailData {
+                    text: tail.text.clone(),
+                    start_line: tail.start_line,
+                });
+            }
+        }
+        d
+    }
+
+    /// Just the flattened message, for the scopes whose end events carry only
+    /// that (`ExecuteEnd`, the cache spans). Structured detail is surfaced on
+    /// `ResultEnd`, which is where a consumer reports a target's outcome; the
+    /// inner spans would only duplicate it.
+    pub fn into_message(self) -> String {
+        self.message
+    }
+}
+
 struct EndGuard {
     data: Option<Arc<RequestStateData>>,
-    make_end: Option<Box<dyn FnOnce(Option<String>) -> BuildEventKind + Send>>,
-    error: Option<String>,
+    make_end: Option<Box<dyn FnOnce(Option<ErrorDetail>) -> BuildEventKind + Send>>,
+    error: Option<ErrorDetail>,
 }
 
 impl Drop for EndGuard {
@@ -50,7 +113,7 @@ impl Drop for EndGuard {
 pub async fn emit_scope<T>(
     rs: &RequestState,
     start: BuildEventKind,
-    make_end: impl FnOnce(Option<String>) -> BuildEventKind + Send + 'static,
+    make_end: impl FnOnce(Option<ErrorDetail>) -> BuildEventKind + Send + 'static,
     fut: impl Future<Output = anyhow::Result<T>>,
 ) -> anyhow::Result<T> {
     rs.emit(start);
@@ -61,7 +124,7 @@ pub async fn emit_scope<T>(
     };
     let out = fut.await; // guard still armed if this is cancelled mid-await
     if let Err(e) = &out {
-        guard.error = Some(format!("{e:#}"));
+        guard.error = Some(ErrorDetail::from_error(e));
     }
     out // guard drops here → emits *End
 }

--- a/crates/engine/src/engine/execute.rs
+++ b/crates/engine/src/engine/execute.rs
@@ -75,7 +75,7 @@ impl Engine {
             },
             move |error| crate::engine::event::BuildEventKind::ExecuteEnd {
                 addr: addr_str,
-                error,
+                error: error.map(crate::engine::event::ErrorDetail::into_message),
             },
             async {
                 let sandbox_dir = {

--- a/crates/engine/src/engine/request_state.rs
+++ b/crates/engine/src/engine/request_state.rs
@@ -330,7 +330,7 @@ pub struct RequestStateData {
     ///
     /// [`emit`]: RequestState::emit
     pub hooks: Vec<Arc<dyn crate::engine::hook::Hook>>,
-    /// Guards the one-shot `MaxWorkers` announcement so it fires once per request
+    /// Guards the one-shot `RequestConfig` announcement so it fires once per request
     /// regardless of which entry point (`result` / `result_addr`) is hit first.
     pub workers_announced: std::sync::atomic::AtomicBool,
     /// Guards the `Matched` stream so only the first/top-level `result` (or the
@@ -749,16 +749,19 @@ impl RequestState {
         Arc::clone(&self.data)
     }
 
-    /// Emit the `MaxWorkers` capacity event at most once per request. Safe to
+    /// Emit the `RequestConfig` announcement at most once per request. Safe to
     /// call from every top-level entry point (`result`, `result_addr`); only the
     /// first call emits, so dep recursion never re-announces.
-    pub fn announce_max_workers(&self, count: usize) {
+    pub fn announce_request_config(&self, count: usize) {
         if !self
             .data
             .workers_announced
             .swap(true, std::sync::atomic::Ordering::Relaxed)
         {
-            self.emit(crate::engine::event::BuildEventKind::MaxWorkers { count });
+            self.emit(crate::engine::event::BuildEventKind::RequestConfig {
+                max_workers: count,
+                fail_fast: self.data.fail_fast,
+            });
         }
     }
 
@@ -1792,9 +1795,12 @@ mod tests {
             BuildEventKind::ResultStart {
                 addr: "//a:b".into(),
             },
-            |error| BuildEventKind::ResultEnd {
+            |error: Option<crate::engine::event::ErrorDetail>| BuildEventKind::ResultEnd {
                 addr: "//a:b".into(),
-                error,
+                error: error.map(crate::engine::event::ErrorDetail::into_message),
+                upstream_of: None,
+                exit_status: None,
+                log_tail: None,
             },
             async { anyhow::Ok(()) },
         )

--- a/crates/engine/src/engine/result.rs
+++ b/crates/engine/src/engine/result.rs
@@ -1277,7 +1277,7 @@ impl Engine {
         // Announce worker capacity once per request. Covers the single-target
         // entry (`run` of one addr) that bypasses `Engine::result`; the once-guard
         // makes the dep recursion below a no-op.
-        rs.announce_max_workers(self.max_workers);
+        rs.announce_request_config(self.max_workers);
 
         // Single-target entry (`run` of one addr, which bypasses `Engine::result`):
         // claim the matched stream and emit the set-of-one as already-complete
@@ -1603,7 +1603,7 @@ impl Engine {
 
         // Announce worker capacity up front so the client can paint a fixed
         // worker-slot indicator before any execute lands.
-        rs.announce_max_workers(self.max_workers);
+        rs.announce_request_config(self.max_workers);
 
         let fail_fast = rs.fail_fast();
         let mut set: JoinSet<(Addr, anyhow::Result<Arc<EResult>>)> = JoinSet::new();
@@ -1866,9 +1866,21 @@ impl Engine {
             crate::engine::event::BuildEventKind::ResultStart {
                 addr: addr_str.clone(),
             },
-            move |error| crate::engine::event::BuildEventKind::ResultEnd {
-                addr: addr_str,
-                error,
+            // The one scope that carries structured detail: `ResultEnd` is where
+            // a consumer learns a target's outcome, so it is where `upstream_of`
+            // (root vs collateral), the exit status and the log tail belong.
+            move |error| {
+                let (error, upstream_of, exit_status, log_tail) = match error {
+                    Some(d) => (Some(d.message), d.upstream_of, d.exit_status, d.log_tail),
+                    None => (None, None, None, None),
+                };
+                crate::engine::event::BuildEventKind::ResultEnd {
+                    addr: addr_str,
+                    error,
+                    upstream_of,
+                    exit_status,
+                    log_tail,
+                }
             },
             async {
                 // Use _no_track: result_addr set parent=addr before entering the memoizer,
@@ -2320,7 +2332,7 @@ impl Engine {
             },
             move |error| crate::engine::event::BuildEventKind::RemoteCacheReadEnd {
                 addr: addr_s,
-                error,
+                error: error.map(crate::engine::event::ErrorDetail::into_message),
             },
             async {
                 let mut pulls = Vec::with_capacity(missing.len());
@@ -2580,7 +2592,7 @@ impl Engine {
                         },
                         move |error| crate::engine::event::BuildEventKind::RemoteCacheReadEnd {
                             addr: addr_s,
-                            error,
+                            error: error.map(crate::engine::event::ErrorDetail::into_message),
                         },
                         self.probe_remote_revision(ctoken, addr, opts.hashin.as_str(), &needed),
                     )
@@ -3070,7 +3082,7 @@ impl Engine {
                             move |error| {
                                 crate::engine::event::BuildEventKind::LocalCacheWriteEnd {
                                     addr: write_addr,
-                                    error,
+                                    error: error.map(crate::engine::event::ErrorDetail::into_message),
                                 }
                             },
                             engine.cache_locally(
@@ -8244,7 +8256,7 @@ mod tests {
         assert!(
             events.iter().any(|e| matches!(
                 &e.kind,
-                BuildEventKind::ResultEnd { addr, error: None } if addr == "//pkg:a"
+                BuildEventKind::ResultEnd { addr, error: None, .. } if addr == "//pkg:a"
             )),
             "expected ResultEnd{{error:None}}, got {events:?}"
         );
@@ -8259,7 +8271,7 @@ mod tests {
     #[tokio::test]
     async fn single_target_result_addr_announces_max_workers_once() -> anyhow::Result<()> {
         // Regression: `run` of a single addr calls `result_addr` directly,
-        // bypassing `Engine::result`. The MaxWorkers announcement must still fire
+        // bypassing `Engine::result`. The RequestConfig announcement must still fire
         // (so the TUI paints the worker indicator), and exactly once.
         let (engine, _home) = engine_with_home(vec![static_target_run("//pkg:a", "true")])?;
         let addr = hmodel::htaddr::parse_addr("//pkg:a")?;
@@ -8270,14 +8282,14 @@ mod tests {
         let max_workers: Vec<usize> = events
             .iter()
             .filter_map(|e| match &e.kind {
-                BuildEventKind::MaxWorkers { count } => Some(*count),
+                BuildEventKind::RequestConfig { max_workers, .. } => Some(*max_workers),
                 _ => None,
             })
             .collect();
         assert_eq!(
             max_workers.len(),
             1,
-            "expected exactly one MaxWorkers event, got {events:?}"
+            "expected exactly one RequestConfig event, got {events:?}"
         );
         assert!(max_workers[0] >= 1, "worker count must be positive");
         Ok(())
@@ -8470,7 +8482,7 @@ mod tests {
         assert!(
             events.iter().any(|e| matches!(
                 &e.kind,
-                BuildEventKind::ResultEnd { addr, error: Some(_) } if addr == "//pkg:a"
+                BuildEventKind::ResultEnd { addr, error: Some(_), .. } if addr == "//pkg:a"
             )),
             "ResultEnd must carry the error, got {events:?}"
         );

--- a/crates/plugin-gha/src/lib.rs
+++ b/crates/plugin-gha/src/lib.rs
@@ -791,6 +791,9 @@ mod tests {
             BuildEventKind::ResultEnd {
                 addr: "//a:x".into(),
                 error: None,
+                upstream_of: None,
+                exit_status: None,
+                log_tail: None,
             },
         ));
         hook.on_close();

--- a/crates/plugin-gha/src/render.rs
+++ b/crates/plugin-gha/src/render.rs
@@ -66,6 +66,10 @@ const LIVE_LOG_BYTES: usize = 1024;
 /// Final view: table sizes.
 const FINAL_SLOWEST_ROWS: usize = 20;
 const FINAL_PKG_ROWS: usize = 15;
+/// Log-tail budget in the final report: generous, since the summary has ~900 KiB
+/// and this is what the reader came for — but still bounded, because the tail is
+/// attacker-shaped data (it is whatever the target printed).
+const FINAL_LOG_BYTES: usize = 8 * 1024;
 
 /// A `String` that will not grow past a byte budget.
 ///
@@ -300,6 +304,13 @@ pub(crate) fn render_live(t: &Tally, ctx: &RenderCtx<'_>, budget: usize) -> Stri
         ));
     }
 
+    if t.fail_fast() && c.roots_total > 0 {
+        b.push(
+            "\n> [!WARNING]\n> Stopped at the first failure (`--fail-fast`) — \
+             remaining targets were not attempted.\n",
+        );
+    }
+
     push_lock_waits(&mut b, t, ctx);
     push_running_longest(&mut b, t, ctx);
 
@@ -340,7 +351,7 @@ fn push_live_failures(b: &mut Budgeted, t: &Tally, c: &Counters) {
         // Only the first root gets a log tail live: mid-build the reader is
         // answering "is this mine?", and one error answers that where ten don't.
         if i == 0
-            && let Some(tail) = live_log_tail(&r.message)
+            && let Some(tail) = r.log_tail.as_ref().and_then(live_log_tail)
         {
             section.push_str(&format!("\n```\n{tail}\n```\n"));
         }
@@ -365,13 +376,47 @@ fn push_live_failures(b: &mut Budgeted, t: &Tally, c: &Counters) {
     }
 }
 
-/// The log tail is not on the event stream yet (`docs/GHA_REPORTING.md` §7.1), so
-/// live rendering has only the flattened cause chain to work with. Returns
-/// `None` until `ResultEnd` carries a real tail — better nothing than a fake
-/// code block containing the same sentence already printed above it.
-fn live_log_tail(_message: &str) -> Option<String> {
-    let _ = (LIVE_LOG_LINES, LIVE_LOG_BYTES);
-    None
+/// The last few lines of a failing target's log, bounded for the live view.
+///
+/// Mid-build the reader is answering "is this mine?", which one error answers
+/// and ten don't — so this is deliberately shorter than the final view's tail,
+/// and only the first root gets one. The byte cap matters independently of the
+/// line cap: a single line of a minified bundle or a base64 blob can be
+/// megabytes on its own.
+fn live_log_tail(tail: &hcore::events::LogTailData) -> Option<String> {
+    bounded_tail(&tail.text, LIVE_LOG_LINES, LIVE_LOG_BYTES)
+}
+
+/// The full retained tail for the final report, bounded in bytes only — the
+/// engine already applied the user's `--log-lines`, so a line cap here would
+/// silently override their choice.
+fn final_log_tail(tail: &hcore::events::LogTailData) -> Option<String> {
+    bounded_tail(&tail.text, usize::MAX, FINAL_LOG_BYTES)
+}
+
+/// The last `max_lines` lines of `text`, in order, stopping before `max_bytes`.
+///
+/// Both caps are load-bearing. A line cap alone does not bound the output: one
+/// line of a minified bundle, a base64 blob, or a stack trace with a huge inline
+/// value can be megabytes by itself. A byte cap alone would cut mid-line.
+fn bounded_tail(text: &str, max_lines: usize, max_bytes: usize) -> Option<String> {
+    let lines: Vec<&str> = text.lines().collect();
+    let start = lines.len().saturating_sub(max_lines);
+    let mut kept: Vec<&str> = Vec::new();
+    let mut bytes = 0usize;
+    // Walk backwards so the *end* of the log survives — that is where the error
+    // is — then restore order.
+    for line in lines.get(start..).unwrap_or(&[]).iter().rev() {
+        let cost = line.len().saturating_add(1);
+        if bytes.saturating_add(cost) > max_bytes {
+            break;
+        }
+        bytes = bytes.saturating_add(cost);
+        kept.push(line);
+    }
+    kept.reverse();
+    let out = kept.join("\n");
+    (!out.trim().is_empty()).then_some(out)
 }
 
 fn pkg_rollup(r: &crate::tally::RootFailure, limit: usize) -> String {
@@ -591,10 +636,19 @@ fn push_final_failures(b: &mut Budgeted, t: &Tally, c: &Counters) {
         if let Some(d) = r.duration_ms {
             meta.push(format!("executed {}", fmt_duration(d)));
         }
+        if let Some(status) = r.exit_status.as_deref() {
+            meta.push(truncate_chars(status, 64));
+        }
         if !meta.is_empty() {
             s.push_str(&format!("{}\n\n", meta.join(" · ")));
         }
         s.push_str(&format!("{}\n\n", one_line(&r.message, MAX_MSG_CHARS)));
+        // The log tail is the whole product of a failure report — the message is
+        // an index, this is what actually says what went wrong. Bounded in bytes:
+        // one line of a minified bundle can be megabytes on its own.
+        if let Some(tail) = r.log_tail.as_ref().and_then(final_log_tail) {
+            s.push_str(&format!("```\n{tail}\n```\n\n"));
+        }
         s.push_str(&format!("Reproduce: `heph run {}`\n", addr_cell(&r.addr)));
         if r.blocked > 0 {
             s.push_str(&format!(
@@ -695,7 +749,13 @@ mod tests {
     /// `blocked` collateral failures under the first root.
     fn build(matched: usize, failing: usize, blocked: usize) -> Tally {
         let mut t = Tally::default();
-        t.apply(&ev(0, BuildEventKind::MaxWorkers { count: 64 }));
+        t.apply(&ev(
+            0,
+            BuildEventKind::RequestConfig {
+                max_workers: 64,
+                fail_fast: false,
+            },
+        ));
         t.apply(&ev(
             0,
             BuildEventKind::Matched {
@@ -710,9 +770,10 @@ mod tests {
                 1_000,
                 BuildEventKind::ResultEnd {
                     addr: format!("//root{i}:broken"),
-                    error: Some(format!(
-                        "execute //root{i}:broken: process exited with status 1"
-                    )),
+                    error: Some("target failed".into()),
+                    upstream_of: None,
+                    exit_status: Some("exit status: 1".into()),
+                    log_tail: None,
                 },
             ));
         }
@@ -721,9 +782,10 @@ mod tests {
                 2_000,
                 BuildEventKind::ResultEnd {
                     addr: format!("//services/api:t{i}"),
-                    error: Some(
-                        "result //services/api:t: dependency failed (root: //root0:broken)".into(),
-                    ),
+                    error: Some("dependency failed".into()),
+                    upstream_of: Some("//root0:broken".into()),
+                    exit_status: None,
+                    log_tail: None,
                 },
             ));
         }
@@ -813,6 +875,9 @@ mod tests {
                 BuildEventKind::ResultEnd {
                     addr: format!("//pkg{i}:broken"),
                     error: Some(format!("execute failed: {huge}")),
+                    upstream_of: None,
+                    exit_status: None,
+                    log_tail: None,
                 },
             ));
         }
@@ -844,6 +909,9 @@ mod tests {
                 // `format!("{e:#}")` puts the whole chain on ONE line, so a line
                 // cap alone would not bound this.
                 error: Some("y".repeat(10_000)),
+                upstream_of: None,
+                exit_status: None,
+                log_tail: None,
             },
         ));
         let md = render_live(&t, &ctx("heph run //...", 9_000), COMMENT_LIMIT);
@@ -859,6 +927,9 @@ mod tests {
             BuildEventKind::ResultEnd {
                 addr: format!("//パッケージ:{}", "名前".repeat(200)),
                 error: Some("エラー".repeat(500)),
+                upstream_of: None,
+                exit_status: None,
+                log_tail: None,
             },
         ));
         let md = render_live(&t, &ctx("heph run //...", 9_000), COMMENT_LIMIT);
@@ -898,6 +969,9 @@ mod tests {
                 BuildEventKind::ResultEnd {
                     addr: format!("//pkg:t{i}"),
                     error: None,
+                    upstream_of: None,
+                    exit_status: None,
+                    log_tail: None,
                 },
             ));
         }
@@ -946,6 +1020,9 @@ mod tests {
             BuildEventKind::ResultEnd {
                 addr: "//a:slow".into(),
                 error: None,
+                upstream_of: None,
+                exit_status: None,
+                log_tail: None,
             },
         ));
         t.set_closed();
@@ -1002,6 +1079,9 @@ mod tests {
             BuildEventKind::ResultEnd {
                 addr: "//a:x".into(),
                 error: None,
+                upstream_of: None,
+                exit_status: None,
+                log_tail: None,
             },
         ));
         t.set_closed();
@@ -1063,6 +1143,31 @@ mod tests {
         assert_eq!(fmt_count(7), "7");
     }
 
+    #[test]
+    fn fail_fast_mode_is_disclosed() {
+        // Otherwise a one-failure report reads as "one thing is broken" when the
+        // truth is "we stopped looking".
+        //
+        // The mode comes off the event stream, not from argv: the hook is handed
+        // what it needs rather than discovering it, and an argv scan would
+        // false-positive on a flag *value* like `--define X=--ff`.
+        let mut t = build(20_000, 1, 0);
+        t.apply(&ev(
+            0,
+            BuildEventKind::RequestConfig {
+                max_workers: 64,
+                fail_fast: true,
+            },
+        ));
+        let md = render_live(&t, &ctx("heph run //...", 9_000), COMMENT_LIMIT);
+        assert!(md.contains("Stopped at the first failure"), "{md}");
+
+        // And absent by default, so a keep-going build is not mislabelled.
+        let plain = build(20_000, 1, 0);
+        let md = render_live(&plain, &ctx("heph run //...", 9_000), COMMENT_LIMIT);
+        assert!(!md.contains("Stopped at the first failure"), "{md}");
+    }
+
     /// Prints the rendered views for eyeballing against the mockups in
     /// `docs/GHA_REPORTING.md`. Ignored: it asserts nothing, it is a way to look
     /// at the output.
@@ -1094,10 +1199,19 @@ mod tests {
                 BuildEventKind::ResultEnd {
                     addr: format!("//pkg{}:t{i}", i % 50),
                     error: None,
+                    upstream_of: None,
+                    exit_status: None,
+                    log_tail: None,
                 },
             ));
         }
-        t.apply(&ev(0, BuildEventKind::MaxWorkers { count: 64 }));
+        t.apply(&ev(
+            0,
+            BuildEventKind::RequestConfig {
+                max_workers: 64,
+                fail_fast: false,
+            },
+        ));
         println!("\n===== LIVE, healthy =====\n");
         println!(
             "{}",

--- a/crates/plugin-gha/src/tally.rs
+++ b/crates/plugin-gha/src/tally.rs
@@ -28,7 +28,7 @@
 use std::cmp::Reverse;
 use std::collections::BinaryHeap;
 
-use hcore::events::{BuildEvent, BuildEventKind};
+use hcore::events::{BuildEvent, BuildEventKind, LogTailData};
 use rustc_hash::FxHashMap;
 
 /// How many completed targets to retain for the "slowest" table. The heap is
@@ -128,6 +128,12 @@ impl PartialOrd for Completed {
 pub(crate) struct RootFailure {
     pub addr: String,
     pub message: String,
+    /// The subprocess's exit status, when the failure was a subprocess.
+    pub exit_status: Option<String>,
+    /// The last lines of the target's log — the part that actually says what
+    /// went wrong. This is what makes a red build diagnosable from the report
+    /// rather than only from the job log.
+    pub log_tail: Option<LogTailData>,
     pub driver: Option<String>,
     pub duration_ms: Option<u64>,
     /// Targets that failed solely because this one did.
@@ -210,6 +216,9 @@ pub(crate) struct Tally {
     misses_by_pkg: FxHashMap<Box<str>, usize>,
 
     max_workers: usize,
+    /// Whether this invocation stops at the first failure. Reported by the
+    /// engine, never inferred here — see `BuildEventKind::RequestConfig`.
+    fail_fast: bool,
     first_event_ms: Option<u64>,
     last_event_ms: u64,
 
@@ -219,19 +228,20 @@ pub(crate) struct Tally {
     closed: bool,
 }
 
-/// Extract the root addr from a collateral failure's message.
+/// A failing `ResultEnd`, borrowed from the event.
 ///
-/// **Interim.** `UpstreamFailed` renders as `dependency failed (root: //x:y)`
-/// (`crates/plugin/src/error.rs:201`) and `ResultEnd.error` is the whole cause
-/// chain flattened by `format!("{e:#}")`, so sniffing the string is the only way
-/// to tell collateral from root damage today. This is replaced by a structured
-/// `upstream_of` field on `ResultEnd`; see `docs/GHA_REPORTING.md` §7.1.
-fn parse_upstream_root(message: &str) -> Option<&str> {
-    const OPEN: &str = "dependency failed (root: ";
-    let i = message.find(OPEN)?;
-    let after = message.get(i.checked_add(OPEN.len())?..)?;
-    let end = after.find(')')?;
-    after.get(..end)
+/// The engine extracts this structure once at the emit site, so the reporter
+/// never has to re-derive it from prose. It previously told collateral damage
+/// from a root failure by searching the flattened message for
+/// `"dependency failed (root: …)"` — a sniff of a `Display` impl that would
+/// break silently the moment that wording changed, taking the root/collateral
+/// split with it.
+#[derive(Clone, Copy)]
+pub(crate) struct Failure<'a> {
+    pub message: &'a str,
+    pub upstream_of: Option<&'a str>,
+    pub exit_status: Option<&'a str>,
+    pub log_tail: Option<&'a LogTailData>,
 }
 
 /// The package part of `//pkg/sub:name`, or the whole addr if it has no `:`.
@@ -257,7 +267,13 @@ impl Tally {
         // here, not a silent drop. The previous `_ => {}` swallowed six kinds,
         // four of which this renderer wants.
         match &ev.kind {
-            BuildEventKind::MaxWorkers { count } => self.max_workers = *count,
+            BuildEventKind::RequestConfig {
+                max_workers,
+                fail_fast,
+            } => {
+                self.max_workers = *max_workers;
+                self.fail_fast = *fail_fast;
+            }
 
             BuildEventKind::Matched { addrs, complete } => {
                 for a in addrs {
@@ -276,8 +292,23 @@ impl Tally {
                 self.ensure(addr, ev.at_unix_ms);
             }
 
-            BuildEventKind::ResultEnd { addr, error } => {
-                self.finish(addr, error.as_deref(), ev.at_unix_ms);
+            BuildEventKind::ResultEnd {
+                addr,
+                error,
+                upstream_of,
+                exit_status,
+                log_tail,
+            } => {
+                self.finish(
+                    addr,
+                    error.as_deref().map(|message| Failure {
+                        message,
+                        upstream_of: upstream_of.as_deref(),
+                        exit_status: exit_status.as_deref(),
+                        log_tail: log_tail.as_ref(),
+                    }),
+                    ev.at_unix_ms,
+                );
             }
 
             BuildEventKind::ExecuteStart { addr, driver, .. } => {
@@ -367,6 +398,12 @@ impl Tally {
             // Emitted only by `heph tool gc` / `clean`, which this hook does not
             // report on — those commands have their own output.
             BuildEventKind::GcTargetSwept { .. } => {}
+
+            // An event kind from a host newer than this plugin. Skipping it keeps
+            // the rest of the stream flowing; the alternative is a decode failure,
+            // which the SDK treats as end-of-stream and would silently truncate
+            // everything after it.
+            BuildEventKind::Unknown => {}
         }
     }
 
@@ -441,7 +478,7 @@ impl Tally {
         self.misses_by_pkg.insert(pkg.into(), 1);
     }
 
-    fn finish(&mut self, addr: &str, error: Option<&str>, at: u64) {
+    fn finish(&mut self, addr: &str, error: Option<Failure<'_>>, at: u64) {
         let rec = self.live.remove(addr);
 
         // Progress is over the matched top-level set, deduped: the memoizer can
@@ -466,13 +503,13 @@ impl Tally {
             });
         }
 
-        let Some(message) = error else { return };
+        let Some(failure) = error else { return };
 
-        if let Some(root) = parse_upstream_root(message) {
+        if let Some(root) = failure.upstream_of {
             self.record_collateral(root, addr);
             return;
         }
-        self.record_root(addr, message, rec.as_ref(), at);
+        self.record_root(addr, failure, rec.as_ref(), at);
     }
 
     fn push_slowest(&mut self, c: Completed) {
@@ -490,7 +527,7 @@ impl Tally {
         }
     }
 
-    fn record_root(&mut self, addr: &str, message: &str, rec: Option<&TargetRec>, at: u64) {
+    fn record_root(&mut self, addr: &str, failure: Failure<'_>, rec: Option<&TargetRec>, at: u64) {
         self.counters.roots_total = self.counters.roots_total.saturating_add(1);
         if self.root_index.contains_key(addr) {
             // Deduped: one addr can produce several `ResultEnd`s.
@@ -504,7 +541,9 @@ impl Tally {
         self.root_index.insert(addr.into(), self.roots.len());
         self.roots.push(RootFailure {
             addr: addr.to_string(),
-            message: message.to_string(),
+            message: failure.message.to_string(),
+            exit_status: failure.exit_status.map(str::to_string),
+            log_tail: failure.log_tail.cloned(),
             driver: rec.and_then(|r| r.driver.as_deref().map(str::to_string)),
             duration_ms: rec.map(|r| at.saturating_sub(r.started_ms)),
             blocked: 0,
@@ -545,6 +584,10 @@ impl Tally {
 
     pub(crate) fn max_workers(&self) -> usize {
         self.max_workers
+    }
+
+    pub(crate) fn fail_fast(&self) -> bool {
+        self.fail_fast
     }
 
     /// Targets currently inside a *foreground* phase — the denominator for
@@ -726,6 +769,9 @@ mod tests {
             BuildEventKind::ResultEnd {
                 addr: addr.into(),
                 error: None,
+                upstream_of: None,
+                exit_status: None,
+                log_tail: None,
             },
         ));
     }
@@ -740,6 +786,9 @@ mod tests {
             BuildEventKind::ResultEnd {
                 addr: "//base:proto".into(),
                 error: Some("execute //base:proto: process exited with status 1".into()),
+                upstream_of: None,
+                exit_status: None,
+                log_tail: None,
             },
         ));
         for i in 0..4_000 {
@@ -747,9 +796,10 @@ mod tests {
                 20,
                 BuildEventKind::ResultEnd {
                     addr: format!("//services/api:t{i}"),
-                    error: Some(
-                        "result //services/api:t: dependency failed (root: //base:proto)".into(),
-                    ),
+                    error: Some("dependency failed".into()),
+                    upstream_of: Some("//base:proto".into()),
+                    exit_status: None,
+                    log_tail: None,
                 },
             ));
         }
@@ -780,6 +830,9 @@ mod tests {
                 BuildEventKind::ResultEnd {
                     addr: "//a:x".into(),
                     error: Some("boom".into()),
+                    upstream_of: None,
+                    exit_status: None,
+                    log_tail: None,
                 },
             ));
         }
@@ -1070,6 +1123,9 @@ mod tests {
             BuildEventKind::ResultEnd {
                 addr: "//a:x".into(),
                 error: Some("boom".into()),
+                upstream_of: None,
+                exit_status: None,
+                log_tail: None,
             },
         ));
         assert_eq!(t.status_emoji(), "❌", "red before the build finishes");
@@ -1084,6 +1140,9 @@ mod tests {
                 BuildEventKind::ResultEnd {
                     addr: format!("//a:t{i}"),
                     error: Some("boom".into()),
+                    upstream_of: None,
+                    exit_status: None,
+                    log_tail: None,
                 },
             ));
         }
@@ -1102,6 +1161,9 @@ mod tests {
                 BuildEventKind::ResultEnd {
                     addr: addr.into(),
                     error: Some("boom".into()),
+                    upstream_of: None,
+                    exit_status: None,
+                    log_tail: None,
                 },
             ));
         }
@@ -1110,14 +1172,31 @@ mod tests {
     }
 
     #[test]
-    fn upstream_root_parsing() {
-        assert_eq!(
-            parse_upstream_root("result //a:b: dependency failed (root: //base:proto)"),
-            Some("//base:proto")
+    fn a_root_failure_carries_its_exit_status_and_log_tail() {
+        // The whole point of the structured event: the report can show what
+        // actually went wrong instead of one line of a flattened cause chain.
+        let mut t = Tally::default();
+        t.apply(&ev(
+            10,
+            BuildEventKind::ResultEnd {
+                addr: "//services/api:test".into(),
+                error: Some("target failed: //services/api:test".into()),
+                upstream_of: None,
+                exit_status: Some("exit status: 1".into()),
+                log_tail: Some(LogTailData {
+                    text: "--- FAIL: TestCreateUser (0.03s)\n    want 201, got 500".into(),
+                    start_line: 88,
+                }),
+            },
+        ));
+        let root = t.roots().first().expect("root recorded");
+        assert_eq!(root.exit_status.as_deref(), Some("exit status: 1"));
+        assert!(
+            root.log_tail
+                .as_ref()
+                .is_some_and(|l| l.text.contains("TestCreateUser")),
+            "log tail reaches the reporter"
         );
-        assert_eq!(parse_upstream_root("process exited with status 1"), None);
-        // Malformed: no closing paren.
-        assert_eq!(parse_upstream_root("dependency failed (root: //a:b"), None);
     }
 
     #[test]
@@ -1131,12 +1210,21 @@ mod tests {
     #[test]
     fn elapsed_is_bounded_by_the_stream_once_closed() {
         let mut t = Tally::default();
-        t.apply(&ev(1_000, BuildEventKind::MaxWorkers { count: 16 }));
+        t.apply(&ev(
+            1_000,
+            BuildEventKind::RequestConfig {
+                max_workers: 16,
+                fail_fast: false,
+            },
+        ));
         t.apply(&ev(
             5_000,
             BuildEventKind::ResultEnd {
                 addr: "//a:x".into(),
                 error: None,
+                upstream_of: None,
+                exit_status: None,
+                log_tail: None,
             },
         ));
         // Still running: elapsed tracks now.

--- a/crates/telemetry/src/telemetry/collector.rs
+++ b/crates/telemetry/src/telemetry/collector.rs
@@ -482,6 +482,9 @@ mod tests {
         c.observe_event(&BuildEventKind::ResultEnd {
             addr: addr(),
             error: None,
+            upstream_of: None,
+            exit_status: None,
+            log_tail: None,
         });
 
         let s = c.snapshot();

--- a/crates/tui/src/tui/progress.rs
+++ b/crates/tui/src/tui/progress.rs
@@ -731,7 +731,7 @@ pub struct BuildState {
     /// counted as cached. Without the kind there is no way to know which counter
     /// to take it back out of.
     cache_hit: HashMap<String, CacheHitKind>,
-    /// Worker capacity announced by the engine via `MaxWorkers`. `None` until
+    /// Worker capacity announced by the engine via `RequestConfig`. `None` until
     /// the event lands (no worker indicator rendered before then).
     max_workers: Option<usize>,
     /// Server timestamp of the first event seen — the run's start anchor for the
@@ -843,7 +843,9 @@ impl BuildState {
             }
         }
         match &ev.kind {
-            BuildEventKind::MaxWorkers { count } => {
+            BuildEventKind::RequestConfig {
+                max_workers: count, ..
+            } => {
                 self.max_workers = Some(*count);
             }
             BuildEventKind::Matched { addrs, complete } => {
@@ -872,7 +874,7 @@ impl BuildState {
             BuildEventKind::ResultStart { addr } => {
                 self.in_flight_results.insert(addr.clone());
             }
-            BuildEventKind::ResultEnd { addr, error } => {
+            BuildEventKind::ResultEnd { addr, error, .. } => {
                 if self.in_flight_results.remove(addr) {
                     if let Some(err) = error {
                         self.errored += 1;
@@ -956,6 +958,9 @@ impl BuildState {
             // elapsed-clock anchor at the top of `apply` still runs, so the
             // clock works during a gc sweep.
             BuildEventKind::GcTargetSwept { .. } => {}
+            // An event kind newer than this build knows about. Skipped rather
+            // than fatal — see `BuildEventKind::Unknown`.
+            BuildEventKind::Unknown => {}
         }
     }
 
@@ -1259,7 +1264,7 @@ impl BuildState {
             .count()
     }
 
-    /// Announced worker capacity, or `None` before the `MaxWorkers` event.
+    /// Announced worker capacity, or `None` before the `RequestConfig` event.
     pub fn max_workers(&self) -> Option<usize> {
         self.max_workers
     }
@@ -2351,6 +2356,9 @@ mod tests {
         BuildEventKind::ResultEnd {
             addr: addr.into(),
             error,
+            upstream_of: None,
+            exit_status: None,
+            log_tail: None,
         }
     }
     fn execute_start(addr: &str) -> BuildEventKind {
@@ -2763,7 +2771,10 @@ mod tests {
     }
 
     fn max_workers(count: usize) -> BuildEventKind {
-        BuildEventKind::MaxWorkers { count }
+        BuildEventKind::RequestConfig {
+            max_workers: count,
+            fail_fast: false,
+        }
     }
 
     #[test]

--- a/scripts/abi-check.sh
+++ b/scripts/abi-check.sh
@@ -38,6 +38,21 @@ stabby_pin_files=(
 # (don't fail) so doc/comment proto edits stay quiet but real edits get a nudge.
 soft_glob="proto/plugin/v1/"
 
+# The build-event stream. Not a stabby vtable, but it crosses the same dlopen'd
+# seam: every event is serde-JSON encoded to out-of-process hooks, and a plugin
+# cdylib ships as its own artifact pinned independently of the binary — so
+# host/plugin skew is reachable, and a skewed pair loads fine at dlopen and only
+# breaks later. The decode path has no slack: a frame that fails to deserialize
+# is treated as end-of-stream, silently truncating that hook's whole stream.
+#
+# Warn rather than force a bump: additive `#[serde(default)]` fields and new
+# variants (absorbed by `Unknown`'s `#[serde(other)]`) are genuinely safe, and
+# most edits here are those. What we cannot detect cheaply is the unsafe kind —
+# retyping or removing a field — so the warning names it explicitly.
+event_paths=(
+  "crates/core/src/events.rs"
+)
+
 # Resolve the merge-base so we compare only what this branch introduced, not
 # unrelated commits that landed on the base since it forked.
 if ! base_sha=$(git merge-base "$base_ref" HEAD 2>/dev/null); then
@@ -118,4 +133,12 @@ fi
 # wire field, the author should bump at least the minor (see the doc).
 if grep -q "^${soft_glob}" <<<"$changed"; then
   echo "::warning::proto/plugin/v1 changed — if a wire field was added/removed, bump ABI_SEMVER minor (see $doc)" >&2
+fi
+
+# Event stream: see the note by `event_paths`.
+if matches "${event_paths[@]}"; then
+  echo "::warning::${event_paths[*]} changed — the build-event stream is a live wire format to out-of-process hooks." >&2
+  echo "  Safe: adding a field with #[serde(default)], or a new BuildEventKind variant." >&2
+  echo "  NOT safe: changing or removing an existing field's type, or dropping Unknown's #[serde(other)]." >&2
+  echo "  An undecodable event silently ends a skewed plugin's entire stream. See the module docs." >&2
 fi


### PR DESCRIPTION
**Stacked on #372.** Review that first.

Gives the CI reporter the two things it needs to diagnose a failure *before the build ends*: which failure is a root cause vs collateral damage, and the log tail that says what actually went wrong.

## The problem

The reporter told a root failure from collateral damage by searching the flattened cause chain for `"dependency failed (root: …)"` — a sniff of a `Display` impl. It works, until someone rewords that message, at which point the root/collateral split silently inverts and a 20k-target build reports 20,001 failures again. And the log tail lives on `TargetFailure`, which never reaches a hook at all.

`ResultEnd` now carries `upstream_of`, `exit_status` and `log_tail` alongside `error`. `emit_scope`'s end closure takes an `ErrorDetail` extracted once at the emit site by downcasting the chain. All of it attaches only to failing results, so a green 20k build pays nothing.

## `error` keeps its type, and that's the whole point

Retyping it to a struct was my original design. `compatibility` rejected it, and the reasoning is worth reading:

`BuildEvent` is **already a live cross-artifact wire format**, not the "future client/server split" its module doc implied. `StableRemoteHook` serde-encodes every event to out-of-process hooks, and `plugin-gha-cdylib` ships as its own release artifact pinned by manifest URL independently of the `heph` binary — so host/plugin skew is a normal reachable state.

A skewed pair still loads fine at `dlopen`. The break lands later:

```rust
Body::StreamItem(si) => serde_json::from_slice(&si.item).ok(),   // -> None
match decode_event_frame(&bytes) {
    Some(ev) => hook.on_event(&ev),
    None => break,          // ends the WHOLE stream
}
}
hook.on_close();            // hook thinks the build ended normally
```

One undecodable frame **silently truncates that hook's entire stream** and then reports success. Since `error` is only populated on failure, a green build would hide it completely — it'd pass every smoke test and break in the field on exactly the red builds this feature exists to serve.

The sibling fields are `#[serde(default)]`, which is load-bearing: a bare `Option<T>` is **not** absent-tolerant under `serde_derive`.

## Two fragilities closed while here

- **`#[serde(other)] Unknown`.** Adding a *variant* had the identical truncation characteristic — an old plugin meeting an unknown `type` tag lost the rest of its stream. Unknown kinds now decode to a skippable variant. Every consumer handles it explicitly, which the compiler enforced.
- **`crates/core/src/events.rs` joins the abi-check watch set.** It crosses the same dlopen'd seam as the stabby vtables but was in neither the hard paths nor the soft glob, so changes here produced *zero* CI signal. Warns rather than forcing a bump — additive fields and new variants are genuinely safe now — and names the two edits that aren't.

## Tests

The compatibility contract is tested directly, not assumed: an old-host frame missing the new keys decodes; a newer-host frame carrying unknown fields decodes; an unknown event kind decodes to `Unknown`; and a stream **continues past** one (the property that matters, since the failure mode is truncation, not one lost event).

887 tests green across `core`, `engine`, `tui`, `telemetry`, `plugin-gha`.

## Note

`exit_status` is a `String`, not an `i32`, because a string is what the engine has — `ProcessFailed::status` is already formatted. Parsing an integer back out of it in a consumer would be the same guesswork this field exists to remove.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QdtQoQV7ptcJzoiUgXJvJv