### PR TITLE
feat(plugin-gha): diagnose failures before the build ends

### DIFF
--- a/crates/plugin-gha/src/lib.rs
+++ b/crates/plugin-gha/src/lib.rs
@@ -33,6 +33,7 @@
 #[cfg(test)]
 mod comment_tests;
 mod render;
+mod report;
 mod tally;
 
 use std::path::PathBuf;
@@ -562,6 +563,39 @@ struct Inner {
     slow_after_ms: u64,
     /// Link to the workflow run, when the Actions env provides one.
     run_url: Option<String>,
+    /// Where to write the full JSON document, if configured.
+    json_path: Option<PathBuf>,
+    /// Whether to emit `::error::` workflow commands.
+    annotations: bool,
+    /// Root addrs already annotated, so a repeated `ResultEnd` for one addr does
+    /// not repeat its annotation.
+    annotated: Mutex<std::collections::HashSet<String>>,
+    /// Last out-of-band flush, for the floor between failure-triggered syncs.
+    last_flush: Mutex<Option<Instant>>,
+}
+
+/// Minimum gap between out-of-band, failure-triggered comment syncs.
+///
+/// The first root failure flushes immediately — that is the whole point of
+/// diagnosing before the build ends, and waiting up to `refreshSecs` for it
+/// wastes the window. Subsequent roots coalesce into the next tick if they land
+/// inside this floor, so a build breaking in twenty places does not become twenty
+/// API writes. Bounded by *breakage count*, not target count, which is what makes
+/// it safe on a 20k-target graph.
+const FLUSH_FLOOR: Duration = Duration::from_secs(10);
+
+/// Emit a workflow command on stdout.
+///
+/// `println!` is restricted in plugin code, and deliberately so — but a workflow
+/// command has exactly one channel: the step's stdout, read by the Actions
+/// runner. There is no file or API alternative. It is gated on `GITHUB_ACTIONS`
+/// so it can only ever fire inside a runner, where stderr is not a tty and the
+/// TUI has therefore taken its non-interactive backend, leaving stdout free.
+fn emit_workflow_command(line: &str) {
+    if std::env::var("GITHUB_ACTIONS").ok().as_deref() != Some("true") {
+        return;
+    }
+    println!("{line}");
 }
 
 impl Inner {
@@ -571,6 +605,102 @@ impl Inner {
             now_ms: now_unix_ms(),
             slow_after_ms: self.slow_after_ms,
             run_url: self.run_url.as_deref(),
+        }
+    }
+
+    /// React to newly-seen root failures: annotate them, and flush the comment
+    /// out of band so the failure is visible now rather than up to `refreshSecs`
+    /// later.
+    ///
+    /// Only *roots* trigger any of this. Collateral failures bump a counter — at
+    /// 20k targets one broken leaf blocks thousands, and flushing or annotating
+    /// each would be thousands of writes describing one bug.
+    fn notice_failures(&self) {
+        let new_roots: Vec<crate::tally::RootFailure> = {
+            let t = self.tally.lock().unwrap_or_else(|e| e.into_inner());
+            let mut seen = self.annotated.lock().unwrap_or_else(|e| e.into_inner());
+            t.roots()
+                .iter()
+                .filter(|r| seen.insert(r.addr.clone()))
+                .cloned()
+                .collect()
+        };
+        if new_roots.is_empty() {
+            return;
+        }
+
+        if self.annotations {
+            for line in report::annotations(&new_roots, new_roots.len()) {
+                emit_workflow_command(&line);
+            }
+        }
+
+        // Flush immediately on the first failure; coalesce later ones.
+        let should_flush = {
+            let mut last = self.last_flush.lock().unwrap_or_else(|e| e.into_inner());
+            let now = Instant::now();
+            match *last {
+                Some(prev) if now.duration_since(prev) < FLUSH_FLOOR => false,
+                _ => {
+                    *last = Some(now);
+                    true
+                }
+            }
+        };
+        if should_flush {
+            self.sync_comment(None);
+        }
+    }
+
+    /// Write the machine-readable end-of-run surfaces.
+    ///
+    /// Both are best-effort and independent of the comment: an agent reading
+    /// `GITHUB_OUTPUT` must not depend on whether a PR comment was warranted.
+    fn write_machine_surfaces(&self) {
+        let (elapsed, counters) = {
+            let t = self.tally.lock().unwrap_or_else(|e| e.into_inner());
+            (t.elapsed_ms(now_unix_ms()), t.counters())
+        };
+        let json_path_str = self.json_path.as_ref().map(|p| p.display().to_string());
+
+        if let Some(path) = &self.json_path {
+            let t = self.tally.lock().unwrap_or_else(|e| e.into_inner());
+            let doc = report::full_document(
+                &t,
+                &counters,
+                elapsed,
+                &self.title,
+                json_path_str.as_deref(),
+            );
+            match serde_json::to_vec_pretty(&doc) {
+                Ok(bytes) => {
+                    if let Err(e) = std::fs::write(path, bytes) {
+                        tracing::warn!(path = %path.display(), "writing heph json failed: {e}");
+                    }
+                }
+                Err(e) => tracing::warn!("serializing heph json failed: {e}"),
+            }
+        }
+
+        // `$GITHUB_OUTPUT` is an append target, one `key=value` per line.
+        if let Some(out) = std::env::var_os("GITHUB_OUTPUT") {
+            let t = self.tally.lock().unwrap_or_else(|e| e.into_inner());
+            let lines = report::github_outputs(&t, &counters, elapsed, json_path_str.as_deref());
+            drop(t);
+            let opened = std::fs::OpenOptions::new()
+                .create(true)
+                .append(true)
+                .open(&out);
+            match opened {
+                Ok(mut f) => {
+                    use std::io::Write;
+                    let body = format!("{}\n", lines.join("\n"));
+                    if let Err(e) = f.write_all(body.as_bytes()) {
+                        tracing::warn!("writing $GITHUB_OUTPUT failed: {e}");
+                    }
+                }
+                Err(e) => tracing::warn!("opening $GITHUB_OUTPUT failed: {e}"),
+            }
         }
     }
 
