### PR TITLE
fix(config): read the version pin leniently so a pinned upgrade can't be blocked by its own config

### DIFF
--- a/crates/config/src/config_yaml.rs
+++ b/crates/config/src/config_yaml.rs
@@ -27,12 +27,19 @@ pub struct ConfigYaml {
     /// expects. When set and it differs from the running binary, the self-upgrade
     /// check downloads the pinned release and re-execs into it. Omit to disable
     /// self-upgrade for the workspace.
+    ///
+    /// **Mirrored in [`VersionPin`]**, which is what self-upgrade actually reads —
+    /// change this field's name or type and you must change that one too, or the
+    /// pin silently reads as absent and the workspace stays on the wrong binary.
+    /// It is a frozen wire contract; see [`VersionPin`] before retyping it.
     #[serde(default)]
     pub version: Option<String>,
     /// Release flavour to pin `version` to, e.g. `debug`. Selects which published
     /// artifact self-upgrade downloads: empty/omitted is the default "std" build
     /// (`heph_<os>_<arch>`); a non-empty flavour downloads `heph_<flavour>_<os>_<arch>`
     /// (e.g. `heph_debug_darwin_arm64`) instead.
+    ///
+    /// Mirrored in [`VersionPin`] — see the note on [`version`](Self::version).
     #[serde(default)]
     pub version_flavour: Option<String>,
     #[serde(default)]
@@ -506,7 +513,12 @@ pub const PROFILES_ENV: &str = "HEPH_PROFILES";
 
 /// Profiles requested via `HEPH_PROFILES`, in order. Empty/whitespace entries are
 /// dropped, so `HEPH_PROFILES=a,,b ` yields `["a", "b"]`.
-fn profiles_from_env() -> Vec<String> {
+///
+/// Public so a caller that must stay testable — the self-upgrade check, which
+/// reads the version pin before anything else — can take the profile list as an
+/// argument and read the environment once, at its edge, rather than deep inside
+/// the loader.
+pub fn profiles_from_env() -> Vec<String> {
     std::env::var(PROFILES_ENV)
         .ok()
         .map(|v| {
@@ -536,28 +548,106 @@ pub fn load_from_root(root: &Path) -> anyhow::Result<ConfigYaml> {
 /// Core of [`load_from_root`], with the profile list passed in so it can be
 /// exercised without touching the process environment.
 fn load_with_profiles(root: &Path, profiles: &[impl AsRef<str>]) -> anyhow::Result<ConfigYaml> {
+    load_layered(root, profiles, ConfigYaml::merge)
+}
+
+/// The version pin alone, parsed **leniently**: every other key — known,
+/// unknown, or malformed-for-this-binary — is skipped.
+///
+/// This is what the pre-engine self-upgrade check reads, and the leniency is the
+/// whole point. The full [`ConfigYaml`] is `deny_unknown_fields` (a typo in a
+/// config key should be an error, not a silently ignored setting), which makes it
+/// unusable for deciding *which binary should be running*. The binary that reads
+/// the pin is, by definition, the one that may not understand the config the
+/// pinned version was written for:
+///
+/// - **upgrade** — the workspace pins version N and uses a key N introduced. N-1
+///   cannot parse it, and N-1 is exactly the binary that has to read the pin to
+///   hand over to N.
+/// - **downgrade** — the workspace pins N-1 and uses a key N *dropped*. The
+///   running N cannot parse it, and N is the one that has to hand over to N-1.
+///
+/// So the pin is read through a struct that knows only `version` /
+/// `versionFlavour` and ignores the rest of the file. Once the right binary is
+/// running, any command that builds the engine loads the config in full and
+/// reports what it doesn't understand — the strictness is deferred, not dropped.
+///
+/// These two fields are a **frozen wire contract**: every heph that will ever run
+/// against this workspace has to read them, so they must stay plain YAML strings.
+/// Retyping either one (a mapping, say) leaves older binaries hard-erroring at
+/// startup with no upgrade path out of it.
+#[derive(Debug, Deserialize, Default, PartialEq, Eq)]
+#[serde(rename_all = "camelCase")]
+pub struct VersionPin {
+    /// See [`ConfigYaml::version`].
+    #[serde(default)]
+    pub version: Option<String>,
+    /// See [`ConfigYaml::version_flavour`].
+    #[serde(default)]
+    pub version_flavour: Option<String>,
+}
+
+impl VersionPin {
+    /// Apply `other` on top of `self` — each field present in `other` wins.
+    /// Mirrors [`ConfigYaml::merge`] for the two fields it carries, so a profile
+    /// re-pins the version for the lenient loader exactly as it does for the full
+    /// one.
+    pub fn merge(&mut self, other: VersionPin) {
+        if other.version.is_some() {
+            self.version = other.version;
+        }
+        if other.version_flavour.is_some() {
+            self.version_flavour = other.version_flavour;
+        }
+    }
+}
+
+/// Read just the version pin from the workspace, with the same base-file choice
+/// and profile layering as [`load_from_root`] — see [`VersionPin`] for why this
+/// exists as a separate, lenient path.
+///
+/// `profiles` is passed in rather than read from `HEPH_PROFILES` here (callers
+/// use [`profiles_from_env`]) so the self-upgrade path that depends on it stays
+/// testable without touching the process environment.
+pub fn load_version_pin(root: &Path, profiles: &[impl AsRef<str>]) -> anyhow::Result<VersionPin> {
+    load_layered(root, profiles, VersionPin::merge)
+}
+
+/// The base-file + profile layering shared by the full config loader and the
+/// lenient [`VersionPin`] one, so the two can never disagree about *which* files
+/// make up the config or in what order they apply. `merge` is how the shape being
+/// loaded applies an overlay.
+fn load_layered<T: serde::de::DeserializeOwned + Default>(
+    root: &Path,
+    profiles: &[impl AsRef<str>],
+    merge: fn(&mut T, T),
+) -> anyhow::Result<T> {
     let base_name = config_file_name_at(root);
-    let mut cfg = load(&root.join(base_name))?;
+    let mut cfg: T = load_file(&root.join(base_name))?;
     for profile in profiles {
         let profile = profile.as_ref();
         // base_name carries the leading dot, so this is `<profile>.hephconfig`
         // (or `<profile>.hephconfig2` for a legacy workspace).
         let file_name = format!("{profile}{base_name}");
         tracing::debug!(profile, file = %file_name, "applying config profile");
-        let overlay = load(&root.join(&file_name))
+        let overlay: T = load_file(&root.join(&file_name))
             .with_context(|| format!("loading config profile {file_name}"))?;
-        cfg.merge(overlay);
+        merge(&mut cfg, overlay);
     }
     Ok(cfg)
 }
 
 pub fn load(path: &Path) -> anyhow::Result<ConfigYaml> {
+    load_file(path)
+}
+
+fn load_file<T: serde::de::DeserializeOwned + Default>(path: &Path) -> anyhow::Result<T> {
     let bytes =
         std::fs::read(path).with_context(|| format!("reading config file {}", path.display()))?;
     if bytes.is_empty() {
-        return Ok(ConfigYaml::default());
+        return Ok(T::default());
     }
-    let cfg: ConfigYaml = serde_yaml::from_slice(&bytes)
+    let cfg: T = serde_yaml::from_slice(&bytes)
         .with_context(|| format!("parsing YAML config {}", path.display()))?;
     Ok(cfg)
 }
@@ -1126,6 +1216,175 @@ caches:
 
         let cfg = load_with_profiles(root, &["a"]).expect("load");
         assert_eq!(cfg.home_dir.as_deref(), Some(Path::new(".a")));
+    }
+
+    // The lenient version-pin loader. It exists so the running binary can always
+    // find out *which* binary should be running, even when it cannot parse the
+    // config the pinned version was written for — see [`VersionPin`].
+
+    #[test]
+    fn version_pin_ignores_fields_this_binary_does_not_know() {
+        // Everything below `version`/`versionFlavour` is a config this binary has
+        // no idea about: an unknown top-level key, an unknown key nested inside a
+        // block it *does* know, and an unknown key in a plugin entry (whose
+        // hand-rolled deserializer rejects extras on its own).
+        let yaml = r#"
+version: v2.0.0
+versionFlavour: debug
+fromTheFuture:
+  deeply:
+    nested: [1, 2, {a: b}]
+cache:
+  aKeyThisBinaryDropped: 1
+plugins:
+  - builtin: buildfile
+    futureKnob: true
+"#;
+        // The strict shape is what would have blocked the upgrade.
+        assert!(
+            serde_yaml::from_str::<ConfigYaml>(yaml).is_err(),
+            "fixture must be rejected by the strict shape, else it proves nothing"
+        );
+
+        let pin: VersionPin = serde_yaml::from_str(yaml).expect("pin parses leniently");
+        assert_eq!(pin.version.as_deref(), Some("v2.0.0"));
+        assert_eq!(pin.version_flavour.as_deref(), Some("debug"));
+    }
+
+    #[test]
+    fn version_pin_absent_fields_are_none() {
+        let pin: VersionPin = serde_yaml::from_str("fromTheFuture: 1\n").expect("parse");
+        assert_eq!(pin, VersionPin::default());
+    }
+
+    #[test]
+    fn version_pin_reads_the_same_keys_as_the_full_config() {
+        // `VersionPin` restates two of `ConfigYaml`'s fields, and nothing in the
+        // type system ties them together: rename or retype either one on
+        // `ConfigYaml` and the pin loader would quietly start reading `None` —
+        // self-upgrade silently becomes a no-op and the workspace stays on the
+        // wrong binary. Parse one document through both shapes so that drift
+        // fails here instead.
+        let yaml = "version: v1.2.3\nversionFlavour: debug\n";
+        let full: ConfigYaml = serde_yaml::from_str(yaml).expect("full parse");
+        let pin: VersionPin = serde_yaml::from_str(yaml).expect("pin parse");
+
+        assert_eq!(pin.version, full.version);
+        assert_eq!(pin.version_flavour, full.version_flavour);
+        assert_eq!(pin.version.as_deref(), Some("v1.2.3"));
+        assert_eq!(pin.version_flavour.as_deref(), Some("debug"));
+    }
+
+    #[test]
+    fn version_pin_merges_like_the_full_config() {
+        // Same for the overlay rule: an omitted field must not clobber the base,
+        // a present one must win. Drift here would make a profile re-pin the
+        // version for the engine but not for the self-upgrade check.
+        let base_yaml = "version: v1.0.0\nversionFlavour: debug\n";
+        let overlay_yaml = "version: v2.0.0\n";
+
+        let mut full: ConfigYaml = serde_yaml::from_str(base_yaml).expect("full base");
+        full.merge(serde_yaml::from_str(overlay_yaml).expect("full overlay"));
+        let mut pin: VersionPin = serde_yaml::from_str(base_yaml).expect("pin base");
+        pin.merge(serde_yaml::from_str(overlay_yaml).expect("pin overlay"));
+
+        assert_eq!(pin.version, full.version);
+        assert_eq!(pin.version_flavour, full.version_flavour);
+        assert_eq!(pin.version.as_deref(), Some("v2.0.0"));
+        assert_eq!(pin.version_flavour.as_deref(), Some("debug"));
+    }
+
+    #[test]
+    fn version_pin_layered_load_ignores_unknown_fields() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let root = dir.path();
+        std::fs::write(
+            root.join(".hephconfig"),
+            "version: v1.2.3\nfromTheFuture: 1\n",
+        )
+        .expect("write base");
+
+        let pin = load_version_pin(root, &[] as &[&str]).expect("load pin");
+        assert_eq!(pin.version.as_deref(), Some("v1.2.3"));
+        // …while the strict loader on the same tree still rejects it, naming the
+        // offending key — check the message, so this can't pass on some other
+        // error and quietly stop proving anything.
+        let err = load_with_profiles(root, &[] as &[&str]).expect_err("strict loader must reject");
+        assert!(format!("{err:#}").contains("fromTheFuture"), "{err:#}");
+    }
+
+    #[test]
+    fn version_pin_empty_config_is_default() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let root = dir.path();
+        std::fs::write(root.join(".hephconfig"), b"").expect("write base");
+
+        let pin = load_version_pin(root, &[] as &[&str]).expect("load pin");
+        assert_eq!(pin, VersionPin::default());
+    }
+
+    #[test]
+    fn version_pin_layers_profiles_like_the_full_config() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let root = dir.path();
+        std::fs::write(
+            root.join(".hephconfig"),
+            "version: v1.0.0\nversionFlavour: debug\nfromTheFuture: 1\n",
+        )
+        .expect("write base");
+        // Profile re-pins the version and leaves the flavour alone; it also
+        // carries its own unknown key.
+        std::fs::write(
+            root.join("ci.hephconfig"),
+            "version: v2.0.0\nalsoFromTheFuture: [1]\n",
+        )
+        .expect("write profile");
+
+        let pin = load_version_pin(root, &["ci"]).expect("load pin");
+        assert_eq!(pin.version.as_deref(), Some("v2.0.0"));
+        assert_eq!(pin.version_flavour.as_deref(), Some("debug"));
+    }
+
+    #[test]
+    fn version_pin_follows_the_legacy_base_and_its_profile_suffix() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let root = dir.path();
+        // `.hephconfig2` wins over `.hephconfig`, and profiles follow the chosen
+        // base — the pin loader must not diverge from the full loader here.
+        std::fs::write(root.join(".hephconfig"), "version: v1.0.0\n").expect("write canonical");
+        std::fs::write(root.join(".hephconfig2"), "version: v2.0.0\nfuture: 1\n")
+            .expect("write legacy");
+        std::fs::write(root.join("a.hephconfig2"), "version: v3.0.0\n").expect("write profile");
+
+        let pin = load_version_pin(root, &["a"]).expect("load pin");
+        assert_eq!(pin.version.as_deref(), Some("v3.0.0"));
+    }
+
+    #[test]
+    fn version_pin_still_reports_broken_yaml() {
+        // Leniency is about *unknown fields*, not about a file that isn't YAML —
+        // silently pretending there is no pin would strand the workspace on the
+        // wrong binary. The error must name the file.
+        let dir = tempfile::tempdir().expect("tempdir");
+        let root = dir.path();
+        std::fs::write(root.join(".hephconfig"), "version: [unterminated\n").expect("write base");
+
+        let err = load_version_pin(root, &[] as &[&str]).expect_err("must error");
+        let msg = format!("{err:#}");
+        assert!(msg.contains(".hephconfig"), "{msg}");
+    }
+
+    #[test]
+    fn version_pin_missing_profile_errors() {
+        // Same as the full loader: a named profile that isn't there is a hard
+        // error, since the pin it would have set is unknowable.
+        let dir = tempfile::tempdir().expect("tempdir");
+        let root = dir.path();
+        std::fs::write(root.join(".hephconfig"), "version: v1.0.0\n").expect("write base");
+
+        let err = load_version_pin(root, &["missing"]).expect_err("must error");
+        let msg = format!("{err:#}");
+        assert!(msg.contains("missing.hephconfig"), "{msg}");
     }
 
     #[test]

--- a/crates/selfupdate/src/lib.rs
+++ b/crates/selfupdate/src/lib.rs
@@ -12,6 +12,11 @@
 //! `debug`, a build kept unstripped for backtraces) picks
 //! `heph_<flavour>_<os>_<arch>`.
 //!
+//! The pin is read through the *lenient* [`hconfig::VersionPin`] loader, not the
+//! full config shape: the binary that reads the pin is by definition the one that
+//! may not understand the config the pinned version was written for. See
+//! [`read_pin`].
+//!
 //! Only **exact** version pins are acted on today; a constraint expression (e.g.
 //! `>=1.2, <2`) is recognized and skipped with a warning until resolution against
 //! the release index is implemented.
@@ -112,26 +117,64 @@ pub fn maybe_self_upgrade() -> Result<(), SelfUpgradeError> {
     // Not inside a heph workspace: no config, nothing to pin against. Surfaced as
     // a distinct error so the caller can tolerate it for `heph version`.
     let root = hconfig::get_root().map_err(|_e| SelfUpgradeError::NoConfig)?;
-    let cfg = hconfig::load_from_root(&root)?;
-    let Some(desired_version) = cfg.version.as_deref() else {
-        return Ok(());
-    };
-    let flavour = cfg.version_flavour.as_deref().unwrap_or("");
+    let pin = read_pin(&root, &hconfig::profiles_from_env())?;
     let current_flavour = version::flavour();
 
-    match decide(current, &current_flavour, desired_version, flavour) {
+    match plan(&pin, current, &current_flavour) {
         Decision::UpToDate => Ok(()),
         Decision::Unsupported { reason } => {
+            let desired_version = pin.version.as_deref().unwrap_or_default();
             tracing::warn!(desired_version, current, %reason, "ignoring .hephconfig version pin");
             Ok(())
         }
         Decision::Upgrade { target } => {
-            let binary = imp::ensure_binary(&target, flavour)?;
+            let binary = imp::ensure_binary(&target, pin_flavour(&pin))?;
             // Replaces the process image; only returns on failure.
             imp::exec_into(&binary)?;
             Ok(())
         }
     }
+}
+
+/// Read the workspace's version pin, tolerating a config this binary cannot
+/// fully parse.
+///
+/// The pin decides *which binary should be running*, so reading it must not
+/// depend on the running binary understanding the rest of the file — which is
+/// exactly what the full (`deny_unknown_fields`) config shape would require. A
+/// workspace pinning version N while using a key N introduced is unparseable by
+/// N-1, and N-1 is precisely the binary that has to read the pin to hand over to
+/// N; a downgrade pinning N-1 while using a key N *dropped* is the mirror image.
+/// `hconfig::load_version_pin` looks at `version`/`versionFlavour` and skips
+/// everything else, so the handover happens either way.
+///
+/// The strictness is deferred, not dropped: once the right binary is running, any
+/// command that builds the engine loads the config in full and reports what it
+/// doesn't understand. Commands that never build one (`heph version`) now run
+/// against an unparseable config instead of failing the whole process on it.
+///
+/// `profiles` is threaded in rather than read from the environment here so this
+/// path stays testable — see `hconfig::profiles_from_env`.
+#[cfg(any(unix, test))]
+fn read_pin(root: &std::path::Path, profiles: &[String]) -> anyhow::Result<hconfig::VersionPin> {
+    hconfig::load_version_pin(root, profiles)
+}
+
+/// The pinned flavour, defaulting to the std (empty) build when unset.
+#[cfg(any(unix, test))]
+fn pin_flavour(pin: &hconfig::VersionPin) -> &str {
+    pin.version_flavour.as_deref().unwrap_or("")
+}
+
+/// Turn a pin plus the running version/flavour into a [`Decision`]. The glue
+/// [`maybe_self_upgrade`] runs, minus the filesystem and the exec — an unset
+/// `version` means nothing to do, and an unset flavour means the std build.
+#[cfg(any(unix, test))]
+fn plan(pin: &hconfig::VersionPin, current: &str, current_flavour: &str) -> Decision {
+    let Some(desired_version) = pin.version.as_deref() else {
+        return Decision::UpToDate;
+    };
+    decide(current, current_flavour, desired_version, pin_flavour(pin))
 }
 
 #[cfg(not(unix))]
@@ -554,6 +597,87 @@ mod imp {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    fn pin(version: Option<&str>, flavour: Option<&str>) -> hconfig::VersionPin {
+        hconfig::VersionPin {
+            version: version.map(str::to_string),
+            version_flavour: flavour.map(str::to_string),
+        }
+    }
+
+    /// A workspace whose config this binary cannot fully parse must still hand
+    /// over to the version it pins — otherwise the upgrade that would *fix* the
+    /// parse error can never run. This is the seam that regressed: reading the pin
+    /// through the strict loader made the whole run fatal. Covers an unknown
+    /// top-level key (from a newer heph), an unknown *nested* key, and an unknown
+    /// plugin field — the last two are rejected by their own deserializers rather
+    /// than by the top-level struct.
+    #[test]
+    fn reads_the_pin_through_a_config_this_binary_cannot_parse() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let root = dir.path();
+        std::fs::write(
+            root.join(".hephconfig"),
+            "version: v9.9.9\n\
+             versionFlavour: debug\n\
+             fromTheFuture: { deeply: [nested, 1, true] }\n\
+             cache:\n  aKeyThisBinaryDropped: 1\n\
+             plugins:\n  - builtin: buildfile\n    futureKnob: yes\n",
+        )
+        .expect("write config");
+
+        // Sanity: the strict loader is exactly what would have blocked the
+        // upgrade — if this ever stops erroring, the lenient path lost its point.
+        assert!(
+            hconfig::load_from_root(root).is_err(),
+            "fixture must be unparseable under the full config shape"
+        );
+
+        let pin = read_pin(root, &[]).expect("pin must be readable regardless");
+        assert_eq!(pin.version.as_deref(), Some("v9.9.9"));
+        assert_eq!(pin.version_flavour.as_deref(), Some("debug"));
+    }
+
+    /// The pin read from such a config drives the decision the same as any other —
+    /// the point of reading it is to act on it.
+    #[test]
+    fn plan_upgrades_from_a_pin() {
+        assert_eq!(
+            plan(&pin(Some("v2.0.0"), None), "v1.0.0", ""),
+            Decision::Upgrade {
+                target: "v2.0.0".to_string()
+            }
+        );
+    }
+
+    /// No pin is still no pin: a config without `version` must not invent one —
+    /// the run continues on the current binary.
+    #[test]
+    fn plan_without_a_pin_is_a_noop() {
+        assert_eq!(plan(&pin(None, None), "v1.0.0", ""), Decision::UpToDate);
+        // …even when a flavour is pinned on its own: with no version there is no
+        // release to fetch it from.
+        assert_eq!(
+            plan(&pin(None, Some("debug")), "v1.0.0", ""),
+            Decision::UpToDate
+        );
+    }
+
+    /// An omitted `versionFlavour` means the std build, so a std binary on a
+    /// matching version has nothing to do — and a `debug` one does.
+    #[test]
+    fn plan_treats_an_omitted_flavour_as_std() {
+        assert_eq!(
+            plan(&pin(Some("v1.2.3"), None), "v1.2.3", ""),
+            Decision::UpToDate
+        );
+        assert_eq!(
+            plan(&pin(Some("v1.2.3"), None), "v1.2.3", "debug"),
+            Decision::Upgrade {
+                target: "v1.2.3".to_string()
+            }
+        );
+    }
 
     /// `decide` with flavour held constant (both empty) — for tests that only
     /// care about version-number comparison; flavour comparison is covered


### PR DESCRIPTION
## The bug

`heph` could not upgrade or downgrade to the version a workspace pins if the config contained a field the *running* binary didn't know.

`maybe_self_upgrade` read the pin through the full `ConfigYaml`, which is `#[serde(deny_unknown_fields)]`. That makes it unusable for deciding **which binary should be running** — the binary reading the pin is by definition the one that may not understand the config the pinned version was written for:

- **upgrade** — the workspace pins N and uses a key N introduced. N-1 can't parse it, and N-1 is exactly the binary that has to read the pin to hand over to N.
- **downgrade** — the workspace pins N-1 and uses a key N *dropped*. Running N can't parse it, and N is the one that has to hand over to N-1.

Either way the loader errored, `maybe_self_upgrade` returned `Failed`, and `main.rs:87` turned that into `ExitCode::FAILURE`. Every command died on the config error, and the upgrade that would have fixed it could never run — the workspace was stuck with no way out short of editing the config by hand.

## The fix

The pin is read through `VersionPin`, a lenient shape that knows only `version`/`versionFlavour` and skips everything else.

- Base-file selection (`.hephconfig2` over `.hephconfig`) and profile layering are shared with the full loader through `load_layered`, so the two can never disagree about *which* files make up the config or in what order.
- Leniency is scoped to unknown fields only. Malformed YAML and a missing named profile still error, naming the file — silently reporting "no pin" would strand the workspace on the wrong binary just as badly.
- Strictness is deferred, not dropped: once the right binary is running, any command that builds the engine loads the config in full and reports what it doesn't understand.

## Exit-code change (deliberate)

A command that never builds an engine — `heph version` — no longer fails the whole process on a config it can't parse. That was already the documented intent for `version` (it is meant to work independently of a valid workspace config; only `NoConfig` was tolerated before). Engine-building commands still fail loudly at `bootstrap::new_engine`.

## Tests

13 new tests. The load-bearing ones:

- the pin is readable from a config carrying an unknown top-level key, an unknown *nested* key, and an unknown plugin field (the latter two are rejected by their own deserializers, not the top-level struct) — each asserting the strict loader still rejects the same fixture, so the test can't quietly stop proving anything;
- one document parsed through **both** shapes, for fields and for merge, so that renaming or retyping `ConfigYaml::version` without mirroring it in `VersionPin` fails here instead of silently making self-upgrade a no-op;
- profile layering and the legacy base/suffix match the full loader;
- malformed YAML and a missing profile still error.

Tests take the profile list as an argument (`profiles_from_env` is now public and read at the edge) so the pre-engine path is testable without touching the process environment — `HEPH_PROFILES=ci cargo test -p config -p selfupdate` passes. `plan` isolates the pin-to-decision glue `maybe_self_upgrade` actually runs, so the tests cover it rather than re-implement it.

## Known adjacent gap (pre-existing, not addressed here)

Shell tab-completion runs before `maybe_self_upgrade` in `main.rs` and builds an engine through the strict loader, exiting the process on its own. In a workspace with an unknown-field config it yields empty completions silently and never triggers the upgrade that would fix it. Unchanged by this PR; flagging it as a separate follow-up.

## Review board

`compatibility` (versioned boundary: config format + CLI exit codes) — **COMPATIBLE**, no blocker. `code-quality` — **PASS WITH NITS**. All findings addressed, including a MAJOR: the first cut of the selfupdate tests read `HEPH_PROFILES` and failed when it was set.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BfnLbm5KZsBxWMWKxxLYrc