### PR TITLE
chore(plugin-oci): drop the per-target progress logs

### DIFF
--- a/crates/plugin-oci-cdylib/src/lib.rs
+++ b/crates/plugin-oci-cdylib/src/lib.rs
@@ -35,8 +35,9 @@ pub extern "C" fn heph_plugin_create(_cfg: stabby::vec::Vec<u8>) -> PluginCompon
 
 /// Stable ABI log-sink entry: the host calls this right after `create` to hand
 /// the plugin a sink for its `tracing` events. Without it, this cdylib's
-/// statically-linked `tracing` has no subscriber and every `docker_build built` /
-/// `oci_push: pushed` line vanishes.
+/// statically-linked `tracing` has no subscriber and every diagnostic these
+/// drivers emit — an unpinned `oci_pull` tag, a log file that would not open —
+/// vanishes silently.
 #[stabby::export]
 pub extern "C" fn heph_plugin_set_log_sink(sink: DynLogSink) {
     install_log_sink(sink);

--- a/crates/plugin-oci/src/pluginoci/image.rs
+++ b/crates/plugin-oci/src/pluginoci/image.rs
@@ -757,11 +757,6 @@ impl ManagedDriver for Driver {
         )
         .context("write the digest output")?;
 
-        tracing::info!(
-            platforms = def.platforms.join(","),
-            digest,
-            "oci_image: assembled"
-        );
         Ok(ManagedRunResponse { artifacts: vec![] })
     }
 }

--- a/crates/plugin-oci/src/pluginoci/index.rs
+++ b/crates/plugin-oci/src/pluginoci/index.rs
@@ -442,12 +442,6 @@ impl ManagedDriver for Driver {
         )
         .context("write the digest output")?;
 
-        tracing::info!(
-            platforms = seen.keys().cloned().collect::<Vec<_>>().join(","),
-            images = def.images.len(),
-            digest,
-            "oci_index: grouped"
-        );
         Ok(ManagedRunResponse { artifacts: vec![] })
     }
 }

--- a/crates/plugin-oci/src/pluginoci/layer.rs
+++ b/crates/plugin-oci/src/pluginoci/layer.rs
@@ -467,11 +467,6 @@ impl ManagedDriver for Driver {
         write_layer(&out_path, &entries, def.mode)
             .with_context(|| format!("write the layer to {out_path:?}"))?;
 
-        tracing::info!(
-            files = entries.len(),
-            prefix = def.prefix,
-            "oci_layer: packed"
-        );
         Ok(ManagedRunResponse { artifacts: vec![] })
     }
 }

--- a/crates/plugin-oci/src/pluginoci/load.rs
+++ b/crates/plugin-oci/src/pluginoci/load.rs
@@ -426,9 +426,6 @@ impl ManagedDriver for Driver {
             .await
             .with_context(|| format!("tag the loaded image as {image}"))?;
 
-        // Logged, not printed: stdout belongs to the TUI. This is the line that
-        // tells the user what to `docker run`.
-        tracing::info!(image, platform = def.platform, "oci_load: loaded");
         Ok(ManagedRunResponse { artifacts: vec![] })
     }
 }

--- a/crates/plugin-oci/src/pluginoci/pull.rs
+++ b/crates/plugin-oci/src/pluginoci/pull.rs
@@ -328,11 +328,6 @@ impl ManagedDriver for Driver {
         }
         .with_context(|| format!("write the pulled image to {out_path:?}"))?;
 
-        tracing::info!(
-            image = def.src,
-            platform = def.platform.label(),
-            "oci_pull: pulled"
-        );
         Ok(ManagedRunResponse { artifacts: vec![] })
     }
 }

--- a/crates/plugin-oci/src/pluginoci/push.rs
+++ b/crates/plugin-oci/src/pluginoci/push.rs
@@ -164,14 +164,10 @@ impl ManagedDriver for Driver {
         let layout =
             Layout::read(&path).with_context(|| format!("read the image to push from {path:?}"))?;
 
-        let digest = registry::push_layout(&layout, &def.dest, def.insecure)
+        registry::push_layout(&layout, &def.dest, def.insecure)
             .await
             .with_context(|| format!("push {}", def.dest))?;
 
-        // A push is the one place the build graph meets the outside world, so
-        // say what left the machine: without it neither a human nor an agent can
-        // learn what `heph run //app:push` actually shipped.
-        tracing::info!(r#ref = def.dest, digest, "oci_push: pushed");
         Ok(ManagedRunResponse { artifacts: vec![] })
     }
 }


### PR DESCRIPTION
Top of stack #379: #159 → #378 → #381 → #383 → this.

## What

Six `info!` lines saying a driver did the thing it exists to do:

| Driver | Line |
|---|---|
| `oci_pull` | `oci_pull: pulled` |
| `oci_push` | `oci_push: pushed` |
| `oci_load` | `oci_load: loaded` |
| `oci_image` | `oci_image: assembled` |
| `oci_layer` | `oci_layer: packed` |
| `oci_index` | `oci_index: grouped` |

All removed. The engine already reports which targets ran and how long they took, so these restate it in a second, less structured place — and they scale with the graph, which is the wrong direction for a build with a few hundred images.

## What stays

The two `warn!`s, because they say something the engine cannot:

- `oci_pull` on an unpinned tag — the ref string is the cache key, so a moved tag serves a stale archive. Not progress; a correctness caveat.
- a target's `log.txt` failing to open — an error path.

Plus the `debug!` about falling back to anonymous registry credentials, which is what an unexpected 401 gets diagnosed from.

## Fallout

- `oci_push` no longer binds the digest `push_layout` returns.
- The cdylib's log-sink doc cited `docker_build built` / `oci_push: pushed` as the reason the sink exists. It now names the diagnostics that actually depend on it, since the lines it pointed at are gone.

## One thing to decide

`oci_load`'s line was **the only place the derived `<repo>:<hashin>` tag was surfaced.** With it gone, anything that wants to know what to `docker run` has to recompute the name and read `hashin` out of `heph inspect`.

That is a real loss and it is not obviously the right trade. The clean fix is to expose the tag as an output group, the way `oci_image` exposes `digest` — a downstream target could then read it directly, which is better than a log line was. I have not done it here: `oci_load` is an uncached action with no outputs today, so adding one is a design change rather than a cleanup, and it belongs in its own PR.

Say the word and I will add it; otherwise this ships as-is.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WqQZxsTqanJRWLWdPSchBo