### PR TITLE
fix(buildfile): resolve `glob()` excludes like the pattern

### DIFF
--- a/crates/e2e/tests/plugin_buildfile.rs
+++ b/crates/e2e/tests/plugin_buildfile.rs
@@ -70,6 +70,75 @@ async fn test_missing_build_file_not_found() -> anyhow::Result<()> {
     Ok(())
 }
 
+// ── glob() ───────────────────────────────────────────────────────────────────
+
+// A package-relative `exclude` must exclude. The fs driver matches pattern and
+// excludes against the same workspace-root-relative paths, so a raw
+// `vendor/**` written in `//pkg` used to be tested against `pkg/vendor/x.txt`,
+// match nothing, and silently source the very files it named.
+#[tokio::test]
+async fn test_glob_exclude_is_package_relative() -> anyhow::Result<()> {
+    let ws = Workspace::new();
+    ws.write_file("pkg/keep.txt", "keep");
+    ws.write_file("pkg/sub/nested.txt", "nested");
+    ws.write_file("pkg/vendor/skip.txt", "skip");
+    ws.write_file("pkg/vendor/deep/skip.txt", "skip");
+    ws.write_build_file(
+        "pkg",
+        r#"
+target(
+    name = "t",
+    driver = "bash",
+    deps = {"src": [glob("**/*.txt", exclude = ["vendor/**"])]},
+    out = "out.txt",
+    run = 'for f in $SRC_SRC; do echo "$f"; done | sort > $OUT',
+)
+"#,
+    );
+
+    let result = ws.run("//pkg:t").await?;
+    let listed = common::artifact_string(&result);
+
+    assert!(listed.contains("keep.txt"), "sourced files: {listed:?}");
+    assert!(listed.contains("nested.txt"), "sourced files: {listed:?}");
+    assert!(
+        !listed.contains("vendor"),
+        "package-relative exclude must drop pkg/vendor/**, got: {listed:?}"
+    );
+    Ok(())
+}
+
+// `abs = True` opts both sides out of the package prefix, so a
+// workspace-rooted exclude stays expressible.
+#[tokio::test]
+async fn test_glob_exclude_abs_is_root_relative() -> anyhow::Result<()> {
+    let ws = Workspace::new();
+    ws.write_file("pkg/keep.txt", "keep");
+    ws.write_file("vendor/skip.txt", "skip");
+    ws.write_build_file(
+        "pkg",
+        r#"
+target(
+    name = "t",
+    driver = "bash",
+    deps = {"src": [glob("**/*.txt", exclude = ["vendor/**"], abs = True)]},
+    out = "out.txt",
+    run = 'for f in $SRC_SRC; do echo "$f"; done | sort > $OUT',
+)
+"#,
+    );
+
+    let result = ws.run("//pkg:t").await?;
+    let listed = common::artifact_string(&result);
+
+    assert!(listed.contains("keep.txt"), "sourced files: {listed:?}");
+    assert!(
+        !listed.contains("vendor"),
+        "abs exclude must drop the root-level vendor/**, got: {listed:?}"
+    );
+    Ok(())
+}
+
 // ── Spec assertions ──────────────────────────────────────────────────────────
 
 #[tokio::test]

--- a/crates/plugin-buildfile/src/pluginbuildfile/run_file.rs
+++ b/crates/plugin-buildfile/src/pluginbuildfile/run_file.rs
@@ -961,6 +961,10 @@ fn starlark_module(builder: &mut GlobalsBuilder) {
     /// Reference files matching a glob `pattern` (with optional `exclude`) as a
     /// dependency address. Package-relative unless `abs = True`. Returns an `fs`
     /// provider address.
+    ///
+    /// `exclude` resolves exactly like `pattern` — the fs driver matches both
+    /// against workspace-root-relative paths, so a package-relative pattern with
+    /// a raw exclude would silently exclude nothing.
     fn glob<'v>(
         eval: &mut Evaluator<'v, '_, '_>,
         pattern: &str,
@@ -980,6 +984,10 @@ fn starlark_module(builder: &mut GlobalsBuilder) {
             }
             None => vec![],
         };
