### PR TITLE
feat(ci): swap sccache for kache, backed by R2

### DIFF
--- a/.github/actions/setup-nix/action.yml
+++ b/.github/actions/setup-nix/action.yml
@@ -148,6 +148,18 @@ runs:
     #
     # Skipped without credentials — a local-only kache needs no daemon, and the
     # matching drain step in each job tolerates one not running.
+    #
+    # The daemon is started here but drained *there*: every compiling job ends
+    # with its own `kache stats + drain uploads` step. That asymmetry is not a
+    # preference — `post:`/`post-if:` exist only for `runs.using: node20`
+    # JavaScript actions, and this is a composite one, so it has nowhere to hang
+    # a job-end hook. (Nesting a JS action here would work — `actions/cache`
+    # below does exactly that for its save — but it would be this repo's first
+    # JS action, and it would bury `kache stats` in a collapsed post group.)
+    #
+    # The cost of the per-job copies is that a new compiling job can forget one,
+    # and the symptom is silent: the cache still reads correctly, it just stops
+    # filling. If you add a job that compiles, add the drain step too.
     - name: Start kache daemon
       if: inputs.cargo-target != '' && inputs.r2-secret != ''
       shell: bash

--- a/.github/actions/setup-nix/action.yml
+++ b/.github/actions/setup-nix/action.yml
@@ -3,7 +3,7 @@ description: >-
   Install Nix, restore the persisted Nix store, repair/re-substitute any
   invalid paths, install devenv, and warm the devenv shell with self-healing
   retries so a partial or poisoned cache restore recovers instead of failing
-  the job. Optionally restores the cargo registry cache and points sccache at
+  the job. Optionally restores the cargo registry cache and points kache at
   the shared R2 bucket.
 
 inputs:
@@ -25,8 +25,8 @@ inputs:
   r2-secret:
     description: >-
       Cloudflare R2 secret access key (`secrets.CF_SSCACHE`) for the shared
-      sccache bucket. Empty — as on fork PRs, where secrets are not exposed —
-      falls back to an ephemeral local-disk sccache.
+      build-cache bucket. Empty — as on fork PRs, where secrets are not exposed
+      — falls back to an ephemeral local-disk kache with no remote.
     required: false
     default: ""
 
@@ -97,39 +97,64 @@ runs:
         # Surface the real error if the store is still broken after retries.
         devenv shell true
 
-    # sccache stores objects in Cloudflare R2 rather than an actions/cache
+    # kache stores objects in Cloudflare R2 rather than an actions/cache
     # tarball. Object storage is shared across every branch, PR and runner, is
     # not subject to the repo's Actions cache quota, and needs no cache key at
-    # all: sccache's own hash of (source, args, compiler) already separates
-    # lint's check units from the release builds. The tarball scheme could not —
-    # jobs sharing a key clobbered each other, and a job that restored a foreign
-    # tarball compiled the whole workspace at a 0% hit rate, then dropped its
-    # own results because actions/cache does not re-save an existing key.
-    - name: Configure sccache backend
+    # all: kache's own content hash of (source, args, compiler) already
+    # separates lint's check units from the release builds. The tarball scheme
+    # could not — jobs sharing a key clobbered each other, and a job that
+    # restored a foreign tarball compiled the whole workspace at a 0% hit rate,
+    # then dropped its own results because actions/cache does not re-save an
+    # existing key.
+    #
+    # Same bucket and API token as the sccache setup this replaced, under a
+    # distinct `kache/v1` prefix — kache's object layout (`<prefix>/v3/packs/…`,
+    # `<prefix>/v3/manifests/…`) shares no keys with sccache's, so the two never
+    # collide and no new R2 token was needed. Bump the prefix to invalidate
+    # every cached object at once.
+    - name: Configure kache remote (R2)
       if: inputs.cargo-target != ''
       shell: bash
       env:
         R2_SECRET: ${{ inputs.r2-secret }}
       run: |
         if [ -z "$R2_SECRET" ]; then
-          # Fork PRs are not given secrets. Fall back to a local-disk cache so
-          # rustc still has a working wrapper (cold, and discarded with the job).
-          echo "SCCACHE_DIR=$GITHUB_WORKSPACE/.sccache" >> "$GITHUB_ENV"
-          echo "::notice title=sccache::no R2 credentials — using local disk (cold cache)"
+          # Fork PRs are not given secrets. kache still caches to local disk
+          # without a remote (and without a daemon — see the next step), so
+          # rustc keeps a working wrapper; it is cold and dies with the job.
+          echo "::notice title=kache::no R2 credentials — local disk only (cold cache)"
           exit 0
         fi
         {
-          echo "SCCACHE_BUCKET=heph-sscache"
-          echo "SCCACHE_REGION=auto"
-          echo "SCCACHE_ENDPOINT=https://b9d7099532d2613531d6f54b60211d0c.r2.cloudflarestorage.com"
-          # Bump to invalidate every cached object at once.
-          echo "SCCACHE_S3_KEY_PREFIX=v1"
-          echo "AWS_ACCESS_KEY_ID=47bb1ffef0f93339c11fa28d7540fc3c"
-          echo "AWS_SECRET_ACCESS_KEY=$R2_SECRET"
+          echo "KACHE_S3_BUCKET=heph-sscache"
+          echo "KACHE_S3_REGION=auto"
+          echo "KACHE_S3_ENDPOINT=https://b9d7099532d2613531d6f54b60211d0c.r2.cloudflarestorage.com"
+          echo "KACHE_S3_PREFIX=kache/v1"
+          # Both halves are required: given only one, kache logs a warning and
+          # silently falls back to the AWS credential chain, which on a runner
+          # means "no credentials" dressed up as a wrong-credentials error.
+          echo "KACHE_S3_ACCESS_KEY=47bb1ffef0f93339c11fa28d7540fc3c"
+          echo "KACHE_S3_SECRET_KEY=$R2_SECRET"
         } >> "$GITHUB_ENV"
 
