### PR TITLE
feat(plugin-oci): say what an unpinned oci_pull ref resolved to

### DIFF
--- a/crates/plugin-oci/src/pluginoci/pull.rs
+++ b/crates/plugin-oci/src/pluginoci/pull.rs
@@ -314,10 +314,31 @@ impl ManagedDriver for Driver {
         // workspace dir so they are not collected as outputs. The sandbox is
         // torn down after the run, so there is nothing to clean up.
         let blob_dir = req.sandbox_dir.join("heph-oci-blobs");
-        let (index, blobs) =
-            super::registry::pull_layout(&def.src, &def.platform, def.insecure, &blob_dir)
-                .await
-                .with_context(|| format!("pull image {}", def.src))?;
+        let pulled = super::registry::pull_layout(&def.src, &def.platform, def.insecure, &blob_dir)
+            .await
+            .with_context(|| format!("pull image {}", def.src))?;
+        let super::registry::Pulled {
+            index,
+            blobs,
+            pinned_ref,
+        } = pulled;
+
+        // The parse-time warning can only say *that* the ref is mutable — the
+        // digest it currently points at is not known until the registry has been
+        // asked. This is that answer, and it is the whole remedy: paste it back
+        // into `src` and the pull becomes reproducible.
+        //
+        // Only on a real pull, so it does not nag on a cache hit, where nothing
+        // was resolved and the recorded bytes are whatever the tag meant last.
+        if !is_digest_pinned(&def.src) {
+            tracing::warn!(
+                image = def.src,
+                resolved = pinned_ref,
+                "oci_pull: {:?} currently resolves to {pinned_ref:?} — pin `src` to that to \
+                 make this pull reproducible",
+                def.src
+            );
+        }
 
         if def.layout {
             // A layout *directory* is the shape `docker_build`'s `bases` consumes:

--- a/crates/plugin-oci/src/pluginoci/registry.rs
+++ b/crates/plugin-oci/src/pluginoci/registry.rs
@@ -203,6 +203,39 @@ pub(crate) async fn push_layout(
         .context("push manifest list")
 }
 
+/// `<registry>/<repository>@<digest>` — the ref with its tag replaced by what
+/// the registry actually served.
+///
+/// Built from the *resolved* registry and repository rather than by editing the
+/// user's string: `alpine:3.20` and `docker.io/library/alpine:3.20` name one
+/// image, and only the expanded form is unambiguous to paste back into `src`.
+fn pinned_ref(reference: &Reference, digest: &str) -> String {
+    // `registry()`, not `resolve_registry()`: the former keeps the spelling the
+    // BUILD file used and already normalizes Docker Hub shorthand to
+    // `docker.io`, while the latter reports the *API endpoint*
+    // (`index.docker.io`) — correct to connect to, needlessly surprising to
+    // paste back.
+    format!(
+        "{}/{}@{}",
+        reference.registry().trim_end_matches('/'),
+        reference.repository(),
+        digest
+    )
+}
+
+/// What a pull resolved to, beyond the bytes.
+pub(crate) struct Pulled {
+    pub index: OciImageIndex,
+    pub blobs: super::archive::Blobs,
+    /// See [`pinned_ref`] — e.g. `cgr.dev/chainguard/static@sha256:…`.
+    ///
+    /// A tag is a pointer, and heph keys a pull on the *string* — so a caller
+    /// who wants the pull to stay reproducible needs the thing the pointer
+    /// pointed at, at the moment it was followed. This is that, spelled so it
+    /// can be pasted straight back into `src`.
+    pub pinned_ref: String,
+}
+
 /// Pull the selected platforms of `reference` into an in-memory layout.
 ///
 /// Goes through the raw manifest rather than `Client::pull`, which resolves a
@@ -214,7 +247,7 @@ pub(crate) async fn pull_layout(
     platforms: &super::pull::PlatformSelect,
     insecure: bool,
     blob_dir: &std::path::Path,
-) -> anyhow::Result<(OciImageIndex, super::archive::Blobs)> {
+) -> anyhow::Result<Pulled> {
     let reference: Reference = reference
         .parse()
         .with_context(|| format!("parse image reference {reference:?}"))?;
@@ -231,6 +264,8 @@ pub(crate) async fn pull_layout(
         .pull_manifest_raw(&reference, &auth, ACCEPTED)
         .await
         .with_context(|| format!("pull the manifest of {reference}"))?;
+
+    let pinned_ref = pinned_ref(&reference, &digest);
 
     std::fs::create_dir_all(blob_dir)
         .with_context(|| format!("create the blob staging dir {blob_dir:?}"))?;
@@ -262,7 +297,11 @@ pub(crate) async fn pull_layout(
                 }],
                 annotations: None,
             };
-            return Ok((index, blobs));
+            return Ok(Pulled {
+                index,
+                blobs,
+                pinned_ref,
+            });
         }
     };
 
