### PR TITLE
refactor(plugin-exec): remove the `sh` driver

### DIFF
--- a/crates/e2e/tests/engine_core.rs
+++ b/crates/e2e/tests/engine_core.rs
@@ -315,3 +315,40 @@ async fn cache_history_is_enforced_by_the_end_of_the_run() -> anyhow::Result<()>
     }
     Ok(())
 }
+
+/// A pipeline whose *producer* fails must fail the target. Without `-o
+/// pipefail` the status is the last stage's — `cat`'s 0 — so the run
+/// "succeeds" and the engine caches a revision for a build that failed. This
+/// is why the shell drivers are `bash` and not POSIX `sh`, which has no
+/// portable pipefail (dash rejects the option outright).
+#[tokio::test]
+async fn pipeline_producer_failure_fails_the_target() -> anyhow::Result<()> {
+    let ws = Workspace::new();
+    ws.write_build_file(
+        "pipe",
+        r#"target(name = "t", driver = "bash", run = "echo before\n(echo x; exit 1) | cat")"#,
+    );
+    let r = ws.run("//pipe:t").await;
+    assert!(
+        r.is_err(),
+        "a failing pipeline producer must fail the target"
+    );
+    Ok(())
+}
+
+/// `driver = "sh"` is gone: a target naming it must fail to resolve, not
+/// silently fall back to another shell.
+#[tokio::test]
+async fn sh_driver_no_longer_exists() -> anyhow::Result<()> {
+    let ws = Workspace::new();
+    ws.write_build_file("gone", r#"target(name = "t", driver = "sh", run = "true")"#);
+    let err = match ws.run("//gone:t").await {
+        Ok(_) => panic!("expected `sh` to be an unknown driver"),
+        Err(e) => format!("{e:#}"),
+    };
+    assert!(
+        err.contains("driver not found: sh"),
+        "error must name the missing driver, got: {err}"
+    );
+    Ok(())
+}

--- a/crates/plugin-exec/src/pluginexec/SANDBOX.md
+++ b/crates/plugin-exec/src/pluginexec/SANDBOX.md
@@ -72,6 +72,12 @@ Commands are joined with newlines and passed to `bash` with:
 - `-e` — exit on first error
 - `-o pipefail` — pipeline fails if any stage fails
 
+There is deliberately no POSIX `sh` mode. `pipefail` is not in POSIX.1-2017 and
+implementations disagree — macOS `/bin/sh` (bash in POSIX mode) accepts it,
+Linux `/bin/sh` (dash) rejects it — so an `sh` mode would report only a
+pipeline's *last* stage status. A failing producer would then be a silent
+success, and the engine would cache a revision for a build that failed.
+
 ## Process Lifecycle
 
 - `kill_on_drop(true)`: process is terminated if the driver is dropped.

--- a/crates/plugin-exec/src/pluginexec/mod.rs
+++ b/crates/plugin-exec/src/pluginexec/mod.rs
@@ -230,44 +230,6 @@ pub fn bash_args_public(
     Ok(args)
 }
 
-/// Mirrors `BASH_C_INLINE_MAX` — same inline-vs-spill cutoff so the two
-/// drivers behave consistently for sandbox script materialization.
-const SH_C_INLINE_MAX: usize = 500;
-
-pub fn sh_args_public(
-    sandbox_dir: &std::path::Path,
-    cmd: &str,
-    termargs: Vec<String>,
-) -> anyhow::Result<Vec<String>> {
-    // POSIX sh: no `--noprofile`/`--norc` (bash-only) and no `-o pipefail`
-    // (not in POSIX, varies across sh implementations). Plugingo scripts are
-    // pipe-free, so `set -u -e` is enough.
-    let mut args = if cmd.len() > SH_C_INLINE_MAX {
-        let script_path = sandbox_dir.join("cmd.sh");
-        std::fs::write(&script_path, cmd).context("write cmd.sh")?;
-        vec![
-            "sh".to_string(),
-            "-u".to_string(),
-            "-e".to_string(),
-            script_path.to_string_lossy().into_owned(),
-        ]
-    } else {
-        vec![
-            "sh".to_string(),
-            "-u".to_string(),
-            "-e".to_string(),
-            "-c".to_string(),
-            cmd.to_string(),
-        ]
-    };
-
-    if !termargs.is_empty() {
-        args.push("sh".to_string());
-        args.extend(termargs);
-    }
-    Ok(args)
-}
-
 impl Driver {
     pub fn new_exec() -> Self {
         Self {
@@ -316,19 +278,6 @@ impl Driver {
         }
     }
 
-    pub fn new_sh() -> Self {
-        Self {
-            name: "sh".to_string(),
-            search_path: vec![],
-            wrap_run: |sandbox_dir, run| {
-                sh_args_public(sandbox_dir, run.join("\n").as_str(), vec![])
-            },
-            // Interactive --shell debug UX (rcfile templates, history) is
-            // bash-only; recreating it for sh isn't worth the duplication.
-            wrap_run_shell: bash_args_shell,
-        }
-    }
-
     pub fn from_options_exec(opts: &hplugin::config::Options) -> anyhow::Result<Self> {
         Ok(Self {
             search_path: decode_path(opts)?,
@@ -340,13 +289,6 @@ impl Driver {
         Ok(Self {
             search_path: decode_path(opts)?,
             ..Self::new_bash()
-        })
-    }
-
-    pub fn from_options_sh(opts: &hplugin::config::Options) -> anyhow::Result<Self> {
-        Ok(Self {
-            search_path: decode_path(opts)?,
-            ..Self::new_sh()
         })
     }
 }
@@ -2165,40 +2107,6 @@ mod tests {
                 .iter()
                 .any(|a| a == script.to_string_lossy().as_ref())
         );
-    }
-
-    #[test]
-    fn sh_args_public_spills_long_cmd_to_file() {
-        let dir = tempfile::tempdir().expect("tempdir");
-        let short = "echo hi";
-        let short_args = sh_args_public(dir.path(), short, vec![]).expect("short");
-        assert_eq!(short_args.first().map(String::as_str), Some("sh"));
-        assert!(short_args.iter().any(|a| a == "-c"));
-        assert!(short_args.iter().any(|a| a == short));
-        assert!(!short_args.iter().any(|a| a == "--noprofile"));
-        assert!(!short_args.iter().any(|a| a == "--norc"));
-        assert!(!short_args.iter().any(|a| a == "pipefail"));
-        assert!(!dir.path().join("cmd.sh").exists());
-
-        let long = "x".repeat(SH_C_INLINE_MAX + 1);
-        let long_args = sh_args_public(dir.path(), &long, vec![]).expect("long");
-        assert!(!long_args.iter().any(|a| a == "-c"));
-        let script = dir.path().join("cmd.sh");
-        assert!(script.exists());
-        assert_eq!(std::fs::read_to_string(&script).expect("read"), long);
-        assert!(
-            long_args
-                .iter()
-                .any(|a| a == script.to_string_lossy().as_ref())
-        );
-    }
-
-    #[test]
-    fn from_options_sh_no_path() {
-        let opts = hplugin::config::Options::new();
-        let d = Driver::from_options_sh(&opts).expect("from_options");
-        assert_eq!(d.name, "sh");
-        assert!(d.search_path.is_empty());
     }
 
     #[test]

--- a/crates/plugin-go/src/plugingo/provider.rs
+++ b/crates/plugin-go/src/plugingo/provider.rs
@@ -5436,7 +5436,7 @@ golang.org/x/oauth2 v0.0.0-20200107190931-bf48bf16ab8d h1:pE8b58s1HRDMi8RDc79m0H
         let sandbox = copy_fixture("with_dep");
         let p = Provider::new(sandbox.path().to_path_buf(), test_runtime()).unwrap();
         let resp = provider_get(&p, make_addr("cmd", "build")).await.unwrap();
-        assert_eq!(resp.target_spec.driver, "sh");
+        assert_eq!(resp.target_spec.driver, "bash");
         let out = match resp.target_spec.config.get("out").unwrap() {
             Value::Map(m) => m,
             _ => panic!(),
@@ -5458,7 +5458,7 @@ golang.org/x/oauth2 v0.0.0-20200107190931-bf48bf16ab8d h1:pE8b58s1HRDMi8RDc79m0H
         let resp = provider_get(&p, make_addr("@heph/go/std/fmt", "build_lib"))
             .await
             .unwrap();
-        assert_eq!(resp.target_spec.driver, "sh");
+        assert_eq!(resp.target_spec.driver, "bash");
     }
 
     #[tokio::test]
@@ -5480,7 +5480,7 @@ golang.org/x/oauth2 v0.0.0-20200107190931-bf48bf16ab8d h1:pE8b58s1HRDMi8RDc79m0H
         let resp = provider_get(&p, make_addr("pkg", "build_test"))
             .await
             .unwrap();
-        assert_eq!(resp.target_spec.driver, "sh");
+        assert_eq!(resp.target_spec.driver, "bash");
         let out = match resp.target_spec.config.get("out").unwrap() {
             Value::Map(m) => m,
             _ => panic!(),
@@ -6342,7 +6342,7 @@ golang.org/x/oauth2 v0.0.0-20200107190931-bf48bf16ab8d h1:pE8b58s1HRDMi8RDc79m0H
         let resp = provider_get(&p, make_addr("pkg", "build_xtest"))
             .await
             .unwrap();
-        assert_eq!(resp.target_spec.driver, "sh");
+        assert_eq!(resp.target_spec.driver, "bash");
         let out = match resp.target_spec.config.get("out").unwrap() {
             Value::Map(m) => m,
             _ => panic!(),

--- a/crates/plugin-go/src/plugingo/target_bin.rs
+++ b/crates/plugin-go/src/plugingo/target_bin.rs
@@ -144,7 +144,7 @@ pub fn build_spec(
 
     TargetSpec {
         addr,
-        driver: "sh".to_string(),
+        driver: "bash".to_string(),
         config,
         ..Default::default()
     }
@@ -234,7 +234,7 @@ mod tests {
             &LinkConfig::default(),
             V,
         );
-        assert_eq!(spec.driver, "sh");
+        assert_eq!(spec.driver, "bash");
     }
 
     #[test]

--- a/crates/plugin-go/src/plugingo/target_std.rs
+++ b/crates/plugin-go/src/plugingo/target_std.rs
@@ -205,7 +205,7 @@ pub fn build_spec(
 
     TargetSpec {
         addr,
-        driver: "sh".to_string(),
+        driver: "bash".to_string(),
         config,
         labels: vec!["go-build".to_string()],
         ..Default::default()
@@ -346,7 +346,7 @@ mod tests {
             run.contains("@heph/go/std/goroot/pkg/linux_amd64/fmt.a"),
             "build_lib must mv the archive from the install output: {run}"
         );
-        assert_eq!(spec.driver, "sh");
+        assert_eq!(spec.driver, "bash");
     }
 
     #[test]

--- a/crates/plugin-go/src/plugingo/target_test.rs
+++ b/crates/plugin-go/src/plugingo/target_test.rs
@@ -239,7 +239,7 @@ pub fn build_test_spec(
 
     TargetSpec {
         addr,
-        driver: "sh".to_string(),
+        driver: "bash".to_string(),
         config,
         ..Default::default()
     }
@@ -581,7 +581,7 @@ mod tests {
             &[],
             V,
         );
-        assert_eq!(spec.driver, "sh");
+        assert_eq!(spec.driver, "bash");
     }
 
     #[test]

--- a/crates/plugin-go/src/plugingo/thirdparty.rs
+++ b/crates/plugin-go/src/plugingo/thirdparty.rs
@@ -117,7 +117,7 @@ pub fn build_download_spec(
 
     TargetSpec {
         addr,
-        driver: "sh".to_string(),
+        driver: "bash".to_string(),
         config,
         ..Default::default()
     }
@@ -275,7 +275,7 @@ mod tests {
     #[test]
     fn test_download_spec_driver() {
         let spec = build_download_spec(download_addr(), "github.com/go-logr/logr", "v1.4.2", V);
-        assert_eq!(spec.driver, "sh");
+        assert_eq!(spec.driver, "bash");
     }
 
     #[test]

--- a/crates/plugingo-e2e/testdata/codegencycle/BUILD
+++ b/crates/plugingo-e2e/testdata/codegencycle/BUILD
@@ -35,7 +35,7 @@ target(
 # query (run for its `_golist`) re-enters it, closing the false cycle.
 target(
     name = "a-dist",
-    driver = "sh",
+    driver = "bash",
     run = "mv ${SRC} ${OUT}",
     deps = ["//cmd/a:build@v=host"],
     out = "dist/a",
@@ -44,7 +44,7 @@ target(
 
 target(
     name = "b-dist",
-    driver = "sh",
+    driver = "bash",
     run = "mv ${SRC} ${OUT}",
     deps = ["//cmd/b:build@v=host"],
     out = "dist/b",

--- a/crates/plugingo-e2e/tests/common/mod.rs
+++ b/crates/plugingo-e2e/tests/common/mod.rs
@@ -414,7 +414,6 @@ fn make_workspace_ordered(
     }
 
     b.with_managed_driver(Box::new(pluginexec::Driver::new_bash()))
-        .with_managed_driver(Box::new(pluginexec::Driver::new_sh()))
         .with_managed_driver(Box::new(pluginexec::Driver::new_exec()))
         .with_managed_driver(Box::new(plugingo::GoGolistDriver::new()))
         .with_managed_driver(Box::new(plugingo::GoToolchainDriver))

--- a/src/commands/bootstrap.rs
+++ b/src/commands/bootstrap.rs
@@ -159,9 +159,6 @@ pub fn new_engine() -> anyhow::Result<(Arc<engine::Engine>, ShutdownTrigger)> {
     e.register_managed_driver_factory("bash", |_init, opts| {
         Ok(Box::new(pluginexec::Driver::from_options_bash(opts)?))
     })?;
-    e.register_managed_driver_factory("sh", |_init, opts| {
-        Ok(Box::new(pluginexec::Driver::from_options_sh(opts)?))
-    })?;
 
     // Apply every `plugins:` entry: a `builtin:` instantiates the matching
     // factory above; a `path:`/`url:` resolves a manifest, loads the cdylib, and


### PR DESCRIPTION
`sh` ran a target's script under `sh -u -e`, with no `pipefail`, so a pipeline reported only its **last** stage's status. `(echo x; exit 1) | cat` was a success: the run returned `Ok`, the engine wrote a cache revision, and a build that failed was served from the cache from then on. The `bash` driver has always run `-o pipefail`, so the same script meant two different things depending on the driver name.

Everything else already worked — `exit 1`, a trailing or mid-script `false`, `(exit 1)`, a failing command substitution in a plain assignment all failed the target correctly, on both dash and bash. Pipelines were the only divergence:

```
                    sh       bash
plain exit 1        FAIL     FAIL
trailing false      FAIL     FAIL
mid false           FAIL     FAIL
pipeline producer   ok       FAIL   <-- diverges
pipeline mid        ok       FAIL   <-- diverges
```

## Why removal rather than a fix

`pipefail` cannot simply be added: it is not in POSIX.1-2017 (POSIX.1-2024 adds it) and implementations disagree — macOS `/bin/sh` is bash in POSIX mode and takes it, Linux `/bin/sh` is dash and rejects it (`set: Illegal option -o pipefail`). Keeping `sh` correct would have meant probing for a pipefail-capable shell at runtime and falling back to bash anyway.

Nothing justified carrying a second shell for that. The saving was dash's startup — ~0.9ms per spawn (200 spawns: 1.543s dash vs 1.714s bash), noise next to the Go compiles that were its only in-tree user — and the price was a driver whose failure semantics silently differ from the one beside it.

So the driver goes, and its users move to `bash`:

- plugin-go: `build_test`, `build_bin`, `build_std`, thirdparty `go mod download`
- the `codegencycle` plugingo-e2e fixture

The driver name is part of the cache key (`engine/meta.rs`), so the moved targets re-key rather than inheriting any revision an `sh` run produced.

## Breaking

`driver = "sh"` in a BUILD file now fails with `driver not found: sh`. Switch it to `bash`, which is a superset — same `-u -e`, plus pipefail. A plugin cdylib built against an older plugin-go (which emitted `driver = "sh"`) will fail the same way against a host with this change; rebuild or update the plugin.

## Tests

- `e2e`: `pipeline_producer_failure_fails_the_target` — a failing pipeline producer fails the target (this is the contract the removal preserves), and `sh_driver_no_longer_exists` — `driver = "sh"` fails to resolve rather than silently falling back to another shell.
- Suites run locally: `plugin-exec` (90), `plugin-go` (480), `engine` (544), `e2e` (all files), `lint` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01VEXSdwsLuJnPQYnNcV7gqL