+    # The remote is inert without the daemon: the wrapper delegates remote
+    # lookups and uploads to it, so a daemon-less job would fill a local store
+    # that nothing reads and nothing publishes. It must start *after* the step
+    # above, because a running daemon's environment is fixed at spawn — it would
+    # otherwise come up with no R2 config and never pick it up.
+    #
+    # `devenv shell`, not bare `kache`: the binary lives in the devenv profile
+    # (see devenv.nix), which is not on the job's default PATH.
+    #
+    # Skipped without credentials — a local-only kache needs no daemon, and the
+    # matching drain step in each job tolerates one not running.
+    - name: Start kache daemon
+      if: inputs.cargo-target != '' && inputs.r2-secret != ''
+      shell: bash
+      run: devenv shell bash -- -e -c 'kache daemon start && kache daemon'
+
     # Cargo registry/git only — crate downloads + index. Compiled artifacts are
-    # handled by sccache (above), so target/ is intentionally not cached here.
+    # handled by kache (above), so target/ is intentionally not cached here.
     - name: Cargo registry cache
       if: inputs.cargo-target != ''
       uses: actions/cache@v5

--- a/.github/actions/setup-nix/action.yml
+++ b/.github/actions/setup-nix/action.yml
@@ -135,6 +135,20 @@ runs:
           # means "no credentials" dressed up as a wrong-credentials error.
           echo "KACHE_S3_ACCESS_KEY=47bb1ffef0f93339c11fa28d7540fc3c"
           echo "KACHE_S3_SECRET_KEY=$R2_SECRET"
+          # Speculative prefetch off — measured, not assumed. Across two
+          # attempts of the same commit it downloaded 20 MiB and used 0% of it,
+          # while its whole-remote key index cost ~40s of LIST plus a 30s
+          # join-wait per job. Exact-key remote checks and background uploads
+          # are unaffected; only the guessing is.
+          #
+          # It is also a suspect in the miss count it was meant to reduce: a
+          # *negative* entry in that index suppresses the exact remote HEAD for
+          # up to 300s, so a key absent from the snapshot taken at daemon start
+          # is compiled rather than fetched even when it is sitting in R2.
+          #
+          # Must be set before the daemon starts (below): a running daemon's
+          # environment is fixed at spawn, so a later change needs a restart.
+          echo "KACHE_PREFETCH_ENABLED=0"
         } >> "$GITHUB_ENV"
 
     # The remote is inert without the daemon: the wrapper delegates remote

--- a/.github/workflows/heph.yml
+++ b/.github/workflows/heph.yml
@@ -437,7 +437,29 @@ jobs:
         shell: devenv shell bash -- -e {0}
         run: |
           kache stats
+
+          # Resolve the log path from the daemon itself rather than hardcoding
+          # it. Both OSes run this same step and they do not agree: Linux puts
+          # it at `~/.cache/kache/kache.log`, macOS at
+          # `~/Library/Logs/kache/kache.log` — note *Logs*, not the `Caches`
+          # directory the upstream docs name, which is where hardcoding it
+          # would have silently produced nothing on the darwin legs.
+          log=$(kache daemon 2>/dev/null | awk '/^[[:space:]]*Logs:/ {print $2; exit}') || true
+
           kache daemon stop || true
+
+          # Upload outcomes exist *only* in this log. `kache stats` reports what
+          # was read, never what was published, so without this the difference
+          # between "uploaded" and "still queued when the 30s drain cap fired"
+          # is invisible — which is precisely the question a low hit rate on a
+          # re-run raises, and which cost a round trip to answer once already.
+          if [ -n "${log:-}" ] && [ -f "$log" ]; then
+            echo "::group::kache daemon log (tail)"
+            tail -n 200 "$log"
+            echo "::endgroup::"
+          else
+            echo "::warning title=kache::daemon log not found at '${log:-<unresolved>}' — upload outcomes are not diagnosable for this job"
+          fi
 
   upload_artifacts:
     name: Pre-release
@@ -653,7 +675,29 @@ jobs:
         shell: devenv shell bash -- -e {0}
         run: |
           kache stats
+
+          # Resolve the log path from the daemon itself rather than hardcoding
+          # it. Both OSes run this same step and they do not agree: Linux puts
+          # it at `~/.cache/kache/kache.log`, macOS at
+          # `~/Library/Logs/kache/kache.log` — note *Logs*, not the `Caches`
+          # directory the upstream docs name, which is where hardcoding it
+          # would have silently produced nothing on the darwin legs.
+          log=$(kache daemon 2>/dev/null | awk '/^[[:space:]]*Logs:/ {print $2; exit}') || true
+
           kache daemon stop || true
+
+          # Upload outcomes exist *only* in this log. `kache stats` reports what
+          # was read, never what was published, so without this the difference
+          # between "uploaded" and "still queued when the 30s drain cap fired"
+          # is invisible — which is precisely the question a low hit rate on a
+          # re-run raises, and which cost a round trip to answer once already.
+          if [ -n "${log:-}" ] && [ -f "$log" ]; then
+            echo "::group::kache daemon log (tail)"
+            tail -n 200 "$log"
+            echo "::endgroup::"
+          else
+            echo "::warning title=kache::daemon log not found at '${log:-<unresolved>}' — upload outcomes are not diagnosable for this job"
+          fi
 
   test:
     name: Test ${{ matrix.os }}/${{ matrix.arch }}
@@ -736,7 +780,29 @@ jobs:
         shell: devenv shell bash -- -e {0}
         run: |
           kache stats
+
+          # Resolve the log path from the daemon itself rather than hardcoding
+          # it. Both OSes run this same step and they do not agree: Linux puts
+          # it at `~/.cache/kache/kache.log`, macOS at
+          # `~/Library/Logs/kache/kache.log` — note *Logs*, not the `Caches`
+          # directory the upstream docs name, which is where hardcoding it
+          # would have silently produced nothing on the darwin legs.
+          log=$(kache daemon 2>/dev/null | awk '/^[[:space:]]*Logs:/ {print $2; exit}') || true
+
           kache daemon stop || true