+        let excludes = excludes
+            .iter()
+            .map(|e| resolve_fs_path(eval, e, abs))
+            .collect::<anyhow::Result<Vec<String>>>()?;
         let excludes_ref: Vec<&str> = excludes.iter().map(String::as_str).collect();
         Ok(hbuiltins::pluginfs::glob_addr(&resolved, &excludes_ref).format())
     }
@@ -2732,6 +2740,20 @@ target(
         result.targets.first().unwrap().config.clone()
     }
 
+    /// [`run_target_config`] for a BUILD file expected to fail: returns the full
+    /// error chain, so a test can assert on the cause rather than the top frame.
+    fn run_target_config_err(build_content: &str) -> String {
+        let tmp_dir = tempdir().unwrap();
+        let pkg_name = "mypkg";
+        let pkg_path = tmp_dir.path().join(pkg_name);
+        fs::create_dir_all(&pkg_path).unwrap();
+        fs::write(pkg_path.join("BUILD"), build_content).unwrap();
+        let provider = make_provider(&tmp_dir);
+        let err =
+            run_pkg_blocking(&provider, pkg_name).expect_err("expected BUILD evaluation to fail");
+        format!("{err:#}")
+    }
+
     #[test]
     fn test_starlark_file_pkg_relative_by_default() {
         // run_target_config runs in pkg "mypkg" — file("src/main.rs") should resolve
@@ -2785,18 +2807,63 @@ target(
         }
     }
 
