### PR TITLE
feat(group): filter and relocate outputs without copying them

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -867,6 +867,7 @@ dependencies = [
  "tempfile",
  "tokio",
  "tracing",
+ "wax",
  "xxhash-rust",
 ]
 

--- a/crates/builtins/src/plugingroup/mod.rs
+++ b/crates/builtins/src/plugingroup/mod.rs
@@ -677,6 +677,7 @@ mod tests {
                     kind: hcore::hartifactcontent::WalkEntryKind::File {
                         data: Box::new(std::io::Cursor::new(Vec::new())),
                         x: false,
+                        size: 0,
                     },
                 })
             })))

--- a/crates/builtins/src/plugingroup/mod.rs
+++ b/crates/builtins/src/plugingroup/mod.rs
@@ -1,11 +1,47 @@
+//! The `group` driver: re-export other targets' outputs, optionally filtered
+//! and relocated.
+//!
+//! A group has two modes, and which one it is in follows from its config alone:
+//!
+//! * **Aggregate** (no transform configured) — the group is `transparent`, and
+//!   the engine splices its members straight into each consumer's input list.
+//!   It never executes and never produces an artifact of its own. This is the
+//!   original behaviour and stays byte-for-byte what it was.
+//!
+//! * **Filter/relocate** (any of `include`/`exclude`/`strip_prefix`/`prefix`/
+//!   `rename` set) — the group becomes a real target that produces
+//!   [`ContentView`] artifacts: zero-copy windows onto its deps' artifacts with
+//!   rewritten paths. It is marked uncacheable, so no revision, no blob, and no
+//!   remote push is ever created for it; the deps stay cached exactly as
+//!   before, and the group is re-derived from a path list on each build.
+//!
+//! The alternative — an exec target running `cp` — costs a sandbox, a
+//! subprocess, and a second full copy of every byte in both the local and the
+//! remote cache. This costs a few string operations.
+//!
+//! It cannot stay `transparent` in the second mode. A transparent target is
+//! expanded away *before* `hashin` is computed, so its config never reaches a
+//! consumer's cache key — membership changes are caught only because they
+//! change which dep hashouts get folded in. A path transform changes no dep's
+//! hashout, so a transparent one would be invisible to the cache and a consumer
+//! would happily reuse an entry built against the pre-relocation layout. Being
+//! a real target is what puts the transform in the consumer's key, via the
+//! group's own def hash and its artifacts' derived hashouts.
+
 use anyhow::Context as _;
 use async_trait::async_trait;
+use hcore::hartifactcontent::{
+    Content as _, PathTransform, Rename, RenamePlan, SourcePaths, ViewContent,
+};
 use hcore::hasync::Cancellable;
 use hplugin::driver::TargetAddr;
 use hplugin::driver::{
     ApplyTransitiveRequest, ApplyTransitiveResponse, ConfigRequest, ConfigResponse, ParseRequest,
-    ParseResponse, RunRequest, RunResponse,
-    targetdef::{CacheConfig, Input, InputMode, TargetDef},
+    ParseResponse, RunRequest, RunResponse, outputartifact,
+    targetdef::{
+        CacheConfig, Input, InputMode, Output, TargetDef,
+        path::{CodegenMode, Content as PathContent, Path},
+    },
 };
 use hplugin::htspec::Spec;
 use std::sync::Arc;
@@ -19,10 +55,66 @@ pub const DRIVER_NAME: &str = "group";
 struct GroupSpec {
     /// Target addresses this group aggregates; the group re-exports their outputs.
     deps: Vec<String>,
+    /// Glob patterns an output path must match to be re-exported, written the way
+    /// the producing package declares them (`**/*.so`). Empty re-exports everything.
+    include: Vec<String>,
+    /// Glob patterns that drop an output path. Applied after `include`.
+    exclude: Vec<String>,
+    /// Leading directory stripped from re-exported paths, written the way the
+    /// producing package declares it (`build/out`).
+    #[spec(ty = hcore::htvalue::signature::ParamType::String)]
+    strip_prefix: Option<String>,
+    /// Leading directory prepended to re-exported paths (e.g. `lib`).
+    #[spec(ty = hcore::htvalue::signature::ParamType::String)]
+    prefix: Option<String>,
+    /// Where selected outputs are placed. A string (`"bin/myserver"`) renames the
+    /// single output surviving `include`/`exclude`, so you never name a source
+    /// path; it cannot be combined with `strip_prefix`/`prefix`. A dict maps exact
+    /// emitted paths to destinations.
+    rename: Rename,
+}
+
+impl GroupSpec {
+    fn transform(&self) -> anyhow::Result<PathTransform> {
+        let t = PathTransform {
+            include: self.include.clone(),
+            exclude: self.exclude.clone(),
+            strip_prefix: self.strip_prefix.clone(),
+            prefix: self.prefix.clone(),
+            rename: self.rename.clone(),
+        };
+        // A string `rename` fixes the destination outright, so a
+        // `strip_prefix`/`prefix` alongside it would be computed and thrown
+        // away. Rejecting the combination is clearer than silently ignoring
+        // half the config. (The dict form is fine with them: it places the
+        // paths it names, and the prefixes place the rest.)
+        if t.prefixes_are_dead_config() {
+            anyhow::bail!(
+                "a string `rename` sets the destination outright and cannot be combined \
+                 with `strip_prefix`/`prefix` — drop those, or use the dict form of \
+                 `rename` so the prefixes still place everything else"
+            );
+        }
+        Ok(t)
+    }
 }
 
 #[derive(serde::Serialize)]
-struct GroupDef;
+struct GroupDef {
+    transform: PathTransform,
+}
+
+/// The package of the target that produced this input's artifact.
+///
+/// Handed to every [`ViewContent`] so transform patterns can be written the way
+/// the *producing* BUILD file writes them (`build/out/server`) rather than the
+/// way heph emits them (`app/build/out/server`) — see [`SourcePaths`]. An
+/// author writing a group has no reason to know a dep's emitted layout, and
+/// that layout changes if the dep ever moves package.
+fn dep_package(input: &hplugin::driver::RunInput) -> Option<String> {
+    let pkg = input.source_addr.package.as_str();
+    (!pkg.is_empty()).then(|| pkg.to_string())
+}
 
 pub struct Driver;
 
@@ -43,9 +135,9 @@ impl hplugin::driver::Driver for Driver {
         req: ParseRequest,
         _ctoken: &(dyn Cancellable + Send + Sync),
     ) -> anyhow::Result<ParseResponse> {
-        let deps = GroupSpec::from(&req.target_spec.config)
-            .context("parse group config")?
-            .deps;
+        let spec = GroupSpec::from(&req.target_spec.config).context("parse group config")?;
+        let transform = spec.transform().context("group config")?;
+        let deps = spec.deps;
 
         let pkg = req.target_spec.addr.package.clone();
         let inputs = deps
@@ -70,20 +162,74 @@ impl hplugin::driver::Driver for Driver {
         for d in &deps {
             h.update(d.as_bytes());
         }
+        // Folded into the def hash, which is folded into every consumer's
+        // `hashin`. This is what makes changing a `prefix` invalidate the
+        // targets that depend on this group — nothing else would, because a
+        // transform changes no dep's hashout. Written only when non-identity so
+        // the digest of an ordinary aggregate group is byte-identical to what
+        // it was before transforms existed, and no cached revision is
+        // invalidated by this feature landing.
+        let relocating = !transform.is_identity();
+        if relocating {
+            use std::hash::Hash as _;
+            struct Fold<'a>(&'a mut Xxh3);
+            impl std::hash::Hasher for Fold<'_> {
+                fn write(&mut self, bytes: &[u8]) {
+                    self.0.update(bytes);
+                }
+                fn finish(&self) -> u64 {
+                    self.0.digest()
+                }
+            }
+            h.update(b"\0group-transform-v1\0");
+            let mut fold = Fold(&mut h);
+            transform.hash(&mut fold);
+        }
         let hash = format!("{:016x}", h.digest()).into_bytes();
+
+        // A relocating group is a real target (see the module docs for why it
+        // cannot stay transparent), so it must declare an output group for
+        // consumers to select. The declared paths are descriptive only — what
+        // it actually emits is decided at run time from its deps' artifacts —
+        // so they mirror the `include` patterns, or `**` when everything is
+        // re-exported.
+        let outputs = if relocating {
+            let patterns = if transform.include.is_empty() {
+                vec!["**".to_string()]
+            } else {
+                transform.include.clone()
+            };
+            vec![Output {
+                group: String::new(),
+                paths: patterns
+                    .into_iter()
+                    .map(|p| Path {
+                        content: PathContent::Glob(p),
+                        codegen_tree: CodegenMode::None,
+                        collect: false,
+                    })
+                    .collect(),
+            }]
+        } else {
+            vec![]
+        };
 
         Ok(ParseResponse {
             target_def: TargetDef {
                 addr: req.target_spec.addr.clone(),
                 labels: req.target_spec.labels.clone(),
-                raw_def: Arc::new(GroupDef),
+                raw_def: Arc::new(GroupDef { transform }),
                 inputs,
-                outputs: vec![],
+                outputs,
                 support_files: vec![],
+                // Off in both modes, for different reasons: an aggregate group
+                // has nothing of its own to cache, and a relocating one owns no
+                // bytes — its artifacts borrow its deps'. See `is_passthrough`
+                // in the engine.
                 cache: CacheConfig::off(),
                 pty: false,
                 hash,
-                transparent: true,
+                transparent: !relocating,
             },
         })
     }
@@ -98,14 +244,125 @@ impl hplugin::driver::Driver for Driver {
         })
     }
 
+    /// Build one zero-copy [`ViewContent`] per input artifact.
+    ///
+    /// No sandbox is created and no bytes are read: the transform is resolved
+    /// against each artifact's path list (a header-only scan for a tar-backed
+    /// cache artifact), and the resulting `Content` forwards file data by
+    /// handle when a consumer eventually materializes it.
     async fn run<'a, 'io>(
         &self,
-        _req: RunRequest<'a, 'io>,
+        req: RunRequest<'a, 'io>,
         _ctoken: &(dyn Cancellable + Send + Sync),
     ) -> anyhow::Result<RunResponse> {
-        anyhow::bail!(
-            "group driver run() must never be called — groups are inlined before execution"
-        )
+        // `def` (in-process downcast), not `def_de`: `group` is a built-in
+        // driver and its def never crosses the plugin ABI — a view could not
+        // survive the trip anyway.
+        let transform = &req.target.def::<GroupDef>().transform;
+        if transform.is_identity() {
+            anyhow::bail!(
+                "group driver run() must never be called for an aggregate group — \
+                 groups with no include/exclude/strip_prefix/prefix/rename are \
+                 inlined before execution"
+            );
+        }
+
+        // Typo/ambiguity check over the union of every dep's paths, not per
+        // artifact: a `strip_prefix` that applies to one dep and not another is
+        // legitimate (only one matching *nothing at all* is a mistake), and a
+        // `rename` key is ambiguous only relative to every path in play.
+        let mut sources = Vec::with_capacity(req.inputs.len());
+        for input in &req.inputs {
+            if matches!(input.artifact.r#type, hplugin::driver::inputartifact::Type::Dep) {
+                sources.push(SourcePaths::new(
+                    dep_package(input),
+                    input
+                        .artifact
+                        .content
+                        .entry_paths()
+                        .with_context(|| format!("listing paths of dep '{}'", input.source_addr))?,
+                ));
+            }
+        }
+        let plan = transform
+            .plan(&sources)
+            .with_context(|| format!("group {}", req.target.addr.format()))?;
+
+        let mut artifacts = Vec::with_capacity(req.inputs.len());
+        for (i, input) in req.inputs.iter().enumerate() {
+            match input.artifact.r#type {
+                // Support files are an all-or-nothing per-dep set that
+                // materializes *alongside* an output group rather than as part
+                // of it, so the transform does not apply to them; they are
+                // re-exported as they are.
+                hplugin::driver::inputartifact::Type::Support => {
+                    // Wrapped in an identity view rather than passed through
+                    // raw: `Content::View` is what marks an artifact as
+                    // borrowing bytes it does not own, which is what keeps it
+                    // out of the cache. The transform is empty, so every path
+                    // is preserved.
+                    let view = Arc::new(ViewContent::new(
+                        Arc::clone(&input.artifact.content),
+                        PathTransform::default(),
+                        dep_package(input),
+                        RenamePlan::default(),
+                    ));
+                    // Read off the view, not the source: the engine swaps this
+                    // artifact's content for the `ViewContent` itself on the
+                    // passthrough path, so the recorded hashout must be the one
+                    // that content answers with, or the parent's `hashin` would
+                    // be keyed on a value nothing else agrees with.
+                    let hashout = view.hashout().with_context(|| {
+                        format!("hashout of support artifact from '{}'", input.source_addr)
+                    })?;
+                    artifacts.push(outputartifact::OutputArtifact {
+                        group: String::new(),
+                        name: format!("support_{i}"),
+                        r#type: outputartifact::Type::SupportFile,
+                        hashout,
+                        content: outputartifact::Content::View(outputartifact::ContentView {
+                            view,
+                        }),
+                    });
+                }
+                hplugin::driver::inputartifact::Type::Dep => {
+                    let view = Arc::new(ViewContent::new(
+                        Arc::clone(&input.artifact.content),
+                        transform.clone(),
+                        dep_package(input),
+                        plan.clone(),
+                    ));
+                    // Resolving here surfaces a collision as a failure of *this*
+                    // target, naming the group, rather than as a confusing
+                    // staging error inside whichever consumer happened to
+                    // materialize it first.
+                    view.mapping().with_context(|| {
+                        format!(
+                            "applying group {} transform to outputs of '{}'",
+                            req.target.addr.format(),
+                            input.source_addr
+                        )
+                    })?;
+                    let hashout = view.hashout().with_context(|| {
+                        format!("hashout of view over '{}'", input.source_addr)
+                    })?;
+                    artifacts.push(outputartifact::OutputArtifact {
+                        group: String::new(),
+                        name: format!("view_{i}"),
+                        r#type: outputartifact::Type::Output,
+                        hashout,
+                        content: outputartifact::Content::View(outputartifact::ContentView {
+                            view,
+                        }),
+                    });
+                }
+            }
+        }
+
+        Ok(RunResponse {
+            artifacts,
+            ..Default::default()
+        })
     }
 
     async fn run_shell<'a, 'io>(
@@ -143,19 +400,31 @@ mod tests {
         }
     }
 
+    /// Every config key `GroupSpec::from` understands must appear in the LSP
+    /// schema, so the parser and the completion list are caught drifting apart.
     #[test]
-    fn test_schema_lists_deps() {
+    fn test_schema_lists_every_config_key() {
         use hcore::htvalue::signature::ParamType;
         use hplugin::driver::Driver as _;
         let schema = Driver.schema();
-        assert_eq!(schema.fields.len(), 1);
-        let f = &schema.fields[0];
-        assert_eq!(f.name, "deps");
-        assert_eq!(
-            f.ty,
-            ParamType::union(vec![ParamType::String, ParamType::list(ParamType::String)])
-        );
-        assert!(!f.doc.is_empty());
+        let by_name: HashMap<&str, &hplugin::driver::DriverField> =
+            schema.fields.iter().map(|f| (f.name.as_str(), f)).collect();
+        for key in [
+            "deps",
+            "include",
+            "exclude",
+            "strip_prefix",
+            "prefix",
+            "rename",
+        ] {
+            assert!(by_name.contains_key(key), "schema missing field `{key}`");
+            assert!(!by_name[key].doc.is_empty(), "field `{key}` has no doc");
+        }
+        let str_or_list =
+            ParamType::union(vec![ParamType::String, ParamType::list(ParamType::String)]);
+        assert_eq!(by_name["deps"].ty, str_or_list);
+        assert_eq!(by_name["include"].ty, str_or_list);
+        assert_eq!(by_name["strip_prefix"].ty, ParamType::String);
     }
 
     #[tokio::test]
@@ -244,5 +513,416 @@ mod tests {
             .hash;
 
         assert_ne!(empty, with_dep);
+    }
+
+    // ---- filter / relocate mode ----
+
+    fn deps_value(addrs: &[&str]) -> Value {
+        Value::List(
+            addrs
+                .iter()
+                .map(|a| Value::String((*a).to_string()))
+                .collect(),
+        )
+    }
+
+    async fn parse_group(extra: &[(&str, Value)]) -> TargetDef {
+        let mut config = HashMap::from([("deps".to_string(), deps_value(&["//pkg:a"]))]);
+        for (k, v) in extra {
+            config.insert((*k).to_string(), v.clone());
+        }
+        Driver
+            .parse(make_parse_req("//pkg:g", config), &ctoken())
+            .await
+            .expect("parse")
+            .target_def
+    }
+
+    /// The no-regression guard: a group without a transform must stay exactly
+    /// what it was — transparent, no declared outputs, never executed.
+    #[tokio::test]
+    async fn aggregate_group_stays_transparent() {
+        let def = parse_group(&[]).await;
+        assert!(def.transparent, "aggregate group must stay transparent");
+        assert!(def.outputs.is_empty());
+        assert!(!def.cache.enabled);
+    }
+
+    /// ...and its def hash must be byte-identical to the pre-transform digest,
+    /// so shipping this feature invalidates no existing cached revision.
+    #[tokio::test]
+    async fn aggregate_group_hash_is_unchanged_by_the_feature() {
+        let def = parse_group(&[]).await;
+        let mut h = Xxh3::new();
+        h.update(b"//pkg:g");
+        h.update(b"//pkg:a");
+        let expected = format!("{:016x}", h.digest()).into_bytes();
+        assert_eq!(
+            def.hash, expected,
+            "an aggregate group's def hash must not move when transforms exist"
+        );
+    }
+
+    /// A transform makes the group a real target: it can no longer be inlined,
+    /// because inlining would drop the transform out of consumers' cache keys.
+    #[tokio::test]
+    async fn transform_makes_the_group_non_transparent_and_uncacheable() {
+        for (key, value) in [
+            ("include", Value::List(vec![Value::String("**/*.so".into())])),
+            ("exclude", Value::List(vec![Value::String("**/x".into())])),
+            ("strip_prefix", Value::String("build/out".into())),
+            ("prefix", Value::String("lib".into())),
+            (
+                "rename",
+                Value::Map(HashMap::from([("a".to_string(), Value::String("b".into()))])),
+            ),
+        ] {
+            let def = parse_group(&[(key, value)]).await;
+            assert!(!def.transparent, "`{key}` must make the group concrete");
+            assert!(
+                !def.cache.enabled,
+                "`{key}` group owns no bytes and must stay uncacheable"
+            );
+            assert_eq!(def.outputs.len(), 1, "`{key}` must declare an output group");
+            assert_eq!(def.outputs[0].group, "");
+        }
+    }
+
+    /// The cache-key property this whole design rests on: change a transform,
+    /// and the group's def hash moves — which is what propagates into every
+    /// consumer's `hashin`.
+    #[tokio::test]
+    async fn transform_is_folded_into_the_def_hash() {
+        let base = parse_group(&[]).await.hash;
+        let lib = parse_group(&[("prefix", Value::String("lib".into()))])
+            .await
+            .hash;
+        let bin = parse_group(&[("prefix", Value::String("bin".into()))])
+            .await
+            .hash;
+        let lib_again = parse_group(&[("prefix", Value::String("lib".into()))])
+            .await
+            .hash;
+
+        assert_ne!(base, lib, "adding a transform must change the def hash");
+        assert_ne!(lib, bin, "changing a transform must change the def hash");
+        assert_eq!(lib, lib_again, "the same transform must hash stably");
+    }
+
+    /// `rename` is a dict, so its iteration order is not stable; the def hash
+    /// must not depend on it or a target would spuriously miss cache.
+    #[tokio::test]
+    async fn rename_hash_is_independent_of_map_order() {
+        let a = parse_group(&[(
+            "rename",
+            Value::Map(HashMap::from([
+                ("x".to_string(), Value::String("1".into())),
+                ("y".to_string(), Value::String("2".into())),
+            ])),
+        )])
+        .await
+        .hash;
+        let b = parse_group(&[(
+            "rename",
+            Value::Map(HashMap::from([
+                ("y".to_string(), Value::String("2".into())),
+                ("x".to_string(), Value::String("1".into())),
+            ])),
+        )])
+        .await
+        .hash;
+        assert_eq!(a, b);
+    }
+
+    #[tokio::test]
+    async fn include_patterns_are_reflected_in_declared_outputs() {
+        let def = parse_group(&[(
+            "include",
+            Value::List(vec![Value::String("bin/**".into())]),
+        )])
+        .await;
+        let PathContent::Glob(ref g) = def.outputs[0].paths[0].content else {
+            panic!("expected a glob path, got {:?}", def.outputs[0].paths[0]);
+        };
+        assert_eq!(g, "bin/**");
+    }
+
+    #[tokio::test]
+    async fn aggregate_group_run_is_still_a_hard_error() {
+        let def = parse_group(&[]).await;
+        let err = run_group_err(&def, &[]).await;
+        assert!(
+            format!("{err:#}").contains("inlined before execution"),
+            "{err:#}"
+        );
+    }
+
+    // A minimal in-memory `Content` standing in for a dep's cached artifact.
+    struct FakeArtifact {
+        paths: Vec<String>,
+    }
+
+    impl hcore::hartifactcontent::Content for FakeArtifact {
+        fn reader(&self) -> anyhow::Result<Box<dyn std::io::Read>> {
+            anyhow::bail!("not used")
+        }
+        fn walk(
+            &self,
+        ) -> anyhow::Result<
+            Box<dyn Iterator<Item = anyhow::Result<hcore::hartifactcontent::WalkEntry>> + '_>,
+        > {
+            Ok(Box::new(self.paths.iter().map(|p| {
+                Ok(hcore::hartifactcontent::WalkEntry {
+                    path: std::path::PathBuf::from(p),
+                    kind: hcore::hartifactcontent::WalkEntryKind::File {
+                        data: Box::new(std::io::Cursor::new(Vec::new())),
+                        x: false,
+                    },
+                })
+            })))
+        }
+        fn hashout(&self) -> anyhow::Result<String> {
+            Ok("dephash".to_string())
+        }
+        fn entry_paths(&self) -> anyhow::Result<Vec<std::path::PathBuf>> {
+            Ok(self
+                .paths
+                .iter()
+                .map(std::path::PathBuf::from)
+                .collect())
+        }
+    }
+
+    async fn run_group(def: &TargetDef, dep_paths: &[&[&str]]) -> anyhow::Result<RunResponse> {
+        let inputs: Vec<hplugin::driver::RunInput> = dep_paths
+            .iter()
+            .enumerate()
+            .map(|(i, paths)| hplugin::driver::RunInput {
+                artifact: hplugin::driver::inputartifact::InputArtifact {
+                    r#type: hplugin::driver::inputartifact::Type::Dep,
+                    origin_id: format!("dep{i}"),
+                    content: Arc::new(FakeArtifact {
+                        paths: paths.iter().map(|s| (*s).to_string()).collect(),
+                    }),
+                },
+                origin_id: format!("dep{i}"),
+                source_addr: parse_addr("//pkg:a").expect("addr"),
+                filters: vec![],
+                annotations: Default::default(),
+            })
+            .collect();
+
+        Driver
+            .run(
+                RunRequest {
+                    request_id: &"test".to_string(),
+                    target: def,
+                    tree_root_path: Default::default(),
+                    inputs,
+                    hashin: "hashin",
+                    stdin: None,
+                    stdout: None,
+                    stderr: None,
+                    sandbox_dir: Default::default(),
+                },
+                &ctoken(),
+            )
+            .await
+    }
+
+    /// `RunResponse` has no `Debug`, so `expect_err` is unavailable.
+    async fn run_group_err(def: &TargetDef, dep_paths: &[&[&str]]) -> anyhow::Error {
+        match run_group(def, dep_paths).await {
+            Ok(_) => panic!("expected an error, got Ok"),
+            Err(e) => e,
+        }
+    }
+
+    #[tokio::test]
+    async fn run_produces_a_view_artifact_with_rewritten_paths() {
+        let def = parse_group(&[
+            ("strip_prefix", Value::String("build/out".into())),
+            ("prefix", Value::String("lib".into())),
+        ])
+        .await;
+        let resp = run_group(&def, &[&["build/out/server", "build/out/a/b.so"]])
+            .await
+            .expect("run");
+
+        assert_eq!(resp.artifacts.len(), 1);
+        let art = &resp.artifacts[0];
+        assert!(
+            matches!(art.content, outputartifact::Content::View(_)),
+            "must produce a zero-copy view, not a packed artifact"
+        );
+        let mut paths: Vec<String> = hcore::hartifactcontent::Content::entry_paths(art)
+            .expect("entry paths")
+            .iter()
+            .map(|p| p.to_string_lossy().into_owned())
+            .collect();
+        paths.sort();
+        assert_eq!(paths, vec!["lib/a/b.so", "lib/server"]);
+    }
+
+    /// The artifact hashout must reflect the transform, since that is what
+    /// carries the relocation into a consumer's input hash.
+    #[tokio::test]
+    async fn run_artifact_hashout_tracks_the_transform() {
+        let lib = parse_group(&[("prefix", Value::String("lib".into()))]).await;
+        let bin = parse_group(&[("prefix", Value::String("bin".into()))]).await;
+
+        let a = run_group(&lib, &[&["x"]]).await.expect("run").artifacts[0]
+            .hashout
+            .clone();
+        let b = run_group(&bin, &[&["x"]]).await.expect("run").artifacts[0]
+            .hashout
+            .clone();
+
+        assert_ne!(a, b);
+        assert_ne!(a, "dephash", "must not inherit the dep's hashout");
+    }
+
+    /// The string form is a transform like any other: it makes the group
+    /// concrete so it reaches consumers' cache keys.
+    #[tokio::test]
+    async fn string_rename_makes_the_group_concrete() {
+        let def = parse_group(&[("rename", Value::String("bin/myserver".into()))]).await;
+        assert!(!def.transparent);
+        assert!(!def.cache.enabled);
+    }
+
+    /// `rename` as a string fixes the destination, so a prefix alongside it
+    /// would be computed and discarded — rejected rather than silently dropped.
+    #[tokio::test]
+    async fn string_rename_with_a_prefix_is_rejected() {
+        let config = HashMap::from([
+            ("deps".to_string(), deps_value(&["//pkg:a"])),
+            ("rename".to_string(), Value::String("bin/s".into())),
+            ("prefix".to_string(), Value::String("lib".into())),
+        ]);
+        // `ParseResponse` has no `Debug`, so `expect_err` is unavailable.
+        let err = match Driver.parse(make_parse_req("//pkg:g", config), &ctoken()).await {
+            Ok(_) => panic!("must reject dead prefix config"),
+            Err(e) => e,
+        };
+        let msg = format!("{err:#}");
+        assert!(msg.contains("strip_prefix"), "{msg}");
+    }
+
+    /// The dict form coexists with prefixes: it places what it names and the
+    /// prefixes place everything else.
+    #[tokio::test]
+    async fn dict_rename_with_a_prefix_is_allowed() {
+        let config = HashMap::from([
+            ("deps".to_string(), deps_value(&["//pkg:a"])),
+            (
+                "rename".to_string(),
+                Value::Map(HashMap::from([(
+                    "a/x".to_string(),
+                    Value::String("out/x".into()),
+                )])),
+            ),
+            ("prefix".to_string(), Value::String("lib".into())),
+        ]);
+        let def = Driver
+            .parse(make_parse_req("//pkg:g", config), &ctoken())
+            .await
+            .expect("dict rename must coexist with a prefix")
+            .target_def;
+        assert!(!def.transparent);
+    }
+
+    /// The point of the string form: the author writes only a destination, and
+    /// it applies to the dep's single output wherever that output lives.
+    #[tokio::test]
+    async fn string_rename_places_the_sole_output_without_naming_it() {
+        let def = parse_group(&[("rename", Value::String("bin/myserver".into()))]).await;
+        let resp = run_group(&def, &[&["build/out/server"]]).await.expect("run");
+        let paths: Vec<String> = hcore::hartifactcontent::Content::entry_paths(&resp.artifacts[0])
+            .expect("entry paths")
+            .iter()
+            .map(|p| p.to_string_lossy().into_owned())
+            .collect();
+        assert_eq!(paths, vec!["bin/myserver"]);
+    }
+
+    /// Two candidate outputs and one destination is a hard error naming both.
+    #[tokio::test]
+    async fn string_rename_with_two_outputs_is_rejected() {
+        let def = parse_group(&[("rename", Value::String("bin/s".into()))]).await;
+        let err = run_group_err(&def, &[&["a/server", "b/server"]]).await;
+        let msg = format!("{err:#}");
+        assert!(msg.contains("a/server"), "{msg}");
+        assert!(msg.contains("b/server"), "{msg}");
+        assert!(msg.contains("//pkg:g"), "error should name the group: {msg}");
+    }
+
+    /// Every produced artifact's recorded `hashout` must equal what its own
+    /// content answers with. The engine hands the `ViewContent` itself to
+    /// consumers on the passthrough path while the *parent's* `hashin` is
+    /// computed from the recorded field, so the two disagreeing would key a
+    /// cache entry on a value nothing else uses.
+    #[tokio::test]
+    async fn recorded_hashout_matches_the_artifacts_own_content() {
+        let def = parse_group(&[("prefix", Value::String("lib".into()))]).await;
+        let resp = run_group(&def, &[&["a/x", "b/y"]]).await.expect("run");
+        assert!(!resp.artifacts.is_empty());
+        for art in &resp.artifacts {
+            let outputartifact::Content::View(v) = &art.content else {
+                panic!("expected a view artifact");
+            };
+            assert_eq!(
+                art.hashout,
+                v.view.hashout().expect("view hashout"),
+                "recorded hashout must match the content's own"
+            );
+        }
+    }
+
+    /// A `strip_prefix` covering one dep but not another is legitimate — the
+    /// typo check runs over the union, not per dep.
+    #[tokio::test]
+    async fn strip_prefix_covering_only_one_dep_is_accepted() {
+        let def = parse_group(&[("strip_prefix", Value::String("build/out".into()))]).await;
+        let resp = run_group(&def, &[&["build/out/server"], &["assets/logo.png"]])
+            .await
+            .expect("must accept a prefix that only covers one dep");
+        assert_eq!(resp.artifacts.len(), 2);
+    }
+
+    #[tokio::test]
+    async fn strip_prefix_matching_no_dep_is_rejected() {
+        let def = parse_group(&[("strip_prefix", Value::String("nope".into()))]).await;
+        let err = run_group_err(&def, &[&["build/out/server"]]).await;
+        let msg = format!("{err:#}");
+        assert!(msg.contains("nope"), "{msg}");
+        assert!(msg.contains("build/out/server"), "should list what is available: {msg}");
+    }
+
+    #[tokio::test]
+    async fn rename_typo_is_rejected_naming_the_group() {
+        let def = parse_group(&[(
+            "rename",
+            Value::Map(HashMap::from([(
+                "sever".to_string(),
+                Value::String("bin/s".into()),
+            )])),
+        )])
+        .await;
+        let err = run_group_err(&def, &[&["server"]]).await;
+        let msg = format!("{err:#}");
+        assert!(msg.contains("sever"), "{msg}");
+        assert!(msg.contains("//pkg:g"), "error should name the group: {msg}");
+    }
+
+    /// Two files colliding must fail here, naming the group, rather than
+    /// surfacing later as a staging error inside an unrelated consumer.
+    #[tokio::test]
+    async fn collision_fails_in_the_group_not_the_consumer() {
+        let def = parse_group(&[("strip_prefix", Value::String("a".into()))]).await;
+        let err = run_group_err(&def, &[&["a/x", "x"]]).await;
+        let msg = format!("{err:#}");
+        assert!(msg.contains("collision"), "{msg}");
+        assert!(msg.contains("//pkg:g"), "error should name the group: {msg}");
     }
 }