+
+          # Upload outcomes exist *only* in this log. `kache stats` reports what
+          # was read, never what was published, so without this the difference
+          # between "uploaded" and "still queued when the 30s drain cap fired"
+          # is invisible — which is precisely the question a low hit rate on a
+          # re-run raises, and which cost a round trip to answer once already.
+          if [ -n "${log:-}" ] && [ -f "$log" ]; then
+            echo "::group::kache daemon log (tail)"
+            tail -n 200 "$log"
+            echo "::endgroup::"
+          else
+            echo "::warning title=kache::daemon log not found at '${log:-<unresolved>}' — upload outcomes are not diagnosable for this job"
+          fi
 
   # Compile `bin_e2e`'s test binaries ahead of the job that runs them. `tst`
   # excludes the crate (it needs staged artifacts to run) and nothing else in
@@ -810,7 +876,29 @@ jobs:
         shell: devenv shell bash -- -e {0}
         run: |
           kache stats
+
+          # Resolve the log path from the daemon itself rather than hardcoding
+          # it. Both OSes run this same step and they do not agree: Linux puts
+          # it at `~/.cache/kache/kache.log`, macOS at
+          # `~/Library/Logs/kache/kache.log` — note *Logs*, not the `Caches`
+          # directory the upstream docs name, which is where hardcoding it
+          # would have silently produced nothing on the darwin legs.
+          log=$(kache daemon 2>/dev/null | awk '/^[[:space:]]*Logs:/ {print $2; exit}') || true
+
           kache daemon stop || true
+
+          # Upload outcomes exist *only* in this log. `kache stats` reports what
+          # was read, never what was published, so without this the difference
+          # between "uploaded" and "still queued when the 30s drain cap fired"
+          # is invisible — which is precisely the question a low hit rate on a
+          # re-run raises, and which cost a round trip to answer once already.
+          if [ -n "${log:-}" ] && [ -f "$log" ]; then
+            echo "::group::kache daemon log (tail)"
+            tail -n 200 "$log"
+            echo "::endgroup::"
+          else
+            echo "::warning title=kache::daemon log not found at '${log:-<unresolved>}' — upload outcomes are not diagnosable for this job"
+          fi
 
   # Black-box tests against the artifacts the `build` job just produced — the
   # exact bytes that get published. Covers only what `test` structurally cannot:
@@ -897,7 +985,29 @@ jobs:
         shell: devenv shell bash -- -e {0}
         run: |
           kache stats
+
+          # Resolve the log path from the daemon itself rather than hardcoding
+          # it. Both OSes run this same step and they do not agree: Linux puts
+          # it at `~/.cache/kache/kache.log`, macOS at
+          # `~/Library/Logs/kache/kache.log` — note *Logs*, not the `Caches`
+          # directory the upstream docs name, which is where hardcoding it
+          # would have silently produced nothing on the darwin legs.
+          log=$(kache daemon 2>/dev/null | awk '/^[[:space:]]*Logs:/ {print $2; exit}') || true
+
           kache daemon stop || true
+
+          # Upload outcomes exist *only* in this log. `kache stats` reports what
+          # was read, never what was published, so without this the difference
+          # between "uploaded" and "still queued when the 30s drain cap fired"
+          # is invisible — which is precisely the question a low hit rate on a
+          # re-run raises, and which cost a round trip to answer once already.
+          if [ -n "${log:-}" ] && [ -f "$log" ]; then
+            echo "::group::kache daemon log (tail)"
+            tail -n 200 "$log"
+            echo "::endgroup::"
+          else
+            echo "::warning title=kache::daemon log not found at '${log:-<unresolved>}' — upload outcomes are not diagnosable for this job"
+          fi
 
   # Perf-regression check (own workflow: .github/workflows/perf.yml) —
   # generates one synthetic corpus, times a fixed scenario set against N and

--- a/.github/workflows/heph.yml
+++ b/.github/workflows/heph.yml
@@ -361,23 +361,6 @@ jobs:
           rust-strip --strip-all $BIN_NAME
           bash scripts/patch-flavour.sh $BIN_NAME ""
 
-      # Also the upload barrier, which is why it is `always()` and why every
-      # compiling job needs one. The daemon uploads to R2 in the background so
-      # no rustc invocation waits on the network — but an ephemeral runner is
-      # torn down the moment the job ends, taking any queued upload with it.
-      # `daemon stop` drains the queue (up to 30s) before returning, so what
-      # this job compiled is actually published. Without it the cache still
-      # reads correctly, it just never fills.
-      #
-      # `|| true`: fork PRs run with no remote and therefore no daemon (see
-      # setup-nix), and this must not turn a green build red on the way out.
-      - name: kache stats + drain uploads
-        if: always()
-        shell: devenv shell bash -- -e {0}
-        run: |
-          kache stats
-          kache daemon stop || true
-
       # Runs wherever this runner can actually execute what it just built: the
       # darwin leg and the linux/amd64 leg both build for the runner's own
       # arch. linux/arm64 cross-compiles on an amd64 runner (see the zigbuild
@@ -444,6 +427,17 @@ jobs:
         with:
           name: ${{steps.build.outputs.plugin_oci_name}}
           path: ${{steps.build.outputs.plugin_oci_name}}
+
+      # Last, deliberately. This is the only job with steps after its compile,
+      # and the drain must not sit in front of them: it would still be correct
+      # today (nothing after `Build` compiles) but only by accident, and a
+      # compiling step appended later would silently stop being published.
+      - name: kache stats + drain uploads
+        if: always()
+        shell: devenv shell bash -- -e {0}
+        run: |
+          kache stats
+          kache daemon stop || true
 
   upload_artifacts:
     name: Pre-release

