### PR TITLE
fix(plugin-gha): make the comment transport testable and correct

### DIFF
--- a/crates/plugin-gha/src/comment_tests.rs
+++ b/crates/plugin-gha/src/comment_tests.rs
@@ -1,0 +1,366 @@
+//! Tests for the sticky-comment HTTP layer.
+//!
+//! This layer is where the feature actually lives — adopt-vs-reset, the section
+//! merge, capturing the id from a POST, and every failure mode — and until the
+//! [`CommentConfig`] seam existed none of it could be tested at all:
+//! `CommentClient::from_env` read `std::env` directly, so constructing one meant
+//! mutating global process state.
+//!
+//! Worse, the branch that *ships* was the branch never exercised. The suite only
+//! stayed quiet because `GITHUB_TOKEN` happens to be absent from the test job's
+//! environment — an undeclared ambient invariant. Under Actions
+//! `GITHUB_REPOSITORY` and `GITHUB_REF` are always set, so the day someone added
+//! a token to that job, the tests would have started POSTing comments onto the
+//! PR under test.
+//!
+//! These drive a real loopback HTTP server (the pattern from
+//! `crates/e2e/tests/http_fetch.rs` — a std `TcpListener` on `127.0.0.1:0`, no
+//! new dependency) so the client's actual request/response handling is covered,
+//! not a mock of it.
+
+use std::io::{BufRead, BufReader, Read, Write};
+use std::sync::atomic::{AtomicUsize, Ordering};
+use std::sync::{Arc, Mutex};
+use std::time::Duration;
+
+use super::*;
+
+/// One request the fake GitHub saw.
+#[derive(Debug, Clone)]
+struct Seen {
+    method: String,
+    path: String,
+    body: String,
+}
+
+/// A scripted GitHub API stand-in.
+struct FakeGitHub {
+    url: String,
+    seen: Arc<Mutex<Vec<Seen>>>,
+    hits: Arc<AtomicUsize>,
+}
+
+impl FakeGitHub {
+    /// Serve `responses` in order, one per request; the last is reused once
+    /// exhausted. Each entry is `(status_line, json_body)`.
+    fn start(responses: Vec<(&'static str, String)>) -> Self {
+        let listener = std::net::TcpListener::bind("127.0.0.1:0").expect("bind");
+        let url = format!("http://{}", listener.local_addr().expect("addr"));
+        let seen = Arc::new(Mutex::new(Vec::new()));
+        let hits = Arc::new(AtomicUsize::new(0));
+
+        let seen_w = Arc::clone(&seen);
+        let hits_w = Arc::clone(&hits);
+        std::thread::spawn(move || {
+            let mut i = 0usize;
+            while let Ok((sock, _)) = listener.accept() {
+                let n = hits_w.fetch_add(1, Ordering::SeqCst);
+                let (status, body) = responses
+                    .get(i)
+                    .or_else(|| responses.last())
+                    .cloned()
+                    .unwrap_or(("200 OK", "{}".to_string()));
+                i = i.saturating_add(1);
+                let _ = n;
+                handle(sock, status, &body, &seen_w);
+            }
+        });
+
+        Self { url, seen, hits }
+    }
+
+    fn requests(&self) -> Vec<Seen> {
+        self.seen.lock().unwrap_or_else(|e| e.into_inner()).clone()
+    }
+
+    fn hits(&self) -> usize {
+        self.hits.load(Ordering::SeqCst)
+    }
+
+    /// The body of the last write (POST or PATCH), which is the comment as it
+    /// would appear on the PR.
+    fn last_written_body(&self) -> Option<String> {
+        self.requests()
+            .iter()
+            .rev()
+            .find(|r| r.method == "POST" || r.method == "PATCH")
+            .map(|r| r.body.clone())
+    }
+}
+
+fn handle(sock: std::net::TcpStream, status: &str, body: &str, seen: &Arc<Mutex<Vec<Seen>>>) {
+    let mut reader = BufReader::new(sock);
+    let mut request_line = String::new();
+    if reader.read_line(&mut request_line).is_err() {
+        return;
+    }
+    let mut parts = request_line.split_whitespace();
+    let method = parts.next().unwrap_or("").to_string();
+    let path = parts.next().unwrap_or("").to_string();
+
+    // Headers, to find the body length.
+    let mut len = 0usize;
+    loop {
+        let mut line = String::new();
+        if reader.read_line(&mut line).is_err() || line == "\r\n" || line.is_empty() {
+            break;
+        }
+        if let Some(v) = line.to_ascii_lowercase().strip_prefix("content-length:") {
+            len = v.trim().parse().unwrap_or(0);
+        }
+    }
+    let mut payload = vec![0u8; len];
+    if len > 0 {
+        drop(reader.read_exact(&mut payload));
+    }
+    // The client sends `{"body": "..."}`; unwrap it so assertions read cleanly.
+    let raw = String::from_utf8_lossy(&payload).to_string();
+    let body_text = serde_json::from_str::<serde_json::Value>(&raw)
+        .ok()
+        .and_then(|v| v.get("body").and_then(|b| b.as_str()).map(str::to_string))
+        .unwrap_or(raw);
+
+    seen.lock().unwrap_or_else(|e| e.into_inner()).push(Seen {
+        method,
+        path,
+        body: body_text,
+    });
+
+    let mut sock = reader.into_inner();
+    let head = format!(
+        "HTTP/1.1 {status}\r\nContent-Type: application/json\r\nContent-Length: {}\r\nConnection: close\r\n\r\n",
+        body.len()
+    );
+    drop(sock.write_all(head.as_bytes()));
+    drop(sock.write_all(body.as_bytes()));
+    drop(sock.flush());
+}
+
+fn config(url: &str, section: &str, run_id: &str) -> CommentConfig {
+    CommentConfig {
+        api_url: url.to_string(),
+        repo: "o/r".to_string(),
+        token: "t".to_string(),
+        pr: 7,
+        job_key: "test".to_string(),
+        run_id: run_id.to_string(),
+        section_key: section.to_string(),
+        timeout: Duration::from_secs(5),
+    }
+}
+
+/// An empty comment list, then a created comment carrying an id.
+fn create_flow() -> Vec<(&'static str, String)> {
+    vec![
+        ("200 OK", "[]".to_string()),
+        (
+            "201 Created",
+            serde_json::json!({"id": 4242, "html_url": "http://example/c"}).to_string(),
+        ),
+        ("200 OK", "{}".to_string()),
+    ]
+}
+
+#[test]
+fn creates_a_comment_then_patches_the_same_id() {
+    let gh = FakeGitHub::start(create_flow());
+    let c = CommentClient::new(config(&gh.url, "sec", "1-1"));
+
+    c.sync(|| "first".to_string(), None);
+    c.sync(|| "second".to_string(), None);
+
+    let reqs = gh.requests();
+    let writes: Vec<&Seen> = reqs
+        .iter()
+        .filter(|r| r.method == "POST" || r.method == "PATCH")
+        .collect();
+    assert_eq!(writes.len(), 2, "one create then one edit: {reqs:#?}");
+    assert_eq!(writes[0].method, "POST");
+    assert_eq!(writes[1].method, "PATCH");
+    assert!(
+        writes[1].path.contains("/comments/4242"),
+        "the id returned by the POST is reused, not a second comment: {}",
+        writes[1].path
+    );
+    assert!(
+        writes[1].body.contains("second"),
+        "latest content written: {}",
+        writes[1].body
+    );
+}
+
+#[test]
+fn adopting_a_same_run_comment_preserves_other_steps() {
+    // Another step in this job already wrote its section. Ours must merge, not
+    // replace — that is the whole point of the per-step sections.
+    let other = assemble_body(
+        "<!-- heph-gha:test -->",
+        "1-1",
+        &[(
+            "othersection".to_string(),
+            "## step one\nits results".into(),
+        )],
+    );
+    let gh = FakeGitHub::start(vec![
+        (
+            "200 OK",
+            serde_json::json!([{"id": 99, "body": other}]).to_string(),
+        ),
+        ("200 OK", "{}".to_string()),
+    ]);
+
+    let c = CommentClient::new(config(&gh.url, "mysection", "1-1"));
+    c.sync(|| "## step two\nmy results".to_string(), None);
+
+    let body = gh.last_written_body().expect("a write happened");
+    assert!(body.contains("its results"), "other step kept: {body}");
+    assert!(body.contains("my results"), "our section added: {body}");
+    assert_eq!(parse_sections(&body).len(), 2, "two sections: {body}");
+}
+
+#[test]
+fn a_new_run_resets_the_previous_builds_sections() {
+    // The comment is reused across runs, but a new run must start clean or the
+    // previous build's sections pile up forever.
+    let stale = assemble_body(
+        "<!-- heph-gha:test -->",
+        "1-1",
+        &[
+            ("a".to_string(), "old step a".into()),
+            ("b".to_string(), "old step b".into()),
+        ],
+    );
+    let gh = FakeGitHub::start(vec![
+        (
+            "200 OK",
+            serde_json::json!([{"id": 99, "body": stale}]).to_string(),
+        ),
+        ("200 OK", "{}".to_string()),
+    ]);
+
+    // Different run id → reset.
+    let c = CommentClient::new(config(&gh.url, "fresh", "2-1"));
+    c.sync(|| "new build".to_string(), None);
+
+    let body = gh.last_written_body().expect("a write happened");
+    assert!(!body.contains("old step a"), "stale cleared: {body}");
+    assert!(!body.contains("old step b"), "stale cleared: {body}");
+    assert!(body.contains("new build"), "{body}");
+    assert_eq!(parse_sections(&body).len(), 1, "only ours: {body}");
+    assert_eq!(parse_run_id(&body).as_deref(), Some("2-1"));
+}
+
+#[test]
+fn a_422_leaves_the_client_usable() {
+    // Over GitHub's size cap the API answers 422. The old code logged a warning
+    // nobody reads and the comment froze for the rest of the job. At minimum the
+    // client must not wedge: the next sync still attempts a write.
+    let gh = FakeGitHub::start(vec![
+        ("200 OK", "[]".to_string()),
+        ("422 Unprocessable Entity", "{}".to_string()),
+        ("201 Created", serde_json::json!({"id": 5}).to_string()),
+    ]);
+    let c = CommentClient::new(config(&gh.url, "sec", "1-1"));
+
+    c.sync(|| "too big".to_string(), None);
+    let after_first = gh.hits();
+    c.sync(|| "retry".to_string(), None);
+
+    assert!(
+        gh.hits() > after_first,
+        "a failed write must not stop later syncs"
+    );
+}
+
+#[test]
+fn a_404_mid_run_does_not_wedge() {
+    // Someone deleted the comment while the build was running.
+    let gh = FakeGitHub::start(vec![
+        (
+            "200 OK",
+            serde_json::json!([{"id": 12, "body": "<!-- heph-gha:test -->\n<!-- heph-gha-run:1-1 -->"}])
+                .to_string(),
+        ),
+        ("404 Not Found", "{}".to_string()),
+        ("404 Not Found", "{}".to_string()),
+    ]);
+    let c = CommentClient::new(config(&gh.url, "sec", "1-1"));
+
+    c.sync(|| "one".to_string(), None);
+    c.sync(|| "two".to_string(), None);
+
+    assert!(gh.hits() >= 3, "kept trying rather than giving up silently");
+}
+
+#[test]
+fn the_close_deadline_bounds_a_hanging_api() {
+    // `on_close` runs inside the host's drain barrier before process exit, so an
+    // unresponsive GitHub must not add its latency to `heph`'s exit.
+    let listener = std::net::TcpListener::bind("127.0.0.1:0").expect("bind");
+    let url = format!("http://{}", listener.local_addr().expect("addr"));
+    // Accept but never respond.
+    std::thread::spawn(move || {
+        let mut held = Vec::new();
+        while let Ok((sock, _)) = listener.accept() {
+            held.push(sock);
+        }
+    });
+
+    let mut cfg = config(&url, "sec", "1-1");
+    cfg.timeout = Duration::from_millis(300);
+    let c = CommentClient::new(cfg);
+
+    let start = std::time::Instant::now();
+    c.sync(
+        || "body".to_string(),
+        Some(std::time::Instant::now() + Duration::from_millis(500)),
+    );
+    let elapsed = start.elapsed();
+    assert!(
+        elapsed < Duration::from_secs(20),
+        "close sync must be bounded, took {elapsed:?}"
+    );
+}
+
+#[test]
+fn a_section_key_containing_the_delimiter_does_not_grow_the_body() {
+    // The regression that made the body grow until GitHub rejected it: a raw key
+    // containing " -->" closed the marker early, so `upsert_section` never
+    // matched it again and every tick appended a new section. `section_id`
+    // hashes the key, so this must now update in place.
+    let key = section_id("run //a:b --> oops");
+    let gh = FakeGitHub::start(create_flow());
+    let c = CommentClient::new(config(&gh.url, &key, "1-1"));
+
+    for i in 0..5 {
+        c.sync(|| format!("tick {i}"), None);
+    }
+
+    let body = gh.last_written_body().expect("a write happened");
+    assert_eq!(
+        parse_sections(&body).len(),
+        1,
+        "one section after five ticks: {body}"
+    );
+    assert!(body.contains("tick 4"), "latest content: {body}");
+}
+
+#[test]
+fn two_matrix_legs_do_not_share_a_comment() {
+    // Distinct job keys mean distinct container markers, so neither leg adopts
+    // the other's comment and neither can erase it.
+    let a = CommentClient::new({
+        let mut c = config("http://127.0.0.1:1", "sec", "1-1");
+        c.job_key = comment_key("run //...", Some("test".into()), Some("Linux-X64".into()));
+        c
+    });
+    let b = CommentClient::new({
+        let mut c = config("http://127.0.0.1:1", "sec", "1-1");
+        c.job_key = comment_key("run //...", Some("test".into()), Some("macOS-ARM64".into()));
+        c
+    });
+    assert_ne!(
+        a.container_marker, b.container_marker,
+        "matrix legs must not share a comment"
+    );
+}

--- a/crates/plugin-gha/src/lib.rs
+++ b/crates/plugin-gha/src/lib.rs
@@ -30,13 +30,15 @@
 //! `BuildState`: that aggregator is coupled to ratatui and lives in the
 //! (terminal) `tui` crate.
 
+#[cfg(test)]
+mod comment_tests;
 mod render;
 mod tally;
 
 use std::path::PathBuf;
 use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::{Arc, Mutex};
-use std::time::Duration;
+use std::time::{Duration, Instant};
 
 use hcore::events::{BuildEvent, now_unix_ms};
 use hplugin::config::{Options, decode_opt, deny_unknown};
@@ -44,15 +46,59 @@ use hplugin::hook::Hook;
 
 use crate::tally::Tally;
 
-/// Scopes the sticky comment to one per job: the Actions job id (`GITHUB_JOB`) when
-/// present, else the heph command (so local / non-Actions runs still get a stable
-/// key). A job keeps a single comment across all its steps.
-fn comment_key(command: &str, job: Option<String>) -> String {
-    match job.filter(|s| !s.is_empty()) {
+/// Scopes the sticky comment to one per job **leg**.
+///
+/// `GITHUB_JOB` alone is not enough: it is the job id *from the workflow file*,
+/// so every leg of a matrix reports the same value. With that as the sole key,
+/// all legs race `fetch_existing`, all find nothing, and all POST — producing
+/// duplicate comments — after which each caches the section list once and never
+/// re-reads, so the legs permanently erase each other's sections. This repo's own
+/// `test` job has three legs.
+///
+/// `leg` disambiguates them. It is the runner's OS/arch (`RUNNER_OS`,
+/// `RUNNER_ARCH`) rather than the matrix context, because the matrix is not
+/// exposed to a process as an env var while the runner identity always is, and
+/// the overwhelmingly common matrix axis *is* the platform. A matrix that varies
+/// something else (a Go version, a feature flag) still collides — hence the
+/// `commentKey` option, which overrides this wholesale.
+fn comment_key(command: &str, job: Option<String>, leg: Option<String>) -> String {
+    let base = match job.filter(|s| !s.is_empty()) {
         Some(job) => job,
         None if command.is_empty() => "heph".to_string(),
         None => command.to_string(),
+    };
+    match leg.filter(|s| !s.is_empty()) {
+        Some(leg) => format!("{base}:{leg}"),
+        None => base,
     }
+}
+
+/// The runner's identity, used to separate matrix legs. `None` outside Actions.
+fn runner_leg() -> Option<String> {
+    let os = std::env::var("RUNNER_OS").ok().filter(|s| !s.is_empty());
+    let arch = std::env::var("RUNNER_ARCH").ok().filter(|s| !s.is_empty());
+    match (os, arch) {
+        (Some(os), Some(arch)) => Some(format!("{os}-{arch}")),
+        (Some(v), None) | (None, Some(v)) => Some(v),
+        (None, None) => None,
+    }
+}
+
+/// A stable, delimiter-safe identifier for a section key.
+///
+/// The key goes into an HTML comment (`<!-- heph-gha-step:KEY -->`), so it must
+/// not contain the delimiter or a newline. It used to be the raw command: a
+/// command containing `" -->"` terminated the opening marker early, so
+/// `upsert_section` never matched that section again and every step **appended a
+/// new one** — growing the body until it hit GitHub's cap and 422'd.
+///
+/// Hashing rather than escaping, because the key is a hidden marker nobody reads;
+/// it only has to be stable and unambiguous.
+fn section_id(key: &str) -> String {
+    use std::hash::{Hash, Hasher};
+    let mut h = std::collections::hash_map::DefaultHasher::new();
+    key.hash(&mut h);
+    format!("{:016x}", h.finish())
 }
 
 /// Longest command label rendered into a public comment.
@@ -279,27 +325,66 @@ struct CommentState {
 /// their own results instead of overwriting one another.
 struct CommentClient {
     http: std::sync::OnceLock<reqwest::blocking::Client>,
+    cfg: CommentConfig,
+    /// Hidden marker (`<!-- heph-gha:<job> -->`) identifying *this job's* comment.
+    container_marker: String,
+    state: Mutex<CommentState>,
+}
+
+/// Everything a [`CommentClient`] needs, with no ambient environment.
+///
+/// Split out from [`CommentClient::from_env`] so the client is constructible in a
+/// test. It previously read `std::env` directly, which meant nothing could build
+/// one without mutating global process state — so the entire HTTP layer, where
+/// this feature actually lives, had zero tests. Worse, the branch that ships
+/// (comment enabled) was the one never exercised: the suite only stayed quiet
+/// because `GITHUB_TOKEN` happens to be absent from the test job's env, an
+/// undeclared ambient invariant that would have posted comments onto the PR
+/// under test the day someone added it.
+#[derive(Debug, Clone)]
+struct CommentConfig {
     api_url: String,
     repo: String,
     token: String,
     /// The PR to comment on.
     pr: u64,
-    /// Hidden marker (`<!-- heph-gha:<job> -->`) identifying *this job's* comment.
-    container_marker: String,
+    /// Scopes the comment — one per job leg.
+    job_key: String,
     /// Identifies the current workflow run (run id + attempt). When an adopted
     /// comment carries a different run, its sections are from a prior build and
     /// are reset. Empty outside Actions (local runs keep reusing the comment).
     run_id: String,
-    /// This process's section key (the heph command) within that comment.
+    /// This process's section key within that comment.
     section_key: String,
-    state: Mutex<CommentState>,
+    /// Per-request timeout. Explicit rather than reqwest's 30s default, because
+    /// `on_close` runs inside the host's drain barrier before process exit.
+    timeout: Duration,
 }
 
+/// Total budget for the close-time sync.
+///
+/// `fetch_existing` can walk several pages, and the host awaits `Hook::drain`
+/// before exiting — so without a ceiling a slow or hanging GitHub API adds
+/// minutes to `heph`'s exit. The comment is best-effort; the step summary is the
+/// durable artifact, and it is written whether or not this succeeds.
+const CLOSE_SYNC_BUDGET: Duration = Duration::from_secs(10);
+
+/// Per-request timeout for live updates.
+const REQUEST_TIMEOUT: Duration = Duration::from_secs(10);
+
 impl CommentClient {
+    fn new(cfg: CommentConfig) -> Self {
+        Self {
+            http: std::sync::OnceLock::new(),
+            container_marker: format!("<!-- heph-gha:{} -->", cfg.job_key),
+            cfg,
+            state: Mutex::new(CommentState::default()),
+        }
+    }
+
     /// Build from the Actions env, or `None` outside a PR / without a token.
-    /// `job_key` scopes the comment (one per job); `section_key` scopes this
-    /// process's block within it. `token_env` names the token var (default
-    /// `GITHUB_TOKEN`).
+    /// `job_key` scopes the comment; `section_key` scopes this process's block
+    /// within it. `token_env` names the token var (default `GITHUB_TOKEN`).
     fn from_env(job_key: &str, section_key: &str, token_env: Option<String>) -> Option<Self> {
         let nonempty = |v: String| Some(v).filter(|s| !s.is_empty());
         let token_var = token_env
@@ -321,35 +406,45 @@ impl CommentClient {
         } else {
             format!("{run}-{attempt}")
         };
-        Some(Self {
-            http: std::sync::OnceLock::new(),
+        Some(Self::new(CommentConfig {
             api_url,
             repo,
             token,
             pr,
-            container_marker: format!("<!-- heph-gha:{job_key} -->"),
+            job_key: job_key.to_string(),
             run_id,
             section_key: section_key.to_string(),
-            state: Mutex::new(CommentState::default()),
-        })
+            timeout: REQUEST_TIMEOUT,
+        }))
     }
 
     fn http(&self) -> &reqwest::blocking::Client {
-        self.http.get_or_init(reqwest::blocking::Client::new)
+        self.http.get_or_init(|| {
+            reqwest::blocking::Client::builder()
+                .timeout(self.cfg.timeout)
+                .build()
+                .unwrap_or_default()
+        })
     }
 
     /// Find this job's comment (by `container_marker`), returning its id + body.
     /// Pages through the PR's comments, capped to bound work.
-    fn fetch_existing(&self) -> Option<(u64, String)> {
+    fn fetch_existing(&self, deadline: Option<Instant>) -> Option<(u64, String)> {
         const MAX_PAGES: u32 = 10;
         for page in 1..=MAX_PAGES {
+            // The host awaits `Hook::drain` before process exit, so an unbounded
+            // page walk here adds its latency straight onto `heph`'s exit.
+            if deadline.is_some_and(|d| Instant::now() >= d) {
+                tracing::warn!("listing PR comments hit the deadline; giving up");
+                return None;
+            }
             let resp = self
                 .http()
                 .get(format!(
                     "{}/repos/{}/issues/{}/comments?per_page=100&page={page}",
-                    self.api_url, self.repo, self.pr
+                    self.cfg.api_url, self.cfg.repo, self.cfg.pr
                 ))
-                .headers(gh_headers(&self.token))
+                .headers(gh_headers(&self.cfg.token))
                 .send()
                 .and_then(|r| r.error_for_status())
                 .and_then(|r| r.json::<Vec<serde_json::Value>>());
@@ -381,25 +476,35 @@ impl CommentClient {
         None
     }
 
-    /// Upsert this process's section with `markdown` and write the merged comment.
-    /// On the first call it adopts any existing comment for this job (inheriting the
-    /// other steps' sections); afterwards it edits only its own block.
-    fn sync(&self, markdown: String) {
+    /// Upsert this process's section and write the merged comment.
+    ///
+    /// `render` is called **under the comment lock**, not before it. That is the
+    /// fix for a silent race: the live thread used to render (taking and
+    /// releasing the tally lock) and only then take the comment lock, so if
+    /// `on_close` landed in that window, the already-rendered "⏳ still running"
+    /// body would PATCH over the final one — leaving a finished build showing as
+    /// in-progress, permanently, with no error anywhere. Rendering inside the
+    /// lock makes render-and-write atomic with respect to other syncs.
+    ///
+    /// On the first call it adopts any existing comment for this job (inheriting
+    /// the other steps' sections); afterwards it edits only its own block.
+    fn sync(&self, render: impl FnOnce() -> String, deadline: Option<Instant>) {
         let mut st = self.state.lock().unwrap_or_else(|e| e.into_inner());
+        let markdown = render();
         if !st.loaded {
-            if let Some((cid, body)) = self.fetch_existing() {
+            if let Some((cid, body)) = self.fetch_existing(deadline) {
                 st.id = Some(cid);
                 // Same run → inherit the other steps' sections. Different (or
                 // missing) run → the comment is from a prior build; start fresh so
                 // its stale sections don't pile up.
-                if parse_run_id(&body).as_deref() == Some(self.run_id.as_str()) {
+                if parse_run_id(&body).as_deref() == Some(self.cfg.run_id.as_str()) {
                     st.sections = parse_sections(&body);
                 }
             }
             st.loaded = true;
         }
-        upsert_section(&mut st.sections, &self.section_key, &markdown);
-        let body = assemble_body(&self.container_marker, &self.run_id, &st.sections);
+        upsert_section(&mut st.sections, &self.cfg.section_key, &markdown);
+        let body = assemble_body(&self.container_marker, &self.cfg.run_id, &st.sections);
 
         let mut payload = serde_json::Map::new();
         payload.insert("body".into(), serde_json::json!(body));
@@ -409,9 +514,9 @@ impl CommentClient {
                 .http()
                 .patch(format!(
                     "{}/repos/{}/issues/comments/{cid}",
-                    self.api_url, self.repo
+                    self.cfg.api_url, self.cfg.repo
                 ))
-                .headers(gh_headers(&self.token))
+                .headers(gh_headers(&self.cfg.token))
                 .json(&serde_json::Value::Object(payload))
                 .send()
                 .and_then(|r| r.error_for_status())
@@ -420,9 +525,9 @@ impl CommentClient {
                 .http()
                 .post(format!(
                     "{}/repos/{}/issues/{}/comments",
-                    self.api_url, self.repo, self.pr
+                    self.cfg.api_url, self.cfg.repo, self.cfg.pr
                 ))
-                .headers(gh_headers(&self.token))
+                .headers(gh_headers(&self.cfg.token))
                 .json(&serde_json::Value::Object(payload))
                 .send()
                 .and_then(|r| r.error_for_status())
@@ -467,6 +572,16 @@ impl Inner {
             slow_after_ms: self.slow_after_ms,
             run_url: self.run_url.as_deref(),
         }
+    }
+
+    /// Write the live comment.
+    ///
+    /// Unconditional: the comment is created at job start and kept current for
+    /// the whole run, so it is present and findable from the moment the job
+    /// begins rather than appearing partway through.
+    fn sync_comment(&self, deadline: Option<Instant>) {
+        let Some(c) = &self.comment else { return };
+        c.sync(|| self.render_live(), deadline);
     }
 
     /// The live comment body for the current tally.
@@ -536,7 +651,13 @@ impl GhaHook {
         deny_unknown(
             "gha hook",
             opts,
-            &["refreshSecs", "summaryPath", "tokenEnv", "slowAfterSecs"],
+            &[
+                "refreshSecs",
+                "summaryPath",
+                "tokenEnv",
+                "slowAfterSecs",
+                "commentKey",
+            ],
         )?;
         tracing::info!("gha hook loaded");
         let refresh_secs: u64 = decode_opt(opts, "gha hook", "refreshSecs")?
@@ -566,15 +687,16 @@ impl GhaHook {
         let run_url = run_url_from_env();
 
         let token_env = decode_opt::<String>(opts, "gha hook", "tokenEnv")?;
-        // One sticky PR comment per job (keyed by GITHUB_JOB, command as fallback);
-        // within it, one section per heph command so a job's steps each keep their
-        // own results.
-        let job_key = comment_key(&command, std::env::var("GITHUB_JOB").ok());
-        let section_key = if command.is_empty() {
-            "heph".to_string()
-        } else {
-            command.clone()
-        };
+        // One sticky PR comment per job leg; within it, one section per heph
+        // command so a job's steps each keep their own results.
+        let job_key =
+            match decode_opt::<String>(opts, "gha hook", "commentKey")?.filter(|s| !s.is_empty()) {
+                Some(explicit) => explicit,
+                None => comment_key(&command, std::env::var("GITHUB_JOB").ok(), runner_leg()),
+            };
+        // Hashed: the raw command can contain the marker delimiter, which used to
+        // append a new section on every step until the body hit GitHub's cap.
+        let section_key = section_id(if command.is_empty() { "heph" } else { &command });
         let comment = CommentClient::from_env(&job_key, &section_key, token_env);
         if comment.is_none() {
             tracing::info!(
@@ -595,22 +717,18 @@ impl GhaHook {
 
         // Live updates run only when a comment is configured. A plain thread (no
         // async runtime) keeps the hook free of runtime entanglement; it creates
-        // the comment up front so it appears at job start, then PATCHes it every
-        // `refreshSecs` until `on_close` sets `stop`.
+        // the comment up front so it is present from job start, then PATCHes it
+        // every `refreshSecs` until `on_close` sets `stop`.
         if inner.comment.is_some() {
             let t = Arc::clone(&inner);
             std::thread::spawn(move || {
-                if let Some(c) = &t.comment {
-                    c.sync(t.render_live());
-                }
+                t.sync_comment(None);
                 while !t.stop.load(Ordering::Acquire) {
                     std::thread::sleep(Duration::from_secs(refresh_secs));
                     if t.stop.load(Ordering::Acquire) {
                         break;
                     }
-                    if let Some(c) = &t.comment {
-                        c.sync(t.render_live());
-                    }
+                    t.sync_comment(None);
                 }
             });
         }
@@ -643,9 +761,10 @@ impl Hook for GhaHook {
             .lock()
             .unwrap_or_else(|e| e.into_inner())
             .set_closed();
-        if let Some(c) = &self.inner.comment {
-            c.sync(self.inner.render_live());
-        }
+        self.inner
+            .sync_comment(Some(Instant::now() + CLOSE_SYNC_BUDGET));
+        // The summary is the durable report; the comment is only a notification.
+        // durable report, the comment is only a notification.
         self.inner.write_summary();
     }
 }
@@ -665,16 +784,67 @@ mod tests {
     #[test]
     fn comment_key_prefers_job_then_command() {
         // Job id wins → one comment per job.
-        assert_eq!(comment_key("run //a:x", Some("test".into())), "test");
+        assert_eq!(comment_key("run //a:x", Some("test".into()), None), "test");
         // No job → command keeps it stable (local / non-Actions).
-        assert_eq!(comment_key("run //a:x", None), "run //a:x");
+        assert_eq!(comment_key("run //a:x", None, None), "run //a:x");
         // Empty job string treated as absent.
         assert_eq!(
-            comment_key("query //...", Some(String::new())),
+            comment_key("query //...", Some(String::new()), None),
             "query //..."
         );
         // Empty command → stable fallback.
-        assert_eq!(comment_key("", None), "heph");
+        assert_eq!(comment_key("", None, None), "heph");
+    }
+
+    #[test]
+    fn matrix_legs_get_distinct_comment_keys() {
+        // `GITHUB_JOB` is the job id from the workflow file, so it is IDENTICAL
+        // across matrix legs. Keyed on that alone, three legs raced to create
+        // three comments and then erased each other's sections forever. This
+        // repo's own `test` job has three legs.
+        let job = || Some("test".to_string());
+        let linux_amd = comment_key("run //...", job(), Some("Linux-X64".into()));
+        let linux_arm = comment_key("run //...", job(), Some("Linux-ARM64".into()));
+        let macos = comment_key("run //...", job(), Some("macOS-ARM64".into()));
+
+        assert_eq!(linux_amd, "test:Linux-X64");
+        let all = [&linux_amd, &linux_arm, &macos];
+        for (i, a) in all.iter().enumerate() {
+            for b in all.iter().skip(i + 1) {
+                assert_ne!(a, b, "every leg must own its own comment");
+            }
+        }
+        // Outside Actions there is no leg, and the key stays what it was.
+        assert_eq!(comment_key("run //...", job(), None), "test");
+    }
+
+    #[test]
+    fn section_id_is_delimiter_safe_and_stable() {
+        // The key lands inside `<!-- heph-gha-step:KEY -->`. A raw command
+        // containing " -->" used to terminate the marker early, so the section
+        // was never matched again and every step APPENDED a new one until the
+        // body hit GitHub's cap.
+        let nasty = section_id("run //a:b --> injected <!-- x\nnewline");
+        assert!(!nasty.contains("-->"), "no delimiter: {nasty}");
+        assert!(!nasty.contains('\n'), "no newline: {nasty}");
+        assert!(!nasty.contains('<'), "no markup: {nasty}");
+
+        // Stable across calls — the same step must find its own section next tick.
+        assert_eq!(section_id("run //a:b"), section_id("run //a:b"));
+        assert_ne!(section_id("run //a:b"), section_id("run //a:c"));
+
+        // And it round-trips through the real section machinery.
+        let mut sections = Vec::new();
+        upsert_section(&mut sections, &nasty, "body one");
+        upsert_section(&mut sections, &nasty, "body two");
+        let assembled = assemble_body("<!-- heph-gha:job -->", "1-1", &sections);
+        let parsed = parse_sections(&assembled);
+        assert_eq!(
+            parsed.len(),
+            1,
+            "updated in place, not appended: {assembled}"
+        );
+        assert_eq!(parsed.first().map(|(_, c)| c.as_str()), Some("body two"));
     }
 
     #[test]

--- a/docs/GHA_REPORTING.md
+++ b/docs/GHA_REPORTING.md
@@ -795,9 +795,8 @@ Current: `refreshSecs`, `summaryPath`, `tokenEnv`. Keep the names and the camelC
 
 | Option | Default | Why |
 |---|---|---|
-| `comment` | `onFailureOrSlow` | `always`/`never`/`onFailure`/`onFailureOrSlow`. A 3-second all-cached step must not post. The single biggest spam fix |
 | `commentKey` | `$GITHUB_JOB` + leg discriminator | Fixes the matrix collision (§13) |
-| `slowAfterSecs` | `30` | Both the "running longest" threshold and the `onFailureOrSlow` gate. One knob |
+| `slowAfterSecs` | `30` | How long a target must run before it is surfaced as "running longest" |
 | `jsonPath` | unset | The agent surface |
 | `annotations` | `true` | `::error::` workflow commands |
 | `detail` | `auto` | `compact`/`full`/`auto` (compact on success, full on failure) |
@@ -872,7 +871,7 @@ seam. Do not put summary-content assertions there.
 
 1. **Rendering, keying, and the test seam — no engine changes.** Bugs 1, 3, 4, 5, 6, 7, 8, 9, 10;
    split `render_live`/`render_final`; elapsed + `updated …Z`; `executed` rename across both
-   surfaces; `comment: onFailureOrSlow`; drop the t=0 sync; byte budgets. This alone fixes the live
+   surfaces; byte budgets. This alone fixes the live
    view and every comment bug.
 2. **`ResultEnd` structured failure detail** (§7.1) — gates live failure diagnosis, the highest-value
    item. Consult `compatibility` on the shape first.
@@ -904,6 +903,8 @@ seam. Do not put summary-content assertions there.
   fallback render at `progress.rs:1092`, and the stale doc comment at `progress.rs:2050` that
   advertises a header the code no longer produces).
 - Counts are **graph-wide**, not matched-only.
-- `comment` defaults to **`onFailureOrSlow`**.
+- The comment is **always posted**, from job start. An earlier draft gated it behind a
+  `comment: onFailureOrSlow` policy to avoid posting for short green steps; that was reversed —
+  a comment that is always present is findable and predictable, which beats saving two API writes.
 - Diagrams: **one gantt, step summary only.** No SVG, no badges, no cone flowchart.
 - The hook **never** influences `fail_fast`; it reports the mode.


### PR DESCRIPTION
**Stacked on #373.** Review the stack bottom-up.

## The blocker this clears

The sticky-comment HTTP layer is where this feature actually lives — adopt-vs-reset, the section merge, capturing the id from a POST, every failure mode — and **none of it could be tested**. `from_env` read `std::env` directly, so nothing could construct a `CommentClient` without mutating global process state.

Worse, the branch that *ships* was the one never exercised. The suite stayed quiet only because `GITHUB_TOKEN` happens to be absent from the test job's environment — an undeclared ambient invariant. Under Actions `GITHUB_REPOSITORY` and `GITHUB_REF` are always set, so the day someone added a token to that job, the tests would have started POSTing comments onto the PR under test.

`CommentConfig` splits out from a thin `from_env` adapter, and the tests drive a **real loopback HTTP server** (the `crates/e2e/tests/http_fetch.rs` pattern — std `TcpListener` on `127.0.0.1:0`, no new dependency): create-then-PATCH reuses the returned id, adopt preserves other steps' sections, a different run id resets, a 422 leaves the client usable, a 404 mid-run doesn't wedge, and the close-time sync is bounded.

## Four bugs, each with a test

| | |
|---|---|
| **Matrix legs collide** | `GITHUB_JOB` is the job id *from the workflow file* — identical across legs. All legs raced `fetch_existing`, all found nothing, all POSTed, then each cached its section list once and never re-read, so they permanently erased each other. This repo's own `test` job has three legs. The key now folds in the runner's OS/arch, with `commentKey` for matrices varying something else. |
| **A `" -->"` in the key grew the body forever** | The raw command was the section key; that substring closed the marker early, so `upsert_section` never matched it again and every tick **appended** a new section until the body hit GitHub's cap and 422'd. Keys are hashed now. |
| **The live thread could overwrite the final comment** | It rendered (releasing the tally lock) and only *then* took the comment lock. `on_close` landing in that window left a finished build showing "⏳ still running" permanently, silently. `sync` takes a closure and renders **under** the lock. |
| **No request deadline** | `fetch_existing` walked up to 10 pages at reqwest's 30s default while the host awaited `Hook::drain` before process exit — minutes added to `heph`'s exit against a slow API. Explicit client timeout plus a total budget on the close-time sync. The step summary is the durable artifact and is written regardless. |

## Note on comment cadence

An earlier revision of this PR gated the comment behind a `comment: onFailureOrSlow` policy so a 3-second all-cached step wouldn't post. **That was reversed** — the comment is now always created at job start and kept current, so it is present and findable from the moment the job begins rather than appearing partway through.

`slowAfterSecs` (default 30) remains, now purely as the "running longest" threshold — it replaces a hardcoded 10s that, against a 30s refresh, listed half a cold build as slow.

## Tests

54 in `plugin-gha`, clippy clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QdtQoQV7ptcJzoiUgXJvJv