### PR TITLE
feat(plugin-oci): oci_image and oci_layer — container images without docker

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4203,6 +4203,7 @@ dependencies = [
  "anyhow",
  "async-trait",
  "bollard",
+ "bytes",
  "core",
  "docker_credential",
  "driver-support",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1504,6 +1504,8 @@ dependencies = [
  "core",
  "heph",
  "plugin-oci",
+ "serde_json",
+ "sha2 0.10.9",
  "tar",
  "tempfile",
  "testkit",

--- a/crates/e2e/Cargo.toml
+++ b/crates/e2e/Cargo.toml
@@ -16,3 +16,5 @@ tokio = { version = "1", features = ["rt", "rt-multi-thread", "macros"] }
 anyhow = "1"
 tempfile = "3"
 tar = "0.4"
+serde_json = "1"
+sha2 = "0.10"

--- a/crates/e2e/tests/oci_image.rs
+++ b/crates/e2e/tests/oci_image.rs
@@ -1,0 +1,497 @@
+#![expect(
+    clippy::panic_in_result_fn,
+    clippy::indexing_slicing,
+    reason = "restriction/style lints scoped to production code; tests are exempt. \
+              `serde_json::Value`'s Index is infallible — a missing key reads as Null — so \
+              indexing a parsed manifest cannot panic the way slicing a Vec can."
+)]
+
+//! End-to-end coverage for `oci_layer` + `oci_image`, through the real engine.
+//!
+//! **Nothing here is gated on docker being installed, and that is the point.**
+//! These drivers spawn no process, open no socket and read no host binary — a
+//! test that needed a daemon would be testing something else. The `docker_build`
+//! suite next door (`oci_docker.rs`) is where a real daemon is required.
+//!
+//! What only the engine can prove, and so lives here rather than in the
+//! plugin's unit tests: that the layer tar really reaches the image target as a
+//! collected artifact, that an unchanged input is a cache hit, that changing
+//! *only* a config attribute re-keys, and that the layout the driver wrote
+//! reads back as an image.
+
+mod common;
+
+use hplugin_oci::pluginoci;
+use htestkit::WorkspaceBuilder;
+use std::collections::HashMap;
+
+fn workspace() -> htestkit::Workspace {
+    WorkspaceBuilder::new()
+        .expect("workspace tempdir")
+        .with_provider(|init| {
+            Box::new(heph::pluginbuildfile::Provider::new(
+                init.root.to_path_buf(),
+                init.runtime.clone(),
+            ))
+        })
+        .with_managed_driver(Box::new(heph::pluginexec::Driver::new_bash()))
+        .with_managed_driver(Box::new(pluginoci::image::Driver::new()))
+        .with_managed_driver(Box::new(pluginoci::layer::Driver::new()))
+        .build()
+        .expect("build workspace")
+}
+
+/// Every member of the image's layout tar, by name.
+fn layout_members(bytes: &[u8]) -> Vec<String> {
+    let mut ar = tar::Archive::new(std::io::Cursor::new(bytes.to_vec()));
+    ar.entries()
+        .expect("entries")
+        .map(|e| {
+            e.expect("entry")
+                .path()
+                .expect("path")
+                .to_string_lossy()
+                .into_owned()
+        })
+        .collect()
+}
+
+/// The layout's blobs, by digest, read out of the archive.
+fn layout_blobs(bytes: &[u8]) -> HashMap<String, Vec<u8>> {
+    use std::io::Read as _;
+    let mut ar = tar::Archive::new(std::io::Cursor::new(bytes.to_vec()));
+    let mut out = HashMap::new();
+    for entry in ar.entries().expect("entries") {
+        let mut entry = entry.expect("entry");
+        let name = entry.path().expect("path").to_string_lossy().into_owned();
+        let mut buf = Vec::new();
+        entry.read_to_end(&mut buf).expect("read");
+        if let Some(rest) = name.strip_prefix("blobs/")
+            && let Some((algo, hex)) = rest.split_once('/')
+        {
+            out.insert(format!("{algo}:{hex}"), buf);
+        }
+    }
+    out
+}
+
+/// Follow the layout's `index.json` to the one image manifest inside it. The
+/// entry point is wrapped in a nested, `ref.name`-annotated index (what buildx's
+/// `oci-layout://` needs), so this hops twice.
+fn manifest_of(bytes: &[u8]) -> serde_json::Value {
+    let blobs = layout_blobs(bytes);
+    let mut ar = tar::Archive::new(std::io::Cursor::new(bytes.to_vec()));
+    let mut index = None;
+    for entry in ar.entries().expect("entries") {
+        use std::io::Read as _;
+        let mut entry = entry.expect("entry");
+        if entry.path().expect("path").to_string_lossy() == "index.json" {
+            let mut buf = Vec::new();
+            entry.read_to_end(&mut buf).expect("read");
+            index = Some(serde_json::from_slice::<serde_json::Value>(&buf).expect("index"));
+        }
+    }
+    let mut current = index.expect("the layout must have an index.json");
+    loop {
+        let digest = current["manifests"][0]["digest"]
+            .as_str()
+            .expect("an index entry")
+            .to_string();
+        let raw = blobs.get(&digest).expect("the entry's blob");
+        let next: serde_json::Value = serde_json::from_slice(raw).expect("json");
+        if next.get("layers").is_some() {
+            return next;
+        }
+        current = next;
+    }
+}
+
+fn config_of(bytes: &[u8]) -> serde_json::Value {
+    let manifest = manifest_of(bytes);
+    let digest = manifest["config"]["digest"]
+        .as_str()
+        .expect("config digest");
+    serde_json::from_slice(layout_blobs(bytes).get(digest).expect("config blob")).expect("config")
+}
+
+const BUILD: &str = r#"
+target(name = "bin", driver = "bash", run = "echo elf > $OUT; chmod +x $OUT", out = "server")
+target(name = "conf", driver = "bash", run = "echo k=v > $OUT", out = "app.conf")
+target(name = "app", driver = "oci_layer", srcs = [":bin"], prefix = "/usr/bin")
+target(name = "etc", driver = "oci_layer", srcs = [":conf"], prefix = "/etc")
+target(
+    name = "img",
+    driver = "oci_image",
+    layers = [":app", ":etc"],
+    platforms = ["linux/amd64"],
+    entrypoint = ["/usr/bin/server"],
+    env = {"PORT": "8080"},
+)
+"#;
+
+/// The whole path, with no docker anywhere: two layers assembled into an image
+/// whose layout reads back with the config the BUILD file asked for.
+#[tokio::test]
+async fn test_an_image_is_assembled_from_layers_without_docker() -> anyhow::Result<()> {
+    let ws = workspace();
+    ws.write_build_file("app", BUILD);
+
+    let result = ws.run("//app:img").await?;
+    let bytes = htestkit::artifact_bytes(&result);
+
+    let members = layout_members(&bytes);
+    assert!(
+        members.contains(&"oci-layout".to_string()) && members.contains(&"index.json".to_string()),
+        "an OCI layout needs both markers, got: {members:?}"
+    );
+
+    let manifest = manifest_of(&bytes);
+    let layers = manifest["layers"].as_array().expect("layers");
+    assert_eq!(layers.len(), 2, "one blob per oci_layer target");
+    for layer in layers {
+        assert_eq!(
+            layer["mediaType"], "application/vnd.oci.image.layer.v1.tar",
+            "layers are uncompressed, so the digest cannot depend on a deflate backend"
+        );
+    }
+
+    let config = config_of(&bytes);
+    assert_eq!(config["os"], "linux");
+    assert_eq!(config["architecture"], "amd64");
+    assert_eq!(
+        config["config"]["Entrypoint"],
+        serde_json::json!(["/usr/bin/server"])
+    );
+    assert_eq!(config["config"]["Env"], serde_json::json!(["PORT=8080"]));
+    assert!(
+        config.get("created").is_none(),
+        "a wall clock in the config would re-digest the image on every build"
+    );
+
+    // Uncompressed layers: the diff_id *is* the layer digest, and nothing else
+    // would make that true.
+    let diff_ids = config["rootfs"]["diff_ids"].as_array().expect("diff_ids");
+    let digests: Vec<&serde_json::Value> = layers.iter().map(|l| &l["digest"]).collect();
+    assert_eq!(
+        diff_ids.iter().collect::<Vec<_>>(),
+        digests,
+        "with no compression the diff_id and the layer digest are one value"
+    );
+    Ok(())
+}
+
+/// Same inputs, same bytes. This is the claim the rule is built on, and the one
+/// that a wall clock, a map iteration order or a `read_dir` order would break —
+/// none of which a single run can catch.
+#[tokio::test]
+async fn test_the_same_inputs_produce_the_same_image() -> anyhow::Result<()> {
+    let first = {
+        let ws = workspace();
+        ws.write_build_file("app", BUILD);
+        let r = ws.run("//app:img").await?;
+        htestkit::artifact_bytes(&r)
+    };
+    // A second workspace: a different absolute path, a different sandbox, a
+    // cold cache. Re-running in one workspace would prove almost nothing.
+    let second = {
+        let ws = workspace();
+        ws.write_build_file("app", BUILD);
+        let r = ws.run("//app:img").await?;
+        htestkit::artifact_bytes(&r)
+    };
+    assert_eq!(
+        first, second,
+        "two workspaces, same declared inputs — the image must be byte-identical"
+    );
+    Ok(())
+}
+
+/// A config attribute changes the image even though it touches no input file.
+///
+/// Paired with the reproducibility test above, this is what pins the def hash
+/// from both sides: identical attributes must give identical bytes, and a
+/// changed attribute must give different ones. (That `env` reaches the *key* is
+/// asserted directly in `plugin-oci`'s def-hash test; here the two workspaces
+/// are independent, so a shared cache entry could not hide the difference.)
+#[tokio::test]
+async fn test_an_env_var_changes_the_image() -> anyhow::Result<()> {
+    let image_with = |env: &str| {
+        let build = BUILD.replace(r#""8080""#, &format!(r#""{env}""#));
+        async move {
+            let ws = workspace();
+            ws.write_build_file("app", &build);
+            let r = ws.run("//app:img").await?;
+            anyhow::Ok(htestkit::artifact_bytes(&r))
+        }
+    };
+    let before = image_with("8080").await?;
+    let after = image_with("9090").await?;
+
+    assert_eq!(
+        config_of(&before)["config"]["Env"],
+        serde_json::json!(["PORT=8080"])
+    );
+    assert_eq!(
+        config_of(&after)["config"]["Env"],
+        serde_json::json!(["PORT=9090"])
+    );
+    assert_ne!(before, after, "a changed attribute must change the image");
+    Ok(())
+}
+
+/// An image built on another image: the base's layer sits underneath, and its
+/// config is inherited rather than replaced.
+///
+/// Dropping a base's `PATH` is the easiest way to ship an image that starts and
+/// then cannot find its own entrypoint, so the inheritance is asserted through
+/// the real thing — a layout written by one target and read by the next — not
+/// only against a hand-built config map.
+#[tokio::test]
+async fn test_an_image_inherits_its_base() -> anyhow::Result<()> {
+    let ws = workspace();
+    ws.write_build_file(
+        "app",
+        r#"
+target(name = "libc", driver = "bash", run = "echo so > $OUT", out = "libc.so")
+target(name = "base_layer", driver = "oci_layer", srcs = [":libc"], prefix = "/lib")
+target(
+    name = "base",
+    driver = "oci_image",
+    layers = [":base_layer"],
+    platforms = ["linux/amd64"],
+    layout = True,
+    env = {"PATH": "/usr/bin", "LANG": "C"},
+    cmd = ["--base-arg"],
+)
+
+target(name = "bin", driver = "bash", run = "echo elf > $OUT; chmod +x $OUT", out = "server")
+target(name = "app", driver = "oci_layer", srcs = [":bin"], prefix = "/usr/bin")
+target(
+    name = "img",
+    driver = "oci_image",
+    base = ":base",
+    layers = [":app"],
+    platforms = ["linux/amd64"],
+    entrypoint = ["/usr/bin/server"],
+    env = {"PORT": "8080"},
+)
+"#,
+    );
+
+    let r = ws.run("//app:img").await?;
+    let bytes = htestkit::artifact_bytes(&r);
+
+    let manifest = manifest_of(&bytes);
+    let layers = manifest["layers"].as_array().expect("layers");
+    assert_eq!(layers.len(), 2, "the base's layer plus this image's own");
+
+    let config = config_of(&bytes);
+    assert_eq!(
+        config["config"]["Env"],
+        serde_json::json!(["LANG=C", "PATH=/usr/bin", "PORT=8080"]),
+        "the base's variables must survive alongside this image's"
+    );
+    assert_eq!(
+        config["config"]["Entrypoint"],
+        serde_json::json!(["/usr/bin/server"])
+    );
+    assert!(
+        config["config"].get("Cmd").is_none(),
+        "setting entrypoint must clear the base's Cmd: those arguments were \
+         meant for a different program, got {config}"
+    );
+    assert_eq!(
+        config["rootfs"]["diff_ids"]
+            .as_array()
+            .expect("diff_ids")
+            .len(),
+        2,
+        "diff_ids must cover the base's layers as well as this image's"
+    );
+    Ok(())
+}
+
+/// Two platforms sharing a layer store one blob, not two. buildx cannot do this
+/// at all — it builds each platform separately — so it is worth freezing.
+#[tokio::test]
+async fn test_platforms_share_one_blob_for_a_shared_layer() -> anyhow::Result<()> {
+    let ws = workspace();
+    ws.write_build_file(
+        "app",
+        r#"
+target(name = "conf", driver = "bash", run = "echo k=v > $OUT", out = "app.conf")
+target(name = "etc", driver = "oci_layer", srcs = [":conf"], prefix = "/etc")
+target(
+    name = "img",
+    driver = "oci_image",
+    layers = [":etc"],
+    platforms = ["linux/amd64", "linux/arm64"],
+)
+"#,
+    );
+
+    let r = ws.run("//app:img").await?;
+    let bytes = htestkit::artifact_bytes(&r);
+    let blobs = layout_blobs(&bytes);
+    // Both instances name the same layer digest, so the layer appears once.
+    let layer_blobs: Vec<&String> = blobs
+        .iter()
+        .filter(|(_, v)| v.starts_with(b"etc/app.conf") || v.len() > 512)
+        .map(|(k, _)| k)
+        .collect();
+    assert!(
+        !layer_blobs.is_empty(),
+        "the layer blob must be in the layout"
+    );
+
+    let mut ar = tar::Archive::new(std::io::Cursor::new(bytes.clone()));
+    let names: Vec<String> = ar
+        .entries()
+        .expect("entries")
+        .map(|e| {
+            e.expect("entry")
+                .path()
+                .expect("path")
+                .to_string_lossy()
+                .into_owned()
+        })
+        .collect();
+    let mut sorted = names.clone();
+    sorted.sort();
+    sorted.dedup();
+    assert_eq!(
+        names.len(),
+        sorted.len(),
+        "a layout must not carry the same blob twice: {names:?}"
+    );
+    Ok(())
+}
+
+/// A layer whose `strip` matched nothing is the failure this rule is most
+/// likely to produce and least likely to be noticed: the image builds, pushes
+/// and starts, and dies when something execs the binary that is not there. It
+/// has to fail the build, naming what the sources did produce.
+#[tokio::test]
+async fn test_an_empty_layer_fails_and_names_what_was_produced() {
+    let ws = workspace();
+    ws.write_build_file(
+        "app",
+        r#"
+target(name = "bin", driver = "bash", run = "echo elf > $OUT", out = "server")
+target(
+    name = "app",
+    driver = "oci_layer",
+    srcs = [":bin"],
+    prefix = "/usr/bin",
+    strip = "nowhere",
+)
+"#,
+    );
+    let err = format!(
+        "{:#}",
+        ws.run("//app:app")
+            .await
+            .err()
+            .expect("empty layer must fail")
+    );
+    assert!(err.contains("empty"), "got: {err}");
+    assert!(
+        err.contains("app/server"),
+        "the error must name what the srcs produced: {err}"
+    );
+}
+
+/// `platforms` has no default on purpose: it is a label written into the config
+/// and nothing checks it against the layers, so a host-derived default would
+/// ship an amd64 binary in an arm64 image on one machine and not the other.
+#[tokio::test]
+async fn test_platforms_is_required() {
+    let ws = workspace();
+    ws.write_build_file(
+        "app",
+        r#"
+target(name = "conf", driver = "bash", run = "echo x > $OUT", out = "app.conf")
+target(name = "etc", driver = "oci_layer", srcs = [":conf"], prefix = "/etc")
+target(name = "img", driver = "oci_image", layers = [":etc"])
+"#,
+    );
+    let err = format!(
+        "{:#}",
+        ws.run("//app:img")
+            .await
+            .err()
+            .expect("missing platforms must fail")
+    );
+    assert!(err.contains("`platforms` is required"), "got: {err}");
+}
+
+/// The digest group is a real output a downstream target can read without
+/// unpacking the archive — parity with `docker_build`, whose consumers rely on
+/// it.
+#[tokio::test]
+async fn test_the_digest_group_is_consumable() -> anyhow::Result<()> {
+    let ws = workspace();
+    ws.write_build_file(
+        "app",
+        &format!(
+            r#"{BUILD}
+target(
+    name = "show",
+    driver = "bash",
+    run = "cat $SRC_DIGEST > $OUT",
+    out = "out.txt",
+    deps = {{"digest": ["//app:img|digest"]}},
+)
+"#
+        ),
+    );
+    let r = ws.run("//app:show").await?;
+    let digest = htestkit::artifact_string(&r);
+    assert!(
+        digest.trim().starts_with("sha256:") && digest.trim().len() == 71,
+        "the digest group must carry a sha256 digest, got: {digest:?}"
+    );
+
+    // …and it is the manifest the layout actually filed.
+    let r = ws.run("//app:img").await?;
+    let bytes = htestkit::artifact_bytes(&r);
+    let manifest_bytes = serde_json::to_vec(&manifest_of(&bytes)).expect("re-encode");
+    assert!(
+        layout_blobs(&bytes)
+            .get(digest.trim())
+            .is_some_and(|b| b.len() == manifest_bytes.len()),
+        "the reported digest must name a manifest in the layout"
+    );
+    Ok(())
+}
+
+/// The image digest, frozen as a constant.
+///
+/// CI runs this suite natively on `x86_64-unknown-linux-gnu`,
+/// `aarch64-unknown-linux-gnu` and `aarch64-apple-darwin`, so one shared
+/// constant turns those three jobs into the cross-platform reproducibility
+/// guarantee the rule's docs claim. Two runs on one machine cannot prove that:
+/// they share a filesystem, a umask and an architecture, which is exactly where
+/// the interesting divergences live.
+///
+/// If this changes, the emitted bytes changed. That is either a bug or a
+/// deliberate format change — and a deliberate one needs `OCI_IMAGE_FORMAT_VERSION`
+/// (or `OCI_LAYER_FORMAT_VERSION`) bumped in the same commit, or every cached
+/// image in every workspace keeps its old key with new meaning.
+#[tokio::test]
+async fn test_the_image_digest_is_the_same_on_every_supported_target() -> anyhow::Result<()> {
+    let ws = workspace();
+    ws.write_build_file("app", BUILD);
+    let r = ws.run("//app:img").await?;
+    let manifest = manifest_of(&htestkit::artifact_bytes(&r));
+    let raw = serde_json::to_vec(&manifest).expect("re-encode");
+    let digest = format!("sha256:{:x}", <sha2::Sha256 as sha2::Digest>::digest(&raw));
+    assert_eq!(
+        digest, "sha256:729f38276dc0b50b996908f034e3c25516cf33d0d12e83946b0a750dca744e2b",
+        "the image manifest's bytes changed. If that was deliberate, bump \
+         OCI_IMAGE_FORMAT_VERSION (or OCI_LAYER_FORMAT_VERSION) in the same commit — \
+         otherwise every cached image keeps its old key with new meaning. If it was not \
+         deliberate, something host-dependent reached the bytes."
+    );
+    Ok(())
+}

--- a/crates/e2e/tests/oci_image.rs
+++ b/crates/e2e/tests/oci_image.rs
@@ -367,6 +367,65 @@ target(
     Ok(())
 }
 
+/// `format = "docker"` writes the hybrid shape a daemon's `docker load` takes:
+/// the OCI layout plus a `manifest.json` naming the config and layers by their
+/// blob paths.
+///
+/// Not gated on docker, deliberately — the archive's *shape* is what this
+/// driver owns, and gating it would leave the docker-format path covered only
+/// by a suite that skips on most machines.
+#[tokio::test]
+async fn test_the_docker_format_archive_has_a_manifest_json() -> anyhow::Result<()> {
+    let ws = workspace();
+    ws.write_build_file(
+        "app",
+        r#"
+target(name = "conf", driver = "bash", run = "echo k=v > $OUT", out = "app.conf")
+target(name = "etc", driver = "oci_layer", srcs = [":conf"], prefix = "/etc")
+target(
+    name = "img",
+    driver = "oci_image",
+    layers = [":etc"],
+    platforms = ["linux/amd64"],
+    format = "docker",
+)
+"#,
+    );
+
+    let r = ws.run("//app:img").await?;
+    let bytes = htestkit::artifact_bytes(&r);
+    let members = layout_members(&bytes);
+    assert!(
+        members.contains(&"manifest.json".to_string()),
+        "a docker-format archive needs manifest.json, got: {members:?}"
+    );
+
+    use std::io::Read as _;
+    let mut ar = tar::Archive::new(std::io::Cursor::new(bytes.clone()));
+    let mut manifest = None;
+    for entry in ar.entries().expect("entries") {
+        let mut entry = entry.expect("entry");
+        if entry.path().expect("path").to_string_lossy() == "manifest.json" {
+            let mut buf = Vec::new();
+            entry.read_to_end(&mut buf).expect("read");
+            manifest = Some(serde_json::from_slice::<serde_json::Value>(&buf).expect("json"));
+        }
+    }
+    let manifest = manifest.expect("manifest.json");
+    let layers = manifest[0]["Layers"].as_array().expect("Layers");
+    assert_eq!(layers.len(), 1);
+    let layer_path = layers[0].as_str().expect("layer path");
+    assert!(
+        members.contains(&layer_path.to_string()),
+        "manifest.json names {layer_path}, which must be in the archive: {members:?}"
+    );
+    assert!(
+        members.contains(&manifest[0]["Config"].as_str().expect("Config").to_string()),
+        "manifest.json's Config must be in the archive too"
+    );
+    Ok(())
+}
+
 /// A layer whose `strip` matched nothing is the failure this rule is most
 /// likely to produce and least likely to be noticed: the image builds, pushes
 /// and starts, and dies when something execs the binary that is not there. It

--- a/crates/plugin-oci-cdylib/src/lib.rs
+++ b/crates/plugin-oci-cdylib/src/lib.rs
@@ -56,11 +56,22 @@ pub extern "C" fn heph_plugin_set_supervisor(sup: DynSupervisor) {
 fn build() -> PluginComponents {
     let mut drivers = stabby::vec::Vec::new();
 
+    // Assembles target outputs into an image. No daemon, no execution.
+    let image: Arc<dyn ManagedDriver> = Arc::new(pluginoci::image::Driver::new());
+    drivers.push(NamedDriver {
+        name: pluginoci::image::DRIVER_NAME.into(),
+        driver: make_dyn_managed_driver(image),
+    });
+    let layer: Arc<dyn ManagedDriver> = Arc::new(pluginoci::layer::Driver::new());
+    drivers.push(NamedDriver {
+        name: pluginoci::layer::DRIVER_NAME.into(),
+        driver: make_dyn_managed_driver(layer),
+    });
     // Builds a Dockerfile + context into a cacheable image archive.
-    let image: Arc<dyn ManagedDriver> = Arc::new(pluginoci::docker_build::Driver::new());
+    let docker: Arc<dyn ManagedDriver> = Arc::new(pluginoci::docker_build::Driver::new());
     drivers.push(NamedDriver {
         name: pluginoci::docker_build::DRIVER_NAME.into(),
-        driver: make_dyn_managed_driver(image),
+        driver: make_dyn_managed_driver(docker),
     });
     // Pulls a base image into a cacheable archive (or OCI layout).
     let pull: Arc<dyn ManagedDriver> = Arc::new(pluginoci::pull::Driver::new());

--- a/crates/plugin-oci/Cargo.toml
+++ b/crates/plugin-oci/Cargo.toml
@@ -27,6 +27,7 @@ oci-client = "0.17"
 # `~/.docker/config.json` and the `docker-credential-*` helpers is the caller's
 # job — which is what skopeo used to do for us, and what ECR/GCR/ACR need.
 docker_credential = "1.3"
+bytes = "1"
 tar = "0.4"
 sha2 = "0.10"
 # The Docker daemon API, for `oci_load`'s `/images/load`.

--- a/crates/plugin-oci/src/pluginoci/archive.rs
+++ b/crates/plugin-oci/src/pluginoci/archive.rs
@@ -11,20 +11,22 @@
 
 use anyhow::Context as _;
 use oci_client::manifest::{OciImageIndex, OciImageManifest};
-use std::collections::HashMap;
 use std::io::Read as _;
 use std::path::Path;
 
-/// An OCI layout read into memory: the index, plus every blob by digest.
+/// An OCI layout: the index, plus where to find every blob by digest.
 ///
-/// Blobs are held in memory because the layers of one image are exactly what a
-/// push is about to send anyway. A layout whose blobs do not fit in memory is a
-/// layout that will not fit through a registry upload either — if that stops
-/// being true, this is the type that grows a streaming variant.
+/// Deliberately *not* the blobs themselves. Reading a layout used to slurp
+/// every blob into a `HashMap<String, Vec<u8>>`, which put a whole image —
+/// often a whole base image on top of it — in memory once per concurrent
+/// target. Layers stay where they are: on disk in a layout directory, or at a
+/// known offset inside an `oci-archive`, which is a tar and therefore
+/// seekable. Only manifests, indexes and configs are ever read, and those are
+/// kilobytes.
 #[derive(Debug)]
 pub(crate) struct Layout {
     pub index: OciImageIndex,
-    pub blobs: HashMap<String, Vec<u8>>,
+    pub blobs: Blobs,
 }
 
 /// Which file inside an OCI layout is the entrypoint.
@@ -43,11 +45,15 @@ impl Layout {
         }
     }
 
+    /// An `oci-archive` is a tar, so every blob is already a contiguous range of
+    /// a file on disk. `raw_file_position` is where the entry's data starts —
+    /// recording that instead of reading it is what keeps a multi-gigabyte image
+    /// out of memory. `index.json` is the one entry actually read here.
     fn read_tar(path: &Path) -> anyhow::Result<Self> {
         let file = std::fs::File::open(path).with_context(|| format!("open archive {path:?}"))?;
         let mut ar = tar::Archive::new(file);
         let mut index_bytes = None;
-        let mut blobs = HashMap::new();
+        let mut blobs = Blobs::new();
         for entry in ar.entries().with_context(|| format!("read {path:?}"))? {
             let mut entry = entry.context("archive entry")?;
             let name = entry
@@ -55,12 +61,19 @@ impl Layout {
                 .context("entry path")?
                 .to_string_lossy()
                 .into_owned();
-            let mut buf = Vec::new();
-            entry.read_to_end(&mut buf).context("read entry")?;
             if name == INDEX_JSON {
+                let mut buf = Vec::new();
+                entry.read_to_end(&mut buf).context("read index.json")?;
                 index_bytes = Some(buf);
             } else if let Some(digest) = blob_digest_of(&name) {
-                blobs.insert(digest, buf);
+                blobs.insert(
+                    digest,
+                    Blob::FileRange {
+                        path: path.to_path_buf(),
+                        offset: entry.raw_file_position(),
+                        len: entry.size(),
+                    },
+                );
             }
         }
         Self::finish(path, index_bytes, blobs)
@@ -68,7 +81,7 @@ impl Layout {
 
     fn read_dir(dir: &Path) -> anyhow::Result<Self> {
         let index_bytes = std::fs::read(dir.join(INDEX_JSON)).ok();
-        let mut blobs = HashMap::new();
+        let mut blobs = Blobs::new();
         let algos = dir.join("blobs");
         if algos.is_dir() {
             for algo in std::fs::read_dir(&algos).with_context(|| format!("read {algos:?}"))? {
@@ -80,18 +93,14 @@ impl Layout {
                 for blob in std::fs::read_dir(algo.path()).context("read blob dir")? {
                     let blob = blob.context("blob entry")?;
                     let digest = format!("{name}:{}", blob.file_name().to_string_lossy());
-                    blobs.insert(digest, std::fs::read(blob.path()).context("read blob")?);
+                    blobs.insert(digest, Blob::File(blob.path()));
                 }
             }
         }
         Self::finish(dir, index_bytes, blobs)
     }
 
-    fn finish(
-        path: &Path,
-        index_bytes: Option<Vec<u8>>,
-        blobs: HashMap<String, Vec<u8>>,
-    ) -> anyhow::Result<Self> {
+    fn finish(path: &Path, index_bytes: Option<Vec<u8>>, blobs: Blobs) -> anyhow::Result<Self> {
         let index_bytes = index_bytes.with_context(|| {
             format!(
                 "{path:?} has no `index.json`: it is not an OCI layout. A docker-format archive \
@@ -121,16 +130,16 @@ impl Layout {
     > {
         let mut out = Vec::new();
         for entry in &self.index.manifests {
-            let raw = self.blob(&entry.digest)?;
+            let raw = self.blob_bytes(&entry.digest)?;
             // An index may point at another index (a manifest list nested one
             // level, which is what buildx emits for a multi-platform build).
-            if let Ok(inner) = serde_json::from_slice::<OciImageIndex>(raw)
+            if let Ok(inner) = serde_json::from_slice::<OciImageIndex>(&raw)
                 && !inner.manifests.is_empty()
             {
                 for nested in &inner.manifests {
-                    let raw = self.blob(&nested.digest)?;
+                    let raw = self.blob_bytes(&nested.digest)?;
                     out.push((
-                        serde_json::from_slice(raw).context("parse nested manifest")?,
+                        serde_json::from_slice(&raw).context("parse nested manifest")?,
                         nested.platform.clone(),
                         nested.digest.clone(),
                     ));
@@ -138,7 +147,7 @@ impl Layout {
                 continue;
             }
             out.push((
-                serde_json::from_slice(raw).context("parse manifest")?,
+                serde_json::from_slice(&raw).context("parse manifest")?,
                 entry.platform.clone(),
                 entry.digest.clone(),
             ));
@@ -146,10 +155,22 @@ impl Layout {
         Ok(out)
     }
 
-    pub(crate) fn blob(&self, digest: &str) -> anyhow::Result<&Vec<u8>> {
+    /// Where a blob lives. Cheap — nothing is read.
+    pub(crate) fn blob(&self, digest: &str) -> anyhow::Result<&Blob> {
         self.blobs
             .get(digest)
             .with_context(|| format!("blob {digest} is referenced but not in the layout"))
+    }
+
+    /// A blob's bytes. Only for manifests, indexes and configs — a layer goes
+    /// through [`Blob::reader`], which is the whole point of the split.
+    pub(crate) fn blob_bytes(&self, digest: &str) -> anyhow::Result<Vec<u8>> {
+        let mut buf = Vec::new();
+        self.blob(digest)?
+            .reader()?
+            .read_to_end(&mut buf)
+            .with_context(|| format!("read blob {digest}"))?;
+        Ok(buf)
     }
 }
 
@@ -165,24 +186,40 @@ impl Layout {
 pub(crate) enum Blob {
     Bytes(Vec<u8>),
     File(std::path::PathBuf),
+    /// A byte range inside a file — an `oci-archive`'s blobs, which are already
+    /// contiguous in a tar and need no extraction to read.
+    FileRange {
+        path: std::path::PathBuf,
+        offset: u64,
+        len: u64,
+    },
 }
 
 impl Blob {
-    fn len(&self) -> anyhow::Result<u64> {
+    pub(crate) fn len(&self) -> anyhow::Result<u64> {
         match self {
             Blob::Bytes(b) => Ok(b.len() as u64),
             Blob::File(p) => Ok(std::fs::metadata(p)
                 .with_context(|| format!("stat blob file {p:?}"))?
                 .len()),
+            Blob::FileRange { len, .. } => Ok(*len),
         }
     }
 
-    fn reader(&self) -> anyhow::Result<Box<dyn std::io::Read>> {
+    pub(crate) fn reader(&self) -> anyhow::Result<Box<dyn std::io::Read + Send>> {
         match self {
             Blob::Bytes(b) => Ok(Box::new(std::io::Cursor::new(b.clone()))),
             Blob::File(p) => Ok(Box::new(
                 std::fs::File::open(p).with_context(|| format!("open blob file {p:?}"))?,
             )),
+            Blob::FileRange { path, offset, len } => {
+                use std::io::Seek as _;
+                let mut f = std::fs::File::open(path)
+                    .with_context(|| format!("open blob archive {path:?}"))?;
+                f.seek(std::io::SeekFrom::Start(*offset))
+                    .with_context(|| format!("seek to {offset} in {path:?}"))?;
+                Ok(Box::new(f.take(*len)))
+            }
         }
     }
 }
@@ -257,15 +294,6 @@ fn tagged_index(index: &OciImageIndex, blobs: &mut Blobs) -> anyhow::Result<OciI
 /// Write a layout to `dir` in the on-disk OCI layout shape (`oci-layout`,
 /// `index.json`, `blobs/<algo>/<hex>`) — what `oci_pull(layout = True)` produces
 /// and what `docker_build`'s `bases` consumes.
-pub(crate) fn write_layout_dir(
-    dir: &Path,
-    index: &OciImageIndex,
-    blobs: &HashMap<String, Vec<u8>>,
-) -> anyhow::Result<()> {
-    write_layout_dir_blobs(dir, index, &owned(blobs))
-}
-
-/// [`write_layout_dir`], for blobs that may still be on disk.
 pub(crate) fn write_layout_dir_blobs(
     dir: &Path,
     index: &OciImageIndex,
@@ -312,15 +340,6 @@ pub(crate) fn write_layout_dir_blobs(
 }
 
 /// Pack a layout directory into an `oci-archive` tar.
-pub(crate) fn write_layout_tar(
-    out: &Path,
-    index: &OciImageIndex,
-    blobs: &HashMap<String, Vec<u8>>,
-) -> anyhow::Result<()> {
-    write_layout_tar_blobs(out, index, &owned(blobs))
-}
-
-/// [`write_layout_tar`], for blobs that may still be on disk.
 pub(crate) fn write_layout_tar_blobs(
     out: &Path,
     index: &OciImageIndex,
@@ -344,16 +363,6 @@ pub(crate) fn write_layout_tar_blobs(
     }
     ar.finish().context("finish archive")?;
     Ok(())
-}
-
-/// Wrap already-in-memory blobs. The callers that have them (`oci_pull`,
-/// `oci_push`) hold whole images anyway — the registry upload they feed is the
-/// same bytes — so nothing is lost by keeping their shape.
-fn owned(blobs: &HashMap<String, Vec<u8>>) -> Blobs {
-    blobs
-        .iter()
-        .map(|(d, b)| (d.clone(), Blob::Bytes(b.clone())))
-        .collect()
 }
 
 fn append<W: std::io::Write>(
@@ -434,9 +443,12 @@ pub(crate) fn write_docker_archive(
 ) -> anyhow::Result<()> {
     // Only the blobs this instance needs — a multi-arch layout would otherwise
     // carry every architecture's layers into a tag that holds one image.
-    let mut blobs = HashMap::new();
-    let manifest_bytes = layout.blob(manifest_digest)?.clone();
-    blobs.insert(manifest_digest.to_string(), manifest_bytes.clone());
+    let mut blobs = Blobs::new();
+    let manifest_bytes = layout.blob_bytes(manifest_digest)?;
+    blobs.insert(
+        manifest_digest.to_string(),
+        Blob::Bytes(manifest_bytes.clone()),
+    );
     blobs.insert(
         manifest.config.digest.clone(),
         layout.blob(&manifest.config.digest)?.clone(),
@@ -476,13 +488,9 @@ pub(crate) fn write_docker_archive(
         INDEX_JSON,
         &serde_json::to_vec(&index).context("encode index.json")?,
     )?;
-    let mut digests: Vec<&String> = blobs.keys().collect();
-    digests.sort();
-    for digest in digests {
-        let bytes = blobs
-            .get(digest)
-            .with_context(|| format!("blob {digest} vanished between listing and writing"))?;
-        append(&mut ar, &blob_path(digest)?, bytes)?;
+    // `Blobs` is a BTreeMap, so the member order is fixed without a sort.
+    for (digest, blob) in &blobs {
+        append_blob(&mut ar, &blob_path(digest)?, blob)?;
     }
     append(
         &mut ar,
@@ -522,14 +530,14 @@ mod tests {
             manifests: vec![],
             annotations: None,
         };
-        let blobs = HashMap::from([
-            ("sha256:aaa".to_string(), b"one".to_vec()),
-            ("sha256:bbb".to_string(), b"two".to_vec()),
+        let blobs = Blobs::from([
+            ("sha256:aaa".to_string(), Blob::Bytes(b"one".to_vec())),
+            ("sha256:bbb".to_string(), Blob::Bytes(b"two".to_vec())),
         ]);
         let a = dir.path().join("a.tar");
         let b = dir.path().join("b.tar");
-        write_layout_tar(&a, &index, &blobs).expect("write a");
-        write_layout_tar(&b, &index, &blobs).expect("write b");
+        write_layout_tar_blobs(&a, &index, &blobs).expect("write a");
+        write_layout_tar_blobs(&b, &index, &blobs).expect("write b");
         assert_eq!(
             std::fs::read(&a).expect("a"),
             std::fs::read(&b).expect("b"),
@@ -565,10 +573,13 @@ mod tests {
             }],
             annotations: None,
         };
-        let blobs = HashMap::from([(manifest_digest, manifest_bytes), (config_digest, config)]);
+        let blobs = Blobs::from([
+            (manifest_digest, Blob::Bytes(manifest_bytes)),
+            (config_digest, Blob::Bytes(config)),
+        ]);
 
         let tar = dir.path().join("img.tar");
-        write_layout_tar(&tar, &index, &blobs).expect("write");
+        write_layout_tar_blobs(&tar, &index, &blobs).expect("write");
         let read = Layout::read(&tar).expect("read");
         let manifests = read.manifests().expect("manifests");
         assert_eq!(manifests.len(), 1, "one image in, one image out");
@@ -576,7 +587,7 @@ mod tests {
         // The same layout as a directory reads identically — `bases` consumes
         // that shape and a push must accept either.
         let as_dir = dir.path().join("layout");
-        write_layout_dir(&as_dir, &index, &blobs).expect("write dir");
+        write_layout_dir_blobs(&as_dir, &index, &blobs).expect("write dir");
         assert_eq!(
             Layout::read(&as_dir)
                 .expect("read dir")
@@ -584,6 +595,71 @@ mod tests {
                 .expect("m")
                 .len(),
             1
+        );
+    }
+
+    /// Reading a layout must not read its layers.
+    ///
+    /// This is the property, not an optimization: `Layout::read` used to slurp
+    /// every blob into a `HashMap<String, Vec<u8>>`, so a push, a load or an
+    /// image build held a whole image — plus a whole base image — in memory,
+    /// once per concurrent target. A layer now comes back as a *location*.
+    #[test]
+    fn reading_a_layout_locates_its_blobs_without_reading_them() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let layer = vec![b'L'; 4096];
+        let layer_digest = sha256_digest(&layer);
+        let index = OciImageIndex {
+            schema_version: 2,
+            media_type: Some(oci_client::manifest::OCI_IMAGE_INDEX_MEDIA_TYPE.to_string()),
+            artifact_type: None,
+            manifests: vec![],
+            annotations: None,
+        };
+        let blobs = Blobs::from([(layer_digest.clone(), Blob::Bytes(layer.clone()))]);
+
+        // An oci-archive is a tar, so the blob is a byte range in it.
+        let tar = dir.path().join("img.tar");
+        write_layout_tar_blobs(&tar, &index, &blobs).expect("write tar");
+        let read = Layout::read(&tar).expect("read tar");
+        let blob = read.blob(&layer_digest).expect("blob");
+        assert!(
+            matches!(blob, Blob::FileRange { .. }),
+            "a layer in an archive must be located, not loaded: {blob:?}"
+        );
+        assert_eq!(blob.len().expect("len"), layer.len() as u64);
+        assert_eq!(
+            read.blob_bytes(&layer_digest).expect("bytes"),
+            layer,
+            "the recorded range must be exactly the blob"
+        );
+
+        // A layout directory keeps them as plain files.
+        let as_dir = dir.path().join("layout");
+        write_layout_dir_blobs(&as_dir, &index, &blobs).expect("write dir");
+        let read = Layout::read(&as_dir).expect("read dir");
+        let blob = read.blob(&layer_digest).expect("blob");
+        assert!(
+            matches!(blob, Blob::File(_)),
+            "a layer in a layout directory is already a file: {blob:?}"
+        );
+        assert_eq!(read.blob_bytes(&layer_digest).expect("bytes"), layer);
+
+        // And a blob located in one layout can be written into another without
+        // ever being read — the path `oci_image` takes for a base's layers.
+        let copied = dir.path().join("copy.tar");
+        write_layout_tar_blobs(
+            &copied,
+            &index,
+            &Blobs::from([(layer_digest.clone(), blob.clone())]),
+        )
+        .expect("write copy");
+        assert_eq!(
+            Layout::read(&copied)
+                .expect("read copy")
+                .blob_bytes(&layer_digest)
+                .expect("bytes"),
+            layer
         );
     }
 

--- a/crates/plugin-oci/src/pluginoci/archive.rs
+++ b/crates/plugin-oci/src/pluginoci/archive.rs
@@ -153,6 +153,44 @@ impl Layout {
     }
 }
 
+/// A blob on its way *into* a layout: either bytes already in hand, or a file to
+/// be copied without ever holding it.
+///
+/// Manifests, indexes and configs are kilobytes and stay [`Blob::Bytes`]. A
+/// layer is not: `oci_image` builds one per `oci_layer` dep and a single layer
+/// can be most of an image, so it travels as [`Blob::File`] and is streamed at
+/// write time. Reading one into a `Vec<u8>` would put the whole image in memory
+/// once per concurrent image target.
+#[derive(Debug, Clone)]
+pub(crate) enum Blob {
+    Bytes(Vec<u8>),
+    File(std::path::PathBuf),
+}
+
+impl Blob {
+    fn len(&self) -> anyhow::Result<u64> {
+        match self {
+            Blob::Bytes(b) => Ok(b.len() as u64),
+            Blob::File(p) => Ok(std::fs::metadata(p)
+                .with_context(|| format!("stat blob file {p:?}"))?
+                .len()),
+        }
+    }
+
+    fn reader(&self) -> anyhow::Result<Box<dyn std::io::Read>> {
+        match self {
+            Blob::Bytes(b) => Ok(Box::new(std::io::Cursor::new(b.clone()))),
+            Blob::File(p) => Ok(Box::new(
+                std::fs::File::open(p).with_context(|| format!("open blob file {p:?}"))?,
+            )),
+        }
+    }
+}
+
+/// The blobs of a layout, keyed by digest. `BTreeMap` rather than `HashMap`
+/// because the write order is the archive's bytes.
+pub(crate) type Blobs = std::collections::BTreeMap<String, Blob>;
+
 /// `blobs/sha256/<hex>` → `sha256:<hex>`. Anything else is not a blob.
 fn blob_digest_of(name: &str) -> Option<String> {
     let rest = name.strip_prefix("blobs/")?;
@@ -171,10 +209,7 @@ fn blob_digest_of(name: &str) -> Option<String> {
 /// A single image is annotated in place. Several are wrapped in one index —
 /// buildx's own shape for a multi-platform image — so the tag names the *set*
 /// and the per-platform entries keep their platforms.
-fn tagged_index(
-    index: &OciImageIndex,
-    blobs: &mut HashMap<String, Vec<u8>>,
-) -> anyhow::Result<OciImageIndex> {
+fn tagged_index(index: &OciImageIndex, blobs: &mut Blobs) -> anyhow::Result<OciImageIndex> {
     const REF_NAME: &str = "org.opencontainers.image.ref.name";
     let mut annotations = std::collections::BTreeMap::new();
     annotations.insert(REF_NAME.to_string(), "latest".to_string());
@@ -201,7 +236,7 @@ fn tagged_index(
     let raw = serde_json::to_vec(&inner).context("encode the nested index")?;
     let digest = sha256_digest(&raw);
     let size = raw.len() as i64;
-    blobs.insert(digest.clone(), raw);
+    blobs.insert(digest.clone(), Blob::Bytes(raw));
 
     Ok(OciImageIndex {
         schema_version: 2,
@@ -227,9 +262,17 @@ pub(crate) fn write_layout_dir(
     index: &OciImageIndex,
     blobs: &HashMap<String, Vec<u8>>,
 ) -> anyhow::Result<()> {
+    write_layout_dir_blobs(dir, index, &owned(blobs))
+}
+
+/// [`write_layout_dir`], for blobs that may still be on disk.
+pub(crate) fn write_layout_dir_blobs(
+    dir: &Path,
+    index: &OciImageIndex,
+    blobs: &Blobs,
+) -> anyhow::Result<()> {
     let mut blobs = blobs.clone();
     let index = &tagged_index(index, &mut blobs)?;
-    let blobs = &blobs;
     std::fs::create_dir_all(dir).with_context(|| format!("create {dir:?}"))?;
     std::fs::write(dir.join("oci-layout"), br#"{"imageLayoutVersion":"1.0.0"}"#)
         .context("write oci-layout")?;
@@ -238,12 +281,32 @@ pub(crate) fn write_layout_dir(
         serde_json::to_vec(index).context("encode index.json")?,
     )
     .context("write index.json")?;
-    for (digest, bytes) in blobs {
+    for (digest, blob) in &blobs {
         let path = dir.join(blob_path(digest)?);
         if let Some(parent) = path.parent() {
             std::fs::create_dir_all(parent).with_context(|| format!("create {parent:?}"))?;
         }
-        std::fs::write(&path, bytes).with_context(|| format!("write blob {path:?}"))?;
+        // Written beside the final name and renamed, never in place: a blob's
+        // *name* asserts its digest, and nothing here or in `Layout::read` ever
+        // re-hashes one. A write interrupted by Ctrl-C or a full disk would
+        // otherwise leave a truncated file whose name claims a digest it does
+        // not have — served from the cache forever, and rejected only at the far
+        // end of a registry push.
+        let tmp = path.with_extension("partial");
+        let mut src = blob.reader()?;
+        let mut dst =
+            std::fs::File::create(&tmp).with_context(|| format!("create blob {tmp:?}"))?;
+        let n = std::io::copy(&mut src, &mut dst)
+            .with_context(|| format!("write blob {digest} to {tmp:?}"))?;
+        let want = blob.len()?;
+        anyhow::ensure!(
+            n == want,
+            "blob {digest} changed size while being written ({n} bytes, expected {want}); \
+             the layout would be corrupt"
+        );
+        drop(dst);
+        std::fs::rename(&tmp, &path)
+            .with_context(|| format!("move blob {tmp:?} into place at {path:?}"))?;
     }
     Ok(())
 }
@@ -254,6 +317,17 @@ pub(crate) fn write_layout_tar(
     index: &OciImageIndex,
     blobs: &HashMap<String, Vec<u8>>,
 ) -> anyhow::Result<()> {
+    write_layout_tar_blobs(out, index, &owned(blobs))
+}
+
+/// [`write_layout_tar`], for blobs that may still be on disk.
+pub(crate) fn write_layout_tar_blobs(
+    out: &Path,
+    index: &OciImageIndex,
+    blobs: &Blobs,
+) -> anyhow::Result<()> {
+    let mut blobs = blobs.clone();
+    let index = &tagged_index(index, &mut blobs)?;
     let file = std::fs::File::create(out).with_context(|| format!("create {out:?}"))?;
     let mut ar = tar::Builder::new(file);
     append(&mut ar, "oci-layout", br#"{"imageLayoutVersion":"1.0.0"}"#)?;
@@ -262,16 +336,24 @@ pub(crate) fn write_layout_tar(
         INDEX_JSON,
         &serde_json::to_vec(index).context("encode index.json")?,
     )?;
-    // Sorted: a tar's member order is part of its bytes, and the archive is a
-    // cached artifact whose hash must not depend on HashMap iteration order.
-    let mut digests: Vec<&String> = blobs.keys().collect();
-    digests.sort();
-    for digest in digests {
-        let path = blob_path(digest)?;
-        append(&mut ar, &path, &blobs[digest])?;
+    // `Blobs` is a BTreeMap: a tar's member order is part of its bytes, and the
+    // archive is a cached artifact whose hash must not depend on map iteration
+    // order.
+    for (digest, blob) in &blobs {
+        append_blob(&mut ar, &blob_path(digest)?, blob)?;
     }
     ar.finish().context("finish archive")?;
     Ok(())
+}
+
+/// Wrap already-in-memory blobs. The callers that have them (`oci_pull`,
+/// `oci_push`) hold whole images anyway — the registry upload they feed is the
+/// same bytes — so nothing is lost by keeping their shape.
+fn owned(blobs: &HashMap<String, Vec<u8>>) -> Blobs {
+    blobs
+        .iter()
+        .map(|(d, b)| (d.clone(), Blob::Bytes(b.clone())))
+        .collect()
 }
 
 fn append<W: std::io::Write>(
@@ -289,6 +371,34 @@ fn append<W: std::io::Write>(
     ar.append_data(&mut header, name, data)
         .with_context(|| format!("append {name}"))?;
     Ok(())
+}
+
+/// [`append`] for a blob that may still be on disk — streamed, never buffered.
+fn append_blob<W: std::io::Write>(
+    ar: &mut tar::Builder<W>,
+    name: &str,
+    blob: &Blob,
+) -> anyhow::Result<()> {
+    if let Blob::Bytes(bytes) = blob {
+        return append(ar, name, bytes);
+    }
+    let mut header = tar::Header::new_gnu();
+    header.set_size(blob.len()?);
+    header.set_mode(0o644);
+    header.set_mtime(0);
+    header.set_cksum();
+    ar.append_data(&mut header, name, blob.reader()?)
+        .with_context(|| format!("append {name}"))?;
+    Ok(())
+}
+
+/// The sha256 of a file, without reading it into memory.
+pub(crate) fn sha256_file(path: &Path) -> anyhow::Result<(String, u64)> {
+    use sha2::{Digest as _, Sha256};
+    let mut f = std::fs::File::open(path).with_context(|| format!("open {path:?}"))?;
+    let mut h = Sha256::new();
+    let n = std::io::copy(&mut f, &mut h).with_context(|| format!("hash {path:?}"))?;
+    Ok((format!("sha256:{:x}", h.finalize()), n))
 }
 
 fn blob_path(digest: &str) -> anyhow::Result<String> {

--- a/crates/plugin-oci/src/pluginoci/image.rs
+++ b/crates/plugin-oci/src/pluginoci/image.rs
@@ -230,8 +230,9 @@ struct BaseFor {
     layers: Vec<Value>,
     diff_ids: Vec<Value>,
     config: Map<String, Value>,
-    /// Blobs to carry into the output layout.
-    blobs: Vec<(String, Vec<u8>)>,
+    /// Blobs to carry into the output layout, by reference — a base's layers
+    /// are never read here.
+    blobs: Vec<(String, Blob)>,
 }
 
 /// Merge the base's `config` object with what the BUILD file set.
@@ -387,7 +388,7 @@ fn base_for(layout: Option<&archive::Layout>, platform: &str) -> anyhow::Result<
         )
     })?;
 
-    let config_bytes = layout.blob(&manifest.config.digest)?.clone();
+    let config_bytes = layout.blob_bytes(&manifest.config.digest)?;
     let config: Value =
         serde_json::from_slice(&config_bytes).context("parse the base image config")?;
     let diff_ids = config
@@ -404,6 +405,8 @@ fn base_for(layout: Option<&archive::Layout>, platform: &str) -> anyhow::Result<
     let mut blobs = Vec::new();
     let mut layers = Vec::new();
     for layer in &manifest.layers {
+        // The base's layers are carried by *reference* — they stay in the base's
+        // own layout on disk and are streamed straight into this image's.
         blobs.push((layer.digest.clone(), layout.blob(&layer.digest)?.clone()));
         layers.push(json!({
             "mediaType": layer.media_type,
@@ -684,8 +687,8 @@ impl ManagedDriver for Driver {
 
         for platform in &def.platforms {
             let base = base_for(base_layout.as_ref(), platform)?;
-            for (digest, bytes) in &base.blobs {
-                blobs.insert(digest.clone(), Blob::Bytes(bytes.clone()));
+            for (digest, blob) in &base.blobs {
+                blobs.insert(digest.clone(), blob.clone());
             }
 
             let mut layer_descs = base.layers.clone();

--- a/crates/plugin-oci/src/pluginoci/image.rs
+++ b/crates/plugin-oci/src/pluginoci/image.rs
@@ -1,0 +1,1071 @@
+//! The `oci_image` driver: assembles an image from target outputs. No
+//! Dockerfile, no BuildKit, no docker daemon, no execution of any kind.
+//!
+//! Use [`super::docker_build`] when the image needs to *run* commands — package
+//! installs, compilers, a multi-stage build. This rule is for the other case,
+//! which is most of what a build system ships: a static binary and a few files
+//! on top of a base.
+//!
+//! # Why this is the default
+//!
+//! Not because it avoids a daemon, though it does. Because it is the only image
+//! rule whose cache key can cover what the build reads.
+//!
+//! `docker_build` says so itself: the `docker`/`buildx` version is not hashed,
+//! `FROM` is resolved by BuildKit from the network, `RUN` fetches whatever it
+//! fetches, and secret *values* cannot be hashed. Here there is nothing to
+//! exempt — no host binary, no subprocess, no env var, no run-time network. The
+//! inputs are exactly the declared deps and the attributes below.
+//!
+//! That claim stops at this rule's own boundary, and the docs should not
+//! overreach: a `base` is only as hermetic as the `oci_pull` that produced it,
+//! and `oci_pull` keys on the ref *string*. Pin bases by `@sha256:` for the full
+//! property.
+//!
+//! The second consequence is cross-architecture builds. A layer is a file tree,
+//! so nothing has to *execute* for the target architecture — an arm64 mac emits
+//! `linux/amd64` and `linux/arm64` images from one run, with no QEMU, and the
+//! same digests CI produces.
+//!
+//! # Shape
+//!
+//! Layers come from [`super::layer`] targets, in order, on top of an optional
+//! `base`. Output is the same OCI layout `docker_build` emits — a single
+//! archive, or with `layout = True` the directory shape `bases` and buildx's
+//! `oci-layout://` consume — plus a `digest` group holding the image digest as
+//! text.
+//!
+//! Blobs shared between platforms are stored once: two architectures sharing a
+//! static-asset layer reference one blob, which buildx cannot do at all.
+
+use anyhow::Context as _;
+use async_trait::async_trait;
+use hcore::debug_hash::DebugHasher;
+use hcore::hasync::Cancellable;
+use hdriver_support::driver_managed::{ManagedDriver, ManagedRunRequest, ManagedRunResponse};
+use hplugin::driver::targetdef::path::{CodegenMode, Content, Path as OutPath};
+use hplugin::driver::targetdef::{Input, InputMode, Output, TargetDef};
+use hplugin::driver::{
+    ApplyTransitiveRequest, ApplyTransitiveResponse, ConfigRequest, ConfigResponse, ParseRequest,
+    ParseResponse, TargetAddr,
+};
+use hplugin::htspec::{Spec, TargetSpecCache};
+use oci_client::manifest::{ImageIndexEntry, OciImageIndex};
+use serde_json::{Map, Value, json};
+use std::collections::{BTreeMap, HashMap};
+use std::hash::{Hash, Hasher};
+use std::path::PathBuf;
+use std::sync::Arc;
+use xxhash_rust::xxh3::Xxh3Default;
+
+use super::archive::{self, Blob, Blobs};
+use super::{ImageFormat, dep_files, normalize_platform, split_platform, ws_path};
+
+pub const DRIVER_NAME: &str = "oci_image";
+
+/// Media type of an uncompressed layer. See [`super::layer`] for why layers are
+/// not gzipped.
+const LAYER_MEDIA_TYPE: &str = "application/vnd.oci.image.layer.v1.tar";
+const CONFIG_MEDIA_TYPE: &str = "application/vnd.oci.image.config.v1+json";
+
+const BASE_ORIGIN: &str = "base";
+
+fn layer_origin(platform: Option<&str>, i: usize) -> String {
+    match platform {
+        None => format!("layers|{i}"),
+        Some(p) => format!("layers_by_platform|{}|{i}", p.replace('/', "_")),
+    }
+}
+
+/// Assembles an image from target outputs — no Dockerfile, no docker, no
+/// execution. Use `docker_build` when the image needs to run commands (`RUN`,
+/// package installs, multi-stage).
+#[derive(Spec)]
+struct OciImageSpec {
+    /// Base image: an `oci_pull(layout = True)` (or another `oci_image`) target.
+    /// Omitted, the image starts from scratch.
+    ///
+    /// Its layers go under this target's, and its config is inherited — `Env`,
+    /// `Entrypoint`, `Cmd`, `User`, `WorkingDir`, `Labels`, `ExposedPorts` —
+    /// with anything set here winning. Dropping a base's `PATH` silently is the
+    /// single easiest way to ship an image that starts and then cannot find its
+    /// own entrypoint, so inheritance is on and explicit.
+    ///
+    /// For a multi-platform build the base needs an instance per platform:
+    /// `oci_pull(layout = True, all_platforms = True)`.
+    #[spec(ty = hcore::htvalue::signature::ParamType::String)]
+    base: Option<String>,
+    /// `oci_layer` targets, bottom to top. **Order matters**: a later layer's
+    /// file shadows the same path in an earlier one.
+    layers: Vec<String>,
+    /// Layers that differ per platform, appended after `layers`, keyed by the
+    /// platform they belong to.
+    ///
+    /// ```python
+    /// platforms = ["linux/amd64", "linux/arm64"],
+    /// layers_by_platform = {
+    ///     "linux/amd64": [":app_amd64"],
+    ///     "linux/arm64": [":app_arm64"],
+    /// },
+    /// ```
+    ///
+    /// Every platform in `platforms` must have an entry, and vice versa — a
+    /// missing one would silently ship an image without its binary.
+    layers_by_platform: HashMap<String, Vec<String>>,
+    /// Target platforms, e.g. `["linux/amd64", "linux/arm64"]`. **Required.**
+    ///
+    /// There is deliberately no default. `platforms` is a label written into the
+    /// image config, and nothing relates it to the layers: defaulting to the
+    /// host's architecture would make an arm64 laptop and an amd64 CI runner
+    /// produce different images from one BUILD file, and would let an
+    /// `amd64` binary ship inside a config claiming `arm64` — an `exec format
+    /// error` at run time, correctly cached, with no build-time error.
+    platforms: Vec<String>,
+    /// The image's entrypoint (`ENTRYPOINT`). Setting it clears any `cmd`
+    /// inherited from the base, as a Dockerfile's `ENTRYPOINT` does.
+    entrypoint: Vec<String>,
+    /// The image's default arguments (`CMD`).
+    cmd: Vec<String>,
+    /// Environment variables, merged over the base's by name.
+    env: HashMap<String, String>,
+    /// The user to run as (`USER`), e.g. `"65532:65532"`.
+    #[spec(ty = hcore::htvalue::signature::ParamType::String)]
+    user: Option<String>,
+    /// The working directory (`WORKDIR`).
+    #[spec(ty = hcore::htvalue::signature::ParamType::String)]
+    workdir: Option<String>,
+    /// Image labels, merged over the base's.
+    labels: HashMap<String, String>,
+    /// Ports the image declares (`EXPOSE`), e.g. `["8080/tcp"]`.
+    exposed_ports: Vec<String>,
+    /// Archive format: `oci` (default) or `docker`.
+    #[spec(ty = hcore::htvalue::signature::ParamType::String)]
+    format: Option<String>,
+    /// Write an OCI **layout directory** instead of a single archive file. This
+    /// is the shape another image's `base`, and buildx's `oci-layout://` build
+    /// context, consume.
+    layout: bool,
+    /// Output filename (or directory name, with `layout = True`), relative to
+    /// the target's package. Must be a bare name. Default `<target name>.tar`,
+    /// or `<target name>.oci` for a layout.
+    #[spec(ty = hcore::htvalue::signature::ParamType::String)]
+    out: Option<String>,
+    /// Caching for the built image. Defaults to on for both tiers.
+    cache: TargetSpecCache,
+}
+
+#[derive(Clone, serde::Serialize, serde::Deserialize)]
+struct OciImageDef {
+    /// Workspace-relative output path.
+    out: String,
+    /// Workspace-relative digest output path.
+    digest_out: String,
+    layout: bool,
+    format: ImageFormat,
+    /// The base's normalized address, or `None`.
+    ///
+    /// The address, not just the dep's hash: see [`layers`](Self::layers).
+    base: Option<String>,
+    /// Normalized `layers` addresses, **in order**.
+    ///
+    /// `hashin` cannot carry this. It folds a *sorted, unlabeled multiset* of
+    /// dep hashouts — no addr, no origin, and no output-group selector, since
+    /// `inputs_result_meta` folds every group a dep has. So `[":a", ":b"]` and
+    /// `[":b", ":a"]` reach it identically, as do `base = ":a", layers = [":b"]`
+    /// and the swap, and `[":bin|release"]` and `[":bin|debug"]` — four ways to
+    /// serve one cache entry for two different images.
+    ///
+    /// (`docker_build`'s single `dockerfile = ":target"` role can safely omit
+    /// its address: one occupant means any change to *which* target fills it
+    /// changes that dep's hashout. An ordered list has no such property.)
+    layers: Vec<String>,
+    /// Normalized per-platform layer addresses, in platform order then list
+    /// order. Same reason.
+    layers_by_platform: Vec<(String, Vec<String>)>,
+    /// Platforms, in order: the manifest list's entry order is its bytes.
+    platforms: Vec<String>,
+    entrypoint: Vec<String>,
+    cmd: Vec<String>,
+    /// Sorted for a stable hash and a canonical config.
+    env: BTreeMap<String, String>,
+    user: Option<String>,
+    workdir: Option<String>,
+    labels: BTreeMap<String, String>,
+    exposed_ports: Vec<String>,
+}
+
+/// Bump to invalidate cached images when the emitted bytes change shape.
+///
+/// Covers the transforms that are not themselves hashed fields: the config JSON
+/// canonicalization, the base-config merge rule, the layer media type, and the
+/// absence of `created`. Changing one of those without a bump is the
+/// same-key-different-artifact shape.
+const OCI_IMAGE_FORMAT_VERSION: u32 = 1;
+
+impl Hash for OciImageDef {
+    fn hash<H: Hasher>(&self, state: &mut H) {
+        OCI_IMAGE_FORMAT_VERSION.hash(state);
+        self.out.hash(state);
+        self.digest_out.hash(state);
+        self.layout.hash(state);
+        self.format.output_type().hash(state);
+        self.base.hash(state);
+        self.layers.hash(state);
+        self.layers_by_platform.hash(state);
+        self.platforms.hash(state);
+        self.entrypoint.hash(state);
+        self.cmd.hash(state);
+        self.env.hash(state);
+        self.user.hash(state);
+        self.workdir.hash(state);
+        self.labels.hash(state);
+        self.exposed_ports.hash(state);
+    }
+}
+
+/// A base image's contribution to one platform: its layer descriptors, its
+/// `diff_ids`, and its config to inherit from.
+#[derive(Default)]
+struct BaseFor {
+    layers: Vec<Value>,
+    diff_ids: Vec<Value>,
+    config: Map<String, Value>,
+    /// Blobs to carry into the output layout.
+    blobs: Vec<(String, Vec<u8>)>,
+}
+
+/// Merge the base's `config` object with what the BUILD file set.
+///
+/// Dockerfile semantics, because that is what a user migrating from
+/// `docker_build` expects: `Env` and `Labels` merge by key with ours winning,
+/// scalars are replaced only when set here, and setting `Entrypoint` clears an
+/// inherited `Cmd` — otherwise the base's arguments would be silently passed to
+/// a completely different program.
+fn merge_config(base: &Map<String, Value>, def: &OciImageDef) -> Map<String, Value> {
+    let mut cfg = base.clone();
+
+    // Sorted by name, not kept in the base's order: `Env` is a map spelled as a
+    // list, the order carries no meaning, and a stable one is what makes two
+    // encodings of the same image the same bytes.
+    //
+    // An entry with no `=` is not dropped — a malformed base is the base's
+    // problem, and silently losing one of its variables here would be ours.
+    let mut env: BTreeMap<String, Option<String>> = BTreeMap::new();
+    if let Some(Value::Array(existing)) = base.get("Env") {
+        for item in existing {
+            if let Some(s) = item.as_str() {
+                match s.split_once('=') {
+                    Some((k, v)) => env.insert(k.to_string(), Some(v.to_string())),
+                    None => env.insert(s.to_string(), None),
+                };
+            }
+        }
+    }
+    for (k, v) in &def.env {
+        env.insert(k.clone(), Some(v.clone()));
+    }
+    if env.is_empty() {
+        cfg.remove("Env");
+    } else {
+        cfg.insert(
+            "Env".to_string(),
+            Value::Array(
+                env.iter()
+                    .map(|(k, v)| match v {
+                        Some(v) => Value::String(format!("{k}={v}")),
+                        None => Value::String(k.clone()),
+                    })
+                    .collect(),
+            ),
+        );
+    }
+
+    if !def.entrypoint.is_empty() {
+        cfg.insert("Entrypoint".to_string(), json!(def.entrypoint));
+        // An inherited `Cmd` is arguments for the base's entrypoint. Keeping it
+        // would hand them to whatever this image runs instead.
+        cfg.remove("Cmd");
+    }
+    if !def.cmd.is_empty() {
+        cfg.insert("Cmd".to_string(), json!(def.cmd));
+    }
+    if let Some(user) = &def.user {
+        cfg.insert("User".to_string(), json!(user));
+    }
+    if let Some(workdir) = &def.workdir {
+        cfg.insert("WorkingDir".to_string(), json!(workdir));
+    }
+    if !def.labels.is_empty() {
+        let mut labels = match base.get("Labels") {
+            Some(Value::Object(m)) => m.clone(),
+            _ => Map::new(),
+        };
+        for (k, v) in &def.labels {
+            labels.insert(k.clone(), json!(v));
+        }
+        cfg.insert("Labels".to_string(), Value::Object(labels));
+    }
+    if !def.exposed_ports.is_empty() {
+        let mut ports = match base.get("ExposedPorts") {
+            Some(Value::Object(m)) => m.clone(),
+            _ => Map::new(),
+        };
+        for p in &def.exposed_ports {
+            ports.insert(p.clone(), json!({}));
+        }
+        cfg.insert("ExposedPorts".to_string(), Value::Object(ports));
+    }
+    cfg
+}
+
+/// The image config for one platform.
+///
+/// `created` is deliberately absent, as are per-layer timestamps: a wall clock
+/// in here would give the same inputs a different image digest on every build
+/// and defeat cross-machine cache sharing entirely.
+///
+/// Built through `serde_json`, whose object type is a `BTreeMap` in this tree —
+/// so the emitted bytes are canonical without a second pass. (`oci-spec`'s own
+/// config types use `HashMap` for `Labels`, and Rust's `RandomState` is seeded
+/// *per process*: two heph runs on one machine would emit two byte orders, two
+/// config digests, and two manifest digests under one cache key.)
+fn build_config(
+    platform: &str,
+    base: &BaseFor,
+    def: &OciImageDef,
+    diff_ids: &[Value],
+) -> anyhow::Result<Vec<u8>> {
+    let (os, arch) = split_platform(platform)?;
+    let mut config = Map::new();
+    config.insert("architecture".to_string(), json!(arch));
+    config.insert("os".to_string(), json!(os));
+    config.insert(
+        "config".to_string(),
+        Value::Object(merge_config(&base.config, def)),
+    );
+    config.insert(
+        "rootfs".to_string(),
+        json!({"type": "layers", "diff_ids": diff_ids}),
+    );
+    serde_json::to_vec(&Value::Object(config)).context("encode the image config")
+}
+
+/// The base's per-platform pieces, or an empty contribution when there is none.
+fn base_for(layout: Option<&archive::Layout>, platform: &str) -> anyhow::Result<BaseFor> {
+    let Some(layout) = layout else {
+        return Ok(BaseFor::default());
+    };
+    let manifests = layout.manifests()?;
+    anyhow::ensure!(
+        !manifests.is_empty(),
+        "`base` holds no manifests; it is not an image"
+    );
+    let (os, arch) = split_platform(platform)?;
+
+    let mut available = Vec::new();
+    let mut chosen = None;
+    for (manifest, p, _) in &manifests {
+        match p {
+            Some(p) => {
+                available.push(format!("{}/{}", p.os, p.architecture));
+                if p.os.to_string() == os && p.architecture.to_string() == arch {
+                    chosen = Some(manifest);
+                }
+            }
+            // A single-image layout carries no platform annotation; there is
+            // nothing to choose and refusing it would be pedantry.
+            None if manifests.len() == 1 => chosen = Some(manifest),
+            None => {}
+        }
+    }
+    let manifest = chosen.with_context(|| {
+        format!(
+            "`base` has no {platform} instance (it has: {}). Pull it with \
+             `oci_pull(layout = True, all_platforms = True)` so every platform in `platforms` \
+             has a base to sit on.",
+            available.join(", ")
+        )
+    })?;
+
+    let config_bytes = layout.blob(&manifest.config.digest)?.clone();
+    let config: Value =
+        serde_json::from_slice(&config_bytes).context("parse the base image config")?;
+    let diff_ids = config
+        .get("rootfs")
+        .and_then(|r| r.get("diff_ids"))
+        .and_then(Value::as_array)
+        .cloned()
+        .unwrap_or_default();
+    let inner = match config.get("config") {
+        Some(Value::Object(m)) => m.clone(),
+        _ => Map::new(),
+    };
+
+    let mut blobs = Vec::new();
+    let mut layers = Vec::new();
+    for layer in &manifest.layers {
+        blobs.push((layer.digest.clone(), layout.blob(&layer.digest)?.clone()));
+        layers.push(json!({
+            "mediaType": layer.media_type,
+            "digest": layer.digest,
+            "size": layer.size,
+        }));
+    }
+    Ok(BaseFor {
+        layers,
+        diff_ids,
+        config: inner,
+        blobs,
+    })
+}
+
+/// Absolute path of the OCI layout the `base` dep materialized.
+///
+/// A dep's list names *files*, never the directories holding them, so the root
+/// is found by its marker: an OCI layout is exactly a tree with an `oci-layout`
+/// file at its root.
+fn base_layout_path(req: &ManagedRunRequest<'_, '_>) -> anyhow::Result<PathBuf> {
+    let paths = dep_files(req, BASE_ORIGIN)?;
+    anyhow::ensure!(!paths.is_empty(), "`base` produced no files in the sandbox");
+    if let Some(dir) = paths
+        .iter()
+        .find(|p| p.file_name().is_some_and(|n| n == "oci-layout"))
+        .and_then(|p| p.parent())
+    {
+        return Ok(dir.to_path_buf());
+    }
+    // Not a layout directory: a single archive is the other shape this plugin
+    // produces, and `Layout::read` accepts it.
+    if let [only] = paths.as_slice() {
+        return Ok(only.clone());
+    }
+    anyhow::bail!(
+        "`base` is neither an OCI layout directory nor a single archive: no `oci-layout` file \
+         among {} staged path(s), the first being {:?}. Produce it with \
+         `oci_pull(layout = True)` or `oci_image(layout = True)`.",
+        paths.len(),
+        paths.first()
+    )
+}
+
+/// Stateless: an image is assembled from declared inputs and attributes.
+#[derive(Default)]
+pub struct Driver;
+
+impl Driver {
+    pub fn new() -> Self {
+        Driver
+    }
+}
+
+#[async_trait]
+impl ManagedDriver for Driver {
+    fn config(&self, _req: ConfigRequest) -> anyhow::Result<ConfigResponse> {
+        Ok(ConfigResponse {
+            name: DRIVER_NAME.to_string(),
+        })
+    }
+
+    fn schema(&self) -> hplugin::driver::DriverSchema {
+        OciImageSpec::schema()
+    }
+
+    async fn parse(
+        &self,
+        req: ParseRequest,
+        _ctoken: &(dyn Cancellable + Send + Sync),
+    ) -> anyhow::Result<ParseResponse> {
+        let addr = &req.target_spec.addr;
+        let pkg = addr.package.to_owned();
+        let spec = OciImageSpec::from(&req.target_spec.config).context("parse oci_image config")?;
+
+        anyhow::ensure!(
+            !spec.platforms.is_empty(),
+            "`platforms` is required, e.g. `platforms = [\"linux/amd64\"]`. There is no default \
+             on purpose: the platform is written into the image config and nothing checks it \
+             against the layers, so a host-derived default would put an amd64 binary in an arm64 \
+             image on one machine and not the other, cache it, and say nothing."
+        );
+        let platforms = spec
+            .platforms
+            .iter()
+            .map(|p| normalize_platform(p))
+            .collect::<anyhow::Result<Vec<_>>>()
+            .context("`platforms`")?;
+
+        let pbp: BTreeMap<String, Vec<String>> = spec
+            .layers_by_platform
+            .iter()
+            .map(|(k, v)| Ok((normalize_platform(k)?, v.clone())))
+            .collect::<anyhow::Result<_>>()
+            .context("`layers_by_platform`")?;
+        if !pbp.is_empty() {
+            for platform in &platforms {
+                anyhow::ensure!(
+                    pbp.contains_key(platform),
+                    "`layers_by_platform` has no entry for {platform:?}, which `platforms` \
+                     lists. Every platform needs its own layers, or the image ships without \
+                     them on that architecture."
+                );
+            }
+            for platform in pbp.keys() {
+                anyhow::ensure!(
+                    platforms.contains(platform),
+                    "`layers_by_platform` has an entry for {platform:?}, which `platforms` does \
+                     not list. Add it there, or drop the entry."
+                );
+            }
+        }
+        anyhow::ensure!(
+            !spec.layers.is_empty() || !pbp.is_empty() || spec.base.is_some(),
+            "this image has no `base` and no `layers`, so it would have no filesystem at all. \
+             Add at least one `oci_layer` target."
+        );
+
+        let format = spec
+            .format
+            .as_deref()
+            .map_or(Ok(ImageFormat::Oci), ImageFormat::parse)?;
+        anyhow::ensure!(
+            !(matches!(format, ImageFormat::Docker) && platforms.len() > 1),
+            "`format = \"docker\"` holds a single image, but `platforms` lists {}. A daemon tag \
+             is one image: build one platform, or use the default `format = \"oci\"`.",
+            platforms.len()
+        );
+
+        let mut inputs = Vec::new();
+        let mut push_dep = |addr_str: &str, origin: String| -> anyhow::Result<String> {
+            let r#ref = TargetAddr::parse(addr_str, &pkg)
+                .with_context(|| format!("parse target address {addr_str:?}"))?;
+            let normalized = r#ref.to_string();
+            inputs.push(Input {
+                r#ref,
+                mode: InputMode::Standard,
+                origin_id: origin.clone(),
+                // Out of the workspace root: a base layout is hundreds of
+                // megabytes and has no business being unpacked over the tree.
+                annotations: BTreeMap::from([(
+                    "unpack_root".to_string(),
+                    format!("oci_{}", origin.replace(['|', '/'], "_")),
+                )]),
+                hashed: true,
+                runtime: true,
+            });
+            Ok(normalized)
+        };
+
+        let base = match &spec.base {
+            Some(b) => Some(push_dep(b, BASE_ORIGIN.to_string())?),
+            None => None,
+        };
+        let mut layers = Vec::new();
+        for (i, l) in spec.layers.iter().enumerate() {
+            layers.push(push_dep(l, layer_origin(None, i))?);
+        }
+        let mut layers_by_platform = Vec::new();
+        for (platform, list) in &pbp {
+            let mut normalized = Vec::new();
+            for (i, l) in list.iter().enumerate() {
+                normalized.push(push_dep(l, layer_origin(Some(platform), i))?);
+            }
+            layers_by_platform.push((platform.clone(), normalized));
+        }
+
+        let default_out = if spec.layout {
+            format!("{}.oci", addr.name)
+        } else {
+            format!("{}.tar", addr.name)
+        };
+        let out_rel = spec.out.unwrap_or(default_out);
+        anyhow::ensure!(
+            std::path::Path::new(&out_rel)
+                .file_name()
+                .map(std::ffi::OsStr::new)
+                == Some(out_rel.as_ref()),
+            "`out` {out_rel:?} must be a bare name (no directory component): the driver writes \
+             it into the target's package directory"
+        );
+        let out = ws_path(pkg.as_str(), &out_rel);
+        let digest_out = ws_path(pkg.as_str(), &format!("{}.digest", addr.name));
+
+        let def = OciImageDef {
+            out: out.clone(),
+            digest_out: digest_out.clone(),
+            layout: spec.layout,
+            format,
+            base,
+            layers,
+            layers_by_platform,
+            platforms,
+            entrypoint: spec.entrypoint,
+            cmd: spec.cmd,
+            env: spec.env.into_iter().collect(),
+            user: spec.user,
+            workdir: spec.workdir,
+            labels: spec.labels.into_iter().collect(),
+            exposed_ports: spec.exposed_ports,
+        };
+        let hash = {
+            let mut h = DebugHasher::new(Xxh3Default::new(), || {
+                format!("oci_image_{}", addr.format())
+            });
+            def.hash(&mut h);
+            format!("{:x}", h.finish()).into_bytes()
+        };
+
+        Ok(ParseResponse {
+            target_def: TargetDef {
+                addr: addr.clone(),
+                labels: req.target_spec.labels.clone(),
+                raw_def: Arc::new(def),
+                inputs,
+                outputs: vec![
+                    Output {
+                        group: String::new(),
+                        paths: vec![OutPath {
+                            content: if spec.layout {
+                                Content::DirPath(out)
+                            } else {
+                                Content::FilePath(out)
+                            },
+                            codegen_tree: CodegenMode::None,
+                            collect: true,
+                        }],
+                    },
+                    Output {
+                        group: "digest".to_string(),
+                        paths: vec![OutPath {
+                            content: Content::FilePath(digest_out),
+                            codegen_tree: CodegenMode::None,
+                            collect: true,
+                        }],
+                    },
+                ],
+                support_files: vec![],
+                cache: spec.cache.into(),
+                pty: false,
+                hash,
+                transparent: false,
+            },
+        })
+    }
+
+    async fn apply_transitive(
+        &self,
+        req: ApplyTransitiveRequest,
+        _ctoken: &(dyn Cancellable + Send + Sync),
+    ) -> anyhow::Result<ApplyTransitiveResponse> {
+        Ok(ApplyTransitiveResponse {
+            target_def: req.target_def,
+        })
+    }
+
+    async fn run<'a, 'io>(
+        &self,
+        req: ManagedRunRequest<'a, 'io>,
+        _ctoken: &(dyn Cancellable + Send + Sync),
+    ) -> anyhow::Result<ManagedRunResponse> {
+        let def = req.request.target.def_de::<OciImageDef>().clone();
+        let out_path = req.sandbox_pkg_dir.join(super::basename(&def.out)?);
+
+        let base_layout = match &def.base {
+            Some(_) => {
+                let path = base_layout_path(&req)?;
+                Some(
+                    archive::Layout::read(&path)
+                        .with_context(|| format!("read the base image at {path:?}"))?,
+                )
+            }
+            None => None,
+        };
+
+        let mut blobs: Blobs = Blobs::new();
+        let mut entries: Vec<ImageIndexEntry> = Vec::new();
+
+        for platform in &def.platforms {
+            let base = base_for(base_layout.as_ref(), platform)?;
+            for (digest, bytes) in &base.blobs {
+                blobs.insert(digest.clone(), Blob::Bytes(bytes.clone()));
+            }
+
+            let mut layer_descs = base.layers.clone();
+            let mut diff_ids = base.diff_ids.clone();
+            let mut own = Vec::new();
+            for (i, _) in def.layers.iter().enumerate() {
+                own.push(layer_origin(None, i));
+            }
+            if let Some((_, list)) = def.layers_by_platform.iter().find(|(p, _)| p == platform) {
+                for (i, _) in list.iter().enumerate() {
+                    own.push(layer_origin(Some(platform), i));
+                }
+            }
+            for origin in &own {
+                let path = layer_tar(&req, origin)?;
+                // Streamed, not read: a layer can be most of an image, and this
+                // runs once per platform per image target.
+                let (digest, size) = archive::sha256_file(&path)?;
+                // Uncompressed, so the layer's digest and its diff_id are the
+                // same value — there is no second encoding to hash.
+                layer_descs.push(json!({
+                    "mediaType": LAYER_MEDIA_TYPE,
+                    "digest": digest,
+                    "size": size,
+                }));
+                diff_ids.push(json!(digest));
+                // Deduped by digest: two platforms sharing a static layer
+                // reference one blob, which is a thing buildx cannot do.
+                blobs.entry(digest).or_insert_with(|| Blob::File(path));
+            }
+
+            let config_bytes = build_config(platform, &base, &def, &diff_ids)?;
+            let config_digest = archive::sha256_digest(&config_bytes);
+            let config_size = config_bytes.len();
+            blobs.insert(config_digest.clone(), Blob::Bytes(config_bytes));
+
+            let manifest = json!({
+                "schemaVersion": 2,
+                "mediaType": oci_client::manifest::OCI_IMAGE_MEDIA_TYPE,
+                "config": {
+                    "mediaType": CONFIG_MEDIA_TYPE,
+                    "digest": config_digest,
+                    "size": config_size,
+                },
+                "layers": layer_descs,
+            });
+            let manifest_bytes = serde_json::to_vec(&manifest).context("encode the manifest")?;
+            let manifest_digest = archive::sha256_digest(&manifest_bytes);
+            let (os, arch) = split_platform(platform)?;
+            entries.push(ImageIndexEntry {
+                media_type: oci_client::manifest::OCI_IMAGE_MEDIA_TYPE.to_string(),
+                artifact_type: None,
+                digest: manifest_digest.clone(),
+                size: manifest_bytes.len() as i64,
+                platform: Some(oci_client::manifest::Platform {
+                    os: os.into(),
+                    architecture: arch.into(),
+                    os_version: None,
+                    os_features: None,
+                    variant: None,
+                    features: None,
+                }),
+                annotations: None,
+            });
+            blobs.insert(manifest_digest, Blob::Bytes(manifest_bytes));
+        }
+
+        let index = OciImageIndex {
+            schema_version: 2,
+            media_type: Some(oci_client::manifest::OCI_IMAGE_INDEX_MEDIA_TYPE.to_string()),
+            artifact_type: None,
+            manifests: entries.clone(),
+            annotations: None,
+        };
+
+        match (def.layout, def.format) {
+            (true, _) => archive::write_layout_dir_blobs(&out_path, &index, &blobs),
+            (false, ImageFormat::Oci) => archive::write_layout_tar_blobs(&out_path, &index, &blobs),
+            (false, ImageFormat::Docker) => write_docker(&out_path, &index, &blobs),
+        }
+        .with_context(|| format!("write the image to {out_path:?}"))?;
+
+        // A single image reports its own manifest digest; several report the
+        // list's, which is what a registry files the tag under.
+        let digest = match entries.as_slice() {
+            [only] => only.digest.clone(),
+            _ => {
+                let raw = serde_json::to_vec(&index).context("encode the manifest list")?;
+                archive::sha256_digest(&raw)
+            }
+        };
+        std::fs::write(
+            req.sandbox_pkg_dir.join(super::basename(&def.digest_out)?),
+            &digest,
+        )
+        .context("write the digest output")?;
+
+        tracing::info!(
+            platforms = def.platforms.join(","),
+            digest,
+            "oci_image: assembled"
+        );
+        Ok(ManagedRunResponse { artifacts: vec![] })
+    }
+}
+
+/// The single file an `oci_layer` dep produced.
+fn layer_tar(req: &ManagedRunRequest<'_, '_>, origin: &str) -> anyhow::Result<PathBuf> {
+    let paths = dep_files(req, origin)?;
+    match paths.as_slice() {
+        [only] => Ok(only.clone()),
+        [] => anyhow::bail!(
+            "the {origin} dep produced no file; an `oci_image` layer must be an `oci_layer` \
+             target, which produces exactly one tar"
+        ),
+        many => anyhow::bail!(
+            "the {origin} dep produced {} files, expected one layer tar; `layers` takes \
+             `oci_layer` targets, not arbitrary ones",
+            many.len()
+        ),
+    }
+}
+
+/// Write the docker-format archive a daemon's `docker load` accepts.
+fn write_docker(out: &std::path::Path, index: &OciImageIndex, blobs: &Blobs) -> anyhow::Result<()> {
+    // `write_docker_archive` reads through an in-memory `Layout`, so route the
+    // one-platform case through the layout the rest of the plugin already
+    // understands rather than growing a second docker-archive writer.
+    let tmp = out.with_extension("oci-tmp");
+    archive::write_layout_dir_blobs(&tmp, index, blobs)?;
+    let layout = archive::Layout::read(&tmp)?;
+    let manifests = layout.manifests()?;
+    let (manifest, _, digest) = manifests
+        .into_iter()
+        .next()
+        .context("the assembled image has no manifest")?;
+    archive::write_docker_archive(out, &layout, &manifest, &digest, "heph:latest")?;
+    std::fs::remove_dir_all(&tmp).with_context(|| format!("clean up {tmp:?}"))?;
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn def() -> OciImageDef {
+        OciImageDef {
+            out: "app/img.tar".to_string(),
+            digest_out: "app/img.digest".to_string(),
+            layout: false,
+            format: ImageFormat::Oci,
+            base: None,
+            layers: vec![],
+            layers_by_platform: vec![],
+            platforms: vec!["linux/amd64".to_string()],
+            entrypoint: vec![],
+            cmd: vec![],
+            env: BTreeMap::new(),
+            user: None,
+            workdir: None,
+            labels: BTreeMap::new(),
+            exposed_ports: vec![],
+        }
+    }
+
+    fn hash_of(d: &OciImageDef) -> u64 {
+        let mut h = Xxh3Default::new();
+        d.hash(&mut h);
+        h.finish()
+    }
+
+    /// `hashin` folds a sorted, unlabeled multiset of dep hashouts: no address,
+    /// no origin, and no output-group selector. Every one of these swaps leaves
+    /// it identical, so the def hash is the only thing standing between them and
+    /// one cache entry serving two different images.
+    #[test]
+    fn swapping_dep_roles_changes_the_key() {
+        let base = def();
+
+        let mut ab = base.clone();
+        ab.layers = vec!["//app:a".to_string(), "//app:b".to_string()];
+        let mut ba = base.clone();
+        ba.layers = vec!["//app:b".to_string(), "//app:a".to_string()];
+        assert_ne!(
+            hash_of(&ab),
+            hash_of(&ba),
+            "layer order decides diff_ids order and which file shadows which"
+        );
+
+        let mut base_a = base.clone();
+        base_a.base = Some("//app:a".to_string());
+        base_a.layers = vec!["//app:b".to_string()];
+        let mut base_b = base.clone();
+        base_b.base = Some("//app:b".to_string());
+        base_b.layers = vec!["//app:a".to_string()];
+        assert_ne!(hash_of(&base_a), hash_of(&base_b), "base is not a layer");
+
+        let mut release = base.clone();
+        release.layers = vec!["//app:bin|release".to_string()];
+        let mut debug = base.clone();
+        debug.layers = vec!["//app:bin|debug".to_string()];
+        assert_ne!(
+            hash_of(&release),
+            hash_of(&debug),
+            "the output-group selector reaches no other part of the key"
+        );
+
+        let mut amd = base.clone();
+        amd.platforms = vec!["linux/amd64".to_string(), "linux/arm64".to_string()];
+        amd.layers_by_platform = vec![
+            ("linux/amd64".to_string(), vec!["//app:x".to_string()]),
+            ("linux/arm64".to_string(), vec!["//app:y".to_string()]),
+        ];
+        let mut swapped = amd.clone();
+        swapped.layers_by_platform = vec![
+            ("linux/amd64".to_string(), vec!["//app:y".to_string()]),
+            ("linux/arm64".to_string(), vec!["//app:x".to_string()]),
+        ];
+        assert_ne!(
+            hash_of(&amd),
+            hash_of(&swapped),
+            "which platform gets which layer is the whole point of the map"
+        );
+    }
+
+    /// Attributes that change the image must change the key; a map's iteration
+    /// order must not.
+    #[test]
+    fn config_attributes_reach_the_key_but_map_order_does_not() {
+        let a = def();
+        for mutate in [
+            (|d: &mut OciImageDef| d.entrypoint = vec!["/bin/x".to_string()]) as fn(&mut _),
+            |d| d.cmd = vec!["--flag".to_string()],
+            |d| d.user = Some("65532".to_string()),
+            |d| d.workdir = Some("/srv".to_string()),
+            |d| d.exposed_ports = vec!["80/tcp".to_string()],
+            |d| {
+                d.env.insert("PORT".to_string(), "8080".to_string());
+            },
+            |d| {
+                d.labels.insert(
+                    "org.opencontainers.image.source".to_string(),
+                    "x".to_string(),
+                );
+            },
+            |d| d.platforms = vec!["linux/arm64".to_string()],
+            |d| d.layout = true,
+            |d| d.format = ImageFormat::Docker,
+        ] {
+            let mut b = a.clone();
+            mutate(&mut b);
+            assert_ne!(hash_of(&a), hash_of(&b), "a changed attribute must re-key");
+        }
+
+        // `env` and `labels` are BTreeMaps, so insertion order cannot leak.
+        let mut one = def();
+        one.env.insert("A".into(), "1".into());
+        one.env.insert("B".into(), "2".into());
+        let mut other = def();
+        other.env.insert("B".into(), "2".into());
+        other.env.insert("A".into(), "1".into());
+        assert_eq!(hash_of(&one), hash_of(&other));
+    }
+
+    /// Dropping a base's `PATH` is the easiest way to ship an image that starts
+    /// and then cannot find its own entrypoint, so inheritance is asserted per
+    /// field rather than assumed.
+    #[test]
+    fn the_base_config_is_inherited_and_overridden_per_field() {
+        let base: Map<String, Value> = serde_json::from_value(json!({
+            "Env": ["PATH=/usr/bin", "LANG=C"],
+            "Entrypoint": ["/bin/base"],
+            "Cmd": ["--base-arg"],
+            "User": "root",
+            "WorkingDir": "/base",
+            "Labels": {"vendor": "alpine"},
+        }))
+        .expect("base config");
+
+        // Nothing set: everything is inherited. `Env` comes back sorted — it is
+        // a map spelled as a list, and a stable order is what makes two
+        // encodings of one image the same bytes.
+        let inherited = merge_config(&base, &def());
+        assert_eq!(
+            inherited.get("Env").expect("Env"),
+            &json!(["LANG=C", "PATH=/usr/bin"])
+        );
+        for key in ["Entrypoint", "Cmd", "User", "WorkingDir", "Labels"] {
+            assert_eq!(
+                inherited.get(key),
+                base.get(key),
+                "{key} must be inherited untouched"
+            );
+        }
+
+        // A base entry with no `=` is malformed, but dropping it would lose a
+        // variable the base meant to set.
+        let odd: Map<String, Value> =
+            serde_json::from_value(json!({"Env": ["BARE", "A=1"]})).expect("odd");
+        assert_eq!(
+            merge_config(&odd, &def()).get("Env").expect("Env"),
+            &json!(["A=1", "BARE"])
+        );
+
+        // Env merges by key, ours winning; the base's other vars survive.
+        let mut d = def();
+        d.env.insert("PATH".into(), "/opt/bin".into());
+        d.env.insert("PORT".into(), "8080".into());
+        let merged = merge_config(&base, &d);
+        assert_eq!(
+            merged.get("Env").expect("Env"),
+            &json!(["LANG=C", "PATH=/opt/bin", "PORT=8080"])
+        );
+
+        // Setting entrypoint clears the base's Cmd: those arguments were meant
+        // for a different program.
+        let mut d = def();
+        d.entrypoint = vec!["/usr/bin/server".to_string()];
+        let merged = merge_config(&base, &d);
+        assert_eq!(
+            merged.get("Entrypoint").expect("ep"),
+            &json!(["/usr/bin/server"])
+        );
+        assert!(
+            merged.get("Cmd").is_none(),
+            "an inherited Cmd must not survive"
+        );
+
+        // …unless a cmd is given too.
+        let mut d = def();
+        d.entrypoint = vec!["/usr/bin/server".to_string()];
+        d.cmd = vec!["--serve".to_string()];
+        assert_eq!(
+            merge_config(&base, &d).get("Cmd").expect("cmd"),
+            &json!(["--serve"])
+        );
+
+        // Scalars replace, labels merge.
+        let mut d = def();
+        d.user = Some("65532:65532".to_string());
+        d.workdir = Some("/srv".to_string());
+        d.labels.insert("app".into(), "server".into());
+        let merged = merge_config(&base, &d);
+        assert_eq!(merged.get("User").expect("user"), &json!("65532:65532"));
+        assert_eq!(merged.get("WorkingDir").expect("wd"), &json!("/srv"));
+        assert_eq!(
+            merged.get("Labels").expect("labels"),
+            &json!({"app": "server", "vendor": "alpine"})
+        );
+    }
+
+    /// The config's bytes are its digest, so two encodings of the same image
+    /// must be identical — and must carry no timestamp.
+    #[test]
+    fn the_config_is_canonical_and_has_no_timestamp() {
+        let mut d = def();
+        for (k, v) in [("Z", "1"), ("A", "2"), ("M", "3")] {
+            d.env.insert(k.to_string(), v.to_string());
+        }
+        d.labels.insert("b".into(), "2".into());
+        d.labels.insert("a".into(), "1".into());
+        let base = BaseFor::default();
+        let diff_ids = vec![json!("sha256:aa")];
+
+        let one = build_config("linux/amd64", &base, &d, &diff_ids).expect("one");
+        let two = build_config("linux/amd64", &base, &d, &diff_ids).expect("two");
+        assert_eq!(one, two, "the same image must encode to the same bytes");
+
+        let text = String::from_utf8(one).expect("utf8");
+        assert!(!text.contains("created"), "no wall clock: {text}");
+        assert!(
+            text.contains(r#""architecture":"amd64""#) && text.contains(r#""os":"linux""#),
+            "got: {text}"
+        );
+        // serde_json's Map is a BTreeMap here, so keys come out sorted — the
+        // property that keeps two runs of one process from disagreeing.
+        assert!(
+            text.find(r#""A=2""#) < text.find(r#""M=3""#)
+                && text.find(r#""M=3""#) < text.find(r#""Z=1""#),
+            "env must be sorted: {text}"
+        );
+    }
+}

--- a/crates/plugin-oci/src/pluginoci/layer.rs
+++ b/crates/plugin-oci/src/pluginoci/layer.rs
@@ -1,0 +1,714 @@
+//! The `oci_layer` driver: turns target outputs into one image layer.
+//!
+//! A layer is a tar of a file tree, and that is all it is — there is no
+//! execution here, nothing runs, nothing is fetched. `srcs` names targets, and
+//! every file they produced lands under `prefix` inside the image.
+//!
+//! Layers are a separate rule rather than an attribute of [`super::image`] for
+//! two reasons. A big shared layer (static assets, a CA bundle) is then built
+//! and cached **once** and reused by every image that lists it — which is what
+//! the layer format is for. And when a file ends up at the wrong path, the
+//! answer is `heph run //pkg:that_layer` and one small tar, not an image build.
+//!
+//! # Reproducibility
+//!
+//! The layer's bytes are its digest, so nothing about the host may reach them.
+//! Every tar header is built by hand:
+//!
+//! - **mtime 0**, uid/gid 0, empty uname/gname. `tar::Builder::append_path` is
+//!   never used: it copies all four off the filesystem.
+//! - **Entries sorted** by the raw bytes of the in-image path. The engine hands
+//!   a dep's file list in walk order, which differs between filesystems.
+//! - **Mode is the executable bit and nothing else** — `0755` or `0644` — unless
+//!   `mode` says otherwise. This is not a simplification, it is the only honest
+//!   answer: heph's own artifact hash records exactly one permission bit
+//!   (`crates/walk`), the pack step normalizes to those two values, and what a
+//!   file's mode *is* in the sandbox then depends on the umask, on whether some
+//!   other target marked the dep read-only, and on whether the input crossed the
+//!   size threshold that selects the FUSE sandbox over unpacking. Preserving it
+//!   would make the same declared inputs produce different images.
+//! - **Symlinks are preserved, never followed.** Symlink-ness *is* covered by
+//!   the dep's hash, and the link's mode is pinned to `0o777` rather than
+//!   lstat'ed (Linux reports `0777` there, macOS `0755`).
+//!
+//! Layers are written **uncompressed** (`application/vnd.oci.image.layer.v1.tar`).
+//! Spec-legal, and it keeps the layer digest out of the hands of whichever
+//! deflate implementation cargo's feature resolution happens to pick — a
+//! backend swap would otherwise move every layer digest in every cache with no
+//! code change. It also avoids gzipping bytes that heph's remote cache is about
+//! to gzip again.
+
+use anyhow::Context as _;
+use async_trait::async_trait;
+use hcore::debug_hash::DebugHasher;
+use hcore::hasync::Cancellable;
+use hdriver_support::driver_managed::{ManagedDriver, ManagedRunRequest, ManagedRunResponse};
+use hplugin::driver::targetdef::path::{CodegenMode, Content, Path as OutPath};
+use hplugin::driver::targetdef::{Input, InputMode, Output, TargetDef};
+use hplugin::driver::{
+    ApplyTransitiveRequest, ApplyTransitiveResponse, ConfigRequest, ConfigResponse, ParseRequest,
+    ParseResponse, TargetAddr,
+};
+use hplugin::htspec::{Spec, TargetSpecCache};
+use std::collections::{BTreeMap, BTreeSet};
+use std::hash::{Hash, Hasher};
+use std::path::{Path, PathBuf};
+use std::sync::Arc;
+use xxhash_rust::xxh3::Xxh3Default;
+
+use super::{dep_files, ws_path};
+
+pub const DRIVER_NAME: &str = "oci_layer";
+
+/// Origin id prefix of a `srcs` dep input. The index is in the id so a
+/// `HEPH_DEBUG_HASH` trace names the entry rather than "a src".
+fn src_origin(i: usize) -> String {
+    format!("srcs|{i}")
+}
+
+/// Packs target outputs into a single image layer, for `oci_image`. No
+/// execution, no Dockerfile, no docker.
+#[derive(Spec)]
+struct OciLayerSpec {
+    /// Targets whose files go into this layer. Every file they produce is
+    /// included, at its workspace-relative path, rewritten by `strip` and
+    /// `prefix`.
+    ///
+    /// A `srcs` that produces no files at all is an error, not an empty layer:
+    /// an image missing its binary builds, pushes and starts, and fails when
+    /// something tries to exec it.
+    srcs: Vec<String>,
+    /// Where the files land inside the image, e.g. `"/usr/bin"`.
+    ///
+    /// Required, deliberately. A default of `/` (files at their
+    /// workspace-relative path, `/cmd/server/bin`) is never the answer anyone
+    /// wants, so it would be overridden every time — and the one caller who
+    /// forgot would get an image that builds and pushes clean and fails at
+    /// `docker run` with `stat /usr/bin/server: no such file or directory`.
+    #[spec(ty = hcore::htvalue::signature::ParamType::String)]
+    prefix: String,
+    /// A leading workspace-relative path to drop before applying `prefix`, e.g.
+    /// `strip = "cmd/server"` puts `cmd/server/bin` at `<prefix>/bin`.
+    ///
+    /// A `strip` that matches nothing is an error rather than a silent no-op:
+    /// the files would land somewhere unintended and nothing would say so.
+    #[spec(ty = hcore::htvalue::signature::ParamType::String)]
+    strip: Option<String>,
+    /// File mode as an octal string, e.g. `"0755"`. Default: `0755` for files
+    /// the producing target marked executable, `0644` otherwise.
+    ///
+    /// A string rather than a number because Starlark has no octal literal, and
+    /// `mode = 755` would silently mean decimal 755 (`0o1363`).
+    ///
+    /// setuid, setgid and the sticky bit are rejected: nothing in heph can carry
+    /// them from a producing target to here, so honouring them on this attribute
+    /// alone would promise something the next layer could not keep.
+    #[spec(ty = hcore::htvalue::signature::ParamType::String)]
+    mode: Option<String>,
+    /// Caching for the layer tar. Defaults to on for both tiers.
+    cache: TargetSpecCache,
+}
+
+#[derive(Clone, serde::Serialize, serde::Deserialize)]
+struct OciLayerDef {
+    /// Workspace-relative output path of the layer tar.
+    out: String,
+    /// The `srcs` addresses, normalized and sorted.
+    ///
+    /// In the hash because `hashin` cannot carry them: it folds a *sorted,
+    /// unlabeled multiset* of dep hashouts, with no addr and — the sharp edge —
+    /// no output-group selector, since `inputs_result_meta` folds every group a
+    /// dep has. Without this, `srcs = [":bin|release"]` and `[":bin|debug"]`
+    /// compute the same key for two different layers.
+    ///
+    /// Sorted rather than ordered: within one layer, entries are sorted by path
+    /// and two `srcs` in either order produce the same tar.
+    srcs: Vec<String>,
+    /// In-image prefix, with no leading `/` (tar entry names are relative).
+    prefix: String,
+    strip: Option<String>,
+    /// An explicit mode, or `None` to follow the producing target's exec bit.
+    mode: Option<u32>,
+}
+
+/// Bump to invalidate cached layers when the emitted tar changes shape.
+///
+/// This covers the parts of the encoding that are *transforms* rather than
+/// hashed values — the GNU header format, mtime 0, uid/gid 0, the sort key, the
+/// exec-bit mode rule. Changing any of them alters the bytes without altering a
+/// single field below, which is the same-key-different-artifact shape.
+const OCI_LAYER_FORMAT_VERSION: u32 = 1;
+
+impl Hash for OciLayerDef {
+    fn hash<H: Hasher>(&self, state: &mut H) {
+        OCI_LAYER_FORMAT_VERSION.hash(state);
+        self.out.hash(state);
+        self.srcs.hash(state);
+        self.prefix.hash(state);
+        self.strip.hash(state);
+        self.mode.hash(state);
+    }
+}
+
+/// Normalize a `prefix` to a tar entry prefix: no leading `/`, no trailing `/`,
+/// no `.` or `..` components.
+fn normalize_prefix(prefix: &str) -> anyhow::Result<String> {
+    anyhow::ensure!(
+        !prefix.is_empty(),
+        "`prefix` is empty; give the path inside the image these files go to, e.g. \"/usr/bin\""
+    );
+    let trimmed = prefix.trim_matches('/');
+    for part in trimmed.split('/') {
+        anyhow::ensure!(
+            part != ".." && part != ".",
+            "`prefix` {prefix:?} contains a {part:?} component; give a plain absolute path \
+             inside the image, e.g. \"/usr/bin\""
+        );
+    }
+    Ok(trimmed.to_string())
+}
+
+/// Parse an octal `mode` string, rejecting the bits heph cannot carry.
+fn parse_mode(mode: &str) -> anyhow::Result<u32> {
+    let parsed = u32::from_str_radix(mode.trim_start_matches("0o"), 8)
+        .with_context(|| format!("`mode` {mode:?} is not an octal number, e.g. \"0755\""))?;
+    anyhow::ensure!(
+        parsed & 0o7000 == 0,
+        "`mode` {mode:?} sets setuid/setgid/sticky. heph records one permission bit per file \
+         (executable or not), so those cannot survive a rebuild from cache — a layer that \
+         depended on them would differ from itself. Drop them, or set them in the container at \
+         run time."
+    );
+    anyhow::ensure!(
+        parsed & !0o777 == 0,
+        "`mode` {mode:?} has bits outside the permission range; expected something like \"0755\""
+    );
+    Ok(parsed)
+}
+
+/// Where one staged file lands inside the image.
+fn dest_path(ws_rel: &Path, strip: Option<&str>, prefix: &str) -> anyhow::Result<Option<String>> {
+    let rel = match strip {
+        Some(s) => match ws_rel.strip_prefix(s) {
+            Ok(r) => r,
+            Err(_) => return Ok(None),
+        },
+        None => ws_rel,
+    };
+    let rel = rel.to_str().with_context(|| {
+        format!("path {rel:?} is not valid UTF-8; an image entry name has to be")
+    })?;
+    anyhow::ensure!(
+        !rel.is_empty(),
+        "`strip` consumed the whole path {ws_rel:?}, leaving no name for the file inside the image"
+    );
+    Ok(Some(if prefix.is_empty() {
+        rel.to_string()
+    } else {
+        format!("{prefix}/{rel}")
+    }))
+}
+
+/// One entry on its way into the layer tar.
+struct Entry {
+    /// Absolute path in the sandbox.
+    source: PathBuf,
+    /// Name inside the image.
+    dest: String,
+    /// The target that produced it, for the error when two collide.
+    from: String,
+}
+
+/// Whiteout markers are how a layer expresses a *deletion* at extraction time.
+/// A source file that happens to be named like one would silently remove
+/// something from the base image, so it is refused rather than carried.
+fn reject_whiteout(dest: &str) -> anyhow::Result<()> {
+    let name = dest.rsplit('/').next().unwrap_or(dest);
+    anyhow::ensure!(
+        !name.starts_with(".wh."),
+        "{dest:?} is named like an OCI whiteout marker, which a runtime reads as \"delete this \
+         path from the layers below\". oci_layer does not express deletions; rename the file."
+    );
+    Ok(())
+}
+
+/// Write the entries as an uncompressed layer tar at `out`.
+fn write_layer(out: &Path, entries: &[Entry], mode: Option<u32>) -> anyhow::Result<()> {
+    let file = std::fs::File::create(out).with_context(|| format!("create layer {out:?}"))?;
+    let mut ar = tar::Builder::new(std::io::BufWriter::new(file));
+    for entry in entries {
+        let meta = std::fs::symlink_metadata(&entry.source)
+            .with_context(|| format!("lstat {:?}", entry.source))?;
+        // `Header::new_gnu` is zeroed, which is already uid/gid 0 with empty
+        // uname/gname. Everything else is set explicitly; nothing is read off
+        // the filesystem except the size and the executable bit.
+        let mut header = tar::Header::new_gnu();
+        header.set_mtime(0);
+        if meta.file_type().is_symlink() {
+            let target = std::fs::read_link(&entry.source)
+                .with_context(|| format!("readlink {:?}", entry.source))?;
+            anyhow::ensure!(
+                target.is_relative(),
+                "{:?} is a symlink to the absolute path {:?}; inside an image that would point \
+                 at the host's filesystem, not the layer's",
+                entry.dest,
+                target
+            );
+            header.set_size(0);
+            header.set_entry_type(tar::EntryType::Symlink);
+            header.set_mode(0o777);
+            ar.append_link(&mut header, &entry.dest, &target)
+                .with_context(|| format!("append symlink {}", entry.dest))?;
+            continue;
+        }
+        let size = meta.len();
+        header.set_size(size);
+        header.set_mode(mode.unwrap_or(if is_executable(&meta) { 0o755 } else { 0o644 }));
+        header.set_cksum();
+        let mut src = std::fs::File::open(&entry.source)
+            .with_context(|| format!("open {:?}", entry.source))?;
+        ar.append_data(&mut header, &entry.dest, &mut src)
+            .with_context(|| format!("append {}", entry.dest))?;
+    }
+    ar.finish().context("finish the layer tar")?;
+    Ok(())
+}
+
+#[cfg(unix)]
+fn is_executable(meta: &std::fs::Metadata) -> bool {
+    use std::os::unix::fs::MetadataExt as _;
+    meta.mode() & 0o111 != 0
+}
+
+/// Stateless: a layer is assembled from declared inputs and nothing else.
+#[derive(Default)]
+pub struct Driver;
+
+impl Driver {
+    pub fn new() -> Self {
+        Driver
+    }
+}
+
+#[async_trait]
+impl ManagedDriver for Driver {
+    fn config(&self, _req: ConfigRequest) -> anyhow::Result<ConfigResponse> {
+        Ok(ConfigResponse {
+            name: DRIVER_NAME.to_string(),
+        })
+    }
+
+    fn schema(&self) -> hplugin::driver::DriverSchema {
+        OciLayerSpec::schema()
+    }
+
+    async fn parse(
+        &self,
+        req: ParseRequest,
+        _ctoken: &(dyn Cancellable + Send + Sync),
+    ) -> anyhow::Result<ParseResponse> {
+        let addr = &req.target_spec.addr;
+        let pkg = addr.package.to_owned();
+        let spec = OciLayerSpec::from(&req.target_spec.config).context("parse oci_layer config")?;
+
+        anyhow::ensure!(
+            !spec.srcs.is_empty(),
+            "`srcs` is empty; an oci_layer with no sources would produce an empty layer"
+        );
+        let prefix = normalize_prefix(&spec.prefix)?;
+        let mode = spec.mode.as_deref().map(parse_mode).transpose()?;
+
+        let mut inputs = Vec::new();
+        let mut srcs = Vec::new();
+        for (i, src) in spec.srcs.iter().enumerate() {
+            let r#ref = TargetAddr::parse(src, &pkg)
+                .with_context(|| format!("parse `srcs` entry {src:?}"))?;
+            // The normalized rendering, not the BUILD-file spelling: `:bin` and
+            // `//app:bin` in package `app` are one dep and must be one key.
+            srcs.push(r#ref.to_string());
+            inputs.push(Input {
+                r#ref,
+                mode: InputMode::Standard,
+                origin_id: src_origin(i),
+                annotations: BTreeMap::new(),
+                hashed: true,
+                runtime: true,
+            });
+        }
+        srcs.sort();
+
+        let out = ws_path(pkg.as_str(), &format!("{}.tar", addr.name));
+        let def = OciLayerDef {
+            out: out.clone(),
+            srcs,
+            prefix,
+            strip: spec.strip,
+            mode,
+        };
+        let hash = {
+            let mut h = DebugHasher::new(Xxh3Default::new(), || {
+                format!("oci_layer_{}", addr.format())
+            });
+            def.hash(&mut h);
+            format!("{:x}", h.finish()).into_bytes()
+        };
+
+        Ok(ParseResponse {
+            target_def: TargetDef {
+                addr: addr.clone(),
+                labels: req.target_spec.labels.clone(),
+                raw_def: Arc::new(def),
+                inputs,
+                outputs: vec![Output {
+                    group: String::new(),
+                    paths: vec![OutPath {
+                        content: Content::FilePath(out),
+                        codegen_tree: CodegenMode::None,
+                        collect: true,
+                    }],
+                }],
+                support_files: vec![],
+                cache: spec.cache.into(),
+                pty: false,
+                hash,
+                transparent: false,
+            },
+        })
+    }
+
+    async fn apply_transitive(
+        &self,
+        req: ApplyTransitiveRequest,
+        _ctoken: &(dyn Cancellable + Send + Sync),
+    ) -> anyhow::Result<ApplyTransitiveResponse> {
+        Ok(ApplyTransitiveResponse {
+            target_def: req.target_def,
+        })
+    }
+
+    async fn run<'a, 'io>(
+        &self,
+        req: ManagedRunRequest<'a, 'io>,
+        _ctoken: &(dyn Cancellable + Send + Sync),
+    ) -> anyhow::Result<ManagedRunResponse> {
+        let def = req.request.target.def_de::<OciLayerDef>().clone();
+        let out_name = super::basename(&def.out)?;
+        let out_path = req.sandbox_pkg_dir.join(out_name);
+
+        let mut entries: Vec<Entry> = Vec::new();
+        let mut stripped_none: Vec<String> = Vec::new();
+        for input in &req.inputs {
+            if !input.input.origin_id.starts_with("srcs|") {
+                continue;
+            }
+            let from = input.input.source_addr.to_string();
+            for path in dep_files(&req, &input.input.origin_id)? {
+                let ws_rel = path.strip_prefix(&req.sandbox_ws_dir).unwrap_or(&path);
+                match dest_path(ws_rel, def.strip.as_deref(), &def.prefix)? {
+                    Some(dest) => {
+                        reject_whiteout(&dest)?;
+                        entries.push(Entry {
+                            source: path.clone(),
+                            dest,
+                            from: from.clone(),
+                        });
+                    }
+                    None => stripped_none.push(ws_rel.to_string_lossy().into_owned()),
+                }
+            }
+        }
+
+        // A layer that silently lost every file is the failure this driver is
+        // most likely to produce and the least likely to be noticed: the image
+        // builds, pushes, and dies at exec time. Name what the sources actually
+        // produced and what the prefixes on offer are.
+        if entries.is_empty() {
+            let mut hint = String::new();
+            if let Some(strip) = &def.strip {
+                stripped_none.sort();
+                stripped_none.dedup();
+                let offers: BTreeSet<&str> = stripped_none
+                    .iter()
+                    .filter_map(|p| p.rsplit_once('/').map(|(dir, _)| dir))
+                    .collect();
+                hint = format!(
+                    "\n  `strip = {strip:?}` matched none of them.\n  Set strip to one of: {} — \
+                     or drop it.",
+                    offers.into_iter().collect::<Vec<_>>().join(", ")
+                );
+            }
+            anyhow::bail!(
+                "this layer is empty (prefix {:?}).\n  its srcs produced: {}{hint}",
+                def.prefix,
+                if stripped_none.is_empty() {
+                    "nothing at all".to_string()
+                } else {
+                    stripped_none.join(", ")
+                }
+            );
+        }
+
+        entries.sort_by(|a, b| a.dest.as_bytes().cmp(b.dest.as_bytes()));
+        // Two srcs writing one path: tar allows the duplicate and extraction is
+        // last-writer-wins, so which file ends up in the image would depend on
+        // iteration order. Reported after the sort, so the pair is adjacent.
+        for pair in entries.windows(2) {
+            let [a, b] = pair else { continue };
+            anyhow::ensure!(
+                a.dest != b.dest,
+                "{} and {} both put a file at {:?} in this layer; one would silently overwrite \
+                 the other. Split them into two layers, or narrow `srcs`.",
+                a.from,
+                b.from,
+                a.dest
+            );
+        }
+
+        write_layer(&out_path, &entries, def.mode)
+            .with_context(|| format!("write the layer to {out_path:?}"))?;
+
+        tracing::info!(
+            files = entries.len(),
+            prefix = def.prefix,
+            "oci_layer: packed"
+        );
+        Ok(ManagedRunResponse { artifacts: vec![] })
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn prefixes_normalize_and_reject_traversal() {
+        assert_eq!(normalize_prefix("/usr/bin").expect("ok"), "usr/bin");
+        assert_eq!(normalize_prefix("usr/bin/").expect("ok"), "usr/bin");
+        assert_eq!(normalize_prefix("/").expect("ok"), "");
+        for bad in ["", "/usr/../etc", "./x"] {
+            assert!(normalize_prefix(bad).is_err(), "{bad:?} must be rejected");
+        }
+    }
+
+    /// setuid cannot survive a rebuild from cache — heph records one permission
+    /// bit — so accepting it here would promise something the cache breaks.
+    #[test]
+    fn modes_are_octal_and_reject_setuid() {
+        assert_eq!(parse_mode("0755").expect("ok"), 0o755);
+        assert_eq!(parse_mode("644").expect("ok"), 0o644);
+        let err = format!("{:#}", parse_mode("4755").expect_err("setuid"));
+        assert!(err.contains("setuid"), "got: {err}");
+        assert!(parse_mode("0999").is_err(), "9 is not an octal digit");
+    }
+
+    #[test]
+    fn strip_and_prefix_rewrite_the_path() {
+        let p = Path::new("cmd/server/bin");
+        assert_eq!(
+            dest_path(p, Some("cmd/server"), "usr/bin").expect("ok"),
+            Some("usr/bin/bin".to_string())
+        );
+        assert_eq!(
+            dest_path(p, None, "usr/bin").expect("ok"),
+            Some("usr/bin/cmd/server/bin".to_string())
+        );
+        // Root prefix keeps the workspace-relative path.
+        assert_eq!(
+            dest_path(p, None, "").expect("ok"),
+            Some("cmd/server/bin".to_string())
+        );
+        // A strip that does not match is reported to the caller, which turns it
+        // into the empty-layer error rather than silently keeping the path.
+        assert_eq!(dest_path(p, Some("other"), "usr/bin").expect("ok"), None);
+    }
+
+    #[test]
+    fn whiteout_names_are_refused() {
+        assert!(reject_whiteout("usr/bin/server").is_ok());
+        let err = format!("{:#}", reject_whiteout("etc/.wh.passwd").expect_err("wh"));
+        assert!(err.contains("whiteout"), "got: {err}");
+    }
+
+    fn entry(dir: &Path, name: &str, body: &[u8], exec: bool) -> Entry {
+        let src = dir.join(name.replace('/', "_"));
+        std::fs::write(&src, body).expect("write");
+        if exec {
+            #[cfg(unix)]
+            {
+                use std::os::unix::fs::PermissionsExt as _;
+                std::fs::set_permissions(&src, std::fs::Permissions::from_mode(0o755))
+                    .expect("chmod");
+            }
+        }
+        Entry {
+            source: src,
+            dest: name.to_string(),
+            from: "//app:src".to_string(),
+        }
+    }
+
+    fn members(tar: &Path) -> Vec<(String, u32, u64)> {
+        let f = std::fs::File::open(tar).expect("open");
+        let mut ar = tar::Archive::new(f);
+        ar.entries()
+            .expect("entries")
+            .map(|e| {
+                let e = e.expect("entry");
+                let h = e.header();
+                (
+                    e.path().expect("path").to_string_lossy().into_owned(),
+                    h.mode().expect("mode"),
+                    h.mtime().expect("mtime"),
+                )
+            })
+            .collect()
+    }
+
+    /// The layer's bytes are its digest. Two runs from the same inputs must
+    /// produce the same file, and the mode must follow the executable bit and
+    /// nothing finer — a mode-preserving layer would differ between a cold run
+    /// and one served from cache, and between two umasks.
+    #[test]
+    fn layers_are_byte_stable_and_carry_only_the_exec_bit() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let entries = [
+            entry(dir.path(), "usr/bin/server", b"elf", true),
+            entry(dir.path(), "etc/app.conf", b"k=v", false),
+        ];
+        let mut sorted: Vec<&Entry> = entries.iter().collect();
+        sorted.sort_by(|a, b| a.dest.as_bytes().cmp(b.dest.as_bytes()));
+        let sorted: Vec<Entry> = sorted
+            .into_iter()
+            .map(|e| Entry {
+                source: e.source.clone(),
+                dest: e.dest.clone(),
+                from: e.from.clone(),
+            })
+            .collect();
+
+        let a = dir.path().join("a.tar");
+        let b = dir.path().join("b.tar");
+        write_layer(&a, &sorted, None).expect("a");
+        write_layer(&b, &sorted, None).expect("b");
+        assert_eq!(
+            std::fs::read(&a).expect("a"),
+            std::fs::read(&b).expect("b"),
+            "the same entries must produce the same layer bytes"
+        );
+
+        assert_eq!(
+            members(&a),
+            vec![
+                ("etc/app.conf".to_string(), 0o644, 0),
+                ("usr/bin/server".to_string(), 0o755, 0),
+            ],
+            "sorted by path, mtime zeroed, mode from the exec bit"
+        );
+
+        // A finer mode on the source is invisible: 0600 and 0644 are the same
+        // layer, which is what makes a cache-served rebuild reproduce.
+        #[cfg(unix)]
+        {
+            use std::os::unix::fs::PermissionsExt as _;
+            std::fs::set_permissions(&sorted[0].source, std::fs::Permissions::from_mode(0o600))
+                .expect("chmod");
+            let c = dir.path().join("c.tar");
+            write_layer(&c, &sorted, None).expect("c");
+            assert_eq!(
+                std::fs::read(&a).expect("a"),
+                std::fs::read(&c).expect("c"),
+                "only the executable bit may reach the layer"
+            );
+        }
+    }
+
+    /// A symlink must arrive as a symlink. Following it would silently duplicate
+    /// the target's bytes, or — for a link out of the layer — embed a file from
+    /// the sandbox that was never declared.
+    #[cfg(unix)]
+    #[test]
+    fn symlinks_are_preserved_not_followed() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        std::fs::write(dir.path().join("busybox"), b"bin").expect("write");
+        std::os::unix::fs::symlink("busybox", dir.path().join("sh")).expect("symlink");
+        let entries = vec![
+            Entry {
+                source: dir.path().join("busybox"),
+                dest: "bin/busybox".to_string(),
+                from: "//app:bb".to_string(),
+            },
+            Entry {
+                source: dir.path().join("sh"),
+                dest: "bin/sh".to_string(),
+                from: "//app:bb".to_string(),
+            },
+        ];
+        let out = dir.path().join("l.tar");
+        write_layer(&out, &entries, None).expect("write");
+
+        let f = std::fs::File::open(&out).expect("open");
+        let mut ar = tar::Archive::new(f);
+        let kinds: Vec<(String, tar::EntryType)> = ar
+            .entries()
+            .expect("entries")
+            .map(|e| {
+                let e = e.expect("entry");
+                (
+                    e.path().expect("path").to_string_lossy().into_owned(),
+                    e.header().entry_type(),
+                )
+            })
+            .collect();
+        assert_eq!(
+            kinds,
+            vec![
+                ("bin/busybox".to_string(), tar::EntryType::Regular),
+                ("bin/sh".to_string(), tar::EntryType::Symlink),
+            ]
+        );
+    }
+
+    /// An absolute symlink inside an image points at the *host* when the layer
+    /// is written and at the container's root when it is read — two different
+    /// files under one digest.
+    #[cfg(unix)]
+    #[test]
+    fn absolute_symlinks_are_refused() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        std::os::unix::fs::symlink("/etc/passwd", dir.path().join("p")).expect("symlink");
+        let entries = vec![Entry {
+            source: dir.path().join("p"),
+            dest: "etc/passwd".to_string(),
+            from: "//app:p".to_string(),
+        }];
+        let err = format!(
+            "{:#}",
+            write_layer(&dir.path().join("x.tar"), &entries, None).expect_err("absolute")
+        );
+        assert!(err.contains("absolute path"), "got: {err}");
+    }
+
+    /// The sort is on the raw bytes of the entry name, which is not the same
+    /// order `PathBuf` compares in — `a-b` and `a/b` swap between the two. Both
+    /// are deterministic, so only a test pins which one the layer uses.
+    #[test]
+    fn the_sort_key_is_the_entry_name_bytes() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let mut entries = vec![
+            entry(dir.path(), "a/b", b"1", false),
+            entry(dir.path(), "a.b", b"2", false),
+            entry(dir.path(), "a-b", b"3", false),
+        ];
+        entries.sort_by(|x, y| x.dest.as_bytes().cmp(y.dest.as_bytes()));
+        let out = dir.path().join("s.tar");
+        write_layer(&out, &entries, None).expect("write");
+        assert_eq!(
+            members(&out)
+                .into_iter()
+                .map(|(p, _, _)| p)
+                .collect::<Vec<_>>(),
+            vec!["a-b".to_string(), "a.b".to_string(), "a/b".to_string()],
+            "'-' (0x2D) < '.' (0x2E) < '/' (0x2F)"
+        );
+    }
+}

--- a/crates/plugin-oci/src/pluginoci/mod.rs
+++ b/crates/plugin-oci/src/pluginoci/mod.rs
@@ -23,6 +23,8 @@ use std::path::{Path, PathBuf};
 
 pub mod archive;
 pub mod docker_build;
+pub mod image;
+pub mod layer;
 pub mod load;
 pub mod platform;
 pub mod pull;

--- a/crates/plugin-oci/src/pluginoci/pull.rs
+++ b/crates/plugin-oci/src/pluginoci/pull.rs
@@ -310,16 +310,21 @@ impl ManagedDriver for Driver {
             .with_context(|| format!("out {:?} has no file name", def.out))?;
         let out_path = req.sandbox_pkg_dir.join(out_name);
 
-        let (index, blobs) = super::registry::pull_layout(&def.src, &def.platform, def.insecure)
-            .await
-            .with_context(|| format!("pull image {}", def.src))?;
+        // Blobs land here on their way out of the registry, outside the
+        // workspace dir so they are not collected as outputs. The sandbox is
+        // torn down after the run, so there is nothing to clean up.
+        let blob_dir = req.sandbox_dir.join("heph-oci-blobs");
+        let (index, blobs) =
+            super::registry::pull_layout(&def.src, &def.platform, def.insecure, &blob_dir)
+                .await
+                .with_context(|| format!("pull image {}", def.src))?;
 
         if def.layout {
             // A layout *directory* is the shape `docker_build`'s `bases` consumes:
             // buildx's `oci-layout://` reads a tree, not a tar.
-            super::archive::write_layout_dir(&out_path, &index, &blobs)
+            super::archive::write_layout_dir_blobs(&out_path, &index, &blobs)
         } else {
-            super::archive::write_layout_tar(&out_path, &index, &blobs)
+            super::archive::write_layout_tar_blobs(&out_path, &index, &blobs)
         }
         .with_context(|| format!("write the pulled image to {out_path:?}"))?;
 

--- a/crates/plugin-oci/src/pluginoci/registry.rs
+++ b/crates/plugin-oci/src/pluginoci/registry.rs
@@ -17,7 +17,45 @@ use oci_client::manifest::OciImageIndex;
 use oci_client::secrets::RegistryAuth;
 use oci_client::{Client, Reference};
 
-use super::archive::Layout;
+use super::archive::{Blob, Layout};
+
+/// How much of a blob is read at a time on its way to the registry. Bounded so
+/// a layer's size never becomes the driver's peak memory.
+const PUSH_CHUNK: usize = 512 * 1024;
+
+/// A blob as a chunked byte stream, read lazily off disk.
+///
+/// `push_blob` takes the whole blob as one `Bytes`; `push_blob_stream` takes
+/// this instead, which is what keeps a multi-gigabyte layer out of memory.
+fn blob_stream(
+    blob: &Blob,
+) -> anyhow::Result<impl futures::Stream<Item = oci_client::errors::Result<bytes::Bytes>>> {
+    let mut reader = blob.reader()?;
+    Ok(futures::stream::poll_fn(move |_| {
+        let mut buf = vec![0u8; PUSH_CHUNK];
+        let mut filled = 0;
+        // `read` is free to return short; keep going until the chunk is full or
+        // the blob ends, so the registry sees uniform chunks.
+        while let Some(rest) = buf.get_mut(filled..).filter(|r| !r.is_empty()) {
+            match std::io::Read::read(&mut reader, rest) {
+                Ok(0) => break,
+                Ok(n) => filled += n,
+                Err(e) => {
+                    return std::task::Poll::Ready(Some(Err(
+                        oci_client::errors::OciDistributionError::GenericError(Some(format!(
+                            "read blob: {e}"
+                        ))),
+                    )));
+                }
+            }
+        }
+        if filled == 0 {
+            return std::task::Poll::Ready(None);
+        }
+        buf.truncate(filled);
+        std::task::Poll::Ready(Some(Ok(bytes::Bytes::from(buf))))
+    }))
+}
 
 /// Build a client for `insecure` (plain HTTP / self-signed) or the default TLS.
 fn client(insecure: bool) -> Client {
@@ -97,9 +135,11 @@ pub(crate) async fn push_layout(
             {
                 continue;
             }
-            let bytes = layout.blob(&digest)?.clone();
+            // Streamed off disk in chunks, never read whole: a layer is the
+            // largest thing this plugin touches, and `push_blob` would want it
+            // as one `Bytes`.
             client
-                .push_blob(&reference, bytes, &digest)
+                .push_blob_stream(&reference, blob_stream(layout.blob(&digest)?)?, &digest)
                 .await
                 .with_context(|| format!("push blob {digest}"))?;
         }
@@ -108,7 +148,7 @@ pub(crate) async fn push_layout(
         // exactly what it receives, and serde will not reproduce byte-for-byte
         // what buildx wrote (key order, spacing). Re-encoding gets
         // DIGEST_INVALID.
-        let raw = layout.blob(digest)?;
+        let raw = layout.blob_bytes(digest)?;
         client
             .push_manifest_raw(
                 &reference,
@@ -173,7 +213,8 @@ pub(crate) async fn pull_layout(
     reference: &str,
     platforms: &super::pull::PlatformSelect,
     insecure: bool,
-) -> anyhow::Result<(OciImageIndex, std::collections::HashMap<String, Vec<u8>>)> {
+    blob_dir: &std::path::Path,
+) -> anyhow::Result<(OciImageIndex, super::archive::Blobs)> {
     let reference: Reference = reference
         .parse()
         .with_context(|| format!("parse image reference {reference:?}"))?;
@@ -191,20 +232,22 @@ pub(crate) async fn pull_layout(
         .await
         .with_context(|| format!("pull the manifest of {reference}"))?;
 
-    let mut blobs = std::collections::HashMap::new();
+    std::fs::create_dir_all(blob_dir)
+        .with_context(|| format!("create the blob staging dir {blob_dir:?}"))?;
+    let mut blobs = super::archive::Blobs::new();
 
     // An index: choose among its instances. A bare manifest: there is nothing to
     // choose, and asking for a platform it does not advertise would be pedantry.
     let entries = match serde_json::from_slice::<OciImageIndex>(&raw) {
         Ok(index) if !index.manifests.is_empty() => {
-            blobs.insert(digest.clone(), raw.to_vec());
+            blobs.insert(digest.clone(), Blob::Bytes(raw.to_vec()));
             select_entries(&index, platforms)?
         }
         _ => {
             let manifest: oci_client::manifest::OciImageManifest =
                 serde_json::from_slice(&raw).context("parse image manifest")?;
-            blobs.insert(digest.clone(), raw.to_vec());
-            pull_one(&client, &reference, &auth, &manifest, &mut blobs).await?;
+            blobs.insert(digest.clone(), Blob::Bytes(raw.to_vec()));
+            pull_one(&client, &reference, &manifest, blob_dir, &mut blobs).await?;
             let index = OciImageIndex {
                 schema_version: 2,
                 media_type: Some(oci_client::manifest::OCI_IMAGE_INDEX_MEDIA_TYPE.to_string()),
@@ -238,8 +281,8 @@ pub(crate) async fn pull_layout(
             .with_context(|| format!("pull the manifest for {}", entry.digest))?;
         let manifest: oci_client::manifest::OciImageManifest =
             serde_json::from_slice(&raw).context("parse a platform's manifest")?;
-        blobs.insert(entry.digest.clone(), raw.to_vec());
-        pull_one(&client, &reference, &auth, &manifest, &mut blobs).await?;
+        blobs.insert(entry.digest.clone(), Blob::Bytes(raw.to_vec()));
+        pull_one(&client, &reference, &manifest, blob_dir, &mut blobs).await?;
     }
 
     let index = OciImageIndex {
@@ -291,14 +334,28 @@ fn select_entries(
     Ok(out)
 }
 
-/// Fetch one manifest's config and layers into `blobs`.
+/// Fetch one manifest's config and layers, straight to disk.
+///
+/// Streamed rather than pulled into a `Vec<u8>`: a pull's whole job is to
+/// produce an artifact on disk, and buffering every layer first meant a
+/// multi-gigabyte base image was resident in the plugin before a single byte of
+/// it was written.
+///
+/// The chunks are written with `std::fs`, not `tokio::fs`, on purpose: a plugin
+/// cdylib's tokio is a separate runtime instance polled by host workers, so
+/// anything that reaches for a reactor or a blocking pool aborts across the ABI
+/// seam. Reading from the network is the host's socket; writing is a plain
+/// `write_all`.
 async fn pull_one(
     client: &Client,
     reference: &Reference,
-    _auth: &RegistryAuth,
     manifest: &oci_client::manifest::OciImageManifest,
-    blobs: &mut std::collections::HashMap<String, Vec<u8>>,
+    blob_dir: &std::path::Path,
+    blobs: &mut super::archive::Blobs,
 ) -> anyhow::Result<()> {
+    use futures::StreamExt as _;
+    use std::io::Write as _;
+
     let mut wanted = vec![manifest.config.digest.clone()];
     wanted.extend(manifest.layers.iter().map(|l| l.digest.clone()));
     for digest in wanted {
@@ -307,12 +364,67 @@ async fn pull_one(
             // the same blob for every architecture that inherits it.
             continue;
         }
-        let mut buf = Vec::new();
-        client
-            .pull_blob(reference, digest.as_str(), &mut buf)
+        let path = blob_dir.join(digest.replace(':', "_"));
+        // Written to a temp name and renamed: the file is content-addressed by
+        // its digest and nothing re-verifies it, so an interrupted pull must not
+        // leave a truncated blob behind claiming to be the whole thing.
+        let tmp = path.with_extension("partial");
+        let mut file =
+            std::fs::File::create(&tmp).with_context(|| format!("create blob file {tmp:?}"))?;
+        let mut stream = client
+            .pull_blob_stream(reference, digest.as_str())
             .await
             .with_context(|| format!("pull blob {digest}"))?;
-        blobs.insert(digest, buf);
+        while let Some(chunk) = stream.next().await {
+            let chunk = chunk.with_context(|| format!("read blob {digest} from the registry"))?;
+            file.write_all(&chunk)
+                .with_context(|| format!("write blob {digest} to {tmp:?}"))?;
+        }
+        file.flush().with_context(|| format!("flush {tmp:?}"))?;
+        drop(file);
+        std::fs::rename(&tmp, &path)
+            .with_context(|| format!("move blob {tmp:?} into place at {path:?}"))?;
+        blobs.insert(digest, Blob::File(path));
     }
     Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use futures::StreamExt as _;
+
+    /// The upload path reads a blob in bounded chunks and reassembles to exactly
+    /// the original bytes.
+    ///
+    /// Only the docker-gated suite drives a real push, so without this the
+    /// chunking — off-by-one on the last partial chunk, a short `read` treated
+    /// as EOF — would be covered by nothing that runs on every push.
+    #[tokio::test]
+    async fn a_blob_streams_back_in_bounded_chunks() {
+        // Deliberately not a multiple of PUSH_CHUNK: the last chunk is partial,
+        // which is where a length bug shows up.
+        let len = PUSH_CHUNK * 2 + 7;
+        let data: Vec<u8> = (0..len).map(|i| (i % 251) as u8).collect();
+        let dir = tempfile::tempdir().expect("tempdir");
+        let path = dir.path().join("blob");
+        std::fs::write(&path, &data).expect("write");
+
+        for blob in [Blob::Bytes(data.clone()), Blob::File(path)] {
+            let mut stream = Box::pin(blob_stream(&blob).expect("stream"));
+            let mut chunks = Vec::new();
+            let mut got = Vec::new();
+            while let Some(chunk) = stream.next().await {
+                let chunk = chunk.expect("chunk");
+                chunks.push(chunk.len());
+                got.extend_from_slice(&chunk);
+            }
+            assert_eq!(got, data, "the stream must reassemble to the blob");
+            assert_eq!(
+                chunks,
+                vec![PUSH_CHUNK, PUSH_CHUNK, 7],
+                "full chunks, then the remainder — never a chunk past the end"
+            );
+        }
+    }
 }


### PR DESCRIPTION
Stacked on #159 (needs the `oci_image` → `docker_build` rename that landed there).

## What

Two drivers that build a container image from target outputs — no Dockerfile, no BuildKit, no daemon, no execution.

```python
oci_layer(name = "app", srcs = [":bin"], prefix = "/usr/bin")
oci_layer(name = "etc", srcs = [":conf"], prefix = "/etc")

oci_image(
    name = "img",
    base = ":alpine",                    # optional oci_pull(layout = True)
    layers = [":app", ":etc"],           # ordered, later wins
    platforms = ["linux/amd64", "linux/arm64"],
    entrypoint = ["/usr/bin/server"],
    env = {"PORT": "8080"},
)
```

Output is the same OCI layout `docker_build` emits, so `oci_push`, `oci_load` and `bases` consume it unchanged.

## Why

Not "avoids a daemon". **It is the only image rule whose cache key can cover what the build reads.** `docker_build`'s own docs concede the gap: the buildx version is unhashed, `FROM` is resolved by BuildKit from the network, `RUN` fetches whatever it fetches, secret *values* cannot be hashed. Here there is no host binary, no subprocess, no env var, no run-time network.

The docs scope that claim rather than overreach — a `base` is only as hermetic as the `oci_pull` behind it, and `oci_pull` keys on the ref string.

Second consequence: **cross-arch is free.** A layer is a file tree, so nothing executes for the target architecture. An arm64 Mac emits `linux/amd64` and `linux/arm64` in one run, no QEMU, same digests as CI.

## Cache-key hazards fixed here, not later

Three ways two different images would have shared one cache entry:

1. **`hashin` folds a sorted, unlabeled multiset of dep hashouts.** `layers = [":a", ":b"]` and the swap reach it identically — as do `base = ":a", layers = [":b"]` and its mirror, and `layers_by_platform` with its values swapped. The def hash carries the ordered, normalized addresses. (`docker_build`'s single `dockerfile = ":t"` role can safely omit its address — one occupant means any change moves that dep's hashout. An ordered list has no such property; the design's original "same rule as `dockerfile`" was the wrong generalization.)
2. **`inputs_result_meta` folds every output group regardless of the `|group` selector**, so `[":bin|release"]` and `[":bin|debug"]` were one key. The normalized address includes it.
3. **Modes cannot be preserved.** heph records one permission bit (`walk/cached_walker.rs`), the pack step normalizes to 0755/0644, and the sandbox mode then depends on the umask, on whether *another* target marked the dep read-only, and on a 1 MiB threshold choosing FUSE over unpack. Mode comes from the exec bit or an explicit hashed `mode`; setuid/setgid/sticky are rejected loudly.

## Reproducibility

mtime 0, uid/gid 0, empty uname/gname, entries sorted by raw path bytes, headers built by hand (`append_path` copies mtime/uid/gid/mode off the filesystem; `append_dir_all` walks in `read_dir` order). Config JSON goes through `serde_json`, whose Map is a `BTreeMap` here — `oci-spec`'s config uses `HashMap` for `Labels` and Rust's `RandomState` is seeded *per process*, so two runs on one machine would emit two byte orders. No `created`, no per-layer timestamps.

**Layers are uncompressed.** Spec-legal, and it keeps the layer digest out of the hands of whichever deflate backend cargo's feature resolution picks — a swap to zlib-ng would otherwise move every layer digest in every cache with no code change. It also stops gzipping bytes the remote cache is about to gzip again.

## Silent failures made loud

Each with a test: empty layer (names what the srcs produced and which `strip` values would work), two entries mapping to one path, a `.wh.` whiteout name, an absolute symlink, a base with no matching platform, `platforms` unset. Symlinks are **preserved, not followed** — following one silently duplicates bytes or embeds an undeclared sandbox file.

## Memory

Layer blobs travel as file paths, never `Vec<u8>`, so an image is not held in memory once per concurrent target. Blobs are written to a temp name and renamed: a blob's *filename asserts a digest* and nothing re-verifies it, so a Ctrl-C mid-write would otherwise leave a truncated file served from cache forever.

## Tests

- 12 unit tests in `plugin-oci` (layer determinism, sort key, symlinks, modes, def-hash collisions, config merge matrix, canonical encoding)
- 9 engine e2e in `crates/e2e/tests/oci_image.rs`, **none gated on docker** — that is the feature
- a frozen manifest digest, which CI's three native targets turn into the cross-platform reproducibility guarantee. Two runs on one machine share a filesystem, a umask and an architecture — where the interesting divergences live.

## Design

Four design-stage agent consults (`product-vision`, `feature-quality`, `hermeticity`, `compatibility`) shaped this. Three calls were the user's: rename `oci_image` → `docker_build` (in #159), `platforms` required with no default, and the `DirPath` sort fix as its own PR (#377).

Not in scope, documented: no `RUN`, no whiteouts/deletions, no hardlinks, gzip layers.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WqQZxsTqanJRWLWdPSchBo