--- a/.github/workflows/heph.yml
+++ b/.github/workflows/heph.yml
@@ -535,11 +535,18 @@ jobs:
   # The gate check-builds every workspace member's libs *and* test targets,
   # three times (default features, --all-features, --no-default-features),
   # where it used to build the root package alone in ~1m35s. A fork PR gets no
-  # R2 credentials and runs every pass stone cold. Even warm, the workspace's
-  # own crates go through `clippy-driver` via RUSTC_WORKSPACE_WRAPPER rather
-  # than the plain wrapper, so a warm cache mostly saves the dependency
-  # compiles. A timeout renders as a red lint leg indistinguishable from a real
-  # lint failure, so the 30min headroom is deliberate.
+  # R2 credentials and runs every pass stone cold, so the headroom is sized for
+  # that case. Under sccache this job was uncacheable on top of that — it did
+  # not cache `clippy-driver` at all, which is why these legs used to report
+  # ~200 "non-cacheable calls". kache does: cargo runs workspace members as
+  # `$RUSTC_WRAPPER $RUSTC_WORKSPACE_WRAPPER $RUSTC`, so the wrapper sees the
+  # clippy invocation and keys it on clippy-driver's own compiler identity,
+  # separately from the equivalent `cargo build` unit. Measured on a workspace
+  # member: `cargo clean -p <crate>` then `cargo clippy -p <crate>
+  # --all-targets` restores from cache rather than re-linting.
+  #
+  # A timeout renders as a red lint leg indistinguishable from a real lint
+  # failure, so the 30min headroom is deliberate.
   #
   # Both platforms, because macOS-only code was clippy-linted nowhere.
   # `Test darwin/arm64` compiles it, but nothing there passes `-D warnings`, so

--- a/.github/workflows/heph.yml
+++ b/.github/workflows/heph.yml
@@ -24,13 +24,21 @@ concurrency:
   group: ci-${{ github.event_name == 'pull_request' && github.ref || github.sha }}
   cancel-in-progress: ${{ github.event_name == 'pull_request' }}
 
-# sccache config shared by every compiling job. RUSTC_WRAPPER=sccache is set by
-# the devenv shell; the storage backend (R2, or local disk on fork PRs) is wired
-# up by the setup-nix action. Incremental compilation is off because sccache
-# cannot cache incremental units, and fresh runners have no warm incremental dir
-# to reuse. SCCACHE_CACHE_SIZE bounds only the local-disk fallback.
+# kache config shared by every compiling job. RUSTC_WRAPPER=kache is set by the
+# devenv shell; the storage backend (R2, or local disk on fork PRs) and the
+# daemon that talks to it are wired up by the setup-nix action. Incremental
+# compilation is off because kache caches whole artifacts rather than
+# incremental units, and fresh runners have no warm incremental dir to reuse.
+#
+# KACHE_MAX_SIZE bounds the runner's local store. Well under kache's own 50GiB
+# default, which is sized for a workstation: a runner only needs this build's
+# artifacts, and on Linux (ext4, no reflink) kache *copies* rather than
+# hardlinks the mutable outputs — bin, dylib, cdylib, proc-macro — so those
+# cost their bytes twice, once in the store and once in target/. macOS (APFS)
+# reflinks them for free. Overshooting here is a disk-full test failure, which
+# this repo has hit before, not a slow build.
 env:
-  SCCACHE_CACHE_SIZE: "2G"
+  KACHE_MAX_SIZE: "10GiB"
   CARGO_INCREMENTAL: "0"
 
 jobs:
@@ -353,10 +361,22 @@ jobs:
           rust-strip --strip-all $BIN_NAME
           bash scripts/patch-flavour.sh $BIN_NAME ""
 
-      - name: sccache stats
+      # Also the upload barrier, which is why it is `always()` and why every
+      # compiling job needs one. The daemon uploads to R2 in the background so
+      # no rustc invocation waits on the network — but an ephemeral runner is
+      # torn down the moment the job ends, taking any queued upload with it.
+      # `daemon stop` drains the queue (up to 30s) before returning, so what
+      # this job compiled is actually published. Without it the cache still
+      # reads correctly, it just never fills.
+      #
+      # `|| true`: fork PRs run with no remote and therefore no daemon (see
+      # setup-nix), and this must not turn a green build red on the way out.
+      - name: kache stats + drain uploads
         if: always()
         shell: devenv shell bash -- -e {0}
-        run: sccache --show-stats
+        run: |
+          kache stats
+          kache daemon stop || true
 
       # Runs wherever this runner can actually execute what it just built: the
       # darwin leg and the linux/amd64 leg both build for the runner's own
@@ -521,12 +541,11 @@ jobs:
   # The gate check-builds every workspace member's libs *and* test targets,
   # three times (default features, --all-features, --no-default-features),
   # where it used to build the root package alone in ~1m35s. A fork PR gets no
-  # R2 sccache credentials and runs every pass stone cold — and clippy's work is
-  # not sccache-cacheable at all (`sccache` does not cache `clippy-driver`,
-  # which is why these jobs' own stats report ~200 "non-cacheable calls"), so a
-  # warm cache only saves the dependency compiles. A timeout renders as a red
-  # lint leg indistinguishable from a real lint failure, so the 30min headroom
-  # is deliberate.
+  # R2 credentials and runs every pass stone cold. Even warm, the workspace's
+  # own crates go through `clippy-driver` via RUSTC_WORKSPACE_WRAPPER rather
+  # than the plain wrapper, so a warm cache mostly saves the dependency
+  # compiles. A timeout renders as a red lint leg indistinguishable from a real
+  # lint failure, so the 30min headroom is deliberate.
   #
   # Both platforms, because macOS-only code was clippy-linted nowhere.
   # `Test darwin/arm64` compiles it, but nothing there passes `-D warnings`, so