@@ -597,7 +727,24 @@ impl Inner {
     /// The end-of-run report for `$GITHUB_STEP_SUMMARY`.
     fn render_final(&self) -> String {
         let tally = self.tally.lock().unwrap_or_else(|e| e.into_inner());
-        render::render_final(&tally, &self.ctx(), render::SUMMARY_BUDGET)
+        // The embed is reserved out of the budget *before* the prose, because a
+        // truncated fact is recoverable for a human while a truncated JSON object
+        // is unparseable — it would break the agent that depends on it.
+        let embed = report::embed_marker(&report::embedded_document(
+            &tally,
+            &tally.counters(),
+            tally.elapsed_ms(now_unix_ms()),
+            self.json_path
+                .as_ref()
+                .map(|p| p.display().to_string())
+                .as_deref(),
+        ));
+        let budget = render::SUMMARY_BUDGET.saturating_sub(embed.len().saturating_add(2));
+        let mut out = render::render_final(&tally, &self.ctx(), budget);
+        out.push('\n');
+        out.push_str(&embed);
+        out.push('\n');
+        out
     }
 
     /// Append the final report to the step-summary file.
@@ -657,6 +804,8 @@ impl GhaHook {
                 "tokenEnv",
                 "slowAfterSecs",
                 "commentKey",
+                "jsonPath",
+                "annotations",
             ],
         )?;
         tracing::info!("gha hook loaded");
@@ -686,6 +835,8 @@ impl GhaHook {
         };
         let run_url = run_url_from_env();
 
+        let json_path = decode_opt::<String>(opts, "gha hook", "jsonPath")?.map(PathBuf::from);
+        let annotations = decode_opt::<bool>(opts, "gha hook", "annotations")?.unwrap_or(true);
         let token_env = decode_opt::<String>(opts, "gha hook", "tokenEnv")?;
         // One sticky PR comment per job leg; within it, one section per heph
         // command so a job's steps each keep their own results.
@@ -713,6 +864,10 @@ impl GhaHook {
             stop: AtomicBool::new(false),
             slow_after_ms: slow_after_secs.saturating_mul(1000),
             run_url,
+            json_path,
+            annotations,
+            annotated: Mutex::new(std::collections::HashSet::new()),
+            last_flush: Mutex::new(None),
         });
 
         // Live updates run only when a comment is configured. A plain thread (no
