### PR TITLE
feat(plugin-oci): oci_index groups per-platform images into one

### DIFF
--- a/crates/e2e/tests/oci_image.rs
+++ b/crates/e2e/tests/oci_image.rs
@@ -37,6 +37,7 @@ fn workspace() -> htestkit::Workspace {
         .with_managed_driver(Box::new(heph::pluginexec::Driver::new_bash()))
         .with_managed_driver(Box::new(pluginoci::image::Driver::new()))
         .with_managed_driver(Box::new(pluginoci::layer::Driver::new()))
+        .with_managed_driver(Box::new(pluginoci::index::Driver::new()))
         .build()
         .expect("build workspace")
 }
@@ -551,6 +552,195 @@ async fn test_the_image_digest_is_the_same_on_every_supported_target() -> anyhow
          OCI_IMAGE_FORMAT_VERSION (or OCI_LAYER_FORMAT_VERSION) in the same commit — \
          otherwise every cached image keeps its old key with new meaning. If it was not \
          deliberate, something host-dependent reached the bytes."
+    );
+    Ok(())
+}
+
+/// `oci_index` groups images built *separately* into one multi-platform image.
+///
+/// This is the shape `docker_build` cannot express on its own: one buildx
+/// invocation means one Dockerfile for every platform, so platforms needing
+/// genuinely different recipes have nowhere to put the difference. Here each
+/// platform is its own target with its own layers, and the index makes them one
+/// image from the repo's point of view.
+///
+/// Built out of `oci_image` rather than `docker_build` so it needs no daemon —
+/// the grouping is the same either way, and the driver takes any layout.
+#[tokio::test]
+async fn test_an_index_groups_separately_built_images() -> anyhow::Result<()> {
+    let ws = workspace();
+    ws.write_build_file(
+        "app",
+        r#"
+target(name = "bin_amd64", driver = "bash", run = "echo amd > $OUT", out = "server-amd64")
+target(name = "bin_arm64", driver = "bash", run = "echo arm > $OUT", out = "server-arm64")
+target(name = "l_amd64", driver = "oci_layer", srcs = [":bin_amd64"], prefix = "/usr/bin")
+target(name = "l_arm64", driver = "oci_layer", srcs = [":bin_arm64"], prefix = "/usr/bin")
+
+# Deliberately different per platform: different layers, different entrypoint,
+# different env. One `docker_build` could not produce both.
+target(
+    name = "amd64",
+    driver = "oci_image",
+    layers = [":l_amd64"],
+    platforms = ["linux/amd64"],
+    entrypoint = ["/usr/bin/server-amd64"],
+    env = {"ARCH": "amd64"},
+)
+target(
+    name = "arm64",
+    driver = "oci_image",
+    layers = [":l_arm64"],
+    platforms = ["linux/arm64"],
+    entrypoint = ["/usr/bin/server-arm64"],
+)
+
+target(name = "img", driver = "oci_index", images = [":amd64", ":arm64"])
+"#,
+    );
+
+    let r = ws.run("//app:img").await?;
+    let bytes = htestkit::artifact_bytes(&r);
+
+    // The entry point is a manifest *list* naming both platforms — not the
+    // single manifest each input held.
+    let blobs = layout_blobs(&bytes);
+    let mut ar = tar::Archive::new(std::io::Cursor::new(bytes.clone()));
+    let mut index = None;
+    for entry in ar.entries().expect("entries") {
+        use std::io::Read as _;
+        let mut entry = entry.expect("entry");
+        if entry.path().expect("path").to_string_lossy() == "index.json" {
+            let mut buf = Vec::new();
+            entry.read_to_end(&mut buf).expect("read");
+            index = Some(serde_json::from_slice::<serde_json::Value>(&buf).expect("index"));
+        }
+    }
+    // `write_layout_*` wraps a multi-image set in a nested, ref.name-annotated
+    // index so buildx can resolve it; the list is one hop in.
+    let outer = index.expect("index.json");
+    let inner_digest = outer["manifests"][0]["digest"]
+        .as_str()
+        .expect("entry digest");
+    let list: serde_json::Value =
+        serde_json::from_slice(blobs.get(inner_digest).expect("list blob")).expect("list");
+    let manifests = list["manifests"].as_array().expect("manifests");
+    assert_eq!(manifests.len(), 2, "one entry per grouped image");
+
+    let mut seen: Vec<String> = manifests
+        .iter()
+        .map(|m| {
+            format!(
+                "{}/{}",
+                m["platform"]["os"].as_str().unwrap_or("?"),
+                m["platform"]["architecture"].as_str().unwrap_or("?")
+            )
+        })
+        .collect();
+    seen.sort();
+    assert_eq!(seen, vec!["linux/amd64", "linux/arm64"]);
+
+    // Each entry still points at the image its own target built, config and all
+    // — nothing was rebuilt or merged.
+    for m in manifests {
+        let manifest: serde_json::Value = serde_json::from_slice(
+            blobs
+                .get(m["digest"].as_str().expect("digest"))
+                .expect("blob"),
+        )
+        .expect("manifest");
+        let config: serde_json::Value = serde_json::from_slice(
+            blobs
+                .get(
+                    manifest["config"]["digest"]
+                        .as_str()
+                        .expect("config digest"),
+                )
+                .expect("config blob"),
+        )
+        .expect("config");
+        let arch = config["architecture"].as_str().expect("arch");
+        assert_eq!(
+            config["config"]["Entrypoint"],
+            serde_json::json!([format!("/usr/bin/server-{arch}")]),
+            "each platform keeps the entrypoint its own target set"
+        );
+    }
+    Ok(())
+}
+
+/// Two images claiming one platform would silently shadow each other, and which
+/// one shipped would depend on the order `images` happens to be written in.
+#[tokio::test]
+async fn test_two_images_for_one_platform_is_an_error() {
+    let ws = workspace();
+    ws.write_build_file(
+        "app",
+        r#"
+target(name = "a", driver = "bash", run = "echo a > $OUT", out = "a.txt")
+target(name = "b", driver = "bash", run = "echo b > $OUT", out = "b.txt")
+target(name = "la", driver = "oci_layer", srcs = [":a"], prefix = "/etc")
+target(name = "lb", driver = "oci_layer", srcs = [":b"], prefix = "/etc")
+target(name = "ia", driver = "oci_image", layers = [":la"], platforms = ["linux/amd64"])
+target(name = "ib", driver = "oci_image", layers = [":lb"], platforms = ["linux/amd64"])
+target(name = "img", driver = "oci_index", images = [":ia", ":ib"])
+"#,
+    );
+    let err = format!(
+        "{:#}",
+        ws.run("//app:img")
+            .await
+            .err()
+            .expect("duplicate platforms must fail")
+    );
+    assert!(err.contains("linux/amd64"), "must name the platform: {err}");
+    assert!(
+        err.contains("//app:ia") && err.contains("//app:ib"),
+        "must name both images: {err}"
+    );
+}
+
+/// The grouped image is consumable downstream exactly like any other: the
+/// digest group is there, and the layout reads back as a multi-platform image.
+#[tokio::test]
+async fn test_a_grouped_image_reads_back_as_one_image() -> anyhow::Result<()> {
+    let ws = workspace();
+    ws.write_build_file(
+        "app",
+        r#"
+target(name = "a", driver = "bash", run = "echo a > $OUT", out = "a.txt")
+target(name = "la", driver = "oci_layer", srcs = [":a"], prefix = "/etc")
+target(name = "ia", driver = "oci_image", layers = [":la"], platforms = ["linux/amd64"])
+target(name = "ib", driver = "oci_image", layers = [":la"], platforms = ["linux/arm64"])
+target(name = "img", driver = "oci_index", images = [":ia", ":ib"], layout = True)
+target(
+    name = "show",
+    driver = "bash",
+    run = "cat $SRC_DIGEST > $OUT",
+    out = "out.txt",
+    deps = {"digest": ["//app:img|digest"]},
+)
+"#,
+    );
+    let r = ws.run("//app:show").await?;
+    let digest = htestkit::artifact_string(&r);
+    assert!(
+        digest.trim().starts_with("sha256:") && digest.trim().len() == 71,
+        "the digest group must carry the manifest list digest, got: {digest:?}"
+    );
+
+    // Both platforms share one layer, so the blob is stored once.
+    let r = ws.run("//app:img").await?;
+    let paths = htestkit::artifact_paths(&r);
+    let layer_blobs: Vec<_> = paths
+        .iter()
+        .filter(|p| p.to_string_lossy().contains("blobs/sha256/"))
+        .collect();
+    let unique: std::collections::BTreeSet<_> = layer_blobs.iter().collect();
+    assert_eq!(
+        layer_blobs.len(),
+        unique.len(),
+        "a layout must not carry the same blob twice: {layer_blobs:?}"
     );
     Ok(())
 }