@@ -618,10 +637,22 @@ jobs:
         shell: devenv shell bash -- -e {0}
         run: lint
 
-      - name: sccache stats
+      # Also the upload barrier, which is why it is `always()` and why every
+      # compiling job needs one. The daemon uploads to R2 in the background so
+      # no rustc invocation waits on the network — but an ephemeral runner is
+      # torn down the moment the job ends, taking any queued upload with it.
+      # `daemon stop` drains the queue (up to 30s) before returning, so what
+      # this job compiled is actually published. Without it the cache still
+      # reads correctly, it just never fills.
+      #
+      # `|| true`: fork PRs run with no remote and therefore no daemon (see
+      # setup-nix), and this must not turn a green build red on the way out.
+      - name: kache stats + drain uploads
         if: always()
         shell: devenv shell bash -- -e {0}
-        run: sccache --show-stats
+        run: |
+          kache stats
+          kache daemon stop || true
 
   test:
     name: Test ${{ matrix.os }}/${{ matrix.arch }}
@@ -689,10 +720,22 @@ jobs:
           RUST_BACKTRACE: "1"
         run: tst
 
-      - name: sccache stats
+      # Also the upload barrier, which is why it is `always()` and why every
+      # compiling job needs one. The daemon uploads to R2 in the background so
+      # no rustc invocation waits on the network — but an ephemeral runner is
+      # torn down the moment the job ends, taking any queued upload with it.
+      # `daemon stop` drains the queue (up to 30s) before returning, so what
+      # this job compiled is actually published. Without it the cache still
+      # reads correctly, it just never fills.
+      #
+      # `|| true`: fork PRs run with no remote and therefore no daemon (see
+      # setup-nix), and this must not turn a green build red on the way out.
+      - name: kache stats + drain uploads
         if: always()
         shell: devenv shell bash -- -e {0}
-        run: sccache --show-stats
+        run: |
+          kache stats
+          kache daemon stop || true
 
   # Compile `bin_e2e`'s test binaries ahead of the job that runs them. `tst`
   # excludes the crate (it needs staged artifacts to run) and nothing else in
@@ -701,8 +744,9 @@ jobs:
   # downloading the artifacts, on the critical path to `release`.
   #
   # This job needs only `gen`, so it runs concurrently with `build` and `test`
-  # and is long finished before `bin_e2e` starts. sccache is shared across jobs
-  # through R2, and the registry cache key is the same `-bin-e2e` suffix, so
+  # and is long finished before `bin_e2e` starts. The kache store is shared
+  # across jobs through R2, and the registry cache key is the same `-bin-e2e`
+  # suffix, so
   # `bin_e2e` restores both and starts running tests instead of compiling.
   #
   # Its own job rather than a step in `test`: both compile the test profile, so
@@ -750,10 +794,22 @@ jobs:
         shell: devenv shell bash -- -e {0}
         run: cargo test --locked -p bin-e2e --no-run
 
-      - name: sccache stats
+      # Also the upload barrier, which is why it is `always()` and why every
+      # compiling job needs one. The daemon uploads to R2 in the background so
+      # no rustc invocation waits on the network — but an ephemeral runner is
+      # torn down the moment the job ends, taking any queued upload with it.
+      # `daemon stop` drains the queue (up to 30s) before returning, so what
+      # this job compiled is actually published. Without it the cache still
+      # reads correctly, it just never fills.
+      #
+      # `|| true`: fork PRs run with no remote and therefore no daemon (see
+      # setup-nix), and this must not turn a green build red on the way out.
+      - name: kache stats + drain uploads
         if: always()
         shell: devenv shell bash -- -e {0}
-        run: sccache --show-stats
+        run: |
+          kache stats
+          kache daemon stop || true
 
   # Black-box tests against the artifacts the `build` job just produced — the
   # exact bytes that get published. Covers only what `test` structurally cannot:
@@ -769,7 +825,7 @@ jobs:
     timeout-minutes: 30
     # bin_e2e_warm is a hard dependency, not just an optimisation running
     # nearby: both jobs pay the same nix-store restore before compiling
-    # anything, so on a run where `build` is mostly sccache hits it can finish
+    # anything, so on a run where `build` is mostly cache hits it can finish
     # first and this job would start while the warm is still going — compiling
     # the same crates concurrently, with neither seeing the other's objects.
     # Waiting makes the cache hit deterministic. The warm needs only `gen`, so
@@ -825,10 +881,22 @@ jobs:
           HEPH_E2E_FROM: dist
         run: e2e
 
-      - name: sccache stats
+      # Also the upload barrier, which is why it is `always()` and why every
+      # compiling job needs one. The daemon uploads to R2 in the background so
+      # no rustc invocation waits on the network — but an ephemeral runner is
+      # torn down the moment the job ends, taking any queued upload with it.
+      # `daemon stop` drains the queue (up to 30s) before returning, so what
+      # this job compiled is actually published. Without it the cache still
+      # reads correctly, it just never fills.
+      #
+      # `|| true`: fork PRs run with no remote and therefore no daemon (see
+      # setup-nix), and this must not turn a green build red on the way out.
+      - name: kache stats + drain uploads
         if: always()
         shell: devenv shell bash -- -e {0}
-        run: sccache --show-stats
+        run: |
+          kache stats
+          kache daemon stop || true
 
   # Perf-regression check (own workflow: .github/workflows/perf.yml) —
   # generates one synthetic corpus, times a fixed scenario set against N and

--- a/.gitignore
+++ b/.gitignore
@@ -19,9 +19,6 @@ target-verify/
 #  option (not recommended) you can uncomment the following to ignore the entire idea folder.
 #.idea/
 