+    // The fs driver matches pattern and excludes against the same
+    // workspace-root-relative paths, so a package-relative `exclude` must be
+    // prefixed exactly like the pattern — left raw, `vendor/**` in `//mypkg`
+    // matches `vendor/x.go` at the root and excludes nothing from the glob.
     #[test]
     fn test_starlark_glob_with_exclude_pkg_relative() {
         let content = r#"
 target(
     name = "t",
     driver = "d",
-    srcs = glob("**/*.go", exclude = ["vendor/**", "gen/**"]),
+    srcs = glob("**/*.go", exclude = ["vendor/**", "./gen/**"]),
 )
 "#;
         let config = run_target_config(content);
         let expected =
-            hbuiltins::pluginfs::glob_addr("mypkg/**/*.go", &["vendor/**", "gen/**"]).format();
+            hbuiltins::pluginfs::glob_addr("mypkg/**/*.go", &["mypkg/vendor/**", "mypkg/gen/**"])
+                .format();
+        match config.get("srcs") {
+            Some(htvalue::Value::String(s)) => assert_eq!(s, &expected),
+            other => panic!("expected glob addr string, got {:?}", other),
+        }
+    }
+
+    // A bare-string `exclude` takes the same path as the list form.
+    #[test]
+    fn test_starlark_glob_with_string_exclude_pkg_relative() {
+        let content = r#"
+target(
+    name = "t",
+    driver = "d",
+    srcs = glob("**/*.go", exclude = "vendor/**"),
+)
+"#;
+        let config = run_target_config(content);
+        let expected =
+            hbuiltins::pluginfs::glob_addr("mypkg/**/*.go", &["mypkg/vendor/**"]).format();
+        match config.get("srcs") {
+            Some(htvalue::Value::String(s)) => assert_eq!(s, &expected),
+            other => panic!("expected glob addr string, got {:?}", other),
+        }
+    }
+
+    // `**/…` keeps matching anywhere under the package: the prefixed
+    // `mypkg/**/*.pb.go` still matches `mypkg/x.pb.go` (`**` spans zero
+    // components), so the common idiom is unaffected.
+    #[test]
+    fn test_starlark_glob_exclude_doublestar_prefixed() {
+        let content = r#"
+target(
+    name = "t",
+    driver = "d",
+    srcs = glob("**/*.go", exclude = ["**/*.pb.go"]),
+)
+"#;
+        let config = run_target_config(content);
+        let expected =
+            hbuiltins::pluginfs::glob_addr("mypkg/**/*.go", &["mypkg/**/*.pb.go"]).format();
         match config.get("srcs") {
             Some(htvalue::Value::String(s)) => assert_eq!(s, &expected),
             other => panic!("expected glob addr string, got {:?}", other),
@@ -2818,6 +2885,43 @@ target(
             Some(htvalue::Value::String(s)) => assert_eq!(s, &expected),
             other => panic!("expected glob addr string, got {:?}", other),
         }
+    }
+
+    // `abs = True` governs both sides: neither pattern nor excludes are
+    // prefixed, so a workspace-rooted exclude stays writable.
+    #[test]
+    fn test_starlark_glob_abs_skips_pkg_prefix_for_exclude() {
+        let content = r#"
+target(
+    name = "t",
+    driver = "d",
+    srcs = glob("**/*.rs", exclude = ["vendor/**"], abs = True),
+)
+"#;
+        let config = run_target_config(content);
+        let expected = hbuiltins::pluginfs::glob_addr("**/*.rs", &["vendor/**"]).format();
+        match config.get("srcs") {
+            Some(htvalue::Value::String(s)) => assert_eq!(s, &expected),
+            other => panic!("expected glob addr string, got {:?}", other),
+        }
+    }
+
+    // A `..` in an exclude escapes the workspace root exactly as it does in the
+    // pattern, rather than being silently accepted and matching nothing.
+    #[test]
+    fn test_starlark_glob_exclude_escaping_root_errors() {
+        let content = r#"
+target(
+    name = "t",
+    driver = "d",
+    srcs = glob("**/*.go", exclude = ["../../../etc/**"]),
+)
+"#;
+        let err = run_target_config_err(content);
+        assert!(
+            err.contains("escapes workspace root"),
+            "expected escape error, got: {err}"
+        );
     }
 
     #[test]


### PR DESCRIPTION
## The bug

`glob()` resolved its `pattern` against the calling package but passed `exclude` through untouched:

```python
# in //pkg/BUILD
srcs = glob("**/*.go", exclude = ["vendor/**"])
```

→ pattern `pkg/**/*.go`, exclude `vendor/**`.

The `fs` driver matches **both** against workspace-root-relative paths (`emit_glob_file` strips the tree root before testing `glob.is_match` / `not.is_match`), so `vendor/**` was tested against `pkg/vendor/x.go`, matched nothing, and every file the author named was silently sourced anyway. Getting it to work meant writing `pkg/vendor/**` — which is unwritable in a macro shared across packages, and inconsistent with how the pattern next to it behaves.

## The fix

`exclude` entries go through the same `resolve_fs_path` as `pattern`: package-relative by default, raw under `abs = True`, and a `..` escaping the workspace root errors instead of quietly matching nothing. Include and exclude are now the same thing spelled twice.

## Compatibility

**Breaking, BUILD-file Starlark API** — narrowly:

- A workspace-rooted exclude written as a workaround (`exclude = ["pkg/vendor/**"]` inside `//pkg`) now gets the prefix applied twice and stops matching. Write it package-relative, or keep it rooted with `abs = True`.
- The `**/…` idiom is unaffected: `**` spans zero components, so the prefixed `pkg/**/*.pb.go` still matches `pkg/x.pb.go`.
- Exclude strings feed the fs def hash, so targets using excludes take a one-time cache miss. No cached result becomes wrong; the direction of the change is *more* files excluded, i.e. previously-over-declared inputs going away.
- No in-tree BUILD file used a rooted exclude. `plugin-go`'s internal `glob_addr` callers construct root-relative addrs directly and don't go through this builtin.

## Tests

`crates/e2e/tests/plugin_buildfile.rs` — end to end over the real walk, asserting the *file set*, not the address:

- `test_glob_exclude_is_package_relative` — `//pkg` globbing `**/*.txt` with `exclude = ["vendor/**"]` keeps `pkg/keep.txt` + `pkg/sub/nested.txt` and drops `pkg/vendor/**`. Verified to fail on master (it listed both vendor files).
- `test_glob_exclude_abs_is_root_relative` — `abs = True` excludes the root-level `vendor/**`.

`crates/plugin-buildfile` unit tests on the resolved address: list form, bare-string form, `**/`-prefixed exclude, `abs = True` on both sides, and `..` escaping the root. The pre-existing `test_starlark_glob_with_exclude_pkg_relative` asserted the buggy behaviour under a name claiming the opposite — it now asserts what it says.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FfuJbPjc9QcXrMCozcK9ZY