@@ -743,11 +898,17 @@ impl Hook for GhaHook {
     }
 
     fn on_event(&self, ev: &BuildEvent) {
-        self.inner
-            .tally
-            .lock()
-            .unwrap_or_else(|e| e.into_inner())
-            .apply(ev);
+        let newly_failed = {
+            let mut t = self.inner.tally.lock().unwrap_or_else(|e| e.into_inner());
+            let before = t.counters().roots_total;
+            t.apply(ev);
+            t.counters().roots_total > before
+        };
+        // Only on the edge, so the ~160k events of a 20k-target build do no work
+        // here beyond the fold itself.
+        if newly_failed {
+            self.inner.notice_failures();
+        }
     }
 
     fn on_close(&self) {
@@ -766,6 +927,7 @@ impl Hook for GhaHook {
         // The summary is the durable report; the comment is only a notification.
         // durable report, the comment is only a notification.
         self.inner.write_summary();
+        self.inner.write_machine_surfaces();
     }
 }
 
@@ -1054,5 +1216,118 @@ mod tests {
 
     fn label_from(args: &[&str]) -> String {
         command_label_from(args.iter().map(|s| (*s).to_string()))
+    }
+
+    fn hook_with(opts: &[(&str, &str)]) -> GhaHook {
+        let opts: Options = opts
+            .iter()
+            .map(|(k, v)| {
+                (
+                    (*k).to_string(),
+                    serde_yaml::Value::String((*v).to_string()),
+                )
+            })
+            .collect();
+        GhaHook::from_options(&opts).expect("hook")
+    }
+
+    #[test]
+    fn the_summary_carries_a_parseable_embedded_json_document() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let summary = dir.path().join("summary.md");
+        let json = dir.path().join("heph.json");
+        let hook = hook_with(&[
+            ("summaryPath", &summary.to_string_lossy()),
+            ("jsonPath", &json.to_string_lossy()),
+        ]);
+
+        hook.on_event(&ev(
+            0,
+            BuildEventKind::Matched {
+                addrs: vec!["//a:x".into()],
+                complete: true,
+            },
+        ));
+        hook.on_event(&ev(
+            1_000,
+            BuildEventKind::ResultEnd {
+                addr: "//a:x".into(),
+                error: Some("target failed".into()),
+                upstream_of: None,
+                exit_status: Some("exit status: 1".into()),
+                log_tail: None,
+            },
+        ));
+        hook.on_close();
+
+        // The embed must survive in the summary AND parse — a truncated JSON
+        // object would break the agent that reads it.
+        let body = std::fs::read_to_string(&summary).expect("summary written");
+        let start = body.find(report::EMBED_OPEN).expect("embed present");
+        let rest = body.get(start + report::EMBED_OPEN.len()..).expect("after");
+        let end = rest.find(report::EMBED_CLOSE).expect("embed closed");
+        let raw = rest.get(..end).expect("json slice");
+        assert!(
+            raw.len() <= report::EMBED_MAX,
+            "embed capped: {}",
+            raw.len()
+        );
+        let v: serde_json::Value = serde_json::from_str(raw).expect("embed parses");
+        assert_eq!(v["status"], "failed");
+        assert_eq!(v["targets"]["failed"], 1);
+
+        // And the full document is written separately, with the detail the embed
+        // deliberately omits.
+        let full: serde_json::Value =
+            serde_json::from_str(&std::fs::read_to_string(&json).expect("json written"))
+                .expect("full doc parses");
+        assert_eq!(full["schema"], report::SCHEMA);
+        assert_eq!(
+            full["failures"][0]["exit_status"], "exit status: 1",
+            "detail lives in the file, not the embed"
+        );
+    }
+
+    #[test]
+    fn a_collateral_cone_does_not_reach_the_json_failure_list() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let json = dir.path().join("heph.json");
+        let hook = hook_with(&[
+            ("summaryPath", &dir.path().join("s.md").to_string_lossy()),
+            ("jsonPath", &json.to_string_lossy()),
+        ]);
+        hook.on_event(&ev(
+            10,
+            BuildEventKind::ResultEnd {
+                addr: "//base:proto".into(),
+                error: Some("boom".into()),
+                upstream_of: None,
+                exit_status: None,
+                log_tail: None,
+            },
+        ));
+        for i in 0..4_117 {
+            hook.on_event(&ev(
+                20,
+                BuildEventKind::ResultEnd {
+                    addr: format!("//svc:t{i}"),
+                    error: Some("dependency failed".into()),
+                    upstream_of: Some("//base:proto".into()),
+                    exit_status: None,
+                    log_tail: None,
+                },
+            ));
+        }
+        hook.on_close();
+
+        let v: serde_json::Value =
+            serde_json::from_str(&std::fs::read_to_string(&json).expect("json")).expect("parses");
+        assert_eq!(
+            v["failures"].as_array().map(Vec::len),
+            Some(1),
+            "one root, not 4,118 entries"
+        );
+        assert_eq!(v["targets"]["blocked"], 4_117);
+        assert_eq!(v["failures"][0]["blocked_count"], 4_117);
     }
 }

