### PR TITLE
fix(cache): derive dep/tool ids from content, not HashMap order

### DIFF
--- a/crates/e2e/tests/deps.rs
+++ b/crates/e2e/tests/deps.rs
@@ -293,6 +293,203 @@ target(
     Ok(())
 }
 
+/// Build `addr` through a *fresh* engine over `ws`'s root — a second `heph`
+/// invocation's view of the same on-disk cache — and wait for the cache write to
+/// land. A fresh engine is the point: everything memoized per-engine (the spec,
+/// the def, and every `HashMap` built while producing them) is rebuilt, which is
+/// what a per-process hash instability needs in order to show.
+async fn run_in_a_fresh_engine(ws: &Workspace, addr_str: &str) -> anyhow::Result<()> {
+    use heph::engine::{Engine, OutputMatcher, ResultOptions};
+    use std::sync::Arc;
+    use std::sync::atomic::{AtomicUsize, Ordering};
+
+    let addr = heph::htaddr::parse_addr(addr_str)?;
+    let engine = ws.reopen()?;
+    let bg: Arc<AtomicUsize> = Arc::new(AtomicUsize::new(0));
+    let rs = engine.new_state_full(
+        true,
+        None,
+        Arc::clone(&bg),
+        Engine::DEFAULT_LOG_TAIL_LINES,
+        None,
+    );
+    let result = engine
+        .clone()
+        .result_addr(
+            rs.clone(),
+            &addr,
+            OutputMatcher::All,
+            &ResultOptions::default(),
+        )
+        .await?;
+    drop(result);
+    drop(rs);
+
+    let deadline = std::time::Instant::now() + std::time::Duration::from_secs(60);
+    while bg.load(Ordering::Acquire) > 0 {
+        assert!(
+            std::time::Instant::now() < deadline,
+            "background work never drained"
+        );
+        tokio::time::sleep(std::time::Duration::from_millis(5)).await;
+    }
+    Ok(())
+}
+
+/// Revisions the cache holds for `addr`, read destructively via `clean` — the
+/// count of distinct `hashin`s the runs above produced. A stable hash means one
+/// revision no matter how many times it ran; one revision per run means the
+/// cache never hits and every build is cold.
+///
+/// The targets under test must raise `cache.history`: it defaults to 1, and the
+/// post-write GC enforces it, so a target left at the default keeps exactly one
+/// revision whether or not its hash is stable — an oracle that reads "stable"
+/// for every input.
+async fn revisions(ws: &Workspace, addr_str: &str) -> anyhow::Result<usize> {
+    let engine = ws.reopen()?;
+    let m = heph::htmatcher::Matcher::Addr(heph::htaddr::parse_addr(addr_str)?);
+    Ok(engine
+        .clone()
+        .clean(engine.new_state(), &m)
+        .await?
+        .revisions_removed)
+}
+
+// A transitive sandbox with more than one dep group must hash the same in every
+// process. The group ids are built by enumerating the parsed `{group: [dep]}`
+// map, whose iteration order is randomized per `HashMap` instance, and each id
+// reaches this consumer's def hash as an `Input::origin_id`. One group is always
+// index 0 — hence stable, and hence why every other fixture here misses this.
+#[tokio::test]
+async fn test_multi_group_transitive_hashes_the_same_every_run() -> anyhow::Result<()> {
+    let ws = Workspace::new();
+    ws.write_build_file(
+        "mgt",
+        r#"
+target(name = "p", driver = "bash", run = "printf p > $OUT", out = "p.txt")
+target(name = "q", driver = "bash", run = "printf q > $OUT", out = "q.txt")
+target(name = "r", driver = "bash", run = "printf r > $OUT", out = "r.txt")
+target(name = "s", driver = "bash", run = "printf s > $OUT", out = "s.txt")
+target(
+    name = "carrier",
+    driver = "bash",
+    run = "printf carrier > $OUT",
+    out = "c.txt",
+    transitive = {"deps": {"gp": ["//mgt:p"], "gq": ["//mgt:q"],
+                           "gr": ["//mgt:r"], "gs": ["//mgt:s"]}},
+)
+target(
+    name = "consumer",
+    driver = "bash",
+    run = "printf consumed > $OUT",
+    out = "out.txt",
+    cache = {"history": 8},
+    deps = {"carrier": ["//mgt:carrier"]},
+)
+"#,
+    );
+
+    for _ in 0..4 {
+        run_in_a_fresh_engine(&ws, "//mgt:consumer").await?;
+    }
+    assert_eq!(
+        revisions(&ws, "//mgt:consumer").await?,
+        1,
+        "consumer's hashin moved between runs: every build is a cold cache"
+    );
+    Ok(())
+}
+
+// The same property for the *consumer* side: the transitive collector numbers
+// each merged sandbox by its position in the consumer's input list, and that
+// number lands in the merged ids. With more than one dep group, that list is
+// assembled by iterating a `HashMap`, so the position — and the hash — is drawn
+// from a per-process random order.
+#[tokio::test]
+async fn test_multi_group_consumer_hashes_the_same_every_run() -> anyhow::Result<()> {
+    let ws = Workspace::new();
+    ws.write_build_file(
+        "mgc",
+        r#"
+target(name = "hidden", driver = "bash", run = "printf hidden > $OUT", out = "h.txt")
+target(
+    name = "carrier",
+    driver = "bash",
+    run = "printf carrier > $OUT",
+    out = "c.txt",
+    transitive = {"deps": {"hidden": ["//mgc:hidden"]}},
+)
+target(name = "a", driver = "bash", run = "printf a > $OUT", out = "a.txt")
+target(name = "b", driver = "bash", run = "printf b > $OUT", out = "b.txt")
+target(name = "c", driver = "bash", run = "printf c > $OUT", out = "cc.txt")
+target(
+    name = "consumer",
+    driver = "bash",
+    run = "printf consumed > $OUT",
+    out = "out.txt",
+    cache = {"history": 8},
+    deps = {"ga": ["//mgc:a"], "gb": ["//mgc:b"], "gc": ["//mgc:c"],
+            "carrier": ["//mgc:carrier"]},
+)
+"#,
+    );
+
+    for _ in 0..4 {
+        run_in_a_fresh_engine(&ws, "//mgc:consumer").await?;
+    }
+    assert_eq!(
+        revisions(&ws, "//mgc:consumer").await?,
+        1,
+        "consumer's hashin moved between runs: every build is a cold cache"
+    );
+    Ok(())
+}
+
+// Two deps in one transitive group each need their own `origin_id`: it names the
+// per-input list file (`list/input_<origin_id>.list`) that the exec driver reads
+// back to build `$SRC_<group>`, and the lookup is a `find` on that id. Sharing an
+// id makes both deps append to one list file and the first input answer for both,
+// so every path lands in `$SRC_G` twice.
+#[tokio::test]
+async fn test_transitive_group_with_two_deps_lists_each_once() -> anyhow::Result<()> {
+    let ws = Workspace::new();
+    ws.write_build_file(
+        "dupsrc",
+        r#"
+target(name = "x", driver = "bash", run = "printf x > $OUT", out = "x.txt")
+target(name = "y", driver = "bash", run = "printf y > $OUT", out = "y.txt")
+target(
+    name = "carrier",
+    driver = "bash",
+    run = "printf carrier > $OUT",
+    out = "c.txt",
+    transitive = {"deps": {"g": ["//dupsrc:x", "//dupsrc:y"]}},
+)
+target(
+    name = "consumer",
+    driver = "bash",
+    run = "printf '%s' \"$SRC_G\" > $OUT",
+    out = "out.txt",
+    deps = {"carrier": ["//dupsrc:carrier"]},
+)
+"#,
+    );
+
+    let result = ws.run("//dupsrc:consumer").await?;
+    let content = common::artifact_string(&result);
+    let paths: Vec<&str> = content.split_whitespace().collect();
+    let mut uniq: Vec<&str> = paths.clone();
+    uniq.sort_unstable();
+    uniq.dedup();
+    assert_eq!(
+        paths.len(),
+        uniq.len(),
+        "$SRC_G repeats a path, got: {content:?}"
+    );
+    assert_eq!(paths.len(), 2, "expected x.txt and y.txt, got: {content:?}");
+    Ok(())
+}
+
 // Direct cycle A → B → A must be rejected
 #[tokio::test]
 async fn test_direct_cyclic_dep_detected() -> anyhow::Result<()> {

--- a/crates/plugin-buildfile/src/pluginbuildfile/run_file.rs
+++ b/crates/plugin-buildfile/src/pluginbuildfile/run_file.rs
@@ -505,6 +505,20 @@ fn approval_from(v: htvalue::Value) -> anyhow::Result<Approval> {
     }
 }
 