--- a/crates/plugin-oci-cdylib/src/lib.rs
+++ b/crates/plugin-oci-cdylib/src/lib.rs
@@ -67,6 +67,12 @@ fn build() -> PluginComponents {
         name: pluginoci::layer::DRIVER_NAME.into(),
         driver: make_dyn_managed_driver(layer),
     });
+    // Groups per-platform images into one multi-platform image.
+    let index: Arc<dyn ManagedDriver> = Arc::new(pluginoci::index::Driver::new());
+    drivers.push(NamedDriver {
+        name: pluginoci::index::DRIVER_NAME.into(),
+        driver: make_dyn_managed_driver(index),
+    });
     // Builds a Dockerfile + context into a cacheable image archive.
     let docker: Arc<dyn ManagedDriver> = Arc::new(pluginoci::docker_build::Driver::new());
     drivers.push(NamedDriver {

--- a/crates/plugin-oci/src/pluginoci/image.rs
+++ b/crates/plugin-oci/src/pluginoci/image.rs
@@ -59,7 +59,7 @@ use std::sync::Arc;
 use xxhash_rust::xxh3::Xxh3Default;
 
 use super::archive::{self, Blob, Blobs};
-use super::{ImageFormat, dep_files, normalize_platform, split_platform, ws_path};
+use super::{ImageFormat, dep_files, layout_path, normalize_platform, split_platform, ws_path};
 
 pub const DRIVER_NAME: &str = "oci_image";
 
@@ -422,35 +422,6 @@ fn base_for(layout: Option<&archive::Layout>, platform: &str) -> anyhow::Result<
     })
 }
 
