### PR TITLE
feat(exec-runner): the seam for running a target in a chosen environment

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1434,6 +1434,7 @@ dependencies = [
  "config",
  "core",
  "driver-support",
+ "exec-runner",
  "model",
  "plugin",
  "rayon",
@@ -1450,6 +1451,7 @@ dependencies = [
  "anyhow",
  "async-trait",
  "core",
+ "exec-runner",
  "glob",
  "lock",
  "model",
@@ -1702,6 +1704,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f1a05365e3b1c6d1650318537c7460c6923f1abdd272ad6842baa2b509957a06"
 dependencies = [
  "num-traits",
+]
+
+[[package]]
+name = "exec-runner"
+version = "0.1.0"
+dependencies = [
+ "anyhow",
+ "async-trait",
+ "core",
+ "proc",
+ "tokio",
 ]
 
 [[package]]
@@ -2231,6 +2244,7 @@ dependencies = [
  "enclose",
  "engine",
  "erased-serde 0.4.10",
+ "exec-runner",
  "flate2",
  "futures",
  "glob",
@@ -4065,6 +4079,7 @@ dependencies = [
  "crossterm",
  "driver-support",
  "enclose",
+ "exec-runner",
  "glob",
  "libc",
  "minijinja",
@@ -4186,6 +4201,7 @@ dependencies = [
  "async-trait",
  "core",
  "driver-support",
+ "exec-runner",
  "model",
  "plugin",
  "proc",
@@ -4208,6 +4224,7 @@ dependencies = [
  "core",
  "docker_credential",
  "driver-support",
+ "exec-runner",
  "futures",
  "model",
  "oci-client",
@@ -4257,6 +4274,7 @@ dependencies = [
  "async-trait",
  "core",
  "driver-support",
+ "exec-runner",
  "futures",
  "model",
  "plugin",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,7 +4,7 @@ version = "0.1.0"
 edition = "2024"
 
 [workspace]
-members = ["gen/proto", "crates/e2e", "crates/bin-e2e", "crates/testkit", "crates/plugingo-e2e", "crates/htspec-derive", "crates/core", "crates/config", "crates/walk", "crates/proc", "crates/model", "crates/sandboxfuse", "crates/plugin", "crates/plugin-abi", "crates/plugin-stabby", "crates/plugin-sdk", "crates/plugin-go-cdylib", "crates/builtins", "crates/plugin-buildfile", "crates/driver-support", "crates/driver-bridge", "crates/plugin-exec", "crates/plugin-nix", "crates/plugin-http", "crates/plugin-oci", "crates/plugin-query", "crates/plugin-go", "crates/plugin-gha", "crates/plugin-gha-cdylib", "crates/plugin-oci-cdylib", "crates/telemetry", "crates/tui", "crates/lock", "crates/selfupdate", "crates/engine", "crates/xstarlark-fmt", "crates/bench-corpus", "crates/bench"]
+members = ["gen/proto", "crates/e2e", "crates/bin-e2e", "crates/testkit", "crates/plugingo-e2e", "crates/htspec-derive", "crates/core", "crates/config", "crates/walk", "crates/proc", "crates/model", "crates/sandboxfuse", "crates/plugin", "crates/plugin-abi", "crates/plugin-stabby", "crates/plugin-sdk", "crates/plugin-go-cdylib", "crates/builtins", "crates/plugin-buildfile", "crates/driver-support", "crates/driver-bridge", "crates/exec-runner", "crates/plugin-exec", "crates/plugin-nix", "crates/plugin-http", "crates/plugin-oci", "crates/plugin-query", "crates/plugin-go", "crates/plugin-gha", "crates/plugin-gha-cdylib", "crates/plugin-oci-cdylib", "crates/telemetry", "crates/tui", "crates/lock", "crates/selfupdate", "crates/engine", "crates/xstarlark-fmt", "crates/bench-corpus", "crates/bench"]
 
 [profile.profiling]
 inherits = "release"
@@ -109,6 +109,7 @@ hproto-gen = { package = "proto-gen", path = "gen/proto", features = ["proto_ful
 hcore = { package = "core", path = "crates/core" }
 hwalk = { package = "walk", path = "crates/walk" }
 hproc = { package = "proc", path = "crates/proc" }
+hexec-runner = { package = "exec-runner", path = "crates/exec-runner" }
 hmodel = { package = "model", path = "crates/model" }
 hsandboxfuse = { package = "sandboxfuse", path = "crates/sandboxfuse", default-features = false }
 hplugin = { package = "plugin", path = "crates/plugin" }

--- a/crates/driver-bridge/Cargo.toml
+++ b/crates/driver-bridge/Cargo.toml
@@ -11,6 +11,7 @@ hcore = { package = "core", path = "../core" }
 hconfig = { package = "config", path = "../config" }
 hplugin = { package = "plugin", path = "../plugin" }
 hdriver-support = { package = "driver-support", path = "../driver-support" }
+hexec-runner = { package = "exec-runner", path = "../exec-runner" }
 htelemetry = { package = "telemetry", path = "../telemetry" }
 # The FUSE machinery (and its `fuser`/libfuse link) lives behind this crate so
 # the contract-level `driver-support` — and therefore every plugin — stays

--- a/crates/driver-bridge/src/bridge.rs
+++ b/crates/driver-bridge/src/bridge.rs
@@ -4,6 +4,7 @@ use async_trait::async_trait;
 use hcore::hasync::Cancellable;
 use hdriver_support::driver_managed::{ManagedDriver, ShellFallback};
 use hdriver_support::driver_managed_os::ManagedDriverOs;
+use hexec_runner::{ExecSession, LocalSession};
 use hplugin::driver::{
     ApplyTransitiveRequest, ApplyTransitiveResponse, ConfigRequest, ConfigResponse, Driver,
     ParseRequest, ParseResponse, RunInput, RunRequest, RunResponse,
@@ -47,10 +48,17 @@ impl ManagedDriverBridge {
         fuse: Option<FuseSlot>,
     ) -> Self {
         let driver = Arc::new(driver);
+        // Phase 0: one `local` session shared by both sandbox runners. It is an
+        // identity transform, so behaviour is byte-for-byte what it was before
+        // the seam existed. Phase 1 replaces this with per-target resolution —
+        // the bridge is already where the per-target `Os` vs `Fuse` choice is
+        // made, so it is the natural place for the per-target runner choice too.
+        let runner: Arc<dyn ExecSession> = Arc::new(LocalSession::new());
         let os = ManagedDriverOs {
             driver: driver.clone(),
             shell_fallback: shell_fallback.clone(),
             stage_dir: Some(home.join("stage")),
+            runner: Arc::clone(&runner),
         };
         let fuse = fuse.map(|f| ManagedDriverFuse {
             driver: driver.clone(),
@@ -59,6 +67,7 @@ impl ManagedDriverBridge {
             fs: f.fs,
             fuse_lower: f.fuse_lower,
             fuse_upper: f.fuse_upper,
+            runner: Arc::clone(&runner),
         });
         Self { cfg, os, fuse }
     }
@@ -76,6 +85,7 @@ impl ManagedDriverBridge {
                 driver: Arc::new(driver),
                 shell_fallback,
                 stage_dir: None,
+                runner: Arc::new(LocalSession::new()),
             },
             fuse: None,
         }

--- a/crates/driver-bridge/src/driver_managed_fuse.rs
+++ b/crates/driver-bridge/src/driver_managed_fuse.rs
@@ -6,6 +6,7 @@ use hdriver_support::driver_managed::{
     detect_output_collisions_blocking, invoke_inner, list_path_for, resolve_unpack_root,
     unpack_blocking, write_source_map_blocking,
 };
+use hexec_runner::ExecSession;
 use hplugin::driver::{RunInput, RunRequest, RunResponse, SandboxGuard};
 use hsandboxfuse as sandboxfuse;
 use std::collections::BTreeMap;
@@ -23,6 +24,8 @@ pub struct ManagedDriverFuse {
     pub(crate) fs: Arc<sandboxfuse::LayeredFs>,
     pub(crate) fuse_lower: PathBuf,
     pub(crate) fuse_upper: PathBuf,
+    /// See [`hdriver_support::driver_managed_os::ManagedDriverOs::runner`].
+    pub(crate) runner: Arc<dyn ExecSession>,
 }
 
 impl ManagedDriverFuse {
@@ -156,6 +159,7 @@ impl ManagedDriverFuse {
             sandbox_pkg_dir.clone(),
             inputs,
             &self.shell_fallback,
+            Arc::clone(&self.runner),
         )
         .await?;
 

--- a/crates/driver-support/Cargo.toml
+++ b/crates/driver-support/Cargo.toml
@@ -11,6 +11,7 @@ hcore = { package = "core", path = "../core" }
 hmodel = { package = "model", path = "../model" }
 hplugin = { package = "plugin", path = "../plugin" }
 hlock = { package = "lock", path = "../lock" }
+hexec-runner = { package = "exec-runner", path = "../exec-runner" }
 anyhow = "1.0.102"
 async-trait = "0.1.89"
 serde = { version = "1", features = ["derive"] }

--- a/crates/driver-support/src/driver_managed.rs
+++ b/crates/driver-support/src/driver_managed.rs
@@ -2,6 +2,7 @@ use anyhow::Context;
 use async_trait::async_trait;
 use hcore::hartifactcontent;
 use hcore::hasync::{self, Cancellable};
+use hexec_runner::ExecSession;
 use hmodel::htaddr::Addr;
 use hplugin::driver::inputartifact;
 use hplugin::driver::outputartifact::Content::TarPath;
@@ -52,6 +53,14 @@ pub struct ManagedRunRequest<'a, 'io> {
     pub sandbox_ws_dir: PathBuf,
     pub sandbox_pkg_dir: PathBuf,
     pub inputs: Vec<ManagedRunInput>,
+    /// The environment this target's processes are created in. Always present;
+    /// `LocalSession` (an identity transform) unless a runner was selected.
+    ///
+    /// A driver creates processes through this rather than calling
+    /// `proc_exec::{spawn,output}` directly — that is the whole of the
+    /// exec-runner seam (`docs/EXEC_RUNNERS.md` §4.2). A driver that creates no
+    /// process ignores it.
+    pub runner: Arc<dyn ExecSession>,
 }
 pub struct ManagedRunResponse {
     pub artifacts: Vec<outputartifact::OutputArtifact>,
@@ -130,6 +139,7 @@ pub async fn invoke_inner<'a, 'io>(
     sandbox_pkg_dir: PathBuf,
     inputs: Vec<ManagedRunInput>,
     shell_fallback: &ShellFallback,
+    runner: Arc<dyn ExecSession>,
 ) -> anyhow::Result<ManagedRunResponse> {
     // Some inner drivers (e.g. pluginexec writing `init.sh`) read
     // `req.request.sandbox_dir` for filesystem ops. Keep both consistent
@@ -141,6 +151,7 @@ pub async fn invoke_inner<'a, 'io>(
         sandbox_pkg_dir,
         request: req,
         inputs,
+        runner,
     };
     let res = if shell {
         if driver.supports_shell() {
@@ -178,6 +189,7 @@ async fn run_shell_fallback<'a, 'io>(
         sandbox_ws_dir,
         sandbox_pkg_dir,
         inputs,
+        runner,
     } = mreq;
     let RunRequest {
         request_id,
@@ -230,6 +242,12 @@ async fn run_shell_fallback<'a, 'io>(
         sandbox_ws_dir,
         sandbox_pkg_dir,
         inputs,
+        // The synthetic shell target inherits the ORIGINAL target's session.
+        // Without this, `heph run --shell` on a driver that doesn't implement
+        // `run_shell` would drop the user into a *host* shell while claiming to
+        // show what the target sees — a lie about the environment, and exactly
+        // the question `--shell` exists to answer.
+        runner,
     };
     shell_fallback.driver.run_shell(new_mreq, ctoken).await
 }

--- a/crates/driver-support/src/driver_managed_os.rs
+++ b/crates/driver-support/src/driver_managed_os.rs
@@ -5,6 +5,7 @@ use crate::driver_managed::{
 };
 use anyhow::Context;
 use hcore::hasync::Cancellable;
+use hexec_runner::{ExecSession, LocalSession};
 use hplugin::driver::{RunInput, RunRequest, RunResponse};
 use std::collections::BTreeMap;
 use std::fs;
@@ -24,6 +25,10 @@ pub struct ManagedDriverOs {
     /// staging (read-only inputs fall back to the plain copy path) — used by
     /// the standalone [`ManagedDriverOs::new`] constructor.
     pub stage_dir: Option<PathBuf>,
+    /// The environment target processes are created in. Phase 0 always holds a
+    /// `LocalSession` (an identity transform); Phase 1 resolves it per target
+    /// from the target's `runner =`.
+    pub runner: Arc<dyn ExecSession>,
 }
 
 impl ManagedDriverOs {
@@ -36,6 +41,7 @@ impl ManagedDriverOs {
             driver: Arc::new(driver),
             shell_fallback,
             stage_dir: None,
+            runner: Arc::new(LocalSession::new()),
         }
     }
 
@@ -147,6 +153,7 @@ impl ManagedDriverOs {
             sandbox_pkg_dir.clone(),
             inputs,
             &self.shell_fallback,
+            Arc::clone(&self.runner),
         )
         .await?;
 

--- a/crates/exec-runner/Cargo.toml
+++ b/crates/exec-runner/Cargo.toml
@@ -1,0 +1,16 @@
+[package]
+name = "exec-runner"
+version = "0.1.0"
+edition = "2024"
+
+[lints]
+workspace = true
+
+[dependencies]
+hcore = { package = "core", path = "../core" }
+hproc = { package = "proc", path = "../proc" }
+anyhow = "1.0.102"
+async-trait = "0.1.89"
+
+[dev-dependencies]
+tokio = { version = "1.52.3", features = ["rt", "macros"] }

--- a/crates/exec-runner/src/lib.rs
+++ b/crates/exec-runner/src/lib.rs
@@ -1,0 +1,392 @@
+//! The exec-runner contract: *in what environment is a target's process created?*
+//!
+//! Design: `docs/EXEC_RUNNERS.md`. This crate carries **Phase 0** — the seam and
+//! the `local` session. The `ExecRunner`/pool/`open` side (Phase 1) is deliberately
+//! not here yet: it has no caller until `runner =` exists, and an API with no
+//! caller is an API that is wrong.
+//!
+//! ## Why `prepare`, and not a process factory
+//!
+//! For the two exec modes that matter first — `Direct` (a devenv env snapshot)
+//! and `Wrap` (a container, a chroot) — a session is a **pure transformation of
+//! the [`Spec`]**: merge a base environment underneath the caller's own, prepend
+//! an argv prefix. The host then calls the ordinary [`proc_exec::spawn`] /
+//! [`proc_exec::output`] on the result.
+//!
+//! Making [`ExecSession::prepare`] the seam, rather than trait-objectifying
+//! process creation, is what keeps all of the following untouched:
+//!
+//! - `proc_exec::spawn` stays **synchronous**. There is no suspension point
+//!   between the fork and the caller receiving the `Handle`, so a cancellation
+//!   cannot land there and orphan a child that was never registered with the
+//!   supervisor. An `async fn spawn` would open exactly that window, and under
+//!   fail-fast it is the common cancellation shape, not an exotic one.
+//! - `Handle`'s "the spawn is the API" invariant (waiting and draining must not
+//!   share a task) and its OS-divergent reader-termination discipline stay
+//!   concrete rather than erased behind a trait object.
+//! - PTY allocation stays where it is. A `StdioSpec::Pty` variant looked
+//!   attractive until it had to carry `termios` — `openpty(3)` on macOS leaves
+//!   the slave's termios unspecified, which is why `pluginexec::pty::inherit_termios`
+//!   exists — and until it needed a return path for the master. What actually has
+//!   to move for a non-forking runner is fd *transport*, not pty allocation.
+//!
+//! ## Both `spawn` and `output`, deliberately
+//!
+//! Six of heph's eight process-creation sites are [`proc_exec::output`], not
+//! `spawn`, and **`output` cannot be built on `spawn`**: it drains with
+//! `DrainCapacity::Unbounded` because nothing consumes the channel until the
+//! wait returns, where `spawn` is bounded at 512 KiB for backpressure. A
+//! `go list` emitting more than that, routed through `spawn` + wait, wedges on
+//! darwin and passes on linux. So the batch/streaming drain policy stays inside
+//! `hproc`, and this trait exposes both.
+
+use hcore::hasync::Cancellable;
+use hproc::proc_exec::{self, Handle, Spec};
+use std::process::Output;
+use std::ffi::OsString;
+
+/// How well-pinned a session's environment is. Diagnostics only — it never
+/// changes whether heph caches a target. Choosing a weakly-pinned environment
+/// is the user's decision; heph's job is to report the tradeoff, not to
+/// override `cache`.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum Identity {
+    /// The environment is described by content the cache key already covers
+    /// (a lockfile resolving to store paths, an image digest).
+    Pinned { by: String },
+    /// The environment is asserted rather than observed. A stale hit is
+    /// possible where a `Pinned` environment would have missed.
+    Asserted { why: String },
+}
+
+impl Identity {
+    pub fn is_pinned(&self) -> bool {
+        matches!(self, Identity::Pinned { .. })
+    }
+}
+
+/// Capabilities of one acquired session.
+///
+/// Per-**session**, not per-runner: one runner can open a `Direct` session that
+/// allocates a pty trivially and an `Agent` session that can only do so over an
+/// fd-passing socket, so a runner-level answer would be wrong for one of them.
+#[derive(Debug, Clone)]
+pub struct SessionCaps {
+    /// Whether a controlling terminal can be allocated — gates `--shell`.
+    pub pty: bool,
+    /// Max concurrent processes this session serves. `None` = the engine's
+    /// worker pool is the only cap.
+    ///
+    /// Whoever enforces this must do so at **admission**, before the engine's
+    /// worker permit is taken — never as a second semaphore under a held
+    /// permit. The latter converts a per-session cap into global starvation:
+    /// with 24 workers and a cap of 1, 24 targets take every permit while 23
+    /// park inside the session, and an unrelated local target then waits for a
+    /// permit that will not free.
+    pub max_concurrent: Option<usize>,
+    pub identity: Identity,
+}
+
+/// What a human sees for this session in `heph inspect` and the in-flight report.
+#[derive(Debug, Clone)]
+pub struct SessionDescription {
+    /// The runner that opened it (`local`, or a runner target's addr).
+    pub runner: String,
+    /// Content-addressed key this session was opened for. Empty for `local`,
+    /// which contributes nothing to any cache key.
+    pub key: String,
+    /// One line for a human: what this environment is.
+    pub summary: String,
+}
+
+/// Where a `PATH` came from, so a "not found" can say which one it searched.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum PathSource {
+    /// The driver's own `path` option (or its built-in default).
+    Driver,
+    /// Supplied by the session's base environment.
+    Session { runner: String },
+}
+
+/// Typed because two distinct callers match on the outcome: the exec driver, to
+/// render a diagnostic naming *which* PATH was searched; and (in Phase 1) the
+/// session pool, to decide whether a failure poisons the session.
+/// `io::ErrorKind` cannot carry either — it has no variant for "the session is
+/// gone", and a non-forking session reports a missing program as a protocol
+/// error rather than `NotFound`.
+#[derive(Debug)]
+pub enum SpawnError {
+    ProgramNotFound {
+        program: String,
+        /// The `PATH` that was actually searched.
+        path: String,
+        /// Which layer supplied that `PATH` — the difference between "fix your
+        /// `.hephconfig`" and "fix your runner", which are different files.
+        source: PathSource,
+        /// The child's working directory. A missing cwd fails the same syscall
+        /// with the same errno, so naming it saves a wrong-turn diagnosis.
+        cwd: String,
+        io: std::io::Error,
+    },
+    SessionDied {
+        key: String,
+        reason: String,
+    },
+    Io(std::io::Error),
+}
+
+impl std::fmt::Display for SpawnError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            SpawnError::ProgramNotFound {
+                program,
+                path,
+                source,
+                cwd,
+                io,
+            } => match source {
+                PathSource::Driver => write!(
+                    f,
+                    "spawn child process {program:?}: {io} — not found in the driver's sandbox \
+                     PATH ({path}). This PATH is set by the driver's `path` option in .hephconfig \
+                     and is independent of the invoking shell's PATH — a program on your \
+                     interactive PATH can still be missing here. Also check that the working \
+                     directory {cwd:?} exists."
+                ),
+                PathSource::Session { runner } => write!(
+                    f,
+                    "spawn child process {program:?}: {io} — not found in the PATH provided by \
+                     runner `{runner}` ({path}). The driver's own `path` option is not applied \
+                     when a runner supplies PATH, so a program on the host is not reachable here \
+                     — declare it as a `tools =` dep, or add it to the runner's environment. Also \
+                     check that the working directory {cwd:?} exists."
+                ),
+            },
+            SpawnError::SessionDied { key, reason } => write!(
+                f,
+                "exec session {key} died before the process could be created: {reason}"
+            ),
+            SpawnError::Io(e) => write!(f, "spawn child process: {e}"),
+        }
+    }
+}
+
+impl std::error::Error for SpawnError {
+    fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
+        match self {
+            SpawnError::Io(e) | SpawnError::ProgramNotFound { io: e, .. } => Some(e),
+            SpawnError::SessionDied { .. } => None,
+        }
+    }
+}
+
+impl From<std::io::Error> for SpawnError {
+    fn from(e: std::io::Error) -> Self {
+        SpawnError::Io(e)
+    }
+}
+
+/// Cleanup a session hands back for the host to run.
+///
+/// **Synchronous on purpose**, and not an `async fn close`. The weak argument is
+/// "`Drop` cannot await" — which does not hold on its own, since the pool owns
+/// the session and an aborted build never drops it. The real reasons:
+///
+/// 1. An async teardown detached at exit (`tokio::spawn(close())`) is silently
+///    dropped when the runtime is already shutting down — which is the common
+///    case for "heph is exiting". It works in tests and leaks in production.
+/// 2. The mechanism that actually guarantees completion before process exit is
+///    `sandbox_cleaner`'s `bg_pending` accounting, and it is `FnOnce`-shaped.
+/// 3. That lane may not move onto tokio at all, per the macOS cross-thread waker
+///    hazard (`docs/RCA_MACOS_WAKER.md`).
+///
+/// Teardown is `docker rm` / `kill` — blocking calls that belong on a dedicated
+/// thread. It returns `Result` so a failure is a `warn!` rather than silence.
+pub type TeardownJob = Box<dyn FnOnce() -> anyhow::Result<()> + Send + 'static>;
+
+/// One acquired exec environment, shared by every target that resolved to it.
+#[async_trait::async_trait]
+pub trait ExecSession: Send + Sync {
+    /// Transform a spec so the process is created in this environment: merge
+    /// [`base_env`](Self::base_env) **underneath** the spec's own entries, and
+    /// prepend any argv prefix.
+    ///
+    /// The caller's entries win. A driver has already resolved the target's
+    /// `env` / `pass_env` / `runtime_env` and the sandbox's `$OUT`/`$SRC`
+    /// routing by this point; the session supplies the floor beneath them.
+    fn prepare(&self, spec: Spec) -> Result<Spec, SpawnError>;
+
+    /// Streaming creation. Bounded drain, for a caller that consumes output
+    /// concurrently with the child.
+    fn spawn(&self, spec: Spec) -> Result<Handle, SpawnError> {
+        Ok(proc_exec::spawn(self.prepare(spec)?)?)
+    }
+
+    /// Batch creation. Unbounded drain — see the module docs for why this is
+    /// not `spawn` plus a wait.
+    async fn output(
+        &self,
+        spec: Spec,
+        cancel: &(dyn Cancellable + Send + Sync),
+    ) -> Result<Output, SpawnError> {
+        Ok(proc_exec::output(self.prepare(spec)?, cancel).await?)
+    }
+
+    /// The environment every process here starts from, or `None` when it cannot
+    /// be enumerated host-side (a container's environment lives inside the
+    /// container). Callers that report "where did this PATH entry come from"
+    /// must degrade explicitly rather than pretend an empty environment.
+    fn base_env(&self) -> Option<&[(OsString, OsString)]>;
+
+    fn caps(&self) -> &SessionCaps;
+
+    fn describe(&self) -> &SessionDescription;
+
+    /// See [`TeardownJob`]. `None` when there is nothing to tear down.
+    fn teardown(&self) -> Option<TeardownJob> {
+        None
+    }
+}
+
+/// The zero-configuration session: the process is created exactly as it would
+/// have been before exec runners existed.
+///
+/// `prepare` is the identity function, and that is load-bearing rather than
+/// lazy. `local` contributes **nothing** to any cache key, which is only sound
+/// while it is byte-for-byte today's behaviour — the invariant is that
+/// *`local` is the zero-configuration session; any configuration on it must
+/// reach the key*. Adding a `base_env` or a `path` here without also making it
+/// hash is a silent wrong-build.
+#[derive(Debug)]
+pub struct LocalSession {
+    caps: SessionCaps,
+    description: SessionDescription,
+}
+
+impl Default for LocalSession {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl LocalSession {
+    pub fn new() -> Self {
+        Self {
+            caps: SessionCaps {
+                pty: true,
+                max_concurrent: None,
+                // Honest rather than flattering: `local` is in truth the
+                // *least*-pinned environment in the system — the host's
+                // `/usr/bin`, plus a `path` option that is not hashed. It is
+                // absent from the cache key for compatibility (no existing
+                // artifact may be invalidated by exec runners shipping), not
+                // because it is well-pinned. A user who sees no warning here
+                // should not read that as a guarantee.
+                identity: Identity::Asserted {
+                    why: "the host environment; not described by any cache key".to_string(),
+                },
+            },
+            description: SessionDescription {
+                runner: "local".to_string(),
+                key: String::new(),
+                summary: "host process, no environment applied".to_string(),
+            },
+        }
+    }
+}
+
+#[async_trait::async_trait]
+impl ExecSession for LocalSession {
+    fn prepare(&self, spec: Spec) -> Result<Spec, SpawnError> {
+        Ok(spec)
+    }
+
+    fn base_env(&self) -> Option<&[(OsString, OsString)]> {
+        None
+    }
+
+    fn caps(&self) -> &SessionCaps {
+        &self.caps
+    }
+
+    fn describe(&self) -> &SessionDescription {
+        &self.description
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::path::PathBuf;
+
+    fn spec(program: &str) -> Spec {
+        Spec {
+            program: PathBuf::from(program),
+            args: vec![],
+            env: vec![(OsString::from("A"), OsString::from("1"))],
+            cwd: PathBuf::from("/"),
+            stdin: proc_exec::StdioSpec::Null,
+            stdout: proc_exec::StdioSpec::Null,
+            stderr: proc_exec::StdioSpec::Null,
+            setsid: false,
+            ctty: false,
+        }
+    }
+
+    /// `local` must not perturb the spec at all. If this ever fails, every
+    /// cached artifact built before exec runners shipped is suspect: `local`
+    /// contributes nothing to `hashin` precisely because it changes nothing.
+    #[test]
+    fn local_prepare_is_the_identity() {
+        let s = LocalSession::new();
+        let before = spec("/bin/echo");
+        let after = s.prepare(spec("/bin/echo")).expect("prepare");
+
+        assert_eq!(after.program, before.program);
+        assert_eq!(after.args, before.args);
+        assert_eq!(after.env, before.env);
+        assert_eq!(after.cwd, before.cwd);
+        assert_eq!(after.setsid, before.setsid);
+        assert_eq!(after.ctty, before.ctty);
+    }
+
+    #[test]
+    fn local_reports_no_environment_rather_than_an_empty_one() {
+        // `Some(&[])` would read as "this environment is empty", which is a
+        // different and false claim.
+        assert!(LocalSession::new().base_env().is_none());
+    }
+
+    #[test]
+    fn local_has_nothing_to_tear_down() {
+        assert!(LocalSession::new().teardown().is_none());
+    }
+
+    #[test]
+    fn program_not_found_names_which_path_it_searched() {
+        let nf = || std::io::Error::from(std::io::ErrorKind::NotFound);
+        let driver = SpawnError::ProgramNotFound {
+            program: "cargo".to_string(),
+            path: "/usr/bin:/bin".to_string(),
+            source: PathSource::Driver,
+            cwd: "/ws".to_string(),
+            io: nf(),
+        }
+        .to_string();
+        assert!(driver.contains("driver's sandbox PATH"), "{driver}");
+        assert!(driver.contains("`path` option in .hephconfig"), "{driver}");
+
+        let session = SpawnError::ProgramNotFound {
+            program: "cargo".to_string(),
+            path: "/nix/store/x/bin".to_string(),
+            source: PathSource::Session {
+                runner: "//:devenv".to_string(),
+            },
+            cwd: "/ws".to_string(),
+            io: nf(),
+        }
+        .to_string();
+        assert!(session.contains("runner `//:devenv`"), "{session}");
+        assert!(session.contains("tools ="), "{session}");
+    }
+}

--- a/crates/exec-runner/src/lib.rs
+++ b/crates/exec-runner/src/lib.rs
@@ -42,8 +42,8 @@
 
 use hcore::hasync::Cancellable;
 use hproc::proc_exec::{self, Handle, Spec};
-use std::process::Output;
 use std::ffi::OsString;
+use std::process::Output;
 
 /// How well-pinned a session's environment is. Diagnostics only — it never
 /// changes whether heph caches a target. Choosing a weakly-pinned environment

--- a/crates/plugin-exec/Cargo.toml
+++ b/crates/plugin-exec/Cargo.toml
@@ -11,6 +11,7 @@ hcore = { package = "core", path = "../core" }
 hmodel = { package = "model", path = "../model" }
 hplugin = { package = "plugin", path = "../plugin" }
 hproc = { package = "proc", path = "../proc" }
+hexec-runner = { package = "exec-runner", path = "../exec-runner" }
 hdriver-support = { package = "driver-support", path = "../driver-support" }
 anyhow = "1.0.102"
 serde = { version = "1", features = ["derive"] }

--- a/crates/plugin-exec/src/pluginexec/mod.rs
+++ b/crates/plugin-exec/src/pluginexec/mod.rs
@@ -1090,6 +1090,19 @@ impl Driver {
         if shell && let Ok(term) = std::env::var("TERM") {
             env.insert("TERM".to_string(), term);
         }
+        // Where the child's PATH came from, for the spawn-failure diagnostic.
+        // A session that reports no environment (`local`, and any runner whose
+        // environment cannot be enumerated host-side) leaves the driver's own
+        // `path` option in charge, which is the pre-runner behaviour.
+        let path_source = match req.runner.base_env() {
+            Some(base) if base.iter().any(|(k, _)| k == "PATH") => {
+                hexec_runner::PathSource::Session {
+                    runner: req.runner.describe().runner.clone(),
+                }
+            }
+            _ => hexec_runner::PathSource::Driver,
+        };
+
         env.insert("PATH".to_string(), self.sandbox_path_display());
         env.insert(
             "WORKSPACE_ROOT".to_string(),
@@ -1455,16 +1468,29 @@ impl Driver {
         // and `req` are still fully owned locals at this point (only cloned
         // versions of their fields were moved into `spec` above), so no work
         // happens on the far more common spawn-succeeds path.
-        let mut handle = proc_exec::spawn(spec).map_err(|e| {
+        // Through the session, not `proc_exec::spawn` directly: that is the
+        // whole exec-runner seam (`docs/EXEC_RUNNERS.md` §4.2). Under `local`
+        // the session's `prepare` is the identity function, so this is the same
+        // fork it always was.
+        let mut handle = req.runner.spawn(spec).map_err(|e| {
             let program = run.first().map_or("", String::as_str);
-            if e.kind() == std::io::ErrorKind::NotFound {
-                anyhow::anyhow!(
-                    "spawn child process {program:?}: {e} — not found in the driver's sandbox PATH ({path}). This PATH is set by the driver's `path` option in .hephconfig and is independent of the invoking shell's PATH — a program on your interactive PATH can still be missing here. Also check that the working directory {cwd:?} exists.",
-                    path = self.sandbox_path_display(),
-                    cwd = req.sandbox_pkg_dir,
-                )
-            } else {
-                anyhow::Error::new(e).context(format!("spawn child process {program:?}"))
+            match e {
+                // Classified here rather than in the session because only the
+                // driver knows *which* PATH it composed and where that PATH came
+                // from. The session reports whether it supplied one; the naming
+                // of the fix — `.hephconfig` vs the runner — follows from that.
+                hexec_runner::SpawnError::Io(io) if io.kind() == std::io::ErrorKind::NotFound => {
+                    anyhow::Error::new(hexec_runner::SpawnError::ProgramNotFound {
+                        program: program.to_string(),
+                        path: self.sandbox_path_display(),
+                        source: path_source,
+                        cwd: req.sandbox_pkg_dir.display().to_string(),
+                        io,
+                    })
+                }
+                other => {
+                    anyhow::Error::new(other).context(format!("spawn child process {program:?}"))
+                }
             }
         })?;
 
@@ -2084,6 +2110,7 @@ mod tests {
             sandbox_ws_dir: path.clone(),
             sandbox_pkg_dir: path,
             inputs: vec![],
+            runner: Arc::new(hexec_runner::LocalSession::new()),
         }
     }
 
@@ -4111,6 +4138,7 @@ mod tests {
                     sandbox_pkg_dir: tmp.path().to_path_buf(),
                     request: req,
                     inputs: vec![managed_input],
+                    runner: Arc::new(hexec_runner::LocalSession::new()),
                 },
                 &ctoken,
             )
@@ -4157,6 +4185,7 @@ mod tests {
                     sandbox_pkg_dir: tmp.path().to_path_buf(),
                     request: req,
                     inputs: vec![managed_input],
+                    runner: Arc::new(hexec_runner::LocalSession::new()),
                 },
                 &ctoken,
             )
@@ -4235,6 +4264,7 @@ mod tests {
                     sandbox_pkg_dir: tmp.path().to_path_buf(),
                     request: req,
                     inputs: vec![managed_input],
+                    runner: Arc::new(hexec_runner::LocalSession::new()),
                 },
                 &ctoken,
             )
@@ -4486,6 +4516,7 @@ mod tests {
                     sandbox_pkg_dir: tmp.path().to_path_buf(),
                     request: req,
                     inputs: managed_inputs,
+                    runner: Arc::new(hexec_runner::LocalSession::new()),
                 },
                 &ctoken,
             )
@@ -4644,6 +4675,7 @@ mod tests {
                     sandbox_pkg_dir: tmp.path().to_path_buf(),
                     request: req,
                     inputs: vec![mi_a, mi_b],
+                    runner: Arc::new(hexec_runner::LocalSession::new()),
                 },
                 &ctoken,
             )
@@ -4745,6 +4777,7 @@ mod tests {
                     sandbox_pkg_dir: tmp.path().to_path_buf(),
                     request: req,
                     inputs: vec![mi_a, mi_b],
+                    runner: Arc::new(hexec_runner::LocalSession::new()),
                 },
                 &ctoken,
             )

--- a/crates/plugin-exec/src/pluginexec/mod.rs
+++ b/crates/plugin-exec/src/pluginexec/mod.rs
@@ -3308,6 +3308,142 @@ mod tests {
         Ok(())
     }
 
+    /// Golden freeze of the child process's environment.
+    ///
+    /// The exec-runner design (`docs/EXEC_RUNNERS.md` §4.4) inserts a runner's
+    /// `base_env` beneath the driver's `PATH` and skips the driver's `path`
+    /// default when a runner supplies one. Everything else about this sequence
+    /// must stay byte-identical — and an earlier draft of that design stated a
+    /// precedence order that was the *inverse* of what this code does in two
+    /// places, which would have silently changed what existing targets see
+    /// while `hashin` stayed put (`runtime_*` values are unhashed).
+    ///
+    /// So this freezes the parts a layer table cannot express:
+    ///
+    /// - `pass_env` / `runtime_pass_env` / `runtime_env` are applied AFTER the
+    ///   heph-computed vars, so they override `WORKSPACE_ROOT` / `OUT_*`.
+    /// - `env` is applied BEFORE them, so `OUT_*` APPENDS to an `env`-supplied
+    ///   value rather than replacing it (`entry().or_default()`, not `insert`).
+    /// - `runtime_env` beats `pass_env` for the same key.
+    /// - Nothing ambient leaks in: the spawn is `env_clear`ed.
+    ///
+    /// `env_clear` is what makes this assertable at all — the child's
+    /// environment is exactly what the driver put there, so the only entries to
+    /// filter are the four bash sets for itself.
+    #[tokio::test]
+    async fn env_composition_golden() -> anyhow::Result<()> {
+        unsafe {
+            std::env::set_var("heph_TEST_GOLDEN_RUNTIME_PASS", "from_runtime_pass_env");
+        }
+
+        let driver = Driver::new_bash();
+        let ctoken = StdCancellationToken::new();
+        let tmp = tempfile::tempdir()?;
+
+        let out_path = |p: &str| Path {
+            content: Content::FilePath(p.to_string()),
+            codegen_tree: CodegenMode::None,
+            collect: true,
+        };
+
+        let target_def = EngineTargetDef {
+            addr: Addr::default(),
+            labels: vec![],
+            raw_def: Arc::new(TargetDef {
+                run: vec!["env".to_string()],
+                dep_group_inputs: BTreeMap::new(),
+                runtime_dep_group_inputs: BTreeMap::new(),
+                tool_group_inputs: BTreeMap::new(),
+                outputs: BTreeMap::new(),
+                support_files: vec![],
+                // `OUT` collides with the heph-computed output var on purpose:
+                // it is the append-merge case.
+                env: BTreeMap::from([
+                    ("OUT".to_string(), "from_env".to_string()),
+                    ("PLAIN".to_string(), "from_env".to_string()),
+                    ("OVERRIDDEN".to_string(), "from_env".to_string()),
+                ]),
+                // Collides with a heph-computed var (`WORKSPACE_ROOT`) and with
+                // `env` (`OVERRIDDEN`) on purpose.
+                pass_env: BTreeMap::from([
+                    ("WORKSPACE_ROOT".to_string(), "from_pass_env".to_string()),
+                    ("OVERRIDDEN".to_string(), "from_pass_env".to_string()),
+                ]),
+                runtime_pass_env: vec!["heph_TEST_GOLDEN_RUNTIME_PASS".to_string()],
+                // Beats `pass_env` for the same key.
+                runtime_env: HashMap::from([(
+                    "OVERRIDDEN".to_string(),
+                    "from_runtime_env".to_string(),
+                )]),
+            }),
+            inputs: vec![],
+            outputs: vec![
+                Output {
+                    group: String::new(),
+                    paths: vec![out_path("default.txt")],
+                },
+                Output {
+                    group: "named".to_string(),
+                    paths: vec![out_path("named.txt")],
+                },
+            ],
+            support_files: vec![],
+            cache: CacheConfig::on(true),
+            pty: false,
+            hash: vec![],
+            transparent: false,
+        };
+
+        let mut stdout = Vec::new();
+        let request_id = "env-golden".to_string();
+        let req = RunRequest {
+            request_id: &request_id,
+            target: &target_def,
+            tree_root_path: "".to_string().into(),
+            inputs: vec![],
+            hashin: "",
+            stdin: None,
+            stdout: Some(&mut stdout),
+            stderr: None,
+            sandbox_dir: tmp.path().to_path_buf(),
+        };
+        driver.run(make_req(req), &ctoken).await?;
+
+        let raw = String::from_utf8(stdout)?;
+        let sandbox = tmp.path().to_string_lossy().into_owned();
+
+        // Bash sets these for itself after `execve`; they are not part of what
+        // the driver composed and are not what this test is freezing.
+        const BASH_OWN: &[&str] = &["PWD=", "SHLVL=", "_=", "OLDPWD="];
+
+        let mut got: Vec<String> = raw
+            .lines()
+            .filter(|l| l.contains('=') && !BASH_OWN.iter().any(|b| l.starts_with(b)))
+            .map(|l| l.replace(&sandbox, "<SANDBOX>"))
+            .collect();
+        got.sort();
+
+        let want = vec![
+            "OUT=from_env default.txt".to_string(),
+            "OUT_NAMED=named.txt".to_string(),
+            "OVERRIDDEN=from_runtime_env".to_string(),
+            "PATH=/usr/local/bin:/usr/bin:/bin".to_string(),
+            "PLAIN=from_env".to_string(),
+            "WORKSPACE_ROOT=from_pass_env".to_string(),
+            "heph_TEST_GOLDEN_RUNTIME_PASS=from_runtime_pass_env".to_string(),
+        ];
+
+        assert_eq!(
+            got, want,
+            "child env drifted.\n got: {got:#?}\nwant: {want:#?}\n\
+             If this is a deliberate change to env composition, it changes what \
+             existing targets see under an unchanged cache key — see \
+             docs/EXEC_RUNNERS.md §4.4 before updating this golden."
+        );
+
+        Ok(())
+    }
+
     #[tokio::test]
     async fn test_parse_pass_env_resolves_value() -> anyhow::Result<()> {
         unsafe {

--- a/crates/plugin-nix/Cargo.toml
+++ b/crates/plugin-nix/Cargo.toml
@@ -11,6 +11,7 @@ hcore = { package = "core", path = "../core" }
 hmodel = { package = "model", path = "../model" }
 hplugin = { package = "plugin", path = "../plugin" }
 hproc = { package = "proc", path = "../proc" }
+hexec-runner = { package = "exec-runner", path = "../exec-runner" }
 hdriver-support = { package = "driver-support", path = "../driver-support" }
 anyhow = "1.0.102"
 serde = { version = "1", features = ["derive"] }

--- a/crates/plugin-nix/src/pluginnix/mod.rs
+++ b/crates/plugin-nix/src/pluginnix/mod.rs
@@ -3,6 +3,7 @@ use async_trait::async_trait;
 use hcore::hasync::Cancellable;
 use hcore::htvalue::signature::ParamType;
 use hdriver_support::driver_managed::{ManagedDriver, ManagedRunRequest, ManagedRunResponse};
+use hexec_runner::ExecSession;
 use hmodel::htpkg::PkgBuf;
 use hplugin::driver::targetdef::path::{CodegenMode, Content, Path as TPath};
 use hplugin::driver::targetdef::{CacheConfig, Input, InputMode, Output, TargetDef};
@@ -141,6 +142,7 @@ fn passthrough_nix_env() -> Vec<(OsString, OsString)> {
 async fn lock_flake_url(
     nix_bin: &str,
     url: &str,
+    runner: &dyn ExecSession,
     ctoken: &(dyn Cancellable + Send + Sync),
 ) -> anyhow::Result<String> {
     let args: Vec<OsString> = [
@@ -171,7 +173,8 @@ async fn lock_flake_url(
         ctty: false,
     };
 
-    let output = proc_exec::output(spec, ctoken)
+    let output = runner
+        .output(spec, ctoken)
         .await
         .context("wait for nix flake metadata")?;
     if !output.status.success() {
@@ -384,7 +387,7 @@ impl ManagedDriver for Driver {
         // eval cache (the single biggest avoidable eval cost — jvns).
         // `nix flake metadata --json <url>` resolves to an immutable URL
         // (containing rev / narHash) which `getFlake` accepts in pure mode.
-        let locked_flake_url = lock_flake_url(&nix_bin, &def.nixpkgs, ctoken)
+        let locked_flake_url = lock_flake_url(&nix_bin, &def.nixpkgs, &*req.runner, ctoken)
             .await
             .with_context(|| format!("lock flake url {}", def.nixpkgs))?;
 
@@ -420,7 +423,12 @@ impl ManagedDriver for Driver {
             ctty: false,
         };
 
-        let output = proc_exec::output(spec, ctoken)
+        // Through the session — see `docs/EXEC_RUNNERS.md` §4.2. `output`, not
+        // `spawn`: nix build output is collected in full after the wait, which
+        // needs the unbounded drain.
+        let output = req
+            .runner
+            .output(spec, ctoken)
             .await
             .with_context(|| format!("wait for nix build for {addr_str}"))?;
 

--- a/crates/plugin-oci/Cargo.toml
+++ b/crates/plugin-oci/Cargo.toml
@@ -11,6 +11,7 @@ hcore = { package = "core", path = "../core" }
 hmodel = { package = "model", path = "../model" }
 hplugin = { package = "plugin", path = "../plugin" }
 hproc = { package = "proc", path = "../proc" }
+hexec-runner = { package = "exec-runner", path = "../exec-runner" }
 hdriver-support = { package = "driver-support", path = "../driver-support" }
 futures = "0.3.32"
 anyhow = "1.0.102"

--- a/crates/plugin-oci/src/pluginoci/mod.rs
+++ b/crates/plugin-oci/src/pluginoci/mod.rs
@@ -468,6 +468,7 @@ pub(crate) mod testfake {
             sandbox_ws_dir: sandbox.ws.clone(),
             sandbox_pkg_dir: sandbox.pkg.clone(),
             inputs,
+            runner: std::sync::Arc::new(hexec_runner::LocalSession::new()),
         }
     }
 }

--- a/crates/plugin-sdk/Cargo.toml
+++ b/crates/plugin-sdk/Cargo.toml
@@ -21,6 +21,7 @@ anyhow = "1.0.102"
 hplugin-stabby = { package = "plugin-stabby", path = "../plugin-stabby", default-features = false, optional = true }
 plugin-abi = { path = "../plugin-abi", features = ["convert"], optional = true }
 hdriver-support = { package = "driver-support", path = "../driver-support", optional = true }
+hexec-runner = { package = "exec-runner", path = "../exec-runner", optional = true }
 # The cdylib's own copy of `proc` — its supervisor tracker is wired to the host's
 # over the ABI so children the plugin spawns are reaped by the host's sidecar.
 hproc = { package = "proc", path = "../proc", optional = true }
@@ -51,6 +52,7 @@ stabby = [
     "dep:hplugin-stabby",
     "dep:plugin-abi",
     "dep:hdriver-support",
+    "dep:hexec-runner",
     "dep:hproc",
     "dep:stabby",
     "dep:async-trait",

--- a/crates/plugin-sdk/src/serve.rs
+++ b/crates/plugin-sdk/src/serve.rs
@@ -1275,6 +1275,18 @@ async fn run_once(
         sandbox_ws_dir: PathBuf::from(req.sandbox_ws_dir),
         sandbox_pkg_dir: PathBuf::from(req.sandbox_pkg_dir),
         inputs: managed_inputs,
+        // Guest-side `local`: an identity transform, matching what a cdylib
+        // driver did before the seam existed.
+        //
+        // A runner selected host-side does NOT reach a plugin driver yet — the
+        // `runner_*` fields on `pb::ManagedRunRequest` are Phase 2. Until they
+        // exist WITH the positive-ack handshake, the host refuses `runner !=
+        // local` for any ABI-served driver rather than letting it build in the
+        // host environment under a cache key that asserts the runner's. That
+        // refusal is the host's to make: an older cdylib has no field to notice
+        // and could not even log the discrepancy — prost drops unknown bytes
+        // before guest code runs.
+        runner: std::sync::Arc::new(hexec_runner::LocalSession::new()),
     };
     let result = if shell {
         driver.run_shell(mrr, ct).await

--- a/devenv.nix
+++ b/devenv.nix
@@ -53,7 +53,7 @@ let
   };
 
   binLocation = "$HOME/.local/bin/heph3";
-  qualityCrates = "-p heph -p e2e -p bin-e2e -p testkit -p plugingo-e2e -p htspec-derive -p core -p config -p walk -p proc -p model -p sandboxfuse -p plugin -p plugin-abi -p plugin-sdk -p plugin-stabby -p plugin-go-cdylib -p builtins -p plugin-buildfile -p driver-support -p driver-bridge -p plugin-exec -p plugin-nix -p plugin-http -p plugin-oci -p plugin-query -p plugin-go -p plugin-gha -p plugin-gha-cdylib -p plugin-oci-cdylib -p telemetry -p tui -p lock -p selfupdate -p engine -p xstarlark-fmt -p bench-corpus -p bench";
+  qualityCrates = "-p heph -p e2e -p bin-e2e -p testkit -p plugingo-e2e -p htspec-derive -p core -p config -p walk -p proc -p model -p sandboxfuse -p plugin -p plugin-abi -p plugin-sdk -p plugin-stabby -p plugin-go-cdylib -p builtins -p plugin-buildfile -p driver-support -p driver-bridge -p exec-runner -p plugin-exec -p plugin-nix -p plugin-http -p plugin-oci -p plugin-query -p plugin-go -p plugin-gha -p plugin-gha-cdylib -p plugin-oci-cdylib -p telemetry -p tui -p lock -p selfupdate -p engine -p xstarlark-fmt -p bench-corpus -p bench";
 in
 {
   # https://devenv.sh/basics/


### PR DESCRIPTION
Phase 0 of #404. **No behaviour change** — nothing selects a non-default session yet.

Two commits, and the order matters:

1. **`test(plugin-exec): freeze the composed child environment`** — the golden. Check this commit out on its own and it is green *without* the seam; that is what makes commit 2's inertness checkable rather than asserted.
2. **`feat(exec-runner): the seam`** — the change. The golden still passes, unmodified.

## Why a golden first

The only existing freeze is `hashin`, and it **cannot see an env reordering**, because `runtime_*` values are deliberately unhashed. So a change to env composition would alter what existing targets see under an unchanged cache key — silently. Writing the golden also caught two places where an early draft had the precedence order *backwards*:

- `pass_env` / `runtime_pass_env` / `runtime_env` are applied **after** the heph-computed vars, so they override `WORKSPACE_ROOT` / `OUT_*`.
- `env` is applied **before** them, so `OUT_*` **appends** to an `env`-supplied value rather than replacing it (`entry().or_default()`, not `insert`) — a merge no layer table can express.

## The seam

`prepare(spec) -> Spec`, not a trait-objectified process factory. For the modes that matter first — a devenv env snapshot, a container, a chroot — a session is a pure transformation of the `Spec`. Keeping it there is what lets `proc_exec` stay exactly as it is:

- **`spawn` stays synchronous.** There is no suspension point between the fork and the caller receiving the `Handle`, so a cancellation cannot land there and orphan a child that was never registered with the supervisor. An `async fn spawn` would open exactly that window — and under fail-fast that is the *common* cancellation shape, not an exotic one.
- **`Handle`'s "the spawn is the API" invariant** and its OS-divergent reader-termination discipline stay concrete rather than erased behind a trait object.
- **PTY allocation stays put.** A `StdioSpec::Pty` variant looked right until it had to carry `termios` — `openpty(3)` on macOS leaves the slave's termios unspecified, which is why `pty::inherit_termios` exists — and until it needed a return path for the master.

**Both `spawn` and `output`, deliberately.** Six of the eight sites are `output`, and it cannot be built on `spawn`: unbounded drain, because nothing consumes the channel until the wait returns. Routing a large `go list` through `spawn` + wait wedges on darwin and passes on linux.

**`SpawnError` is typed** because two callers match on it: the exec driver, to name *which* PATH it searched (`.hephconfig` and a runner are different files to go fix), and the Phase 1 pool, to decide poisoning. `io::ErrorKind` carries neither. Classification stays in the driver — the only layer that knows which PATH it composed.

**`ShellFallback` forwards the session.** Without it, `--shell` on a driver that doesn't implement `run_shell` would drop you into a *host* shell while claiming to show what the target sees.

## Scope

Converts the statically-linked sites (`plugin-exec`, `plugin-nix`). **`plugin-go` and `plugin-oci` stay on `proc_exec` until Phase 2** — they are cdylib-only, and an ABI-served driver cannot receive a non-local session until the `runner_*` fields and their positive ack exist (#411). Converting them now would thread a guaranteed-`LocalSession` through two large crates and be redone in Phase 2 anyway.

`LocalSession::prepare` is the identity function, and that is load-bearing: `local` contributes nothing to any cache key, which is sound only while it is byte-for-byte the previous behaviour. Its `Identity` is recorded as `Asserted` — the honest reading, since the host `/usr/bin` plus an unhashed `path` option is the least-pinned environment in the system. It is absent from the key for compatibility, not because it is safe.

## Testing

`lint` clean. Full `tst` green: 481 e2e, 183 engine, 91 plugin-exec (incl. the golden and the missing-program diagnostic), 102 plugin-go, 39 plugin-nix, 15 driver-bridge.

The repo's own `lint_gate` caught the new crate missing from `qualityCrates`, which would have left it unformatted and green — fixed here.

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>
