### PR TITLE
feat(plugin-go): test_race — run Go tests under the race detector

### DIFF
--- a/.github/workflows/heph.yml
+++ b/.github/workflows/heph.yml
@@ -749,7 +749,17 @@ jobs:
   test:
     name: Test ${{ matrix.os }}/${{ matrix.arch }}
     runs-on: ${{ matrix.runs-on }}
-    timeout-minutes: 30
+    # 30 was sized when the macOS leg silently skipped every Go test (`go` was
+    # absent from the runner and `require_go!` returned Ok — the whole go-plugin
+    # suite "passed" in under a second). Now that devenv supplies a Go, darwin
+    # does the work it was always meant to: 480 `plugin-go` unit tests in 150s,
+    # ~11min of `plugingo-e2e` on top. It landed at 30m19s and got cancelled
+    # while running out the last few crates.
+    #
+    # 45 covers that with room for a cold kache. The linux legs sit near 24min,
+    # so this is headroom for them too rather than a licence to grow — if a leg
+    # starts approaching it, find out what got slower.
+    timeout-minutes: 45
     needs: gen
     strategy:
       fail-fast: false

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4308,6 +4308,7 @@ dependencies = [
  "tempfile",
  "testkit",
  "tokio",
+ "which",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4307,6 +4307,7 @@ dependencies = [
  "tempfile",
  "testkit",
  "tokio",
+ "which",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4134,6 +4134,7 @@ dependencies = [
  "reqwest",
  "serde",
  "serde_json",
+ "serde_yaml",
  "sha2 0.11.0",
  "tar",
  "tempfile",

--- a/crates/plugin-go/Cargo.toml
+++ b/crates/plugin-go/Cargo.toml
@@ -43,3 +43,6 @@ tracing = "0.1"
 
 [dev-dependencies]
 tempfile = "3"
+# `hplugin::config::Options` is a map of `serde_yaml::Value`, so building one to
+# exercise the provider's option parsing needs the same crate hconfig uses.
+serde_yaml = "0.9"

--- a/crates/plugin-go/src/plugingo/addr_util.rs
+++ b/crates/plugin-go/src/plugingo/addr_util.rs
@@ -424,8 +424,23 @@ pub fn go_run_prelude(go_version: &str) -> Vec<String> {
 /// GOOS/GOARCH stay in `runtime_env` (the target addr's factor args already key
 /// the cache per platform).
 pub fn go_build_env() -> Value {
+    build_env("0")
+}
+
+/// [`go_build_env`] for a target that builds under a concrete factor set: same
+/// map, but `CGO_ENABLED` follows the factors — `1` for a race build off darwin,
+/// which needs cgo to pull in `runtime/race` (see
+/// [`crate::plugingo::factors::cgo_required`]), `0` for everything else.
+pub fn go_build_env_for(factors: &crate::plugingo::factors::Factors) -> Value {
+    build_env(factors.cgo_enabled_value())
+}
+
+fn build_env(cgo_enabled: &str) -> Value {
     Value::Map(HashMap::from([
-        ("CGO_ENABLED".to_string(), Value::String("0".to_string())),
+        (
+            "CGO_ENABLED".to_string(),
+            Value::String(cgo_enabled.to_string()),
+        ),
         (
             "GOTOOLCHAIN".to_string(),
             Value::String("local".to_string()),

--- a/crates/plugin-go/src/plugingo/cc_toolchain.rs
+++ b/crates/plugin-go/src/plugingo/cc_toolchain.rs
@@ -20,23 +20,25 @@ use std::collections::HashMap;
 /// Dep group the C compiler is staged under.
 pub const CC_DEP_GROUP: &str = "cc";
 
-/// Default `cc` provider option: the host's C compiler, exposed as a target by
-/// the hostbin provider. Mirrors how `gotool = "//@heph/bin:go"` reaches the host
-/// toolchain — an explicit, addressable dependency rather than an ambient one.
+/// Default for the `cctool` provider option: the host's C compiler, exposed as a
+/// target by the hostbin provider. Mirrors how `gotool = "//@heph/bin:go"`
+/// reaches the host toolchain — an explicit, addressable dependency rather than
+/// an ambient one, so pointing `cctool` at a hermetic compiler instead is a
+/// one-line config change.
 pub fn default_addr() -> String {
     "//@heph/bin:cc".to_string()
 }
 
-/// `(group, value)` dep entry staging the C compiler for a race build that needs
-/// cgo. `None` when this build does not — an ordinary build, or a race build on
-/// darwin — so no `cc` target is ever resolved for them.
-pub fn cc_dep(cc_addr: &str, goos: &str, race: bool) -> Option<(String, Value)> {
+/// `(group, value)` dep entry staging the `cctool` target for a race build that
+/// needs cgo. `None` when this build does not — an ordinary build, or a race
+/// build on darwin — so no `cctool` target is ever resolved for them.
+pub fn cc_dep(cctool_addr: &str, goos: &str, race: bool) -> Option<(String, Value)> {
     if !crate::plugingo::factors::cgo_required(goos, race) {
         return None;
     }
     Some((
         CC_DEP_GROUP.to_string(),
-        Value::List(vec![Value::String(cc_addr.to_string())]),
+        Value::List(vec![Value::String(cctool_addr.to_string())]),
     ))
 }
 

--- a/crates/plugin-go/src/plugingo/cc_toolchain.rs
+++ b/crates/plugin-go/src/plugingo/cc_toolchain.rs
@@ -1,0 +1,170 @@
+//! The C compiler a **race** build needs, and only where it needs one.
+//!
+//! Go's race detector ships as a prebuilt TSan runtime that has to be reachable
+//! from Go code. On darwin that link is pure Go — `runtime/race/race_darwin_*.go`
+//! carries the syso-derived symbol information — so a darwin race build stays as
+//! hermetic as an ordinary one and never comes near this module. Everywhere else
+//! `runtime/race` is a **cgo** package, so building the standard library with
+//! `-race` means compiling C, which means a C compiler.
+//!
+//! Only [`crate::plugingo::target_std::install_spec`] uses it: `go install -race
+//! std` is the single step that compiles C. The per-package compiles are pure Go
+//! either way, and the link resolves the TSan runtime internally — both were
+//! verified to succeed with an empty `PATH` and no compiler in sight.
+//!
+//! See [`crate::plugingo::factors::cgo_required`] for the platform rule.
+
+use hcore::htvalue::Value;
+use std::collections::HashMap;
+
+/// Dep group the C compiler is staged under.
+pub const CC_DEP_GROUP: &str = "cc";
+
+/// Default `cc` provider option: the host's C compiler, exposed as a target by
+/// the hostbin provider. Mirrors how `gotool = "//@heph/bin:go"` reaches the host
+/// toolchain — an explicit, addressable dependency rather than an ambient one.
+pub fn default_addr() -> String {
+    "//@heph/bin:cc".to_string()
+}
+
+/// `(group, value)` dep entry staging the C compiler for a race build that needs
+/// cgo. `None` when this build does not — an ordinary build, or a race build on
+/// darwin — so no `cc` target is ever resolved for them.
+pub fn cc_dep(cc_addr: &str, goos: &str, race: bool) -> Option<(String, Value)> {
+    if !crate::plugingo::factors::cgo_required(goos, race) {
+        return None;
+    }
+    Some((
+        CC_DEP_GROUP.to_string(),
+        Value::List(vec![Value::String(cc_addr.to_string())]),
+    ))
+}
+
+/// Shell lines pointing `go` at the staged compiler, for a script that already
+/// carries the [`cc_dep`] group. Empty when this build needs no compiler.
+///
+/// `$SRC_CC` is the exec driver's auto-injected path for the `cc` dep group.
+pub fn cc_prelude(goos: &str, race: bool) -> Vec<String> {
+    if !crate::plugingo::factors::cgo_required(goos, race) {
+        return Vec::new();
+    }
+    vec![
+        // Absolute: `go` re-invokes CC from various working directories.
+        "CC=\"$(cd \"$(dirname \"$SRC_CC\")\" && pwd)/$(basename \"$SRC_CC\")\"".to_string(),
+        "export CC".to_string(),
+    ]
+}
+
+/// Env names a cgo-enabled race build must see at run time, unhashed.
+///
+/// `PATH` is unavoidable: the C compiler finds its own subprograms (`as`, `ld`,
+/// `cc1`) through it, and with an empty `PATH` cgo fails with
+/// `cannot execute 'as'`. Runtime rather than hashed, matching how the plugin
+/// already treats a non-hermetic toolchain's `PATH`. Empty when no compiler is
+/// needed, so a hermetic build stays PATH-independent.
+pub fn cc_runtime_pass_env(goos: &str, race: bool) -> Vec<String> {
+    if crate::plugingo::factors::cgo_required(goos, race) {
+        vec!["PATH".to_string()]
+    } else {
+        Vec::new()
+    }
+}
+
+/// Merge [`cc_runtime_pass_env`] into an existing `runtime_pass_env` config value,
+/// preserving whatever the caller already set and de-duplicating.
+pub fn merge_runtime_pass_env(config: &mut HashMap<String, Value>, goos: &str, race: bool) {
+    let extra = cc_runtime_pass_env(goos, race);
+    if extra.is_empty() {
+        return;
+    }
+    let mut names: Vec<String> = match config.get("runtime_pass_env") {
+        Some(Value::List(v)) => v
+            .iter()
+            .filter_map(|x| match x {
+                Value::String(s) => Some(s.clone()),
+                _ => None,
+            })
+            .collect(),
+        _ => Vec::new(),
+    };
+    for name in extra {
+        if !names.contains(&name) {
+            names.push(name);
+        }
+    }
+    config.insert(
+        "runtime_pass_env".to_string(),
+        Value::List(names.into_iter().map(Value::String).collect()),
+    );
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn no_cc_for_an_ordinary_build() {
+        assert!(cc_dep("//@heph/bin:cc", "linux", false).is_none());
+        assert!(cc_prelude("linux", false).is_empty());
+        assert!(cc_runtime_pass_env("linux", false).is_empty());
+    }
+
+    #[test]
+    fn no_cc_for_a_darwin_race_build() {
+        // darwin's runtime/race is pure Go + a syso, so a race build there must
+        // stay hermetic — no compiler dep, no PATH passthrough.
+        assert!(cc_dep("//@heph/bin:cc", "darwin", true).is_none());
+        assert!(cc_prelude("darwin", true).is_empty());
+        assert!(cc_runtime_pass_env("darwin", true).is_empty());
+    }
+
+    #[test]
+    fn linux_race_build_stages_the_compiler() {
+        let (group, value) = cc_dep("//@heph/bin:cc", "linux", true).expect("cc dep");
+        assert_eq!(group, CC_DEP_GROUP);
+        assert!(matches!(value, Value::List(v) if v.len() == 1));
+        assert!(cc_prelude("linux", true).iter().any(|l| l.contains("CC")));
+        assert_eq!(cc_runtime_pass_env("linux", true), vec!["PATH".to_string()]);
+    }
+
+    #[test]
+    fn merge_runtime_pass_env_keeps_existing_names() {
+        let mut config = HashMap::from([(
+            "runtime_pass_env".to_string(),
+            Value::List(vec![Value::String("HOME".to_string())]),
+        )]);
+        merge_runtime_pass_env(&mut config, "linux", true);
+        let names = match config.get("runtime_pass_env") {
+            Some(Value::List(v)) => v.clone(),
+            other => panic!("expected list, got {other:?}"),
+        };
+        assert_eq!(
+            names,
+            vec![
+                Value::String("HOME".to_string()),
+                Value::String("PATH".to_string())
+            ]
+        );
+    }
+
+    #[test]
+    fn merge_runtime_pass_env_does_not_duplicate() {
+        let mut config = HashMap::from([(
+            "runtime_pass_env".to_string(),
+            Value::List(vec![Value::String("PATH".to_string())]),
+        )]);
+        merge_runtime_pass_env(&mut config, "linux", true);
+        let names = match config.get("runtime_pass_env") {
+            Some(Value::List(v)) => v.clone(),
+            other => panic!("expected list, got {other:?}"),
+        };
+        assert_eq!(names, vec![Value::String("PATH".to_string())]);
+    }
+
+    #[test]
+    fn merge_runtime_pass_env_is_a_noop_without_cgo() {
+        let mut config: HashMap<String, Value> = HashMap::new();
+        merge_runtime_pass_env(&mut config, "darwin", true);
+        assert!(!config.contains_key("runtime_pass_env"));
+    }
+}

--- a/crates/plugin-go/src/plugingo/driver_compile.rs
+++ b/crates/plugin-go/src/plugingo/driver_compile.rs
@@ -100,6 +100,10 @@ struct GoCompileSpec {
     goexperiment: Vec<String>,
     /// Extra flags passed verbatim to `go tool compile` (the variant's gcflags).
     gcflags: Vec<String>,
+    /// Race-detector build: pass `-race` to `go tool compile`, instrumenting every
+    /// memory access in this package. Whole-program — every archive in the link
+    /// must agree — so it rides the address and keys this archive's cache.
+    race: bool,
     /// Import paths of the transitive libs, in deterministic order — each maps to
     /// a `lib_<sanitized>` dep group carrying that archive, used to build
     /// importcfg.
@@ -124,6 +128,8 @@ struct GoCompileDef {
     go_version: String,
     goexperiment: Vec<String>,
     gcflags: Vec<String>,
+    /// See [`GoCompileSpec::race`].
+    race: bool,
     import_paths: Vec<String>,
     s_files: Vec<String>,
     embed_variant: Option<EmbedVariant>,
@@ -150,6 +156,12 @@ impl Hash for GoCompileDef {
         // `gcflags` order is semantically meaningful, so hash as-is.
         self.goexperiment.hash(state);
         self.gcflags.hash(state);
+        // Hashed only when set, so introducing race mode left every ordinary
+        // archive's def hash — and the caches holding them — untouched. The
+        // marker is a distinct string, so it cannot alias a neighbouring field.
+        if self.race {
+            "race".hash(state);
+        }
         // `import_paths` order is not semantically meaningful — it comes from a
         // closure walk that dedups through a per-process-randomized `HashSet`,
         // and `run()` re-sorts before writing importcfg, so the archive is
@@ -257,6 +269,7 @@ impl ManagedDriver for GoCompileDriver {
             go_version: spec.go_version,
             goexperiment: spec.goexperiment,
             gcflags: spec.gcflags,
+            race: spec.race,
             import_paths: spec.import_paths,
             s_files: spec.s_files,
             embed_variant,
@@ -358,7 +371,14 @@ impl ManagedDriver for GoCompileDriver {
         );
         env.insert("GOTOOLCHAIN".to_string(), "local".to_string());
         env.insert("GOWORK".to_string(), "off".to_string());
-        env.insert("CGO_ENABLED".to_string(), "0".to_string());
+        // `1` only for a race build off darwin, matching the golist and link
+        // sandboxes — see `factors::cgo_required`. The archives this driver
+        // produces are pure Go either way; the setting exists so `go tool
+        // compile`'s view of the build config matches everyone else's.
+        env.insert(
+            "CGO_ENABLED".to_string(),
+            crate::plugingo::factors::cgo_enabled_value(&def.goos, def.race).to_string(),
+        );
         if !def.goexperiment.is_empty() {
             env.insert("GOEXPERIMENT".to_string(), def.goexperiment.join(","));
         }
@@ -404,7 +424,18 @@ impl ManagedDriver for GoCompileDriver {
         };
 
         let has_asm = !def.s_files.is_empty();
-        let shared = "-shared";
+        // `-shared` must agree with the buildmode the link will use, or asm
+        // relocations from transitive deps fail to resolve. Everything links PIE
+        // except a race build on linux, which links `-buildmode=exe` (see
+        // `factors::link_buildmode`) — and the stdlib archives `go install -race`
+        // produced for that case were compiled without `-shared` too, so ours
+        // have to match.
+        let shared_arg: Vec<String> =
+            if crate::plugingo::factors::link_buildmode(&def.goos, def.race) == "pie" {
+                vec!["-shared".to_string()]
+            } else {
+                Vec::new()
+            };
         let trimpath = format!("-trimpath={ws_root}");
         let goinc = format!("{}/pkg/include", goroot.to_string_lossy());
 
@@ -428,11 +459,13 @@ impl ManagedDriver for GoCompileDriver {
                 format!("GOOS_{}", def.goos),
                 "-D".to_string(),
                 format!("GOARCH_{}", def.goarch),
-                shared.to_string(),
+            ];
+            args.extend(shared_arg.iter().cloned());
+            args.extend([
                 "-gensymabis".to_string(),
                 "-o".to_string(),
                 "symabis".to_string(),
-            ];
+            ]);
             for s in &def.s_files {
                 args.push(format!("./{s}"));
             }
@@ -458,6 +491,12 @@ impl ManagedDriver for GoCompileDriver {
             "-importcfg".to_string(),
             importcfg_path.to_string_lossy().into_owned(),
         ];
+        // Race instrumentation. Before the variant gcflags so a variant can still
+        // override it if it ever needs to, and so the flag order matches what
+        // `go build -race` itself emits.
+        if def.race {
+            cargs.push("-race".to_string());
+        }
         // Variant gcflags — raw `go tool compile` flags (what `-gcflags` forwards),
         // in declared order, before the source responses.
         cargs.extend(def.gcflags.iter().cloned());
@@ -471,7 +510,7 @@ impl ManagedDriver for GoCompileDriver {
             cargs.push("-embedcfg".to_string());
             cargs.push("embedcfg".to_string());
         }
-        cargs.push(shared.to_string());
+        cargs.extend(shared_arg.iter().cloned());
         cargs.push("-o".to_string());
         cargs.push(def.out_file.clone());
         cargs.push(format!("@{}", rsp_path.to_string_lossy()));
@@ -482,7 +521,7 @@ impl ManagedDriver for GoCompileDriver {
         if has_asm {
             for s in &def.s_files {
                 let obj = format!("{}.o", s.trim_end_matches(".s"));
-                let args = vec![
+                let mut args = vec![
                     "tool".to_string(),
                     "asm".to_string(),
                     "-p".to_string(),
@@ -496,11 +535,9 @@ impl ManagedDriver for GoCompileDriver {
                     format!("GOOS_{}", def.goos),
                     "-D".to_string(),
                     format!("GOARCH_{}", def.goarch),
-                    shared.to_string(),
-                    "-o".to_string(),
-                    obj,
-                    format!("./{s}"),
                 ];
+                args.extend(shared_arg.iter().cloned());
+                args.extend(["-o".to_string(), obj, format!("./{s}")]);
                 self.exec_go(&go_bin, run_go(args), &env, pkg_dir, ctoken, "asm")
                     .await?;
             }
@@ -821,6 +858,11 @@ pub fn build_compile_spec(p: CompileParams) -> TargetSpec {
         str_list(&p.factors.goexperiment),
     );
     config.insert("gcflags".to_string(), str_list(&p.factors.gcflags));
+    // Set only for a race build, so an ordinary archive's spec (and def hash) is
+    // exactly what it was before race mode existed.
+    if p.factors.race {
+        config.insert("race".to_string(), Value::Bool(true));
+    }
     config.insert("import_paths".to_string(), Value::List(import_paths));
     config.insert("s_files".to_string(), str_list(p.s_files));
     config.insert(
@@ -1095,6 +1137,86 @@ mod driver_tests {
     // bypassing `build_compile_spec`'s own sort — the regression the HEPH_DEBUG_HASH
     // dumps revealed: import_paths reached the hash in HashSet order and flipped
     // the cache key run-to-run.
+    /// The spec only carries `race` when it is on, so an ordinary archive's spec
+    /// is exactly what it was before race mode existed.
+    #[test]
+    fn compile_spec_carries_race_only_when_set() {
+        let racy = Factors {
+            race: true,
+            ..factors()
+        };
+        assert!(!spec_with_factors(&factors()).config.contains_key("race"));
+        assert!(matches!(
+            spec_with_factors(&racy).config.get("race"),
+            Some(Value::Bool(true))
+        ));
+    }
+
+    fn spec_with_factors(f: &Factors) -> TargetSpec {
+        build_compile_spec(CompileParams {
+            addr: Addr::new(
+                hmodel::htpkg::PkgBuf::from("mylib"),
+                "build_lib".to_string(),
+                Default::default(),
+            ),
+            p_flag: "example.com/mylib".to_string(),
+            out_file: "mylib.a".to_string(),
+            factors: f,
+            go_version: crate::plugingo::toolchain::DEFAULT_GO_VERSION,
+            transitive_libs: &[],
+            src_addrs: &[],
+            s_files: &[],
+            s_file_addrs: &[],
+            hdr_addrs: &[],
+            golist_addr: None,
+            embed_variant: "",
+            embed_file_addrs: &[],
+            embed_src_addrs: &[],
+        })
+    }
+
+    /// Race must key the archive: the same source compiled with and without
+    /// instrumentation is two different `.a` files, and mixing them in one link
+    /// is a fingerprint mismatch at best.
+    #[test]
+    fn compile_def_hash_differs_for_race() {
+        let plain = compile_def(false);
+        let racy = compile_def(true);
+        assert_ne!(def_hash(&plain), def_hash(&racy));
+    }
+
+    /// …and adding the field must not have moved the hash for ordinary archives,
+    /// or every cached Go archive in existence would be invalidated. The constant
+    /// is the hash this def produced before `race` existed — with `race: false`
+    /// the hasher is fed exactly the byte sequence it was fed before, because the
+    /// new contribution sits behind `if self.race`.
+    ///
+    /// Update it only alongside a deliberate `GO_COMPILE_FORMAT_VERSION` bump.
+    #[test]
+    fn compile_def_hash_unchanged_for_non_race() {
+        assert_eq!(def_hash(&compile_def(false)), NON_RACE_COMPILE_HASH);
+    }
+
+    const NON_RACE_COMPILE_HASH: u64 = 18189111901699849713;
+
+    fn compile_def(race: bool) -> GoCompileDef {
+        GoCompileDef {
+            p_flag: "example.com/mylib".to_string(),
+            out_file: "x.a".to_string(),
+            goos: "linux".to_string(),
+            goarch: "amd64".to_string(),
+            go_version: "1.26.4".to_string(),
+            goexperiment: vec![],
+            gcflags: vec![],
+            race,
+            import_paths: vec!["fmt".to_string()],
+            s_files: vec![],
+            embed_variant: None,
+            golist_origin_id: None,
+            embed_src_origin_ids: vec![],
+        }
+    }
+
     #[test]
     fn compile_def_hash_invariant_under_import_path_permutation() {
         let mk = |ips: &[&str]| GoCompileDef {
@@ -1105,6 +1227,7 @@ mod driver_tests {
             go_version: "1.26.4".to_string(),
             goexperiment: vec![],
             gcflags: vec![],
+            race: false,
             import_paths: ips.iter().map(|s| s.to_string()).collect(),
             s_files: vec![],
             embed_variant: None,

--- a/crates/plugin-go/src/plugingo/driver_compile.rs
+++ b/crates/plugin-go/src/plugingo/driver_compile.rs
@@ -105,6 +105,10 @@ struct GoCompileSpec {
     /// compile/asm steps get `-shared`, which must agree with the link's
     /// `-buildmode=` (see `BuildMode::needs_shared`).
     buildmode: String,
+    /// Race-detector build: pass `-race` to `go tool compile`, instrumenting every
+    /// memory access in this package. Whole-program — every archive in the link
+    /// must agree — so it rides the address and keys this archive's cache.
+    race: bool,
     /// Import paths of the transitive libs, in deterministic order — each maps to
     /// a `lib_<sanitized>` dep group carrying that archive, used to build
     /// importcfg.
@@ -130,6 +134,8 @@ struct GoCompileDef {
     goexperiment: Vec<String>,
     gcflags: Vec<String>,
     buildmode: BuildMode,
+    /// See [`GoCompileSpec::race`].
+    race: bool,
     import_paths: Vec<String>,
     s_files: Vec<String>,
     embed_variant: Option<EmbedVariant>,
@@ -159,6 +165,12 @@ impl Hash for GoCompileDef {
         // `-shared` presence hangs off this, and a `-shared` archive is not
         // interchangeable with a plain one.
         self.buildmode.hash(state);
+        // Hashed only when set, so introducing race mode left every ordinary
+        // archive's def hash — and the caches holding them — untouched. The
+        // marker is a distinct string, so it cannot alias a neighbouring field.
+        if self.race {
+            "race".hash(state);
+        }
         // `import_paths` order is not semantically meaningful — it comes from a
         // closure walk that dedups through a per-process-randomized `HashSet`,
         // and `run()` re-sorts before writing importcfg, so the archive is
@@ -282,6 +294,7 @@ impl ManagedDriver for GoCompileDriver {
             goexperiment: spec.goexperiment,
             gcflags: spec.gcflags,
             buildmode,
+            race: spec.race,
             import_paths: spec.import_paths,
             s_files: spec.s_files,
             embed_variant,
@@ -383,7 +396,14 @@ impl ManagedDriver for GoCompileDriver {
         );
         env.insert("GOTOOLCHAIN".to_string(), "local".to_string());
         env.insert("GOWORK".to_string(), "off".to_string());
-        env.insert("CGO_ENABLED".to_string(), "0".to_string());
+        // `1` only for a race build off darwin, matching the golist and link
+        // sandboxes — see `factors::cgo_required`. The archives this driver
+        // produces are pure Go either way; the setting exists so `go tool
+        // compile`'s view of the build config matches everyone else's.
+        env.insert(
+            "CGO_ENABLED".to_string(),
+            crate::plugingo::factors::cgo_enabled_value(&def.goos, def.race).to_string(),
+        );
         if !def.goexperiment.is_empty() {
             env.insert("GOEXPERIMENT".to_string(), def.goexperiment.join(","));
         }
@@ -430,7 +450,10 @@ impl ManagedDriver for GoCompileDriver {
 
         let has_asm = !def.s_files.is_empty();
         // `-shared` iff the link is PIE — cmd/go couples them the same way, and a
-        // mismatch is a link failure, not a slower binary.
+        // mismatch is a link failure, not a slower binary. A race build on linux
+        // already had its buildmode forced to `exe` at variant resolution
+        // (`BuildMode::for_race`), so it lands here as a plain archive — matching
+        // the stdlib `go install -race` produced for that mode.
         let shared: Option<&str> = def.buildmode.needs_shared().then_some("-shared");
         let trimpath = format!("-trimpath={ws_root}");
         let goinc = format!("{}/pkg/include", goroot.to_string_lossy());
@@ -487,6 +510,12 @@ impl ManagedDriver for GoCompileDriver {
             "-importcfg".to_string(),
             importcfg_path.to_string_lossy().into_owned(),
         ];
+        // Race instrumentation. Before the variant gcflags so a variant can still
+        // override it if it ever needs to, and so the flag order matches what
+        // `go build -race` itself emits.
+        if def.race {
+            cargs.push("-race".to_string());
+        }
         // Variant gcflags — raw `go tool compile` flags (what `-gcflags` forwards),
         // in declared order, before the source responses.
         cargs.extend(def.gcflags.iter().cloned());
@@ -852,6 +881,11 @@ pub fn build_compile_spec(p: CompileParams) -> TargetSpec {
         "buildmode".to_string(),
         Value::String(p.factors.buildmode.as_str().to_string()),
     );
+    // Set only for a race build, so an ordinary archive's spec (and def hash) is
+    // exactly what it was before race mode existed.
+    if p.factors.race {
+        config.insert("race".to_string(), Value::Bool(true));
+    }
     config.insert("import_paths".to_string(), Value::List(import_paths));
     config.insert("s_files".to_string(), str_list(p.s_files));
     config.insert(
@@ -1195,6 +1229,90 @@ mod driver_tests {
     // bypassing `build_compile_spec`'s own sort — the regression the HEPH_DEBUG_HASH
     // dumps revealed: import_paths reached the hash in HashSet order and flipped
     // the cache key run-to-run.
+    /// The spec only carries `race` when it is on, so an ordinary archive's spec
+    /// is exactly what it was before race mode existed.
+    #[test]
+    fn compile_spec_carries_race_only_when_set() {
+        let racy = Factors {
+            race: true,
+            ..factors()
+        };
+        assert!(!spec_with_factors(&factors()).config.contains_key("race"));
+        assert!(matches!(
+            spec_with_factors(&racy).config.get("race"),
+            Some(Value::Bool(true))
+        ));
+    }
+
+    fn spec_with_factors(f: &Factors) -> TargetSpec {
+        build_compile_spec(CompileParams {
+            addr: Addr::new(
+                hmodel::htpkg::PkgBuf::from("mylib"),
+                "build_lib".to_string(),
+                Default::default(),
+            ),
+            p_flag: "example.com/mylib".to_string(),
+            out_file: "mylib.a".to_string(),
+            factors: f,
+            go_version: crate::plugingo::toolchain::DEFAULT_GO_VERSION,
+            transitive_libs: &[],
+            src_addrs: &[],
+            s_files: &[],
+            s_file_addrs: &[],
+            hdr_addrs: &[],
+            golist_addr: None,
+            embed_variant: "",
+            embed_file_addrs: &[],
+            embed_src_addrs: &[],
+        })
+    }
+
+    /// Race must key the archive: the same source compiled with and without
+    /// instrumentation is two different `.a` files, and mixing them in one link
+    /// is a fingerprint mismatch at best.
+    #[test]
+    fn compile_def_hash_differs_for_race() {
+        let plain = compile_def(false);
+        let racy = compile_def(true);
+        assert_ne!(def_hash(&plain), def_hash(&racy));
+    }
+
+    /// …and adding the field must not have moved the hash for ordinary archives,
+    /// or every cached Go archive in existence would be invalidated. With
+    /// `race: false` the hasher is fed exactly the byte sequence it was fed
+    /// before race mode existed, because the new contribution sits behind
+    /// `if self.race`.
+    ///
+    /// Update the constant only alongside a deliberate
+    /// `GO_COMPILE_FORMAT_VERSION` bump — an unexplained change here means the
+    /// whole archive cache is being thrown away.
+    #[test]
+    fn compile_def_hash_unchanged_for_non_race() {
+        assert_eq!(def_hash(&compile_def(false)), NON_RACE_COMPILE_HASH);
+    }
+
+    /// Pinned at `GO_COMPILE_FORMAT_VERSION` 4 (the `buildmode` field's version).
+    const NON_RACE_COMPILE_HASH: u64 = 11506013216469835997;
+
+    fn compile_def(race: bool) -> GoCompileDef {
+        GoCompileDef {
+            p_flag: "example.com/mylib".to_string(),
+            out_file: "x.a".to_string(),
+            goos: "linux".to_string(),
+            goarch: "amd64".to_string(),
+            go_version: "1.26.4".to_string(),
+            goexperiment: vec![],
+            gcflags: vec![],
+            buildmode: BuildMode::default(),
+            race,
+            import_paths: vec!["fmt".to_string()],
+            s_files: vec![],
+            embed_variant: None,
+            golist_origin_id: None,
+            embed_src_origin_ids: vec![],
+        }
+    }
+
     #[test]
     fn compile_def_hash_invariant_under_import_path_permutation() {
         let mk = |ips: &[&str]| GoCompileDef {
@@ -1206,6 +1324,7 @@ mod driver_tests {
             goexperiment: vec![],
             gcflags: vec![],
             buildmode: BuildMode::default(),
+            race: false,
             import_paths: ips.iter().map(|s| s.to_string()).collect(),
             s_files: vec![],
             embed_variant: None,

--- a/crates/plugin-go/src/plugingo/driver_golist.rs
+++ b/crates/plugin-go/src/plugingo/driver_golist.rs
@@ -57,6 +57,10 @@ struct GoGolistSpec {
     build_tags: Vec<String>,
     /// `GOEXPERIMENT` values from the variant (sorted). Empty → unset.
     goexperiment: Vec<String>,
+    /// Race-detector build: pass `-race` to `go list`. Changes both the file set
+    /// (`//go:build race`) and the import graph, so the listing must be done in
+    /// the same mode the archives will be compiled in.
+    race: bool,
     /// Pass `-test` to `go list` — needed only when the package has `_test.go`
     /// files whose imports and embed patterns must be resolved. See
     /// [`crate::plugingo::target_golist`] for who sets it.
@@ -111,6 +115,8 @@ struct GoGolistDef {
     go_version: String,
     build_tags: Vec<String>,
     goexperiment: Vec<String>,
+    /// See [`GoGolistSpec::race`].
+    race: bool,
     with_test: bool,
     dep_inputs: Vec<Input>,
     /// For thirdparty packages: the `download` target whose filtered outputs
@@ -141,6 +147,13 @@ impl Hash for GoGolistDef {
         self.go_version.hash(state);
         self.build_tags.hash(state);
         self.goexperiment.hash(state);
+        // Hashed only when set, so introducing race mode left every ordinary
+        // `_golist` def hash — and therefore every cached listing — untouched.
+        // The marker is a distinct string, so it cannot alias a neighbouring
+        // field's contribution.
+        if self.race {
+            "race".hash(state);
+        }
         // Flips the `go list` command line, and with it which fields come back
         // populated — so it must key the cache.
         self.with_test.hash(state);
@@ -219,6 +232,7 @@ impl ManagedDriver for GoGolistDriver {
             go_version: spec.go_version,
             build_tags: spec.build_tags,
             goexperiment: spec.goexperiment,
+            race: spec.race,
             with_test: spec.with_test,
             dep_inputs: dep_inputs.clone(),
             thirdparty_download_addr: spec.thirdparty_download_addr,
@@ -312,6 +326,7 @@ impl ManagedDriver for GoGolistDriver {
                 goarch: def.goarch.clone(),
                 build_tags: def.build_tags.clone(),
                 goexperiment: def.goexperiment.clone(),
+                race: def.race,
             },
             &req.sandbox_pkg_dir.join(".heph-gocache"),
         )?;
@@ -328,12 +343,16 @@ impl ManagedDriver for GoGolistDriver {
         // resolution is reproducible regardless of host config.
         env.insert("GOTOOLCHAIN".to_string(), "local".to_string());
         env.insert("GOWORK".to_string(), "off".to_string());
-        // Pin CGO_ENABLED=0 to keep this list call's view of transitive deps
-        // consistent with the bash-driven compile/link sandboxes. Letting Go
-        // autodetect produces drift across hosts (PATH-dependent) — e.g. an
-        // Ubuntu host with gcc on PATH pulls runtime/cgo here but later link
-        // steps run without it, breaking importcfg.
-        env.insert("CGO_ENABLED".to_string(), "0".to_string());
+        // Pin CGO_ENABLED rather than letting Go autodetect it: autodetection is
+        // PATH-dependent and drifts across hosts — e.g. an Ubuntu host with gcc on
+        // PATH pulls runtime/cgo in here but later link steps run without it,
+        // breaking importcfg. The value must match what the compile/link sandboxes
+        // use, which is `0` for every ordinary build and `1` only for a race build
+        // off darwin (see `factors::cgo_required`).
+        env.insert(
+            "CGO_ENABLED".to_string(),
+            crate::plugingo::factors::cgo_enabled_value(&def.goos, def.race).to_string(),
+        );
         if !def.goexperiment.is_empty() {
             env.insert("GOEXPERIMENT".to_string(), def.goexperiment.join(","));
         }
@@ -577,6 +596,12 @@ fn golist_args(def: &GoGolistDef) -> Vec<String> {
     }
     if !def.build_tags.is_empty() {
         args.push(format!("-tags={}", def.build_tags.join(",")));
+    }
+    // `-race` rather than `-tags=race`: besides the build tag it also adds
+    // `runtime/race` to the listed deps, which is how the linker gets told about
+    // the TSan runtime (nothing in the source graph imports it).
+    if def.race {
+        args.push("-race".to_string());
     }
     args.push(def.import_path.clone());
     args
@@ -962,6 +987,7 @@ mod tests {
             go_version: crate::plugingo::toolchain::DEFAULT_GO_VERSION.to_string(),
             build_tags,
             goexperiment: vec![],
+            race: false,
             with_test,
             dep_inputs: vec![],
             thirdparty_download_addr: None,
@@ -980,6 +1006,48 @@ mod tests {
         // the import path stays last.
         assert!(args.iter().any(|a| a == "-e"));
         assert_eq!(args.last().map(String::as_str), Some("example.com/mylib"));
+    }
+
+    /// `-race` (not `-tags=race`): besides the build tag it adds `runtime/race`
+    /// to the listed deps, which is the only reason the listing knows about the
+    /// TSan runtime at all.
+    #[test]
+    fn golist_args_pass_race_when_set() {
+        let mut def = def_with(false, vec![]);
+        assert!(!golist_args(&def).iter().any(|a| a == "-race"));
+        def.race = true;
+        assert!(golist_args(&def).iter().any(|a| a == "-race"));
+    }
+
+    /// Race must key the listing: the file set and the import graph both differ.
+    #[test]
+    fn golist_def_hash_differs_for_race() {
+        let plain = def_with(false, vec![]);
+        let racy = GoGolistDef {
+            race: true,
+            ..plain.clone()
+        };
+        assert_ne!(def_hash(&plain), def_hash(&racy));
+    }
+
+    /// …but adding the field must not have moved the hash for everyone else, or
+    /// every cached `_golist` artifact in existence would be invalidated. The
+    /// constant is the hash this def produced before `race` was introduced.
+    #[test]
+    fn golist_def_hash_unchanged_for_non_race() {
+        assert_eq!(def_hash(&def_with(false, vec![])), NON_RACE_GOLIST_HASH);
+    }
+
+    /// Pinned pre-`race` value of `def_hash(def_with(false, vec![]))`. Update it
+    /// only alongside a deliberate `GO_GOLIST_FORMAT_VERSION` bump — a change
+    /// here means every cached listing is being thrown away.
+    const NON_RACE_GOLIST_HASH: u64 = 642058481220411298;
+
+    fn def_hash(def: &GoGolistDef) -> u64 {
+        use std::hash::{Hash, Hasher};
+        let mut h = xxhash_rust::xxh3::Xxh3Default::new();
+        def.hash(&mut h);
+        h.finish()
     }
 
     #[test]

--- a/crates/plugin-go/src/plugingo/factors.rs
+++ b/crates/plugin-go/src/plugingo/factors.rs
@@ -25,9 +25,64 @@ pub struct Factors {
     /// Flags passed verbatim to `go tool link` (the `-ldflags` equivalent).
     /// Order preserved.
     pub ldflags: Vec<String>,
+    /// Build with the race detector (`-race` on `go list`, `go tool compile` and
+    /// `go tool link`). Not a variant field: it is selected by asking for a
+    /// `*_race` target, and rides the addr as `race=1` (see [`VariantRef::race`]).
+    ///
+    /// Race instrumentation is a whole-program property — every archive in the
+    /// link, stdlib included, must be built with it — so it keys the archive
+    /// cache exactly like `goos`/`goarch` do.
+    pub race: bool,
+}
+
+/// Whether a build for `goos` with race mode `race` needs cgo.
+///
+/// Only race builds ever do, and only off darwin. Go's `runtime/race` — the
+/// package that pulls in the prebuilt TSan runtime — is a **cgo** package
+/// everywhere except darwin, where `race_darwin_<arch>.go` supplies the
+/// syso-derived symbol information directly and no C toolchain is needed. So a
+/// darwin race build stays as hermetic as an ordinary one (`CGO_ENABLED=0`,
+/// internal linking), while a linux race build enables cgo and links externally.
+///
+/// This is an implementation split, not a semantic one: `test_race` behaves
+/// identically on all three supported targets.
+pub fn cgo_required(goos: &str, race: bool) -> bool {
+    race && goos != "darwin"
+}
+
+/// `CGO_ENABLED` value for these coordinates — see [`cgo_required`].
+pub fn cgo_enabled_value(goos: &str, race: bool) -> &'static str {
+    if cgo_required(goos, race) { "1" } else { "0" }
+}
+
+/// `go tool link -buildmode=` value for these coordinates.
+///
+/// `pie` everywhere, except a race build on linux: the race runtime needs a
+/// fixed address layout, so `go build` itself refuses `-buildmode=pie` with
+/// `-race` there ("-buildmode=pie not supported when -race is enabled on
+/// linux/amd64"). `go tool link` does *not* enforce that — it accepts the
+/// combination and emits a binary that dies at startup with "ThreadSanitizer
+/// failed to allocate", so the choice has to be made here. darwin supports
+/// pie+race and keeps it.
+pub fn link_buildmode(goos: &str, race: bool) -> &'static str {
+    if race && goos == "linux" {
+        "exe"
+    } else {
+        "pie"
+    }
 }
 
 impl Factors {
+    /// `-buildmode=` value for linking under these factors. See [`link_buildmode`].
+    pub fn link_buildmode(&self) -> &'static str {
+        link_buildmode(&self.goos, self.race)
+    }
+
+    /// `CGO_ENABLED` value this factor set builds under. See [`cgo_required`].
+    pub fn cgo_enabled_value(&self) -> &'static str {
+        cgo_enabled_value(&self.goos, self.race)
+    }
+
     /// `GOEXPERIMENT` env value (`"a,b"`), or `None` when no experiments are set.
     pub fn goexperiment_env(&self) -> Option<String> {
         if self.goexperiment.is_empty() {
@@ -51,6 +106,12 @@ impl Factors {
 pub struct VariantRef {
     pub name: String,
     pub pkg: String,
+    /// Race-detector build (see [`Factors::race`]). Part of the coordinate, not
+    /// of the variant: a `test_race` target threads `race=1` onto every
+    /// dependency address so the whole graph — first-party, thirdparty and
+    /// stdlib alike — resolves to race-instrumented archives, distinct from the
+    /// ordinary ones under the same variant name.
+    pub race: bool,
 }
 
 impl VariantRef {
@@ -58,17 +119,51 @@ impl VariantRef {
         Self {
             name: name.into(),
             pkg: pkg.into(),
+            race: false,
         }
     }
 
-    /// Encode as addr args `{v, vp}`. `vp` is always emitted (even empty, for the
-    /// root package) so a present `vp` key unambiguously marks a fully-resolved
-    /// internal address vs. a bare user `@v=` address.
+    /// This coordinate with the race flag set to `race`.
+    pub fn with_race(mut self, race: bool) -> Self {
+        self.race = race;
+        self
+    }
+
+    /// Encode as addr args `{v, vp}`, plus `race=1` for a race build. `vp` is
+    /// always emitted (even empty, for the root package) so a present `vp` key
+    /// unambiguously marks a fully-resolved internal address vs. a bare user
+    /// `@v=` address.
+    ///
+    /// `race` is emitted **only when set**, so every ordinary target's address —
+    /// and therefore its cache key — is byte-identical to what it was before
+    /// race mode existed.
     pub fn to_args(&self) -> BTreeMap<String, String> {
         let mut args = BTreeMap::new();
         args.insert("v".to_string(), self.name.clone());
         args.insert("vp".to_string(), self.pkg.clone());
+        if self.race {
+            args.insert(RACE_ARG.to_string(), "1".to_string());
+        }
         args
+    }
+}
+
+/// Addr arg carrying the race flag down the dependency graph. `race=1` is the
+/// only accepted value; the key is absent on an ordinary build.
+pub const RACE_ARG: &str = "race";
+
+/// Read the `race` addr arg. Absent → `false`; `1` → `true`; anything else is an
+/// error, so a typo (`race=true`, `race=yes`) fails loudly instead of silently
+/// building without instrumentation and reporting a clean run.
+pub fn race_from_args(args: &BTreeMap<String, String>) -> anyhow::Result<bool> {
+    match args.get(RACE_ARG) {
+        None => Ok(false),
+        Some(v) if v == "1" => Ok(true),
+        Some(other) => anyhow::bail!(
+            "invalid `{RACE_ARG}` addr arg `{other}` (the only accepted value is `1`); \
+             ask for a race build with the `test_race`/`xtest_race` target rather than \
+             setting `{RACE_ARG}` by hand"
+        ),
     }
 }
 
@@ -99,6 +194,101 @@ mod tests {
         let vref = VariantRef::new("release", "");
         let args = vref.to_args();
         assert_eq!(args.get("vp").map(String::as_str), Some(""));
+    }
+
+    // ---- race ----
+
+    /// The load-bearing compatibility property: an ordinary target's addr args
+    /// are byte-identical to what they were before race mode existed, so no
+    /// cached archive is invalidated by this feature landing.
+    #[test]
+    fn non_race_variant_ref_emits_no_race_arg() {
+        let args = VariantRef::new("dev", "app").to_args();
+        assert_eq!(args.keys().collect::<Vec<_>>(), vec!["v", "vp"]);
+        assert!(!args.contains_key(RACE_ARG));
+    }
+
+    #[test]
+    fn race_variant_ref_emits_race_arg() {
+        let args = VariantRef::new("dev", "app").with_race(true).to_args();
+        assert_eq!(args.get(RACE_ARG).map(String::as_str), Some("1"));
+        // The variant coordinate itself is untouched — race is orthogonal.
+        assert_eq!(args.get("v").map(String::as_str), Some("dev"));
+        assert_eq!(args.get("vp").map(String::as_str), Some("app"));
+    }
+
+    #[test]
+    fn race_from_args_reads_the_flag() {
+        assert!(!race_from_args(&BTreeMap::new()).unwrap());
+        assert!(race_from_args(&VariantRef::new("d", "").with_race(true).to_args()).unwrap());
+    }
+
+    /// A typo must fail loudly. Silently treating `race=true` as "no race" would
+    /// build without instrumentation and report a clean run — the one failure
+    /// mode of this feature that a user cannot detect.
+    #[test]
+    fn race_from_args_rejects_anything_but_one() {
+        for bad in ["true", "yes", "0", ""] {
+            let args = BTreeMap::from([(RACE_ARG.to_string(), bad.to_string())]);
+            let err = race_from_args(&args).expect_err("must reject `{bad}`");
+            assert!(
+                err.to_string().contains("test_race"),
+                "the error should point at the supported way in: {err}"
+            );
+        }
+    }
+
+    /// The platform split. darwin's `runtime/race` is pure Go plus a syso, so a
+    /// darwin race build needs no C toolchain; everywhere else it is a cgo
+    /// package. Nothing but a race build ever enables cgo.
+    #[test]
+    fn cgo_only_for_a_non_darwin_race_build() {
+        assert!(cgo_required("linux", true));
+        assert!(!cgo_required("darwin", true));
+        assert!(!cgo_required("linux", false));
+        assert!(!cgo_required("darwin", false));
+        assert_eq!(cgo_enabled_value("linux", true), "1");
+        assert_eq!(cgo_enabled_value("darwin", true), "0");
+        assert_eq!(cgo_enabled_value("linux", false), "0");
+    }
+
+    /// `go build` refuses `-buildmode=pie` with `-race` on linux, but `go tool
+    /// link` accepts it and emits a binary that dies at startup with
+    /// "ThreadSanitizer failed to allocate" — so the choice has to be made here.
+    #[test]
+    fn linux_race_links_non_pie() {
+        assert_eq!(link_buildmode("linux", true), "exe");
+        assert_eq!(link_buildmode("darwin", true), "pie");
+        assert_eq!(link_buildmode("linux", false), "pie");
+        assert_eq!(link_buildmode("darwin", false), "pie");
+    }
+
+    #[test]
+    fn factors_expose_the_same_rules() {
+        let f = Factors {
+            goos: "linux".into(),
+            goarch: "arm64".into(),
+            race: true,
+            ..Default::default()
+        };
+        assert_eq!(f.cgo_enabled_value(), "1");
+        assert_eq!(f.link_buildmode(), "exe");
+    }
+
+    /// Race participates in the factor identity, so two otherwise-identical
+    /// factor sets are different cache keys.
+    #[test]
+    fn race_changes_factor_identity() {
+        let base = Factors {
+            goos: "linux".into(),
+            goarch: "amd64".into(),
+            ..Default::default()
+        };
+        let racy = Factors {
+            race: true,
+            ..base.clone()
+        };
+        assert_ne!(base, racy);
     }
 
     #[test]

--- a/crates/plugin-go/src/plugingo/factors.rs
+++ b/crates/plugin-go/src/plugingo/factors.rs
@@ -55,6 +55,29 @@ impl BuildMode {
     pub fn needs_shared(self) -> bool {
         matches!(self, Self::Pie)
     }
+
+    /// The mode a build with these coordinates must actually link in: `self`,
+    /// except a **race** build on linux, which is forced to [`Self::Exe`].
+    ///
+    /// The race runtime needs a fixed address layout, and `go build` refuses
+    /// `-buildmode=pie` with `-race` on linux outright ("-buildmode=pie not
+    /// supported when -race is enabled on linux/amd64"). `go tool link` — which
+    /// is what this plugin calls — does **not** enforce that: it accepts the
+    /// combination and emits a binary that dies at startup with
+    /// "ThreadSanitizer failed to allocate", so the choice has to be made here.
+    ///
+    /// darwin supports pie+race, so a variant asking for `pie` there keeps it.
+    ///
+    /// Applied once, at variant resolution, so `Factors::buildmode` is already
+    /// the effective mode everywhere downstream — which keeps `needs_shared` and
+    /// the link's `-buildmode=` agreeing without either having to know about race.
+    pub fn for_race(self, goos: &str, race: bool) -> Self {
+        if race && goos == "linux" {
+            Self::Exe
+        } else {
+            self
+        }
+    }
 }
 
 /// Resolved build variant: the concrete set of Go toolchain factors a target
@@ -86,11 +109,45 @@ pub struct Factors {
     pub ldflags: Vec<String>,
     /// Link buildmode. Drives both `go tool link -buildmode=` and whether the
     /// compile steps get `-shared` — the two are coupled, see
-    /// [`BuildMode::needs_shared`].
+    /// [`BuildMode::needs_shared`]. A race build on linux overrides whatever the
+    /// variant declared, see [`BuildMode::for_race`].
     pub buildmode: BuildMode,
+    /// Build with the race detector (`-race` on `go list`, `go tool compile` and
+    /// `go tool link`). Not a variant field: it is selected by asking for a
+    /// `*_race` target, and rides the addr as `race=1` (see [`VariantRef::race`]).
+    ///
+    /// Race instrumentation is a whole-program property — every archive in the
+    /// link, stdlib included, must be built with it — so it keys the archive
+    /// cache exactly like `goos`/`goarch` do.
+    pub race: bool,
+}
+
+/// Whether a build for `goos` with race mode `race` needs cgo.
+///
+/// Only race builds ever do, and only off darwin. Go's `runtime/race` — the
+/// package that pulls in the prebuilt TSan runtime — is a **cgo** package
+/// everywhere except darwin, where `race_darwin_<arch>.go` supplies the
+/// syso-derived symbol information directly and no C toolchain is needed. So a
+/// darwin race build stays as hermetic as an ordinary one (`CGO_ENABLED=0`,
+/// internal linking), while a linux race build enables cgo and links externally.
+///
+/// This is an implementation split, not a semantic one: `test_race` behaves
+/// identically on all three supported targets.
+pub fn cgo_required(goos: &str, race: bool) -> bool {
+    race && goos != "darwin"
+}
+
+/// `CGO_ENABLED` value for these coordinates — see [`cgo_required`].
+pub fn cgo_enabled_value(goos: &str, race: bool) -> &'static str {
+    if cgo_required(goos, race) { "1" } else { "0" }
 }
 
 impl Factors {
+    /// `CGO_ENABLED` value this factor set builds under. See [`cgo_required`].
+    pub fn cgo_enabled_value(&self) -> &'static str {
+        cgo_enabled_value(&self.goos, self.race)
+    }
+
     /// `GOEXPERIMENT` env value (`"a,b"`), or `None` when no experiments are set.
     pub fn goexperiment_env(&self) -> Option<String> {
         if self.goexperiment.is_empty() {
@@ -114,6 +171,12 @@ impl Factors {
 pub struct VariantRef {
     pub name: String,
     pub pkg: String,
+    /// Race-detector build (see [`Factors::race`]). Part of the coordinate, not
+    /// of the variant: a `test_race` target threads `race=1` onto every
+    /// dependency address so the whole graph — first-party, thirdparty and
+    /// stdlib alike — resolves to race-instrumented archives, distinct from the
+    /// ordinary ones under the same variant name.
+    pub race: bool,
 }
 
 impl VariantRef {
@@ -121,17 +184,51 @@ impl VariantRef {
         Self {
             name: name.into(),
             pkg: pkg.into(),
+            race: false,
         }
     }
 
-    /// Encode as addr args `{v, vp}`. `vp` is always emitted (even empty, for the
-    /// root package) so a present `vp` key unambiguously marks a fully-resolved
-    /// internal address vs. a bare user `@v=` address.
+    /// This coordinate with the race flag set to `race`.
+    pub fn with_race(mut self, race: bool) -> Self {
+        self.race = race;
+        self
+    }
+
+    /// Encode as addr args `{v, vp}`, plus `race=1` for a race build. `vp` is
+    /// always emitted (even empty, for the root package) so a present `vp` key
+    /// unambiguously marks a fully-resolved internal address vs. a bare user
+    /// `@v=` address.
+    ///
+    /// `race` is emitted **only when set**, so every ordinary target's address —
+    /// and therefore its cache key — is byte-identical to what it was before
+    /// race mode existed.
     pub fn to_args(&self) -> BTreeMap<String, String> {
         let mut args = BTreeMap::new();
         args.insert("v".to_string(), self.name.clone());
         args.insert("vp".to_string(), self.pkg.clone());
+        if self.race {
+            args.insert(RACE_ARG.to_string(), "1".to_string());
+        }
         args
+    }
+}
+
+/// Addr arg carrying the race flag down the dependency graph. `race=1` is the
+/// only accepted value; the key is absent on an ordinary build.
+pub const RACE_ARG: &str = "race";
+
+/// Read the `race` addr arg. Absent → `false`; `1` → `true`; anything else is an
+/// error, so a typo (`race=true`, `race=yes`) fails loudly instead of silently
+/// building without instrumentation and reporting a clean run.
+pub fn race_from_args(args: &BTreeMap<String, String>) -> anyhow::Result<bool> {
+    match args.get(RACE_ARG) {
+        None => Ok(false),
+        Some(v) if v == "1" => Ok(true),
+        Some(other) => anyhow::bail!(
+            "invalid `{RACE_ARG}` addr arg `{other}` (the only accepted value is `1`); \
+             ask for a race build with the `test_race`/`xtest_race` target rather than \
+             setting `{RACE_ARG}` by hand"
+        ),
     }
 }
 
@@ -188,6 +285,121 @@ mod tests {
     #[test]
     fn buildmode_defaults_to_exe() {
         assert_eq!(Factors::default().buildmode, BuildMode::Exe);
+    }
+
+    // ---- race ----
+
+    /// The load-bearing compatibility property: an ordinary target's addr args
+    /// are byte-identical to what they were before race mode existed, so no
+    /// cached archive is invalidated by this feature landing.
+    #[test]
+    fn non_race_variant_ref_emits_no_race_arg() {
+        let args = VariantRef::new("dev", "app").to_args();
+        assert_eq!(args.keys().collect::<Vec<_>>(), vec!["v", "vp"]);
+        assert!(!args.contains_key(RACE_ARG));
+    }
+
+    #[test]
+    fn race_variant_ref_emits_race_arg() {
+        let args = VariantRef::new("dev", "app").with_race(true).to_args();
+        assert_eq!(args.get(RACE_ARG).map(String::as_str), Some("1"));
+        // The variant coordinate itself is untouched — race is orthogonal.
+        assert_eq!(args.get("v").map(String::as_str), Some("dev"));
+        assert_eq!(args.get("vp").map(String::as_str), Some("app"));
+    }
+
+    #[test]
+    fn race_from_args_reads_the_flag() {
+        assert!(!race_from_args(&BTreeMap::new()).unwrap());
+        assert!(race_from_args(&VariantRef::new("d", "").with_race(true).to_args()).unwrap());
+    }
+
+    /// A typo must fail loudly. Silently treating `race=true` as "no race" would
+    /// build without instrumentation and report a clean run — the one failure
+    /// mode of this feature that a user cannot detect.
+    #[test]
+    fn race_from_args_rejects_anything_but_one() {
+        for bad in ["true", "yes", "0", ""] {
+            let args = BTreeMap::from([(RACE_ARG.to_string(), bad.to_string())]);
+            let err = race_from_args(&args).expect_err("must reject `{bad}`");
+            assert!(
+                err.to_string().contains("test_race"),
+                "the error should point at the supported way in: {err}"
+            );
+        }
+    }
+
+    /// The platform split. darwin's `runtime/race` is pure Go plus a syso, so a
+    /// darwin race build needs no C toolchain; everywhere else it is a cgo
+    /// package. Nothing but a race build ever enables cgo.
+    #[test]
+    fn cgo_only_for_a_non_darwin_race_build() {
+        assert!(cgo_required("linux", true));
+        assert!(!cgo_required("darwin", true));
+        assert!(!cgo_required("linux", false));
+        assert!(!cgo_required("darwin", false));
+        assert_eq!(cgo_enabled_value("linux", true), "1");
+        assert_eq!(cgo_enabled_value("darwin", true), "0");
+        assert_eq!(cgo_enabled_value("linux", false), "0");
+    }
+
+    /// `go build` refuses `-buildmode=pie` with `-race` on linux, but `go tool
+    /// link` accepts it and emits a binary that dies at startup with
+    /// "ThreadSanitizer failed to allocate" — so the choice has to be made here.
+    /// A linux race build must not link PIE — `go tool link` accepts the
+    /// combination `go build` rejects and produces a binary that dies at startup
+    /// with "ThreadSanitizer failed to allocate". The override wins over an
+    /// explicit `buildmode = "pie"` in the variant, since the alternative is
+    /// emitting something that cannot run.
+    #[test]
+    fn linux_race_is_forced_off_pie() {
+        assert_eq!(BuildMode::Pie.for_race("linux", true), BuildMode::Exe);
+        assert_eq!(BuildMode::Exe.for_race("linux", true), BuildMode::Exe);
+    }
+
+    /// …and nothing else is touched: darwin supports pie+race, and an ordinary
+    /// build keeps exactly the mode its variant asked for.
+    #[test]
+    fn for_race_leaves_every_other_case_alone() {
+        assert_eq!(BuildMode::Pie.for_race("darwin", true), BuildMode::Pie);
+        assert_eq!(BuildMode::Pie.for_race("linux", false), BuildMode::Pie);
+        assert_eq!(BuildMode::Pie.for_race("darwin", false), BuildMode::Pie);
+        assert_eq!(BuildMode::Exe.for_race("darwin", true), BuildMode::Exe);
+    }
+
+    /// The override has to keep the compile and link sides agreeing: forcing
+    /// `exe` also drops `-shared`, which is what makes the archives linkable.
+    #[test]
+    fn forcing_exe_for_race_also_drops_shared() {
+        assert!(!BuildMode::Pie.for_race("linux", true).needs_shared());
+        assert!(BuildMode::Pie.for_race("darwin", true).needs_shared());
+    }
+
+    #[test]
+    fn factors_expose_the_cgo_rule() {
+        let f = Factors {
+            goos: "linux".into(),
+            goarch: "arm64".into(),
+            race: true,
+            ..Default::default()
+        };
+        assert_eq!(f.cgo_enabled_value(), "1");
+    }
+
+    /// Race participates in the factor identity, so two otherwise-identical
+    /// factor sets are different cache keys.
+    #[test]
+    fn race_changes_factor_identity() {
+        let base = Factors {
+            goos: "linux".into(),
+            goarch: "amd64".into(),
+            ..Default::default()
+        };
+        let racy = Factors {
+            race: true,
+            ..base.clone()
+        };
+        assert_ne!(base, racy);
     }
 
     #[test]

--- a/crates/plugin-go/src/plugingo/golist_gocache.rs
+++ b/crates/plugin-go/src/plugingo/golist_gocache.rs
@@ -64,6 +64,11 @@ pub(crate) struct GocacheKey {
     pub goarch: String,
     pub build_tags: Vec<String>,
     pub goexperiment: Vec<String>,
+    /// Race builds see a different file set (`//go:build race`) and a different
+    /// import graph, so they get their own slot rather than churning the ordinary
+    /// one. Go's own cache would key the entries correctly either way; this keeps
+    /// the two working sets from evicting each other.
+    pub race: bool,
 }
 
 impl GocacheKey {
@@ -132,6 +137,7 @@ mod tests {
             goarch: "amd64".to_string(),
             build_tags: vec![],
             goexperiment: vec![],
+            race: false,
         }
     }
 

--- a/crates/plugin-go/src/plugingo/mod.rs
+++ b/crates/plugin-go/src/plugingo/mod.rs
@@ -1,4 +1,5 @@
 mod addr_util;
+mod cc_toolchain;
 mod driver_compile;
 mod driver_format;
 mod driver_golist;

--- a/crates/plugin-go/src/plugingo/provider.rs
+++ b/crates/plugin-go/src/plugingo/provider.rs
@@ -2,8 +2,9 @@ use crate::plugingo::addr_util::{
     GoPackageKind, decode_package, encode_firstparty, encode_stdlib, encode_thirdparty,
     encode_thirdparty_download,
 };
+use crate::plugingo::cc_toolchain;
 use crate::plugingo::errors::NoGoFilesError;
-use crate::plugingo::factors::{Factors, VariantRef, current_goarch, current_goos};
+use crate::plugingo::factors::{self, Factors, VariantRef, current_goarch, current_goos};
 use crate::plugingo::govet;
 use crate::plugingo::pkg_analysis::{
     GoPackage, PackageAddrs, decode_go_package, decode_package_addrs, find_module_for_import,
@@ -63,6 +64,15 @@ pub struct Config {
     /// factors (`goos`/`goarch`) are added, since the tool always runs natively
     /// (see [`ProviderInner::govet_tool_addr`]).
     pub govet: String,
+    /// Addr of a target producing a C compiler, used only where a **race** build
+    /// needs cgo — i.e. on linux, where Go's `runtime/race` is a cgo package (see
+    /// [`factors::cgo_required`]). Defaults to [`cc_toolchain::default_addr`], the
+    /// host `cc` exposed by the hostbin provider. Point it at another target
+    /// (a nix-built gcc, say) to avoid depending on the host's.
+    ///
+    /// Nothing references it unless a race target is built, so an ordinary build
+    /// — and a darwin race build — never resolves it.
+    pub cc: String,
     /// Directories pruned during package discovery: engine skip dirs/globs plus
     /// this provider's own `skip` option. See [`hwalk::Ignore`].
     pub skip: Arc<Ignore>,
@@ -89,6 +99,7 @@ impl Default for Config {
             go_version: toolchain::DEFAULT_GO_VERSION.to_string(),
             sdk_checksums: HashMap::new(),
             govet: govet::default_addr(),
+            cc: cc_toolchain::default_addr(),
             skip: Arc::new(Ignore::default()),
             foreign_name_guard: true,
             walker: Arc::new(CachedWalker::disabled()),
@@ -113,6 +124,8 @@ pub(crate) struct ProviderInner {
     sdk_checksums: HashMap<String, String>,
     /// Addr of the `heph-govet` binary lint/format exec (see [`Config::govet`]).
     govet: String,
+    /// Addr of the C compiler a cgo-needing race build stages (see [`Config::cc`]).
+    cc: String,
     /// Directories pruned during `collect_go_packages` (engine home + user globs).
     skip: Arc<Ignore>,
     /// Shared cross-run fs-walk cache backing the package walk. See [`Config::walker`].
@@ -242,7 +255,7 @@ impl Provider {
         hplugin::config::deny_unknown(
             "go provider",
             opts,
-            &["gotool", "govet", "skip", "checksums"],
+            &["gotool", "govet", "cc", "skip", "checksums"],
         )?;
         let go_version: String = hplugin::config::decode_opt(opts, "go provider", "gotool")?
             .ok_or_else(|| {
@@ -265,6 +278,11 @@ impl Provider {
         // target (`//tools/heph-govet:build`) to run one built from source.
         let govet: String = hplugin::config::decode_opt(opts, "go provider", "govet")?
             .unwrap_or_else(govet::default_addr);
+        // Optional: the C compiler a race build stages where race needs cgo (linux
+        // only — see `factors::cgo_required`). Unset → the host `cc` via hostbin.
+        // Never resolved unless a race target is actually built.
+        let cc: String = hplugin::config::decode_opt(opts, "go provider", "cc")?
+            .unwrap_or_else(cc_toolchain::default_addr);
         // Engine-wide `fs.skip` globs are merged ahead of this provider's own
         // `skip` option so both prune the same workspace-relative paths.
         let mut globs = skip_globs.to_vec();
@@ -278,6 +296,7 @@ impl Provider {
                 go_version,
                 sdk_checksums,
                 govet,
+                cc,
                 skip,
                 walker,
                 ..Default::default()
@@ -297,6 +316,7 @@ impl Provider {
                 go_version: config.go_version,
                 sdk_checksums: config.sdk_checksums,
                 govet: config.govet,
+                cc: config.cc,
                 skip: config.skip,
                 walker: config.walker,
                 foreign_name_guard: config.foreign_name_guard,
@@ -518,7 +538,9 @@ impl ProviderTrait for Provider {
                     "Test settings for this package. `test = False` skips its tests, \
                      `test = True` (or unset) runs them. \
                      The struct form configures the generated `test`/`xtest` run \
-                     targets — `env`/`runtime_env` (map[string]) and \
+                     targets — and their `test_race`/`xtest_race` counterparts, which \
+                     are the same targets built with the race detector — \
+                     `env`/`runtime_env` (map[string]) and \
                      `pass_env`/`runtime_pass_env` (list[string]) set env, and \
                      `pre_run` (list[string]) runs shell lines before the test binary \
                      (switching the target to the bash driver). By default applies \
@@ -784,7 +806,20 @@ impl ProviderInner {
                     if !skip_tests {
                         push_names(
                             &mut addrs,
-                            &["embed_xtest", "build_test", "test", "build_xtest", "xtest"],
+                            &[
+                                "embed_xtest",
+                                "build_test",
+                                "test",
+                                "build_xtest",
+                                "xtest",
+                                // Race flavours of the two runnable test targets.
+                                // Like `test`/`xtest` they only list for
+                                // host-matching variants (`is_run_test_target_name`)
+                                // — a race binary built for another platform can't
+                                // run here either.
+                                "test_race",
+                                "xtest_race",
+                            ],
                         );
                     }
                 }
@@ -881,6 +916,8 @@ fn pick_codegen_root(states: &[State]) -> Option<&State> {
 const TEST_TARGET_NAMES: &[&str] = &[
     "test",
     "xtest",
+    "test_race",
+    "xtest_race",
     "build_test",
     "build_xtest",
     "build_test_lib",
@@ -897,6 +934,54 @@ fn is_test_target_name(name: &str) -> bool {
     TEST_TARGET_NAMES.contains(&name)
 }
 
+/// The user-facing entry points into race mode, mapped to the target they are a
+/// race flavour of.
+///
+/// `test_race` is not a distinct kind of target — it is `test` built with the
+/// race detector on. Resolving the name to its base and flipping the `race`
+/// factor is the whole mechanism: from there the ordinary code path builds the
+/// spec, and every dependency address it derives carries `race=1`, so the entire
+/// graph beneath it (first-party, thirdparty, stdlib) resolves to
+/// race-instrumented archives kept separate from the ordinary ones.
+///
+/// A separate *name* rather than an addr arg on `test` because race is opt-in:
+/// it is several times slower to build and to run, so `//...` must not silently
+/// double every test. Asking for it is explicit and greppable.
+fn race_entry_base(name: &str) -> Option<&'static str> {
+    match name {
+        "test_race" => Some("test"),
+        "xtest_race" => Some("xtest"),
+        _ => None,
+    }
+}
+
+/// Import paths a link needs on top of what the source graph reveals. Empty
+/// unless this is a race build.
+///
+/// `runtime/race` carries the prebuilt TSan runtime the linker resolves the
+/// instrumentation calls against, but **nothing imports it** — `go build -race`
+/// injects it into the link itself. This provider's closure walk only follows
+/// import edges, so without seeding it here the race link fails on undefined
+/// `__tsan_*` symbols. Seeding it as an *import* (rather than appending the
+/// archive at link time) runs it through the normal stdlib path, so it brings
+/// its own closure with it.
+///
+/// Where race needs cgo (everywhere but darwin — see [`factors::cgo_required`]),
+/// `runtime/cgo` has to be seeded as well. `runtime/race` is a cgo package
+/// there, so its only *listed* import is the pseudo-package `C` — which the walk
+/// drops along with `unsafe` — and the real edge to `runtime/cgo` is one the go
+/// command synthesises rather than something in the source.
+fn race_link_imports(factors: &Factors) -> Vec<String> {
+    if !factors.race {
+        return Vec::new();
+    }
+    let mut imports = vec!["runtime/race".to_string()];
+    if factors::cgo_required(&factors.goos, factors.race) {
+        imports.push("runtime/cgo".to_string());
+    }
+    imports
+}
+
 /// User-facing **entry / binary** target names — the ones a user selects a
 /// variant on directly (bare `@v`, resolved by module-bounded ancestry). Every
 /// other target is a **library / intermediate** (carries `vp`, resolved against
@@ -908,7 +993,10 @@ fn is_test_target_name(name: &str) -> bool {
 /// `lint-check`/`lint`, which aggregate over every ancestry variant instead of
 /// being selected with one (see [`VARIANT_AGGREGATE_TARGET_NAMES`]).
 fn is_entry_target_name(name: &str) -> bool {
-    matches!(name, "build" | "test" | "xtest")
+    matches!(
+        name,
+        "build" | "test" | "xtest" | "test_race" | "xtest_race"
+    )
 }
 
 /// **Runnable** test target names — the ones that execute the built test binary
@@ -916,7 +1004,7 @@ fn is_entry_target_name(name: &str) -> bool {
 /// these are gated to the host `goos`/`goarch` in `list`, since a test binary
 /// built for another platform can't run here.
 fn is_run_test_target_name(name: &str) -> bool {
-    matches!(name, "test" | "xtest")
+    matches!(name, "test" | "xtest" | "test_race" | "xtest_race")
 }
 
 /// Workspace-relative go.mod directory of a decoded package (`""` for a root
@@ -1514,7 +1602,7 @@ impl ProviderInner {
                 variant::resolve(addr, &req.states, "", req.executor.as_ref(), true)
                     .await
                     .map_err(GetError::Other)?;
-            let spec = target_std::install_spec(addr.clone(), &factors, &self.go_version);
+            let spec = target_std::install_spec(addr.clone(), &factors, &self.go_version, &self.cc);
             return Ok(GetResponse { target_spec: spec });
         }
 
@@ -1686,14 +1774,19 @@ impl ProviderInner {
         }
 
         // Strict addr args: every variant-parameterized go target accepts only `v`
-        // (entry) and `vp` (library/dep pin). Reject anything else rather than
+        // (entry), `vp` (library/dep pin) and `race` (race-detector build, threaded
+        // down from a `*_race` entry target). Reject anything else rather than
         // silently ignoring it — notably a legacy `goos`/`goarch` from a pre-variant
         // BUILD file, which must surface as an actionable error, not resolve to the
         // wrong thing. (The host-keyed toolchain/govet targets, which do carry
         // `goos`/`goarch`, are handled earlier and never reach here.)
-        if let Some(bad) = addr.args.keys().find(|k| !matches!(k.as_str(), "v" | "vp")) {
+        if let Some(bad) = addr
+            .args
+            .keys()
+            .find(|k| !matches!(k.as_str(), "v" | "vp" | factors::RACE_ARG))
+        {
             return Err(GetError::Other(anyhow::anyhow!(
-                "unknown addr arg `{bad}` on go target `:{}` (allowed: v, vp); \
+                "unknown addr arg `{bad}` on go target `:{}` (allowed: v, vp, race); \
                  select a build variant with `@v=NAME` — `goos`/`goarch` are no \
                  longer addr args, declare a variant instead",
                 addr.name,
@@ -1727,6 +1820,21 @@ impl ProviderInner {
         )
         .await
         .map_err(GetError::Other)?;
+
+        // `test_race`/`xtest_race` are the entry points into race mode: the same
+        // targets as `test`/`xtest`, with the race factor on. Turning the flag on
+        // here — before anything derives a dependency address — is what threads
+        // `race=1` through the whole graph, since every internal addr is built
+        // from `vref`. `dispatch_name` is what the spec-building `match` below
+        // keys on; the spec keeps the address the user asked for.
+        let (dispatch_name, factors, vref) = match race_entry_base(&addr.name) {
+            Some(base) => {
+                let mut f = factors;
+                f.race = true;
+                (base, f, vref.with_race(true))
+            }
+            None => (addr.name.as_str(), factors, vref),
+        };
 
         // _golist — generate spec without executing go list (before stdlib check so
         // stdlib packages can also expose a _golist target for cached dep resolution)
@@ -1793,7 +1901,7 @@ impl ProviderInner {
             GoPackageKind::Stdlib { .. } => return Err(GetError::NotFound),
         };
 
-        match addr.name.as_str() {
+        match dispatch_name {
             "build_lib" => {
                 // A library with no Go source files isn't buildable. Previously
                 // caught by a shared `go_files.is_empty() && error.is_some()`
@@ -1955,7 +2063,7 @@ impl ProviderInner {
                     .collect_transitive_libs(
                         Arc::clone(&req.executor),
                         &pkg,
-                        &[],
+                        &race_link_imports(&factors),
                         &vref,
                         &module_root,
                     )
@@ -2271,6 +2379,7 @@ impl ProviderInner {
                             .collect::<Vec<_>>()
                             .iter(),
                     )
+                    .chain(race_link_imports(&factors).iter())
                     .cloned()
                     .collect();
                 let transitive = Arc::clone(&self)
@@ -2331,6 +2440,7 @@ impl ProviderInner {
                             .collect::<Vec<_>>()
                             .iter(),
                     )
+                    .chain(race_link_imports(&factors).iter())
                     .cloned()
                     .collect();
                 // Walk from a synthetic pkg whose imports are xtest_extra; pkg.imports
@@ -2423,6 +2533,7 @@ impl ProviderInner {
                     build_test_addr,
                     &data_query_addr,
                     &test_env,
+                    factors.race,
                 );
                 Ok(GetResponse { target_spec: spec })
             }
@@ -2441,6 +2552,7 @@ impl ProviderInner {
                     build_xtest_addr,
                     &data_query_addr,
                     &test_env,
+                    factors.race,
                 );
                 Ok(GetResponse { target_spec: spec })
             }
@@ -5371,6 +5483,145 @@ golang.org/x/oauth2 v0.0.0-20200107190931-bf48bf16ab8d h1:pE8b58s1HRDMi8RDc79m0H
         );
     }
 
+    // ---- race ----
+
+    /// Bare `test_race@v=host` — the user-facing entry point. It must resolve,
+    /// and its binary dep must be the *race* flavour of `build_test`: the whole
+    /// mechanism is that `race=1` gets threaded onto every derived address.
+    #[tokio::test]
+    async fn test_race_deps_on_the_race_flavour_of_build_test() {
+        require_go!();
+        let sandbox = copy_fixture("with_test");
+        let p = Provider::new(sandbox.path().to_path_buf(), test_runtime()).unwrap();
+        let resp = provider_get(&p, make_addr("pkg", "test_race"))
+            .await
+            .unwrap();
+        // The spec keeps the address the user asked for.
+        assert_eq!(resp.target_spec.addr.name, "test_race");
+        let deps = match resp.target_spec.config.get("deps").unwrap() {
+            Value::Map(m) => m.clone(),
+            other => panic!("expected deps map: {other:?}"),
+        };
+        let bin = match deps.get("bin").unwrap() {
+            Value::List(v) => match &v[0] {
+                Value::String(s) => s.clone(),
+                other => panic!("expected string: {other:?}"),
+            },
+            other => panic!("expected list: {other:?}"),
+        };
+        assert!(bin.contains("build_test"), "{bin}");
+        assert!(
+            bin.contains("race=1"),
+            "the binary dep must be the race build, not the ordinary one: {bin}"
+        );
+    }
+
+    /// The ordinary `test` target is untouched: no `race` arg anywhere, so its
+    /// address — and every cache key beneath it — is what it always was.
+    #[tokio::test]
+    async fn ordinary_test_carries_no_race_arg() {
+        require_go!();
+        let sandbox = copy_fixture("with_test");
+        let p = Provider::new(sandbox.path().to_path_buf(), test_runtime()).unwrap();
+        let resp = provider_get(&p, make_addr("pkg", "test")).await.unwrap();
+        let deps = match resp.target_spec.config.get("deps").unwrap() {
+            Value::Map(m) => m.clone(),
+            other => panic!("expected deps map: {other:?}"),
+        };
+        let bin = match deps.get("bin").unwrap() {
+            Value::List(v) => match &v[0] {
+                Value::String(s) => s.clone(),
+                other => panic!("expected string: {other:?}"),
+            },
+            other => panic!("expected list: {other:?}"),
+        };
+        assert!(!bin.contains("race"), "{bin}");
+    }
+
+    /// The race link must include `runtime/race`, which carries the TSan runtime.
+    /// Nothing imports it — `go build -race` injects it — so if the provider
+    /// stops seeding it the link fails on undefined `__tsan_*` symbols.
+    #[tokio::test]
+    async fn race_build_test_link_includes_the_race_runtime() {
+        require_go!();
+        let sandbox = copy_fixture("with_test");
+        let p = Provider::new(sandbox.path().to_path_buf(), test_runtime()).unwrap();
+        let addr = Addr::new(
+            PkgBuf::from("pkg"),
+            "build_test".to_string(),
+            VariantRef::new("host", "").with_race(true).to_args(),
+        );
+        let resp = provider_get(&p, addr).await.unwrap();
+        let deps = match resp.target_spec.config.get("deps").unwrap() {
+            Value::Map(m) => m.clone(),
+            other => panic!("expected deps map: {other:?}"),
+        };
+        let group = crate::plugingo::addr_util::import_path_to_dep_group("runtime/race");
+        assert!(
+            deps.contains_key(&group),
+            "race link must carry runtime/race: {:?}",
+            deps.keys().collect::<Vec<_>>()
+        );
+        // And every staged archive must be a race one, stdlib included —
+        // mixing instrumented and uninstrumented archives is a link error.
+        for (name, value) in &deps {
+            if name == crate::plugingo::addr_util::GO_SDK_DEP_GROUP {
+                continue;
+            }
+            if let Value::List(v) = value {
+                for entry in v {
+                    if let Value::String(s) = entry {
+                        assert!(s.contains("race=1"), "dep {name} is not a race build: {s}");
+                    }
+                }
+            }
+        }
+    }
+
+    /// An ordinary `build_test` must NOT drag `runtime/race` in.
+    #[tokio::test]
+    async fn non_race_build_test_omits_the_race_runtime() {
+        require_go!();
+        let sandbox = copy_fixture("with_test");
+        let p = Provider::new(sandbox.path().to_path_buf(), test_runtime()).unwrap();
+        let resp = provider_get(&p, make_addr("pkg", "build_test"))
+            .await
+            .unwrap();
+        let deps = match resp.target_spec.config.get("deps").unwrap() {
+            Value::Map(m) => m.clone(),
+            other => panic!("expected deps map: {other:?}"),
+        };
+        let group = crate::plugingo::addr_util::import_path_to_dep_group("runtime/race");
+        assert!(!deps.contains_key(&group));
+    }
+
+    /// A `race` value other than `1` is rejected rather than ignored. Silently
+    /// treating it as "no race" would build without instrumentation and report a
+    /// clean run — the one failure mode a user cannot spot.
+    #[tokio::test]
+    async fn bogus_race_arg_is_rejected() {
+        require_go!();
+        let sandbox = copy_fixture("with_test");
+        let p = Provider::new(sandbox.path().to_path_buf(), test_runtime()).unwrap();
+        let addr = Addr::new(
+            PkgBuf::from("pkg"),
+            "test".to_string(),
+            BTreeMap::from([
+                ("v".to_string(), "host".to_string()),
+                ("vp".to_string(), String::new()),
+                ("race".to_string(), "true".to_string()),
+            ]),
+        );
+        match provider_get(&p, addr).await {
+            Err(GetError::Other(e)) => {
+                let msg = format!("{e:#}");
+                assert!(msg.contains("race"), "{msg}");
+            }
+            Err(GetError::NotFound) => panic!("expected an error for `race=true`, got NotFound"),
+            Ok(_) => panic!("expected an error for `race=true`, got a spec"),
+        }
+    }
+
     // ---- with_test_cycle ----
     // pkgb has internal _test.go (no cycle: internal tests can't import pkga
     // because pkga imports pkgb — Go rejects). pkgb also has xtest
@@ -5890,6 +6141,22 @@ golang.org/x/oauth2 v0.0.0-20200107190931-bf48bf16ab8d h1:pE8b58s1HRDMi8RDc79m0H
             "expected test in list: {:?}",
             names
         );
+    }
+
+    /// The race targets are discoverable, so `heph query` shows them and a user
+    /// does not have to know the name from documentation alone.
+    #[tokio::test]
+    async fn test_list_with_test_includes_race_targets() {
+        require_go!();
+        let sandbox = copy_fixture("with_test");
+        let p = Provider::new(sandbox.path().to_path_buf(), test_runtime()).unwrap();
+        let names = provider_list(&p, "pkg").await;
+        for want in ["test_race", "xtest_race"] {
+            assert!(
+                names.iter().any(|n| n == want),
+                "expected {want} in list: {names:?}"
+            );
+        }
     }
 
     // `list` now emits the full candidate set unconditionally for any dir

--- a/crates/plugin-go/src/plugingo/provider.rs
+++ b/crates/plugin-go/src/plugingo/provider.rs
@@ -3835,10 +3835,26 @@ mod tests {
             .unwrap_or(false)
     }
 
+    /// Skipping is fine on a dev machine without Go; in CI it is a broken job.
+    ///
+    /// A runner without `go` turns every test behind this macro green instantly
+    /// — indistinguishable from a suite that passed. That is how these 463 tests
+    /// came to finish in 0.55s on CI's macOS leg (62s on linux) with nobody
+    /// noticing. Under `CI` a missing `go` is a hard failure instead.
+    fn no_go_or_panic() {
+        assert!(
+            std::env::var_os("CI").is_none(),
+            "go is not on PATH, so this test would silently skip. In CI that is \
+             a broken job, not a skip: the devenv shell provides `pkgs.go` (see \
+             devenv.nix), so reaching this means the test is not running inside it."
+        );
+        eprintln!("skipping: go not in PATH");
+    }
+
     macro_rules! require_go {
         () => {
             if !go_available() {
-                eprintln!("skipping: go not in PATH");
+                no_go_or_panic();
                 return;
             }
         };

--- a/crates/plugin-go/src/plugingo/provider.rs
+++ b/crates/plugin-go/src/plugingo/provider.rs
@@ -64,15 +64,19 @@ pub struct Config {
     /// factors (`goos`/`goarch`) are added, since the tool always runs natively
     /// (see [`ProviderInner::govet_tool_addr`]).
     pub govet: String,
-    /// Addr of a target producing a C compiler, used only where a **race** build
-    /// needs cgo — i.e. on linux, where Go's `runtime/race` is a cgo package (see
-    /// [`factors::cgo_required`]). Defaults to [`cc_toolchain::default_addr`], the
-    /// host `cc` exposed by the hostbin provider. Point it at another target
-    /// (a nix-built gcc, say) to avoid depending on the host's.
+    /// C toolchain spec, the `cc` counterpart to [`Config::go_version`]'s
+    /// `gotool`: the addr of a target producing a C compiler. Used only where a
+    /// **race** build needs cgo — i.e. on linux, where Go's `runtime/race` is a
+    /// cgo package (see [`factors::cgo_required`]).
+    ///
+    /// Set via the optional `cctool` provider option. Defaults to
+    /// [`cc_toolchain::default_addr`] — the host `cc` exposed by the hostbin
+    /// provider, mirroring `gotool = "//@heph/bin:go"`. Point it at another
+    /// target (a nix-built gcc, say) to stop depending on the host's.
     ///
     /// Nothing references it unless a race target is built, so an ordinary build
     /// — and a darwin race build — never resolves it.
-    pub cc: String,
+    pub cctool: String,
     /// Directories pruned during package discovery: engine skip dirs/globs plus
     /// this provider's own `skip` option. See [`hwalk::Ignore`].
     pub skip: Arc<Ignore>,
@@ -99,7 +103,7 @@ impl Default for Config {
             go_version: toolchain::DEFAULT_GO_VERSION.to_string(),
             sdk_checksums: HashMap::new(),
             govet: govet::default_addr(),
-            cc: cc_toolchain::default_addr(),
+            cctool: cc_toolchain::default_addr(),
             skip: Arc::new(Ignore::default()),
             foreign_name_guard: true,
             walker: Arc::new(CachedWalker::disabled()),
@@ -124,8 +128,9 @@ pub(crate) struct ProviderInner {
     sdk_checksums: HashMap<String, String>,
     /// Addr of the `heph-govet` binary lint/format exec (see [`Config::govet`]).
     govet: String,
-    /// Addr of the C compiler a cgo-needing race build stages (see [`Config::cc`]).
-    cc: String,
+    /// Addr of the C compiler a cgo-needing race build stages (see
+    /// [`Config::cctool`]).
+    cctool: String,
     /// Directories pruned during `collect_go_packages` (engine home + user globs).
     skip: Arc<Ignore>,
     /// Shared cross-run fs-walk cache backing the package walk. See [`Config::walker`].
@@ -255,7 +260,7 @@ impl Provider {
         hplugin::config::deny_unknown(
             "go provider",
             opts,
-            &["gotool", "govet", "cc", "skip", "checksums"],
+            &["gotool", "govet", "cctool", "skip", "checksums"],
         )?;
         let go_version: String = hplugin::config::decode_opt(opts, "go provider", "gotool")?
             .ok_or_else(|| {
@@ -278,10 +283,12 @@ impl Provider {
         // target (`//tools/heph-govet:build`) to run one built from source.
         let govet: String = hplugin::config::decode_opt(opts, "go provider", "govet")?
             .unwrap_or_else(govet::default_addr);
-        // Optional: the C compiler a race build stages where race needs cgo (linux
-        // only — see `factors::cgo_required`). Unset → the host `cc` via hostbin.
+        // Optional: `cctool` is the C-toolchain counterpart to `gotool` — the
+        // target producing the `cc` a race build stages where race needs cgo
+        // (linux only; see `factors::cgo_required`). Unset → the host `cc` via
+        // the hostbin provider, as `gotool = "//@heph/bin:go"` does for `go`.
         // Never resolved unless a race target is actually built.
-        let cc: String = hplugin::config::decode_opt(opts, "go provider", "cc")?
+        let cctool: String = hplugin::config::decode_opt(opts, "go provider", "cctool")?
             .unwrap_or_else(cc_toolchain::default_addr);
         // Engine-wide `fs.skip` globs are merged ahead of this provider's own
         // `skip` option so both prune the same workspace-relative paths.
@@ -296,7 +303,7 @@ impl Provider {
                 go_version,
                 sdk_checksums,
                 govet,
-                cc,
+                cctool,
                 skip,
                 walker,
                 ..Default::default()
@@ -316,7 +323,7 @@ impl Provider {
                 go_version: config.go_version,
                 sdk_checksums: config.sdk_checksums,
                 govet: config.govet,
-                cc: config.cc,
+                cctool: config.cctool,
                 skip: config.skip,
                 walker: config.walker,
                 foreign_name_guard: config.foreign_name_guard,
@@ -1609,7 +1616,8 @@ impl ProviderInner {
                 variant::resolve(addr, &req.states, "", req.executor.as_ref(), true)
                     .await
                     .map_err(GetError::Other)?;
-            let spec = target_std::install_spec(addr.clone(), &factors, &self.go_version, &self.cc);
+            let spec =
+                target_std::install_spec(addr.clone(), &factors, &self.go_version, &self.cctool);
             return Ok(GetResponse { target_spec: spec });
         }
 
@@ -5491,6 +5499,75 @@ golang.org/x/oauth2 v0.0.0-20200107190931-bf48bf16ab8d h1:pE8b58s1HRDMi8RDc79m0H
     }
 
     // ---- race ----
+
+    /// Options a `from_options` test needs beyond the one under test: `gotool` is
+    /// required, everything else is optional.
+    fn opts_with(extra: &[(&str, &str)]) -> hplugin::config::Options {
+        let mut opts = hplugin::config::Options::new();
+        opts.insert(
+            "gotool".to_string(),
+            serde_yaml::Value::String(toolchain::HOST.to_string()),
+        );
+        for (k, v) in extra {
+            opts.insert(
+                (*k).to_string(),
+                serde_yaml::Value::String((*v).to_string()),
+            );
+        }
+        opts
+    }
+
+    fn cctool_from(opts: &hplugin::config::Options) -> String {
+        let p = Provider::from_options(
+            PathBuf::from("/nonexistent"),
+            &[],
+            &[],
+            opts,
+            Arc::new(CachedWalker::disabled()),
+            test_runtime(),
+        )
+        .expect("provider from options");
+        p.inner.cctool.clone()
+    }
+
+    /// Unset `cctool` falls back to the host `cc` via hostbin — the same shape
+    /// `gotool = "//@heph/bin:go"` uses for the Go toolchain.
+    #[test]
+    fn cctool_defaults_to_hostbin() {
+        assert_eq!(cctool_from(&opts_with(&[])), "//@heph/bin:cc");
+    }
+
+    /// …and can be pointed at any target, so a workspace can supply a hermetic
+    /// compiler instead of the host's.
+    #[test]
+    fn cctool_option_overrides_the_default() {
+        let opts = opts_with(&[("cctool", "//toolchain:gcc")]);
+        assert_eq!(cctool_from(&opts), "//toolchain:gcc");
+    }
+
+    /// A misspelled option must be rejected rather than silently ignored — a
+    /// typo'd `cctool` would otherwise fall back to the host compiler and quietly
+    /// undo the hermeticity the user was configuring.
+    #[test]
+    fn unknown_option_is_rejected() {
+        let opts = opts_with(&[("cctoolz", "//toolchain:gcc")]);
+        let msg = match Provider::from_options(
+            PathBuf::from("/nonexistent"),
+            &[],
+            &[],
+            &opts,
+            Arc::new(CachedWalker::disabled()),
+            test_runtime(),
+        ) {
+            Ok(_) => String::new(),
+            Err(e) => format!("{e:#}"),
+        };
+        assert!(
+            msg.contains("cctoolz"),
+            "a misspelled option must be rejected by name (empty means it was \
+             silently accepted); got: {msg}"
+        );
+    }
 
     /// Bare `test_race@v=host` — the user-facing entry point. It must resolve,
     /// and its binary dep must be the *race* flavour of `build_test`: the whole

--- a/crates/plugin-go/src/plugingo/provider.rs
+++ b/crates/plugin-go/src/plugingo/provider.rs
@@ -2,8 +2,9 @@ use crate::plugingo::addr_util::{
     GoPackageKind, decode_package, encode_firstparty, encode_stdlib, encode_thirdparty,
     encode_thirdparty_download,
 };
+use crate::plugingo::cc_toolchain;
 use crate::plugingo::errors::NoGoFilesError;
-use crate::plugingo::factors::{Factors, VariantRef, current_goarch, current_goos};
+use crate::plugingo::factors::{self, Factors, VariantRef, current_goarch, current_goos};
 use crate::plugingo::govet;
 use crate::plugingo::pkg_analysis::{
     GoPackage, PackageAddrs, decode_go_package, decode_package_addrs, find_module_for_import,
@@ -63,6 +64,15 @@ pub struct Config {
     /// factors (`goos`/`goarch`) are added, since the tool always runs natively
     /// (see [`ProviderInner::govet_tool_addr`]).
     pub govet: String,
+    /// Addr of a target producing a C compiler, used only where a **race** build
+    /// needs cgo — i.e. on linux, where Go's `runtime/race` is a cgo package (see
+    /// [`factors::cgo_required`]). Defaults to [`cc_toolchain::default_addr`], the
+    /// host `cc` exposed by the hostbin provider. Point it at another target
+    /// (a nix-built gcc, say) to avoid depending on the host's.
+    ///
+    /// Nothing references it unless a race target is built, so an ordinary build
+    /// — and a darwin race build — never resolves it.
+    pub cc: String,
     /// Directories pruned during package discovery: engine skip dirs/globs plus
     /// this provider's own `skip` option. See [`hwalk::Ignore`].
     pub skip: Arc<Ignore>,
@@ -89,6 +99,7 @@ impl Default for Config {
             go_version: toolchain::DEFAULT_GO_VERSION.to_string(),
             sdk_checksums: HashMap::new(),
             govet: govet::default_addr(),
+            cc: cc_toolchain::default_addr(),
             skip: Arc::new(Ignore::default()),
             foreign_name_guard: true,
             walker: Arc::new(CachedWalker::disabled()),
@@ -113,6 +124,8 @@ pub(crate) struct ProviderInner {
     sdk_checksums: HashMap<String, String>,
     /// Addr of the `heph-govet` binary lint/format exec (see [`Config::govet`]).
     govet: String,
+    /// Addr of the C compiler a cgo-needing race build stages (see [`Config::cc`]).
+    cc: String,
     /// Directories pruned during `collect_go_packages` (engine home + user globs).
     skip: Arc<Ignore>,
     /// Shared cross-run fs-walk cache backing the package walk. See [`Config::walker`].
@@ -242,7 +255,7 @@ impl Provider {
         hplugin::config::deny_unknown(
             "go provider",
             opts,
-            &["gotool", "govet", "skip", "checksums"],
+            &["gotool", "govet", "cc", "skip", "checksums"],
         )?;
         let go_version: String = hplugin::config::decode_opt(opts, "go provider", "gotool")?
             .ok_or_else(|| {
@@ -265,6 +278,11 @@ impl Provider {
         // target (`//tools/heph-govet:build`) to run one built from source.
         let govet: String = hplugin::config::decode_opt(opts, "go provider", "govet")?
             .unwrap_or_else(govet::default_addr);
+        // Optional: the C compiler a race build stages where race needs cgo (linux
+        // only — see `factors::cgo_required`). Unset → the host `cc` via hostbin.
+        // Never resolved unless a race target is actually built.
+        let cc: String = hplugin::config::decode_opt(opts, "go provider", "cc")?
+            .unwrap_or_else(cc_toolchain::default_addr);
         // Engine-wide `fs.skip` globs are merged ahead of this provider's own
         // `skip` option so both prune the same workspace-relative paths.
         let mut globs = skip_globs.to_vec();
@@ -278,6 +296,7 @@ impl Provider {
                 go_version,
                 sdk_checksums,
                 govet,
+                cc,
                 skip,
                 walker,
                 ..Default::default()
@@ -297,6 +316,7 @@ impl Provider {
                 go_version: config.go_version,
                 sdk_checksums: config.sdk_checksums,
                 govet: config.govet,
+                cc: config.cc,
                 skip: config.skip,
                 walker: config.walker,
                 foreign_name_guard: config.foreign_name_guard,
@@ -525,7 +545,9 @@ impl ProviderTrait for Provider {
                     "Test settings for this package. `test = False` skips its tests, \
                      `test = True` (or unset) runs them. \
                      The struct form configures the generated `test`/`xtest` run \
-                     targets — `env`/`runtime_env` (map[string]) and \
+                     targets — and their `test_race`/`xtest_race` counterparts, which \
+                     are the same targets built with the race detector — \
+                     `env`/`runtime_env` (map[string]) and \
                      `pass_env`/`runtime_pass_env` (list[string]) set env, and \
                      `pre_run` (list[string]) runs shell lines before the test binary \
                      (switching the target to the bash driver). By default applies \
@@ -791,7 +813,20 @@ impl ProviderInner {
                     if !skip_tests {
                         push_names(
                             &mut addrs,
-                            &["embed_xtest", "build_test", "test", "build_xtest", "xtest"],
+                            &[
+                                "embed_xtest",
+                                "build_test",
+                                "test",
+                                "build_xtest",
+                                "xtest",
+                                // Race flavours of the two runnable test targets.
+                                // Like `test`/`xtest` they only list for
+                                // host-matching variants (`is_run_test_target_name`)
+                                // — a race binary built for another platform can't
+                                // run here either.
+                                "test_race",
+                                "xtest_race",
+                            ],
                         );
                     }
                 }
@@ -888,6 +923,8 @@ fn pick_codegen_root(states: &[State]) -> Option<&State> {
 const TEST_TARGET_NAMES: &[&str] = &[
     "test",
     "xtest",
+    "test_race",
+    "xtest_race",
     "build_test",
     "build_xtest",
     "build_test_lib",
@@ -904,6 +941,54 @@ fn is_test_target_name(name: &str) -> bool {
     TEST_TARGET_NAMES.contains(&name)
 }
 
+/// The user-facing entry points into race mode, mapped to the target they are a
+/// race flavour of.
+///
+/// `test_race` is not a distinct kind of target — it is `test` built with the
+/// race detector on. Resolving the name to its base and flipping the `race`
+/// factor is the whole mechanism: from there the ordinary code path builds the
+/// spec, and every dependency address it derives carries `race=1`, so the entire
+/// graph beneath it (first-party, thirdparty, stdlib) resolves to
+/// race-instrumented archives kept separate from the ordinary ones.
+///
+/// A separate *name* rather than an addr arg on `test` because race is opt-in:
+/// it is several times slower to build and to run, so `//...` must not silently
+/// double every test. Asking for it is explicit and greppable.
+fn race_entry_base(name: &str) -> Option<&'static str> {
+    match name {
+        "test_race" => Some("test"),
+        "xtest_race" => Some("xtest"),
+        _ => None,
+    }
+}
+
+/// Import paths a link needs on top of what the source graph reveals. Empty
+/// unless this is a race build.
+///
+/// `runtime/race` carries the prebuilt TSan runtime the linker resolves the
+/// instrumentation calls against, but **nothing imports it** — `go build -race`
+/// injects it into the link itself. This provider's closure walk only follows
+/// import edges, so without seeding it here the race link fails on undefined
+/// `__tsan_*` symbols. Seeding it as an *import* (rather than appending the
+/// archive at link time) runs it through the normal stdlib path, so it brings
+/// its own closure with it.
+///
+/// Where race needs cgo (everywhere but darwin — see [`factors::cgo_required`]),
+/// `runtime/cgo` has to be seeded as well. `runtime/race` is a cgo package
+/// there, so its only *listed* import is the pseudo-package `C` — which the walk
+/// drops along with `unsafe` — and the real edge to `runtime/cgo` is one the go
+/// command synthesises rather than something in the source.
+fn race_link_imports(factors: &Factors) -> Vec<String> {
+    if !factors.race {
+        return Vec::new();
+    }
+    let mut imports = vec!["runtime/race".to_string()];
+    if factors::cgo_required(&factors.goos, factors.race) {
+        imports.push("runtime/cgo".to_string());
+    }
+    imports
+}
+
 /// User-facing **entry / binary** target names — the ones a user selects a
 /// variant on directly (bare `@v`, resolved by module-bounded ancestry). Every
 /// other target is a **library / intermediate** (carries `vp`, resolved against
@@ -915,7 +1000,10 @@ fn is_test_target_name(name: &str) -> bool {
 /// `lint-check`/`lint`, which aggregate over every ancestry variant instead of
 /// being selected with one (see [`VARIANT_AGGREGATE_TARGET_NAMES`]).
 fn is_entry_target_name(name: &str) -> bool {
-    matches!(name, "build" | "test" | "xtest")
+    matches!(
+        name,
+        "build" | "test" | "xtest" | "test_race" | "xtest_race"
+    )
 }
 
 /// **Runnable** test target names — the ones that execute the built test binary
@@ -923,7 +1011,7 @@ fn is_entry_target_name(name: &str) -> bool {
 /// these are gated to the host `goos`/`goarch` in `list`, since a test binary
 /// built for another platform can't run here.
 fn is_run_test_target_name(name: &str) -> bool {
-    matches!(name, "test" | "xtest")
+    matches!(name, "test" | "xtest" | "test_race" | "xtest_race")
 }
 
 /// Workspace-relative go.mod directory of a decoded package (`""` for a root
@@ -1521,7 +1609,7 @@ impl ProviderInner {
                 variant::resolve(addr, &req.states, "", req.executor.as_ref(), true)
                     .await
                     .map_err(GetError::Other)?;
-            let spec = target_std::install_spec(addr.clone(), &factors, &self.go_version);
+            let spec = target_std::install_spec(addr.clone(), &factors, &self.go_version, &self.cc);
             return Ok(GetResponse { target_spec: spec });
         }
 
@@ -1693,14 +1781,19 @@ impl ProviderInner {
         }
 
         // Strict addr args: every variant-parameterized go target accepts only `v`
-        // (entry) and `vp` (library/dep pin). Reject anything else rather than
+        // (entry), `vp` (library/dep pin) and `race` (race-detector build, threaded
+        // down from a `*_race` entry target). Reject anything else rather than
         // silently ignoring it — notably a legacy `goos`/`goarch` from a pre-variant
         // BUILD file, which must surface as an actionable error, not resolve to the
         // wrong thing. (The host-keyed toolchain/govet targets, which do carry
         // `goos`/`goarch`, are handled earlier and never reach here.)
-        if let Some(bad) = addr.args.keys().find(|k| !matches!(k.as_str(), "v" | "vp")) {
+        if let Some(bad) = addr
+            .args
+            .keys()
+            .find(|k| !matches!(k.as_str(), "v" | "vp" | factors::RACE_ARG))
+        {
             return Err(GetError::Other(anyhow::anyhow!(
-                "unknown addr arg `{bad}` on go target `:{}` (allowed: v, vp); \
+                "unknown addr arg `{bad}` on go target `:{}` (allowed: v, vp, race); \
                  select a build variant with `@v=NAME` — `goos`/`goarch` are no \
                  longer addr args, declare a variant instead",
                 addr.name,
@@ -1734,6 +1827,21 @@ impl ProviderInner {
         )
         .await
         .map_err(GetError::Other)?;
+
+        // `test_race`/`xtest_race` are the entry points into race mode: the same
+        // targets as `test`/`xtest`, with the race factor on. Turning the flag on
+        // here — before anything derives a dependency address — is what threads
+        // `race=1` through the whole graph, since every internal addr is built
+        // from `vref`. `dispatch_name` is what the spec-building `match` below
+        // keys on; the spec keeps the address the user asked for.
+        let (dispatch_name, factors, vref) = match race_entry_base(&addr.name) {
+            Some(base) => {
+                let mut f = factors;
+                f.race = true;
+                (base, f, vref.with_race(true))
+            }
+            None => (addr.name.as_str(), factors, vref),
+        };
 
         // _golist — generate spec without executing go list (before stdlib check so
         // stdlib packages can also expose a _golist target for cached dep resolution)
@@ -1800,7 +1908,7 @@ impl ProviderInner {
             GoPackageKind::Stdlib { .. } => return Err(GetError::NotFound),
         };
 
-        match addr.name.as_str() {
+        match dispatch_name {
             "build_lib" => {
                 // A library with no Go source files isn't buildable. Previously
                 // caught by a shared `go_files.is_empty() && error.is_some()`
@@ -1962,7 +2070,7 @@ impl ProviderInner {
                     .collect_transitive_libs(
                         Arc::clone(&req.executor),
                         &pkg,
-                        &[],
+                        &race_link_imports(&factors),
                         &vref,
                         &module_root,
                     )
@@ -2278,6 +2386,7 @@ impl ProviderInner {
                             .collect::<Vec<_>>()
                             .iter(),
                     )
+                    .chain(race_link_imports(&factors).iter())
                     .cloned()
                     .collect();
                 let transitive = Arc::clone(&self)
@@ -2338,6 +2447,7 @@ impl ProviderInner {
                             .collect::<Vec<_>>()
                             .iter(),
                     )
+                    .chain(race_link_imports(&factors).iter())
                     .cloned()
                     .collect();
                 // Walk from a synthetic pkg whose imports are xtest_extra; pkg.imports
@@ -2430,6 +2540,7 @@ impl ProviderInner {
                     build_test_addr,
                     &data_query_addr,
                     &test_env,
+                    factors.race,
                 );
                 Ok(GetResponse { target_spec: spec })
             }
@@ -2448,6 +2559,7 @@ impl ProviderInner {
                     build_xtest_addr,
                     &data_query_addr,
                     &test_env,
+                    factors.race,
                 );
                 Ok(GetResponse { target_spec: spec })
             }
@@ -5378,6 +5490,145 @@ golang.org/x/oauth2 v0.0.0-20200107190931-bf48bf16ab8d h1:pE8b58s1HRDMi8RDc79m0H
         );
     }
 
+    // ---- race ----
+
+    /// Bare `test_race@v=host` — the user-facing entry point. It must resolve,
+    /// and its binary dep must be the *race* flavour of `build_test`: the whole
+    /// mechanism is that `race=1` gets threaded onto every derived address.
+    #[tokio::test]
+    async fn test_race_deps_on_the_race_flavour_of_build_test() {
+        require_go!();
+        let sandbox = copy_fixture("with_test");
+        let p = Provider::new(sandbox.path().to_path_buf(), test_runtime()).unwrap();
+        let resp = provider_get(&p, make_addr("pkg", "test_race"))
+            .await
+            .unwrap();
+        // The spec keeps the address the user asked for.
+        assert_eq!(resp.target_spec.addr.name, "test_race");
+        let deps = match resp.target_spec.config.get("deps").unwrap() {
+            Value::Map(m) => m.clone(),
+            other => panic!("expected deps map: {other:?}"),
+        };
+        let bin = match deps.get("bin").unwrap() {
+            Value::List(v) => match &v[0] {
+                Value::String(s) => s.clone(),
+                other => panic!("expected string: {other:?}"),
+            },
+            other => panic!("expected list: {other:?}"),
+        };
+        assert!(bin.contains("build_test"), "{bin}");
+        assert!(
+            bin.contains("race=1"),
+            "the binary dep must be the race build, not the ordinary one: {bin}"
+        );
+    }
+
+    /// The ordinary `test` target is untouched: no `race` arg anywhere, so its
+    /// address — and every cache key beneath it — is what it always was.
+    #[tokio::test]
+    async fn ordinary_test_carries_no_race_arg() {
+        require_go!();
+        let sandbox = copy_fixture("with_test");
+        let p = Provider::new(sandbox.path().to_path_buf(), test_runtime()).unwrap();
+        let resp = provider_get(&p, make_addr("pkg", "test")).await.unwrap();
+        let deps = match resp.target_spec.config.get("deps").unwrap() {
+            Value::Map(m) => m.clone(),
+            other => panic!("expected deps map: {other:?}"),
+        };
+        let bin = match deps.get("bin").unwrap() {
+            Value::List(v) => match &v[0] {
+                Value::String(s) => s.clone(),
+                other => panic!("expected string: {other:?}"),
+            },
+            other => panic!("expected list: {other:?}"),
+        };
+        assert!(!bin.contains("race"), "{bin}");
+    }
+
+    /// The race link must include `runtime/race`, which carries the TSan runtime.
+    /// Nothing imports it — `go build -race` injects it — so if the provider
+    /// stops seeding it the link fails on undefined `__tsan_*` symbols.
+    #[tokio::test]
+    async fn race_build_test_link_includes_the_race_runtime() {
+        require_go!();
+        let sandbox = copy_fixture("with_test");
+        let p = Provider::new(sandbox.path().to_path_buf(), test_runtime()).unwrap();
+        let addr = Addr::new(
+            PkgBuf::from("pkg"),
+            "build_test".to_string(),
+            VariantRef::new("host", "").with_race(true).to_args(),
+        );
+        let resp = provider_get(&p, addr).await.unwrap();
+        let deps = match resp.target_spec.config.get("deps").unwrap() {
+            Value::Map(m) => m.clone(),
+            other => panic!("expected deps map: {other:?}"),
+        };
+        let group = crate::plugingo::addr_util::import_path_to_dep_group("runtime/race");
+        assert!(
+            deps.contains_key(&group),
+            "race link must carry runtime/race: {:?}",
+            deps.keys().collect::<Vec<_>>()
+        );
+        // And every staged archive must be a race one, stdlib included —
+        // mixing instrumented and uninstrumented archives is a link error.
+        for (name, value) in &deps {
+            if name == crate::plugingo::addr_util::GO_SDK_DEP_GROUP {
+                continue;
+            }
+            if let Value::List(v) = value {
+                for entry in v {
+                    if let Value::String(s) = entry {
+                        assert!(s.contains("race=1"), "dep {name} is not a race build: {s}");
+                    }
+                }
+            }
+        }
+    }
+
+    /// An ordinary `build_test` must NOT drag `runtime/race` in.
+    #[tokio::test]
+    async fn non_race_build_test_omits_the_race_runtime() {
+        require_go!();
+        let sandbox = copy_fixture("with_test");
+        let p = Provider::new(sandbox.path().to_path_buf(), test_runtime()).unwrap();
+        let resp = provider_get(&p, make_addr("pkg", "build_test"))
+            .await
+            .unwrap();
+        let deps = match resp.target_spec.config.get("deps").unwrap() {
+            Value::Map(m) => m.clone(),
+            other => panic!("expected deps map: {other:?}"),
+        };
+        let group = crate::plugingo::addr_util::import_path_to_dep_group("runtime/race");
+        assert!(!deps.contains_key(&group));
+    }
+
+    /// A `race` value other than `1` is rejected rather than ignored. Silently
+    /// treating it as "no race" would build without instrumentation and report a
+    /// clean run — the one failure mode a user cannot spot.
+    #[tokio::test]
+    async fn bogus_race_arg_is_rejected() {
+        require_go!();
+        let sandbox = copy_fixture("with_test");
+        let p = Provider::new(sandbox.path().to_path_buf(), test_runtime()).unwrap();
+        let addr = Addr::new(
+            PkgBuf::from("pkg"),
+            "test".to_string(),
+            BTreeMap::from([
+                ("v".to_string(), "host".to_string()),
+                ("vp".to_string(), String::new()),
+                ("race".to_string(), "true".to_string()),
+            ]),
+        );
+        match provider_get(&p, addr).await {
+            Err(GetError::Other(e)) => {
+                let msg = format!("{e:#}");
+                assert!(msg.contains("race"), "{msg}");
+            }
+            Err(GetError::NotFound) => panic!("expected an error for `race=true`, got NotFound"),
+            Ok(_) => panic!("expected an error for `race=true`, got a spec"),
+        }
+    }
+
     // ---- with_test_cycle ----
     // pkgb has internal _test.go (no cycle: internal tests can't import pkga
     // because pkga imports pkgb — Go rejects). pkgb also has xtest
@@ -5897,6 +6148,22 @@ golang.org/x/oauth2 v0.0.0-20200107190931-bf48bf16ab8d h1:pE8b58s1HRDMi8RDc79m0H
             "expected test in list: {:?}",
             names
         );
+    }
+
+    /// The race targets are discoverable, so `heph query` shows them and a user
+    /// does not have to know the name from documentation alone.
+    #[tokio::test]
+    async fn test_list_with_test_includes_race_targets() {
+        require_go!();
+        let sandbox = copy_fixture("with_test");
+        let p = Provider::new(sandbox.path().to_path_buf(), test_runtime()).unwrap();
+        let names = provider_list(&p, "pkg").await;
+        for want in ["test_race", "xtest_race"] {
+            assert!(
+                names.iter().any(|n| n == want),
+                "expected {want} in list: {names:?}"
+            );
+        }
     }
 
     // `list` now emits the full candidate set unconditionally for any dir

--- a/crates/plugin-go/src/plugingo/target_bin.rs
+++ b/crates/plugin-go/src/plugingo/target_bin.rs
@@ -1,5 +1,5 @@
 use crate::plugingo::addr_util::{
-    go_build_env, go_host_pass_env_config, go_run_prelude, go_sdk_dep, go_sdk_read_only_config,
+    go_build_env_for, go_host_pass_env_config, go_run_prelude, go_sdk_dep, go_sdk_read_only_config,
     import_path_to_dep_group, to_run_value, write_importcfg_script,
 };
 use crate::plugingo::factors::{BuildMode, Factors};
@@ -140,7 +140,7 @@ pub fn build_spec(
     config.insert("runtime_env".to_string(), Value::Map(runtime_env));
     // CGO/toolchain pins live in `env` (hashed) so stale archives don't survive
     // cache lookups (pluginexec/mod.rs:70 excludes runtime_env from the def hash).
-    config.insert("env".to_string(), go_build_env());
+    config.insert("env".to_string(), go_build_env_for(factors));
 
     TargetSpec {
         addr,

--- a/crates/plugin-go/src/plugingo/target_bin.rs
+++ b/crates/plugin-go/src/plugingo/target_bin.rs
@@ -1,5 +1,5 @@
 use crate::plugingo::addr_util::{
-    go_build_env, go_host_pass_env_config, go_run_prelude, go_sdk_dep, go_sdk_read_only_config,
+    go_build_env_for, go_host_pass_env_config, go_run_prelude, go_sdk_dep, go_sdk_read_only_config,
     import_path_to_dep_group, to_run_value, write_importcfg_script,
 };
 use crate::plugingo::factors::Factors;
@@ -139,7 +139,7 @@ pub fn build_spec(
     config.insert("runtime_env".to_string(), Value::Map(runtime_env));
     // CGO/toolchain pins live in `env` (hashed) so stale archives don't survive
     // cache lookups (pluginexec/mod.rs:70 excludes runtime_env from the def hash).
-    config.insert("env".to_string(), go_build_env());
+    config.insert("env".to_string(), go_build_env_for(factors));
 
     TargetSpec {
         addr,

--- a/crates/plugin-go/src/plugingo/target_golist.rs
+++ b/crates/plugin-go/src/plugingo/target_golist.rs
@@ -152,6 +152,11 @@ fn build_spec_inner(
             ),
         );
     }
+    // Set only for a race build, so an ordinary `_golist` spec (and the def hash
+    // derived from it) is exactly what it was before race mode existed.
+    if factors.race {
+        config.insert("race".to_string(), Value::Bool(true));
+    }
     if !deps.is_empty() {
         config.insert("deps".to_string(), Value::Map(deps));
     }

--- a/crates/plugin-go/src/plugingo/target_std.rs
+++ b/crates/plugin-go/src/plugingo/target_std.rs
@@ -1,6 +1,7 @@
 use crate::plugingo::addr_util::{
     go_host_pass_env_config, go_run_prelude, go_sdk_dep, go_sdk_read_only_config, to_run_value,
 };
+use crate::plugingo::cc_toolchain;
 use crate::plugingo::factors::{Factors, VariantRef};
 use hcore::htvalue::Value;
 use hmodel::htaddr::Addr;
@@ -37,8 +38,15 @@ pub fn install_addr(vref: &VariantRef) -> Addr {
 /// `goroot/pkg/linux_amd64`. The install target's package (`@heph/go/std`) is
 /// prepended by the engine, so consumers read from
 /// `$WORKSPACE_ROOT/@heph/go/std/goroot/pkg/<goos>_<goarch>`.
+///
+/// A race build installs alongside under `<goos>_<goarch>_race` — the
+/// `-installsuffix race` layout `go install -race` writes and `go tool link`
+/// expects. The two sets are genuinely different archives (every std package is
+/// instrumented, and `//go:build race` files change the sources), so they must
+/// not share a directory.
 fn pkg_subdir(factors: &Factors) -> String {
-    format!("goroot/pkg/{}_{}", factors.goos, factors.goarch)
+    let suffix = if factors.race { "_race" } else { "" };
+    format!("goroot/pkg/{}_{}{}", factors.goos, factors.goarch, suffix)
 }
 
 /// Build the `@heph/go/std:install` target: compile the *entire* standard
@@ -47,10 +55,14 @@ fn pkg_subdir(factors: &Factors) -> String {
 /// `$GOROOT` to a writable tree and `go install std` into it (with
 /// `installgoroot=all`), then dump `go list -json std` for downstream metadata.
 /// Reads nothing from the host — `$GOROOT` is the staged toolchain.
-pub fn install_spec(addr: Addr, factors: &Factors, go_version: &str) -> TargetSpec {
+pub fn install_spec(addr: Addr, factors: &Factors, go_version: &str, cc_addr: &str) -> TargetSpec {
     let subdir = pkg_subdir(factors);
 
     let mut run = go_run_prelude(go_version);
+    // A race build that needs cgo compiles C here (`runtime/cgo`, and the cgo
+    // half of `runtime/race`), so point `go` at the staged compiler. No-op for
+    // every other build — see `cc_toolchain`.
+    run.extend(cc_toolchain::cc_prelude(&factors.goos, factors.race));
     run.extend([
         // Copy the staged GOROOT into a writable tree so `go install` can
         // populate pkg/. `-L` dereferences symlinks: staged dep files may be
@@ -71,13 +83,22 @@ pub fn install_spec(addr: Addr, factors: &Factors, go_version: &str) -> TargetSp
         "chmod -R u+w \"$GOROOT\"".to_string(),
         // A throwaway module keeps `go` from reading the workspace go.mod.
         "echo 'module heph_std' > go.mod".to_string(),
-        "\"$GOROOT/bin/go\" install --trimpath std".to_string(),
-        format!("\"$GOROOT/bin/go\" list -json std > \"{subdir}/list.json\""),
+        format!(
+            "\"$GOROOT/bin/go\" install --trimpath{} std",
+            if factors.race { " -race" } else { "" }
+        ),
+        format!(
+            "\"$GOROOT/bin/go\" list{} -json std > \"{subdir}/list.json\"",
+            if factors.race { " -race" } else { "" }
+        ),
     ]);
 
     let mut deps: HashMap<String, Value> = HashMap::new();
     if let Some((sdk_group, sdk_val)) = go_sdk_dep(go_version) {
         deps.insert(sdk_group, sdk_val);
+    }
+    if let Some((cc_group, cc_val)) = cc_toolchain::cc_dep(cc_addr, &factors.goos, factors.race) {
+        deps.insert(cc_group, cc_val);
     }
 
     let mut config: HashMap<String, Value> = HashMap::new();
@@ -89,6 +110,11 @@ pub fn install_spec(addr: Addr, factors: &Factors, go_version: &str) -> TargetSp
     if let Some((pe_k, pe_v)) = go_host_pass_env_config(go_version) {
         config.insert(pe_k, pe_v);
     }
+    // A staged C compiler still needs `PATH` to reach its own subprograms (`as`,
+    // `ld`); without it cgo fails with `cannot execute 'as'`. Merged rather than
+    // set so a non-hermetic toolchain's passthrough above survives. No-op unless
+    // this build needs a compiler.
+    cc_toolchain::merge_runtime_pass_env(&mut config, &factors.goos, factors.race);
     config.insert(
         "out".to_string(),
         Value::Map(HashMap::from([
@@ -109,7 +135,10 @@ pub fn install_spec(addr: Addr, factors: &Factors, go_version: &str) -> TargetSp
         Value::Map(HashMap::from([
             ("GOOS".to_string(), Value::String(factors.goos.clone())),
             ("GOARCH".to_string(), Value::String(factors.goarch.clone())),
-            ("CGO_ENABLED".to_string(), Value::String("0".to_string())),
+            (
+                "CGO_ENABLED".to_string(),
+                Value::String(factors.cgo_enabled_value().to_string()),
+            ),
             (
                 "GOTOOLCHAIN".to_string(),
                 Value::String("local".to_string()),
@@ -223,7 +252,12 @@ mod tests {
 
     #[test]
     fn test_install_builds_std_from_source() {
-        let spec = install_spec(install_addr(&test_vref()), &test_factors(), V);
+        let spec = install_spec(
+            install_addr(&test_vref()),
+            &test_factors(),
+            V,
+            "//@heph/bin:cc",
+        );
         let run = run_str(&spec);
         assert!(
             run.contains("install --trimpath std"),
@@ -235,7 +269,12 @@ mod tests {
 
     #[test]
     fn test_install_reads_no_host_go() {
-        let spec = install_spec(install_addr(&test_vref()), &test_factors(), V);
+        let spec = install_spec(
+            install_addr(&test_vref()),
+            &test_factors(),
+            V,
+            "//@heph/bin:cc",
+        );
         let run = run_str(&spec);
         // GOROOT must come from the staged hermetic SDK, never the host.
         assert!(
@@ -258,7 +297,12 @@ mod tests {
 
     #[test]
     fn test_install_out_has_pkg_dir_and_list() {
-        let spec = install_spec(install_addr(&test_vref()), &test_factors(), V);
+        let spec = install_spec(
+            install_addr(&test_vref()),
+            &test_factors(),
+            V,
+            "//@heph/bin:cc",
+        );
         let out = match spec.config.get("out").unwrap() {
             Value::Map(m) => m,
             _ => panic!("out must be map"),
@@ -278,7 +322,7 @@ mod tests {
             build_tags: vec![],
             ..Default::default()
         };
-        let spec = install_spec(install_addr(&test_vref()), &factors, V);
+        let spec = install_spec(install_addr(&test_vref()), &factors, V, "//@heph/bin:cc");
         let env = match spec.config.get("env").unwrap() {
             Value::Map(m) => m,
             _ => panic!("env must be map"),
@@ -341,5 +385,129 @@ mod tests {
             archive_filename("internal/chacha8rand"),
             "internal_chacha8rand.a"
         );
+    }
+
+    // ---- race ----
+
+    fn race_factors(goos: &str) -> Factors {
+        Factors {
+            goos: goos.into(),
+            goarch: "arm64".into(),
+            race: true,
+            ..Default::default()
+        }
+    }
+
+    const CC: &str = "//@heph/bin:cc";
+
+    /// A race build installs std with `-race`, into the `_race` directory
+    /// `go install -race` writes and the linker expects. The two archive sets are
+    /// genuinely different, so they must not share a directory.
+    #[test]
+    fn race_install_uses_race_flag_and_its_own_pkg_dir() {
+        let spec = install_spec(install_addr(&test_vref()), &race_factors("linux"), V, CC);
+        let run = run_str(&spec);
+        assert!(
+            run.contains("install --trimpath -race std"),
+            "std must be compiled with -race: {run}"
+        );
+        assert!(
+            run.contains("goroot/pkg/linux_arm64_race"),
+            "race archives belong in their own pkg dir: {run}"
+        );
+        // `go list` has to agree with the install, or it reports the non-race
+        // file set and import graph for archives that were built racy.
+        assert!(run.contains("list -race -json std"), "{run}");
+    }
+
+    #[test]
+    fn non_race_install_is_unchanged() {
+        let spec = install_spec(install_addr(&test_vref()), &test_factors(), V, CC);
+        let run = run_str(&spec);
+        assert!(run.contains("install --trimpath std"), "{run}");
+        assert!(
+            !run.contains("-race"),
+            "no race flag on an ordinary build: {run}"
+        );
+        assert!(!run.contains("_race"), "{run}");
+    }
+
+    /// `build_lib` extracts from whichever pkg dir its factors name, so a race
+    /// consumer reads the race archive rather than silently getting the ordinary
+    /// one.
+    #[test]
+    fn race_build_lib_reads_the_race_archive() {
+        let vref = test_vref().with_race(true);
+        let spec = build_spec(
+            build_lib_addr(),
+            "runtime/race",
+            &race_factors("linux"),
+            &vref,
+        );
+        let run = run_str(&spec);
+        assert!(
+            run.contains("goroot/pkg/linux_arm64_race/runtime/race.a"),
+            "{run}"
+        );
+        // …and it deps on the race flavour of the install, not the ordinary one.
+        let deps = match spec.config.get("deps").unwrap() {
+            Value::Map(m) => m.clone(),
+            other => panic!("expected deps map: {other:?}"),
+        };
+        let install = match deps.get("install").unwrap() {
+            Value::List(v) => match &v[0] {
+                Value::String(s) => s.clone(),
+                other => panic!("expected string: {other:?}"),
+            },
+            other => panic!("expected list: {other:?}"),
+        };
+        assert!(install.contains("race=1"), "{install}");
+    }
+
+    /// linux race needs cgo, so the compiler is staged and `CC` points at it.
+    #[test]
+    fn linux_race_install_stages_a_c_compiler() {
+        let spec = install_spec(install_addr(&test_vref()), &race_factors("linux"), V, CC);
+        let deps = match spec.config.get("deps").unwrap() {
+            Value::Map(m) => m.clone(),
+            other => panic!("expected deps map: {other:?}"),
+        };
+        assert!(
+            deps.contains_key(crate::plugingo::cc_toolchain::CC_DEP_GROUP),
+            "linux race must dep on a C compiler: {:?}",
+            deps.keys().collect::<Vec<_>>()
+        );
+        assert!(run_str(&spec).contains("export CC"), "{}", run_str(&spec));
+        let env = match spec.config.get("env").unwrap() {
+            Value::Map(m) => m.clone(),
+            other => panic!("expected env map: {other:?}"),
+        };
+        assert!(matches!(env.get("CGO_ENABLED"), Some(Value::String(s)) if s == "1"));
+        // The compiler finds `as`/`ld` through PATH; without it cgo dies with
+        // `cannot execute 'as'`.
+        let pass = match spec.config.get("runtime_pass_env") {
+            Some(Value::List(v)) => v.clone(),
+            other => panic!("expected runtime_pass_env list: {other:?}"),
+        };
+        assert!(pass.contains(&Value::String("PATH".to_string())));
+    }
+
+    /// darwin race stays hermetic: `runtime/race` is pure Go plus a syso there,
+    /// so no compiler dep, no cgo, no PATH passthrough.
+    #[test]
+    fn darwin_race_install_needs_no_c_compiler() {
+        let spec = install_spec(install_addr(&test_vref()), &race_factors("darwin"), V, CC);
+        let deps = match spec.config.get("deps").unwrap() {
+            Value::Map(m) => m.clone(),
+            other => panic!("expected deps map: {other:?}"),
+        };
+        assert!(!deps.contains_key(crate::plugingo::cc_toolchain::CC_DEP_GROUP));
+        assert!(!run_str(&spec).contains("export CC"));
+        let env = match spec.config.get("env").unwrap() {
+            Value::Map(m) => m.clone(),
+            other => panic!("expected env map: {other:?}"),
+        };
+        assert!(matches!(env.get("CGO_ENABLED"), Some(Value::String(s)) if s == "0"));
+        assert!(!spec.config.contains_key("runtime_pass_env"));
     }
 }

--- a/crates/plugin-go/src/plugingo/target_std.rs
+++ b/crates/plugin-go/src/plugingo/target_std.rs
@@ -55,7 +55,12 @@ fn pkg_subdir(factors: &Factors) -> String {
 /// `$GOROOT` to a writable tree and `go install std` into it (with
 /// `installgoroot=all`), then dump `go list -json std` for downstream metadata.
 /// Reads nothing from the host — `$GOROOT` is the staged toolchain.
-pub fn install_spec(addr: Addr, factors: &Factors, go_version: &str, cc_addr: &str) -> TargetSpec {
+pub fn install_spec(
+    addr: Addr,
+    factors: &Factors,
+    go_version: &str,
+    cctool_addr: &str,
+) -> TargetSpec {
     let subdir = pkg_subdir(factors);
 
     let mut run = go_run_prelude(go_version);
@@ -97,7 +102,8 @@ pub fn install_spec(addr: Addr, factors: &Factors, go_version: &str, cc_addr: &s
     if let Some((sdk_group, sdk_val)) = go_sdk_dep(go_version) {
         deps.insert(sdk_group, sdk_val);
     }
-    if let Some((cc_group, cc_val)) = cc_toolchain::cc_dep(cc_addr, &factors.goos, factors.race) {
+    if let Some((cc_group, cc_val)) = cc_toolchain::cc_dep(cctool_addr, &factors.goos, factors.race)
+    {
         deps.insert(cc_group, cc_val);
     }
 

--- a/crates/plugin-go/src/plugingo/target_test.rs
+++ b/crates/plugin-go/src/plugingo/target_test.rs
@@ -1,5 +1,5 @@
 use crate::plugingo::addr_util::{
-    go_build_env, go_host_pass_env_config, go_run_prelude, go_sdk_dep, go_sdk_read_only_config,
+    go_build_env_for, go_host_pass_env_config, go_run_prelude, go_sdk_dep, go_sdk_read_only_config,
     import_path_to_dep_group, to_run_value, write_importcfg_script,
 };
 use crate::plugingo::driver_compile::{CompileParams, build_compile_spec};
@@ -184,8 +184,14 @@ pub fn build_test_spec(
     } else {
         format!(" {}", factors.ldflags.join(" "))
     };
+    // `-race` links the TSan runtime out of `runtime/race.a` (which the caller
+    // put in `all_libs`) and switches the linker to the race-aware layout. The
+    // buildmode is not fixed: race on linux must not be PIE (see
+    // `factors::link_buildmode`).
+    let race = if factors.race { " -race" } else { "" };
+    let buildmode = factors.link_buildmode();
     script.push(format!(
-        "\"$GO\" tool link -importcfg \"$importcfg\" -buildmode=pie{ldflags} -o test_binary \"$SRC_TESTMAIN\""
+        "\"$GO\" tool link -importcfg \"$importcfg\" -buildmode={buildmode}{race}{ldflags} -o test_binary \"$SRC_TESTMAIN\""
     ));
 
     let mut deps: BTreeMap<String, Value> = BTreeMap::new();
@@ -227,7 +233,7 @@ pub fn build_test_spec(
     config.insert("runtime_env".to_string(), Value::Map(runtime_env));
     // CGO/toolchain pins live in `env` (hashed) so stale archives don't survive
     // cache lookups (pluginexec/mod.rs:70 excludes runtime_env from the def hash).
-    config.insert("env".to_string(), go_build_env());
+    config.insert("env".to_string(), go_build_env_for(factors));
 
     TargetSpec {
         addr,
@@ -253,6 +259,7 @@ pub fn test_spec(
     build_test_addr: Addr,
     data_query_addr: &Addr,
     test_env: &TestEnv,
+    race: bool,
 ) -> TargetSpec {
     // Both drivers run with cwd = the target's package dir, and the engine
     // stages dep outputs at <pkg>/<file> under ws_dir
@@ -311,11 +318,22 @@ pub fn test_spec(
         );
     }
 
+    // A race target deliberately does NOT carry the generic `test`/`go-test`
+    // labels. A race build is several times slower to produce and to run, so
+    // `heph run 'label(test)'` (and CI built on it) must keep meaning the
+    // ordinary suite; opting in is `label(test-race)`. Both are still reachable
+    // together as `label(test) || label(test-race)`.
+    let labels = if race {
+        vec!["test-race".to_string(), "go-test-race".to_string()]
+    } else {
+        vec!["test".to_string(), "go-test".to_string()]
+    };
+
     TargetSpec {
         addr,
         driver: driver.to_string(),
         config,
-        labels: vec!["test".to_string(), "go-test".to_string()],
+        labels,
         ..Default::default()
     }
 }
@@ -715,6 +733,7 @@ mod tests {
             build_addr.clone(),
             &query_addr("mypkg"),
             &TestEnv::default(),
+            false,
         );
         let deps = match spec.config.get("deps").unwrap() {
             Value::Map(m) => m.clone(),
@@ -735,6 +754,7 @@ mod tests {
             mk_addr("mypkg", "build_test"),
             &query_addr("mypkg"),
             &TestEnv::default(),
+            false,
         );
         assert_eq!(spec.driver, "exec");
         let run = match spec.config.get("run").expect("run present") {
@@ -761,6 +781,7 @@ mod tests {
             mk_addr("mypkg", "build_test"),
             &query_addr("mypkg"),
             &TestEnv::default(),
+            false,
         );
         assert!(!spec.config.contains_key("env"));
         assert!(!spec.config.contains_key("runtime_env"));
@@ -782,6 +803,7 @@ mod tests {
             mk_addr("mypkg", "build_test"),
             &query_addr("mypkg"),
             &test_env,
+            false,
         );
 
         let env = match spec.config.get("env").expect("env present") {
@@ -879,6 +901,7 @@ mod tests {
             mk_addr("mypkg", "build_test"),
             &query_addr("mypkg"),
             &TestEnv::default(),
+            false,
         );
         assert!(spec.labels.contains(&"test".to_string()));
         assert!(spec.labels.contains(&"go-test".to_string()));
@@ -892,6 +915,7 @@ mod tests {
             mk_addr("mypkg", "build_test"),
             &qa,
             &TestEnv::default(),
+            false,
         );
         let deps = match spec.config.get("deps").unwrap() {
             Value::Map(m) => m.clone(),
@@ -932,6 +956,7 @@ mod tests {
             mk_addr("mypkg", "build_test"),
             &query_addr("mypkg"),
             &test_env,
+            false,
         );
         assert_eq!(spec.driver, "bash");
         let lines: Vec<String> = match spec.config.get("run").expect("run present") {
@@ -955,6 +980,105 @@ mod tests {
         );
     }
 
+    // ---- race ----
+
+    fn race_factors(goos: &str) -> Factors {
+        Factors {
+            goos: goos.into(),
+            goarch: "arm64".into(),
+            race: true,
+            ..Default::default()
+        }
+    }
+
+    fn link_spec(factors: &Factors) -> TargetSpec {
+        build_test_spec(
+            mk_addr("pkg", "build_test"),
+            factors,
+            &mk_addr("pkg", "build_testmain_lib"),
+            &[],
+            V,
+        )
+    }
+
+    /// The linker needs `-race` to pull the TSan runtime in and lay the binary
+    /// out for it.
+    #[test]
+    fn race_link_passes_race_flag() {
+        assert!(run_str(&link_spec(&race_factors("darwin"))).contains(" -race"));
+        assert!(!run_str(&link_spec(&test_factors())).contains("-race"));
+    }
+
+    /// `go build` refuses pie+race on linux, and `go tool link` — which is what
+    /// we call — does not enforce that: it produces a binary that dies at
+    /// startup with "ThreadSanitizer failed to allocate". So the buildmode has to
+    /// be chosen here.
+    #[test]
+    fn linux_race_link_is_not_pie() {
+        let run = run_str(&link_spec(&race_factors("linux")));
+        assert!(run.contains("-buildmode=exe"), "{run}");
+        assert!(!run.contains("-buildmode=pie"), "{run}");
+    }
+
+    /// darwin supports pie+race, so it keeps the ordinary buildmode.
+    #[test]
+    fn darwin_race_link_stays_pie() {
+        assert!(
+            run_str(&link_spec(&race_factors("darwin"))).contains("-buildmode=pie"),
+            "{}",
+            run_str(&link_spec(&race_factors("darwin")))
+        );
+    }
+
+    #[test]
+    fn non_race_link_stays_pie_everywhere() {
+        for goos in ["linux", "darwin"] {
+            let f = Factors {
+                goos: goos.into(),
+                goarch: "arm64".into(),
+                ..Default::default()
+            };
+            assert!(run_str(&link_spec(&f)).contains("-buildmode=pie"), "{goos}");
+        }
+    }
+
+    /// linux race enables cgo (for `runtime/race`), and the value lives in the
+    /// hashed `env` so a stale non-cgo link can't be served from cache.
+    #[test]
+    fn race_link_env_tracks_cgo() {
+        let cgo = |f: &Factors| match link_spec(f).config.get("env").unwrap() {
+            Value::Map(m) => match m.get("CGO_ENABLED") {
+                Some(Value::String(s)) => s.clone(),
+                other => panic!("expected CGO_ENABLED string: {other:?}"),
+            },
+            other => panic!("expected env map: {other:?}"),
+        };
+        assert_eq!(cgo(&race_factors("linux")), "1");
+        assert_eq!(cgo(&race_factors("darwin")), "0");
+        assert_eq!(cgo(&test_factors()), "0");
+    }
+
+    /// A race run target is labelled apart from the ordinary suite. `label(test)`
+    /// must keep meaning "the fast tests" — a race build is several times slower
+    /// to produce and to run, so `//...` must not silently double every test.
+    #[test]
+    fn race_test_spec_is_labelled_separately() {
+        let racy = test_spec(
+            mk_addr("mypkg", "test_race"),
+            mk_addr("mypkg", "build_test"),
+            &query_addr("mypkg"),
+            &TestEnv::default(),
+            true,
+        );
+        assert!(racy.labels.contains(&"test-race".to_string()));
+        assert!(racy.labels.contains(&"go-test-race".to_string()));
+        assert!(
+            !racy.labels.contains(&"test".to_string()),
+            "a race target must not join the ordinary test suite: {:?}",
+            racy.labels
+        );
+    }
+
     #[test]
     fn test_test_spec_empty_pre_run_stays_exec() {
         let spec = test_spec(
@@ -962,6 +1086,7 @@ mod tests {
             mk_addr("mypkg", "build_test"),
             &query_addr("mypkg"),
             &TestEnv::default(),
+            false,
         );
         assert_eq!(spec.driver, "exec");
     }

--- a/crates/plugin-go/src/plugingo/target_test.rs
+++ b/crates/plugin-go/src/plugingo/target_test.rs
@@ -1,5 +1,5 @@
 use crate::plugingo::addr_util::{
-    go_build_env, go_host_pass_env_config, go_run_prelude, go_sdk_dep, go_sdk_read_only_config,
+    go_build_env_for, go_host_pass_env_config, go_run_prelude, go_sdk_dep, go_sdk_read_only_config,
     import_path_to_dep_group, to_run_value, write_importcfg_script,
 };
 use crate::plugingo::driver_compile::{CompileParams, build_compile_spec};
@@ -185,10 +185,15 @@ pub fn build_test_spec(
         format!(" {}", factors.ldflags.join(" "))
     };
     // Same coupling as the binary link (see `target_bin::generate_link_script`):
-    // the mode here must match what the archives were compiled under.
+    // the mode here must match what the archives were compiled under. A race
+    // build on linux already had it forced to `exe` at variant resolution
+    // (`BuildMode::for_race`), so nothing race-specific is decided here.
     let mode = factors.buildmode.as_str();
+    // `-race` links the TSan runtime out of `runtime/race.a`, which the caller
+    // put in `all_libs`.
+    let race = if factors.race { " -race" } else { "" };
     script.push(format!(
-        "\"$GO\" tool link -importcfg \"$importcfg\" -buildmode={mode}{ldflags} -o test_binary \"$SRC_TESTMAIN\""
+        "\"$GO\" tool link -importcfg \"$importcfg\" -buildmode={mode}{race}{ldflags} -o test_binary \"$SRC_TESTMAIN\""
     ));
 
     let mut deps: BTreeMap<String, Value> = BTreeMap::new();
@@ -230,7 +235,7 @@ pub fn build_test_spec(
     config.insert("runtime_env".to_string(), Value::Map(runtime_env));
     // CGO/toolchain pins live in `env` (hashed) so stale archives don't survive
     // cache lookups (pluginexec/mod.rs:70 excludes runtime_env from the def hash).
-    config.insert("env".to_string(), go_build_env());
+    config.insert("env".to_string(), go_build_env_for(factors));
 
     TargetSpec {
         addr,
@@ -256,6 +261,7 @@ pub fn test_spec(
     build_test_addr: Addr,
     data_query_addr: &Addr,
     test_env: &TestEnv,
+    race: bool,
 ) -> TargetSpec {
     // Both drivers run with cwd = the target's package dir, and the engine
     // stages dep outputs at <pkg>/<file> under ws_dir
@@ -314,11 +320,22 @@ pub fn test_spec(
         );
     }
 
+    // A race target deliberately does NOT carry the generic `test`/`go-test`
+    // labels. A race build is several times slower to produce and to run, so
+    // `heph run 'label(test)'` (and CI built on it) must keep meaning the
+    // ordinary suite; opting in is `label(test-race)`. Both are still reachable
+    // together as `label(test) || label(test-race)`.
+    let labels = if race {
+        vec!["test-race".to_string(), "go-test-race".to_string()]
+    } else {
+        vec!["test".to_string(), "go-test".to_string()]
+    };
+
     TargetSpec {
         addr,
         driver: driver.to_string(),
         config,
-        labels: vec!["test".to_string(), "go-test".to_string()],
+        labels,
         ..Default::default()
     }
 }
@@ -746,6 +763,7 @@ mod tests {
             build_addr.clone(),
             &query_addr("mypkg"),
             &TestEnv::default(),
+            false,
         );
         let deps = match spec.config.get("deps").unwrap() {
             Value::Map(m) => m.clone(),
@@ -766,6 +784,7 @@ mod tests {
             mk_addr("mypkg", "build_test"),
             &query_addr("mypkg"),
             &TestEnv::default(),
+            false,
         );
         assert_eq!(spec.driver, "exec");
         let run = match spec.config.get("run").expect("run present") {
@@ -792,6 +811,7 @@ mod tests {
             mk_addr("mypkg", "build_test"),
             &query_addr("mypkg"),
             &TestEnv::default(),
+            false,
         );
         assert!(!spec.config.contains_key("env"));
         assert!(!spec.config.contains_key("runtime_env"));
@@ -813,6 +833,7 @@ mod tests {
             mk_addr("mypkg", "build_test"),
             &query_addr("mypkg"),
             &test_env,
+            false,
         );
 
         let env = match spec.config.get("env").expect("env present") {
@@ -910,6 +931,7 @@ mod tests {
             mk_addr("mypkg", "build_test"),
             &query_addr("mypkg"),
             &TestEnv::default(),
+            false,
         );
         assert!(spec.labels.contains(&"test".to_string()));
         assert!(spec.labels.contains(&"go-test".to_string()));
@@ -923,6 +945,7 @@ mod tests {
             mk_addr("mypkg", "build_test"),
             &qa,
             &TestEnv::default(),
+            false,
         );
         let deps = match spec.config.get("deps").unwrap() {
             Value::Map(m) => m.clone(),
@@ -963,6 +986,7 @@ mod tests {
             mk_addr("mypkg", "build_test"),
             &query_addr("mypkg"),
             &test_env,
+            false,
         );
         assert_eq!(spec.driver, "bash");
         let lines: Vec<String> = match spec.config.get("run").expect("run present") {
@@ -986,6 +1010,100 @@ mod tests {
         );
     }
 
+    // ---- race ----
+
+    fn race_factors(goos: &str) -> Factors {
+        Factors {
+            goos: goos.into(),
+            goarch: "arm64".into(),
+            race: true,
+            ..Default::default()
+        }
+    }
+
+    fn link_spec(factors: &Factors) -> TargetSpec {
+        build_test_spec(
+            mk_addr("pkg", "build_test"),
+            factors,
+            &mk_addr("pkg", "build_testmain_lib"),
+            &[],
+            V,
+        )
+    }
+
+    /// The linker needs `-race` to pull the TSan runtime in and lay the binary
+    /// out for it.
+    #[test]
+    fn race_link_passes_race_flag() {
+        assert!(run_str(&link_spec(&race_factors("darwin"))).contains(" -race"));
+        assert!(!run_str(&link_spec(&test_factors())).contains("-race"));
+    }
+
+    // The linux "race cannot be PIE" override is applied once, at variant
+    // resolution, so this link script just spells out whatever buildmode it is
+    // handed. It is tested where the decision is made — `BuildMode::for_race`,
+    // and `variant::resolve` for the integration.
+
+    /// darwin supports pie+race, so a variant that asked for `pie` keeps it —
+    /// the override is linux-only, not "race means exe".
+    #[test]
+    fn darwin_race_link_keeps_a_requested_pie() {
+        let factors = Factors {
+            buildmode: crate::plugingo::factors::BuildMode::Pie,
+            ..race_factors("darwin")
+        };
+        let run = run_str(&link_spec(&factors));
+        assert!(run.contains("-buildmode=pie"), "{run}");
+        assert!(run.contains(" -race"), "{run}");
+    }
+
+    /// And a race build still honours the default (`exe`) rather than forcing
+    /// anything of its own — on darwin as much as on linux.
+    #[test]
+    fn race_link_honours_the_default_buildmode() {
+        for goos in ["linux", "darwin"] {
+            let run = run_str(&link_spec(&race_factors(goos)));
+            assert!(run.contains("-buildmode=exe"), "{goos}: {run}");
+        }
+    }
+
+    /// linux race enables cgo (for `runtime/race`), and the value lives in the
+    /// hashed `env` so a stale non-cgo link can't be served from cache.
+    #[test]
+    fn race_link_env_tracks_cgo() {
+        let cgo = |f: &Factors| match link_spec(f).config.get("env").unwrap() {
+            Value::Map(m) => match m.get("CGO_ENABLED") {
+                Some(Value::String(s)) => s.clone(),
+                other => panic!("expected CGO_ENABLED string: {other:?}"),
+            },
+            other => panic!("expected env map: {other:?}"),
+        };
+        assert_eq!(cgo(&race_factors("linux")), "1");
+        assert_eq!(cgo(&race_factors("darwin")), "0");
+        assert_eq!(cgo(&test_factors()), "0");
+    }
+
+    /// A race run target is labelled apart from the ordinary suite. `label(test)`
+    /// must keep meaning "the fast tests" — a race build is several times slower
+    /// to produce and to run, so `//...` must not silently double every test.
+    #[test]
+    fn race_test_spec_is_labelled_separately() {
+        let racy = test_spec(
+            mk_addr("mypkg", "test_race"),
+            mk_addr("mypkg", "build_test"),
+            &query_addr("mypkg"),
+            &TestEnv::default(),
+            true,
+        );
+        assert!(racy.labels.contains(&"test-race".to_string()));
+        assert!(racy.labels.contains(&"go-test-race".to_string()));
+        assert!(
+            !racy.labels.contains(&"test".to_string()),
+            "a race target must not join the ordinary test suite: {:?}",
+            racy.labels
+        );
+    }
+
     #[test]
     fn test_test_spec_empty_pre_run_stays_exec() {
         let spec = test_spec(
@@ -993,6 +1111,7 @@ mod tests {
             mk_addr("mypkg", "build_test"),
             &query_addr("mypkg"),
             &TestEnv::default(),
+            false,
         );
         assert_eq!(spec.driver, "exec");
     }

--- a/crates/plugin-go/src/plugingo/variant.rs
+++ b/crates/plugin-go/src/plugingo/variant.rs
@@ -26,7 +26,7 @@
 //! **same `variants` map** and override selected fields (list fields replace, not
 //! append). `goos`/`goarch` may be omitted when inherited. Cycles are rejected.
 
-use crate::plugingo::factors::{Factors, VariantRef};
+use crate::plugingo::factors::{Factors, VariantRef, race_from_args};
 use anyhow::{Context, bail};
 use hcore::htvalue::{Value, parse_strings};
 use hmodel::htaddr::Addr;
@@ -348,6 +348,14 @@ pub async fn resolve(
             defined_variant_names(req_states).join(", ")
         );
     };
+    // Race is orthogonal to the variant: it comes off the addr, not the
+    // `variants` declaration, and overlays whichever factor set resolves below.
+    let race = race_from_args(&addr.args)?;
+    let apply_race = |(mut f, v): (Factors, VariantRef)| -> (Factors, VariantRef) {
+        f.race = race;
+        (f, v.with_race(race))
+    };
+
     match addr.args.get("vp") {
         // Only honor `vp` when it lies within the target's OWN go module. The
         // variant universe is bounded to the module: a `vp` threaded from a
@@ -365,7 +373,7 @@ pub async fn resolve(
                 .find_map(|s| variant_in_state(s, name).transpose())
                 .transpose()?
             {
-                return Ok((f, vref));
+                return Ok(apply_race((f, vref)));
             }
             // Otherwise fetch `vp`'s own declaration directly. `states_under(vp)`
             // includes `vp`'s package (siblings of the target are reachable this
@@ -376,10 +384,10 @@ pub async fn resolve(
                 .with_context(|| format!("fetching variant declaration at `{vp}`"))?;
             let universe = build_universe(&vp_states)?;
             let f = resolve_in_universe(&vref, &universe)?;
-            Ok((f, vref))
+            Ok(apply_race((f, vref)))
         }
         // No `vp`, or a `vp` outside this module: resolve by module-bounded ancestry.
-        _ => resolve_ancestry(name, req_states, module_root),
+        _ => resolve_ancestry(name, req_states, module_root).map(apply_race),
     }
 }
 

--- a/crates/plugin-go/src/plugingo/variant.rs
+++ b/crates/plugin-go/src/plugingo/variant.rs
@@ -26,7 +26,7 @@
 //! **same `variants` map** and override selected fields (list fields replace, not
 //! append). `goos`/`goarch` may be omitted when inherited. Cycles are rejected.
 
-use crate::plugingo::factors::{BuildMode, Factors, VariantRef};
+use crate::plugingo::factors::{BuildMode, Factors, VariantRef, race_from_args};
 use anyhow::{Context, bail};
 use hcore::htvalue::{Value, parse_strings};
 use hmodel::htaddr::Addr;
@@ -363,6 +363,21 @@ pub async fn resolve(
             defined_variant_names(req_states).join(", ")
         );
     };
+    // Race is orthogonal to the variant: it comes off the addr, not the
+    // `variants` declaration, and overlays whichever factor set resolves below.
+    let race = race_from_args(&addr.args)?;
+    let apply_race = |(mut f, v): (Factors, VariantRef)| -> (Factors, VariantRef) {
+        f.race = race;
+        // Resolve the effective buildmode once, here, rather than at each of the
+        // places that consume it: a linux race build cannot be PIE (see
+        // `BuildMode::for_race`). Doing it at resolution keeps the compile's
+        // `-shared` and the link's `-buildmode=` deriving from one value, so they
+        // cannot drift apart — and it means the override is visible in the def
+        // hash, so a race archive is never confused with a `pie` one.
+        f.buildmode = f.buildmode.for_race(&f.goos, race);
+        (f, v.with_race(race))
+    };
+
     match addr.args.get("vp") {
         // Only honor `vp` when it lies within the target's OWN go module. The
         // variant universe is bounded to the module: a `vp` threaded from a
@@ -380,7 +395,7 @@ pub async fn resolve(
                 .find_map(|s| variant_in_state(s, name).transpose())
                 .transpose()?
             {
-                return Ok((f, vref));
+                return Ok(apply_race((f, vref)));
             }
             // Otherwise fetch `vp`'s own declaration directly. `states_under(vp)`
             // includes `vp`'s package (siblings of the target are reachable this
@@ -391,10 +406,10 @@ pub async fn resolve(
                 .with_context(|| format!("fetching variant declaration at `{vp}`"))?;
             let universe = build_universe(&vp_states)?;
             let f = resolve_in_universe(&vref, &universe)?;
-            Ok((f, vref))
+            Ok(apply_race((f, vref)))
         }
         // No `vp`, or a `vp` outside this module: resolve by module-bounded ancestry.
-        _ => resolve_ancestry(name, req_states, module_root),
+        _ => resolve_ancestry(name, req_states, module_root).map(apply_race),
     }
 }
 
@@ -744,5 +759,97 @@ mod tests {
             vref.pkg, "dev/app",
             "vp rebased to the target's own module, not the foreign `mgmt/go`"
         );
+    }
+
+    // ---- race ----
+
+    fn race_addr(pkg: &str, variant: &str) -> Addr {
+        Addr::new(
+            PkgBuf::from(pkg),
+            "build_test".to_string(),
+            VariantRef::new(variant, "").with_race(true).to_args(),
+        )
+    }
+
+    fn no_universe() -> UniverseExec {
+        UniverseExec {
+            under: HashMap::new(),
+        }
+    }
+
+    /// The integration point for the linux race rule: a variant that explicitly
+    /// declares `buildmode = "pie"` still resolves to `exe` under race, because
+    /// `go tool link` would otherwise emit a binary that dies at startup with
+    /// "ThreadSanitizer failed to allocate".
+    ///
+    /// Resolving it here (rather than at each consumer) is what keeps the
+    /// compile's `-shared` and the link's `-buildmode=` deriving from one value.
+    #[tokio::test]
+    async fn linux_race_resolves_pie_down_to_exe() {
+        let pie_linux = variant_val(&[
+            ("goos", s("linux")),
+            ("goarch", s("amd64")),
+            ("buildmode", s("pie")),
+        ]);
+        let states = vec![go_state("app", &[("dev", pie_linux)])];
+        let (f, vref) = resolve(
+            &race_addr("app", "dev"),
+            &states,
+            "app",
+            &no_universe(),
+            false,
+        )
+        .await
+        .expect("resolves");
+        assert_eq!(f.buildmode, BuildMode::Exe, "linux race must not be PIE");
+        assert!(!f.buildmode.needs_shared(), "and must drop -shared with it");
+        assert!(f.race);
+        assert!(vref.race, "the race flag threads onto dependency addrs");
+    }
+
+    /// darwin supports pie+race, so the same declaration is honoured there —
+    /// the override is scoped to where Go actually forbids the combination.
+    #[tokio::test]
+    async fn darwin_race_keeps_a_declared_pie() {
+        let pie_darwin = variant_val(&[
+            ("goos", s("darwin")),
+            ("goarch", s("arm64")),
+            ("buildmode", s("pie")),
+        ]);
+        let states = vec![go_state("app", &[("dev", pie_darwin)])];
+        let (f, _) = resolve(
+            &race_addr("app", "dev"),
+            &states,
+            "app",
+            &no_universe(),
+            false,
+        )
+        .await
+        .expect("resolves");
+        assert_eq!(f.buildmode, BuildMode::Pie);
+        assert!(f.buildmode.needs_shared());
+    }
+
+    /// An ordinary (non-race) build is untouched by any of this: the declared
+    /// buildmode survives on linux too.
+    #[tokio::test]
+    async fn non_race_linux_keeps_a_declared_pie() {
+        let pie_linux = variant_val(&[
+            ("goos", s("linux")),
+            ("goarch", s("amd64")),
+            ("buildmode", s("pie")),
+        ]);
+        let states = vec![go_state("app", &[("dev", pie_linux)])];
+        let addr = Addr::new(
+            PkgBuf::from("app"),
+            "build_test".to_string(),
+            VariantRef::new("dev", "").to_args(),
+        );
+        let (f, vref) = resolve(&addr, &states, "app", &no_universe(), false)
+            .await
+            .expect("resolves");
+        assert_eq!(f.buildmode, BuildMode::Pie);
+        assert!(!f.race);
+        assert!(!vref.race);
     }
 }

--- a/crates/plugingo-e2e/Cargo.toml
+++ b/crates/plugingo-e2e/Cargo.toml
@@ -21,3 +21,5 @@ tempfile = "3"
 futures = "0.3"
 # Reads the program headers of a linked Go binary, to assert its buildmode.
 object = { version = "0.37", default-features = false, features = ["read_core", "elf", "std"] }
+# Locates the host C compiler the race e2e stages as `//@heph/bin:cc`.
+which = "8.0.3"

--- a/crates/plugingo-e2e/Cargo.toml
+++ b/crates/plugingo-e2e/Cargo.toml
@@ -19,3 +19,4 @@ tokio = { version = "1", features = ["rt", "rt-multi-thread", "macros"] }
 anyhow = "1"
 tempfile = "3"
 futures = "0.3"
+which = "8.0.3"

--- a/crates/plugingo-e2e/testdata/race/clean/clean.go
+++ b/crates/plugingo-e2e/testdata/race/clean/clean.go
@@ -1,0 +1,9 @@
+package clean
+
+// Sum adds through a channel handoff, so the two goroutines are properly
+// ordered and the race detector has nothing to report.
+func Sum(a, b int) int {
+	ch := make(chan int)
+	go func() { ch <- a }()
+	return <-ch + b
+}

--- a/crates/plugingo-e2e/testdata/race/clean/clean_test.go
+++ b/crates/plugingo-e2e/testdata/race/clean/clean_test.go
@@ -1,0 +1,9 @@
+package clean
+
+import "testing"
+
+func TestSum(t *testing.T) {
+	if got := Sum(1, 2); got != 3 {
+		t.Fatalf("Sum(1, 2) = %d, want 3", got)
+	}
+}

--- a/crates/plugingo-e2e/testdata/race/go.mod
+++ b/crates/plugingo-e2e/testdata/race/go.mod
@@ -1,0 +1,3 @@
+module example.com/race
+
+go 1.21

--- a/crates/plugingo-e2e/testdata/race/racy/racy.go
+++ b/crates/plugingo-e2e/testdata/race/racy/racy.go
@@ -1,0 +1,16 @@
+package racy
+
+// Increment deliberately races: the spawned goroutine and the caller both write
+// `n` with no synchronisation between them. The channel only signals completion,
+// so it orders the final read but not the two writes.
+func Increment() int {
+	n := 0
+	done := make(chan struct{})
+	go func() {
+		n++
+		close(done)
+	}()
+	n++
+	<-done
+	return n
+}

--- a/crates/plugingo-e2e/testdata/race/racy/racy_test.go
+++ b/crates/plugingo-e2e/testdata/race/racy/racy_test.go
@@ -1,0 +1,11 @@
+package racy
+
+import "testing"
+
+func TestIncrement(t *testing.T) {
+	// Passes without instrumentation — the assertion is deliberately loose, so
+	// the only thing that can fail this test is the race detector itself.
+	if got := Increment(); got < 1 {
+		t.Fatalf("Increment() = %d, want >= 1", got)
+	}
+}

--- a/crates/plugingo-e2e/tests/common/mod.rs
+++ b/crates/plugingo-e2e/tests/common/mod.rs
@@ -49,6 +49,17 @@ pub fn fixture(name: &str) -> anyhow::Result<TempDir> {
     copy_dir_to_tempdir(&testdata(name))
 }
 
+/// Absolute path to the host C compiler, or `None` if there isn't one.
+///
+/// Only a race build that needs cgo (linux — see `plugingo::factors::cgo_required`)
+/// ever resolves the `cc` target this backs; on darwin nothing asks for it.
+fn cc_bin_path() -> Option<String> {
+    ["cc", "gcc", "clang"]
+        .iter()
+        .find_map(|name| which::which(name).ok())
+        .map(|p| p.to_string_lossy().into_owned())
+}
+
 fn go_bin_path() -> String {
     let output = std::process::Command::new("go")
         .args(["env", "GOROOT"])
@@ -265,6 +276,7 @@ fn make_workspace_ordered(
 ) -> anyhow::Result<Workspace> {
     let gotool = gotool.to_string();
     let go_bin = go_bin_path();
+    let cc_bin = cc_bin_path();
     // `fs` is auto-registered by `Engine::new`.
     let mut b = WorkspaceBuilder::from_dir(dir).with_fs_skip(fs_skip.iter().copied());
 
@@ -300,19 +312,35 @@ fn make_workspace_ordered(
             ))
         })
         .with_provider(move |_| {
-            Box::new(
-                pluginstatictarget::Provider::new(vec![pluginstatictarget::Target {
-                    addr: "//@heph/bin:go".to_string(),
+            let mut targets = vec![pluginstatictarget::Target {
+                addr: "//@heph/bin:go".to_string(),
+                driver: "bash".to_string(),
+                run: Some(format!("cp -p \"{go_bin}\" go")),
+                out: std::collections::HashMap::from([(String::new(), vec!["go".to_string()])]),
+                codegen: None,
+                deps: Default::default(),
+                labels: vec![],
+                ..Default::default()
+            }];
+            // Stand-in for the hostbin `//@heph/bin:cc` a real workspace uses,
+            // which a race build stages where race needs cgo. A *shim* rather
+            // than a copy of the binary: gcc locates its own subprograms
+            // relative to argv[0], so a copied driver can't find `cc1`.
+            if let Some(cc_bin) = &cc_bin {
+                targets.push(pluginstatictarget::Target {
+                    addr: "//@heph/bin:cc".to_string(),
                     driver: "bash".to_string(),
-                    run: Some(format!("cp -p \"{go_bin}\" go")),
-                    out: std::collections::HashMap::from([(String::new(), vec!["go".to_string()])]),
+                    run: Some(format!(
+                        "printf '#!/bin/sh\\nexec \"{cc_bin}\" \"$@\"\\n' > cc\nchmod +x cc"
+                    )),
+                    out: std::collections::HashMap::from([(String::new(), vec!["cc".to_string()])]),
                     codegen: None,
                     deps: Default::default(),
                     labels: vec![],
                     ..Default::default()
-                }])
-                .expect("static provider"),
-            )
+                });
+            }
+            Box::new(pluginstatictarget::Provider::new(targets).expect("static provider"))
         });
 
     if !go_first {

--- a/crates/plugingo-e2e/tests/common/mod.rs
+++ b/crates/plugingo-e2e/tests/common/mod.rs
@@ -72,6 +72,17 @@ pub fn fixture(name: &str) -> anyhow::Result<TempDir> {
     copy_dir_to_tempdir(&testdata(name))
 }
 
+/// Absolute path to the host C compiler, or `None` if there isn't one.
+///
+/// Only a race build that needs cgo (linux — see `plugingo::factors::cgo_required`)
+/// ever resolves the `cc` target this backs; on darwin nothing asks for it.
+fn cc_bin_path() -> Option<String> {
+    ["cc", "gcc", "clang"]
+        .iter()
+        .find_map(|name| which::which(name).ok())
+        .map(|p| p.to_string_lossy().into_owned())
+}
+
 fn go_bin_path() -> String {
     let output = std::process::Command::new("go")
         .args(["env", "GOROOT"])
@@ -299,6 +310,7 @@ fn make_workspace_ordered(
 ) -> anyhow::Result<Workspace> {
     let gotool = gotool.to_string();
     let go_bin = go_bin_path();
+    let cc_bin = cc_bin_path();
     // `fs` is auto-registered by `Engine::new`.
     let mut b = WorkspaceBuilder::from_dir(dir).with_fs_skip(fs_skip.iter().copied());
 
@@ -334,19 +346,35 @@ fn make_workspace_ordered(
             ))
         })
         .with_provider(move |_| {
-            Box::new(
-                pluginstatictarget::Provider::new(vec![pluginstatictarget::Target {
-                    addr: "//@heph/bin:go".to_string(),
+            let mut targets = vec![pluginstatictarget::Target {
+                addr: "//@heph/bin:go".to_string(),
+                driver: "bash".to_string(),
+                run: Some(format!("cp -p \"{go_bin}\" go")),
+                out: std::collections::HashMap::from([(String::new(), vec!["go".to_string()])]),
+                codegen: None,
+                deps: Default::default(),
+                labels: vec![],
+                ..Default::default()
+            }];
+            // Stand-in for the hostbin `//@heph/bin:cc` a real workspace uses,
+            // which a race build stages where race needs cgo. A *shim* rather
+            // than a copy of the binary: gcc locates its own subprograms
+            // relative to argv[0], so a copied driver can't find `cc1`.
+            if let Some(cc_bin) = &cc_bin {
+                targets.push(pluginstatictarget::Target {
+                    addr: "//@heph/bin:cc".to_string(),
                     driver: "bash".to_string(),
-                    run: Some(format!("cp -p \"{go_bin}\" go")),
-                    out: std::collections::HashMap::from([(String::new(), vec!["go".to_string()])]),
+                    run: Some(format!(
+                        "printf '#!/bin/sh\\nexec \"{cc_bin}\" \"$@\"\\n' > cc\nchmod +x cc"
+                    )),
+                    out: std::collections::HashMap::from([(String::new(), vec!["cc".to_string()])]),
                     codegen: None,
                     deps: Default::default(),
                     labels: vec![],
                     ..Default::default()
-                }])
-                .expect("static provider"),
-            )
+                });
+            }
+            Box::new(pluginstatictarget::Provider::new(targets).expect("static provider"))
         });
 
     if !go_first {

--- a/crates/plugingo-e2e/tests/common/mod.rs
+++ b/crates/plugingo-e2e/tests/common/mod.rs
@@ -24,7 +24,7 @@ pub use htestkit::{artifact_bytes, artifact_paths, artifact_string};
 macro_rules! require_go {
     () => {
         if !crate::common::go_available() {
-            eprintln!("skipping: go not in PATH");
+            crate::common::no_go_or_panic();
             return Ok(());
         }
     };
@@ -37,6 +37,22 @@ pub fn go_available() -> bool {
         .output()
         .map(|o| o.status.success())
         .unwrap_or(false)
+}
+
+/// Skipping is fine on a dev machine without Go; in CI it is a broken job.
+///
+/// Every test in this crate needs `go` on PATH, so a runner without it turns the
+/// whole suite green in a quarter of a second — indistinguishable from a suite
+/// that passed, and exactly how the macOS leg went untested for as long as it
+/// did. Under `CI` this is a hard failure instead.
+pub fn no_go_or_panic() {
+    assert!(
+        std::env::var_os("CI").is_none(),
+        "go is not on PATH, so this test would silently skip. In CI that is a \
+         broken job, not a skip: the devenv shell provides `pkgs.go` (see \
+         devenv.nix), so reaching this means the test is not running inside it."
+    );
+    eprintln!("skipping: go not in PATH");
 }
 
 /// Whether a linked ELF executable declares a `PT_INTERP` program header — i.e.

--- a/crates/plugingo-e2e/tests/race.rs
+++ b/crates/plugingo-e2e/tests/race.rs
@@ -1,0 +1,82 @@
+#![expect(
+    clippy::panic_in_result_fn,
+    reason = "restriction/style lints scoped to production code; tests are exempt"
+)]
+
+//! End-to-end coverage for the `test_race` targets.
+//!
+//! Everything else about race mode — which flags reach `go tool compile`, what
+//! the addresses and cache keys look like, which archives the link pulls in — is
+//! asserted in `plugin-go`'s unit tests, where it runs in milliseconds. What can
+//! only be proven here is the part no spec assertion reaches: that the binary
+//! heph builds is *actually instrumented* and reports a real data race.
+//!
+//! [`race_detects_a_real_data_race`] is the load-bearing one. A `test_race` that
+//! silently dropped `-race` somewhere in the pipeline would still build, still
+//! run, and still pass — reporting a clean run for racy code, which is worse
+//! than not having the feature. That test fails unless TSan is genuinely live.
+//!
+//! These build the standard library with `-race` (a separate archive set from
+//! the ordinary one), so they are slower than the rest of the suite. Two tests
+//! rather than one because a detector that fires on everything is as broken as
+//! one that never fires — [`race_passes_on_a_clean_package`] pins the other end.
+
+mod common;
+
+use common::{fixture, make_workspace, require_go};
+
+/// A race build of a correctly-synchronised package passes. Proves the race
+/// pipeline — `go install -race std`, the instrumented per-package compiles, the
+/// `runtime/race` archive seeded into the link, the non-PIE buildmode on linux —
+/// produces a binary that runs and exits clean.
+#[tokio::test]
+async fn race_passes_on_a_clean_package() -> anyhow::Result<()> {
+    require_go!();
+    let dir = fixture("race")?;
+    let ws = make_workspace(dir)?;
+    ws.run("//clean:test_race@v=host").await?;
+    Ok(())
+}
+
+/// The one that proves the instrumentation is real: a package with an unguarded
+/// concurrent write fails under `test_race`, with the detector's own report in
+/// the output.
+///
+/// The fixture's assertion is deliberately loose (`want >= 1`), so the test
+/// cannot fail for any reason *except* the race detector firing.
+#[tokio::test]
+async fn race_detects_a_real_data_race() -> anyhow::Result<()> {
+    require_go!();
+    let dir = fixture("race")?;
+    let ws = make_workspace(dir)?;
+    // Empty when the target *succeeded* — which is itself a failure here, and
+    // the assertion below reports it.
+    let err = ws
+        .run("//racy:test_race@v=host")
+        .await
+        .err()
+        .map(|e| format!("{e:#}"))
+        .unwrap_or_default();
+    // `testing`'s own summary line, not the detector's `WARNING: DATA RACE`
+    // banner: heph reports only the tail of the log, and the banner sits above
+    // the goroutine stacks that fill it.
+    assert!(
+        err.contains("race detected during execution of test"),
+        "test_race must fail with the race detector's report on a package with a \
+         real data race (empty means it wrongly passed); got: {err}"
+    );
+    Ok(())
+}
+
+/// The control for [`race_detects_a_real_data_race`]: the *same* racy package
+/// passes under the ordinary `test` target. Without this, that test would also
+/// pass if the fixture were simply broken — this pins the failure on the
+/// instrumentation, and confirms race mode left the ordinary target alone.
+#[tokio::test]
+async fn ordinary_test_ignores_the_race() -> anyhow::Result<()> {
+    require_go!();
+    let dir = fixture("race")?;
+    let ws = make_workspace(dir)?;
+    ws.run("//racy:test@v=host").await?;
+    Ok(())
+}

--- a/crates/plugingo-e2e/tests/race.rs
+++ b/crates/plugingo-e2e/tests/race.rs
@@ -57,16 +57,36 @@ async fn race_detects_a_real_data_race() -> anyhow::Result<()> {
         .err()
         .map(|e| format!("{e:#}"))
         .unwrap_or_default();
-    // `testing`'s own summary line, not the detector's `WARNING: DATA RACE`
-    // banner: heph reports only the tail of the log, and the banner sits above
-    // the goroutine stacks that fill it.
     assert!(
-        err.contains("race detected during execution of test"),
+        RACE_MARKERS.iter().any(|m| err.contains(m)),
         "test_race must fail with the race detector's report on a package with a \
          real data race (empty means it wrongly passed); got: {err}"
     );
     Ok(())
 }
+
+/// Strings that only a ThreadSanitizer report produces, any one of which proves
+/// the binary was instrumented and fired.
+///
+/// It has to be a set rather than one line, because all we get is the **last 10
+/// lines** of the process log (`Engine::DEFAULT_LOG_TAIL_LINES`) and which part
+/// of the report lands in that window varies with how deep the goroutine stacks
+/// in the final report happen to be — deeper stacks on a CI runner pushed
+/// `race detected during execution of test` out of it, failing this test while
+/// the feature worked perfectly.
+///
+/// `==================` is the load-bearing one: it delimits every report, so it
+/// is always within the last few lines of a race-failing binary. The other two
+/// are friendlier to read when they do survive.
+const RACE_MARKERS: &[&str] = &[
+    // The report's own delimiter — always at or near the end of the output.
+    "==================",
+    // The banner, when the report is short enough to fit.
+    "DATA RACE",
+    // `testing`'s summary, when the race is caught during the test rather than
+    // at exit.
+    "race detected during execution of test",
+];
 
 /// The control for [`race_detects_a_real_data_race`]: the *same* racy package
 /// passes under the ordinary `test` target. Without this, that test would also

--- a/devenv.nix
+++ b/devenv.nix
@@ -61,6 +61,17 @@ in
   # https://devenv.sh/packages/
   packages = [
     pkgs.git
+    # The Go toolchain the go-plugin tests build against. Everything that calls
+    # `require_go!` runs `go` from PATH (`gotool = "host"`), so without this the
+    # whole suite depends on whatever the machine happens to have — and CI's
+    # macOS runner has none, which silently skipped every Go test there: 463
+    # `plugin-go` unit tests finished in 0.55s instead of 62s, and all 33
+    # `plugingo-e2e` tests in 0.25s instead of ~10min. Pinning it here fixes
+    # that for CI and local runs at once, and `gen-go-large` gets a `go` too.
+    #
+    # A `gotool = "<version>"` workspace downloads its own hermetic SDK and is
+    # unaffected by this; only the `host` toolchain reads it.
+    pkgs.go
     pkgs.buf
     pkgs.protoc-gen-prost
     pkgs.protoc-gen-prost-serde


### PR DESCRIPTION
Adds `test_race` / `xtest_race`: the same targets as `test` / `xtest`, built with `-race`.

```
heph run //mypkg:test_race@v=dev
heph run 'label(test-race)'
```

## Shape

Race instrumentation is a whole-program property — every archive in the link, stdlib included, has to agree — so this is a new build **factor** rather than a flag on one target. It rides the address as `race=1` and threads down the entire graph, so first-party, thirdparty and stdlib all resolve to race-instrumented archives kept separate from the ordinary ones.

`test_race` is a separate *name* rather than an addr arg on `test` because race is opt-in: it is several times slower to build and to run. For the same reason it is labelled `test-race` / `go-test-race` and deliberately does **not** carry `test`, so `heph run 'label(test)'` keeps meaning the ordinary suite. Both together is `label(test) || label(test-race)`.

The pipeline is `go list -race` (the file set *and* the import graph differ), `go tool compile -race` per package, `go install -race std` into its own `pkg/<goos>_<goarch>_race` dir, and `go tool link -race`. `runtime/race` is seeded into the link explicitly — it carries the prebuilt TSan runtime but **nothing imports it**, because `go build -race` injects it into the link itself; without the seed the link fails on undefined `__tsan_*` symbols.

## Two per-platform differences, both forced by Go

Neither changes what `test_race` means — it behaves identically on all three supported targets.

**cgo.** Go's `runtime/race` is a cgo package everywhere except darwin, which ships `race_darwin_<arch>.go` with syso-derived symbol info instead. So a darwin race build stays as hermetic as an ordinary one (`CGO_ENABLED=0`, no C toolchain at all), while linux enables cgo for the std install and stages a compiler — a new `cc` provider option defaulting to the hostbin `//@heph/bin:cc`. Only the std install needs it: the per-package compiles are pure Go, and the link resolves the TSan runtime internally. Both were verified with an empty `PATH` and no compiler present.

**buildmode.** `go build` refuses `-buildmode=pie` with `-race` on linux. `go tool link` — which is what this plugin calls — does *not* enforce that: it accepts the combination and produces a binary that dies at startup with `ThreadSanitizer failed to allocate`. So linux race links `-buildmode=exe`, and `-shared` drops with it to match the archives `go install -race` produced.

## No cache invalidation

The `race` addr arg is omitted when unset, and the golist/compile def hashes contribute nothing when it is false, so every ordinary target's address and cache key are byte-identical to what they were before this landed. Both hashes are pinned by tests that fail if that stops being true.

A `race` value other than `1` is rejected rather than ignored — silently building without instrumentation and reporting a clean run is the one failure mode of this feature a user cannot spot.

## Testing

Unit tests cover the factor threading, flag emission, the `runtime/race` seeding, the platform rules, the labels, and the two cache-key properties.

`crates/plugingo-e2e/tests/race.rs` covers what no spec assertion can — that the binary is *actually* instrumented:

- a package with a real data race **fails** under `test_race`, with the detector's report;
- the same package **passes** under plain `test` (the control — pins the failure on the instrumentation, not a broken fixture);
- a clean package **passes** under `test_race`.

Verified end to end on darwin/arm64 locally and on linux/arm64 in a container. These build std with `-race`, so they are slower than the rest of the suite.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014ZMMAeMTepMcKRYuRtcqP4