### PR TITLE
feat(plugin-go): link binaries statically by default, with a `buildmode` knob

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4302,6 +4302,7 @@ dependencies = [
  "futures",
  "heph",
  "model",
+ "object 0.37.3",
  "plugin",
  "plugin-go",
  "tempfile",

--- a/crates/plugin-go/src/plugingo/driver_compile.rs
+++ b/crates/plugin-go/src/plugingo/driver_compile.rs
@@ -13,6 +13,7 @@
 //! byte-compatible.
 
 use crate::plugingo::embed;
+use crate::plugingo::factors::BuildMode;
 use crate::plugingo::pkg_analysis::decode_go_package;
 use anyhow::Context;
 use async_trait::async_trait;
@@ -100,6 +101,10 @@ struct GoCompileSpec {
     goexperiment: Vec<String>,
     /// Extra flags passed verbatim to `go tool compile` (the variant's gcflags).
     gcflags: Vec<String>,
+    /// Variant buildmode (`exe`/`pie`); empty → `exe`. Decides whether the
+    /// compile/asm steps get `-shared`, which must agree with the link's
+    /// `-buildmode=` (see `BuildMode::needs_shared`).
+    buildmode: String,
     /// Import paths of the transitive libs, in deterministic order — each maps to
     /// a `lib_<sanitized>` dep group carrying that archive, used to build
     /// importcfg.
@@ -124,6 +129,7 @@ struct GoCompileDef {
     go_version: String,
     goexperiment: Vec<String>,
     gcflags: Vec<String>,
+    buildmode: BuildMode,
     import_paths: Vec<String>,
     s_files: Vec<String>,
     embed_variant: Option<EmbedVariant>,
@@ -135,7 +141,7 @@ struct GoCompileDef {
 
 /// Bump to invalidate every cached `go_compile` archive whenever the compile
 /// command shape or embed resolution semantics change.
-const GO_COMPILE_FORMAT_VERSION: u32 = 3;
+const GO_COMPILE_FORMAT_VERSION: u32 = 4;
 
 impl Hash for GoCompileDef {
     fn hash<H: Hasher>(&self, state: &mut H) {
@@ -150,6 +156,9 @@ impl Hash for GoCompileDef {
         // `gcflags` order is semantically meaningful, so hash as-is.
         self.goexperiment.hash(state);
         self.gcflags.hash(state);
+        // `-shared` presence hangs off this, and a `-shared` archive is not
+        // interchangeable with a plain one.
+        self.buildmode.hash(state);
         // `import_paths` order is not semantically meaningful — it comes from a
         // closure walk that dedups through a per-process-randomized `HashSet`,
         // and `run()` re-sorts before writing importcfg, so the archive is
@@ -249,6 +258,21 @@ impl ManagedDriver for GoCompileDriver {
             .first()
             .and_then(|s| EmbedVariant::parse(s));
 
+        // Absent (or empty) means the default `exe`; an unrecognized spelling is
+        // a hard error rather than a silent fallback — it would change the
+        // linkage of the produced binary.
+        let buildmode = if spec.buildmode.is_empty() {
+            BuildMode::default()
+        } else {
+            BuildMode::parse(&spec.buildmode).ok_or_else(|| {
+                anyhow::anyhow!(
+                    "unknown `buildmode` `{}` (allowed: {})",
+                    spec.buildmode,
+                    BuildMode::NAMES.join(", ")
+                )
+            })?
+        };
+
         let def = GoCompileDef {
             p_flag: spec.p_flag,
             out_file: spec.out_file,
@@ -257,6 +281,7 @@ impl ManagedDriver for GoCompileDriver {
             go_version: spec.go_version,
             goexperiment: spec.goexperiment,
             gcflags: spec.gcflags,
+            buildmode,
             import_paths: spec.import_paths,
             s_files: spec.s_files,
             embed_variant,
@@ -404,7 +429,9 @@ impl ManagedDriver for GoCompileDriver {
         };
 
         let has_asm = !def.s_files.is_empty();
-        let shared = "-shared";
+        // `-shared` iff the link is PIE — cmd/go couples them the same way, and a
+        // mismatch is a link failure, not a slower binary.
+        let shared: Option<&str> = def.buildmode.needs_shared().then_some("-shared");
         let trimpath = format!("-trimpath={ws_root}");
         let goinc = format!("{}/pkg/include", goroot.to_string_lossy());
 
@@ -428,11 +455,13 @@ impl ManagedDriver for GoCompileDriver {
                 format!("GOOS_{}", def.goos),
                 "-D".to_string(),
                 format!("GOARCH_{}", def.goarch),
-                shared.to_string(),
+            ];
+            args.extend(shared.map(str::to_string));
+            args.extend([
                 "-gensymabis".to_string(),
                 "-o".to_string(),
                 "symabis".to_string(),
-            ];
+            ]);
             for s in &def.s_files {
                 args.push(format!("./{s}"));
             }
@@ -471,7 +500,7 @@ impl ManagedDriver for GoCompileDriver {
             cargs.push("-embedcfg".to_string());
             cargs.push("embedcfg".to_string());
         }
-        cargs.push(shared.to_string());
+        cargs.extend(shared.map(str::to_string));
         cargs.push("-o".to_string());
         cargs.push(def.out_file.clone());
         cargs.push(format!("@{}", rsp_path.to_string_lossy()));
@@ -482,7 +511,7 @@ impl ManagedDriver for GoCompileDriver {
         if has_asm {
             for s in &def.s_files {
                 let obj = format!("{}.o", s.trim_end_matches(".s"));
-                let args = vec![
+                let mut args = vec![
                     "tool".to_string(),
                     "asm".to_string(),
                     "-p".to_string(),
@@ -496,11 +525,9 @@ impl ManagedDriver for GoCompileDriver {
                     format!("GOOS_{}", def.goos),
                     "-D".to_string(),
                     format!("GOARCH_{}", def.goarch),
-                    shared.to_string(),
-                    "-o".to_string(),
-                    obj,
-                    format!("./{s}"),
                 ];
+                args.extend(shared.map(str::to_string));
+                args.extend(["-o".to_string(), obj, format!("./{s}")]);
                 self.exec_go(&go_bin, run_go(args), &env, pkg_dir, ctoken, "asm")
                     .await?;
             }
@@ -821,6 +848,10 @@ pub fn build_compile_spec(p: CompileParams) -> TargetSpec {
         str_list(&p.factors.goexperiment),
     );
     config.insert("gcflags".to_string(), str_list(&p.factors.gcflags));
+    config.insert(
+        "buildmode".to_string(),
+        Value::String(p.factors.buildmode.as_str().to_string()),
+    );
     config.insert("import_paths".to_string(), Value::List(import_paths));
     config.insert("s_files".to_string(), str_list(p.s_files));
     config.insert(
@@ -1021,6 +1052,75 @@ mod driver_tests {
         );
     }
 
+    fn spec_with_buildmode(buildmode: BuildMode) -> TargetSpec {
+        build_compile_spec(CompileParams {
+            addr: Addr::new(
+                PkgBuf::from("mylib"),
+                "build_lib".to_string(),
+                Default::default(),
+            ),
+            p_flag: "example.com/mylib".to_string(),
+            out_file: "x.a".to_string(),
+            factors: &Factors {
+                buildmode,
+                ..factors()
+            },
+            go_version: V,
+            transitive_libs: &[],
+            src_addrs: &["//mylib:a.go".to_string()],
+            s_files: &[],
+            s_file_addrs: &[],
+            hdr_addrs: &[],
+            golist_addr: None,
+            embed_variant: "",
+            embed_file_addrs: &[],
+            embed_src_addrs: &[],
+        })
+    }
+
+    // A `pie` archive is compiled `-shared` and an `exe` one is not; the two are
+    // NOT interchangeable (a `-shared` archive fails a non-PIE link). Serving one
+    // from a cache entry keyed by the other is a build that cannot link.
+    #[tokio::test]
+    async fn buildmode_keys_the_compile_cache() {
+        let exe = parse_def(spec_with_buildmode(BuildMode::Exe)).await;
+        let pie = parse_def(spec_with_buildmode(BuildMode::Pie)).await;
+        assert_eq!(exe.def::<GoCompileDef>().buildmode, BuildMode::Exe);
+        assert_eq!(pie.def::<GoCompileDef>().buildmode, BuildMode::Pie);
+        assert_ne!(
+            exe.hash, pie.hash,
+            "exe and pie archives must not share a cache key"
+        );
+    }
+
+    // An unparseable buildmode must fail the parse rather than quietly linking a
+    // different kind of binary than the author asked for.
+    #[tokio::test]
+    async fn unknown_buildmode_is_rejected() {
+        let mut spec = spec_with_buildmode(BuildMode::Exe);
+        spec.config.insert(
+            "buildmode".to_string(),
+            Value::String("c-archive".to_string()),
+        );
+        let ct = hcore::hasync::StdCancellationToken::new();
+        let Err(err) = GoCompileDriver::new()
+            .parse(
+                ParseRequest {
+                    request_id: "t".to_string(),
+                    target_spec: std::sync::Arc::new(spec),
+                },
+                &ct,
+            )
+            .await
+        else {
+            panic!("an unknown buildmode must not parse");
+        };
+        assert!(
+            format!("{err:#}").contains("unknown `buildmode` `c-archive`"),
+            "{err:#}"
+        );
+    }
+
     fn def_hash(def: &GoCompileDef) -> u64 {
         let mut h = std::collections::hash_map::DefaultHasher::new();
         def.hash(&mut h);
@@ -1105,6 +1205,7 @@ mod driver_tests {
             go_version: "1.26.4".to_string(),
             goexperiment: vec![],
             gcflags: vec![],
+            buildmode: BuildMode::default(),
             import_paths: ips.iter().map(|s| s.to_string()).collect(),
             s_files: vec![],
             embed_variant: None,

--- a/crates/plugin-go/src/plugingo/factors.rs
+++ b/crates/plugin-go/src/plugingo/factors.rs
@@ -1,5 +1,62 @@
 use std::collections::BTreeMap;
 
+/// Link buildmode — the `go build -buildmode=` equivalent, narrowed to the two
+/// modes that make sense for an executable heph links itself.
+///
+/// [`BuildMode::Exe`] is the default, matching what plain `go build` produces:
+/// on Linux the binary is **statically linked** with no `PT_INTERP`, so it runs
+/// in a `FROM scratch` image. [`BuildMode::Pie`] asks for a position-independent
+/// executable, which on Linux always carries an interpreter
+/// (`/lib/ld-linux-<arch>.so.1`) even with cgo disabled and internal linking —
+/// that is Go's behaviour, not a heph choice.
+///
+/// Uniform across the supported targets: on darwin/arm64 the Go linker upgrades
+/// `exe` to PIE unconditionally (`cmd/link`: "on these platforms, everything is
+/// PIE"), so both modes link and both produce a PIE Mach-O. The knob is honored
+/// everywhere; darwin simply has one possible answer.
+#[derive(
+    Debug, Clone, Copy, PartialEq, Eq, Hash, Default, serde::Serialize, serde::Deserialize,
+)]
+pub enum BuildMode {
+    #[default]
+    Exe,
+    Pie,
+}
+
+impl BuildMode {
+    /// Accepted spellings, for schema docs and "allowed: [...]" errors.
+    pub const NAMES: &'static [&'static str] = &["exe", "pie"];
+
+    pub fn parse(s: &str) -> Option<Self> {
+        match s {
+            "exe" => Some(Self::Exe),
+            "pie" => Some(Self::Pie),
+            _ => None,
+        }
+    }
+
+    /// The `-buildmode=` value handed to `go tool link`.
+    pub fn as_str(self) -> &'static str {
+        match self {
+            Self::Exe => "exe",
+            Self::Pie => "pie",
+        }
+    }
+
+    /// Whether `go tool compile` / `go tool asm` need `-shared`.
+    ///
+    /// Mirrors cmd/go (`internal/work/init.go`): `-buildmode=pie` adds `-shared`
+    /// to the codegen flags, `-buildmode=exe` does not. The two **must** agree —
+    /// a `-shared` archive fails a non-PIE internal link with `cannot handle
+    /// R_ARM64_TLS_IE (sym runtime.load_g) when linking internally`. The reverse
+    /// (plain archives into a PIE link) is fine, which is why the std library —
+    /// built by `go install std`, i.e. under cmd/go's own defaults — links into
+    /// either mode.
+    pub fn needs_shared(self) -> bool {
+        matches!(self, Self::Pie)
+    }
+}
+
 /// Resolved build variant: the concrete set of Go toolchain factors a target
 /// compiles/links under. Produced by resolving a [`VariantRef`] (`v`/`vp` addr
 /// args) against the `variants` provider_state (see
@@ -10,7 +67,9 @@ use std::collections::BTreeMap;
 /// functions). GOOS/GOARCH/GOEXPERIMENT/CGO are set as process env in the driver
 /// `run()` (never as hashed config keys), so they are hashed via those `Def`s;
 /// gcflags land on the `go tool compile` command line; ldflags land on the link
-/// script (hashed transitively by the exec driver's run-script hash).
+/// script (hashed transitively by the exec driver's run-script hash); `buildmode`
+/// lands on both — `-shared` on the compile (hashed by `GoCompileDef`) and
+/// `-buildmode=` on the link script.
 #[derive(Debug, Clone, PartialEq, Eq, Hash, Default)]
 pub struct Factors {
     pub goos: String,
@@ -25,6 +84,10 @@ pub struct Factors {
     /// Flags passed verbatim to `go tool link` (the `-ldflags` equivalent).
     /// Order preserved.
     pub ldflags: Vec<String>,
+    /// Link buildmode. Drives both `go tool link -buildmode=` and whether the
+    /// compile steps get `-shared` — the two are coupled, see
+    /// [`BuildMode::needs_shared`].
+    pub buildmode: BuildMode,
 }
 
 impl Factors {
@@ -99,6 +162,32 @@ mod tests {
         let vref = VariantRef::new("release", "");
         let args = vref.to_args();
         assert_eq!(args.get("vp").map(String::as_str), Some(""));
+    }
+
+    // The compile-side `-shared` and the link-side `-buildmode=` are a single
+    // decision expressed twice. A `-shared` archive cannot be linked into a
+    // non-PIE executable — the link dies on `cannot handle R_ARM64_TLS_IE (sym
+    // runtime.load_g)`. If these two ever disagree, every Go binary stops linking.
+    #[test]
+    fn shared_is_required_exactly_for_pie() {
+        assert!(BuildMode::Pie.needs_shared());
+        assert!(!BuildMode::Exe.needs_shared());
+    }
+
+    // `NAMES` feeds the "allowed: …" errors and the state schema; it must stay in
+    // step with what `parse` accepts and what `as_str` emits.
+    #[test]
+    fn buildmode_names_roundtrip_through_parse() {
+        for name in BuildMode::NAMES {
+            let mode = BuildMode::parse(name).unwrap_or_else(|| panic!("`{name}` must parse"));
+            assert_eq!(mode.as_str(), *name);
+        }
+        assert!(BuildMode::parse("c-archive").is_none());
+    }
+
+    #[test]
+    fn buildmode_defaults_to_exe() {
+        assert_eq!(Factors::default().buildmode, BuildMode::Exe);
     }
 
     #[test]

--- a/crates/plugin-go/src/plugingo/provider.rs
+++ b/crates/plugin-go/src/plugingo/provider.rs
@@ -476,6 +476,7 @@ impl ProviderTrait for Provider {
             ("goexperiment", ParamType::list(ParamType::String)),
             ("gcflags", ParamType::list(ParamType::String)),
             ("ldflags", ParamType::list(ParamType::String)),
+            ("buildmode", ParamType::String),
         ]);
         Some(StateSchema {
             fields: vec![
@@ -485,8 +486,14 @@ impl ProviderTrait for Provider {
                     "Named Go build variants for this package (and its descendants, via \
                      closest-ancestor lookup). Maps a variant name to a static factor set: \
                      `goos`/`goarch` (required), plus optional `tags` (build tags), \
-                     `goexperiment` (GOEXPERIMENT), `gcflags` (extra `go tool compile` flags) \
-                     and `ldflags` (extra `go tool link` flags). \
+                     `goexperiment` (GOEXPERIMENT), `gcflags` (extra `go tool compile` flags), \
+                     `ldflags` (extra `go tool link` flags) and `buildmode` \
+                     (`exe`, the default, or `pie`). `exe` matches plain `go build`: on \
+                     Linux it links a static binary with no interpreter, so it runs in a \
+                     `FROM scratch` image; `pie` produces a position-independent executable, \
+                     which on Linux always needs `/lib/ld-linux-<arch>.so.1` present. On \
+                     darwin/arm64 the Go linker makes every executable PIE, so both modes \
+                     land in the same place there. \
                      A user-facing target selects one with `@v=NAME`, resolving the closest \
                      ancestor package that defines that name; variants do NOT compound across \
                      the tree (each definition is self-contained).",

--- a/crates/plugin-go/src/plugingo/target_bin.rs
+++ b/crates/plugin-go/src/plugingo/target_bin.rs
@@ -2,7 +2,7 @@ use crate::plugingo::addr_util::{
     go_build_env, go_host_pass_env_config, go_run_prelude, go_sdk_dep, go_sdk_read_only_config,
     import_path_to_dep_group, to_run_value, write_importcfg_script,
 };
-use crate::plugingo::factors::Factors;
+use crate::plugingo::factors::{BuildMode, Factors};
 use hcore::htvalue::Value;
 use hmodel::htaddr::Addr;
 use hplugin::provider::TargetSpec;
@@ -69,6 +69,7 @@ pub fn build_spec(
         &binary_name,
         transitive_libs,
         &link_flags,
+        factors.buildmode,
     ));
 
     let mut deps: BTreeMap<String, Value> = transitive_libs
@@ -154,6 +155,7 @@ fn generate_link_script(
     binary_name: &str,
     transitive_libs: &[(String, Addr)],
     link_flags: &[String],
+    buildmode: BuildMode,
 ) -> Vec<String> {
     // The main package is passed as a positional arg to the linker, not via importcfg.
     let mut lines = write_importcfg_script(transitive_libs, Some(self_import_path));
@@ -165,11 +167,14 @@ fn generate_link_script(
     } else {
         format!(" {}", link_flags.join(" "))
     };
-    // -buildmode=pie matches Go's default on darwin/arm64 (and most modern
-    // platforms). Libs were compiled with -shared, so the link must agree on
-    // PIE — otherwise asm relocations from transitive deps fail to resolve.
+    // The variant's buildmode, defaulting to `exe` — same as plain `go build`,
+    // so on Linux the binary comes out statically linked with no PT_INTERP. It
+    // must agree with whether the libs were compiled `-shared`
+    // (`BuildMode::needs_shared`): a `-shared` archive cannot be linked into a
+    // non-PIE executable, its asm relocations fail to resolve.
+    let mode = buildmode.as_str();
     lines.push(format!(
-        "\"$GO\" tool link -importcfg \"$importcfg\" -buildmode=pie{flags} -o {} \"${}\"",
+        "\"$GO\" tool link -importcfg \"$importcfg\" -buildmode={mode}{flags} -o {} \"${}\"",
         binary_name, self_env_var
     ));
     lines
@@ -270,6 +275,61 @@ mod tests {
         let run = run_str(&spec);
         assert!(run.contains("tool link"));
         assert!(run.contains("importcfg"));
+    }
+
+    // heph used to hardcode `-buildmode=pie`, which on Linux emits a PT_INTERP
+    // even with cgo off — the binary then fails to exec in a scratch image. The
+    // default must be `exe`, what plain `go build` does.
+    #[test]
+    fn test_link_defaults_to_buildmode_exe() {
+        let spec = build_spec(
+            test_addr(),
+            "example.com/cmd",
+            &test_factors(),
+            &[],
+            &LinkConfig::default(),
+            V,
+        );
+        let run = run_str(&spec);
+        assert!(run.contains("-buildmode=exe"), "{run}");
+        assert!(!run.contains("-buildmode=pie"), "{run}");
+    }
+
+    #[test]
+    fn test_link_honors_the_pie_buildmode() {
+        let factors = Factors {
+            buildmode: BuildMode::Pie,
+            ..test_factors()
+        };
+        let spec = build_spec(
+            test_addr(),
+            "example.com/cmd",
+            &factors,
+            &[],
+            &LinkConfig::default(),
+            V,
+        );
+        assert!(run_str(&spec).contains("-buildmode=pie"));
+    }
+
+    // The buildmode must precede the user's ldflags, so a variant can still pass
+    // linker flags without them being swallowed by the mode argument.
+    #[test]
+    fn test_ldflags_follow_the_buildmode() {
+        let factors = Factors {
+            ldflags: vec!["-X".to_string(), "main.v=1".to_string()],
+            ..test_factors()
+        };
+        let spec = build_spec(
+            test_addr(),
+            "example.com/cmd",
+            &factors,
+            &[],
+            &LinkConfig::default(),
+            V,
+        );
+        let run = run_str(&spec);
+        assert!(run.contains("-buildmode=exe -X main.v=1 -o"), "{run}");
     }
 
     #[test]

--- a/crates/plugin-go/src/plugingo/target_test.rs
+++ b/crates/plugin-go/src/plugingo/target_test.rs
@@ -184,8 +184,11 @@ pub fn build_test_spec(
     } else {
         format!(" {}", factors.ldflags.join(" "))
     };
+    // Same coupling as the binary link (see `target_bin::generate_link_script`):
+    // the mode here must match what the archives were compiled under.
+    let mode = factors.buildmode.as_str();
     script.push(format!(
-        "\"$GO\" tool link -importcfg \"$importcfg\" -buildmode=pie{ldflags} -o test_binary \"$SRC_TESTMAIN\""
+        "\"$GO\" tool link -importcfg \"$importcfg\" -buildmode={mode}{ldflags} -o test_binary \"$SRC_TESTMAIN\""
     ));
 
     let mut deps: BTreeMap<String, Value> = BTreeMap::new();
@@ -603,6 +606,34 @@ mod tests {
             !run.contains("test -c"),
             "build_test run must NOT use go test -c: {run}"
         );
+    }
+
+    // The test binary links from the same archives as the `build` binary, so its
+    // buildmode must track the variant too — a `pie` link over `exe`-compiled
+    // archives (or the reverse) is a link failure, not a slower test.
+    #[test]
+    fn test_build_test_spec_link_follows_the_variant_buildmode() {
+        let testmain_lib = mk_addr("pkg", "build_testmain_lib");
+        let exe = run_str(&build_test_spec(
+            mk_addr("pkg", "build_test"),
+            &test_factors(),
+            &testmain_lib,
+            &[],
+            V,
+        ));
+        assert!(exe.contains("-buildmode=exe"), "{exe}");
+
+        let pie = run_str(&build_test_spec(
+            mk_addr("pkg", "build_test"),
+            &Factors {
+                buildmode: crate::plugingo::factors::BuildMode::Pie,
+                ..test_factors()
+            },
+            &testmain_lib,
+            &[],
+            V,
+        ));
+        assert!(pie.contains("-buildmode=pie"), "{pie}");
     }
 
     #[test]

--- a/crates/plugin-go/src/plugingo/variant.rs
+++ b/crates/plugin-go/src/plugingo/variant.rs
@@ -26,7 +26,7 @@
 //! **same `variants` map** and override selected fields (list fields replace, not
 //! append). `goos`/`goarch` may be omitted when inherited. Cycles are rejected.
 
-use crate::plugingo::factors::{Factors, VariantRef};
+use crate::plugingo::factors::{BuildMode, Factors, VariantRef};
 use anyhow::{Context, bail};
 use hcore::htvalue::{Value, parse_strings};
 use hmodel::htaddr::Addr;
@@ -46,6 +46,7 @@ const VARIANT_KEYS: &[&str] = &[
     "goexperiment",
     "gcflags",
     "ldflags",
+    "buildmode",
     "inherit",
 ];
 
@@ -60,6 +61,7 @@ struct RawVariant {
     goexperiment: Option<Vec<String>>,
     gcflags: Option<Vec<String>>,
     ldflags: Option<Vec<String>>,
+    buildmode: Option<BuildMode>,
     inherit: Option<String>,
 }
 
@@ -101,6 +103,15 @@ fn parse_raw(name: &str, v: &Value) -> anyhow::Result<RawVariant> {
             None => Ok(None),
         }
     };
+    let buildmode = match opt_str("buildmode")? {
+        Some(s) => Some(BuildMode::parse(&s).ok_or_else(|| {
+            anyhow::anyhow!(
+                "go variant `{name}`: unknown `buildmode` `{s}` (allowed: {})",
+                BuildMode::NAMES.join(", ")
+            )
+        })?),
+        None => None,
+    };
     Ok(RawVariant {
         goos: opt_str("goos")?,
         goarch: opt_str("goarch")?,
@@ -108,6 +119,7 @@ fn parse_raw(name: &str, v: &Value) -> anyhow::Result<RawVariant> {
         goexperiment: opt_list("goexperiment")?,
         gcflags: opt_list("gcflags")?,
         ldflags: opt_list("ldflags")?,
+        buildmode,
         inherit: opt_str("inherit")?,
     })
 }
@@ -175,6 +187,9 @@ fn resolve_in_map(
     }
     if let Some(v) = &def.ldflags {
         f.ldflags = v.clone();
+    }
+    if let Some(v) = def.buildmode {
+        f.buildmode = v;
     }
 
     if f.goos.is_empty() || f.goarch.is_empty() {
@@ -469,6 +484,91 @@ mod tests {
         assert_eq!(f.goexperiment, vec!["arenas"]);
         assert_eq!(f.gcflags, vec!["-l", "-N"]); // order preserved
         assert_eq!(f.ldflags, vec!["-s", "-w"]);
+    }
+
+    #[test]
+    fn buildmode_defaults_to_exe() {
+        let st = go_state("", &[("v", linux_amd64())]);
+        let f = variant_in_state(&st, "v").unwrap().unwrap();
+        assert_eq!(
+            f.buildmode,
+            BuildMode::Exe,
+            "an undeclared buildmode must match plain `go build`, not PIE"
+        );
+    }
+
+    #[test]
+    fn buildmode_pie_is_parsed() {
+        let st = go_state(
+            "",
+            &[(
+                "v",
+                variant_val(&[
+                    ("goos", s("linux")),
+                    ("goarch", s("amd64")),
+                    ("buildmode", s("pie")),
+                ]),
+            )],
+        );
+        let f = variant_in_state(&st, "v").unwrap().unwrap();
+        assert_eq!(f.buildmode, BuildMode::Pie);
+    }
+
+    // An unrecognized buildmode silently falling back to the default would change
+    // the linkage of the shipped binary without saying so.
+    #[test]
+    fn buildmode_unknown_value_errors() {
+        let st = go_state(
+            "",
+            &[(
+                "v",
+                variant_val(&[
+                    ("goos", s("linux")),
+                    ("goarch", s("amd64")),
+                    ("buildmode", s("c-shared")),
+                ]),
+            )],
+        );
+        let err = variant_in_state(&st, "v").unwrap_err();
+        let msg = format!("{err:#}");
+        assert!(msg.contains("unknown `buildmode` `c-shared`"), "{msg}");
+        assert!(
+            msg.contains("exe, pie"),
+            "must list the allowed modes: {msg}"
+        );
+    }
+
+    #[test]
+    fn buildmode_is_inherited_and_overridable() {
+        let st = go_state(
+            "",
+            &[
+                (
+                    "base",
+                    variant_val(&[
+                        ("goos", s("linux")),
+                        ("goarch", s("amd64")),
+                        ("buildmode", s("pie")),
+                    ]),
+                ),
+                ("child", variant_val(&[("inherit", s("base"))])),
+                (
+                    "child_exe",
+                    variant_val(&[("inherit", s("base")), ("buildmode", s("exe"))]),
+                ),
+            ],
+        );
+        assert_eq!(
+            variant_in_state(&st, "child").unwrap().unwrap().buildmode,
+            BuildMode::Pie
+        );
+        assert_eq!(
+            variant_in_state(&st, "child_exe")
+                .unwrap()
+                .unwrap()
+                .buildmode,
+            BuildMode::Exe
+        );
     }
 
     #[test]

--- a/crates/plugingo-e2e/Cargo.toml
+++ b/crates/plugingo-e2e/Cargo.toml
@@ -19,3 +19,5 @@ tokio = { version = "1", features = ["rt", "rt-multi-thread", "macros"] }
 anyhow = "1"
 tempfile = "3"
 futures = "0.3"
+# Reads the program headers of a linked Go binary, to assert its buildmode.
+object = { version = "0.37", default-features = false, features = ["read_core", "elf", "std"] }

--- a/crates/plugingo-e2e/tests/build.rs
+++ b/crates/plugingo-e2e/tests/build.rs
@@ -159,6 +159,44 @@ async fn test_with_dep_cmd_build() -> anyhow::Result<()> {
     Ok(())
 }
 
+/// The default buildmode (`exe`) must produce a Linux binary with **no**
+/// `PT_INTERP` — a static executable that runs in a `FROM scratch` image. heph
+/// used to hardcode `-buildmode=pie`, which emits an interpreter even with cgo
+/// off and internal linking, so a scratch container failed at `execve`.
+///
+/// Cross-compiled to linux/amd64 so the assertion holds on every build host; the
+/// link itself is the other half of the test, since `exe` mode also drops
+/// `-shared` from the compile and a mismatch between the two fails the link.
+#[tokio::test]
+async fn test_default_buildmode_links_a_static_binary() -> anyhow::Result<()> {
+    require_go!();
+    let dir = fixture("with_dep")?;
+    let ws = make_workspace_hermetic(dir)?;
+    let result = ws.run("//cmd:build@v=linux_amd64").await?;
+    assert!(
+        !common::has_interp(&common::artifact_bytes(&result))?,
+        "default (buildmode=exe) must link statically — no PT_INTERP"
+    );
+    Ok(())
+}
+
+/// The `buildmode = "pie"` knob is the escape hatch, and it must still work: the
+/// compile side has to put `-shared` back, otherwise the PIE link fails on the
+/// asm relocations of transitive deps. The result carries `PT_INTERP` — the very
+/// thing `exe` avoids — so the two tests together pin both directions.
+#[tokio::test]
+async fn test_pie_buildmode_links_a_position_independent_binary() -> anyhow::Result<()> {
+    require_go!();
+    let dir = fixture("with_dep")?;
+    let ws = make_workspace_hermetic(dir)?;
+    let result = ws.run("//cmd:build@v=linux_amd64_pie").await?;
+    assert!(
+        common::has_interp(&common::artifact_bytes(&result))?,
+        "buildmode=pie must produce a PIE with an interpreter"
+    );
+    Ok(())
+}
+
 /// End-to-end proof of the cross-subtree variant universe: the `release` variant
 /// is declared ONLY at `//cmd` (via its BUILD `provider_state`). Building
 /// `//cmd:build@v=release` threads `vp=cmd` onto the `//lib` dependency, whose own

--- a/crates/plugingo-e2e/tests/common/mod.rs
+++ b/crates/plugingo-e2e/tests/common/mod.rs
@@ -19,7 +19,7 @@ use plugin_go::plugingo;
 use std::path::PathBuf;
 use tempfile::TempDir;
 
-pub use htestkit::{artifact_paths, artifact_string};
+pub use htestkit::{artifact_bytes, artifact_paths, artifact_string};
 
 macro_rules! require_go {
     () => {
@@ -37,6 +37,29 @@ pub fn go_available() -> bool {
         .output()
         .map(|o| o.status.success())
         .unwrap_or(false)
+}
+
+/// Whether a linked ELF executable declares a `PT_INTERP` program header — i.e.
+/// needs a dynamic loader (`/lib/ld-linux-<arch>.so.1`) present at exec time.
+///
+/// This is the distinction `file(1)` reports as `dynamically linked, interpreter
+/// …` vs `statically linked`, and the one that decides whether the binary runs
+/// in a `FROM scratch` image. A pure-Go `-buildmode=pie` link has no `DT_NEEDED`
+/// entries yet still carries `PT_INTERP`, so "does it link against libc" is the
+/// wrong question — this is the right one.
+///
+/// Mach-O has no equivalent (every darwin executable is dynamically linked
+/// against libSystem), so callers gate this on a Linux host.
+pub fn has_interp(data: &[u8]) -> anyhow::Result<bool> {
+    use object::read::elf::{FileHeader as _, ProgramHeader as _};
+    let header =
+        object::elf::FileHeader64::<object::Endianness>::parse(data).context("parse as ELF64")?;
+    let endian = header.endian().context("ELF endianness")?;
+    Ok(header
+        .program_headers(endian, data)
+        .context("read ELF program headers")?
+        .iter()
+        .any(|ph| ph.p_type(endian) == object::elf::PT_INTERP))
 }
 
 pub fn testdata(name: &str) -> PathBuf {
@@ -105,9 +128,14 @@ fn sdk_checksums_for(gotool: &str) -> std::collections::HashMap<String, String> 
 
 /// A minimal provider that injects the Go build *variants* every e2e workspace
 /// needs, without editing each fixture's BUILD file. Its `probe` returns, for the
-/// root package, a `provider="go"` state declaring two variants:
+/// root package, a `provider="go"` state declaring three variants:
 ///   - `host`: the build host's own GOOS/GOARCH (the default the suite uses),
-///   - `linux_amd64`: pinned linux/amd64 (for the build-tag cross-compile tests).
+///   - `linux_amd64`: pinned linux/amd64 (for the build-tag cross-compile tests),
+///   - `linux_amd64_pie`: as `linux_amd64`, but `buildmode = "pie"`.
+///
+/// The buildmode tests use the pinned pair rather than `host` so they assert on
+/// an ELF whatever the build host is — the distinction they care about
+/// (`PT_INTERP` or not) has no Mach-O equivalent.
 ///
 /// Every other endpoint is empty — targets/packages come from the real providers.
 struct VariantInjector;
@@ -121,12 +149,18 @@ impl VariantInjector {
                 ("goarch".to_string(), Value::String(goarch.to_string())),
             ]))
         };
+        let linux_amd64_pie = Value::Map(std::collections::HashMap::from([
+            ("goos".to_string(), Value::String("linux".to_string())),
+            ("goarch".to_string(), Value::String("amd64".to_string())),
+            ("buildmode".to_string(), Value::String("pie".to_string())),
+        ]));
         let variants = Value::Map(std::collections::HashMap::from([
             (
                 "host".to_string(),
                 variant(hcore::htplatform::os(), hcore::htplatform::arch()),
             ),
             ("linux_amd64".to_string(), variant("linux", "amd64")),
+            ("linux_amd64_pie".to_string(), linux_amd64_pie),
         ]));
         hplugin::provider::State {
             package: hmodel::htpkg::PkgBuf::from(""),


### PR DESCRIPTION
## The bug

Every binary the Go plugin produced came out dynamically linked on Linux:

```
dist/core-fleet: ELF 64-bit LSB pie executable, ARM aarch64, dynamically linked,
                 interpreter /lib/ld-linux-aarch64.so.1, with debug_info, not stripped
```

Not cgo — `CGO_ENABLED=0` was already pinned everywhere. The cause was a hardcoded `-buildmode=pie` on the link (`target_bin.rs`, `target_test.rs`) plus the `-shared` it requires on every `go tool compile`/`asm` (`driver_compile.rs`).

On Linux, `-buildmode=pie` emits a `PT_INTERP` even with cgo off and internal linking. There are no `DT_NEEDED` entries — the binary is self-contained — but it still needs `ld-linux-<arch>.so.1` to exist, so it fails at `execve` in a `FROM scratch` or distroless image.

Plain `go build` does not do this. Verified against go1.25.1, `GOOS=linux GOARCH=arm64 CGO_ENABLED=0`:

| build | `file` output |
|---|---|
| `-buildmode=pie` (what heph did) | `pie executable … dynamically linked, interpreter /lib/ld-linux-aarch64.so.1` |
| `-buildmode=exe` (Go's default on linux) | `executable … statically linked` |

The comment at `target_bin.rs:168` said pie "matches Go's default on darwin/arm64" — true for darwin, but it was applied to every platform.

## The change

A `buildmode` variant factor, `exe` (default) or `pie`, threaded to both sites:

```python
provider_state(provider = "go", variants = {
    "release": {"goos": "linux", "goarch": "arm64", "buildmode": "pie"},
})
```

The two flags are **one decision**, not two. Verified both directions:

- `-shared` compile + `exe` link → **fails**: `link: cannot handle R_ARM64_TLS_IE (sym runtime.load_g) when linking internally`
- no `-shared` + `pie` link → fine (internal PIE doesn't need it)

`BuildMode::needs_shared()` owns that coupling and mirrors cmd/go's own rule in `internal/work/init.go:265`.

## No per-platform split

`cmd/link` upgrades `exe` to PIE on darwin/arm64 unconditionally ("on these platforms, everything is PIE"), so one uniform code path yields a static ELF on Linux and a normal PIE Mach-O on darwin — exactly what `go build` gives on each. No `#[cfg]`, no divergence introduced by heph.

The std library needs no change: it's built by `go install std` under cmd/go's own defaults, and plain archives link into either mode. That was already true before this PR — std archives were never `-shared` while first-party ones were.

## Tests

- `plugingo-e2e`: cross-compiles `//cmd:build` to linux/amd64 in both modes and reads the ELF program headers — `exe` must have no `PT_INTERP`, `pie` must have one. Cross-compiled rather than host-built so the assertion runs on every CI platform. Adds `object` as a dev-dep for the header read (already in the lockfile).
- `variant.rs`: default is `exe`; `pie` parses; an unknown mode is a hard error listing the allowed set; `inherit` propagates and can be overridden.
- `driver_compile.rs`: `buildmode` keys the compile cache (an `exe` and a `pie` archive must not share a key); an unknown mode fails `parse`.
- `target_bin.rs` / `target_test.rs`: link script carries the right `-buildmode=`, and the mode precedes user ldflags.
- `factors.rs`: `needs_shared` is true exactly for `pie`; `NAMES` stays in step with `parse`/`as_str`.

Ran locally: `plugin-go` 436 unit tests, all of `plugingo-e2e` (32), `lint` clean.

## Compatibility

`GO_COMPILE_FORMAT_VERSION` 3 → 4 — the compile command shape changed, so every cached Go archive is invalidated once. No on-disk format break, no ABI change.

Behavior change for anyone relying on PIE/ASLR today: set `buildmode = "pie"` on the variant to keep it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CQ5Te6ok3ntukPoeyj4JSA