--- a/crates/plugin-gha/src/report.rs
+++ b/crates/plugin-gha/src/report.rs
@@ -1,0 +1,471 @@
+//! Machine-readable surfaces: workflow annotations, the JSON document, and the
+//! `GITHUB_OUTPUT` scalars.
+//!
+//! Three consumers, three shapes:
+//!
+//! - **`::error::` annotations** reach a *human* while the job is still running.
+//!   They stream onto the run page and appear inline in the job log at the point
+//!   of failure, cost zero API calls, and are immune to rate limits. Nothing else
+//!   in Actions has all four properties, which is why they are the primary live
+//!   channel rather than a nicety.
+//! - **The JSON document** is what an agent reads to decide what to do next.
+//!   Unbounded, written to a file.
+//! - **The embedded JSON** is a *different, hard-capped* document for an agent
+//!   that can only fetch the comment through the API. See [`EMBED_MAX`].
+
+use crate::render::fmt_duration;
+use crate::tally::{Counters, RootFailure, Tally};
+
+/// Schema identifier. Field names never change within a version.
+pub(crate) const SCHEMA: &str = "heph.gha/1";
+
+/// Hard cap on the JSON embedded in a comment body.
+///
+/// The embed is **not** the same document as the file. It lives inside a body
+/// GitHub caps at 65,536 characters — a budget already shared with the header,
+/// the failure boxes, and every other step's section in the same job. At 20k
+/// targets a naive embed of the full document is tens of KiB on its own and
+/// would consume the entire comment.
+///
+/// So the embed carries counters, status, elapsed and **root addrs only** — no
+/// log tails, no slowest list, no package rollups — and is budgeted *first*,
+/// before any prose. That ordering matters: a truncated *fact* is recoverable for
+/// a human, but a truncated JSON document is **unparseable**, which breaks the
+/// very agent that depends on it.
+pub(crate) const EMBED_MAX: usize = 2048;
+
+/// Longest addr allowed into the embed.
+const EMBED_ADDR_MAX: usize = 128;
+
+/// The marker wrapping the embedded document.
+pub(crate) const EMBED_OPEN: &str = "<!-- heph:json ";
+pub(crate) const EMBED_CLOSE: &str = " -->";
+
+fn truncate_chars(s: &str, max: usize) -> String {
+    let mut out = String::new();
+    for (i, c) in s.chars().enumerate() {
+        if i >= max {
+            out.push('…');
+            return out;
+        }
+        out.push(c);
+    }
+    out
+}
+
+fn status_str(t: &Tally, c: &Counters) -> &'static str {
+    if c.roots_total > 0 {
+        "failed"
+    } else if t.status_emoji() == "✅" {
+        "ok"
+    } else {
+        "running"
+    }
+}
+
+/// The full document — unbounded, for `jsonPath`.
+///
+/// `failures` and `slowest` are sorted deterministically so two runs diff
+/// cleanly, and **collateral failures never appear**: they are `blocked_count`
+/// on their root. An agent reading this must not have to re-derive the
+/// root/collateral split any more than a human does.
+pub(crate) fn full_document(
+    t: &Tally,
+    c: &Counters,
+    elapsed_ms: u64,
+    command: &str,
+    json_path: Option<&str>,
+) -> serde_json::Value {
+    let (done, matched, _) = t.progress();
+    let failures: Vec<serde_json::Value> = t.roots().iter().map(root_json).collect();
+    let slowest: Vec<serde_json::Value> = t
+        .slowest()
+        .iter()
+        .map(|s| {
+            serde_json::json!({
+                "addr": s.addr,
+                "driver": s.driver,
+                "duration_ms": s.duration_ms,
+            })
+        })
+        .collect();
+
+    serde_json::json!({
+        "schema": SCHEMA,
+        "status": status_str(t, c),
+        "command": command,
+        "elapsed_ms": elapsed_ms,
+        "fail_fast": t.fail_fast(),
+        "truncated": false,
+        "json_path": json_path,
+        "targets": {
+            "matched": matched,
+            "done": done,
+            "failed": c.roots_total,
+            "blocked": c.blocked,
+            "cached": c.cached(),
+            "executed": c.executed,
+        },
+        "cache": {
+            "local_hits": c.cached_local,
+            "remote_hits": c.cached_remote,
+            "misses": c.misses(),
+            "hit_rate": c.hit_rate(),
+        },
+        "failures": failures,
+        "slowest": slowest,
+    })
+}
+
+fn root_json(r: &RootFailure) -> serde_json::Value {
+    serde_json::json!({
+        "addr": r.addr,
+        "driver": r.driver,
+        "duration_ms": r.duration_ms,
+        "exit_status": r.exit_status,
+        "blocked_count": r.blocked,
+        "message": r.message,
+        "log_tail": r.log_tail.as_ref().map(|l| &l.text),
+    })
+}
+
+/// The compact document embedded in a comment body, guaranteed to fit
+/// [`EMBED_MAX`] **and to parse**.
+///
+/// Root addrs are dropped oldest-first until it fits, and what was dropped is
+/// recorded *inside* the JSON — an agent reading a truncated view must be able
+/// to tell that it is truncated, and to find the complete document.
+/// `truncated` and `json_path` are therefore always present.
+pub(crate) fn embedded_document(
+    t: &Tally,
+    c: &Counters,
+    elapsed_ms: u64,
+    json_path: Option<&str>,
+) -> String {
+    let (_, matched, _) = t.progress();
+    let mut addrs: Vec<String> = t
+        .roots()
+        .iter()
+        .map(|r| truncate_chars(&r.addr, EMBED_ADDR_MAX))
+        .collect();
+    let mut omitted = c.roots_total.saturating_sub(addrs.len());
+
+    loop {
+        let doc = serde_json::json!({
+            "schema": SCHEMA,
+            "status": status_str(t, c),
+            "elapsed_ms": elapsed_ms,
+            "truncated": omitted > 0,
+            "failures_omitted": omitted,
+            "json_path": json_path,
+            "targets": {
+                "matched": matched,
+                "failed": c.roots_total,
+                "blocked": c.blocked,
+                "cached": c.cached(),
+                "executed": c.executed,
+            },
+            "failures": addrs,
+        });
+        // Compact, never pretty: every byte here is taken from the prose budget.
+        let s = serde_json::to_string(&doc).unwrap_or_else(|_| "{}".to_string());
+        if s.len() <= EMBED_MAX || addrs.is_empty() {
+            return s;
+        }
+        // Drop the oldest root and record it as omitted.
+        addrs.remove(0);
+        omitted = omitted.saturating_add(1);
+    }
+}
+
+/// Wrap the embed in its HTML-comment marker.
+pub(crate) fn embed_marker(json: &str) -> String {
+    format!("{EMBED_OPEN}{json}{EMBED_CLOSE}")
+}
+
+/// `::error::` workflow commands, one per **root** failure.
+///
+/// Capped at the root count and never emitted for collateral: at 20k targets one
+/// broken leaf blocks thousands, and an annotation each would be 4,000+ lines of
+/// noise burying the one that matters.
+///
+/// Target-level only — no `file=`/`line=`. heph cannot produce them:
+/// `TargetFailure` carries an addr, a log tail and a cause chain, nothing more.
+/// Regexing `file:line` out of the log tail here would be a zoo of per-language
+/// heuristics living in a reporter, producing *wrong* annotations on the PR diff,
+/// which is worse than none. That waits on driver-emitted structured diagnostics.
+pub(crate) fn annotations(roots: &[RootFailure], limit: usize) -> Vec<String> {
+    roots
+        .iter()
+        .take(limit)
+        .map(|r| {
+            let mut detail = String::new();
+            if let Some(status) = &r.exit_status {
+                detail.push_str(status);
+                detail.push_str(": ");
+            }
+            detail.push_str(r.message.lines().next().unwrap_or("failed"));
+            if let Some(tail) = &r.log_tail
+                && let Some(last) = tail.text.lines().rev().find(|l| !l.trim().is_empty())
+            {
+                detail.push_str(" — ");
+                detail.push_str(last);
+            }
+            if r.blocked > 0 {
+                detail.push_str(&format!(" ({} targets blocked)", r.blocked));
+            }
+            format!(
+                "::error title=heph {}::{}",
+                escape_annotation(&r.addr),
+                escape_annotation(&truncate_chars(&detail, 400))
+            )
+        })
+        .collect()
+}
+
+/// Escape the characters that would terminate or corrupt a workflow command.
+///
+/// A newline ends the command, so an unescaped multi-line message would spill
+/// the remainder into the log as literal text — and, worse, anything after a
+/// `::` in it could be interpreted as a *new* workflow command. The log tail is
+/// whatever the target printed, so it is untrusted input in this position.
+fn escape_annotation(s: &str) -> String {
+    s.replace('%', "%25")
+        .replace('\r', "%0D")
+        .replace('\n', "%0A")
+        .replace("::", "%3A%3A")
+}
+
+/// `key=value` lines for `$GITHUB_OUTPUT` — the GHA-native agent surface: free,
+/// no parsing, no rate limit, and readable by a downstream step as
+/// `${{ steps.build.outputs.heph_failed }}`.
+pub(crate) fn github_outputs(
+    t: &Tally,
+    c: &Counters,
+    elapsed_ms: u64,
+    json_path: Option<&str>,
+) -> Vec<String> {
+    let mut out = vec![
+        format!("heph_status={}", status_str(t, c)),
+        format!("heph_failed={}", c.roots_total),
+        format!("heph_blocked={}", c.blocked),
+        format!("heph_executed={}", c.executed),
+        format!("heph_cached={}", c.cached()),
+        format!("heph_elapsed_ms={elapsed_ms}"),
+        format!("heph_elapsed={}", fmt_duration(elapsed_ms)),
+    ];
+    if let Some(rate) = c.hit_rate() {
+        out.push(format!("heph_cache_hit_rate={rate:.4}"));
+    }
+    if let Some(p) = json_path {
+        out.push(format!("heph_json_path={p}"));
+    }
+    out
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use hcore::events::{BuildEvent, BuildEventKind, LogTailData};
+
+    fn ev(at: u64, kind: BuildEventKind) -> BuildEvent {
+        BuildEvent {
+            at_unix_ms: at,
+            kind,
+        }
+    }
+
+    fn failing(roots: usize, blocked: usize, msg_len: usize) -> Tally {
+        let mut t = Tally::default();
+        t.apply(&ev(
+            0,
+            BuildEventKind::Matched {
+                addrs: (0..20_000)
+                    .map(|i| format!("//pkg{}:t{i}", i % 50))
+                    .collect(),
+                complete: true,
+            },
+        ));
+        let msg = "e".repeat(msg_len);
+        for i in 0..roots {
+            t.apply(&ev(
+                1_000,
+                BuildEventKind::ResultEnd {
+                    addr: format!("//very/long/package/path/number{i}:some-broken-target"),
+                    error: Some(msg.clone()),
+                    upstream_of: None,
+                    exit_status: Some("exit status: 1".into()),
+                    log_tail: Some(LogTailData {
+                        text: "FAIL\nline two".into(),
+                        start_line: 1,
+                    }),
+                },
+            ));
+        }
+        for i in 0..blocked {
+            t.apply(&ev(
+                2_000,
+                BuildEventKind::ResultEnd {
+                    addr: format!("//svc:t{i}"),
+                    error: Some("dependency failed".into()),
+                    upstream_of: Some("//very/long/package/path/number0:some-broken-target".into()),
+                    exit_status: None,
+                    log_tail: None,
+                },
+            ));
+        }
+        t
+    }
+
+    #[test]
+    fn the_embed_always_fits_and_always_parses() {
+        // The case that matters: many roots with huge messages, at 20k targets.
+        // A truncated fact is survivable; a truncated JSON object is not — it
+        // breaks the agent that depends on it.
+        for roots in [0, 1, 10, 200] {
+            let t = failing(roots, 4_117, 4_096);
+            let c = t.counters();
+            let s = embedded_document(&t, &c, 468_000, Some("/tmp/h.json"));
+            assert!(
+                s.len() <= EMBED_MAX,
+                "embed over cap with {roots} roots: {} bytes",
+                s.len()
+            );
+            let v: serde_json::Value =
+                serde_json::from_str(&s).unwrap_or_else(|e| panic!("must parse ({roots}): {e}"));
+            assert_eq!(v["schema"], SCHEMA);
+            // Mandatory regardless of truncation — without them a truncated view
+            // is a dead end.
+            assert!(v.get("truncated").is_some(), "truncated always present");
+            assert_eq!(
+                v["json_path"], "/tmp/h.json",
+                "always points at the full doc"
+            );
+        }
+    }
+
+    #[test]
+    fn a_truncated_embed_says_so_and_counts_what_it_dropped() {
+        let t = failing(10, 0, 4_096);
+        let c = t.counters();
+        let s = embedded_document(&t, &c, 1_000, Some("/tmp/h.json"));
+        let v: serde_json::Value = serde_json::from_str(&s).expect("parses");
+        // Roots are capped at ROOTS_KEPT=10 in the tally and further trimmed here
+        // by the byte budget; either way the count must stay exact.
+        assert_eq!(v["targets"]["failed"], 10, "true count is never lost");
+        if v["truncated"] == serde_json::Value::Bool(true) {
+            assert!(
+                v["failures_omitted"].as_u64().unwrap_or(0) > 0,
+                "omission is quantified: {s}"
+            );
+        }
+    }
+
+    #[test]
+    fn the_embed_carries_no_log_tails() {
+        // The whole reason it is a separate document from the file.
+        let t = failing(1, 0, 32);
+        let c = t.counters();
+        let s = embedded_document(&t, &c, 1_000, None);
+        assert!(!s.contains("log_tail"), "no tails in the embed: {s}");
+        assert!(!s.contains("slowest"), "no slowest list in the embed: {s}");
+    }
+
+    #[test]
+    fn the_full_document_separates_roots_from_collateral() {
+        let t = failing(2, 4_117, 32);
+        let c = t.counters();
+        let v = full_document(&t, &c, 468_000, "run //...", None);
+        let failures = v["failures"].as_array().expect("failures array");
+        assert_eq!(failures.len(), 2, "collateral is never a failure entry");
+        assert_eq!(v["targets"]["blocked"], 4_117);
+        assert_eq!(
+            failures[0]["blocked_count"], 4_117,
+            "collateral attributed to its root"
+        );
+        assert!(failures[0]["log_tail"].is_string(), "file doc keeps tails");
+    }
+
+    #[test]
+    fn annotations_are_one_per_root_never_per_collateral() {
+        // One broken leaf blocking 4,117 targets must not produce 4,117
+        // annotations.
+        let t = failing(2, 4_117, 32);
+        let a = annotations(t.roots(), 10);
+        assert_eq!(a.len(), 2, "one per root");
+        assert!(
+            a[0].starts_with("::error title=heph //very/long"),
+            "{}",
+            a[0]
+        );
+        assert!(a[0].contains("4117 targets blocked"), "{}", a[0]);
+    }
+
+    #[test]
+    fn an_annotation_cannot_be_broken_by_target_output() {
+        // The log tail is whatever the target printed — untrusted in this
+        // position. A newline would end the workflow command, and a `::` could
+        // start a new one.
+        let mut t = Tally::default();
+        t.apply(&ev(
+            0,
+            BuildEventKind::ResultEnd {
+                addr: "//a:x".into(),
+                error: Some("boom".into()),
+                upstream_of: None,
+                exit_status: None,
+                // The injection attempt is the LAST line, which is the one the
+                // annotation actually quotes.
+                log_tail: Some(LogTailData {
+                    text: "safe 100% done\n::error title=spoofed::not really failing".into(),
+                    start_line: 1,
+                }),
+            },
+        ));
+        let a = annotations(t.roots(), 10);
+        let line = a.first().expect("one annotation");
+        assert_eq!(line.lines().count(), 1, "single line: {line}");
+        assert!(!line.contains('\n'), "no raw newline: {line}");
+        // A workflow command is `::error title=X::message` — exactly two `::` of
+        // its own. Any more would mean the payload injected one.
+        assert_eq!(
+            line.matches("::").count(),
+            2,
+            "payload contributed no command separator: {line}"
+        );
+        assert!(line.contains("%3A%3A"), "payload `::` escaped: {line}");
+        assert!(
+            !line.contains("::error title=spoofed"),
+            "cannot spoof a second annotation: {line}"
+        );
+    }
+
+    #[test]
+    fn github_outputs_are_scalar_and_parseable() {
+        let t = failing(2, 10, 32);
+        let c = t.counters();
+        let out = github_outputs(&t, &c, 468_000, Some("/tmp/h.json"));
+        let joined = out.join("\n");
+        assert!(joined.contains("heph_status=failed"), "{joined}");
+        assert!(joined.contains("heph_failed=2"), "{joined}");
+        assert!(joined.contains("heph_blocked=10"), "{joined}");
+        assert!(joined.contains("heph_json_path=/tmp/h.json"), "{joined}");
+        for line in &out {
+            assert_eq!(line.lines().count(), 1, "one line per key: {line}");
+            assert!(line.contains('='), "key=value: {line}");
+        }
+    }
+
+    #[test]
+    fn hit_rate_is_absent_rather_than_zero_when_never_consulted() {
+        let t = failing(0, 0, 0);
+        let c = t.counters();
+        let out = github_outputs(&t, &c, 1_000, None);
+        assert!(
+            !out.iter().any(|l| l.starts_with("heph_cache_hit_rate")),
+            "no key at all beats a misleading 0: {out:?}"
+        );
+        let v = full_document(&t, &c, 1_000, "run //...", None);
+        assert!(v["cache"]["hit_rate"].is_null());
+    }
+}