--- a/crates/builtins/src/plugingroup/mod.rs
+++ b/crates/builtins/src/plugingroup/mod.rs
@@ -273,7 +273,10 @@ impl hplugin::driver::Driver for Driver {
         // `rename` key is ambiguous only relative to every path in play.
         let mut sources = Vec::with_capacity(req.inputs.len());
         for input in &req.inputs {
-            if matches!(input.artifact.r#type, hplugin::driver::inputartifact::Type::Dep) {
+            if matches!(
+                input.artifact.r#type,
+                hplugin::driver::inputartifact::Type::Dep
+            ) {
                 sources.push(SourcePaths::new(
                     dep_package(input),
                     input
@@ -343,9 +346,9 @@ impl hplugin::driver::Driver for Driver {
                             input.source_addr
                         )
                     })?;
-                    let hashout = view.hashout().with_context(|| {
-                        format!("hashout of view over '{}'", input.source_addr)
-                    })?;
+                    let hashout = view
+                        .hashout()
+                        .with_context(|| format!("hashout of view over '{}'", input.source_addr))?;
                     artifacts.push(outputartifact::OutputArtifact {
                         group: String::new(),
                         name: format!("view_{i}"),
@@ -568,13 +571,19 @@ mod tests {
     #[tokio::test]
     async fn transform_makes_the_group_non_transparent_and_uncacheable() {
         for (key, value) in [
-            ("include", Value::List(vec![Value::String("**/*.so".into())])),
+            (
+                "include",
+                Value::List(vec![Value::String("**/*.so".into())]),
+            ),
             ("exclude", Value::List(vec![Value::String("**/x".into())])),
             ("strip_prefix", Value::String("build/out".into())),
             ("prefix", Value::String("lib".into())),
             (
                 "rename",
-                Value::Map(HashMap::from([("a".to_string(), Value::String("b".into()))])),
+                Value::Map(HashMap::from([(
+                    "a".to_string(),
+                    Value::String("b".into()),
+                )])),
             ),
         ] {
             let def = parse_group(&[(key, value)]).await;
@@ -636,11 +645,8 @@ mod tests {
 
     #[tokio::test]
     async fn include_patterns_are_reflected_in_declared_outputs() {
-        let def = parse_group(&[(
-            "include",
-            Value::List(vec![Value::String("bin/**".into())]),
-        )])
-        .await;
+        let def =
+            parse_group(&[("include", Value::List(vec![Value::String("bin/**".into())]))]).await;
         let PathContent::Glob(ref g) = def.outputs[0].paths[0].content else {
             panic!("expected a glob path, got {:?}", def.outputs[0].paths[0]);
         };
@@ -686,11 +692,7 @@ mod tests {
             Ok("dephash".to_string())
         }
         fn entry_paths(&self) -> anyhow::Result<Vec<std::path::PathBuf>> {
-            Ok(self
-                .paths
-                .iter()
-                .map(std::path::PathBuf::from)
-                .collect())
+            Ok(self.paths.iter().map(std::path::PathBuf::from).collect())
         }
     }
 
@@ -802,7 +804,10 @@ mod tests {
             ("prefix".to_string(), Value::String("lib".into())),
         ]);
         // `ParseResponse` has no `Debug`, so `expect_err` is unavailable.
-        let err = match Driver.parse(make_parse_req("//pkg:g", config), &ctoken()).await {
+        let err = match Driver
+            .parse(make_parse_req("//pkg:g", config), &ctoken())
+            .await
+        {
             Ok(_) => panic!("must reject dead prefix config"),
             Err(e) => e,
         };
@@ -838,7 +843,9 @@ mod tests {
     #[tokio::test]
     async fn string_rename_places_the_sole_output_without_naming_it() {
         let def = parse_group(&[("rename", Value::String("bin/myserver".into()))]).await;
-        let resp = run_group(&def, &[&["build/out/server"]]).await.expect("run");
+        let resp = run_group(&def, &[&["build/out/server"]])
+            .await
+            .expect("run");
         let paths: Vec<String> = hcore::hartifactcontent::Content::entry_paths(&resp.artifacts[0])
             .expect("entry paths")
             .iter()
@@ -855,7 +862,10 @@ mod tests {
         let msg = format!("{err:#}");
         assert!(msg.contains("a/server"), "{msg}");
         assert!(msg.contains("b/server"), "{msg}");
-        assert!(msg.contains("//pkg:g"), "error should name the group: {msg}");
+        assert!(
+            msg.contains("//pkg:g"),
+            "error should name the group: {msg}"
+        );
     }
 
     /// Every produced artifact's recorded `hashout` must equal what its own
@@ -897,7 +907,10 @@ mod tests {
         let err = run_group_err(&def, &[&["build/out/server"]]).await;
         let msg = format!("{err:#}");
         assert!(msg.contains("nope"), "{msg}");
-        assert!(msg.contains("build/out/server"), "should list what is available: {msg}");
+        assert!(
+            msg.contains("build/out/server"),
+            "should list what is available: {msg}"
+        );
     }
 
     #[tokio::test]
@@ -913,7 +926,10 @@ mod tests {
         let err = run_group_err(&def, &[&["server"]]).await;
         let msg = format!("{err:#}");
         assert!(msg.contains("sever"), "{msg}");
-        assert!(msg.contains("//pkg:g"), "error should name the group: {msg}");
+        assert!(
+            msg.contains("//pkg:g"),
+            "error should name the group: {msg}"
+        );
     }
 
     /// Two files colliding must fail here, naming the group, rather than
@@ -924,6 +940,9 @@ mod tests {
         let err = run_group_err(&def, &[&["a/x", "x"]]).await;
         let msg = format!("{err:#}");
         assert!(msg.contains("collision"), "{msg}");
-        assert!(msg.contains("//pkg:g"), "error should name the group: {msg}");
+        assert!(
+            msg.contains("//pkg:g"),
+            "error should name the group: {msg}"
+        );
     }
 }

--- a/crates/core/Cargo.toml
+++ b/crates/core/Cargo.toml
@@ -10,6 +10,7 @@ workspace = true
 anyhow = "1.0.102"
 serde = { version = "1", features = ["derive"] }
 tar = "0.4"
+wax = "0.7"
 futures = "0.3.32"
 enclose = "1"
 xxhash-rust = { version = "0.8.15", features = ["xxh3", "std"] }

--- a/crates/core/src/hartifactcontent/file.rs
+++ b/crates/core/src/hartifactcontent/file.rs
@@ -38,11 +38,15 @@ impl Content for FileContent {
 
     fn walk(&self) -> anyhow::Result<Box<dyn Iterator<Item = anyhow::Result<WalkEntry>> + '_>> {
         let name = self.path.file_name().map(PathBuf::from).unwrap_or_default();
+        let size = std::fs::metadata(&self.path)
+            .with_context(|| format!("stat {}", self.path.display()))?
+            .len();
         let entry = WalkEntry {
             path: name,
             kind: WalkEntryKind::File {
                 data: self.reader()?,
                 x: false,
+                size,
             },
         };
         Ok(Box::new(std::iter::once(Ok(entry))))

--- a/crates/core/src/hartifactcontent/mod.rs
+++ b/crates/core/src/hartifactcontent/mod.rs
@@ -3,8 +3,12 @@ pub mod sniff;
 pub mod tar;
 pub mod tar_index;
 pub mod unpack;
+pub mod view;
 
 pub use file::FileContent;
+pub use view::{
+    PathFilter, PathMapping, PathTransform, Rename, RenamePlan, SourcePaths, ViewContent,
+};
 
 use std::io;
 use std::path::PathBuf;

--- a/crates/core/src/hartifactcontent/mod.rs
+++ b/crates/core/src/hartifactcontent/mod.rs
@@ -19,8 +19,26 @@ pub struct WalkEntry {
 }
 
 pub enum WalkEntryKind {
-    File { data: Box<dyn io::Read>, x: bool },
-    Symlink { target: PathBuf },
+    File {
+        data: Box<dyn io::Read>,
+        x: bool,
+        /// Byte length of `data`.
+        ///
+        /// Carried because a tar header must state an entry's size *before* its
+        /// bytes, so anything re-packing a walk (see
+        /// [`ViewContent`](view::ViewContent)) would otherwise have to buffer
+        /// each entry whole just to measure it. Every producer already knows
+        /// this — a tar walker reads it from the header it just parsed, a file
+        /// walker from `stat`, an in-memory one from `len` — so surfacing it
+        /// makes streaming re-packs possible at no cost.
+        ///
+        /// Must equal the number of bytes `data` yields; a re-pack writes
+        /// exactly this many.
+        size: u64,
+    },
+    Symlink {
+        target: PathBuf,
+    },
 }
 
 #[derive(Clone, Copy)]

--- a/crates/core/src/hartifactcontent/tar.rs
+++ b/crates/core/src/hartifactcontent/tar.rs
@@ -102,6 +102,8 @@ impl Iterator for TarWalker {
                 Err(e) => return Some(Err(e.into())),
             };
             let x = mode & 0o111 != 0;
+            // Straight off the header we just parsed — no extra read.
+            let size = entry.header().size().unwrap_or(0);
             let poison = Arc::new(AtomicBool::new(false));
             self.current_poison = Some(poison.clone());
             // SAFETY: entry borrows from entries which borrows from archive's stable heap allocation.
@@ -118,7 +120,11 @@ impl Iterator for TarWalker {
             };
             return Some(Ok(WalkEntry {
                 path,
-                kind: WalkEntryKind::File { data: reader, x },
+                kind: WalkEntryKind::File {
+                    data: reader,
+                    x,
+                    size,
+                },
             }));
         }
     }

--- a/crates/core/src/hartifactcontent/unpack.rs
+++ b/crates/core/src/hartifactcontent/unpack.rs
@@ -144,7 +144,7 @@ pub fn unpack(
                     );
                 }
             }
-            WalkEntryKind::File { data, x } => {
+            WalkEntryKind::File { data, x, .. } => {
                 let f = fs::File::create(&dest).with_context(|| {
                     format!(
                         "create unpack dest {:?} (entry={:?}, existing={})",

--- a/crates/core/src/hartifactcontent/view.rs
+++ b/crates/core/src/hartifactcontent/view.rs
@@ -923,7 +923,10 @@ mod tests {
     fn rename_is_exact_and_bypasses_prefix_rules() {
         let t = PathTransform {
             prefix: Some("lib".into()),
-            rename: Rename::Exact(BTreeMap::from([("build/out/server".into(), "bin/myserver".into())])),
+            rename: Rename::Exact(BTreeMap::from([(
+                "build/out/server".into(),
+                "bin/myserver".into(),
+            )])),
             ..transform()
         };
         assert_eq!(
@@ -941,7 +944,10 @@ mod tests {
     fn rename_overrides_include_filtering() {
         let t = PathTransform {
             include: vec!["**/*.so".into()],
-            rename: Rename::Exact(BTreeMap::from([("README.md".into(), "docs/README.md".into())])),
+            rename: Rename::Exact(BTreeMap::from([(
+                "README.md".into(),
+                "docs/README.md".into(),
+            )])),
             ..transform()
         };
         assert_eq!(
@@ -1199,9 +1205,10 @@ mod tests {
     #[test]
     fn unknown_exact_rename_key_errors_with_the_available_paths() {
         let t = PathTransform {
-            rename: Rename::Exact(BTreeMap::from([
-                ("app/build/out/sever".into(), "bin/s".into()),
-            ])),
+            rename: Rename::Exact(BTreeMap::from([(
+                "app/build/out/sever".into(),
+                "bin/s".into(),
+            )])),
             ..transform()
         };
         let err = validated_in(&t, Some("app"), &["app/build/out/server"])
@@ -1329,9 +1336,7 @@ mod tests {
         fn reader(&self) -> anyhow::Result<Box<dyn std::io::Read>> {
             anyhow::bail!("not used")
         }
-        fn walk(
-            &self,
-        ) -> anyhow::Result<Box<dyn Iterator<Item = anyhow::Result<WalkEntry>> + '_>> {
+        fn walk(&self) -> anyhow::Result<Box<dyn Iterator<Item = anyhow::Result<WalkEntry>> + '_>> {
             Ok(Box::new(self.entries.iter().map(|(path, data)| {
                 Ok(WalkEntry {
                     path: PathBuf::from(path),
@@ -1363,11 +1368,16 @@ mod tests {
 
     #[test]
     fn view_walk_rewrites_paths_and_preserves_data() {
-        let view = ViewContent::new(source(&[("build/out/server", "elf"), ("build/out/x.txt", "hi")]), PathTransform {
+        let view = ViewContent::new(
+            source(&[("build/out/server", "elf"), ("build/out/x.txt", "hi")]),
+            PathTransform {
                 strip_prefix: Some("build/out".into()),
                 prefix: Some("lib".into()),
                 ..transform()
-            }, None, RenamePlan::default());
+            },
+            None,
+            RenamePlan::default(),
+        );
 
         let mut got: Vec<(String, String)> = Vec::new();
         for entry in view.walk().expect("walk") {
@@ -1391,10 +1401,15 @@ mod tests {
 
     #[test]
     fn view_walk_drops_filtered_entries() {
-        let view = ViewContent::new(source(&[("a.so", "x"), ("a.txt", "y")]), PathTransform {
+        let view = ViewContent::new(
+            source(&[("a.so", "x"), ("a.txt", "y")]),
+            PathTransform {
                 include: vec!["**/*.so".into()],
                 ..transform()
-            }, None, RenamePlan::default());
+            },
+            None,
+            RenamePlan::default(),
+        );
         assert_eq!(view.entry_paths().unwrap(), vec![p("a.so")]);
         assert_eq!(view.walk().unwrap().count(), 1);
     }
@@ -1405,22 +1420,37 @@ mod tests {
     #[test]
     fn view_hashout_changes_with_the_transform() {
         let src = source(&[("a/x", "data")]);
-        let a = ViewContent::new(Arc::clone(&src), PathTransform {
+        let a = ViewContent::new(
+            Arc::clone(&src),
+            PathTransform {
                 prefix: Some("lib".into()),
                 ..transform()
-            }, None, RenamePlan::default())
+            },
+            None,
+            RenamePlan::default(),
+        )
         .hashout()
         .unwrap();
-        let b = ViewContent::new(Arc::clone(&src), PathTransform {
+        let b = ViewContent::new(
+            Arc::clone(&src),
+            PathTransform {
                 prefix: Some("bin".into()),
                 ..transform()
-            }, None, RenamePlan::default())
+            },
+            None,
+            RenamePlan::default(),
+        )
         .hashout()
         .unwrap();
-        let c = ViewContent::new(Arc::clone(&src), PathTransform {
+        let c = ViewContent::new(
+            Arc::clone(&src),
+            PathTransform {
                 prefix: Some("lib".into()),
                 ..transform()
-            }, None, RenamePlan::default())
+            },
+            None,
+            RenamePlan::default(),
+        )
         .hashout()
         .unwrap();
 
@@ -1435,15 +1465,22 @@ mod tests {
             prefix: Some("lib".into()),
             ..transform()
         };
-        let a = ViewContent::new(source(&[("a/x", "one")]), t.clone(), None, RenamePlan::default())
-            .hashout()
-            .unwrap();
+        let a = ViewContent::new(
+            source(&[("a/x", "one")]),
+            t.clone(),
+            None,
+            RenamePlan::default(),
+        )
+        .hashout()
+        .unwrap();
         let mut other = FakeSource {
             entries: vec![("a/x".to_string(), b"one".to_vec())],
             hashout: "different".to_string(),
         };
         other.hashout = "different".to_string();
-        let b = ViewContent::new(Arc::new(other), t, None, RenamePlan::default()).hashout().unwrap();
+        let b = ViewContent::new(Arc::new(other), t, None, RenamePlan::default())
+            .hashout()
+            .unwrap();
         assert_ne!(a, b, "source hashout must be part of the view's identity");
     }
 
@@ -1469,10 +1506,15 @@ mod tests {
 
     #[test]
     fn view_reader_packs_rewritten_paths() {
-        let view = ViewContent::new(source(&[("build/out/server", "elf")]), PathTransform {
+        let view = ViewContent::new(
+            source(&[("build/out/server", "elf")]),
+            PathTransform {
                 strip_prefix: Some("build/out".into()),
                 ..transform()
-            }, None, RenamePlan::default());
+            },
+            None,
+            RenamePlan::default(),
+        );
         let mut buf = Vec::new();
         std::io::copy(&mut view.reader().expect("reader"), &mut buf).expect("copy");
 
@@ -1509,7 +1551,8 @@ mod tests {
             }
             fn walk(
                 &self,
-            ) -> anyhow::Result<Box<dyn Iterator<Item = anyhow::Result<WalkEntry>> + '_>> {
+            ) -> anyhow::Result<Box<dyn Iterator<Item = anyhow::Result<WalkEntry>> + '_>>
+            {
                 Ok(Box::new(std::iter::once(Ok(WalkEntry {
                     path: PathBuf::from("a/x"),
                     kind: WalkEntryKind::File {
@@ -1577,7 +1620,8 @@ mod tests {
             }
             fn walk(
                 &self,
-            ) -> anyhow::Result<Box<dyn Iterator<Item = anyhow::Result<WalkEntry>> + '_>> {
+            ) -> anyhow::Result<Box<dyn Iterator<Item = anyhow::Result<WalkEntry>> + '_>>
+            {
                 Ok(Box::new(std::iter::once(Ok(WalkEntry {
                     path: PathBuf::from("big/blob.bin"),
                     kind: WalkEntryKind::File {
@@ -1676,7 +1720,8 @@ mod tests {
             }
             fn walk(
                 &self,
-            ) -> anyhow::Result<Box<dyn Iterator<Item = anyhow::Result<WalkEntry>> + '_>> {
+            ) -> anyhow::Result<Box<dyn Iterator<Item = anyhow::Result<WalkEntry>> + '_>>
+            {
                 Ok(Box::new(std::iter::once(Err(anyhow::anyhow!(
                     "source blew up mid-walk"
                 )))))
@@ -1710,10 +1755,15 @@ mod tests {
 
     #[test]
     fn view_surfaces_collision_errors_from_walk() {
-        let view = ViewContent::new(source(&[("a/x", "d"), ("x", "e")]), PathTransform {
+        let view = ViewContent::new(
+            source(&[("a/x", "d"), ("x", "e")]),
+            PathTransform {
                 strip_prefix: Some("a".into()),
                 ..transform()
-            }, None, RenamePlan::default());
+            },
+            None,
+            RenamePlan::default(),
+        );
         assert!(view.walk().is_err(), "collision must surface from walk");
     }
 }

--- a/crates/core/src/hartifactcontent/view.rs
+++ b/crates/core/src/hartifactcontent/view.rs
@@ -464,19 +464,34 @@ fn nearest_hint(paths: &[PathBuf]) -> String {
 /// detection, and the source map. They used to each open-code `Path::new(f) ==
 /// rel`, which meant exact paths only and five chances to drift.
 ///
-/// A pattern that does not compile as a glob falls back to an exact
-/// string match. That is what makes this a strict superset of the old
+/// A pattern with no glob metacharacter is kept as a literal and compared with
+/// string equality — never compiled. This is not a micro-optimization: the
+/// overwhelmingly common filter is a single exact path (`plugin-go` emits one
+/// per Go source file, so a build compiles them by the thousand), and
+/// `wax::Glob::new` builds a regex NFA. Measured on that shape, compiling
+/// every pattern made filtering **8x** slower than the exact-compare it
+/// replaced, with ~19µs of that per input in compilation alone. Literals keep
+/// it at parity.
+///
+/// A pattern that *is* a glob but fails to compile also falls back to an exact
+/// match. Together with the above, that makes this a strict superset of the old
 /// behaviour: every literal path keeps matching itself, and a filename
 /// containing glob metacharacters that a user meant literally still works
 /// rather than becoming a hard error.
 #[derive(Debug, Default)]
 pub struct PathFilter {
-    /// Compiled globs, paired with nothing — a pattern that failed to compile
-    /// is in `literals` instead.
+    /// Compiled globs. Only patterns that actually contain a metacharacter and
+    /// compile cleanly land here; everything else is a literal.
     globs: Vec<wax::Glob<'static>>,
     literals: Vec<String>,
     empty: bool,
 }
+
+/// Characters that make a pattern a glob rather than a literal path. Mirrors
+/// `pluginfs::literal_prefix`'s set: wax's metacharacters, plus `\` (its escape)
+/// and `,` (only meaningful inside `{…}`, but a reliable signal the component is
+/// not literal).
+const GLOB_META: &[char] = &['*', '?', '[', ']', '{', '}', '<', '>', '\\', ','];
 
 impl PathFilter {
     /// Compile a filter list. Never fails: an uncompilable pattern degrades to
@@ -485,6 +500,12 @@ impl PathFilter {
         let mut globs = Vec::new();
         let mut literals = Vec::new();
         for p in patterns {
+            // Literal first — see the type docs for why this branch carries the
+            // load.
+            if !p.contains(GLOB_META) {
+                literals.push(p.clone());
+                continue;
+            }
             match wax::Glob::new(p).map(wax::Glob::into_owned) {
                 Ok(g) => globs.push(g),
                 Err(_) => literals.push(p.clone()),
@@ -506,12 +527,16 @@ impl PathFilter {
 
     /// Whether `rel` (a path relative to the artifact root) is exposed.
     /// An empty filter set exposes everything.
+    ///
+    /// `to_string_lossy` borrows for valid UTF-8, so the common literal-only
+    /// case allocates nothing per path.
     pub fn matches(&self, rel: &Path) -> bool {
         if self.empty {
             return true;
         }
-        let s = path_to_slash(rel);
-        matches_any(&self.globs, &s) || self.literals.contains(&s)
+        let s = rel.to_string_lossy();
+        self.literals.iter().any(|l| l.as_str() == s.as_ref())
+            || (!self.globs.is_empty() && matches_any(&self.globs, &s))
     }
 }
 
@@ -531,6 +556,19 @@ pub struct ViewContent {
     /// Held rather than recomputed because key matching is only correct across
     /// every artifact the transform covers, not this one.
     plan: RenamePlan,
+    /// Memoized [`mapping`](Self::mapping).
+    ///
+    /// Resolving reads the source's path list, which for a tar-backed cache
+    /// artifact is a header-only scan of the whole archive — real I/O,
+    /// proportional to entry count. Consumers routinely ask for both
+    /// `entry_paths()` and `walk()` (output-collision detection then
+    /// materialization), and each previously paid that scan again. Artifacts
+    /// are immutable for the life of a build, so the answer cannot change.
+    ///
+    /// A race between two threads simply computes twice and keeps the first;
+    /// the mapping is a pure function of the source and the transform, so both
+    /// results are equal.
+    mapping: std::sync::OnceLock<PathMapping>,
 }
 
 impl ViewContent {
@@ -545,6 +583,7 @@ impl ViewContent {
             transform,
             package,
             plan,
+            mapping: std::sync::OnceLock::new(),
         }
     }
 
@@ -564,54 +603,54 @@ impl ViewContent {
         Ok(SourcePaths::new(self.package.clone(), paths))
     }
 
-    /// Resolve the transform against the source's current path set.
-    pub fn mapping(&self) -> anyhow::Result<PathMapping> {
-        self.transform.resolve(&self.source_paths()?, &self.plan)
+    /// Resolve the transform against the source's path set, memoized — see the
+    /// `mapping` field for why.
+    pub fn mapping(&self) -> anyhow::Result<&PathMapping> {
+        if let Some(m) = self.mapping.get() {
+            return Ok(m);
+        }
+        let m = self.transform.resolve(&self.source_paths()?, &self.plan)?;
+        Ok(self.mapping.get_or_init(|| m))
     }
 }
 
 impl Content for ViewContent {
     /// Re-pack the rewritten tree as a tar stream.
     ///
-    /// This is the one path that touches file bytes, and it exists only for
-    /// consumers that want a raw container rather than a walk. The
-    /// materialization path used by staging and sandbox setup goes through
-    /// [`Content::walk`], which copies nothing.
+    /// **Streams; never buffers the archive.** An artifact can be many
+    /// gigabytes, so materializing one into a `Vec` to hand back a `Cursor`
+    /// would be an unbounded allocation on a path whose whole purpose is to
+    /// avoid copying. Instead a writer thread packs into a pipe and this
+    /// returns the read end: memory is one pipe buffer plus one 512-byte tar
+    /// header, whatever the artifact's size, and a slow consumer throttles the
+    /// packer through pipe backpressure rather than by piling up in RAM.
+    ///
+    /// `tar::Builder` does the packing rather than a hand-rolled header writer,
+    /// so GNU long-name entries, checksums and symlink records stay correct.
+    /// It needs each entry's size up front, which is exactly why
+    /// [`WalkEntryKind::File`] carries one.
+    ///
+    /// This is the only path that touches file bytes at all — staging and
+    /// sandbox setup materialize through [`Content::walk`], which copies
+    /// nothing. One thread per call is therefore cheap in aggregate; a view is
+    /// never cached or uploaded, so nothing streams one in a loop.
     fn reader(&self) -> anyhow::Result<Box<dyn std::io::Read>> {
-        let mut buf = Vec::new();
-        {
-            let mut builder = tar::Builder::new(&mut buf);
-            for entry in self.walk()? {
-                let mut entry = entry?;
-                match &mut entry.kind {
-                    WalkEntryKind::File { data, x } => {
-                        let mut bytes = Vec::new();
-                        std::io::copy(data, &mut bytes).with_context(|| {
-                            format!("read view entry {:?} while packing", entry.path)
-                        })?;
-                        let mut header = tar::Header::new_gnu();
-                        header.set_size(bytes.len() as u64);
-                        header.set_mode(if *x { 0o755 } else { 0o644 });
-                        header.set_entry_type(tar::EntryType::Regular);
-                        header.set_cksum();
-                        builder
-                            .append_data(&mut header, &entry.path, bytes.as_slice())
-                            .with_context(|| format!("pack view entry {:?}", entry.path))?;
-                    }
-                    WalkEntryKind::Symlink { target } => {
-                        let mut header = tar::Header::new_gnu();
-                        header.set_size(0);
-                        header.set_entry_type(tar::EntryType::Symlink);
-                        header.set_cksum();
-                        builder
-                            .append_link(&mut header, &entry.path, &*target)
-                            .with_context(|| format!("pack view symlink {:?}", entry.path))?;
-                    }
-                }
-            }
-            builder.finish().context("finish view tar")?;
-        }
-        Ok(Box::new(std::io::Cursor::new(buf)))
+        // Resolved here, not in the thread, so a bad transform surfaces as an
+        // error from `reader()` rather than as a truncated stream. Cloned
+        // because the packer outlives this borrow; it is a path map, not bytes.
+        let mapping = self.mapping()?.clone();
+        let source = std::sync::Arc::clone(&self.source);
+        let (rx, tx) = std::io::pipe().context("create view tar pipe")?;
+
+        let join = std::thread::Builder::new()
+            .name("heph-view-tar".to_string())
+            .spawn(move || pack_view(source.as_ref(), &mapping, tx))
+            .context("spawn view tar packer")?;
+
+        Ok(Box::new(ViewTarReader {
+            rx,
+            join: Some(join),
+        }))
     }
 
     /// Stream the source's entries, rewriting each path and dropping the ones
@@ -669,7 +708,7 @@ impl Content for ViewContent {
     }
 
     fn entry_paths(&self) -> anyhow::Result<Vec<PathBuf>> {
-        Ok(self.mapping()?.0.into_values().collect())
+        Ok(self.mapping()?.0.values().cloned().collect())
     }
 
     /// Deliberately `None` (the trait default) for both this and
@@ -678,6 +717,80 @@ impl Content for ViewContent {
     /// file or a seek handle would hand it the pre-rewrite tree.
     fn byte_size(&self) -> Option<u64> {
         self.source.byte_size()
+    }
+}
+
+/// Walk `source`, rewrite each path through `mapping`, and pack the result as
+/// a tar into `w`. Runs on the packer thread spawned by
+/// [`ViewContent::reader`]; each entry's bytes are streamed straight from the
+/// source handle into the archive, never collected.
+fn pack_view(
+    source: &dyn Content,
+    mapping: &PathMapping,
+    w: std::io::PipeWriter,
+) -> anyhow::Result<()> {
+    let mut builder = tar::Builder::new(w);
+    for entry in source.walk().context("walk view source for packing")? {
+        let mut entry = entry.context("read view source entry while packing")?;
+        let Some(dst) = mapping.get(&entry.path) else {
+            continue;
+        };
+        let dst = dst.to_path_buf();
+        match &mut entry.kind {
+            WalkEntryKind::File { data, x, size } => {
+                let mut header = tar::Header::new_gnu();
+                header.set_size(*size);
+                header.set_mode(if *x { 0o755 } else { 0o644 });
+                header.set_entry_type(tar::EntryType::Regular);
+                header.set_cksum();
+                // `append_data` reads exactly `size` bytes off `data` — the
+                // streaming step. Nothing is held beyond its internal buffer.
+                builder
+                    .append_data(&mut header, &dst, &mut *data)
+                    .with_context(|| format!("pack view entry {}", dst.display()))?;
+            }
+            WalkEntryKind::Symlink { target } => {
+                let mut header = tar::Header::new_gnu();
+                header.set_size(0);
+                header.set_entry_type(tar::EntryType::Symlink);
+                header.set_cksum();
+                builder
+                    .append_link(&mut header, &dst, &*target)
+                    .with_context(|| format!("pack view symlink {}", dst.display()))?;
+            }
+        }
+    }
+    builder.finish().context("finish view tar")?;
+    Ok(())
+}
+
+/// Read end of [`ViewContent::reader`]'s pipe, which turns a packer-thread
+/// failure into a read error instead of a silently short archive.
+///
+/// The join happens at EOF rather than through a shared error slot: EOF *is*
+/// the packer having dropped its end, so the thread is already finishing and
+/// the join cannot race a not-yet-recorded error. A consumer that drops this
+/// early leaves the packer to die on `EPIPE`.
+struct ViewTarReader {
+    rx: std::io::PipeReader,
+    join: Option<std::thread::JoinHandle<anyhow::Result<()>>>,
+}
+
+impl std::io::Read for ViewTarReader {
+    fn read(&mut self, buf: &mut [u8]) -> std::io::Result<usize> {
+        let n = self.rx.read(buf)?;
+        if n == 0
+            && let Some(join) = self.join.take()
+        {
+            match join.join() {
+                Ok(Ok(())) => {}
+                Ok(Err(e)) => return Err(std::io::Error::other(format!("{e:#}"))),
+                Err(_) => {
+                    return Err(std::io::Error::other("view tar packer thread panicked"));
+                }
+            }
+        }
+        Ok(n)
     }
 }
 
@@ -1223,6 +1336,7 @@ mod tests {
                 Ok(WalkEntry {
                     path: PathBuf::from(path),
                     kind: WalkEntryKind::File {
+                        size: data.len() as u64,
                         data: Box::new(std::io::Cursor::new(data.clone())),
                         x: false,
                     },
@@ -1375,6 +1489,223 @@ mod tests {
             })
             .collect();
         assert_eq!(names, vec!["server".to_string()]);
+    }
+
+    /// Resolving the mapping reads the source's path list — a header-only scan
+    /// of the whole archive for a tar-backed cache artifact. Consumers ask for
+    /// both `entry_paths()` and `walk()` (collision detection, then
+    /// materialization), so that scan must happen once, not per call.
+    #[test]
+    fn view_resolves_its_mapping_only_once() {
+        use std::sync::atomic::{AtomicUsize, Ordering};
+
+        struct CountingSource {
+            scans: Arc<AtomicUsize>,
+        }
+
+        impl Content for CountingSource {
+            fn reader(&self) -> anyhow::Result<Box<dyn std::io::Read>> {
+                anyhow::bail!("not used")
+            }
+            fn walk(
+                &self,
+            ) -> anyhow::Result<Box<dyn Iterator<Item = anyhow::Result<WalkEntry>> + '_>> {
+                Ok(Box::new(std::iter::once(Ok(WalkEntry {
+                    path: PathBuf::from("a/x"),
+                    kind: WalkEntryKind::File {
+                        data: Box::new(std::io::Cursor::new(Vec::new())),
+                        x: false,
+                        size: 0,
+                    },
+                }))))
+            }
+            fn hashout(&self) -> anyhow::Result<String> {
+                Ok("h".to_string())
+            }
+            fn entry_paths(&self) -> anyhow::Result<Vec<PathBuf>> {
+                self.scans.fetch_add(1, Ordering::Relaxed);
+                Ok(vec![PathBuf::from("a/x")])
+            }
+        }
+
+        let scans = Arc::new(AtomicUsize::new(0));
+        let view = ViewContent::new(
+            Arc::new(CountingSource {
+                scans: Arc::clone(&scans),
+            }),
+            PathTransform {
+                prefix: Some("lib".into()),
+                ..transform()
+            },
+            None,
+            RenamePlan::default(),
+        );
+
+        view.entry_paths().expect("entry_paths");
+        view.walk().expect("walk").count();
+        view.entry_paths().expect("entry_paths again");
+        view.mapping().expect("mapping");
+
+        assert_eq!(
+            scans.load(Ordering::Relaxed),
+            1,
+            "the source path list must be scanned once and memoized"
+        );
+    }
+
+    /// `reader()` must stream, not buffer. A view over an artifact far larger
+    /// than any sane buffer has to be readable incrementally — buffering the
+    /// rewritten archive to hand back a `Cursor` is an unbounded allocation on
+    /// the one path whose entire purpose is to avoid copying.
+    ///
+    /// Pinned by consuming a 256 MiB view in small reads from a source that
+    /// *refuses to be fully materialized*: `HugeSource` yields its bytes
+    /// lazily and never holds them, so a buffering implementation would have to
+    /// allocate 256 MiB to satisfy the first `read`. Reading only the first few
+    /// KiB and dropping proves nothing was collected up front.
+    #[test]
+    fn view_reader_streams_without_buffering_the_archive() {
+        /// One entry of `len` zero bytes, produced by a reader that allocates
+        /// only the caller's buffer.
+        struct HugeSource {
+            len: u64,
+        }
+
+        impl Content for HugeSource {
+            fn reader(&self) -> anyhow::Result<Box<dyn std::io::Read>> {
+                anyhow::bail!("not used")
+            }
+            fn walk(
+                &self,
+            ) -> anyhow::Result<Box<dyn Iterator<Item = anyhow::Result<WalkEntry>> + '_>> {
+                Ok(Box::new(std::iter::once(Ok(WalkEntry {
+                    path: PathBuf::from("big/blob.bin"),
+                    kind: WalkEntryKind::File {
+                        data: Box::new(std::io::Read::take(std::io::repeat(0), self.len)),
+                        x: false,
+                        size: self.len,
+                    },
+                }))))
+            }
+            fn hashout(&self) -> anyhow::Result<String> {
+                Ok("hugehash".to_string())
+            }
+            fn entry_paths(&self) -> anyhow::Result<Vec<PathBuf>> {
+                Ok(vec![PathBuf::from("big/blob.bin")])
+            }
+        }
+
+        const HUGE: u64 = 256 * 1024 * 1024;
+        let view = ViewContent::new(
+            Arc::new(HugeSource { len: HUGE }),
+            PathTransform {
+                strip_prefix: Some("big".into()),
+                ..transform()
+            },
+            None,
+            RenamePlan::default(),
+        );
+
+        let mut reader = view.reader().expect("reader");
+        // Enough to cover the tar header and spill into the payload, so the
+        // packer has genuinely started streaming the body.
+        let mut head = vec![0u8; 4096];
+        reader.read_exact(&mut head).expect("read head");
+
+        // The rewritten name is in the header block, so the stream really is
+        // the transformed archive and not the source passed through.
+        let name_field = &head[..100];
+        let name = String::from_utf8_lossy(name_field)
+            .trim_end_matches('\0')
+            .to_string();
+        assert_eq!(name, "blob.bin", "header must carry the rewritten path");
+
+        // Dropping mid-stream must not hang: the packer dies on EPIPE.
+        drop(reader);
+    }
+
+    /// The streaming reader still yields a complete, correct archive when read
+    /// through to the end.
+    #[test]
+    fn view_reader_streams_a_complete_archive() {
+        let view = ViewContent::new(
+            source(&[("build/out/server", "elf"), ("build/out/a/b.so", "lib")]),
+            PathTransform {
+                strip_prefix: Some("build/out".into()),
+                prefix: Some("lib".into()),
+                ..transform()
+            },
+            None,
+            RenamePlan::default(),
+        );
+
+        let mut buf = Vec::new();
+        std::io::copy(&mut view.reader().expect("reader"), &mut buf).expect("copy");
+
+        let mut archive = tar::Archive::new(std::io::Cursor::new(buf));
+        let mut got: Vec<(String, String)> = archive
+            .entries()
+            .expect("entries")
+            .map(|e| {
+                let mut e = e.expect("entry");
+                let path = e.path().expect("path").to_string_lossy().into_owned();
+                let mut s = String::new();
+                std::io::Read::read_to_string(&mut e, &mut s).expect("read");
+                (path, s)
+            })
+            .collect();
+        got.sort();
+        assert_eq!(
+            got,
+            vec![
+                ("lib/a/b.so".to_string(), "lib".to_string()),
+                ("lib/server".to_string(), "elf".to_string()),
+            ]
+        );
+    }
+
+    /// A failure inside the packer thread must surface as a read error, not as
+    /// a silently truncated archive.
+    #[test]
+    fn view_reader_propagates_a_packer_failure() {
+        struct FailingSource;
+
+        impl Content for FailingSource {
+            fn reader(&self) -> anyhow::Result<Box<dyn std::io::Read>> {
+                anyhow::bail!("not used")
+            }
+            fn walk(
+                &self,
+            ) -> anyhow::Result<Box<dyn Iterator<Item = anyhow::Result<WalkEntry>> + '_>> {
+                Ok(Box::new(std::iter::once(Err(anyhow::anyhow!(
+                    "source blew up mid-walk"
+                )))))
+            }
+            fn hashout(&self) -> anyhow::Result<String> {
+                Ok("h".to_string())
+            }
+            fn entry_paths(&self) -> anyhow::Result<Vec<PathBuf>> {
+                Ok(vec![PathBuf::from("x")])
+            }
+        }
+
+        let view = ViewContent::new(
+            Arc::new(FailingSource),
+            PathTransform {
+                prefix: Some("lib".into()),
+                ..transform()
+            },
+            None,
+            RenamePlan::default(),
+        );
+
+        let mut buf = Vec::new();
+        let err = std::io::copy(&mut view.reader().expect("reader"), &mut buf)
+            .expect_err("packer failure must surface");
+        assert!(
+            format!("{err}").contains("source blew up mid-walk"),
+            "got: {err}"
+        );
     }
 
     #[test]

--- a/crates/core/src/hartifactcontent/view.rs
+++ b/crates/core/src/hartifactcontent/view.rs
@@ -1,0 +1,1388 @@
+//! Path-rewriting views over an existing [`Content`].
+//!
+//! A view answers "take this target's outputs, keep a subset, and put them at
+//! different paths" without copying a byte. [`ViewContent`] wraps another
+//! `Content` and rewrites entry *paths* as they stream out of
+//! [`Content::walk`]; the `Read` handle for each file's data is handed through
+//! untouched, so materializing a view costs exactly what materializing the
+//! source cost. Nothing is packed, stored, or duplicated.
+//!
+//! That is the whole point: relocation today means an exec target running `cp`,
+//! which buys a sandbox, a subprocess, and a second full copy of the bytes in
+//! both the local and the remote cache. A view has none of those. Its producer
+//! marks it uncacheable, so no revision is ever written for it — the *source*
+//! target stays cached exactly as before, and the view is re-derived (a few
+//! string operations over a path list) on each build.
+//!
+//! # Hashing
+//!
+//! [`ViewContent::hashout`] is derived from `(source hashout, transform)`
+//! rather than read off the rewritten bytes. That is sound because the
+//! transform is a pure function of the path set: identical source content plus
+//! an identical transform can only produce identical output. It is also what
+//! keeps the view free — computing a true content hash would mean reading every
+//! byte, which is the copy we are trying to avoid.
+//!
+//! # Symlinks
+//!
+//! Entry paths are rewritten; symlink *targets* are not. A relative symlink
+//! interior to the tree survives `strip_prefix`/`prefix` (both move every path
+//! by the same amount, so relative distances are preserved) but can dangle if
+//! `include`/`exclude`/`rename` move or drop only one end of the pair.
+
+use std::collections::BTreeMap;
+use std::path::{Path, PathBuf};
+
+use anyhow::Context;
+
+use super::{Content, WalkEntry, WalkEntryKind};
+
+/// A declarative, hash-stable rewrite of a set of relative artifact paths.
+///
+/// Field order below is also the order the rules apply, and the docs on
+/// [`PathTransform::resolve`] spell out the interactions. The type derives
+/// `Hash` over the *pattern strings* (not compiled globs) so a driver can fold
+/// it straight into its target-def hash — which is what makes a changed
+/// transform invalidate consumers' cache keys.
+#[derive(Debug, Clone, Default, PartialEq, Eq, Hash, serde::Serialize, serde::Deserialize)]
+pub struct PathTransform {
+    /// Glob patterns a path must match to be kept. Empty keeps everything.
+    pub include: Vec<String>,
+    /// Glob patterns that drop a path. Applied after `include`.
+    pub exclude: Vec<String>,
+    /// Leading directory removed from every path under it, in either the
+    /// emitted or the package-relative form. Paths not under it are left alone;
+    /// a prefix matching *nothing* is an error (see [`PathTransform::plan`]).
+    pub strip_prefix: Option<String>,
+    /// Leading directory prepended to every surviving path.
+    pub prefix: Option<String>,
+    /// Where selected outputs are placed — see [`Rename`].
+    pub rename: Rename,
+}
+
+/// How a transform places the outputs it selects.
+///
+/// Two forms, because two different things are being asked for:
+///
+/// * [`Rename::Sole`] — "put this dep's output *here*". No source is named at
+///   all: it renames whatever survives `include`/`exclude`, which must be
+///   exactly one file. This is the form that never makes an author know where a
+///   dependency emitted anything, since there is no emitted path to spell.
+/// * [`Rename::Exact`] — "move precisely these paths". Keys are full emitted
+///   paths, matched exactly. More typing and more coupling, but it moves
+///   several files at once and leaves the rest to `strip_prefix`/`prefix`.
+///
+/// Reach for `Sole` by default and `Exact` when you genuinely need per-path
+/// control.
+#[derive(Debug, Clone, Default, PartialEq, Eq, Hash, serde::Serialize, serde::Deserialize)]
+pub enum Rename {
+    /// No renaming; destinations come from `strip_prefix`/`prefix`.
+    #[default]
+    None,
+    /// Destination for the single output that survives `include`/`exclude`.
+    Sole(String),
+    /// Full emitted path → destination. Entries are kept regardless of
+    /// `include`/`exclude` — naming a file explicitly is a stronger signal than
+    /// a glob — and are placed verbatim, skipping `strip_prefix`/`prefix`.
+    Exact(BTreeMap<String, String>),
+}
+
+impl Rename {
+    pub fn is_none(&self) -> bool {
+        matches!(self, Rename::None)
+    }
+}
+
+impl PathTransform {
+    /// Whether this transform would leave every path untouched. A driver uses
+    /// this to keep its cheap path — there is no reason to build a view that
+    /// rewrites nothing.
+    pub fn is_identity(&self) -> bool {
+        self.include.is_empty()
+            && self.exclude.is_empty()
+            && self.strip_prefix.is_none()
+            && self.prefix.is_none()
+            && self.rename.is_none()
+    }
+
+    /// Whether `strip_prefix`/`prefix` would be dead config.
+    ///
+    /// [`Rename::Sole`] fixes the destination of the only surviving file, so a
+    /// prefix would be computed and then thrown away. Callers reject the
+    /// combination rather than silently ignoring half the config.
+    pub fn prefixes_are_dead_config(&self) -> bool {
+        matches!(self.rename, Rename::Sole(_))
+            && (self.strip_prefix.is_some() || self.prefix.is_some())
+    }
+
+    /// Whether a path survives `include`/`exclude`. Shared by
+    /// [`plan`](Self::plan) and [`resolve`](Self::resolve) so the set `plan`
+    /// counts is exactly the set `resolve` emits.
+    fn survives(
+        &self,
+        full: &str,
+        rel: Option<&str>,
+        include: &[wax::Glob<'static>],
+        exclude: &[wax::Glob<'static>],
+    ) -> bool {
+        (include.is_empty() || matches_either(include, full, rel))
+            && !matches_either(exclude, full, rel)
+    }
+
+    /// Resolve the transform over one artifact's source paths, producing the
+    /// source → destination mapping (paths that are filtered out are absent).
+    ///
+    /// Errors only on a *collision* — two sources landing on one destination,
+    /// which would otherwise mean one output silently clobbering another with
+    /// the winner decided by iteration order.
+    ///
+    /// Takes the `plan` from [`PathTransform::plan`] rather than deciding
+    /// `rename` itself: `rename` applies to whatever survives filtering, and
+    /// "is that exactly one file?" is only answerable across every artifact the
+    /// transform covers. Typo checks live there for the same reason.
+    ///
+    /// Rules, in order:
+    ///
+    /// 1. `include` (when non-empty) must match, then `exclude` must not.
+    /// 2. The one path the `plan` selected goes exactly where `rename` says.
+    /// 3. Otherwise `strip_prefix` is removed if the path is under it,
+    /// 4. and `prefix` is prepended.
+    pub fn resolve(&self, src: &SourcePaths, plan: &RenamePlan) -> anyhow::Result<PathMapping> {
+        let include = compile(&self.include).context("compiling `include` patterns")?;
+        let exclude = compile(&self.exclude).context("compiling `exclude` patterns")?;
+
+        let mut map: BTreeMap<PathBuf, PathBuf> = BTreeMap::new();
+        // Reverse index for the collision message: which source claimed a
+        // destination first. Built alongside rather than derived after, so the
+        // error can name both sides.
+        let mut claimed: BTreeMap<PathBuf, PathBuf> = BTreeMap::new();
+
+        for path in &src.paths {
+            let full = path_to_slash(path);
+            let rel = src.package_relative(&full);
+
+            // The plan is consulted before filtering: a `Rename::Exact` entry
+            // names a file outright, which outranks a glob. (A `Rename::Sole`
+            // entry is by construction already a survivor, so the order is
+            // immaterial for it.)
+            let dst = if let Some(to) = plan.destination(&full) {
+                PathBuf::from(to)
+            } else {
+                if !self.survives(&full, rel, &include, &exclude) {
+                    continue;
+                }
+                let stripped = self.strip(&full, rel);
+                match self.prefix.as_deref() {
+                    Some(p) => PathBuf::from(format!("{}/{}", p.trim_end_matches('/'), stripped)),
+                    None => PathBuf::from(stripped),
+                }
+            };
+
+            if let Some(prev) = claimed.get(&dst) {
+                anyhow::bail!(
+                    "path collision: '{}' and '{}' both map to '{}' — \
+                     narrow `include`/`exclude`, or give one an explicit `rename`",
+                    path_to_slash(prev),
+                    full,
+                    dst.display(),
+                );
+            }
+            claimed.insert(dst.clone(), path.clone());
+            map.insert(path.clone(), dst);
+        }
+
+        Ok(PathMapping(map))
+    }
+
+    /// Apply `strip_prefix` to one path, in whichever form it was written.
+    ///
+    /// Stripping the package-relative form drops the package prefix with it, so
+    /// `strip_prefix = "build/out"` and `strip_prefix = "app/build/out"` both
+    /// land `app/build/out/server` on `server`. Matching by shape rather than
+    /// by spelling is what keeps the two consistent.
+    fn strip<'a>(&self, full: &'a str, rel: Option<&'a str>) -> &'a str {
+        let Some(sp) = self.strip_prefix.as_deref() else {
+            return full;
+        };
+        let sp = sp.trim_end_matches('/');
+        if let Some(stripped) = strip_dir_prefix(full, sp) {
+            return stripped;
+        }
+        if let Some(rel) = rel
+            && let Some(stripped) = strip_dir_prefix(rel, sp)
+        {
+            return stripped;
+        }
+        full
+    }
+
+    /// Decide which single path `rename` applies to, across `sources` — the
+    /// full set of artifacts this transform covers — and reject patterns that
+    /// match nothing.
+    ///
+    /// Runs once, up front; its output is what [`resolve`](Self::resolve)
+    /// consults. The split is not tidiness. `rename` names no source — it
+    /// renames *whatever survives* `include`/`exclude* — so "is that exactly
+    /// one file?" is a question about every artifact at once. Asked per
+    /// artifact, a group over two deps that each emit one file would rename
+    /// both to the same destination.
+    ///
+    /// The union is also the only correct scope for the typo check on
+    /// `strip_prefix`: one applying to a single dep and not another is fine,
+    /// while one applying to *no* dep is a mistake that would silently pass
+    /// every file through untouched.
+    ///
+    /// An empty set is vacuously fine — there is nothing to have typo'd
+    /// against, and a target with no outputs yet is not an error.
+    pub fn plan(&self, sources: &[SourcePaths]) -> anyhow::Result<RenamePlan> {
+        let all: Vec<PathBuf> = sources.iter().flat_map(|s| s.paths.clone()).collect();
+        if all.is_empty() {
+            return Ok(RenamePlan::default());
+        }
+
+        let mut plan: BTreeMap<String, String> = BTreeMap::new();
+        match &self.rename {
+            Rename::None => {}
+            Rename::Sole(dst) => {
+                let include = compile(&self.include).context("compiling `include` patterns")?;
+                let exclude = compile(&self.exclude).context("compiling `exclude` patterns")?;
+
+                let mut survivors: Vec<String> = Vec::new();
+                for src in sources {
+                    for path in &src.paths {
+                        let full = path_to_slash(path);
+                        let rel = src.package_relative(&full);
+                        if self.survives(&full, rel, &include, &exclude) {
+                            survivors.push(full);
+                        }
+                    }
+                }
+                survivors.sort();
+
+                match survivors.as_slice() {
+                    [] => anyhow::bail!(
+                        "`rename` has nothing to rename — no output survived \
+                         `include`/`exclude`{}",
+                        nearest_hint(&all),
+                    ),
+                    [only] => {
+                        plan.insert(only.clone(), dst.clone());
+                    }
+                    many => anyhow::bail!(
+                        "`rename` is a single destination but {} outputs are selected \
+                         ({}). Narrow them with `include` so exactly one is left, use a \
+                         dict to name each path, or use `strip_prefix`/`prefix` to \
+                         relocate them together.",
+                        many.len(),
+                        many.join(", "),
+                    ),
+                }
+            }
+            Rename::Exact(map) => {
+                let present: std::collections::BTreeSet<String> =
+                    all.iter().map(|p| path_to_slash(p)).collect();
+                for (key, dst) in map {
+                    if !present.contains(key) {
+                        anyhow::bail!(
+                            "`rename` key '{key}' matched no output path — dict keys are \
+                             matched exactly against the paths a target emits. Use the \
+                             string form (`rename = \"{dst}\"`) to place the selected \
+                             output without naming its source{}",
+                            nearest_hint(&all),
+                        );
+                    }
+                    plan.insert(key.clone(), dst.clone());
+                }
+            }
+        }
+
+        if let Some(sp) = self.strip_prefix.as_deref() {
+            let trimmed = sp.trim_end_matches('/');
+            let matched = sources.iter().any(|s| {
+                s.paths.iter().any(|p| {
+                    let full = path_to_slash(p);
+                    let rel = s.package_relative(&full);
+                    strip_dir_prefix(&full, trimmed).is_some()
+                        || rel.is_some_and(|r| strip_dir_prefix(r, trimmed).is_some())
+                })
+            });
+            if !matched {
+                anyhow::bail!(
+                    "`strip_prefix` '{sp}' matched no output path{}",
+                    nearest_hint(&all),
+                );
+            }
+        }
+        Ok(RenamePlan(plan))
+    }
+}
+
+/// Which emitted path each rename resolved to, produced by
+/// [`PathTransform::plan`] and consumed by [`PathTransform::resolve`].
+///
+/// Keyed by the *full emitted path* rather than by anything the author wrote,
+/// so applying it is an exact lookup with no matching left to redo — and, for
+/// [`Rename::Sole`], the "exactly one survivor" decision happens once,
+/// globally, rather than once per artifact.
+#[derive(Debug, Clone, Default, PartialEq, Eq)]
+pub struct RenamePlan(BTreeMap<String, String>);
+
+impl RenamePlan {
+    /// Where this path was sent, if a rename selected it.
+    pub fn destination(&self, full_path: &str) -> Option<&str> {
+        self.0.get(full_path).map(String::as_str)
+    }
+
+    pub fn is_empty(&self) -> bool {
+        self.0.is_empty()
+    }
+}
+
+/// One dep's contribution to a transform: the paths it emitted, plus the
+/// package that emitted them.
+///
+/// The package is what lets an author write patterns without knowing where a
+/// dependency's outputs land. Heph emits artifact paths workspace-relative, so
+/// a target in `//app` declaring `out = "build/out/server"` really emits
+/// `app/build/out/server` — a path the author of a *consuming* group has no
+/// reason to know, and which changes if the dep ever moves package. Carrying
+/// the package here means `strip_prefix = "build/out"` (what the dep's own
+/// BUILD file says) works, and so does the full form.
+#[derive(Debug, Clone, Default)]
+pub struct SourcePaths {
+    /// Package of the target that produced `paths`, e.g. `app/sub`. `None`
+    /// when unknown, which simply disables the package-relative forms.
+    pub package: Option<String>,
+    pub paths: Vec<PathBuf>,
+}
+
+impl SourcePaths {
+    pub fn new(package: Option<String>, paths: Vec<PathBuf>) -> Self {
+        Self { package, paths }
+    }
+
+    /// `full` with the producing package stripped, when it is under it.
+    fn package_relative<'a>(&self, full: &'a str) -> Option<&'a str> {
+        let pkg = self.package.as_deref()?.trim_matches('/');
+        if pkg.is_empty() {
+            return None;
+        }
+        strip_dir_prefix(full, pkg)
+    }
+}
+
+/// Whether any glob matches the path in either the emitted or the
+/// package-relative form, so `include = ["**/*.so"]` and
+/// `include = ["app/**/*.so"]` both work.
+fn matches_either(globs: &[wax::Glob<'static>], full: &str, rel: Option<&str>) -> bool {
+    matches_any(globs, full) || rel.is_some_and(|r| matches_any(globs, r))
+}
+
+/// The resolved source → destination mapping produced by
+/// [`PathTransform::resolve`].
+#[derive(Debug, Clone, Default, PartialEq, Eq)]
+pub struct PathMapping(BTreeMap<PathBuf, PathBuf>);
+
+impl PathMapping {
+    /// Destination for a source path, or `None` when it was filtered out.
+    pub fn get(&self, src: &Path) -> Option<&Path> {
+        self.0.get(src).map(PathBuf::as_path)
+    }
+
+    /// Every `(source, destination)` pair, in sorted source order. Drives the
+    /// `inspect` rendering, so a user can see where each file went.
+    pub fn pairs(&self) -> impl Iterator<Item = (&Path, &Path)> {
+        self.0.iter().map(|(s, d)| (s.as_path(), d.as_path()))
+    }
+
+    pub fn len(&self) -> usize {
+        self.0.len()
+    }
+
+    pub fn is_empty(&self) -> bool {
+        self.0.is_empty()
+    }
+}
+
+/// Compile a pattern list into wax programs. Empty in, empty out — callers
+/// treat an empty `include` as "match everything", which is not the same as a
+/// program that matches nothing.
+fn compile(patterns: &[String]) -> anyhow::Result<Vec<wax::Glob<'static>>> {
+    patterns
+        .iter()
+        .map(|p| {
+            wax::Glob::new(p)
+                .map(wax::Glob::into_owned)
+                .with_context(|| format!("invalid glob pattern '{p}'"))
+        })
+        .collect()
+}
+
+fn matches_any(globs: &[wax::Glob<'static>], path: &str) -> bool {
+    use wax::Program as _;
+    globs.iter().any(|g| g.is_match(path))
+}
+
+/// Strip `prefix` from `path` at a directory boundary, so `build/out` does not
+/// match `build/output/x`. Returns `None` when `path` is not under `prefix`.
+fn strip_dir_prefix<'a>(path: &'a str, prefix: &str) -> Option<&'a str> {
+    if prefix.is_empty() {
+        return Some(path);
+    }
+    path.strip_prefix(prefix)?.strip_prefix('/')
+}
+
+/// Artifact paths are always relative and slash-separated on the wire; render
+/// them that way so patterns and `rename` keys are written the same on every
+/// platform.
+fn path_to_slash(p: &Path) -> String {
+    p.to_string_lossy().replace('\\', "/")
+}
+
+/// "did you mean" tail for a miss, listing a few real paths. Cheap and only
+/// built on the error path, where the user has already lost more time than this
+/// costs.
+fn nearest_hint(paths: &[PathBuf]) -> String {
+    if paths.is_empty() {
+        return String::new();
+    }
+    let sample: Vec<String> = paths.iter().take(8).map(|p| path_to_slash(p)).collect();
+    let more = paths.len().saturating_sub(sample.len());
+    let tail = if more > 0 {
+        format!(" (and {more} more)")
+    } else {
+        String::new()
+    };
+    format!(". Available paths: {}{}", sample.join(", "), tail)
+}
+
+/// The compiled form of a dep reference's inline filter list — the
+/// `[a.go,pkg/**]` suffix on `//foo:bar[…]`.
+///
+/// One type so every place that honours filters agrees on what they mean:
+/// sandbox unpack, read-only staging, the FUSE slot index, output-collision
+/// detection, and the source map. They used to each open-code `Path::new(f) ==
+/// rel`, which meant exact paths only and five chances to drift.
+///
+/// A pattern that does not compile as a glob falls back to an exact
+/// string match. That is what makes this a strict superset of the old
+/// behaviour: every literal path keeps matching itself, and a filename
+/// containing glob metacharacters that a user meant literally still works
+/// rather than becoming a hard error.
+#[derive(Debug, Default)]
+pub struct PathFilter {
+    /// Compiled globs, paired with nothing — a pattern that failed to compile
+    /// is in `literals` instead.
+    globs: Vec<wax::Glob<'static>>,
+    literals: Vec<String>,
+    empty: bool,
+}
+
+impl PathFilter {
+    /// Compile a filter list. Never fails: an uncompilable pattern degrades to
+    /// an exact match rather than rejecting the build.
+    pub fn new(patterns: &[String]) -> Self {
+        let mut globs = Vec::new();
+        let mut literals = Vec::new();
+        for p in patterns {
+            match wax::Glob::new(p).map(wax::Glob::into_owned) {
+                Ok(g) => globs.push(g),
+                Err(_) => literals.push(p.clone()),
+            }
+        }
+        Self {
+            empty: patterns.is_empty(),
+            globs,
+            literals,
+        }
+    }
+
+    /// True when no filtering was requested — callers use this to keep their
+    /// whole-tree fast paths (a single directory symlink instead of a per-file
+    /// walk), so it must stay distinct from "a filter that matches everything".
+    pub fn is_empty(&self) -> bool {
+        self.empty
+    }
+
+    /// Whether `rel` (a path relative to the artifact root) is exposed.
+    /// An empty filter set exposes everything.
+    pub fn matches(&self, rel: &Path) -> bool {
+        if self.empty {
+            return true;
+        }
+        let s = path_to_slash(rel);
+        matches_any(&self.globs, &s) || self.literals.contains(&s)
+    }
+}
+
+/// A [`Content`] that presents another `Content` under rewritten paths.
+///
+/// Construction is cheap and infallible; the transform is resolved lazily on
+/// first use (and re-resolved per call, matching how `walk` is already a
+/// fresh-stream-per-call API). See the module docs for what this does and does
+/// not copy.
+pub struct ViewContent {
+    source: std::sync::Arc<dyn Content>,
+    transform: PathTransform,
+    /// Package of the target that produced `source`, enabling the
+    /// package-relative pattern forms — see [`SourcePaths`].
+    package: Option<String>,
+    /// The globally-resolved `rename` bindings from [`PathTransform::plan`].
+    /// Held rather than recomputed because key matching is only correct across
+    /// every artifact the transform covers, not this one.
+    plan: RenamePlan,
+}
+
+impl ViewContent {
+    pub fn new(
+        source: std::sync::Arc<dyn Content>,
+        transform: PathTransform,
+        package: Option<String>,
+        plan: RenamePlan,
+    ) -> Self {
+        Self {
+            source,
+            transform,
+            package,
+            plan,
+        }
+    }
+
+    pub fn transform(&self) -> &PathTransform {
+        &self.transform
+    }
+
+    /// The source's paths, tagged with the producing package.
+    ///
+    /// Uses [`Content::entry_paths`], which a tar-backed cache artifact answers
+    /// with a header-only seek scan — no file data is read.
+    pub fn source_paths(&self) -> anyhow::Result<SourcePaths> {
+        let paths = self
+            .source
+            .entry_paths()
+            .context("listing source artifact paths for view")?;
+        Ok(SourcePaths::new(self.package.clone(), paths))
+    }
+
+    /// Resolve the transform against the source's current path set.
+    pub fn mapping(&self) -> anyhow::Result<PathMapping> {
+        self.transform.resolve(&self.source_paths()?, &self.plan)
+    }
+}
+
+impl Content for ViewContent {
+    /// Re-pack the rewritten tree as a tar stream.
+    ///
+    /// This is the one path that touches file bytes, and it exists only for
+    /// consumers that want a raw container rather than a walk. The
+    /// materialization path used by staging and sandbox setup goes through
+    /// [`Content::walk`], which copies nothing.
+    fn reader(&self) -> anyhow::Result<Box<dyn std::io::Read>> {
+        let mut buf = Vec::new();
+        {
+            let mut builder = tar::Builder::new(&mut buf);
+            for entry in self.walk()? {
+                let mut entry = entry?;
+                match &mut entry.kind {
+                    WalkEntryKind::File { data, x } => {
+                        let mut bytes = Vec::new();
+                        std::io::copy(data, &mut bytes).with_context(|| {
+                            format!("read view entry {:?} while packing", entry.path)
+                        })?;
+                        let mut header = tar::Header::new_gnu();
+                        header.set_size(bytes.len() as u64);
+                        header.set_mode(if *x { 0o755 } else { 0o644 });
+                        header.set_entry_type(tar::EntryType::Regular);
+                        header.set_cksum();
+                        builder
+                            .append_data(&mut header, &entry.path, bytes.as_slice())
+                            .with_context(|| format!("pack view entry {:?}", entry.path))?;
+                    }
+                    WalkEntryKind::Symlink { target } => {
+                        let mut header = tar::Header::new_gnu();
+                        header.set_size(0);
+                        header.set_entry_type(tar::EntryType::Symlink);
+                        header.set_cksum();
+                        builder
+                            .append_link(&mut header, &entry.path, &*target)
+                            .with_context(|| format!("pack view symlink {:?}", entry.path))?;
+                    }
+                }
+            }
+            builder.finish().context("finish view tar")?;
+        }
+        Ok(Box::new(std::io::Cursor::new(buf)))
+    }
+
+    /// Stream the source's entries, rewriting each path and dropping the ones
+    /// the transform filtered out. File data is forwarded by handle — never
+    /// read here.
+    fn walk(&self) -> anyhow::Result<Box<dyn Iterator<Item = anyhow::Result<WalkEntry>> + '_>> {
+        let mapping = self.mapping()?;
+        let inner = self.source.walk().context("walk view source")?;
+        Ok(Box::new(inner.filter_map(move |entry| match entry {
+            Err(e) => Some(Err(e)),
+            Ok(entry) => mapping.get(&entry.path).map(|dst| {
+                Ok(WalkEntry {
+                    path: dst.to_path_buf(),
+                    kind: entry.kind,
+                })
+            }),
+        })))
+    }
+
+    /// Derived from the source hashout and the transform — see the module docs
+    /// for why that is sound and why it is not the rewritten bytes' hash.
+    ///
+    /// It deliberately does *not* fold in the [`RenamePlan`], even though the
+    /// plan can in principle shift without this source changing: a `rename` key
+    /// binds to the best-tier match across every dep, so a *sibling* dep gaining
+    /// or losing a better match rebinds it. That is covered, one level up. The
+    /// plan is a function of the transform and the full path set, and any change
+    /// to a sibling's paths changes that sibling's own hashout (paths are part
+    /// of its content hash) — or, if the sibling appeared or vanished entirely,
+    /// changes the group's `deps` and so its def hash. Either way the consumer's
+    /// `hashin` moves, because it folds in every dep hashout. Hashing the plan
+    /// here would add nothing and would make two artifacts' identities depend on
+    /// each other.
+    fn hashout(&self) -> anyhow::Result<String> {
+        use std::hash::Hash as _;
+
+        let source = self
+            .source
+            .hashout()
+            .context("source hashout for view artifact")?;
+        // An empty source hashout means the backing content is not
+        // content-addressed; propagate that rather than inventing an identity
+        // for it, so callers keying on hashout treat the view the same way they
+        // already treat its source.
+        if source.is_empty() {
+            return Ok(String::new());
+        }
+        let mut h = xxhash_rust::xxh3::Xxh3::new();
+        h.update(b"heph-view-v1\0");
+        h.update(source.as_bytes());
+        h.update(&[0]);
+        let mut fold = FoldHasher(&mut h);
+        self.transform.hash(&mut fold);
+        Ok(format!("{:x}", h.digest()))
+    }
+
+    fn entry_paths(&self) -> anyhow::Result<Vec<PathBuf>> {
+        Ok(self.mapping()?.0.into_values().collect())
+    }
+
+    /// Deliberately `None` (the trait default) for both this and
+    /// [`Content::file_path`]: the backing bytes are a container whose internal
+    /// paths are *not* the ones this view presents, so handing a caller the raw
+    /// file or a seek handle would hand it the pre-rewrite tree.
+    fn byte_size(&self) -> Option<u64> {
+        self.source.byte_size()
+    }
+}
+
+/// Adapts `std::hash::Hasher` onto xxh3 so [`PathTransform`]'s derived `Hash`
+/// can fold into the same digest as the literal writes around it.
+struct FoldHasher<'a>(&'a mut xxhash_rust::xxh3::Xxh3);
+
+impl std::hash::Hasher for FoldHasher<'_> {
+    fn write(&mut self, bytes: &[u8]) {
+        self.0.update(bytes);
+    }
+
+    fn finish(&self) -> u64 {
+        self.0.digest()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::sync::Arc;
+
+    fn p(s: &str) -> PathBuf {
+        PathBuf::from(s)
+    }
+
+    fn transform() -> PathTransform {
+        PathTransform::default()
+    }
+
+    fn src(pkg: Option<&str>, paths: &[&str]) -> SourcePaths {
+        SourcePaths::new(
+            pkg.map(str::to_string),
+            paths.iter().map(|s| p(s)).collect(),
+        )
+    }
+
+    fn resolved(t: &PathTransform, paths: &[&str]) -> anyhow::Result<Vec<(String, String)>> {
+        resolved_in(t, None, paths)
+    }
+
+    fn resolved_in(
+        t: &PathTransform,
+        pkg: Option<&str>,
+        paths: &[&str],
+    ) -> anyhow::Result<Vec<(String, String)>> {
+        let source = src(pkg, paths);
+        let plan = t.plan(std::slice::from_ref(&source))?;
+        Ok(t.resolve(&source, &plan)?
+            .pairs()
+            .map(|(s, d)| (path_to_slash(s), path_to_slash(d)))
+            .collect())
+    }
+
+    #[test]
+    fn identity_transform_is_detected() {
+        assert!(transform().is_identity());
+        assert!(
+            !PathTransform {
+                prefix: Some("lib".into()),
+                ..transform()
+            }
+            .is_identity()
+        );
+    }
+
+    #[test]
+    fn include_globs_select_a_subset() {
+        let t = PathTransform {
+            include: vec!["**/*.so".into()],
+            ..transform()
+        };
+        assert_eq!(
+            resolved(&t, &["a/x.so", "a/x.txt", "b/y.so"]).unwrap(),
+            vec![
+                ("a/x.so".into(), "a/x.so".into()),
+                ("b/y.so".into(), "b/y.so".into())
+            ]
+        );
+    }
+
+    #[test]
+    fn exclude_applies_after_include() {
+        let t = PathTransform {
+            include: vec!["**/*.so".into()],
+            exclude: vec!["**/test_*".into()],
+            ..transform()
+        };
+        assert_eq!(
+            resolved(&t, &["a/x.so", "a/test_y.so"]).unwrap(),
+            vec![("a/x.so".into(), "a/x.so".into())]
+        );
+    }
+
+    #[test]
+    fn strip_prefix_then_prefix() {
+        let t = PathTransform {
+            strip_prefix: Some("build/out".into()),
+            prefix: Some("lib".into()),
+            ..transform()
+        };
+        assert_eq!(
+            resolved(&t, &["build/out/server", "build/out/a/b.so"]).unwrap(),
+            vec![
+                ("build/out/a/b.so".into(), "lib/a/b.so".into()),
+                ("build/out/server".into(), "lib/server".into()),
+            ]
+        );
+    }
+
+    /// `build/out` must not swallow `build/output` — the prefix is a directory,
+    /// not a string.
+    #[test]
+    fn strip_prefix_respects_directory_boundaries() {
+        let t = PathTransform {
+            strip_prefix: Some("build/out".into()),
+            ..transform()
+        };
+        assert_eq!(
+            resolved(&t, &["build/out/x", "build/output/y"]).unwrap(),
+            vec![
+                ("build/out/x".into(), "x".into()),
+                // untouched: not under `build/out`
+                ("build/output/y".into(), "build/output/y".into()),
+            ]
+        );
+    }
+
+    #[test]
+    fn rename_is_exact_and_bypasses_prefix_rules() {
+        let t = PathTransform {
+            prefix: Some("lib".into()),
+            rename: Rename::Exact(BTreeMap::from([("build/out/server".into(), "bin/myserver".into())])),
+            ..transform()
+        };
+        assert_eq!(
+            resolved(&t, &["build/out/server", "other.txt"]).unwrap(),
+            vec![
+                ("build/out/server".into(), "bin/myserver".into()),
+                ("other.txt".into(), "lib/other.txt".into()),
+            ]
+        );
+    }
+
+    /// A renamed path is kept even when `include` would have dropped it —
+    /// naming a file explicitly is a stronger signal than a glob.
+    #[test]
+    fn rename_overrides_include_filtering() {
+        let t = PathTransform {
+            include: vec!["**/*.so".into()],
+            rename: Rename::Exact(BTreeMap::from([("README.md".into(), "docs/README.md".into())])),
+            ..transform()
+        };
+        assert_eq!(
+            resolved(&t, &["x.so", "README.md", "ignored.txt"]).unwrap(),
+            vec![
+                ("README.md".into(), "docs/README.md".into()),
+                ("x.so".into(), "x.so".into()),
+            ]
+        );
+    }
+
+    fn validated(t: &PathTransform, paths: &[&str]) -> anyhow::Result<()> {
+        t.plan(&[src(None, paths)]).map(|_| ())
+    }
+
+    fn validated_in(t: &PathTransform, pkg: Option<&str>, paths: &[&str]) -> anyhow::Result<()> {
+        t.plan(&[src(pkg, paths)]).map(|_| ())
+    }
+
+    #[test]
+    fn unmatched_rename_key_is_an_error_with_available_paths() {
+        let t = PathTransform {
+            rename: Rename::Exact(BTreeMap::from([("build/out/sever".into(), "bin/s".into())])),
+            ..transform()
+        };
+        let err = validated(&t, &["build/out/server"]).expect_err("must reject typo");
+        let msg = format!("{err:#}");
+        assert!(msg.contains("build/out/sever"), "{msg}");
+        assert!(msg.contains("build/out/server"), "{msg}");
+    }
+
+    #[test]
+    fn unmatched_strip_prefix_is_an_error() {
+        let t = PathTransform {
+            strip_prefix: Some("dist".into()),
+            ..transform()
+        };
+        let err = validated(&t, &["build/out/server"]).expect_err("must reject typo");
+        assert!(format!("{err:#}").contains("dist"));
+    }
+
+    /// An empty source set has nothing to typo against, so a prefix that
+    /// matches nothing is vacuous rather than wrong.
+    #[test]
+    fn unmatched_strip_prefix_on_empty_input_is_ok() {
+        let t = PathTransform {
+            strip_prefix: Some("dist".into()),
+            ..transform()
+        };
+        assert!(validated(&t, &[]).is_ok());
+        assert_eq!(resolved(&t, &[]).unwrap(), vec![]);
+    }
+
+    /// The reason validation is split out of `resolve`: a target relocating two
+    /// deps has a `strip_prefix` that legitimately covers one and not the
+    /// other. Checked against the union it passes; checked per-artifact it
+    /// would reject the second dep.
+    #[test]
+    fn strip_prefix_matching_only_some_paths_is_valid_across_the_union() {
+        let t = PathTransform {
+            strip_prefix: Some("build/out".into()),
+            ..transform()
+        };
+        assert!(validated(&t, &["build/out/server", "assets/logo.png"]).is_ok());
+        // And `resolve` alone never complains about it, whichever dep it sees —
+        // which is why the typo check lives in `plan`, over the union.
+        assert!(
+            t.resolve(&src(None, &["assets/logo.png"]), &RenamePlan::default())
+                .is_ok()
+        );
+    }
+
+    /// `resolve` still catches collisions — that check *is* per-artifact-correct
+    /// and must not have moved out with the typo checks.
+    #[test]
+    fn resolve_still_rejects_collisions_without_validate() {
+        let t = PathTransform {
+            strip_prefix: Some("a".into()),
+            ..transform()
+        };
+        assert!(resolved(&t, &["a/x", "x"]).is_err());
+    }
+
+    // ---- writing patterns without knowing where a dep emitted ----
+    //
+    // Heph emits `<pkg>/<declared out path>`. An author writing a group must
+    // not have to know that prefix, nor a dep's internal build layout.
+
+    /// The string form names no source at all, so however deeply a dep buried
+    /// its output — and whatever package it lives in — the author writes only
+    /// the destination.
+    #[test]
+    fn sole_rename_needs_no_knowledge_of_the_source_path() {
+        let t = PathTransform {
+            rename: Rename::Sole("bin/myserver".into()),
+            ..transform()
+        };
+        assert_eq!(
+            resolved_in(&t, Some("app"), &["app/build/out/server"]).unwrap(),
+            vec![("app/build/out/server".into(), "bin/myserver".into())]
+        );
+    }
+
+    /// With more than one output selected there is no single "it" to rename,
+    /// so this fails loudly and lists the candidates rather than picking one.
+    #[test]
+    fn sole_rename_rejects_more_than_one_survivor() {
+        let t = PathTransform {
+            rename: Rename::Sole("bin/s".into()),
+            ..transform()
+        };
+        let err = validated_in(&t, Some("app"), &["app/a/server", "app/b/server"])
+            .expect_err("must reject an ambiguous sole rename");
+        let msg = format!("{err:#}");
+        assert!(msg.contains("app/a/server"), "{msg}");
+        assert!(msg.contains("app/b/server"), "{msg}");
+        assert!(msg.contains("include"), "should suggest narrowing: {msg}");
+    }
+
+    /// `include` is how you narrow to one — the documented fix for the error
+    /// above.
+    #[test]
+    fn include_narrows_a_sole_rename_to_one_survivor() {
+        let t = PathTransform {
+            include: vec!["**/*.so".into()],
+            rename: Rename::Sole("lib/out.so".into()),
+            ..transform()
+        };
+        assert_eq!(
+            resolved_in(&t, Some("app"), &["app/x.so", "app/notes.txt"]).unwrap(),
+            vec![("app/x.so".into(), "lib/out.so".into())]
+        );
+    }
+
+    /// Survivors are counted across every dep, not per artifact — otherwise a
+    /// group over two single-file deps would rename both to one destination.
+    #[test]
+    fn sole_rename_counts_survivors_across_deps() {
+        let t = PathTransform {
+            rename: Rename::Sole("bin/s".into()),
+            ..transform()
+        };
+        let err = t
+            .plan(&[
+                src(Some("app"), &["app/server"]),
+                src(Some("web"), &["web/server"]),
+            ])
+            .expect_err("must count survivors across deps");
+        assert!(format!("{err:#}").contains("2 outputs"));
+    }
+
+    #[test]
+    fn sole_rename_with_nothing_selected_is_an_error() {
+        let t = PathTransform {
+            include: vec!["**/*.so".into()],
+            rename: Rename::Sole("lib/out.so".into()),
+            ..transform()
+        };
+        let err = validated_in(&t, Some("app"), &["app/notes.txt"])
+            .expect_err("nothing to rename must be an error");
+        assert!(format!("{err:#}").contains("nothing to rename"));
+    }
+
+    /// The dict form keeps its original contract: keys are exact emitted paths.
+    #[test]
+    fn exact_rename_keys_are_matched_exactly() {
+        let t = PathTransform {
+            rename: Rename::Exact(BTreeMap::from([("app/a/server".into(), "bin/s".into())])),
+            ..transform()
+        };
+        assert_eq!(
+            resolved_in(&t, Some("app"), &["app/a/server", "app/b/other"]).unwrap(),
+            vec![
+                ("app/a/server".into(), "bin/s".into()),
+                ("app/b/other".into(), "app/b/other".into()),
+            ]
+        );
+        // A file name is not an exact path, and is rejected rather than guessed at.
+        let loose = PathTransform {
+            rename: Rename::Exact(BTreeMap::from([("server".into(), "bin/s".into())])),
+            ..transform()
+        };
+        let err = validated_in(&loose, Some("app"), &["app/a/server"])
+            .expect_err("dict keys must be exact");
+        let msg = format!("{err:#}");
+        assert!(msg.contains("exactly"), "{msg}");
+        assert!(
+            msg.contains("string form"),
+            "should point at the ergonomic form: {msg}"
+        );
+    }
+
+    /// A string `rename` makes `strip_prefix`/`prefix` dead config; the driver
+    /// rejects the combination rather than silently dropping them.
+    #[test]
+    fn sole_rename_flags_prefixes_as_dead_config() {
+        assert!(
+            PathTransform {
+                prefix: Some("lib".into()),
+                rename: Rename::Sole("bin/s".into()),
+                ..transform()
+            }
+            .prefixes_are_dead_config()
+        );
+        // The dict form coexists with them: it places what it names, the
+        // prefixes place the rest.
+        assert!(
+            !PathTransform {
+                prefix: Some("lib".into()),
+                rename: Rename::Exact(BTreeMap::from([("a".into(), "b".into())])),
+                ..transform()
+            }
+            .prefixes_are_dead_config()
+        );
+    }
+
+    /// `strip_prefix` is written as the producing package declares it — no
+    /// package prefix required — and both spellings land on the same result.
+    #[test]
+    fn strip_prefix_accepts_the_package_relative_form() {
+        let pkg_relative = PathTransform {
+            strip_prefix: Some("build/out".into()),
+            ..transform()
+        };
+        let full = PathTransform {
+            strip_prefix: Some("app/build/out".into()),
+            ..transform()
+        };
+        let paths = ["app/build/out/server"];
+        assert_eq!(
+            resolved_in(&pkg_relative, Some("app"), &paths).unwrap(),
+            vec![("app/build/out/server".into(), "server".into())]
+        );
+        assert_eq!(
+            resolved_in(&full, Some("app"), &paths).unwrap(),
+            resolved_in(&pkg_relative, Some("app"), &paths).unwrap(),
+            "both spellings must produce the same layout"
+        );
+    }
+
+    #[test]
+    fn include_accepts_the_package_relative_form() {
+        let t = PathTransform {
+            include: vec!["build/**".into()],
+            ..transform()
+        };
+        assert_eq!(
+            resolved_in(&t, Some("app"), &["app/build/x.so", "app/docs/readme"]).unwrap(),
+            vec![("app/build/x.so".into(), "app/build/x.so".into())]
+        );
+    }
+
+    /// A typo'd dict key is caught and the message lists the real paths, so the
+    /// fix is a copy-paste rather than a hunt.
+    #[test]
+    fn unknown_exact_rename_key_errors_with_the_available_paths() {
+        let t = PathTransform {
+            rename: Rename::Exact(BTreeMap::from([
+                ("app/build/out/sever".into(), "bin/s".into()),
+            ])),
+            ..transform()
+        };
+        let err = validated_in(&t, Some("app"), &["app/build/out/server"])
+            .expect_err("typo must still be caught");
+        let msg = format!("{err:#}");
+        assert!(msg.contains("sever"), "{msg}");
+        assert!(msg.contains("app/build/out/server"), "{msg}");
+    }
+
+    /// Dict keys reach across deps: a key naming a second dep's path resolves
+    /// against the union, not just the artifact being mapped.
+    #[test]
+    fn exact_rename_keys_resolve_across_separate_deps() {
+        let t = PathTransform {
+            rename: Rename::Exact(BTreeMap::from([("web/server".into(), "bin/s".into())])),
+            ..transform()
+        };
+        let sources = [
+            src(Some("app"), &["app/server"]),
+            src(Some("web"), &["web/server"]),
+        ];
+        let plan = t.plan(&sources).expect("plan");
+        assert_eq!(plan.destination("web/server"), Some("bin/s"));
+        assert_eq!(plan.destination("app/server"), None);
+    }
+
+    #[test]
+    fn collision_is_an_error_naming_both_sources() {
+        let t = PathTransform {
+            strip_prefix: Some("a".into()),
+            ..transform()
+        };
+        // `a/x` -> `x`, and a literal `x` is already there.
+        let err = resolved(&t, &["a/x", "x"]).expect_err("must reject collision");
+        let msg = format!("{err:#}");
+        assert!(msg.contains("a/x"), "{msg}");
+        assert!(msg.contains("collision"), "{msg}");
+    }
+
+    #[test]
+    fn invalid_glob_is_reported_with_the_pattern() {
+        let t = PathTransform {
+            include: vec!["a/{unclosed".into()],
+            ..transform()
+        };
+        let err = resolved(&t, &["a/x"]).expect_err("must reject bad glob");
+        assert!(format!("{err:#}").contains("a/{unclosed"));
+    }
+
+    // ---- PathFilter (inline `//foo:bar[…]` dep filters) ----
+
+    fn filter(patterns: &[&str]) -> PathFilter {
+        PathFilter::new(
+            &patterns
+                .iter()
+                .map(|s| (*s).to_string())
+                .collect::<Vec<_>>(),
+        )
+    }
+
+    /// An empty filter list must stay distinguishable from "matches
+    /// everything": callers key their whole-tree symlink fast path on it.
+    #[test]
+    fn empty_filter_is_empty_and_matches_everything() {
+        let f = filter(&[]);
+        assert!(f.is_empty());
+        assert!(f.matches(&p("anything/at/all.go")));
+    }
+
+    /// The compatibility guarantee: every filter that worked before this became
+    /// glob-aware must still select exactly the same files.
+    #[test]
+    fn exact_paths_still_match_exactly() {
+        let f = filter(&["pkg/a.go", "b.go"]);
+        assert!(!f.is_empty());
+        assert!(f.matches(&p("pkg/a.go")));
+        assert!(f.matches(&p("b.go")));
+        assert!(!f.matches(&p("pkg/b.go")));
+        assert!(!f.matches(&p("pkg/a.go.bak")));
+        // An exact filter must not behave like a prefix.
+        assert!(!f.matches(&p("pkg/a.go/nested")));
+    }
+
+    #[test]
+    fn glob_patterns_select_by_shape() {
+        let f = filter(&["**/*.go"]);
+        assert!(f.matches(&p("a.go")));
+        assert!(f.matches(&p("pkg/sub/a.go")));
+        assert!(!f.matches(&p("pkg/a.rs")));
+    }
+
+    #[test]
+    fn directory_globs_select_a_subtree() {
+        let f = filter(&["bin/**"]);
+        assert!(f.matches(&p("bin/server")));
+        assert!(f.matches(&p("bin/sub/tool")));
+        assert!(!f.matches(&p("lib/server")));
+    }
+
+    #[test]
+    fn mixed_exact_and_glob_patterns_both_apply() {
+        let f = filter(&["README.md", "src/**/*.rs"]);
+        assert!(f.matches(&p("README.md")));
+        assert!(f.matches(&p("src/a/b.rs")));
+        assert!(!f.matches(&p("src/a/b.go")));
+    }
+
+    /// A pattern that is not a valid glob degrades to an exact match rather
+    /// than failing the build — the old behaviour for anything wax rejects.
+    #[test]
+    fn uncompilable_pattern_falls_back_to_an_exact_match() {
+        let f = filter(&["a/{unclosed"]);
+        assert!(f.matches(&p("a/{unclosed")));
+        assert!(!f.matches(&p("a/other")));
+    }
+
+    // ---- ViewContent ----
+
+    struct FakeSource {
+        entries: Vec<(String, Vec<u8>)>,
+        hashout: String,
+    }
+
+    impl Content for FakeSource {
+        fn reader(&self) -> anyhow::Result<Box<dyn std::io::Read>> {
+            anyhow::bail!("not used")
+        }
+        fn walk(
+            &self,
+        ) -> anyhow::Result<Box<dyn Iterator<Item = anyhow::Result<WalkEntry>> + '_>> {
+            Ok(Box::new(self.entries.iter().map(|(path, data)| {
+                Ok(WalkEntry {
+                    path: PathBuf::from(path),
+                    kind: WalkEntryKind::File {
+                        data: Box::new(std::io::Cursor::new(data.clone())),
+                        x: false,
+                    },
+                })
+            })))
+        }
+        fn hashout(&self) -> anyhow::Result<String> {
+            Ok(self.hashout.clone())
+        }
+        fn entry_paths(&self) -> anyhow::Result<Vec<PathBuf>> {
+            Ok(self.entries.iter().map(|(p, _)| PathBuf::from(p)).collect())
+        }
+    }
+
+    fn source(entries: &[(&str, &str)]) -> Arc<dyn Content> {
+        Arc::new(FakeSource {
+            entries: entries
+                .iter()
+                .map(|(p, d)| ((*p).to_string(), d.as_bytes().to_vec()))
+                .collect(),
+            hashout: "sourcehash".to_string(),
+        })
+    }
+
+    #[test]
+    fn view_walk_rewrites_paths_and_preserves_data() {
+        let view = ViewContent::new(source(&[("build/out/server", "elf"), ("build/out/x.txt", "hi")]), PathTransform {
+                strip_prefix: Some("build/out".into()),
+                prefix: Some("lib".into()),
+                ..transform()
+            }, None, RenamePlan::default());
+
+        let mut got: Vec<(String, String)> = Vec::new();
+        for entry in view.walk().expect("walk") {
+            let mut entry = entry.expect("entry");
+            let WalkEntryKind::File { ref mut data, .. } = entry.kind else {
+                panic!("expected file");
+            };
+            let mut s = String::new();
+            std::io::Read::read_to_string(data, &mut s).expect("read");
+            got.push((path_to_slash(&entry.path), s));
+        }
+        got.sort();
+        assert_eq!(
+            got,
+            vec![
+                ("lib/server".to_string(), "elf".to_string()),
+                ("lib/x.txt".to_string(), "hi".to_string()),
+            ]
+        );
+    }
+
+    #[test]
+    fn view_walk_drops_filtered_entries() {
+        let view = ViewContent::new(source(&[("a.so", "x"), ("a.txt", "y")]), PathTransform {
+                include: vec!["**/*.so".into()],
+                ..transform()
+            }, None, RenamePlan::default());
+        assert_eq!(view.entry_paths().unwrap(), vec![p("a.so")]);
+        assert_eq!(view.walk().unwrap().count(), 1);
+    }
+
+    /// The cache-key property the whole design rests on: a different transform
+    /// over identical source content must produce a different hashout, or a
+    /// consumer would reuse a stale entry after its dep was relocated.
+    #[test]
+    fn view_hashout_changes_with_the_transform() {
+        let src = source(&[("a/x", "data")]);
+        let a = ViewContent::new(Arc::clone(&src), PathTransform {
+                prefix: Some("lib".into()),
+                ..transform()
+            }, None, RenamePlan::default())
+        .hashout()
+        .unwrap();
+        let b = ViewContent::new(Arc::clone(&src), PathTransform {
+                prefix: Some("bin".into()),
+                ..transform()
+            }, None, RenamePlan::default())
+        .hashout()
+        .unwrap();
+        let c = ViewContent::new(Arc::clone(&src), PathTransform {
+                prefix: Some("lib".into()),
+                ..transform()
+            }, None, RenamePlan::default())
+        .hashout()
+        .unwrap();
+
+        assert_ne!(a, b, "transform must be part of the view's identity");
+        assert_eq!(a, c, "same transform must be stable across constructions");
+        assert_ne!(a, "sourcehash", "view must not inherit the source hashout");
+    }
+
+    #[test]
+    fn view_hashout_changes_with_the_source() {
+        let t = PathTransform {
+            prefix: Some("lib".into()),
+            ..transform()
+        };
+        let a = ViewContent::new(source(&[("a/x", "one")]), t.clone(), None, RenamePlan::default())
+            .hashout()
+            .unwrap();
+        let mut other = FakeSource {
+            entries: vec![("a/x".to_string(), b"one".to_vec())],
+            hashout: "different".to_string(),
+        };
+        other.hashout = "different".to_string();
+        let b = ViewContent::new(Arc::new(other), t, None, RenamePlan::default()).hashout().unwrap();
+        assert_ne!(a, b, "source hashout must be part of the view's identity");
+    }
+
+    /// A non-content-addressed source (empty hashout) stays non-content-addressed
+    /// rather than acquiring a synthetic identity.
+    #[test]
+    fn view_hashout_propagates_empty_source_hashout() {
+        let src: Arc<dyn Content> = Arc::new(FakeSource {
+            entries: vec![],
+            hashout: String::new(),
+        });
+        let view = ViewContent::new(
+            src,
+            PathTransform {
+                prefix: Some("lib".into()),
+                ..transform()
+            },
+            None,
+            RenamePlan::default(),
+        );
+        assert_eq!(view.hashout().unwrap(), "");
+    }
+
+    #[test]
+    fn view_reader_packs_rewritten_paths() {
+        let view = ViewContent::new(source(&[("build/out/server", "elf")]), PathTransform {
+                strip_prefix: Some("build/out".into()),
+                ..transform()
+            }, None, RenamePlan::default());
+        let mut buf = Vec::new();
+        std::io::copy(&mut view.reader().expect("reader"), &mut buf).expect("copy");
+
+        let mut archive = tar::Archive::new(std::io::Cursor::new(buf));
+        let names: Vec<String> = archive
+            .entries()
+            .expect("entries")
+            .map(|e| {
+                e.expect("entry")
+                    .path()
+                    .expect("path")
+                    .to_string_lossy()
+                    .into_owned()
+            })
+            .collect();
+        assert_eq!(names, vec!["server".to_string()]);
+    }
+
+    #[test]
+    fn view_surfaces_collision_errors_from_walk() {
+        let view = ViewContent::new(source(&[("a/x", "d"), ("x", "e")]), PathTransform {
+                strip_prefix: Some("a".into()),
+                ..transform()
+            }, None, RenamePlan::default());
+        assert!(view.walk().is_err(), "collision must surface from walk");
+    }
+}

--- a/crates/driver-bridge/src/driver_managed_fuse.rs
+++ b/crates/driver-bridge/src/driver_managed_fuse.rs
@@ -276,10 +276,8 @@ fn build_slot_layers(
                 format!("build tar index for input origin_id={}", input.origin_id)
             })?;
             if !input.filters.is_empty() {
-                let filters = input.filters.clone();
-                index
-                    .entries
-                    .retain(|p, _| filters.iter().any(|f| Path::new(f) == p));
+                let filters = hcore::hartifactcontent::PathFilter::new(&input.filters);
+                index.entries.retain(|p, _| filters.matches(p));
             }
             let list_write = list_path_for(input, list_dir).map(|list_path| {
                 let abs_paths: Vec<PathBuf> =

--- a/crates/driver-support/src/driver_managed.rs
+++ b/crates/driver-support/src/driver_managed.rs
@@ -347,7 +347,8 @@ pub(crate) fn build_source_map(
             continue;
         }
         let source_addr_str = managed_input.input.source_addr.format();
-        let filters = &managed_input.input.filters;
+        // Compiled once per input, outside the per-path loop below.
+        let filters = hartifactcontent::PathFilter::new(&managed_input.input.filters);
         // Enumerate the artifact's own paths directly instead of reading
         // list_path: after group expansion, multiple inputs share parent
         // origin_id → list_path_for gives them one shared file (opened append).
@@ -359,7 +360,7 @@ pub(crate) fn build_source_map(
         for rel in content.entry_paths().with_context(|| {
             format!("enumerate content for source_map (source={source_addr_str})")
         })? {
-            if !filters.is_empty() && !filters.iter().any(|f| Path::new(f) == rel.as_path()) {
+            if !filters.matches(&rel) {
                 continue;
             }
             source_map.insert(rel.to_string_lossy().into_owned(), source_addr_str.clone());
@@ -462,10 +463,9 @@ pub fn detect_output_collisions(groups: &BTreeMap<PathBuf, Vec<RunInput>>) -> an
                     producer.format(),
                 )
             })?;
+            let filters = hartifactcontent::PathFilter::new(&input.filters);
             for rel in paths {
-                if !input.filters.is_empty()
-                    && !input.filters.iter().any(|f| Path::new(f) == rel.as_path())
-                {
+                if !filters.matches(&rel) {
                     continue;
                 }
                 let abs = unpack_root.join(&rel);
@@ -523,8 +523,9 @@ pub async fn unpack_blocking(
     filters: Vec<String>,
 ) -> anyhow::Result<()> {
     hcore::blocking::run(move || {
-        let pred = |rel: &Path| filters.iter().any(|f| Path::new(f) == rel);
-        let predicate: Option<&dyn Fn(&Path) -> bool> = if filters.is_empty() {
+        let compiled = hartifactcontent::PathFilter::new(&filters);
+        let pred = |rel: &Path| compiled.matches(rel);
+        let predicate: Option<&dyn Fn(&Path) -> bool> = if compiled.is_empty() {
             None
         } else {
             Some(&pred)

--- a/crates/driver-support/src/stage.rs
+++ b/crates/driver-support/src/stage.rs
@@ -479,6 +479,9 @@ fn link_tree(
         None => None,
     };
 
+    // Compiled once, outside the walk.
+    let filters = hcore::hartifactcontent::PathFilter::new(filters);
+
     for ent in walkdir::WalkDir::new(entry) {
         let ent = ent.with_context(|| format!("walk staged tree {:?}", entry))?;
         let rel = match ent.path().strip_prefix(entry) {
@@ -492,7 +495,7 @@ fn link_tree(
                 .with_context(|| format!("create linked dir {:?}", dst))?;
             continue;
         }
-        if !filters.is_empty() && !filters.iter().any(|f| Path::new(f) == rel) {
+        if !filters.matches(rel) {
             continue;
         }
         // A prior input may have linked the same relative path into a shared

--- a/crates/e2e/tests/group_relocate.rs
+++ b/crates/e2e/tests/group_relocate.rs
@@ -1,0 +1,669 @@
+//! End-to-end coverage for `group` in filter/relocate mode — re-exporting
+//! other targets' outputs at different paths without copying their bytes.
+//!
+//! The properties worth freezing here are the ones no unit test can reach:
+//! that a relocated file actually lands at the new path *inside a consuming
+//! target's sandbox*, that changing a transform invalidates that consumer's
+//! cache key, and that the group itself still writes nothing to the cache.
+
+#![expect(
+    clippy::panic_in_result_fn,
+    reason = "restriction/style lints scoped to production code; tests are exempt"
+)]
+
+mod common;
+
+use common::Workspace;
+use heph::htaddr::parse_addr;
+
+/// Output paths are workspace-relative (package-prefixed), so transforms are
+/// written against `<pkg>/…`. That is what lets one group aggregate targets
+/// from several packages without an ambiguous "which package do I strip".
+const PKG: &str = "reloc";
+
+async fn hashin(ws: &Workspace, addr: &str) -> anyhow::Result<String> {
+    let rs = ws.engine.new_state();
+    let meta = ws
+        .engine
+        .clone()
+        .meta(rs, &parse_addr(addr)?)
+        .await?;
+    Ok(meta.hashin)
+}
+
+/// The headline behaviour: a file produced at `build/out/server` is visible to
+/// a consumer at `lib/server`.
+#[tokio::test]
+async fn relocated_output_reaches_the_consumer_sandbox_at_the_new_path() -> anyhow::Result<()> {
+    let ws = Workspace::new();
+    ws.write_build_file(
+        PKG,
+        r#"
+target(
+    name = "bin",
+    driver = "bash",
+    run = "mkdir -p build/out && echo server_bytes > build/out/server",
+    out = "build/out/server",
+)
+target(
+    name = "dist",
+    driver = "group",
+    deps = ["//reloc:bin"],
+    strip_prefix = "reloc/build/out",
+    prefix = "lib",
+)
+target(
+    name = "consumer",
+    driver = "bash",
+    # `$SRC_DIST` is the materialized path inside the sandbox, so this asserts
+    # both that the bytes arrived and that they arrived at the relocated path.
+    run = ["{ cat \"$SRC_DIST\"; echo \"at=$SRC_DIST\"; } > $OUT"],
+    out = "result.txt",
+    deps = {"dist": ["//reloc:dist"]},
+)
+"#,
+    );
+
+    let result = ws.run("//reloc:consumer").await?;
+    let content = common::artifact_string(&result);
+    assert!(
+        content.contains("server_bytes"),
+        "relocated file's bytes did not arrive: {content:?}"
+    );
+    assert!(
+        content.contains("/ws/lib/server\n") || content.ends_with("/ws/lib/server"),
+        "expected the file to materialize at ws/lib/server, got: {content:?}"
+    );
+    Ok(())
+}
+
+#[tokio::test]
+async fn group_artifact_paths_are_the_rewritten_ones() -> anyhow::Result<()> {
+    let ws = Workspace::new();
+    ws.write_build_file(
+        PKG,
+        r#"
+target(
+    name = "bin",
+    driver = "bash",
+    run = "mkdir -p build/out/sub && echo a > build/out/server && echo b > build/out/sub/x.so",
+    out = ["build/out/server", "build/out/sub/x.so"],
+)
+target(
+    name = "dist",
+    driver = "group",
+    deps = ["//reloc:bin"],
+    strip_prefix = "reloc/build/out",
+    prefix = "lib",
+)
+"#,
+    );
+
+    let result = ws.run("//reloc:dist").await?;
+    let mut paths: Vec<String> = common::artifact_paths(&result)
+        .iter()
+        .map(|p| p.to_string_lossy().into_owned())
+        .collect();
+    paths.sort();
+    assert_eq!(paths, vec!["lib/server", "lib/sub/x.so"]);
+    Ok(())
+}
+
+#[tokio::test]
+async fn include_globs_drop_the_rest() -> anyhow::Result<()> {
+    let ws = Workspace::new();
+    ws.write_build_file(
+        PKG,
+        r#"
+target(
+    name = "bin",
+    driver = "bash",
+    run = "echo a > lib.so && echo b > notes.txt",
+    out = ["lib.so", "notes.txt"],
+)
+target(
+    name = "dist",
+    driver = "group",
+    deps = ["//reloc:bin"],
+    include = ["**/*.so"],
+)
+"#,
+    );
+
+    let result = ws.run("//reloc:dist").await?;
+    let paths: Vec<String> = common::artifact_paths(&result)
+        .iter()
+        .map(|p| p.to_string_lossy().into_owned())
+        .collect();
+    assert_eq!(paths, vec!["reloc/lib.so"]);
+    Ok(())
+}
+
+#[tokio::test]
+async fn rename_places_a_file_verbatim() -> anyhow::Result<()> {
+    let ws = Workspace::new();
+    ws.write_build_file(
+        PKG,
+        r#"
+target(name = "bin", driver = "bash", run = "echo a > server", out = "server")
+target(
+    name = "dist",
+    driver = "group",
+    deps = ["//reloc:bin"],
+    rename = {"reloc/server": "bin/myserver"},
+)
+"#,
+    );
+
+    let result = ws.run("//reloc:dist").await?;
+    let paths: Vec<String> = common::artifact_paths(&result)
+        .iter()
+        .map(|p| p.to_string_lossy().into_owned())
+        .collect();
+    assert_eq!(paths, vec!["bin/myserver"]);
+    Ok(())
+}
+
+/// The cache-correctness property the design rests on. A transparent group is
+/// expanded away before `hashin` is computed, so if a relocating group stayed
+/// transparent its transform would never reach a consumer's cache key and the
+/// consumer would reuse an entry built against the old layout.
+#[tokio::test]
+async fn changing_the_transform_invalidates_the_consumers_cache_key() -> anyhow::Result<()> {
+    let build = |prefix: &str| {
+        format!(
+            r#"
+target(name = "bin", driver = "bash", run = "echo a > server", out = "server")
+target(
+    name = "dist",
+    driver = "group",
+    deps = ["//reloc:bin"],
+    prefix = "{prefix}",
+)
+target(
+    name = "consumer",
+    driver = "bash",
+    run = "find . -type f > $OUT",
+    out = "result.txt",
+    deps = {{"dist": ["//reloc:dist"]}},
+)
+"#
+        )
+    };
+
+    let ws = Workspace::new();
+    ws.write_build_file(PKG, &build("lib"));
+    let with_lib = hashin(&ws, "//reloc:consumer").await?;
+
+    let ws2 = Workspace::new();
+    ws2.write_build_file(PKG, &build("bin"));
+    let with_bin = hashin(&ws2, "//reloc:consumer").await?;
+
+    assert_ne!(
+        with_lib, with_bin,
+        "a consumer's hashin must change when its dep group's `prefix` changes, \
+         or it would reuse an entry built against the old paths"
+    );
+    Ok(())
+}
+
+/// The flip side: the same transform must hash identically, or every build
+/// would miss cache.
+#[tokio::test]
+async fn an_unchanged_transform_keeps_the_cache_key_stable() -> anyhow::Result<()> {
+    let src = r#"
+target(name = "bin", driver = "bash", run = "echo a > server", out = "server")
+target(name = "dist", driver = "group", deps = ["//reloc:bin"], prefix = "lib")
+target(
+    name = "consumer",
+    driver = "bash",
+    run = "find . -type f > $OUT",
+    out = "result.txt",
+    deps = {"dist": ["//reloc:dist"]},
+)
+"#;
+    let ws = Workspace::new();
+    ws.write_build_file(PKG, src);
+    let a = hashin(&ws, "//reloc:consumer").await?;
+
+    let ws2 = Workspace::new();
+    ws2.write_build_file(PKG, src);
+    let b = hashin(&ws2, "//reloc:consumer").await?;
+
+    assert_eq!(a, b, "an unchanged transform must hash stably");
+    Ok(())
+}
+
+/// The whole point of the feature: relocating costs no stored bytes. A
+/// relocating group is a real (non-transparent) target, but it must still be
+/// uncacheable so no revision or blob is ever written for it.
+#[tokio::test]
+async fn a_relocating_group_is_concrete_but_never_cached() -> anyhow::Result<()> {
+    let ws = Workspace::new();
+    ws.write_build_file(
+        PKG,
+        r#"
+target(name = "bin", driver = "bash", run = "echo a > server", out = "server")
+target(name = "dist", driver = "group", deps = ["//reloc:bin"], prefix = "lib")
+"#,
+    );
+
+    let rs = ws.engine.new_state();
+    let def = ws
+        .engine
+        .clone()
+        .get_def(rs, &parse_addr("//reloc:dist")?)
+        .await?;
+
+    assert!(
+        !def.target_def.transparent,
+        "a relocating group must be concrete, or its transform escapes consumers' cache keys"
+    );
+    assert!(
+        !def.target_def.cache.enabled,
+        "a relocating group owns no bytes and must never write a cache entry"
+    );
+    Ok(())
+}
+
+/// No-regression guard: a group with no transform keeps its original
+/// zero-cost, inlined behaviour.
+#[tokio::test]
+async fn a_plain_group_is_still_transparent() -> anyhow::Result<()> {
+    let ws = Workspace::new();
+    ws.write_build_file(
+        PKG,
+        r#"
+target(name = "bin", driver = "bash", run = "echo a > server", out = "server")
+target(name = "dist", driver = "group", deps = ["//reloc:bin"])
+"#,
+    );
+
+    let rs = ws.engine.new_state();
+    let def = ws
+        .engine
+        .clone()
+        .get_def(rs, &parse_addr("//reloc:dist")?)
+        .await?;
+    assert!(def.target_def.transparent);
+    assert!(!def.target_def.cache.enabled);
+    Ok(())
+}
+
+/// A typo'd `strip_prefix` must fail the build and say what was available,
+/// rather than silently passing every path through untouched.
+#[tokio::test]
+async fn a_transform_matching_nothing_fails_with_the_available_paths() -> anyhow::Result<()> {
+    let ws = Workspace::new();
+    ws.write_build_file(
+        PKG,
+        r#"
+target(name = "bin", driver = "bash", run = "echo a > server", out = "server")
+target(
+    name = "dist",
+    driver = "group",
+    deps = ["//reloc:bin"],
+    strip_prefix = "nowhere/at/all",
+)
+"#,
+    );
+
+    let err = match ws.run("//reloc:dist").await {
+        Ok(_) => panic!("expected a typo'd strip_prefix to fail the build"),
+        Err(e) => format!("{e:#}"),
+    };
+    assert!(err.contains("nowhere/at/all"), "{err}");
+    assert!(
+        err.contains("reloc/server"),
+        "error should list the real paths: {err}"
+    );
+    Ok(())
+}
+
+/// Two files landing on one destination must fail rather than one silently
+/// clobbering the other.
+#[tokio::test]
+async fn colliding_destinations_fail_the_build() -> anyhow::Result<()> {
+    let ws = Workspace::new();
+    ws.write_build_file(
+        PKG,
+        r#"
+target(
+    name = "bin",
+    driver = "bash",
+    run = "mkdir -p a && echo one > a/x && echo two > x",
+    out = ["a/x", "x"],
+)
+target(
+    name = "dist",
+    driver = "group",
+    deps = ["//reloc:bin"],
+    # Both sources are sent to the same destination.
+    rename = {"reloc/a/x": "out/x", "reloc/x": "out/x"},
+)
+"#,
+    );
+
+    let err = match ws.run("//reloc:dist").await {
+        Ok(_) => panic!("expected colliding destinations to fail the build"),
+        Err(e) => format!("{e:#}"),
+    };
+    assert!(err.contains("collision"), "{err}");
+    Ok(())
+}
+
+/// Relocation composes with the rest of the graph: a group over two producers
+/// in different packages, where the prefix only applies to one of them.
+#[tokio::test]
+async fn a_group_can_relocate_across_packages() -> anyhow::Result<()> {
+    let ws = Workspace::new();
+    ws.write_build_file(
+        "app",
+        r#"
+target(
+    name = "bin",
+    driver = "bash",
+    run = "mkdir -p build && echo app_bytes > build/server",
+    out = "build/server",
+)
+"#,
+    );
+    ws.write_build_file(
+        "web",
+        r#"
+target(name = "assets", driver = "bash", run = "echo css_bytes > site.css", out = "site.css")
+target(
+    name = "dist",
+    driver = "group",
+    deps = ["//app:bin", "//web:assets"],
+    strip_prefix = "app/build",
+    prefix = "release",
+)
+target(
+    name = "consumer",
+    driver = "bash",
+    # `$LIST_SRC_DIST` lists every materialized path for the group.
+    run = ["cat \"$LIST_SRC_DIST\" > $OUT"],
+    out = "result.txt",
+    deps = {"dist": ["//web:dist"]},
+)
+"#,
+    );
+
+    let result = ws.run("//web:consumer").await?;
+    let listed = common::artifact_string(&result);
+    assert!(
+        listed.contains("/ws/release/server"),
+        "app/build/server should relocate to release/server, got: {listed:?}"
+    );
+    assert!(
+        listed.contains("/ws/release/web/site.css"),
+        "web/site.css is not under the stripped prefix and should only gain \
+         the prefix, got: {listed:?}"
+    );
+    Ok(())
+}
+
+/// An author writing a group must not have to know where a dependency emitted
+/// its outputs. Heph emits `<pkg>/<declared out path>`, so the full path here
+/// is `app/build/out/server` — a spelling that leaks the dep's package *and*
+/// its internal build layout, and that breaks if the dep ever moves package.
+/// The string form of `rename` names no source at all.
+#[tokio::test]
+async fn string_rename_needs_no_knowledge_of_the_emitted_path() -> anyhow::Result<()> {
+    let ws = Workspace::new();
+    ws.write_build_file(
+        "app",
+        r#"
+target(
+    name = "bin",
+    driver = "bash",
+    run = "mkdir -p build/out && echo v > build/out/server",
+    out = "build/out/server",
+)
+"#,
+    );
+    ws.write_build_file(
+        "dist",
+        r#"
+target(
+    name = "dist",
+    driver = "group",
+    deps = ["//app:bin"],
+    rename = "bin/myserver",
+)
+"#,
+    );
+
+    let result = ws.run("//dist:dist").await?;
+    let paths: Vec<String> = common::artifact_paths(&result)
+        .iter()
+        .map(|p| p.to_string_lossy().into_owned())
+        .collect();
+    assert_eq!(paths, vec!["bin/myserver"]);
+    Ok(())
+}
+
+/// `include` narrows a multi-output dep down to the one file the string form
+/// needs — the documented fix when it reports too many candidates.
+#[tokio::test]
+async fn include_narrows_a_string_rename_to_one_output() -> anyhow::Result<()> {
+    let ws = Workspace::new();
+    ws.write_build_file(
+        "app",
+        r#"
+target(
+    name = "bin",
+    driver = "bash",
+    run = "echo a > server.so && echo b > notes.txt",
+    out = ["server.so", "notes.txt"],
+)
+target(
+    name = "dist",
+    driver = "group",
+    deps = ["//app:bin"],
+    include = ["**/*.so"],
+    rename = "lib/libserver.so",
+)
+"#,
+    );
+
+    let result = ws.run("//app:dist").await?;
+    let paths: Vec<String> = common::artifact_paths(&result)
+        .iter()
+        .map(|p| p.to_string_lossy().into_owned())
+        .collect();
+    assert_eq!(paths, vec!["lib/libserver.so"]);
+    Ok(())
+}
+
+/// Same constraint for `strip_prefix`: it is written the way the *producing*
+/// BUILD file declares its output (`build/out`), not the way heph emits it
+/// (`app/build/out`). Both spellings must land on the same layout.
+#[tokio::test]
+async fn strip_prefix_is_written_as_the_producer_declares_it() -> anyhow::Result<()> {
+    let build = |prefix: &str| {
+        format!(
+            r#"
+target(
+    name = "dist",
+    driver = "group",
+    deps = ["//app:bin"],
+    strip_prefix = "{prefix}",
+    prefix = "release",
+)
+"#
+        )
+    };
+    let producer = r#"
+target(
+    name = "bin",
+    driver = "bash",
+    run = "mkdir -p build/out && echo v > build/out/server",
+    out = "build/out/server",
+)
+"#;
+
+    let paths_for = async |prefix: &str| -> anyhow::Result<Vec<String>> {
+        let ws = Workspace::new();
+        ws.write_build_file("app", producer);
+        ws.write_build_file("dist", &build(prefix));
+        let result = ws.run("//dist:dist").await?;
+        Ok(common::artifact_paths(&result)
+            .iter()
+            .map(|p| p.to_string_lossy().into_owned())
+            .collect())
+    };
+
+    // Written the way the producer declares it — no `app/` required.
+    assert_eq!(paths_for("build/out").await?, vec!["release/server"]);
+    // And the fully-qualified spelling agrees.
+    assert_eq!(paths_for("app/build/out").await?, vec!["release/server"]);
+    Ok(())
+}
+
+/// One destination and two candidate outputs must fail loudly, naming both and
+/// pointing at the fix, rather than silently picking one.
+#[tokio::test]
+async fn a_string_rename_with_two_outputs_fails_naming_the_candidates() -> anyhow::Result<()> {
+    let ws = Workspace::new();
+    ws.write_build_file(
+        "app",
+        r#"
+target(
+    name = "bin",
+    driver = "bash",
+    run = "mkdir -p a b && echo one > a/server && echo two > b/server",
+    out = ["a/server", "b/server"],
+)
+target(
+    name = "dist",
+    driver = "group",
+    deps = ["//app:bin"],
+    rename = "bin/s",
+)
+"#,
+    );
+
+    let err = match ws.run("//app:dist").await {
+        Ok(_) => panic!("expected an over-broad string rename to fail the build"),
+        Err(e) => format!("{e:#}"),
+    };
+    assert!(err.contains("app/a/server"), "{err}");
+    assert!(err.contains("app/b/server"), "{err}");
+    assert!(err.contains("include"), "should suggest narrowing: {err}");
+    Ok(())
+}
+
+/// A member's `transitive` sandbox must still reach the consumer once the
+/// group stops being transparent.
+///
+/// This works because `collect_transitive_deps` branches on the *driver name*
+/// (`group`), not on `transparent` — so both modes take the pre-computed
+/// `applied_transitive` path. That is easy to break by "tidying" the branch
+/// into a `transparent` check, which is exactly why it is pinned here.
+/// Transitive deps land at their own paths; the transform re-exports outputs,
+/// and is not meant to move them.
+#[tokio::test]
+async fn transitive_deps_still_propagate_through_a_relocating_group() -> anyhow::Result<()> {
+    let ws = Workspace::new();
+    ws.write_build_file(
+        PKG,
+        r#"
+target(name = "tool", driver = "bash", run = "echo tool_value > $OUT", out = "tool.txt")
+target(
+    name = "lib",
+    driver = "bash",
+    run = "echo lib_value > $OUT",
+    out = "lib.txt",
+    transitive = {"deps": {"tool": ["//reloc:tool"]}},
+)
+target(
+    name = "dist",
+    driver = "group",
+    deps = ["//reloc:lib"],
+    prefix = "release",
+)
+target(
+    name = "consumer",
+    driver = "bash",
+    run = ["printf '%s %s' \"$(cat \"$SRC_DIST\")\" \"$(cat \"$SRC_TOOL\")\" > $OUT"],
+    out = "result.txt",
+    deps = {"dist": ["//reloc:dist"]},
+)
+"#,
+    );
+
+    let result = ws.run("//reloc:consumer").await?;
+    let content = common::artifact_string(&result);
+    assert!(
+        content.contains("lib_value"),
+        "relocated output missing: {content:?}"
+    );
+    assert!(
+        content.contains("tool_value"),
+        "transitive dep did not survive the group becoming concrete: {content:?}"
+    );
+    Ok(())
+}
+
+/// Inline dep filters (`//foo:bar[…]`) accept globs, not just exact paths.
+#[tokio::test]
+async fn inline_dep_filters_accept_globs() -> anyhow::Result<()> {
+    let ws = Workspace::new();
+    ws.write_build_file(
+        PKG,
+        r#"
+target(
+    name = "bin",
+    driver = "bash",
+    run = "echo a > keep.so && echo b > drop.txt",
+    out = ["keep.so", "drop.txt"],
+)
+target(
+    name = "consumer",
+    driver = "bash",
+    # cwd is the sandbox's package dir, so the dep's files are alongside.
+    run = "test ! -e drop.txt && cat keep.so > $OUT",
+    out = "result.txt",
+    deps = {"bin": ["//reloc:bin[**/*.so]"]},
+)
+"#,
+    );
+
+    let result = ws.run("//reloc:consumer").await?;
+    assert!(
+        common::artifact_string(&result).contains("a"),
+        "glob filter should have exposed keep.so and hidden drop.txt"
+    );
+    Ok(())
+}
+
+/// The compatibility guarantee for inline filters: an exact path keeps working
+/// exactly as it did before they became glob-aware.
+#[tokio::test]
+async fn inline_dep_filters_still_accept_exact_paths() -> anyhow::Result<()> {
+    let ws = Workspace::new();
+    ws.write_build_file(
+        PKG,
+        r#"
+target(
+    name = "bin",
+    driver = "bash",
+    run = "echo a > keep.txt && echo b > drop.txt",
+    out = ["keep.txt", "drop.txt"],
+)
+target(
+    name = "consumer",
+    driver = "bash",
+    run = "test ! -e drop.txt && cat keep.txt > $OUT",
+    out = "result.txt",
+    deps = {"bin": ["//reloc:bin[reloc/keep.txt]"]},
+)
+"#,
+    );
+
+    let result = ws.run("//reloc:consumer").await?;
+    assert!(common::artifact_string(&result).contains("a"));
+    Ok(())
+}

--- a/crates/e2e/tests/group_relocate.rs
+++ b/crates/e2e/tests/group_relocate.rs
@@ -23,11 +23,7 @@ const PKG: &str = "reloc";
 
 async fn hashin(ws: &Workspace, addr: &str) -> anyhow::Result<String> {
     let rs = ws.engine.new_state();
-    let meta = ws
-        .engine
-        .clone()
-        .meta(rs, &parse_addr(addr)?)
-        .await?;
+    let meta = ws.engine.clone().meta(rs, &parse_addr(addr)?).await?;
     Ok(meta.hashin)
 }
 

--- a/crates/engine/src/engine/local_cache.rs
+++ b/crates/engine/src/engine/local_cache.rs
@@ -456,7 +456,9 @@ fn cache_entry_name(artifact: &outputartifact::OutputArtifact) -> String {
     };
     match &artifact.content {
         // Packed on the way in, so the entry carries the container suffix.
-        outputartifact::Content::Raw(_) | outputartifact::Content::File(_) => {
+        outputartifact::Content::Raw(_)
+        | outputartifact::Content::File(_)
+        | outputartifact::Content::View(_) => {
             format!("{}_{}.tar", type_prefix, artifact.name)
         }
         // Already a container on disk; copied verbatim.
@@ -579,6 +581,32 @@ impl Engine {
                     let size = cw.bytes_written();
                     cw.into_inner().commit().with_context(|| {
                         format!("commit file artifact {addr} {name}")
+                    })?;
+                    (size, hartifactcontent::Type::Tar)
+                }
+                // A view normally never arrives here: `is_passthrough` diverts it
+                // before the cache write, because its whole point is to own no
+                // bytes. It reaches this arm only if a driver returns one from a
+                // *cacheable* target, and then the honest thing is to pack it —
+                // a cached revision must own durable bytes, and a view's source
+                // is free to change or be reclaimed underneath it. That costs a
+                // full copy, which is the cost of having asked to cache it.
+                outputartifact::Content::View(v) => {
+                    let mut cw = CountingWriter::new(
+                        open_writer(&name).with_context(|| {
+                            format!("open cache writer for {addr} {name}")
+                        })?,
+                    );
+                    let mut r = hartifactcontent::Content::reader(v.view.as_ref())
+                        .with_context(|| {
+                            format!("open view artifact reader for {addr} {name}")
+                        })?;
+                    io::copy(&mut r, &mut cw).with_context(|| {
+                        format!("pack view artifact into {addr} {name}")
+                    })?;
+                    let size = cw.bytes_written();
+                    cw.into_inner().commit().with_context(|| {
+                        format!("commit view artifact {addr} {name}")
                     })?;
                     (size, hartifactcontent::Type::Tar)
                 }

--- a/crates/engine/src/engine/result.rs
+++ b/crates/engine/src/engine/result.rs
@@ -677,10 +677,17 @@ impl Content for PassthroughContent {
     }
 
     fn walk(&self) -> anyhow::Result<Box<dyn Iterator<Item = anyhow::Result<WalkEntry>> + '_>> {
+        let size = std::fs::metadata(&self.source_path)
+            .with_context(|| format!("stat passthrough source '{}'", self.source_path))?
+            .len();
         let data: Box<dyn std::io::Read> = Box::new(self.verifying_reader()?);
         Ok(Box::new(std::iter::once(Ok(WalkEntry {
             path: std::path::PathBuf::from(&self.out_path),
-            kind: WalkEntryKind::File { data, x: self.x },
+            kind: WalkEntryKind::File {
+                data,
+                x: self.x,
+                size,
+            },
         }))))
     }
 
@@ -2795,7 +2802,7 @@ impl Engine {
                     let entry = entry
                         .with_context(|| format!("read codegen entry for frozen check: {group}"))?;
                     let (new_bytes, x) = match entry.kind {
-                        WalkEntryKind::File { mut data, x } => {
+                        WalkEntryKind::File { mut data, x, .. } => {
                             let mut buf = Vec::new();
                             std::io::Read::read_to_end(&mut data, &mut buf)
                                 .with_context(|| format!("read generated file {:?}", entry.path))?;
@@ -2895,7 +2902,7 @@ impl Engine {
                         continue;
                     }
                     match entry.kind {
-                        WalkEntryKind::File { mut data, x } => {
+                        WalkEntryKind::File { mut data, x, .. } => {
                             let mut new_bytes = Vec::new();
                             std::io::Read::read_to_end(&mut data, &mut new_bytes)
                                 .with_context(|| format!("read generated file {:?}", entry.path))?;

--- a/crates/engine/src/engine/result.rs
+++ b/crates/engine/src/engine/result.rs
@@ -602,9 +602,9 @@ impl ResultArtifact {
     /// it on consume and fails if it diverges from the hash recorded at
     /// input-hashing time. See [`PassthroughContent`].
     ///
-    /// `is_passthrough` only ever flags a `Content::File`; any other variant
-    /// reaching here is a producer bug, so it falls back to carrying the raw
-    /// artifact rather than panicking.
+    /// `is_passthrough` only ever flags a `Content::File` or a
+    /// `Content::View`; any other variant reaching here is a producer bug, so
+    /// it falls back to carrying the raw artifact rather than panicking.
     fn passthrough(a: outputartifact::OutputArtifact) -> Self {
         let group = a.group.clone();
         let r#type = manifest_artifact_type(&a.r#type);
@@ -615,6 +615,11 @@ impl ResultArtifact {
                 x: f.x,
                 expected: a.hashout,
             }),
+            // Hand the view out directly rather than re-wrapping it in its
+            // `OutputArtifact`: the `ViewContent` is already a full `Content`,
+            // so consumers get its header-only `entry_paths` and its
+            // data-forwarding `walk` instead of the enum's generic fallbacks.
+            outputartifact::Content::View(v) => v.view,
             other => Arc::new(outputartifact::OutputArtifact {
                 content: other,
                 ..a
@@ -739,13 +744,26 @@ fn manifest_artifact_type(t: &outputartifact::Type) -> ManifestArtifactType {
     }
 }
 
-/// Whether a produced output is a zero-copy source-file passthrough that must
-/// skip the local cache. True only on the uncached (`tmp`) path AND when its
-/// producer flagged a `Content::File` as a durable source reference (e.g.
-/// `@heph/fs:file`). A cacheable revision must own a durable copy of its bytes
-/// (`source_path` may change/vanish across runs), so it is never a passthrough.
+/// Whether a produced output is a zero-copy passthrough that must skip the
+/// local cache. Two shapes qualify, both on the uncached (`tmp`) path only:
+///
+/// * a `Content::File` its producer flagged as a durable source reference
+///   (e.g. `@heph/fs:file`);
+/// * a `Content::View` — a path-rewritten window onto another target's
+///   artifact (the `group` driver's relocate/filter mode). Storing it would
+///   duplicate every byte of the source for nothing; the source revision is
+///   already cached, and the view is a few string operations to re-derive.
+///
+/// Both borrow bytes they do not own, which is exactly why a *cacheable*
+/// revision is never a passthrough: it must own a durable copy, since the
+/// borrowed source may change or vanish across runs.
 fn is_passthrough(use_tmp_cache: bool, content: &outputartifact::Content) -> bool {
-    use_tmp_cache && matches!(content, outputartifact::Content::File(f) if f.passthrough)
+    use_tmp_cache
+        && match content {
+            outputartifact::Content::File(f) => f.passthrough,
+            outputartifact::Content::View(_) => true,
+            _ => false,
+        }
 }
 
 /// The `@heph/fs` addrs covering every `codegen = in_place` output path.

--- a/crates/engine/src/engine/result.rs
+++ b/crates/engine/src/engine/result.rs
@@ -658,16 +658,33 @@ struct PassthroughContent {
 
 impl PassthroughContent {
     fn verifying_reader(&self) -> anyhow::Result<VerifyingReader> {
+        Ok(self.open()?.0)
+    }
+
+    /// Open the source once and read its size off the resulting handle.
+    ///
+    /// `fstat` on the open descriptor, not a second `stat` by path: this runs
+    /// once per source file per materialization — the hottest walk in a build —
+    /// so a path-based size lookup would pay a full second path resolution for
+    /// a file already open in this function.
+    fn open(&self) -> anyhow::Result<(VerifyingReader, u64)> {
         let file = std::fs::File::open(&self.source_path)
             .with_context(|| format!("open passthrough source '{}'", self.source_path))?;
-        Ok(VerifyingReader {
-            inner: Box::new(file),
-            hasher: xxhash_rust::xxh3::Xxh3::new(),
-            x: self.x,
-            expected: self.expected.clone(),
-            source_path: self.source_path.clone(),
-            verified: false,
-        })
+        let size = file
+            .metadata()
+            .with_context(|| format!("stat passthrough source '{}'", self.source_path))?
+            .len();
+        Ok((
+            VerifyingReader {
+                inner: Box::new(file),
+                hasher: xxhash_rust::xxh3::Xxh3::new(),
+                x: self.x,
+                expected: self.expected.clone(),
+                source_path: self.source_path.clone(),
+                verified: false,
+            },
+            size,
+        ))
     }
 }
 
@@ -677,10 +694,8 @@ impl Content for PassthroughContent {
     }
 
     fn walk(&self) -> anyhow::Result<Box<dyn Iterator<Item = anyhow::Result<WalkEntry>> + '_>> {
-        let size = std::fs::metadata(&self.source_path)
-            .with_context(|| format!("stat passthrough source '{}'", self.source_path))?
-            .len();
-        let data: Box<dyn std::io::Read> = Box::new(self.verifying_reader()?);
+        let (reader, size) = self.open()?;
+        let data: Box<dyn std::io::Read> = Box::new(reader);
         Ok(Box::new(std::iter::once(Ok(WalkEntry {
             path: std::path::PathBuf::from(&self.out_path),
             kind: WalkEntryKind::File {

--- a/crates/plugin-abi/src/convert.rs
+++ b/crates/plugin-abi/src/convert.rs
@@ -741,7 +741,14 @@ fn oa_type_from_pb(t: i32) -> OaType {
     }
 }
 
-pub fn output_artifact_to_pb(oa: &OutputArtifact) -> pb::OutputArtifactRef {
+/// Encode a driver-produced artifact for the wire.
+///
+/// Fallible for exactly one reason: [`OaContent::View`] holds a live
+/// `Arc<dyn Content>` into the host's cache and has no wire form. It is
+/// unconstructible from a plugin — only in-process built-in drivers make one —
+/// so this is a "cannot happen" that is reported rather than panicked, because
+/// the caller is a plugin cdylib where a panic is a non-unwinding abort.
+pub fn output_artifact_to_pb(oa: &OutputArtifact) -> anyhow::Result<pb::OutputArtifactRef> {
     let content = match &oa.content {
         OaContent::File(f) => pb::output_artifact_ref::Content::File(pb::ContentFile {
             source_path: f.source_path.clone(),
@@ -755,14 +762,20 @@ pub fn output_artifact_to_pb(oa: &OutputArtifact) -> pb::OutputArtifactRef {
         }),
         OaContent::TarPath(p) => pb::output_artifact_ref::Content::TarPath(p.path.clone()),
         OaContent::CpioPath(p) => pb::output_artifact_ref::Content::CpioPath(p.path.clone()),
+        OaContent::View(_) => anyhow::bail!(
+            "artifact '{}' is a path-rewriting view, which references host cache content \
+             and cannot cross the plugin ABI — only in-process built-in drivers may \
+             produce one",
+            oa.name,
+        ),
     };
-    pb::OutputArtifactRef {
+    Ok(pb::OutputArtifactRef {
         group: oa.group.clone(),
         name: oa.name.clone(),
         r#type: oa_type_to_pb(&oa.r#type) as i32,
         content: Some(content),
         hashout: oa.hashout.clone(),
-    }
+    })
 }
 
 pub fn output_artifact_from_pb(oa: pb::OutputArtifactRef) -> OutputArtifact {

--- a/crates/plugin-go/src/plugingo/provider.rs
+++ b/crates/plugin-go/src/plugingo/provider.rs
@@ -3745,6 +3745,7 @@ mod tests {
             let entry = WalkEntry {
                 path: self.path.clone(),
                 kind: WalkEntryKind::File {
+                    size: self.bytes.len() as u64,
                     data: Box::new(io::Cursor::new(self.bytes.clone())),
                     x: false,
                 },

--- a/crates/plugin-sdk/src/serve.rs
+++ b/crates/plugin-sdk/src/serve.rs
@@ -1173,14 +1173,18 @@ async fn run_once(
         driver.run(mrr, ct).await
     };
     match result {
-        Ok(resp) => pb::RunOutFrame {
-            msg: Some(pb::run_out_frame::Msg::Response(pb::ManagedRunResponse {
-                artifacts: resp
-                    .artifacts
-                    .iter()
-                    .map(convert::output_artifact_to_pb)
-                    .collect(),
-            })),
+        Ok(resp) => match resp
+            .artifacts
+            .iter()
+            .map(convert::output_artifact_to_pb)
+            .collect::<anyhow::Result<Vec<_>>>()
+        {
+            Ok(artifacts) => pb::RunOutFrame {
+                msg: Some(pb::run_out_frame::Msg::Response(pb::ManagedRunResponse {
+                    artifacts,
+                })),
+            },
+            Err(e) => run_out_err(err_message(&e)),
         },
         Err(e) => run_out_err(err_message(&e)),
     }

--- a/crates/plugin-sdk/src/serve.rs
+++ b/crates/plugin-sdk/src/serve.rs
@@ -1319,11 +1319,16 @@ impl Content for DiskInputContent {
                 }
             };
             let f = std::fs::File::open(&abs).with_context(|| format!("open {}", abs.display()))?;
+            let size = f
+                .metadata()
+                .with_context(|| format!("stat {}", abs.display()))?
+                .len();
             Ok(WalkEntry {
                 path: rel,
                 kind: WalkEntryKind::File {
                     data: Box::new(f),
                     x,
+                    size,
                 },
             })
         });

--- a/crates/plugin/src/driver.rs
+++ b/crates/plugin/src/driver.rs
@@ -966,6 +966,7 @@ pub mod outputartifact {
                 Content::Raw(raw) => Box::new(std::iter::once(Ok(WalkEntry {
                     path: PathBuf::from(&raw.path),
                     kind: WalkEntryKind::File {
+                        size: raw.data.len() as u64,
                         data: Box::new(io::Cursor::new(raw.data.clone())),
                         x: raw.x,
                     },
@@ -973,6 +974,7 @@ pub mod outputartifact {
                 Content::File(file) => Box::new(std::iter::once(Ok(WalkEntry {
                     path: PathBuf::from(&file.out_path),
                     kind: WalkEntryKind::File {
+                        size: std::fs::metadata(&file.source_path)?.len(),
                         data: Box::new(File::open(&file.source_path)?),
                         x: file.x,
                     },

--- a/crates/plugin/src/driver.rs
+++ b/crates/plugin/src/driver.rs
@@ -971,14 +971,20 @@ pub mod outputartifact {
                         x: raw.x,
                     },
                 }))),
-                Content::File(file) => Box::new(std::iter::once(Ok(WalkEntry {
-                    path: PathBuf::from(&file.out_path),
-                    kind: WalkEntryKind::File {
-                        size: std::fs::metadata(&file.source_path)?.len(),
-                        data: Box::new(File::open(&file.source_path)?),
-                        x: file.x,
-                    },
-                }))),
+                Content::File(file) => Box::new(std::iter::once((|| {
+                    // Opened once and `fstat`ed, rather than a `stat` by path
+                    // plus an open — one path resolution, not two.
+                    let f = File::open(&file.source_path)?;
+                    let size = f.metadata()?.len();
+                    Ok(WalkEntry {
+                        path: PathBuf::from(&file.out_path),
+                        kind: WalkEntryKind::File {
+                            data: Box::new(f),
+                            x: file.x,
+                            size,
+                        },
+                    })
+                })())),
                 Content::TarPath(p) => Box::new(hcore::hartifactcontent::tar::TarWalker::new(
                     File::open(&p.path)?,
                 )?),

--- a/crates/plugin/src/driver.rs
+++ b/crates/plugin/src/driver.rs
@@ -48,6 +48,43 @@ impl Display for TargetAddr {
     }
 }
 
+/// Split a `[…]` filter list on commas, ignoring commas nested inside `{}`.
+///
+/// The filter list is comma-separated and its patterns are globs, and glob
+/// alternation is also comma-separated (`src/{a,b}.go`) — so a naive
+/// `split(',')` would tear `{a,b}` into `{a` and `b}`. Neither half compiles as
+/// a glob, so both would degrade to literal matches and silently select
+/// nothing. Tracking brace depth keeps alternation working and costs one
+/// counter.
+///
+/// Unbalanced braces are left to the glob compiler, which rejects them (and
+/// `PathFilter` then treats the pattern as a literal) — this function only
+/// decides where the commas are.
+fn split_filters(rest: &str) -> Vec<String> {
+    if rest.is_empty() {
+        return vec![];
+    }
+    let mut out = Vec::new();
+    let mut depth = 0usize;
+    let mut cur = String::new();
+    for c in rest.chars() {
+        match c {
+            '{' => {
+                depth += 1;
+                cur.push(c);
+            }
+            '}' => {
+                depth = depth.saturating_sub(1);
+                cur.push(c);
+            }
+            ',' if depth == 0 => out.push(std::mem::take(&mut cur)),
+            _ => cur.push(c),
+        }
+    }
+    out.push(cur);
+    out
+}
+
 impl TargetAddr {
     pub fn parse(v: &str, base: &PkgBuf) -> anyhow::Result<Self> {
         // Strip optional trailing [filter1,filter2] suffix.
@@ -60,11 +97,7 @@ impl TargetAddr {
             let rest = rest
                 .strip_suffix(']')
                 .ok_or_else(|| anyhow::anyhow!("unclosed '[' in target addr: {v}"))?;
-            let filters = if rest.is_empty() {
-                vec![]
-            } else {
-                rest.split(',').map(|s| s.to_string()).collect()
-            };
+            let filters = split_filters(rest);
             (addr_part, filters)
         } else {
             (v, vec![])
@@ -135,6 +168,32 @@ mod tests {
     #[test]
     fn parse_unclosed_bracket_errors() {
         assert!(TargetAddr::parse("//foo:bar[a.go", &base()).is_err());
+    }
+
+    #[test]
+    fn parse_glob_filters() {
+        let t = TargetAddr::parse("//foo:bar[**/*.go,bin/**]", &base()).unwrap();
+        assert_eq!(t.filters, vec!["**/*.go", "bin/**"]);
+    }
+
+    /// Glob alternation is itself comma-separated, so the filter split must be
+    /// brace-aware or `{a,b}` is torn in half and silently matches nothing.
+    #[test]
+    fn parse_keeps_brace_alternation_intact() {
+        let t = TargetAddr::parse("//foo:bar[src/{a,b}.go,README.md]", &base()).unwrap();
+        assert_eq!(t.filters, vec!["src/{a,b}.go", "README.md"]);
+    }
+
+    #[test]
+    fn parse_nested_braces_are_balanced_correctly() {
+        let t = TargetAddr::parse("//foo:bar[{a,{b,c}},d]", &base()).unwrap();
+        assert_eq!(t.filters, vec!["{a,{b,c}}", "d"]);
+    }
+
+    #[test]
+    fn display_roundtrip_with_glob_filters() {
+        let t = TargetAddr::parse("//foo:bar[src/{a,b}.go,bin/**]", &base()).unwrap();
+        assert_eq!(t.to_string(), "//foo:bar[src/{a,b}.go,bin/**]");
     }
 
     #[test]
@@ -852,12 +911,34 @@ pub mod outputartifact {
         }
     }
 
+    /// A zero-copy, path-rewritten view over an artifact the driver received as
+    /// an *input* — see [`hcore::hartifactcontent::view`].
+    ///
+    /// This is how a target relocates or filters another target's outputs
+    /// without copying them: no sandbox, no subprocess, and no second copy of
+    /// the bytes in the cache. The producing target must declare itself
+    /// uncacheable, because the view owns no durable bytes of its own — it
+    /// borrows its source's, exactly as [`ContentFile::passthrough`] borrows a
+    /// workspace file's. The engine enforces nothing here; a driver that
+    /// returns a view from a *cacheable* target would have it packed and
+    /// stored, which is merely wasteful, not wrong.
+    ///
+    /// Host-only: a view holds a live `Arc<dyn Content>` into the host's cache,
+    /// so it cannot cross the plugin ABI (see
+    /// [`output_artifact_to_pb`](../../../plugin_abi/convert/fn.output_artifact_to_pb.html)).
+    /// Only in-process built-in drivers construct one.
+    #[derive(Clone)]
+    pub struct ContentView {
+        pub view: std::sync::Arc<hcore::hartifactcontent::ViewContent>,
+    }
+
     #[derive(Clone)]
     pub enum Content {
         File(ContentFile),
         Raw(ContentRaw),
         TarPath(ContentPath),
         CpioPath(ContentPath),
+        View(ContentView),
     }
 
     #[derive(Clone)]
@@ -876,6 +957,7 @@ pub mod outputartifact {
                 Content::File(file) => Box::new(File::open(&file.source_path)?),
                 Content::TarPath(p) => Box::new(File::open(&p.path)?),
                 Content::CpioPath(p) => Box::new(File::open(&p.path)?),
+                Content::View(v) => v.view.reader()?,
             })
         }
 
@@ -900,11 +982,28 @@ pub mod outputartifact {
                 )?),
                 #[expect(clippy::unimplemented, reason = "cpio format is not yet implemented")]
                 Content::CpioPath(_) => unimplemented!("cpio is not implemented"),
+                Content::View(v) => v.view.walk()?,
             })
         }
 
         fn hashout(&self) -> anyhow::Result<String> {
             Ok(self.hashout.clone())
+        }
+
+        /// Delegated for a view so the path set comes from the source's
+        /// header-only scan rather than the default walk-and-discard.
+        fn entry_paths(&self) -> anyhow::Result<Vec<PathBuf>> {
+            match &self.content {
+                Content::View(v) => v.view.entry_paths(),
+                _ => self.walk()?.map(|r| r.map(|e| e.path)).collect(),
+            }
+        }
+
+        fn byte_size(&self) -> Option<u64> {
+            match &self.content {
+                Content::View(v) => v.view.byte_size(),
+                _ => None,
+            }
         }
     }
 }

--- a/crates/plugin/src/htspec/mod.rs
+++ b/crates/plugin/src/htspec/mod.rs
@@ -29,6 +29,10 @@ pub use htspec_derive::{Spec, SpecEnum, SpecStruct, SpecUnion};
 mod cache;
 pub use cache::TargetSpecCache;
 
+// `Rename`'s type lives in `hcore` (it is applied by `hartifactcontent::view`);
+// only its BUILD-file parsing belongs here.
+mod rename;
+
 // The `Spec` derive macro emits `crate::htspec::DriverField` / `DriverSchema`
 // (portable across the monolith re-export and this crate). Re-export them here
 // so those expansions resolve wherever the macro is used.

--- a/crates/plugin/src/htspec/rename.rs
+++ b/crates/plugin/src/htspec/rename.rs
@@ -1,0 +1,123 @@
+//! The shared `rename` target attribute.
+//!
+//! A driver that lets a target place its selected outputs exposes a `rename`
+//! field of type [`Rename`]. It accepts either form:
+//!
+//! ```python
+//! rename = "bin/myserver"                        # the selected output goes here
+//! rename = {"app/build/out/server": "bin/srv"}   # these exact paths go here
+//! ```
+//!
+//! The string form exists so an author never has to know where a dependency
+//! emitted its outputs: it renames whatever survives `include`/`exclude`, which
+//! must be exactly one file. The dict form is the precise escape hatch for
+//! moving several files at once, and its keys are matched exactly against
+//! emitted paths.
+//!
+//! Defined here, next to [`TargetSpecCache`](super::TargetSpecCache), so every
+//! driver that grows a `rename` knob parses it identically.
+
+use hcore::hartifactcontent::Rename;
+use hcore::htvalue::Value;
+use hcore::htvalue::signature::ParamType;
+
+use crate::htspec::FromSpecValue;
+
+impl FromSpecValue for Rename {
+    fn from_spec_value(v: &Value) -> anyhow::Result<Self> {
+        match v {
+            Value::String(s) => Ok(Rename::Sole(s.clone())),
+            Value::Map(m) => {
+                let mut out = std::collections::BTreeMap::new();
+                for (k, val) in m {
+                    let Value::String(dst) = val else {
+                        anyhow::bail!(
+                            "`rename` dict values must be strings; key '{k}' is not"
+                        );
+                    };
+                    out.insert(k.clone(), dst.clone());
+                }
+                Ok(Rename::Exact(out))
+            }
+            _ => anyhow::bail!(
+                "`rename` must be a string (the destination for the single selected \
+                 output) or a dict of exact source path -> destination"
+            ),
+        }
+    }
+
+    fn spec_param_type() -> ParamType {
+        ParamType::union(vec![ParamType::String, ParamType::map(ParamType::String)])
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::collections::BTreeMap;
+
+    fn parse(v: Value) -> anyhow::Result<Rename> {
+        Rename::from_spec_value(&v)
+    }
+
+    #[test]
+    fn absent_is_the_default() {
+        assert_eq!(Rename::default(), Rename::None);
+        assert!(Rename::default().is_none());
+    }
+
+    #[test]
+    fn string_form_parses_as_sole() {
+        assert_eq!(
+            parse(Value::String("bin/myserver".into())).unwrap(),
+            Rename::Sole("bin/myserver".into())
+        );
+    }
+
+    #[test]
+    fn dict_form_parses_as_exact() {
+        let v = Value::Map(
+            [("a/x".to_string(), Value::String("out/x".into()))]
+                .into_iter()
+                .collect(),
+        );
+        assert_eq!(
+            parse(v).unwrap(),
+            Rename::Exact(BTreeMap::from([("a/x".to_string(), "out/x".to_string())]))
+        );
+    }
+
+    #[test]
+    fn empty_dict_is_an_empty_exact_map() {
+        assert_eq!(
+            parse(Value::Map(Default::default())).unwrap(),
+            Rename::Exact(BTreeMap::new())
+        );
+    }
+
+    #[test]
+    fn non_string_dict_value_names_the_offending_key() {
+        let v = Value::Map(
+            [("a/x".to_string(), Value::Bool(true))]
+                .into_iter()
+                .collect(),
+        );
+        let err = parse(v).expect_err("must reject a non-string destination");
+        assert!(format!("{err:#}").contains("a/x"));
+    }
+
+    #[test]
+    fn other_shapes_are_rejected() {
+        assert!(parse(Value::Bool(true)).is_err());
+        assert!(parse(Value::List(vec![])).is_err());
+    }
+
+    /// The schema drives LSP completion, so it must advertise both forms.
+    #[test]
+    fn param_type_is_the_union_of_both_forms() {
+        assert_eq!(
+            Rename::spec_param_type(),
+            ParamType::union(vec![ParamType::String, ParamType::map(ParamType::String)])
+        );
+    }
+}

--- a/crates/plugin/src/htspec/rename.rs
+++ b/crates/plugin/src/htspec/rename.rs
@@ -31,9 +31,7 @@ impl FromSpecValue for Rename {
                 let mut out = std::collections::BTreeMap::new();
                 for (k, val) in m {
                     let Value::String(dst) = val else {
-                        anyhow::bail!(
-                            "`rename` dict values must be strings; key '{k}' is not"
-                        );
+                        anyhow::bail!("`rename` dict values must be strings; key '{k}' is not");
                     };
                     out.insert(k.clone(), dst.clone());
                 }

--- a/crates/plugingo-e2e/tests/codegen.rs
+++ b/crates/plugingo-e2e/tests/codegen.rs
@@ -80,7 +80,7 @@ async fn test_codegen_build_binary_outputs_hello() -> anyhow::Result<()> {
                 .to_owned();
             let dest = tmp.path().join(&name);
             match entry.kind {
-                heph::hartifactcontent::WalkEntryKind::File { mut data, x } => {
+                heph::hartifactcontent::WalkEntryKind::File { mut data, x, .. } => {
                     let mut buf = Vec::new();
                     data.read_to_end(&mut buf)?;
                     if x {

--- a/example/group/BUILD
+++ b/example/group/BUILD
@@ -11,8 +11,53 @@ target(
     out = "t2.txt",
 )
 
+# Aggregate: `g` re-exports t1 and t2's outputs unchanged. It is inlined into
+# whoever depends on it and never executes.
 target(
     name = "g",
     driver = "group",
-    deps = ["t1", "t2"],
+    deps = [":t1", ":t2"],
+)
+
+target(
+    name = "lib",
+    driver = "bash",
+    run = ["mkdir -p build/out && echo lib > build/out/lib.txt"],
+    out = "build/out/lib.txt",
+)
+
+# Filter and relocate: `dist` re-exports the same bytes at different paths.
+#
+# This copies nothing — no sandbox, no subprocess, and no cache entry of its
+# own. `lib` stays cached as it was, and `dist` is re-derived from a path list
+# on each build. The alternative (a bash target running `cp`) would store a
+# second copy of every byte locally and remotely.
+#
+# Patterns are written the way the *producing* target declares its outputs, so
+# you never need to know where heph materializes them:
+#
+#   build/out/lib.txt  ->  release/lib.txt
+#   t2.txt             ->  release/renamed.txt
+#
+# `heph inspect outputs //group:dist` prints the resulting paths.
+target(
+    name = "dist",
+    driver = "group",
+    deps = [":lib", ":t2"],
+    include = ["**/*.txt"],
+    strip_prefix = "build/out",
+    prefix = "release",
+    # The dict form moves specific paths, matched exactly against what the
+    # target emits. It leaves everything else to strip_prefix/prefix above.
+    rename = {"group/t2.txt": "release/renamed.txt"},
+)
+
+# The simpler form: when a group selects exactly one file, `rename` is just the
+# destination. No source path is named, so this keeps working if `lib` changes
+# where it writes — or moves to another package.
+target(
+    name = "server",
+    driver = "group",
+    deps = [":lib"],
+    rename = "bin/server.txt",
 )

--- a/src/commands/inspect/mod.rs
+++ b/src/commands/inspect/mod.rs
@@ -5,6 +5,7 @@ mod functions;
 mod hashin;
 mod hashout;
 mod labels;
+mod outputs;
 mod packages;
 mod path;
 mod revdeps;
@@ -64,6 +65,23 @@ pub enum InspectCommands {
     ///
     /// Example: `heph inspect hashout //cmd/server:bin`
     Hashout(hashout::Args),
+    /// Print the paths a target actually produces
+    ///
+    /// Runs the target (or reads its cached result) and prints every path in
+    /// its output artifacts, one per line — the paths as a consumer sees them
+    /// in its sandbox, after any filtering or relocation.
+    ///
+    /// This is the answer to "why did that file land there?" for a `group`
+    /// target using `include`/`exclude`/`strip_prefix`/`prefix`/`rename`:
+    /// compare the group's paths with its deps' to see exactly what the
+    /// transform did.
+    ///
+    /// Examples:
+    ///
+    /// `heph inspect outputs //cmd/server:bin`
+    ///
+    /// `heph inspect outputs //cmd:dist --json` — also lists support files
+    Outputs(outputs::Args),
     /// Print a target's spec, as supplied by its provider
     ///
     /// Prints the raw spec — the unresolved definition a provider returns
@@ -179,6 +197,7 @@ impl InspectCommands {
             InspectCommands::Labels(args) => labels::execute(args, sink, global),
             InspectCommands::Hashin(args) => hashin::execute(args, sink, global),
             InspectCommands::Hashout(args) => hashout::execute(args, sink, global),
+            InspectCommands::Outputs(args) => outputs::execute(args, sink, global),
             InspectCommands::Spec(args) => spec::execute(args, sink, global),
             InspectCommands::Def(args) => def::execute(args, sink, global),
             InspectCommands::Deps(args) => deps::execute(args, sink, global),

--- a/src/commands/inspect/outputs.rs
+++ b/src/commands/inspect/outputs.rs
@@ -1,0 +1,121 @@
+use std::sync::Arc;
+
+use anyhow::Context;
+use async_trait::async_trait;
+use clap_complete::engine::ArgValueCompleter;
+use serde::Serialize;
+
+use crate::commands::GlobalOptions;
+use crate::commands::bootstrap;
+use crate::commands::completion::complete_target_addr;
+use crate::engine::{Engine, OutputMatcher, ResultOptions};
+use crate::htaddr::{self, Addr};
+use crate::tui::{self, App, AppContext, LogSink};
+
+#[derive(clap::Args, Clone)]
+pub struct Args {
+    /// Target address (e.g. //pkg:name)
+    #[arg(add = ArgValueCompleter::new(complete_target_addr))]
+    pub addr: String,
+    /// Emit JSON instead of one path per line
+    #[arg(long)]
+    pub json: bool,
+}
+
+#[derive(Serialize)]
+struct OutputsView {
+    addr: String,
+    paths: Vec<String>,
+    support_paths: Vec<String>,
+}
+
+struct OutputsApp {
+    engine: Arc<Engine>,
+    addr: Addr,
+    json: bool,
+    fail_fast: bool,
+}
+
+#[async_trait]
+impl App for OutputsApp {
+    type Output = ();
+    type TuiView = crate::tui::TuiProgressView;
+    type CiView = crate::tui::CiProgressView;
+
+    fn tui_view(&self) -> Self::TuiView {
+        crate::tui::TuiProgressView::new(format!("Outputs {}", self.addr.format()))
+    }
+
+    fn ci_view(&self) -> Self::CiView {
+        crate::tui::CiProgressView::new(format!("Outputs {}", self.addr.format()))
+    }
+
+    async fn run(self, ctx: AppContext) -> anyhow::Result<()> {
+        let rs = self
+            .engine
+            .new_state_with_events(self.fail_fast, ctx.event_sender());
+        // `OutputMatcher::All` rather than `None`: the paths live inside the
+        // artifacts, and `None` resolves hashouts without handing any back.
+        let res = self
+            .engine
+            .clone()
+            .result_addr(
+                rs.clone(),
+                &self.addr,
+                OutputMatcher::All,
+                &ResultOptions::default(),
+            )
+            .await;
+        let addr = self.addr.format();
+        let json = self.json;
+        crate::commands::errors::finalize!(ctx, rs, res, result => {
+            // `entry_paths` is header-only for tar-backed cache artifacts, so
+            // listing a target's outputs does not read their bytes.
+            let collect = |arts: &[Arc<dyn hcore::hartifactcontent::Content>]| -> anyhow::Result<Vec<String>> {
+                let mut out = Vec::new();
+                for art in arts {
+                    for p in art.entry_paths().context("enumerate artifact paths")? {
+                        out.push(p.to_string_lossy().into_owned());
+                    }
+                }
+                out.sort();
+                out.dedup();
+                Ok(out)
+            };
+            let paths = collect(&result.artifacts)?;
+            let support_paths = collect(&result.support_artifacts)?;
+
+            if json {
+                let view = OutputsView { addr, paths, support_paths };
+                println!(
+                    "{}",
+                    serde_json::to_string_pretty(&view).context("serialize outputs")?
+                );
+            } else {
+                for p in &paths {
+                    println!("{p}");
+                }
+            }
+            Ok(())
+        })
+    }
+}
+
+pub fn execute(args: &Args, sink: LogSink, global: &GlobalOptions) -> anyhow::Result<()> {
+    bootstrap::block_on(execute_async(args.clone(), sink, global.clone()))?
+}
+
+async fn execute_async(args: Args, sink: LogSink, global: GlobalOptions) -> anyhow::Result<()> {
+    let base = crate::engine::get_cwp()?;
+    let addr = htaddr::parse_addr_with_base(args.addr.as_ref(), &base)
+        .with_context(|| format!("parse {}", args.addr))?;
+    let (engine, shutdown) = bootstrap::new_engine()?;
+    let app = OutputsApp {
+        engine,
+        addr,
+        json: args.json,
+        fail_fast: global.fail_fast,
+    };
+    let interactive = tui::should_use_tui(global.no_tui);
+    tui::run_app(app, sink, interactive, shutdown).await
+}


### PR DESCRIPTION
Lets a target re-export another target's outputs at different paths, without copying them.

```python
target(
    name = "dist",
    driver = "group",
    deps = ["//app:bin", "//web:assets"],
    include = ["**/*.so", "bin/**"],
    exclude = ["**/*_test"],
    strip_prefix = "build/out",
    prefix = "release",
)

# and one-off, no target needed:
deps = {"web": "//web:assets[**/*.css]"}
```

## Why it's cheap

Relocating today means an exec target running `cp` — a sandbox, a subprocess, and a second full copy of every byte in **both** the local and the remote cache. This costs a few string operations.

A transformed group produces `ContentView` artifacts: zero-copy windows onto its deps' artifacts that rewrite entry paths as they stream out of `walk()` and forward each file's read handle untouched. It declares itself uncacheable, so no revision, blob, or remote push is ever created for it. The deps stay cached exactly as before, and the group is re-derived from a path list each build.

An earlier design stored a manifest referencing the source blob. That was dropped: cache blobs are keyed by `(addr, hashin, name)` rather than globally content-addressed, so a cross-revision reference would have pulled GC (~2k lines) and the remote cache (~3.8k lines) into it. Resolving the view at the engine layer instead gets the same zero-copy property with no cache-format, GC, or remote-cache change.

## The cache-correctness constraint

`hashin = H(driver, own_def.hash, sorted(dep hashouts))` (`crates/engine/src/engine/meta.rs:67`). Per-input metadata is not folded in.

A `transparent` target is expanded away *before* `hashin` is computed, so its config never reaches a consumer's cache key — membership changes are caught only because they change which dep hashouts fold in, and **a path transform changes no dep's hashout**. A transparent relocating group would therefore be invisible to the cache, and consumers would happily reuse entries built against the pre-relocation layout.

That is why a group with a transform becomes a real target. Its transform reaches consumers through its own def hash and its artifacts' derived hashouts.

**A group with no transform is untouched** — still transparent, still inlined, and its def hash is pinned byte-identical to the pre-feature digest by a test, so nothing cached is invalidated by this landing.

## `rename` has two forms

```python
rename = "bin/server"                       # the sole selected output
rename = {"app/build/out/x": "lib/x"}       # exact emitted paths
```

The string form names no source path at all — it renames whatever survives `include`/`exclude`, which must be exactly one file — so it keeps working when a dep changes where it writes, or moves package. `include`/`exclude`/`strip_prefix` likewise accept the spelling the *producing* BUILD file uses (`build/out`) as well as the emitted one (`app/build/out`).

Mistakes are hard errors that name what was available, never silent no-ops: a transform matching nothing, a dict key matching nothing, one destination with several candidates, and two files landing on one path.

## Also here

- **Inline dep filters accept globs.** Five call sites open-coded `Path::new(f) == rel` (exact paths only); they now share one `PathFilter`, which falls back to an exact match for any pattern that will not compile — so every filter that worked before selects the same files. The `[a,b]` split is brace-aware so glob alternation (`{a,b}`) is not torn in half.
- **`heph inspect outputs <addr>`** prints the paths a target produces. Diff a group against its deps to answer "why did that file land there?".
- **`example/group/BUILD`** demonstrates both forms. Its existing `deps = ["t1"]` was never a valid ref (pre-existing breakage) and is fixed to `":t1"`.

## Testing

`lint` clean. Full `tst`: **94 result lines, 2536 passed, 0 failed.**

New coverage — 38 core (transform/view/filter), 25 group driver, 18 e2e. The e2e set proves what unit tests cannot: a file produced at `build/out/server` is readable by a consumer at `ws/lib/server`; changing `prefix` moves the consumer's `hashin`; an unchanged transform keeps it stable; the group stays uncacheable; and transitive deps still reach consumers once the group is concrete (`collect_transitive_deps` branches on driver name, not `transparent` — easy to break by "tidying").

Verified against the real binary:

```
$ heph inspect outputs //group:dist      $ heph inspect outputs //group:server
release/lib.txt                          bin/server.txt
release/renamed.txt
```

## Reviewer notes

- The review board (`product-vision`, `hermeticity`, `compatibility`, `code-quality`) was **not** consulted — the authoring session disallowed subagents. `compatibility` is the one worth a look: this adds the `inspect outputs` subcommand (additive) and makes `output_artifact_to_pb` fallible (`Content::View` holds a live `Arc<dyn Content>` into the host cache and has no wire form; it is unconstructible from a plugin, and this reports rather than panics because the caller is a cdylib where a panic aborts).
- A relocating group used as a `tools` entry fails `link.rs`'s "exactly 1 FilePath" check with a confusing message, since its declared paths are globs. Left as-is, out of scope.
- Symlink *targets* are not rewritten. Relative symlinks interior to a tree survive `strip_prefix`/`prefix` (both shift every path equally) but can dangle if `include`/`exclude`/`rename` move only one end. Documented in the module header.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014LftdsamVrvndpbUZ9WUjK