-/// Absolute path of the OCI layout the `base` dep materialized.
-///
-/// A dep's list names *files*, never the directories holding them, so the root
-/// is found by its marker: an OCI layout is exactly a tree with an `oci-layout`
-/// file at its root.
-fn base_layout_path(req: &ManagedRunRequest<'_, '_>) -> anyhow::Result<PathBuf> {
-    let paths = dep_files(req, BASE_ORIGIN)?;
-    anyhow::ensure!(!paths.is_empty(), "`base` produced no files in the sandbox");
-    if let Some(dir) = paths
-        .iter()
-        .find(|p| p.file_name().is_some_and(|n| n == "oci-layout"))
-        .and_then(|p| p.parent())
-    {
-        return Ok(dir.to_path_buf());
-    }
-    // Not a layout directory: a single archive is the other shape this plugin
-    // produces, and `Layout::read` accepts it.
-    if let [only] = paths.as_slice() {
-        return Ok(only.clone());
-    }
-    anyhow::bail!(
-        "`base` is neither an OCI layout directory nor a single archive: no `oci-layout` file \
-         among {} staged path(s), the first being {:?}. Produce it with \
-         `oci_pull(layout = True)` or `oci_image(layout = True)`.",
-        paths.len(),
-        paths.first()
-    )
-}
-
 /// Stateless: an image is assembled from declared inputs and attributes.
 #[derive(Default)]
 pub struct Driver;