### PR DESCRIPTION
`--fail-fast` is opt-in, so a target that breaks two minutes into a
forty-minute build leaves the developer uninformed for the remaining
thirty-eight. Nothing surfaced the failure until the run finished.

Three surfaces, each shaped for who reads it:

- **`::error::` annotations**, emitted the moment a root failure lands.
  They stream onto the run page while the job runs, appear inline in the
  job log at the point of failure, cost zero API calls and are immune to
  rate limits — nothing else in Actions has all four properties.
  Target-level only; heph cannot produce `file=`/`line=` (a `TargetFailure`
  carries an addr, a log tail and a cause chain, nothing more), and
  regexing them out of the log tail here would be per-language guesswork
  putting *wrong* annotations on the PR diff. That waits on driver-emitted
  diagnostics.
- **Out-of-band comment flush** on the first root failure, then coalescing
  on a 10s floor. Waiting up to `refreshSecs` wastes the window the whole
  feature exists for. Bounded by breakage count, not target count.
- **JSON**, in two deliberately different documents.

Only *roots* trigger any of it. At 20k targets one broken leaf blocks
thousands, and annotating or flushing per collateral failure would be
thousands of writes describing one bug.

On the JSON: the file document is unbounded, but the one embedded in a
comment is a separate, hard-capped 2 KiB document — counters, status and
root addrs only, no log tails or slowest list. It lives inside a body
GitHub caps at 65,536 characters, shared with the prose and every other
step's section. It is reserved out of the budget *before* the prose,
because a truncated fact is recoverable for a human while a truncated JSON
object is unparseable and breaks the agent depending on it. When roots
still don't fit they are dropped oldest-first and the omission is recorded
*inside* the JSON; `truncated` and `json_path` are always present, so a
truncated view is never a dead end.

Annotation payloads are escaped: a log tail is whatever the target
printed, and an unescaped newline would end the workflow command while a
`::` could start a new one. Tested against a tail that tries to spoof a
second annotation.

`emit_workflow_command` uses `println!`, which plugin code otherwise
avoids. A workflow command has exactly one channel — the step's stdout —
with no file or API alternative. It is gated on `GITHUB_ACTIONS=true`, so
it can only fire inside a runner, where stderr is not a tty and the TUI has
taken its non-interactive backend.

Adds `jsonPath` and `annotations` options.

Co-Authored-By: Claude Opus 5 (1M context) <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01QdtQoQV7ptcJzoiUgXJvJv

---

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>