+/// A parsed `{group: [dep]}` attribute, ordered by group name.
+///
+/// `parse_map_string_strings` returns a `HashMap`, whose iteration order is
+/// randomized per instance — so anything derived from that order differs between
+/// two parses of the same BUILD file, in the same process or across processes.
+/// Everything built below reaches a dependent's def hash (dep/tool ids become
+/// `Input::origin_id`), so it has to be derived from the content, never from the
+/// map's order.
+fn sorted_groups(m: &HashMap<String, Vec<String>>) -> Vec<(&String, &Vec<String>)> {
+    let mut groups: Vec<(&String, &Vec<String>)> = m.iter().collect();
+    groups.sort_by(|a, b| a.0.cmp(b.0));
+    groups
+}
+
 /// Parse a BUILD-file `sandbox`/`transitive` value (Starlark → `htvalue`) into a
 /// [`Sandbox`]. Free function rather than an inherent `impl` because `Sandbox`
 /// now lives in the `heph-plugin` contract crate (orphan rule).
@@ -523,8 +537,8 @@ fn sandbox_from(m: htvalue::Value, pkg: &PkgBuf) -> anyhow::Result<Sandbox> {
 
     if let Some(v) = m.remove("deps") {
         let parsed = parse_map_string_strings(v).with_context(|| "parse `deps`")?;
-        for (i, (k, ss)) in parsed.iter().enumerate() {
-            for s in ss {
+        for (k, ss) in sorted_groups(&parsed) {
+            for (i, s) in ss.iter().enumerate() {
                 sandbox.push_dep(Dep {
                     r#ref: TargetAddr::parse(s, pkg).with_context(|| "parse `deps`")?,
                     mode: Mode::None,
@@ -557,8 +571,8 @@ fn sandbox_from(m: htvalue::Value, pkg: &PkgBuf) -> anyhow::Result<Sandbox> {
 
     if let Some(v) = m.remove("tools") {
         let parsed = parse_map_string_strings(v).with_context(|| "parse `tools`")?;
-        for (i, (k, ss)) in parsed.iter().enumerate() {
-            for s in ss {
+        for (k, ss) in sorted_groups(&parsed) {
+            for (i, s) in ss.iter().enumerate() {
                 sandbox.push_tool(Tool {
                     r#ref: TargetAddr::parse(s, pkg).with_context(|| "parse `tools`")?,
                     group: k.to_string(),
@@ -2461,6 +2475,61 @@ target(
             .collect();
         assert!(names.contains(&"a"));
         assert!(names.contains(&"b"));
+        // Each dep in the group gets its own id. The id names the per-input list
+        // file the exec driver reads back to build `$SRC_<group>`, and that
+        // lookup takes the *first* input with a matching id — so two deps
+        // sharing one id makes both answer with the same (shared) list file and
+        // every path lands in `$SRC_G` twice.
+        let ids: Vec<&str> = sandbox.deps.iter().map(|d| d.id.as_str()).collect();
+        assert_eq!(ids, vec!["dep|g|0", "dep|g|1"], "ids must be per-dep");
+    }
+
+    /// `deps`/`tools` parse into a `HashMap` whose iteration order is randomized
+    /// per instance, so an id derived from that order differs between two parses
+    /// of the same BUILD file — and every id reaches a dependent's def hash
+    /// through `Input::origin_id`. Two groups are enough to fire it; one is
+    /// always index 0, which is why the single-group fixtures above never did.
+    #[test]
+    fn test_sandbox_ids_stable_across_group_order() {
+        let content = r#"
+target(
+    name = "t",
+    driver = "d",
+    transitive = {
+        "deps": {"a": ["//mypkg:a"], "b": ["//mypkg:b"], "c": ["//mypkg:c"],
+                 "d": ["//mypkg:d"], "e": ["//mypkg:e"], "f": ["//mypkg:f"]},
+        "tools": {"ta": ["//mypkg:ta"], "tb": ["//mypkg:tb"], "tc": ["//mypkg:tc"],
+                  "td": ["//mypkg:td"], "te": ["//mypkg:te"], "tf": ["//mypkg:tf"]},
+    },
+)
+"#;
+        // Keyed by ref so the comparison is order-independent: what must be
+        // stable is the id each dep gets, not the order they were pushed in.
+        let ids = |sb: &Sandbox| -> Vec<(String, String)> {
+            let mut v: Vec<(String, String)> = sb
+                .deps()
+                .iter()
+                .map(|d| (d.r#ref.r#ref.name.clone(), d.id.clone()))
+                .chain(
+                    sb.tools()
+                        .iter()
+                        .map(|t| (t.r#ref.r#ref.name.clone(), t.id.clone())),
+                )
+                .collect();
+            v.sort();
+            v
+        };
+
+        let first = ids(&run_transitive(content).unwrap());
+        for i in 0..8 {
+            let again = ids(&run_transitive(content).unwrap());
+            assert_eq!(
+                first,
+                again,
+                "ids differ between parse 0 and parse {}",
+                i + 1
+            );
+        }
     }
 
     #[test]

--- a/crates/plugin-exec/src/pluginexec/mod.rs
+++ b/crates/plugin-exec/src/pluginexec/mod.rs
@@ -133,6 +133,19 @@ fn env_key_segment(group: &str) -> String {
         .collect()
 }
 
+/// A `{group: [addr]}` spec attribute as a list ordered by group name.
+///
+/// Every such attribute arrives as a `HashMap`, whose iteration order is
+/// randomized per instance. Consuming one in map order makes the resulting
+/// `def.inputs` order — and anything derived from an input's position in it —
+/// differ between processes, which is a moved def hash and a cache that can
+/// never hit. Order by the group name instead, which is content, not layout.
+fn sorted_by_group(m: HashMap<String, Vec<String>>) -> Vec<(String, Vec<String>)> {
+    let mut v: Vec<(String, Vec<String>)> = m.into_iter().collect();
+    v.sort_by(|a, b| a.0.cmp(&b.0));
+    v
+}
+
 fn render_shell_init(run: &[String]) -> anyhow::Result<String> {
     let cmds = (!run.is_empty()).then(|| run.join("\n"));
 
@@ -801,7 +814,14 @@ impl hdriver_support::driver_managed::ManagedDriver for Driver {
                                 runtime: bool|
          -> anyhow::Result<Vec<(String, Input)>> {
             let read_only_groups = &read_only_groups;
-            deps.into_iter()
+            // Sorted, not `HashMap` order: this is the order of `def.inputs`,
+            // and the transitive collector numbers each merged sandbox by an
+            // input's *position* in that list — a number that ends up in the
+            // merged dep/tool ids, and so in this target's def hash. Left in
+            // map order, a target with two or more dep groups hashes
+            // differently in every process and never hits its cache.
+            sorted_by_group(deps)
+                .into_iter()
                 .flat_map(|(k, v)| {
                     let pkg = pkg.clone();
                     let read_only = read_only_groups.contains(&k);
@@ -852,8 +872,7 @@ impl hdriver_support::driver_managed::ManagedDriver for Driver {
                 .push(input.clone());
         }
 
-        let tool_inputs = spec
-            .tools
+        let tool_inputs = sorted_by_group(spec.tools)
             .into_iter()
             .flat_map(|(k, v)| {
                 let pkg = pkg.clone();
@@ -3620,6 +3639,53 @@ mod tests {
         )]))
         .await?;
         assert_eq!(base.hash, with_hash.hash);
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn test_parse_input_order_stable_across_group_order() -> anyhow::Result<()> {
+        // `deps`/`tools` arrive as `HashMap`s, so two parses of the same spec
+        // iterate their groups in different orders. `def.inputs` order must not
+        // follow: the engine's transitive collector numbers each merged sandbox
+        // by an input's *position* in this list, and that number lands in the
+        // merged dep ids — i.e. in the def hash of a target that depends on
+        // this one. One group is always position 0; it takes two to show.
+        let groups = |prefix: &str| {
+            hcore::htvalue::Value::Map(
+                ["a", "b", "c", "d", "e", "f", "g", "h"]
+                    .iter()
+                    .map(|g| {
+                        (
+                            format!("{prefix}{g}"),
+                            hcore::htvalue::Value::List(vec![hcore::htvalue::Value::String(
+                                format!("//some:{prefix}{g}"),
+                            )]),
+                        )
+                    })
+                    .collect(),
+            )
+        };
+        let parse = || async {
+            parse_with(HashMap::from([
+                ("deps".to_string(), groups("d")),
+                ("tools".to_string(), groups("t")),
+            ]))
+            .await
+        };
+        let origin_ids = |def: &hplugin::driver::targetdef::TargetDef| -> Vec<String> {
+            def.inputs.iter().map(|i| i.origin_id.clone()).collect()
+        };
+
+        let first = parse().await?;
+        for _ in 0..8 {
+            let again = parse().await?;
+            assert_eq!(
+                origin_ids(&first),
+                origin_ids(&again),
+                "input order follows HashMap order"
+            );
+            assert_eq!(first.hash, again.hash, "def hash moved between parses");
+        }
         Ok(())
     }
 


### PR DESCRIPTION
A target's dep and tool ids reach a dependent's def hash as `Input::origin_id`. Two of the places that build them derived the id from the iteration order of a `HashMap` — randomized per instance — so the id, the def hash, and therefore the cache key differed in **every process**. The affected targets never hit their cache. The symptom is "heph is slow", with no wrong output to point at.

Both sites need two or more groups to fire. With one group the index is always 0, and every fixture in the tree is single-group (`example/tool_transitive/BUILD` included) — which is why nothing caught it.

Repeated parses of one BUILD file, before the fix:

```
parse 0: ("c","dep|c|1") ("d","dep|d|4") ("e","dep|e|2")
parse 1: ("c","dep|c|4") ("d","dep|d|2") ("e","dep|e|1")
```

End to end: four runs through four fresh engines left **four cache revisions**, not one.

## The two sites

**`sandbox_from`** (BUILD-file `transitive`) numbered the *group* by its position in the parsed map, so a `transitive` with ≥2 dep or tool groups moved every consumer's hash.

The same index was also shared by every dep *within* a group — and the id names the per-input list file (`list/input_<origin_id>.list`) that the exec driver reads back to build `$SRC_<group>`, a lookup that takes the **first** input with a matching id. Two deps in one group therefore appended to a single list file and both answered from it, so every path landed in `$SRC_<group>` twice (N times for N deps). Deterministic, so no cache impact — just wrong, and quadratic in group size.

Now: groups iterated in sorted order, and the index numbers the dep within its group, matching every other producer in the tree (`pluginexec`, the Go drivers, `docker_build`).

**`pluginexec::parse`** built `def.inputs` in map order. The engine's transitive collector numbers each merged sandbox by an input's *position* in that list and folds that number into the merged ids — so any target with ≥2 dep groups and at least one dep carrying a `transitive` sandbox hashed differently per process. No multi-group transitive required. This one fails independently: with only the `sandbox_from` fix applied, its test still failed 3-vs-1. Now ordered by group name.

**Go targets are unaffected** — the Go provider emits empty transitive sandboxes and computes its own closure, so no positional id is ever assigned. This is the BUILD-file `transitive` feature only, and it does not explain any Go slowness.

## Tests

Each was verified failing before its own fix, and passing after:

- `test_sandbox_ids_stable_across_group_order` — ids identical across repeated parses of one BUILD file.
- `test_parse_input_order_stable_across_group_order` — `def.inputs` order and def hash stable across repeated parses.
- `test_multi_group_transitive_hashes_the_same_every_run` / `test_multi_group_consumer_hashes_the_same_every_run` — four runs through four fresh engines leave one cache revision.
- `test_transitive_group_with_two_deps_lists_each_once` — `$SRC_<group>` lists each path once.

One trap worth knowing, now written down next to the tests: the first version of that cache-revision oracle **passed on the broken code**. `cache.history` defaults to 1 and the post-write GC enforces it, so a target left at the default keeps exactly one revision whether or not its hash is stable. The tests raise it explicitly.

## Compatibility

Def hashes move for the targets described above — a one-time cache miss. Nothing is lost: none of them had a stable hash to begin with. No on-disk format, ABI, or CLI change.

## Follow-up not in this PR

The positional id in `collect_transitive_deps` is still load-bearing — this fixes the ordering *beneath* it rather than removing the positional dependence, so a future driver returning inputs in nondeterministic order re-opens the same hole. `spec.addr.hash_str()` already identifies the contributor uniquely, so the index looks droppable. Kept out of scope rather than widening the diff into the engine.

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Mke17q5BLu8DJHDPoqhoVB