@@ -292,7 +331,11 @@ pub(crate) async fn pull_layout(
         manifests: entries,
         annotations: None,
     };
-    Ok((index, blobs))
+    Ok(Pulled {
+        index,
+        blobs,
+        pinned_ref,
+    })
 }
 
 /// The index entries the selection asks for, or an error naming what is on offer.
@@ -393,6 +436,38 @@ async fn pull_one(
 mod tests {
     use super::*;
     use futures::StreamExt as _;
+
+    /// The remedy the warning offers has to be pasteable: a ref the user can
+    /// drop straight into `src`, naming the digest the tag pointed at.
+    #[test]
+    fn a_resolved_ref_pins_the_digest_and_keeps_the_spelling() {
+        let d = "sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef";
+        let pin = |r: &str| pinned_ref(&r.parse::<Reference>().expect("ref"), d);
+
+        // A private registry keeps the spelling the BUILD file used.
+        assert_eq!(
+            pin("cgr.dev/chainguard/static:latest-glibc"),
+            format!("cgr.dev/chainguard/static@{d}")
+        );
+        // Docker Hub shorthand expands, because `alpine` alone is not a ref any
+        // other tool would resolve the same way.
+        assert_eq!(
+            pin("alpine:3.20"),
+            format!("docker.io/library/alpine@{d}"),
+            "shorthand expands: `alpine@sha256:…` is not a ref every tool agrees on"
+        );
+        // Already pinned: the digest is simply restated, never doubled up.
+        assert_eq!(
+            pin(&format!("cgr.dev/chainguard/static@{d}")),
+            format!("cgr.dev/chainguard/static@{d}")
+        );
+        // The result is a ref again — the whole point is that it round-trips.
+        assert!(
+            pin("cgr.dev/chainguard/static:latest-glibc")
+                .parse::<Reference>()
+                .is_ok()
+        );
+    }
 
     /// The upload path reads a blob in bounded chunks and reassembles to exactly
     /// the original bytes.


### PR DESCRIPTION
Top of stack #379: #159 → #378 → #381 → #383 → #384 → this.

## Why a second line, not the same one

The existing warning fires in `parse` — before anything has been asked of the registry. The digest the tag points at is not knowable there, and that digest is the entire remedy. So it has to be a subsequent line, after the pull.

```
WARN oci_pull: pulling a mutable tag "cgr.dev/chainguard/static:latest-glibc" — heph
     caches on the ref string, so a moved tag serves the stale archive; pin the ref
     by @sha256:digest to make the pull reproducible
WARN oci_pull: "cgr.dev/chainguard/static:latest-glibc" currently resolves to
     "cgr.dev/chainguard/static@sha256:9f2c…" — pin `src` to that to make this
     pull reproducible
```

**Only on a real pull, never on a cache hit.** On a hit nothing was resolved, and the cached bytes are whatever the tag meant when it was last followed — naming a digest there would be a guess presented as a fact.

## The ref is rebuilt, not string-edited

`registry()` rather than `resolve_registry()`:

| Input | Result | |
|---|---|---|
| `cgr.dev/chainguard/static:latest-glibc` | `cgr.dev/chainguard/static@sha256:…` | spelling preserved |
| `alpine:3.20` | `docker.io/library/alpine@sha256:…` | shorthand expands |
| already `@sha256:…` | restated, not doubled | |

`resolve_registry()` would give `index.docker.io` — correct to *connect* to, needlessly surprising to paste back. `registry()` already normalizes Hub shorthand to `docker.io`. Shorthand still has to expand: `alpine@sha256:…` alone is not a ref every tool resolves the same way.

## Shape

`pull_layout` returns a `Pulled` struct instead of a tuple — the resolved ref is a third thing the caller wants, and a 3-tuple at a module boundary says nothing about which field is which.

## Tests

On the construction, not the network: private-registry spelling preserved, Hub shorthand expanded, an already-pinned ref restated rather than doubled, and the result parses back as a `Reference` — the round-trip being the whole point of offering it as a remedy.

Consistent with #384, which removed the per-target progress logs: this is a diagnostic with an action attached, not a progress line.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WqQZxsTqanJRWLWdPSchBo