-# sccache (CI writes its on-disk cache here)
-.sccache
-
 # Devenv
 .devenv*
 devenv.local.nix

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -10,6 +10,30 @@ This project uses [devenv](https://devenv.sh) for reproducible development envir
 devenv shell        # enter the dev shell (provides Rust toolchain, buf, protoc plugins)
 ```
 
+### Build cache
+
+Every `rustc` invocation goes through [kache](https://github.com/kunobi-ninja/kache)
+(`RUSTC_WRAPPER`, set in `devenv.nix` — so it applies in CI too, which runs inside
+this shell). It replaced sccache, which by design cannot cache "crates that invoke
+the system linker" — `bin`, `dylib`, `cdylib`, `proc-macro` — i.e. the `heph`
+binary, the three plugin cdylibs, every proc-macro and every test harness.
+
+- **Local** is a local-disk store only, at `~/.cache/kache` (Linux) or
+  `~/Library/Caches/kache` (macOS). No remote, and therefore **no daemon needed** —
+  the wrapper reads and writes the store directly. On a copy-on-write filesystem
+  (APFS, btrfs, XFS-with-reflink) restores are reflinks, so a restored `target/`
+  costs almost no additional disk and blobs are shared across worktrees.
+- **CI** points the same wrapper at the shared R2 bucket via `KACHE_S3_*` and runs
+  the daemon (`.github/actions/setup-nix`). The remote is inert without the daemon:
+  it owns remote lookups and background uploads. Each compiling job ends with
+  `kache daemon stop`, which drains the upload queue before the runner is torn down.
+- To share CI's cache locally, export the same `KACHE_S3_*` vars and run
+  `kache daemon start`.
+
+`kache stats` for a summary, `kache monitor` for a live TUI, `kache why-miss <crate>`
+to explain a miss, `KACHE_PROGRESS=verbose` for per-crate stderr lines, and
+`kache doctor` when something looks wrong. `KACHE_DISABLED=1` bypasses it entirely.
+
 ## Commands
 
 ```bash

--- a/crates/engine/src/engine/remote_cache_objstore.rs
+++ b/crates/engine/src/engine/remote_cache_objstore.rs
@@ -895,10 +895,15 @@ mod tests {
     /// future edit dropped `.with_retry(retry_config())` from the actual
     /// match arm. And deliberately never embeds the Debug string in an
     /// assertion message: `from_uri` folds the live process environment into
-    /// these builders, and this repo's own CI sets real AWS credentials via
-    /// env for sccache/R2 — printing the store's Debug output on failure
-    /// would risk leaking them into CI logs, even though `AwsCredential`'s
-    /// `Debug` impl currently redacts secrets.
+    /// these builders, so any real `AWS_*` credentials in scope end up inside
+    /// the store — printing its Debug output on failure would risk leaking
+    /// them into CI logs, even though `AwsCredential`'s `Debug` impl currently
+    /// redacts secrets. This repo's CI no longer supplies any: the build cache
+    /// moved from sccache, which needed `AWS_ACCESS_KEY_ID` /
+    /// `AWS_SECRET_ACCESS_KEY`, to kache, which reads its own
+    /// `KACHE_S3_ACCESS_KEY` / `KACHE_S3_SECRET_KEY` that these builders do not
+    /// look at. Keep the practice regardless — it costs nothing, and it is one
+    /// `AWS_PROFILE` in a developer's shell away from mattering again.
     fn assert_wires_retry_config(store: &dyn ObjectStore, scheme: &str) {
         let debug = format!("{store:?}");
         let want = retry_config();

--- a/devenv.nix
+++ b/devenv.nix
@@ -1,6 +1,57 @@
 { pkgs, lib, config, inputs, ... }:
 
 let
+  # kache — the `RUSTC_WRAPPER` (see `env.RUSTC_WRAPPER` below). Not in nixpkgs,
+  # and the upstream flake builds it from source against a pinned toolchain,
+  # which would land in the devenv shell's critical path on every cold CI
+  # runner. The published release binaries are self-contained (static musl on
+  # Linux, signed Mach-O on darwin), so fetch those instead: ~2s and no compile.
+  #
+  # Bumping: change `version`, then re-derive each `hash` — upstream publishes a
+  # `<asset>.sha256` next to every asset, and
+  #   nix hash convert --hash-algo sha256 --to sri <hex>
+  # turns that hex into the SRI form below. All four are verified by Nix at
+  # fetch time, so a wrong hash fails loudly rather than silently installing
+  # something else.
+  kacheVersion = "0.13.0";
+  kacheAssets = {
+    aarch64-darwin = {
+      target = "aarch64-apple-darwin";
+      hash = "sha256-8/TXz+ziDSUfh0Da4iR3fQlqXtKxYIscrplumPYBijE=";
+    };
+    x86_64-darwin = {
+      target = "x86_64-apple-darwin";
+      hash = "sha256-waUdA52DT2qtusGhZrlUTVMgs8qMsEhSD0XH1nqsG7U=";
+    };
+    x86_64-linux = {
+      target = "x86_64-unknown-linux-musl";
+      hash = "sha256-MK7e1NxuYgxACqOq96sWPclccDoPPdtNC6VsUfI/C9A=";
+    };
+    aarch64-linux = {
+      target = "aarch64-unknown-linux-musl";
+      hash = "sha256-th3j3mqauyGjdfqcZRPUe7jPc5H07rJMW+KXJzi4POM=";
+    };
+  };
+  kacheAsset =
+    kacheAssets.${pkgs.stdenv.hostPlatform.system}
+      or (throw "kache: no prebuilt binary for ${pkgs.stdenv.hostPlatform.system}");
+  kache = pkgs.stdenvNoCC.mkDerivation {
+    pname = "kache";
+    version = kacheVersion;
+    src = pkgs.fetchurl {
+      url = "https://github.com/kunobi-ninja/kache/releases/download/v${kacheVersion}/kache-${kacheAsset.target}.tar.gz";
+      inherit (kacheAsset) hash;
+    };
+    # The tarball is a single `kache` at the root — no directory to strip.
+    sourceRoot = ".";
+    dontBuild = true;
+    # Static musl / already-signed Mach-O. patchelf would only break the former
+    # (there is no interpreter to rewrite) and invalidate the latter's signature.
+    dontPatchELF = true;
+    dontStrip = true;
+    installPhase = "install -Dm755 kache $out/bin/kache";
+  };
+
   binLocation = "$HOME/.local/bin/heph3";
   qualityCrates = "-p heph -p e2e -p bin-e2e -p testkit -p plugingo-e2e -p htspec-derive -p core -p config -p walk -p proc -p model -p sandboxfuse -p plugin -p plugin-abi -p plugin-sdk -p plugin-stabby -p plugin-go-cdylib -p builtins -p plugin-buildfile -p driver-support -p driver-bridge -p plugin-exec -p plugin-nix -p plugin-http -p plugin-oci -p plugin-query -p plugin-go -p plugin-gha -p plugin-gha-cdylib -p plugin-oci-cdylib -p telemetry -p tui -p lock -p selfupdate -p engine -p xstarlark-fmt -p bench-corpus -p bench";
 in
@@ -17,7 +68,7 @@ in
     pkgs.zig
     pkgs.cargo-zigbuild
     pkgs.tokio-console
-    pkgs.sccache
+    kache
     # `rust-objcopy`/`rust-strip` (wraps the `llvm-tools` component's
     # llvm-objcopy, below) — used by `scripts/patch-flavour.sh`'s CI caller to
     # derive the "std" release flavour's stripped binary. LLVM-based and
@@ -42,10 +93,35 @@ in
     pkgs.fuse3
   ];
 
-  # Route every rustc invocation through sccache (local + CI, since CI runs
-  # inside this shell). SCCACHE_DIR is left at its platform default locally;
-  # CI overrides it to a workspace path so it can be cached across runs.
-  env.RUSTC_WRAPPER = "sccache";
+  # Route every rustc invocation through kache (local + CI, since CI runs inside
+  # this shell). Replaced sccache, which cannot cache "crates that invoke the
+  # system linker" — i.e. `bin`, `dylib`, `cdylib` and `proc-macro`. That is
+  # exactly this workspace's expensive tail: the `heph` binary, the three plugin
+  # cdylibs, every proc-macro, and every test harness. kache caches all of them.
+  #
+  # No remote is configured here, so a local shell is a local-disk cache and
+  # needs no daemon. CI points the same wrapper at R2 via `KACHE_S3_*` (see
+  # `.github/actions/setup-nix`). To share CI's cache locally, export those same
+  # vars and run `kache daemon start` — the remote is inert without the daemon.
+  env.RUSTC_WRAPPER = "kache";
+
+  # Cache linked `bin` and `--test` executables on macOS too, not just Linux.
+  #
+  # kache defaults this on for Linux and off for macOS: a Mach-O binary carries
+  # only a *debug map* (`N_OSO` entries naming each `.o` by path + mtime) rather
+  # than embedded DWARF, so a restored mac binary points at object files that no
+  # longer match and LLDB drops to function names without file:line. Linux
+  # embeds DWARF in the binary and restores losslessly.
+  #
+  # Turned on anyway, uniformly, because the release artifacts already have no
+  # file:line on macOS to lose: cargo overrides rustc's macOS default to
+  # `split-debuginfo = "unpacked"` for any profile with debug info (including
+  # `[profile.release]`, which sets `debug = "line-tables-only"`), so the shipped
+  # mac binary references `.o` files left behind on a CI runner. Fixing that
+  # needs a `.dSYM` shipped as a release asset — tracked separately, not here.
+  # The only live cost is attaching a debugger to a locally cache-restored mac
+  # binary; touch the crate and rebuild to get a freshly linked one.
+  env.KACHE_CACHE_EXECUTABLES = "1";
 
   # https://devenv.sh/languages/
    languages.rust = {

--- a/orca.yaml
+++ b/orca.yaml
@@ -1,0 +1,53 @@
+# Orca project defaults.
+#
+# `scripts.setup` runs in a new worktree whenever Orca creates one. It lives
+# here rather than in Orca's per-repo settings because this file is shared with
+# the team through git — the settings-pane equivalent is "local settings",
+# stored per-machine, so a teammate's worktrees would not get any of this.
+#
+# Orca prompts to trust this file the first time it appears; neither the hook
+# nor these tabs run until that is accepted.
+
+# Terminal tabs opened in every new worktree.
+#
+# Wrapped in `devenv shell`, not bare `claude`: all development in this repo
+# happens inside the devenv shell (see CLAUDE.md), and an agent started outside
+# it gets a different — usually absent — toolchain. It would find no `cargo`, no
+# `buf`, no `gen`/`tst`/`lint`/`e2e` scripts, and no `kache`, so builds would
+# either fail outright or silently bypass the build cache by running an ambient
+# rustc with no `RUSTC_WRAPPER`. Wrapping the agent is what makes "just run
+# `lint`" work in a fresh worktree.
+#
+# The `--` matters: it ends devenv's own option parsing, so `--permission-mode`
+# reaches claude instead of being eaten as a devenv flag.
+defaultTabs:
+  - title: claude
+    command: devenv shell -- claude --permission-mode auto
+
+scripts:
+  setup: |
+    set -euo pipefail
+
+    # Protobuf codegen. `gen/proto` is generated and not committed, so a fresh
+    # worktree cannot build — and `cargo test` cannot even resolve the
+    # workspace, because `gen/proto` is a declared member whose Cargo.toml does
+    # not exist yet. This is the one step a new worktree genuinely requires
+    # (see the `gen` note in CLAUDE.md), so it is fatal if it fails.
+    #
+    # This also warms the devenv shell for the worktree, which is what puts the
+    # Rust toolchain, buf, and kache on PATH.
+    devenv shell bash -- -e -c gen
+
+    # Code intelligence index. `.codegraph/` is per-worktree state (gitignored),
+    # so it has to be built per worktree rather than inherited. Non-fatal: a
+    # missing index costs search quality, not a working checkout.
+    codegraph init || echo "orca setup: codegraph init failed — run it by hand"
+
+    # kache — the RUSTC_WRAPPER, see CLAUDE.md — deliberately has no step here.
+    # Its store is one machine-global directory (`~/.cache/kache`, or
+    # `~/Library/Caches/kache` on macOS) shared by every worktree, and the
+    # wrapper binary and its env come from devenv.nix, which the `gen` line
+    # above already warmed. A new worktree therefore starts with a fully warm
+    # cache and nothing to install or initialize. Locally there is no remote
+    # and so no daemon to start either; CI is where the R2 remote and its
+    # daemon get wired up (.github/actions/setup-nix).

--- a/tests/lint_gate.rs
+++ b/tests/lint_gate.rs
@@ -602,7 +602,7 @@ fn matrix_include(body: &str) -> Vec<Vec<(String, String)>> {
 
 /// The step blocks of a job body, each starting at a `      - ` line.
 ///
-/// Some invariants are per *step*, not per job: the `sccache stats` step
+/// Some invariants are per *step*, not per job: the `kache stats` step
 /// legitimately carries `if: always()`, so "the Lint step has no `if:`" cannot
 /// be checked by scanning the whole job.
 fn job_steps(body: &str) -> Vec<String> {
@@ -721,7 +721,7 @@ fn a_lint_leg_cannot_report_success_without_running_the_lint() {
             .find(|step| job_run_steps(step).contains(&"lint"))
             .unwrap_or_else(|| panic!("`{id}` has a step running the `lint` script"));
 
-        // Scoped to this step: `sccache stats` legitimately has `if: always()`.
+        // Scoped to this step: `kache stats` legitimately has `if: always()`.
         assert!(
             !lint_step.lines().any(|line| line.trim().starts_with("if:")),
             "the Lint step of the `{id}` leg carries an `if:`. A skipped step \


### PR DESCRIPTION
## Why

sccache, by design, [cannot cache "crates that invoke the system linker"](https://github.com/mozilla/sccache/blob/main/docs/Rust.md) — `bin`, `dylib`, `cdylib` and `proc-macro`. That is exactly this workspace's expensive tail: the `heph` binary, the three plugin cdylibs, every proc-macro, and every test harness. Only dependency rlibs were ever cached; **every link was paid in full on every run**, locally and in CI.

kache caches all of them — `cdylib`/`dylib`/proc-macro unconditionally, and linked `bin`/`--test` executables via `cache_executables`.

## What changed

**`devenv.nix`** — `RUSTC_WRAPPER=kache` replaces sccache; CI inherits it by running inside this shell. kache comes from the upstream release tarball rather than nixpkgs (not there) or the upstream flake (builds from source, which would land on the cold-runner critical path). Hashes pinned and Nix-verified for all four host systems.

**`.github/actions/setup-nix`** — same R2 bucket and API token as before, under a distinct `kache/v1` prefix. The two object layouts share no keys, so **no new bucket and no new secret**; old sccache objects are untouched and can be deleted whenever. The daemon owns remote lookups and background uploads, so it starts *after* `KACHE_S3_*` is written (a running daemon's environment is fixed at spawn). Fork PRs get no credentials and fall back to a local-only store, which needs no daemon.

**`.github/workflows/heph.yml`** — the five `sccache --show-stats` steps become `kache stats` + `kache daemon stop`. The drain is load-bearing: uploads are backgrounded so no rustc waits on the network, and an ephemeral runner would otherwise be torn down with the queue still full. Without it the cache reads correctly but never fills.

**`orca.yaml`** (new) — new Orca worktrees bootstrap themselves: `gen`, `codegraph init`, and a default `claude` tab wrapped in `devenv shell`. Without `gen` a fresh worktree cannot even resolve the cargo workspace, since `gen/proto` is a declared member whose `Cargo.toml` does not exist yet.

## Two judgment calls worth reviewing

**macOS executables — `KACHE_CACHE_EXECUTABLES=1`, uniform across both OSes.** kache defaults this off on macOS because a Mach-O binary carries only a *debug map* (`N_OSO` entries naming each `.o` by path + mtime) instead of embedded DWARF, so a restored mac binary drops to function names without file:line.

It costs nothing here, because of a **pre-existing gap this turned up**: cargo overrides rustc's macOS default to `split-debuginfo = "unpacked"` for any profile with debug info — including `[profile.release]`, which sets `debug = "line-tables-only"` specifically so `--diag-backtrace` resolves to file:line. So the shipped mac binary already references `.o` files left behind on a GitHub runner, and users already get no file:line there. Mach-O has no in-binary DWARF option; the only fix is shipping the `.dSYM` as a release asset. **Not fixed here — worth its own issue.**

**`KACHE_MAX_SIZE: 10GiB`**, well below kache's workstation-sized 50GiB default. On Linux (ext4, no reflink) kache *copies* rather than hardlinks mutable outputs (`bin`, `dylib`, `cdylib`, proc-macro), so those cost their bytes twice — store plus `target/`. macOS (APFS) reflinks them for free. Overshooting is a disk-full test failure, which this repo has hit before.

## Verification

- Full workspace compiled through kache locally in 1m14s; all 9 `lint_gate` tests pass (they assert on the workflow edited here).
- `orca.yaml` validated against Orca's own `parseOrcaYaml`, not by eye.
- `actionlint` output diffed before/after: identical, no new findings.
- `kache doctor`: wrapper wired, APFS reflinks available, rustc 1.96 ≥ kache's 1.95 MSRV.
- Targeted clippy + scoped `cargo fmt --check` clean on the touched crates (Rust changes are doc-comment-only).

CI is the real test — the R2 path, the daemon, and the drain have not run on a runner yet.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01VvPpYwKPYRXsxJKUaPHvwt