@@ -673,7 +644,7 @@ impl ManagedDriver for Driver {
 
         let base_layout = match &def.base {
             Some(_) => {
-                let path = base_layout_path(&req)?;
+                let path = layout_path(&req, BASE_ORIGIN, "`base`")?;
                 Some(
                     archive::Layout::read(&path)
                         .with_context(|| format!("read the base image at {path:?}"))?,

--- a/crates/plugin-oci/src/pluginoci/index.rs
+++ b/crates/plugin-oci/src/pluginoci/index.rs
@@ -1,0 +1,660 @@
+//! The `oci_index` driver: groups per-platform images into one multi-platform
+//! image.
+//!
+//! # What it is for
+//!
+//! `docker_build(platforms = [...])` is **one** buildx invocation. One
+//! Dockerfile, one context, one set of build args, one `--target` stage, for
+//! every platform at once. `context_by_platform` lets the *deps* differ, and
+//! `TARGETPLATFORM` lets the Dockerfile branch — but the build is still one
+//! recipe, and when the platforms need genuinely different ones (a different
+//! base, a different package manager, a stage that only exists on one arch)
+//! there is nowhere to put the difference.
+//!
+//! So build them separately and group them here:
+//!
+//! ```python
+//! docker_build(name = "amd64", dockerfile = ":Dockerfile.amd64",
+//!              platforms = ["linux/amd64"], context = [...])
+//! docker_build(name = "arm64", dockerfile = ":Dockerfile.arm64",
+//!              platforms = ["linux/arm64"], context = [...])
+//!
+//! oci_index(name = "img", images = [":amd64", ":arm64"])
+//! ```
+//!
+//! `//pkg:img` is then one image everywhere downstream: `oci_push` sends the
+//! whole manifest list under one tag, `oci_load` picks the instance for the
+//! host, and `docker_build`'s `bases` resolves the right platform out of it.
+//! The split is a build-time detail that does not leak into what the repo
+//! refers to.
+//!
+//! # Why a separate rule
+//!
+//! It could have been an attribute on `docker_build` — and then a
+//! single-Dockerfile multi-platform build and an N-Dockerfile one would be the
+//! same rule in two modes, with half the attributes inert in each. Grouping is
+//! also not a *build*: nothing is compiled, nothing is executed, no daemon is
+//! touched. This rule reads the layouts its deps produced, writes one index
+//! over them, and copies blobs by reference.
+//!
+//! It takes anything that produces a layout, not just `docker_build` —
+//! `oci_image`, `oci_pull`, or another `oci_index`. Restricting it would be
+//! arbitrary, and mixing is useful: a hand-assembled `oci_image` for one
+//! architecture beside a Dockerfile build for another is exactly the case that
+//! has nowhere else to go.
+//!
+//! # What it does not do
+//!
+//! Nothing is rebuilt or re-hashed. The per-platform images keep their own
+//! digests, so pushing the index pushes blobs the registry may already have,
+//! and each input target caches on its own inputs — changing the arm64
+//! Dockerfile does not rebuild amd64.
+
+use anyhow::Context as _;
+use async_trait::async_trait;
+use hcore::debug_hash::DebugHasher;
+use hcore::hasync::Cancellable;
+use hdriver_support::driver_managed::{ManagedDriver, ManagedRunRequest, ManagedRunResponse};
+use hplugin::driver::targetdef::path::{CodegenMode, Content, Path as OutPath};
+use hplugin::driver::targetdef::{Input, InputMode, Output, TargetDef};
+use hplugin::driver::{
+    ApplyTransitiveRequest, ApplyTransitiveResponse, ConfigRequest, ConfigResponse, ParseRequest,
+    ParseResponse, TargetAddr,
+};
+use hplugin::htspec::{Spec, TargetSpecCache};
+use oci_client::manifest::{ImageIndexEntry, OciImageIndex, OciImageManifest, Platform};
+use std::collections::BTreeMap;
+use std::hash::{Hash, Hasher};
+use std::sync::Arc;
+use xxhash_rust::xxh3::Xxh3Default;
+
+use super::archive::{self, Blobs, Layout};
+use super::{ImageFormat, layout_path, ws_path};
+
+pub const DRIVER_NAME: &str = "oci_index";
+
+fn image_origin(i: usize) -> String {
+    format!("images|{i}")
+}
+
+/// Groups per-platform images into one multi-platform image. Nothing is built:
+/// use it when the platforms need different `docker_build` recipes.
+#[derive(Spec)]
+struct OciIndexSpec {
+    /// The images to group, one per platform — `docker_build`, `oci_image`,
+    /// `oci_pull` or another `oci_index` target.
+    ///
+    /// Each contributes every instance it holds, so grouping two single-platform
+    /// builds is the common case but a multi-platform input is merged rather
+    /// than rejected. Two inputs claiming the same platform is an error: one
+    /// would silently shadow the other, and which one won would depend on the
+    /// order they happen to be written in.
+    #[spec(required)]
+    images: Vec<String>,
+    /// Archive format: `oci` (default). `docker` is rejected — a docker-format
+    /// archive holds a single image, which is the one thing this rule does not
+    /// produce.
+    #[spec(ty = hcore::htvalue::signature::ParamType::String)]
+    format: Option<String>,
+    /// Write an OCI **layout directory** instead of a single archive file. This
+    /// is the shape `docker_build`'s `bases` and buildx's `oci-layout://` build
+    /// context consume.
+    layout: bool,
+    /// Output filename (or directory name, with `layout = True`), relative to
+    /// the target's package. Must be a bare name. Default `<target name>.tar`,
+    /// or `<target name>.oci` for a layout.
+    #[spec(ty = hcore::htvalue::signature::ParamType::String)]
+    out: Option<String>,
+    /// Caching for the grouped image. Defaults to on for both tiers.
+    cache: TargetSpecCache,
+}
+
+#[derive(Clone, serde::Serialize, serde::Deserialize)]
+struct OciIndexDef {
+    /// Workspace-relative output path.
+    out: String,
+    /// Workspace-relative digest output path.
+    digest_out: String,
+    layout: bool,
+    format: ImageFormat,
+    /// Normalized `images` addresses, **in order**.
+    ///
+    /// The addresses, because `hashin` cannot carry them: it folds a *sorted,
+    /// unlabeled multiset* of dep hashouts (`engine/meta.rs`) with no origin,
+    /// no address and no output-group selector. Order matters here too — the
+    /// manifest list's entry order is part of its bytes, and therefore of the
+    /// image's digest.
+    images: Vec<String>,
+}
+
+/// Bump to invalidate cached indexes when the emitted bytes change shape.
+const OCI_INDEX_FORMAT_VERSION: u32 = 1;
+
+impl Hash for OciIndexDef {
+    fn hash<H: Hasher>(&self, state: &mut H) {
+        OCI_INDEX_FORMAT_VERSION.hash(state);
+        self.out.hash(state);
+        self.digest_out.hash(state);
+        self.layout.hash(state);
+        self.format.output_type().hash(state);
+        self.images.hash(state);
+    }
+}
+
+/// The platform an image manifest is for.
+///
+/// The index entry's annotation is preferred when it has one, but it often does
+/// not: a single-platform `--output type=oci` build writes an index whose entry
+/// carries no platform at all. The image **config** always does — `architecture`
+/// and `os` are required fields — so that is the fallback, and it is the
+/// authoritative answer either way since it is what a runtime reads.
+fn platform_of(
+    layout: &Layout,
+    manifest: &OciImageManifest,
+    declared: Option<&Platform>,
+) -> anyhow::Result<Platform> {
+    if let Some(p) = declared {
+        return Ok(p.clone());
+    }
+    let raw = layout
+        .blob_bytes(&manifest.config.digest)
+        .with_context(|| format!("read the image config {}", manifest.config.digest))?;
+    let config: serde_json::Value =
+        serde_json::from_slice(&raw).context("parse the image config")?;
+    let os = config
+        .get("os")
+        .and_then(serde_json::Value::as_str)
+        .context("the image config has no `os`, so there is no platform to file it under")?;
+    let architecture = config
+        .get("architecture")
+        .and_then(serde_json::Value::as_str)
+        .context("the image config has no `architecture`")?;
+    Ok(Platform {
+        os: os.into(),
+        architecture: architecture.into(),
+        // Carried through when the config states one: `linux/arm/v7` and
+        // `linux/arm/v6` are different machines and must stay different entries.
+        variant: config
+            .get("variant")
+            .and_then(serde_json::Value::as_str)
+            .map(str::to_string),
+        os_version: config
+            .get("os.version")
+            .and_then(serde_json::Value::as_str)
+            .map(str::to_string),
+        os_features: None,
+        features: None,
+    })
+}
+
+/// `os/arch[/variant]`, for error messages and duplicate detection.
+fn platform_label(p: &Platform) -> String {
+    match &p.variant {
+        Some(v) if !v.is_empty() => format!("{}/{}/{}", p.os, p.architecture, v),
+        _ => format!("{}/{}", p.os, p.architecture),
+    }
+}
+
+/// Stateless: an index is assembled from declared inputs and nothing else.
+#[derive(Default)]
+pub struct Driver;
+
+impl Driver {
+    pub fn new() -> Self {
+        Driver
+    }
+}
+
+#[async_trait]
+impl ManagedDriver for Driver {
+    fn config(&self, _req: ConfigRequest) -> anyhow::Result<ConfigResponse> {
+        Ok(ConfigResponse {
+            name: DRIVER_NAME.to_string(),
+        })
+    }
+
+    fn schema(&self) -> hplugin::driver::DriverSchema {
+        OciIndexSpec::schema()
+    }
+
+    async fn parse(
+        &self,
+        req: ParseRequest,
+        _ctoken: &(dyn Cancellable + Send + Sync),
+    ) -> anyhow::Result<ParseResponse> {
+        let addr = &req.target_spec.addr;
+        let pkg = addr.package.to_owned();
+        let spec = OciIndexSpec::from(&req.target_spec.config).context("parse oci_index config")?;
+
+        anyhow::ensure!(
+            !spec.images.is_empty(),
+            "`images` is empty; an oci_index groups per-platform images and needs at least one"
+        );
+        let format = spec
+            .format
+            .as_deref()
+            .map_or(Ok(ImageFormat::Oci), ImageFormat::parse)?;
+        anyhow::ensure!(
+            !matches!(format, ImageFormat::Docker),
+            "`format = \"docker\"` holds a single image, which is the one thing an oci_index does \
+             not produce. Use the default `format = \"oci\"`, and `oci_load` to put one instance \
+             of it in a daemon."
+        );
+
+        let mut inputs = Vec::new();
+        let mut images = Vec::new();
+        for (i, image) in spec.images.iter().enumerate() {
+            let mut r#ref = TargetAddr::parse(image, &pkg)
+                .with_context(|| format!("parse `images` entry {image:?}"))?;
+            // Pin to the archive group. Unpinned, the dep also stages the
+            // `digest` group's text file, and the layout root can no longer be
+            // found by its marker among two unrelated files.
+            super::pin_archive_group(&mut r#ref, image)?;
+            images.push(r#ref.to_string());
+            inputs.push(Input {
+                r#ref,
+                mode: InputMode::Standard,
+                origin_id: image_origin(i),
+                // Out of the workspace root: these are whole images, and
+                // unpacking them over the tree would put one target's layers in
+                // another's build context.
+                annotations: BTreeMap::from([(
+                    "unpack_root".to_string(),
+                    format!("oci_index_{i}"),
+                )]),
+                hashed: true,
+                runtime: true,
+            });
+        }
+
+        let default_out = if spec.layout {
+            format!("{}.oci", addr.name)
+        } else {
+            format!("{}.tar", addr.name)
+        };
+        let out_rel = spec.out.unwrap_or(default_out);
+        anyhow::ensure!(
+            std::path::Path::new(&out_rel)
+                .file_name()
+                .map(std::ffi::OsStr::new)
+                == Some(out_rel.as_ref()),
+            "`out` {out_rel:?} must be a bare name (no directory component): the driver writes \
+             it into the target's package directory"
+        );
+        let out = ws_path(pkg.as_str(), &out_rel);
+        let digest_out = ws_path(pkg.as_str(), &format!("{}.digest", addr.name));
+
+        let def = OciIndexDef {
+            out: out.clone(),
+            digest_out: digest_out.clone(),
+            layout: spec.layout,
+            format,
+            images,
+        };
+        let hash = {
+            let mut h = DebugHasher::new(Xxh3Default::new(), || {
+                format!("oci_index_{}", addr.format())
+            });
+            def.hash(&mut h);
+            format!("{:x}", h.finish()).into_bytes()
+        };
+
+        Ok(ParseResponse {
+            target_def: TargetDef {
+                addr: addr.clone(),
+                labels: req.target_spec.labels.clone(),
+                raw_def: Arc::new(def),
+                inputs,
+                outputs: vec![
+                    Output {
+                        group: String::new(),
+                        paths: vec![OutPath {
+                            content: if spec.layout {
+                                Content::DirPath(out)
+                            } else {
+                                Content::FilePath(out)
+                            },
+                            codegen_tree: CodegenMode::None,
+                            collect: true,
+                        }],
+                    },
+                    Output {
+                        group: "digest".to_string(),
+                        paths: vec![OutPath {
+                            content: Content::FilePath(digest_out),
+                            codegen_tree: CodegenMode::None,
+                            collect: true,
+                        }],
+                    },
+                ],
+                support_files: vec![],
+                cache: spec.cache.into(),
+                pty: false,
+                hash,
+                transparent: false,
+            },
+        })
+    }
+
+    async fn apply_transitive(
+        &self,
+        req: ApplyTransitiveRequest,
+        _ctoken: &(dyn Cancellable + Send + Sync),
+    ) -> anyhow::Result<ApplyTransitiveResponse> {
+        Ok(ApplyTransitiveResponse {
+            target_def: req.target_def,
+        })
+    }
+
+    async fn run<'a, 'io>(
+        &self,
+        req: ManagedRunRequest<'a, 'io>,
+        _ctoken: &(dyn Cancellable + Send + Sync),
+    ) -> anyhow::Result<ManagedRunResponse> {
+        let def = req.request.target.def_de::<OciIndexDef>().clone();
+        let out_path = req.sandbox_pkg_dir.join(super::basename(&def.out)?);
+
+        let mut blobs: Blobs = Blobs::new();
+        let mut entries: Vec<ImageIndexEntry> = Vec::new();
+        // Which target contributed each platform, so a collision names both.
+        let mut seen: BTreeMap<String, String> = BTreeMap::new();
+
+        for (i, addr) in def.images.iter().enumerate() {
+            let origin = image_origin(i);
+            let path = layout_path(&req, &origin, "`images`")?;
+            let layout = Layout::read(&path)
+                .with_context(|| format!("read the image {addr} at {path:?}"))?;
+            let manifests = layout
+                .manifests()
+                .with_context(|| format!("read the manifests of {addr}"))?;
+            anyhow::ensure!(
+                !manifests.is_empty(),
+                "`images` entry {addr} holds no manifests; it is not an image"
+            );
+
+            for (manifest, declared, digest) in manifests {
+                let platform = platform_of(&layout, &manifest, declared.as_ref())
+                    .with_context(|| format!("determine the platform of {addr}"))?;
+                let label = platform_label(&platform);
+                if let Some(other) = seen.insert(label.clone(), addr.clone()) {
+                    // Silently keeping one would make which image ships depend
+                    // on the order `images` happens to be written in.
+                    anyhow::bail!(
+                        "{other} and {addr} both provide {label}. An index holds one image per \
+                         platform, so one would shadow the other. Drop one, or narrow its \
+                         `platforms`."
+                    );
+                }
+
+                // Carried by reference: with the blobs located rather than
+                // loaded, grouping N images copies no layer bytes into memory.
+                // Deduped by digest, so a base layer shared between platforms is
+                // stored once.
+                let raw = layout.blob(&digest)?.clone();
+                let size = raw.len()? as i64;
+                blobs.insert(digest.clone(), raw);
+                blobs.insert(
+                    manifest.config.digest.clone(),
+                    layout.blob(&manifest.config.digest)?.clone(),
+                );
+                for layer in &manifest.layers {
+                    blobs
+                        .entry(layer.digest.clone())
+                        .or_insert(layout.blob(&layer.digest)?.clone());
+                }
+
+                entries.push(ImageIndexEntry {
+                    media_type: manifest
+                        .media_type
+                        .clone()
+                        .unwrap_or_else(|| oci_client::manifest::OCI_IMAGE_MEDIA_TYPE.to_string()),
+                    artifact_type: None,
+                    digest,
+                    size,
+                    platform: Some(platform),
+                    annotations: None,
+                });
+            }
+        }
+
+        let index = OciImageIndex {
+            schema_version: 2,
+            media_type: Some(oci_client::manifest::OCI_IMAGE_INDEX_MEDIA_TYPE.to_string()),
+            artifact_type: None,
+            manifests: entries.clone(),
+            annotations: None,
+        };
+
+        if def.layout {
+            archive::write_layout_dir_blobs(&out_path, &index, &blobs)
+        } else {
+            archive::write_layout_tar_blobs(&out_path, &index, &blobs)
+        }
+        .with_context(|| format!("write the grouped image to {out_path:?}"))?;
+
+        // The list's digest, which is what a registry files the tag under — even
+        // when only one image was grouped, since the shape is still a list.
+        let raw = serde_json::to_vec(&index).context("encode the manifest list")?;
+        let digest = archive::sha256_digest(&raw);
+        std::fs::write(
+            req.sandbox_pkg_dir.join(super::basename(&def.digest_out)?),
+            &digest,
+        )
+        .context("write the digest output")?;
+
+        tracing::info!(
+            platforms = seen.keys().cloned().collect::<Vec<_>>().join(","),
+            images = def.images.len(),
+            digest,
+            "oci_index: grouped"
+        );
+        Ok(ManagedRunResponse { artifacts: vec![] })
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use hcore::hasync::StdCancellationToken;
+    use hcore::htvalue::Value;
+    use hmodel::htaddr::parse_addr;
+    use hplugin::provider::TargetSpec;
+    use std::collections::HashMap;
+
+    fn cfg(pairs: &[(&str, Value)]) -> HashMap<String, Value> {
+        pairs
+            .iter()
+            .map(|(k, v)| ((*k).to_string(), v.clone()))
+            .collect()
+    }
+
+    fn images(list: &[&str]) -> Value {
+        Value::List(
+            list.iter()
+                .map(|s| Value::String((*s).to_string()))
+                .collect(),
+        )
+    }
+
+    async fn parse_at(addr: &str, config: HashMap<String, Value>) -> anyhow::Result<ParseResponse> {
+        Driver::new()
+            .parse(
+                ParseRequest {
+                    request_id: "test".to_string(),
+                    target_spec: Arc::new(TargetSpec {
+                        addr: parse_addr(addr).expect("addr"),
+                        driver: DRIVER_NAME.to_string(),
+                        config,
+                        ..Default::default()
+                    }),
+                },
+                &StdCancellationToken::new(),
+            )
+            .await
+    }
+
+    fn def_hash(d: &OciIndexDef) -> u64 {
+        let mut h = Xxh3Default::new();
+        d.hash(&mut h);
+        h.finish()
+    }
+
+    fn bare() -> OciIndexDef {
+        OciIndexDef {
+            out: "app/img.tar".to_string(),
+            digest_out: "app/img.digest".to_string(),
+            layout: false,
+            format: ImageFormat::Oci,
+            images: vec![],
+        }
+    }
+
+    /// Each grouped image is a dep, and both output groups are declared — the
+    /// digest without unpacking the archive, exactly as `docker_build` and
+    /// `oci_image` offer.
+    #[tokio::test]
+    async fn parse_declares_a_dep_per_image_and_two_outputs() {
+        let resp = parse_at(
+            "//app:img",
+            cfg(&[("images", images(&[":amd64", ":arm64"]))]),
+        )
+        .await
+        .expect("parse");
+        let def = resp.target_def.def::<OciIndexDef>();
+        // Pinned to the archive group (`|`), never the sibling `digest` one.
+        assert_eq!(def.images, vec!["//app:amd64|", "//app:arm64|"]);
+        assert_eq!(resp.target_def.inputs.len(), 2);
+        let groups: Vec<&str> = resp
+            .target_def
+            .outputs
+            .iter()
+            .map(|o| o.group.as_str())
+            .collect();
+        assert_eq!(groups, vec!["", "digest"]);
+    }
+
+    /// The manifest list's entry order is part of its bytes, so it is part of
+    /// the digest — and `hashin` cannot carry it: it folds a sorted, unlabeled
+    /// multiset of dep hashouts with no address and no output-group selector.
+    #[test]
+    fn the_order_and_identity_of_the_images_reach_the_key() {
+        let mut ab = bare();
+        ab.images = vec!["//app:a".to_string(), "//app:b".to_string()];
+        let mut ba = bare();
+        ba.images = vec!["//app:b".to_string(), "//app:a".to_string()];
+        assert_ne!(def_hash(&ab), def_hash(&ba), "entry order is the digest");
+
+        let mut rel = bare();
+        rel.images = vec!["//app:a|release".to_string()];
+        let mut dbg = bare();
+        dbg.images = vec!["//app:a|debug".to_string()];
+        assert_ne!(
+            def_hash(&rel),
+            def_hash(&dbg),
+            "the output-group selector reaches no other part of the key"
+        );
+
+        let mut as_layout = bare();
+        as_layout.layout = true;
+        assert_ne!(def_hash(&bare()), def_hash(&as_layout));
+    }
+
+    /// A docker-format archive holds one image, which is the one thing this
+    /// rule does not produce — so the mismatch is refused where it is written,
+    /// not discovered by whatever tries to read the result.
+    #[tokio::test]
+    async fn docker_format_is_refused() {
+        let err = parse_at(
+            "//app:img",
+            cfg(&[
+                ("images", images(&[":amd64"])),
+                ("format", Value::String("docker".to_string())),
+            ]),
+        )
+        .await
+        .err()
+        .expect("docker format must fail");
+        assert!(format!("{err:#}").contains("single image"), "got: {err:#}");
+    }
+
+    #[tokio::test]
+    async fn an_empty_index_is_refused() {
+        let err = parse_at("//app:img", cfg(&[("images", images(&[]))]))
+            .await
+            .err()
+            .expect("empty must fail");
+        assert!(format!("{err:#}").contains("at least one"), "got: {err:#}");
+    }
+
+    /// A platform is read off the image config when the index entry carries no
+    /// annotation — which is the normal case for a single-platform build, so
+    /// this is the path that runs most of the time, not the fallback.
+    #[test]
+    fn the_platform_comes_from_the_config_when_the_entry_omits_it() {
+        let config = serde_json::json!({
+            "architecture": "arm",
+            "os": "linux",
+            "variant": "v7",
+            "rootfs": {"type": "layers", "diff_ids": []},
+        });
+        let config_bytes = serde_json::to_vec(&config).expect("config");
+        let config_digest = archive::sha256_digest(&config_bytes);
+        let manifest: OciImageManifest = serde_json::from_value(serde_json::json!({
+            "schemaVersion": 2,
+            "config": {
+                "mediaType": "application/vnd.oci.image.config.v1+json",
+                "digest": config_digest,
+                "size": config_bytes.len(),
+            },
+            "layers": [],
+        }))
+        .expect("manifest");
+
+        let layout = Layout {
+            index: OciImageIndex {
+                schema_version: 2,
+                media_type: None,
+                artifact_type: None,
+                manifests: vec![],
+                annotations: None,
+            },
+            blobs: Blobs::from([(config_digest, archive::Blob::Bytes(config_bytes))]),
+        };
+
+        let got = platform_of(&layout, &manifest, None).expect("platform");
+        assert_eq!(platform_label(&got), "linux/arm/v7");
+
+        // A declared platform wins without the config being read at all.
+        let declared = Platform {
+            os: "linux".into(),
+            architecture: "amd64".into(),
+            variant: None,
+            os_version: None,
+            os_features: None,
+            features: None,
+        };
+        let got = platform_of(&layout, &manifest, Some(&declared)).expect("platform");
+        assert_eq!(platform_label(&got), "linux/amd64");
+    }
+
+    /// `linux/arm/v7` and `linux/arm/v6` are different machines: the variant has
+    /// to stay in the label, or they would be reported as a duplicate and one of
+    /// them dropped.
+    #[test]
+    fn variants_are_distinct_platforms() {
+        let p = |variant: Option<&str>| Platform {
+            os: "linux".into(),
+            architecture: "arm".into(),
+            variant: variant.map(str::to_string),
+            os_version: None,
+            os_features: None,
+            features: None,
+        };
+        assert_ne!(
+            platform_label(&p(Some("v7"))),
+            platform_label(&p(Some("v6")))
+        );
+        assert_eq!(platform_label(&p(None)), "linux/arm");
+        assert_eq!(platform_label(&p(Some(""))), "linux/arm");
+    }
+}

--- a/crates/plugin-oci/src/pluginoci/mod.rs
+++ b/crates/plugin-oci/src/pluginoci/mod.rs
@@ -24,6 +24,7 @@ use std::path::{Path, PathBuf};
 pub mod archive;
 pub mod docker_build;
 pub mod image;
+pub mod index;
 pub mod layer;
 pub mod load;
 pub mod platform;
@@ -241,6 +242,42 @@ fn dep_files(req: &ManagedRunRequest<'_, '_>, origin_id: &str) -> anyhow::Result
         .map(PathBuf::from)
         .collect())
 }
+/// Absolute path of the OCI layout a dep materialized — a layout *directory*,
+/// or the single archive file that is the other shape this plugin writes.
+///
+/// A dep's list names *files*, never the directories holding them, so the root
+/// cannot be found by looking for a directory entry. It is found by its marker
+/// instead: an OCI layout is exactly a tree with an `oci-layout` file at its
+/// root, which is also what buildx's `oci-layout://` wants pointed at.
+///
+/// `attr` names the BUILD-file attribute in the error, since the same shape is
+/// consumed by `base`, `image` and `images`.
+pub(crate) fn layout_path(
+    req: &ManagedRunRequest<'_, '_>,
+    origin: &str,
+    attr: &str,
+) -> anyhow::Result<PathBuf> {
+    let paths = dep_files(req, origin)?;
+    anyhow::ensure!(!paths.is_empty(), "{attr} produced no files in the sandbox");
+    if let Some(dir) = paths
+        .iter()
+        .find(|p| p.file_name().is_some_and(|n| n == "oci-layout"))
+        .and_then(|p| p.parent())
+    {
+        return Ok(dir.to_path_buf());
+    }
+    if let [only] = paths.as_slice() {
+        return Ok(only.clone());
+    }
+    anyhow::bail!(
+        "{attr} is neither an OCI layout directory nor a single archive: no `oci-layout` file \
+         among {} staged path(s), the first being {:?}. Produce it with \
+         `oci_pull(layout = True)`, `oci_image(...)` or `docker_build(...)`.",
+        paths.len(),
+        paths.first()
+    )
+}
+
 /// Absolute path to the single file a Dep input materialized into the sandbox.
 /// Reads the input's `.list` file (one absolute path per line — see
 /// `driver_managed.rs::list_path_for`). Errors unless exactly one file was


### PR DESCRIPTION
Top of stack #379: #159 → #378 → #381 → this.

## The gap

`docker_build(platforms = [...])` is **one** buildx invocation. One Dockerfile, one context, one set of build args, one `--target` stage, for every platform at once. `context_by_platform` lets the deps differ and `TARGETPLATFORM` lets the Dockerfile branch — but it is still one recipe. Platforms needing genuinely different ones (a different base, a different package manager, a stage that exists on one arch only) have nowhere to put the difference.

## The rule

```python
docker_build(name = "amd64", dockerfile = ":Dockerfile.amd64",
             platforms = ["linux/amd64"], context = [...])
docker_build(name = "arm64", dockerfile = ":Dockerfile.arm64",
             platforms = ["linux/arm64"], context = [...])

oci_index(name = "img", images = [":amd64", ":arm64"])
```

`//pkg:img` is then one image everywhere downstream — `oci_push` sends the whole manifest list under one tag, `oci_load` picks the host's instance, `bases` resolves the right platform out of it. The split stays a build-time detail instead of leaking into what the repo refers to.

## Why a separate rule

As a `docker_build` mode, a single-Dockerfile multi-platform build and an N-Dockerfile one would be one rule in two modes with half the attributes inert in each — the shape `compatibility` and `product-vision` already rejected for `oci_image`. Grouping is also not a build: nothing is compiled, executed, or handed to a daemon.

It accepts any layout-producing target, not only `docker_build`. Mixing a hand-assembled `oci_image` for one arch with a Dockerfile build for another is exactly the case with nowhere else to go.

## Three details

- **The platform comes from the image config** when the index entry has no annotation — which is the *normal* case for a single-platform `--output type=oci` build, so it is the path that runs most of the time rather than a fallback. `architecture`/`os` are required config fields and the config is what a runtime reads. The variant is carried through: `linux/arm/v7` and `linux/arm/v6` are different machines.
- **Two inputs claiming one platform is a hard error** naming both targets. Keeping one would make which image ships depend on the order `images` happens to be written in.
- **`images` is pinned to the archive group.** Unpinned, the dep also stages the sibling `digest` group's text file, and the layout root can no longer be found by its `oci-layout` marker among two unrelated files. Caught by the e2e; same reason `oci_push`/`oci_load` pin theirs.

## Cost

Blobs are carried **by reference** — with #378's located-not-loaded blobs, grouping N images copies no layer bytes through memory, and a layer shared between platforms is stored once. Nothing is rebuilt: each input keeps its own digest and caches on its own inputs, so changing the arm64 Dockerfile does not rebuild amd64.

The def hash carries the ordered normalized `images` addresses — `hashin` folds a sorted, unlabeled multiset of dep hashouts with no address and no output-group selector, and the manifest list's entry order is part of its bytes.

## Tests

6 unit + 3 engine e2e, **none docker-gated**: the e2e builds two `oci_image` targets with different layers, entrypoints and env — something one `docker_build` could not produce — groups them, and asserts the entry point is a manifest list naming both platforms with each entry still pointing at the image its own target built. Plus the duplicate-platform error naming both targets, and blob dedup across platforms.

`base_layout_path` moves to `mod.rs` as `layout_path` since two drivers need it now; it takes the attribute name so the error says `images` rather than always `base`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WqQZxsTqanJRWLWdPSchBo