### PR TITLE
feat(engine): select an exec environment, and put it in the cache key

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -563,6 +563,7 @@ dependencies = [
  "anyhow",
  "async-trait",
  "core",
+ "exec-runner",
  "futures",
  "glob",
  "itertools 0.15.0",
@@ -1503,6 +1504,7 @@ name = "e2e"
 version = "0.1.0"
 dependencies = [
  "anyhow",
+ "async-trait",
  "core",
  "heph",
  "plugin-oci",
@@ -1562,6 +1564,7 @@ dependencies = [
  "driver-bridge",
  "driver-support",
  "enclose",
+ "exec-runner",
  "flate2",
  "futures",
  "glob",
@@ -4008,6 +4011,7 @@ dependencies = [
  "config",
  "core",
  "erased-serde 0.4.10",
+ "exec-runner",
  "futures",
  "htspec-derive",
  "itertools 0.15.0",

--- a/crates/builtins/Cargo.toml
+++ b/crates/builtins/Cargo.toml
@@ -11,6 +11,7 @@ hcore = { package = "core", path = "../core" }
 hmodel = { package = "model", path = "../model" }
 hwalk = { package = "walk", path = "../walk" }
 hplugin = { package = "plugin", path = "../plugin" }
+hexec-runner = { package = "exec-runner", path = "../exec-runner" }
 anyhow = "1.0.102"
 serde = { version = "1", features = ["derive"] }
 async-trait = "0.1.89"

--- a/crates/builtins/src/pluginfs/mod.rs
+++ b/crates/builtins/src/pluginfs/mod.rs
@@ -1533,6 +1533,7 @@ mod tests {
             stdout: None,
             stderr: None,
             sandbox_dir: root,
+            runner: std::sync::Arc::new(hexec_runner::LocalSession::new()),
         }
     }
 

--- a/crates/builtins/src/plugingroup/mod.rs
+++ b/crates/builtins/src/plugingroup/mod.rs
@@ -727,6 +727,7 @@ mod tests {
                     stdout: None,
                     stderr: None,
                     sandbox_dir: Default::default(),
+                    runner: std::sync::Arc::new(hexec_runner::LocalSession::new()),
                 },
                 &ctoken(),
             )

--- a/crates/builtins/src/pluginhostbin/mod.rs
+++ b/crates/builtins/src/pluginhostbin/mod.rs
@@ -325,6 +325,7 @@ mod tests {
             stdout: None,
             stderr: None,
             sandbox_dir: sandbox_dir.to_path_buf(),
+            runner: std::sync::Arc::new(hexec_runner::LocalSession::new()),
         }
     }
 

--- a/crates/builtins/src/plugintextfile/mod.rs
+++ b/crates/builtins/src/plugintextfile/mod.rs
@@ -200,6 +200,7 @@ mod tests {
             stdout: None,
             stderr: None,
             sandbox_dir: sandbox_dir.to_path_buf(),
+            runner: std::sync::Arc::new(hexec_runner::LocalSession::new()),
         }
     }
 

--- a/crates/config/src/config_yaml.rs
+++ b/crates/config/src/config_yaml.rs
@@ -44,6 +44,17 @@ pub struct ConfigYaml {
     pub version_flavour: Option<String>,
     #[serde(default)]
     pub home_dir: Option<PathBuf>,
+    /// Exec environment every target's processes are created in unless the
+    /// target says otherwise (`docs/EXEC_RUNNERS.md` §6). A runner target's
+    /// address, e.g. `//:devenv`.
+    ///
+    /// This is the expected way to use exec runners — "the whole repo builds
+    /// under devenv" — and it is a one-line change with a whole-workspace
+    /// rebuild behind it, because the environment is part of every affected
+    /// target's cache key. Targets opt out with `runner = None`, and the runner
+    /// target itself is never subject to it.
+    #[serde(default)]
+    pub default_runner: Option<String>,
     /// Every provider/driver — built-in or external — is declared as a single
     /// `plugin`. A `builtin:` entry selects a compiled-in plugin by name; a
     /// `path:`/`url:` entry points at a `*-plugin.json` manifest for a loadable

--- a/crates/driver-bridge/src/bridge.rs
+++ b/crates/driver-bridge/src/bridge.rs
@@ -4,7 +4,6 @@ use async_trait::async_trait;
 use hcore::hasync::Cancellable;
 use hdriver_support::driver_managed::{ManagedDriver, ShellFallback};
 use hdriver_support::driver_managed_os::ManagedDriverOs;
-use hexec_runner::{ExecSession, LocalSession};
 use hplugin::driver::{
     ApplyTransitiveRequest, ApplyTransitiveResponse, ConfigRequest, ConfigResponse, Driver,
     ParseRequest, ParseResponse, RunInput, RunRequest, RunResponse,
@@ -48,17 +47,10 @@ impl ManagedDriverBridge {
         fuse: Option<FuseSlot>,
     ) -> Self {
         let driver = Arc::new(driver);
-        // Phase 0: one `local` session shared by both sandbox runners. It is an
-        // identity transform, so behaviour is byte-for-byte what it was before
-        // the seam existed. Phase 1 replaces this with per-target resolution —
-        // the bridge is already where the per-target `Os` vs `Fuse` choice is
-        // made, so it is the natural place for the per-target runner choice too.
-        let runner: Arc<dyn ExecSession> = Arc::new(LocalSession::new());
         let os = ManagedDriverOs {
             driver: driver.clone(),
             shell_fallback: shell_fallback.clone(),
             stage_dir: Some(home.join("stage")),
-            runner: Arc::clone(&runner),
         };
         let fuse = fuse.map(|f| ManagedDriverFuse {
             driver: driver.clone(),
@@ -67,7 +59,6 @@ impl ManagedDriverBridge {
             fs: f.fs,
             fuse_lower: f.fuse_lower,
             fuse_upper: f.fuse_upper,
-            runner: Arc::clone(&runner),
         });
         Self { cfg, os, fuse }
     }
@@ -85,7 +76,6 @@ impl ManagedDriverBridge {
                 driver: Arc::new(driver),
                 shell_fallback,
                 stage_dir: None,
-                runner: Arc::new(LocalSession::new()),
             },
             fuse: None,
         }
@@ -357,6 +347,7 @@ mod shell_fallback_tests {
             stdout: None,
             stderr: None,
             sandbox_dir: sandbox.clone(),
+            runner: std::sync::Arc::new(hexec_runner::LocalSession::new()),
         };
 
         bridge.run_shell(req, &ctoken).await?;

--- a/crates/driver-bridge/src/driver_managed_fuse.rs
+++ b/crates/driver-bridge/src/driver_managed_fuse.rs
@@ -6,7 +6,6 @@ use hdriver_support::driver_managed::{
     detect_output_collisions_blocking, invoke_inner, list_path_for, resolve_unpack_root,
     unpack_blocking, write_source_map_blocking,
 };
-use hexec_runner::ExecSession;
 use hplugin::driver::{RunInput, RunRequest, RunResponse, SandboxGuard};
 use hsandboxfuse as sandboxfuse;
 use std::collections::BTreeMap;
@@ -24,8 +23,6 @@ pub struct ManagedDriverFuse {
     pub(crate) fs: Arc<sandboxfuse::LayeredFs>,
     pub(crate) fuse_lower: PathBuf,
     pub(crate) fuse_upper: PathBuf,
-    /// See [`hdriver_support::driver_managed_os::ManagedDriverOs::runner`].
-    pub(crate) runner: Arc<dyn ExecSession>,
 }
 
 impl ManagedDriverFuse {
@@ -148,6 +145,8 @@ impl ManagedDriverFuse {
 
         let target = req.target;
         let hashin = req.hashin;
+        // Cloned before `req` moves into `invoke_inner`.
+        let session = Arc::clone(&req.runner);
 
         let mut res = invoke_inner(
             &**self.driver,
@@ -159,7 +158,9 @@ impl ManagedDriverFuse {
             sandbox_pkg_dir.clone(),
             inputs,
             &self.shell_fallback,
-            Arc::clone(&self.runner),
+            // The engine resolved this target's environment; the struct field
+            // is only the fallback for callers that build a request by hand.
+            session,
         )
         .await?;
 

--- a/crates/driver-support/src/driver_managed.rs
+++ b/crates/driver-support/src/driver_managed.rs
@@ -201,6 +201,7 @@ async fn run_shell_fallback<'a, 'io>(
         stdout,
         stderr,
         sandbox_dir: req_sandbox_dir,
+        runner: req_runner,
     } = request;
 
     let mut synthetic = (*shell_fallback.spec_template).clone();
@@ -235,6 +236,7 @@ async fn run_shell_fallback<'a, 'io>(
         stdout,
         stderr,
         sandbox_dir: req_sandbox_dir,
+        runner: req_runner,
     };
     let new_mreq = ManagedRunRequest {
         request: new_req,

--- a/crates/driver-support/src/driver_managed_os.rs
+++ b/crates/driver-support/src/driver_managed_os.rs
@@ -5,7 +5,6 @@ use crate::driver_managed::{
 };
 use anyhow::Context;
 use hcore::hasync::Cancellable;
-use hexec_runner::{ExecSession, LocalSession};
 use hplugin::driver::{RunInput, RunRequest, RunResponse};
 use std::collections::BTreeMap;
 use std::fs;
@@ -25,10 +24,6 @@ pub struct ManagedDriverOs {
     /// staging (read-only inputs fall back to the plain copy path) — used by
     /// the standalone [`ManagedDriverOs::new`] constructor.
     pub stage_dir: Option<PathBuf>,
-    /// The environment target processes are created in. Phase 0 always holds a
-    /// `LocalSession` (an identity transform); Phase 1 resolves it per target
-    /// from the target's `runner =`.
-    pub runner: Arc<dyn ExecSession>,
 }
 
 impl ManagedDriverOs {
@@ -41,7 +36,6 @@ impl ManagedDriverOs {
             driver: Arc::new(driver),
             shell_fallback,
             stage_dir: None,
-            runner: Arc::new(LocalSession::new()),
         }
     }
 
@@ -142,6 +136,8 @@ impl ManagedDriverOs {
 
         let target = req.target;
         let hashin = req.hashin;
+        // Cloned before `req` moves into `invoke_inner`.
+        let session = Arc::clone(&req.runner);
 
         let mut res = invoke_inner(
             &**self.driver,
@@ -153,7 +149,9 @@ impl ManagedDriverOs {
             sandbox_pkg_dir.clone(),
             inputs,
             &self.shell_fallback,
-            Arc::clone(&self.runner),
+            // The engine resolved this target's environment; the struct field
+            // is only the fallback for callers that build a request by hand.
+            session,
         )
         .await?;
 

--- a/crates/e2e/Cargo.toml
+++ b/crates/e2e/Cargo.toml
@@ -14,6 +14,7 @@ hplugin-oci = { package = "plugin-oci", path = "../plugin-oci" }
 hcore = { package = "core", path = "../core" }
 tokio = { version = "1", features = ["rt", "rt-multi-thread", "macros"] }
 anyhow = "1"
+async-trait = "0.1.89"
 tempfile = "3"
 tar = "0.4"
 serde_json = "1"

--- a/crates/e2e/tests/common/mod.rs
+++ b/crates/e2e/tests/common/mod.rs
@@ -46,9 +46,180 @@ impl std::ops::Deref for Workspace {
     }
 }
 
+/// A do-nothing managed driver registered as ABI-served, so a test can reach
+/// the engine's refusal without building a cdylib.
+pub struct AbiDriver;
+
+#[async_trait::async_trait]
+impl heph::engine::driver_managed::ManagedDriver for AbiDriver {
+    fn config(
+        &self,
+        _: heph::engine::driver::ConfigRequest,
+    ) -> anyhow::Result<heph::engine::driver::ConfigResponse> {
+        Ok(heph::engine::driver::ConfigResponse {
+            name: "abidriver".to_string(),
+        })
+    }
+    fn schema(&self) -> heph::engine::driver::DriverSchema {
+        Default::default()
+    }
+    async fn parse(
+        &self,
+        req: heph::engine::driver::ParseRequest,
+        _: &(dyn heph::hasync::Cancellable + Send + Sync),
+    ) -> anyhow::Result<heph::engine::driver::ParseResponse> {
+        use heph::engine::driver::targetdef::{CacheConfig, TargetDef};
+        Ok(heph::engine::driver::ParseResponse {
+            target_def: TargetDef {
+                addr: req.target_spec.addr.clone(),
+                labels: vec![],
+                raw_def: Arc::new(()),
+                inputs: vec![],
+                outputs: vec![],
+                support_files: vec![],
+                cache: CacheConfig::off(),
+                pty: false,
+                hash: vec![1],
+                transparent: false,
+            },
+        })
+    }
+    async fn apply_transitive(
+        &self,
+        req: heph::engine::driver::ApplyTransitiveRequest,
+        _: &(dyn heph::hasync::Cancellable + Send + Sync),
+    ) -> anyhow::Result<heph::engine::driver::ApplyTransitiveResponse> {
+        Ok(heph::engine::driver::ApplyTransitiveResponse {
+            target_def: req.target_def,
+        })
+    }
+    async fn run<'a, 'io>(
+        &self,
+        _: heph::engine::driver_managed::ManagedRunRequest<'a, 'io>,
+        _: &(dyn heph::hasync::Cancellable + Send + Sync),
+    ) -> anyhow::Result<heph::engine::driver_managed::ManagedRunResponse> {
+        Ok(heph::engine::driver_managed::ManagedRunResponse { artifacts: vec![] })
+    }
+}
+
+/// A test [`ExecRunner`] that counts its opens and hands back an environment.
+///
+/// The open counter is the point: the whole premise of a session is "acquire
+/// once, serve many", and nothing else can prove it.
+pub struct RecordingExecRunner {
+    pub opens: Arc<std::sync::atomic::AtomicUsize>,
+    /// Env var name/value the returned session applies to every process.
+    pub var: (String, String),
+}
+
+#[async_trait::async_trait]
+impl heph::engine::exec_runner::ExecRunner for RecordingExecRunner {
+    async fn open(
+        &self,
+        req: heph::engine::exec_runner::OpenRequest,
+        _ctoken: &(dyn heph::hasync::Cancellable + Send + Sync),
+    ) -> anyhow::Result<Arc<dyn heph::engine::exec_runner::ExecSession>> {
+        use heph::engine::exec_runner as er;
+        self.opens.fetch_add(1, std::sync::atomic::Ordering::SeqCst);
+
+        // The environment is derived from the artifact, not invented: that is
+        // the rule that keeps `open` a pure parse of content the cache key
+        // already covers (docs/EXEC_RUNNERS.md §4.7).
+        let from_artifact = req
+            .artifacts
+            .first()
+            .map(|a| String::from_utf8_lossy(&a.bytes).trim().to_string())
+            .unwrap_or_default();
+
+        Ok(Arc::new(er::EnvSession::new(
+            vec![
+                (
+                    std::ffi::OsString::from(self.var.0.clone()),
+                    std::ffi::OsString::from(self.var.1.clone()),
+                ),
+                (
+                    std::ffi::OsString::from("HEPH_TEST_RUNNER_ARTIFACT"),
+                    std::ffi::OsString::from(from_artifact),
+                ),
+            ],
+            er::SessionCaps {
+                pty: true,
+                max_concurrent: None,
+                identity: er::Identity::Pinned {
+                    by: req.key.clone(),
+                },
+            },
+            er::SessionDescription {
+                runner: req.runner_addr.clone(),
+                key: req.key,
+                summary: "recording test runner".to_string(),
+            },
+        )))
+    }
+}
+
 impl Workspace {
+    /// A workspace whose `bash`-driven runner targets are served by
+    /// [`RecordingExecRunner`], with `defaultRunner` unset.
+    pub fn with_recording_runner(
+        opens: Arc<std::sync::atomic::AtomicUsize>,
+        var: (&str, &str),
+    ) -> Self {
+        Self {
+            inner: WorkspaceBuilder::new()
+                .expect("workspace tempdir")
+                .with_provider(|init| {
+                    Box::new(pluginbuildfile::Provider::new(
+                        init.root.to_path_buf(),
+                        init.runtime.clone(),
+                    ))
+                })
+                .with_managed_driver(Box::new(pluginexec::Driver::new_exec()))
+                .with_managed_driver(Box::new(pluginexec::Driver::new_bash()))
+                // Keyed by the runner target's DRIVER name — a runner target
+                // built by `bash` is read back by the runner registered here.
+                .with_exec_runner(
+                    "bash",
+                    Arc::new(RecordingExecRunner {
+                        opens,
+                        var: (var.0.to_string(), var.1.to_string()),
+                    }),
+                )
+                .build()
+                .expect("build workspace"),
+            reopen_with: None,
+        }
+    }
+
     pub fn new() -> Self {
         Self::with_parallelism(None)
+    }
+
+    /// Like [`Workspace::with_recording_runner`], plus an `abidriver` managed
+    /// driver registered as though it came from a cdylib.
+    pub fn with_recording_runner_abi_driver(opens: Arc<std::sync::atomic::AtomicUsize>) -> Self {
+        Self {
+            inner: WorkspaceBuilder::new()
+                .expect("workspace tempdir")
+                .with_provider(|init| {
+                    Box::new(pluginbuildfile::Provider::new(
+                        init.root.to_path_buf(),
+                        init.runtime.clone(),
+                    ))
+                })
+                .with_managed_driver(Box::new(pluginexec::Driver::new_bash()))
+                .with_managed_driver_abi(Box::new(AbiDriver))
+                .with_exec_runner(
+                    "bash",
+                    Arc::new(RecordingExecRunner {
+                        opens,
+                        var: ("V".to_string(), "1".to_string()),
+                    }),
+                )
+                .build()
+                .expect("build workspace"),
+            reopen_with: None,
+        }
     }
 
     /// A workspace with `defaultRunner:` set — the exec environment every
@@ -72,6 +243,14 @@ impl Workspace {
                 .with_managed_driver(Box::new(pluginexec::Driver::new_exec()))
                 .with_managed_driver(Box::new(pluginexec::Driver::new_bash()))
                 .with_default_runner(addr)
+                // A default runner is only useful if something can serve it.
+                .with_exec_runner(
+                    "bash",
+                    Arc::new(RecordingExecRunner {
+                        opens: Arc::new(std::sync::atomic::AtomicUsize::new(0)),
+                        var: ("FROM_DEFAULT_RUNNER".to_string(), "1".to_string()),
+                    }),
+                )
                 .build()
                 .expect("build workspace"),
             reopen_with: None,

--- a/crates/e2e/tests/common/mod.rs
+++ b/crates/e2e/tests/common/mod.rs
@@ -51,6 +51,33 @@ impl Workspace {
         Self::with_parallelism(None)
     }
 
+    /// A workspace with `defaultRunner:` set — the exec environment every
+    /// target inherits unless it authored `runner =` or opted out.
+    ///
+    /// Not reopenable: `ReopenConfig` would have to carry the default too, and
+    /// a reopen that silently dropped it would resolve the same targets under
+    /// different keys into the same on-disk cache — the exact confusion that
+    /// struct's doc comment exists to prevent.
+    pub fn with_default_runner(addr: &str) -> Self {
+        let addr = heph::htaddr::parse_addr(addr).expect("parse defaultRunner addr");
+        Self {
+            inner: WorkspaceBuilder::new()
+                .expect("workspace tempdir")
+                .with_provider(|init| {
+                    Box::new(pluginbuildfile::Provider::new(
+                        init.root.to_path_buf(),
+                        init.runtime.clone(),
+                    ))
+                })
+                .with_managed_driver(Box::new(pluginexec::Driver::new_exec()))
+                .with_managed_driver(Box::new(pluginexec::Driver::new_bash()))
+                .with_default_runner(addr)
+                .build()
+                .expect("build workspace"),
+            reopen_with: None,
+        }
+    }
+
     pub fn with_parallelism(parallelism: impl Into<Option<usize>>) -> Self {
         let p = parallelism.into();
         let builder = WorkspaceBuilder::new()

--- a/crates/e2e/tests/exec_runner.rs
+++ b/crates/e2e/tests/exec_runner.rs
@@ -75,7 +75,8 @@ target(name = "b", driver = "bash", run = "echo x > $OUT", out = "o", runner = N
 /// starts matching a file that appeared for reasons the BUILD file cannot see.
 #[tokio::test]
 async fn runner_artifact_is_not_materialized_into_the_sandbox() -> anyhow::Result<()> {
-    let ws = Workspace::new();
+    let opens = std::sync::Arc::new(std::sync::atomic::AtomicUsize::new(0));
+    let ws = Workspace::with_recording_runner(std::sync::Arc::clone(&opens), ("X", "y"));
     ws.write_build_file(
         "mat",
         r#"
@@ -215,5 +216,139 @@ target(name = "user", driver = "bash", run = "echo x > $OUT", out = "o")
     // Resolves rather than cycling.
     let res = ws.run("//self:user").await?;
     assert!(!common::artifact_string(&res).is_empty());
+    Ok(())
+}
+
+/// The session actually reaches the process: a variable the runner supplies is
+/// visible to the target, and one the target sets itself is *not* overwritten
+/// by the runner's value for the same name.
+#[tokio::test]
+async fn the_session_environment_reaches_the_target() -> anyhow::Result<()> {
+    let opens = std::sync::Arc::new(std::sync::atomic::AtomicUsize::new(0));
+    let ws = Workspace::with_recording_runner(
+        std::sync::Arc::clone(&opens),
+        ("FROM_RUNNER", "runner_value"),
+    );
+    ws.write_build_file(
+        "sess",
+        r#"
+target(name = "env", driver = "bash", run = "echo ARTIFACT_BODY > $OUT", out = "env.json")
+target(
+    name = "consumer",
+    driver = "bash",
+    run = "echo \"$FROM_RUNNER|$HEPH_TEST_RUNNER_ARTIFACT|$MINE\" > $OUT",
+    out = "o",
+    env = {"MINE": "target_value"},
+    runner = "//sess:env",
+)
+"#,
+    );
+
+    let res = ws.run("//sess:consumer").await?;
+    let out = common::artifact_string(&res);
+    assert!(
+        out.contains("runner_value"),
+        "runner env did not reach the target: {out:?}"
+    );
+    // The runner derived this from the runner target's artifact, not from thin
+    // air — which is what keeps `open` a pure parse of hashed content.
+    assert!(
+        out.contains("ARTIFACT_BODY"),
+        "runner did not see the runner target's artifact: {out:?}"
+    );
+    assert!(
+        out.contains("target_value"),
+        "the target's own env must survive: {out:?}"
+    );
+    Ok(())
+}
+
+/// "Spawn the shell once and have multiple targets run within that context" —
+/// the requirement the whole session abstraction exists for. Asserted with a
+/// counter, because nothing else can show it.
+#[tokio::test]
+async fn one_open_serves_many_targets() -> anyhow::Result<()> {
+    let opens = std::sync::Arc::new(std::sync::atomic::AtomicUsize::new(0));
+    let ws = Workspace::with_recording_runner(std::sync::Arc::clone(&opens), ("V", "1"));
+    ws.write_build_file(
+        "many",
+        r#"
+target(name = "env", driver = "bash", run = "echo E > $OUT", out = "env.json")
+target(name = "a", driver = "bash", run = "echo a > $OUT", out = "o", runner = "//many:env")
+target(name = "b", driver = "bash", run = "echo b > $OUT", out = "o", runner = "//many:env")
+target(name = "c", driver = "bash", run = "echo c > $OUT", out = "o", runner = "//many:env")
+"#,
+    );
+
+    for t in ["//many:a", "//many:b", "//many:c"] {
+        ws.run(t).await?;
+    }
+
+    assert_eq!(
+        opens.load(std::sync::atomic::Ordering::SeqCst),
+        1,
+        "three targets sharing one environment must open it once",
+    );
+    Ok(())
+}
+
+/// Two runner targets whose artifacts are byte-identical are the *same*
+/// environment, so they share a session. Keying by content rather than by addr
+/// is what makes that true — and it is the same property that lets a renamed
+/// runner target keep its cache.
+#[tokio::test]
+async fn identical_artifacts_share_one_session() -> anyhow::Result<()> {
+    let opens = std::sync::Arc::new(std::sync::atomic::AtomicUsize::new(0));
+    let ws = Workspace::with_recording_runner(std::sync::Arc::clone(&opens), ("V", "1"));
+    ws.write_build_file(
+        "same",
+        r#"
+target(name = "env1", driver = "bash", run = "echo SAME > $OUT", out = "env.json")
+target(name = "env2", driver = "bash", run = "echo SAME > $OUT", out = "env.json")
+target(name = "a", driver = "bash", run = "echo a > $OUT", out = "o", runner = "//same:env1")
+target(name = "b", driver = "bash", run = "echo b > $OUT", out = "o", runner = "//same:env2")
+"#,
+    );
+
+    ws.run("//same:a").await?;
+    ws.run("//same:b").await?;
+
+    assert_eq!(
+        opens.load(std::sync::atomic::Ordering::SeqCst),
+        1,
+        "byte-identical runner artifacts describe one environment and must share a session",
+    );
+    Ok(())
+}
+
+/// A driver served across the plugin ABI cannot yet be told which environment
+/// to build in, so the engine **refuses** the combination rather than degrading.
+///
+/// Degrading is the dangerous option, not the safe one: the runner's hashout is
+/// folded into the target's `hashin` at def time, so a plugin that quietly built
+/// in the host environment would write an artifact whose key asserts an
+/// environment its bytes do not reflect — and push it to the shared remote
+/// cache. An older cdylib could not even warn: prost drops fields it was not
+/// compiled with before guest code runs.
+#[tokio::test]
+async fn abi_served_driver_refuses_a_runner() -> anyhow::Result<()> {
+    let opens = std::sync::Arc::new(std::sync::atomic::AtomicUsize::new(0));
+    let ws = Workspace::with_recording_runner_abi_driver(std::sync::Arc::clone(&opens));
+    ws.write_build_file(
+        "abi",
+        r#"
+target(name = "env", driver = "bash", run = "echo E > $OUT", out = "env.json")
+target(name = "c", driver = "abidriver", run = "true", runner = "//abi:env")
+"#,
+    );
+
+    let msg = match ws.run("//abi:c").await {
+        Ok(_) => panic!("an ABI-served driver must refuse a runner"),
+        Err(e) => format!("{e:#}"),
+    };
+    assert!(
+        msg.contains("plugin ABI") && msg.contains("abidriver"),
+        "error must name the driver and why, got: {msg}"
+    );
     Ok(())
 }

--- a/crates/e2e/tests/exec_runner.rs
+++ b/crates/e2e/tests/exec_runner.rs
@@ -1,0 +1,219 @@
+#![expect(
+    clippy::panic_in_result_fn,
+    reason = "restriction/style lints scoped to production code; tests are exempt"
+)]
+
+//! `runner =` selection and its effect on the cache key.
+//!
+//! Design: `docs/EXEC_RUNNERS.md`. The property under test throughout is §4.3's:
+//! a runner reference is a *target* reference, so the environment reaches
+//! `hashin` through the ordinary dependency mechanism and not through a new
+//! hash component.
+
+mod common;
+
+use common::Workspace;
+use heph::htaddr::parse_addr;
+
+async fn hashin(ws: &Workspace, addr: &str) -> anyhow::Result<String> {
+    let rs = ws.engine.new_state();
+    let meta = ws.engine.clone().meta(rs, &parse_addr(addr)?).await?;
+    Ok(meta.hashin)
+}
+
+/// Two runner targets describing different environments must give their
+/// consumers different keys. This is the whole point of runner-as-dependency:
+/// swap the environment, and every artifact built in it is re-keyed.
+#[tokio::test]
+async fn runner_identity_reaches_the_cache_key() -> anyhow::Result<()> {
+    let ws = Workspace::new();
+    ws.write_build_file(
+        "run",
+        r#"
+target(name = "envA", driver = "bash", run = "echo A > $OUT", out = "env.json")
+target(name = "envB", driver = "bash", run = "echo B > $OUT", out = "env.json")
+target(name = "plain", driver = "bash", run = "echo x > $OUT", out = "o")
+target(name = "under_a", driver = "bash", run = "echo x > $OUT", out = "o", runner = "//run:envA")
+target(name = "under_b", driver = "bash", run = "echo x > $OUT", out = "o", runner = "//run:envB")
+"#,
+    );
+
+    let plain = hashin(&ws, "//run:plain").await?;
+    let a = hashin(&ws, "//run:under_a").await?;
+    let b = hashin(&ws, "//run:under_b").await?;
+
+    assert_ne!(a, b, "different runners must give different keys");
+    assert_ne!(a, plain, "a runner must change the key at all");
+    Ok(())
+}
+
+/// The compatibility promise: a target with no runner hashes exactly as it did
+/// before exec runners existed, so shipping this invalidates nothing. `local`
+/// is the *absence* of a contribution, not a named one.
+#[tokio::test]
+async fn no_runner_and_explicit_local_hash_identically() -> anyhow::Result<()> {
+    let ws = Workspace::new();
+    ws.write_build_file(
+        "loc",
+        r#"
+target(name = "a", driver = "bash", run = "echo x > $OUT", out = "o")
+target(name = "b", driver = "bash", run = "echo x > $OUT", out = "o", runner = None)
+"#,
+    );
+
+    assert_eq!(
+        hashin(&ws, "//loc:a").await?,
+        hashin(&ws, "//loc:b").await?,
+        "`runner = None` must be indistinguishable from not authoring one",
+    );
+    Ok(())
+}
+
+/// The runner is a *hash-only* input: its bytes must never be materialized into
+/// a consumer's sandbox. Otherwise every target under a runner pays a symlink, a
+/// list file and an `SRC_*` entry it never asked for — and an in-sandbox glob
+/// starts matching a file that appeared for reasons the BUILD file cannot see.
+#[tokio::test]
+async fn runner_artifact_is_not_materialized_into_the_sandbox() -> anyhow::Result<()> {
+    let ws = Workspace::new();
+    ws.write_build_file(
+        "mat",
+        r#"
+target(name = "env", driver = "bash", run = "echo SECRET > $OUT", out = "env.json")
+target(
+    name = "consumer",
+    driver = "bash",
+    # Everything the sandbox contains, plus the routing vars a dep would set.
+    run = "ls -A . > $OUT; echo \"SRC=[${SRC:-}] LIST=[${LIST_SRC:-}]\" >> $OUT",
+    out = "o",
+    runner = "//mat:env",
+)
+"#,
+    );
+
+    let res = ws.run("//mat:consumer").await?;
+    let out = common::artifact_string(&res);
+    assert!(
+        !out.contains("env.json"),
+        "runner artifact leaked into the sandbox: {out:?}"
+    );
+    assert!(
+        out.contains("SRC=[] LIST=[]"),
+        "runner must not be wired into SRC_/LIST_ routing: {out:?}"
+    );
+    Ok(())
+}
+
+/// A runner target that produces nothing contributes NO bytes to `hashin` —
+/// `hashin` folds input *hashouts*, and a zero-output target has none. Two
+/// different such runners would give their consumers byte-identical keys, and
+/// an artifact built in one environment would be served for the other. Caught
+/// as a typed failure rather than silently.
+#[tokio::test]
+async fn zero_output_runner_is_rejected() -> anyhow::Result<()> {
+    let ws = Workspace::new();
+    ws.write_build_file(
+        "empty",
+        r#"
+target(name = "env", driver = "bash", run = "true")
+target(name = "consumer", driver = "bash", run = "echo x > $OUT", out = "o", runner = "//empty:env")
+"#,
+    );
+
+    let msg = match ws.run("//empty:consumer").await {
+        Ok(_) => panic!("a runner with no outputs must not resolve"),
+        Err(e) => format!("{e:#}"),
+    };
+    assert!(
+        msg.contains("produces no output artifacts"),
+        "error must name the actual problem, got: {msg}"
+    );
+    Ok(())
+}
+
+/// A bare name is rejected rather than guessed at. `driver = "bash"` sits right
+/// next to `runner =`, so the two look symmetric and are not: a runner names a
+/// target, because the environment it describes has to reach the cache key.
+#[tokio::test]
+async fn bare_runner_name_is_rejected() -> anyhow::Result<()> {
+    let ws = Workspace::new();
+    ws.write_build_file(
+        "bare",
+        r#"
+target(name = "c", driver = "bash", run = "echo x > $OUT", out = "o", runner = "devenv")
+"#,
+    );
+
+    let msg = match ws.run("//bare:c").await {
+        Ok(_) => panic!("a bare runner name must be rejected"),
+        Err(e) => format!("{e:#}"),
+    };
+    assert!(
+        msg.contains("target address"),
+        "error must say what a runner is, got: {msg}"
+    );
+    Ok(())
+}
+
+/// The workspace default applies to targets that did not author one — which §6
+/// calls the expected way to use this ("the whole repo builds under devenv").
+#[tokio::test]
+async fn workspace_default_applies_and_can_be_opted_out_of() -> anyhow::Result<()> {
+    let ws = Workspace::with_default_runner("//def:env");
+    ws.write_build_file(
+        "def",
+        r#"
+target(name = "env", driver = "bash", run = "echo A > $OUT", out = "env.json")
+target(name = "inherits", driver = "bash", run = "echo x > $OUT", out = "o")
+target(name = "opted_out", driver = "bash", run = "echo x > $OUT", out = "o", runner = None)
+"#,
+    );
+
+    let plain = Workspace::new();
+    plain.write_build_file(
+        "def",
+        r#"
+target(name = "env", driver = "bash", run = "echo A > $OUT", out = "env.json")
+target(name = "inherits", driver = "bash", run = "echo x > $OUT", out = "o")
+target(name = "opted_out", driver = "bash", run = "echo x > $OUT", out = "o", runner = None)
+"#,
+    );
+
+    let inherits_under_default = hashin(&ws, "//def:inherits").await?;
+    let inherits_no_default = hashin(&plain, "//def:inherits").await?;
+    assert_ne!(
+        inherits_under_default, inherits_no_default,
+        "setting defaultRunner must re-key targets that inherit it",
+    );
+
+    // `runner = None` is not merely "no runner authored" — it must survive a
+    // workspace default. Without that there is no way to keep a bootstrap
+    // target out of an environment that does not exist yet.
+    assert_eq!(
+        hashin(&ws, "//def:opted_out").await?,
+        hashin(&plain, "//def:opted_out").await?,
+        "`runner = None` must opt out of the workspace default",
+    );
+    Ok(())
+}
+
+/// The runner target itself must not inherit the workspace default, or it
+/// becomes its own dependency. The cycle checker would catch that, but it would
+/// report a graph problem for what is really a config one — so it is excluded
+/// up front and the common case never reaches the checker.
+#[tokio::test]
+async fn runner_target_does_not_inherit_the_default() -> anyhow::Result<()> {
+    let ws = Workspace::with_default_runner("//self:env");
+    ws.write_build_file(
+        "self",
+        r#"
+target(name = "env", driver = "bash", run = "echo A > $OUT", out = "env.json")
+target(name = "user", driver = "bash", run = "echo x > $OUT", out = "o")
+"#,
+    );
+
+    // Resolves rather than cycling.
+    let res = ws.run("//self:user").await?;
+    assert!(!common::artifact_string(&res).is_empty());
+    Ok(())
+}

--- a/crates/engine/Cargo.toml
+++ b/crates/engine/Cargo.toml
@@ -12,6 +12,7 @@ hconfig = { package = "config", path = "../config" }
 hmodel = { package = "model", path = "../model" }
 hwalk = { package = "walk", path = "../walk" }
 hproc = { package = "proc", path = "../proc" }
+hexec-runner = { package = "exec-runner", path = "../exec-runner" }
 hlock = { package = "lock", path = "../lock" }
 hsandboxfuse = { package = "sandboxfuse", path = "../sandboxfuse", default-features = false }
 hplugin = { package = "plugin", path = "../plugin" }

--- a/crates/engine/src/engine/config.rs
+++ b/crates/engine/src/engine/config.rs
@@ -6,6 +6,8 @@
 //! [`ConfigYaml::resolve`]. Everything downstream of [`resolve`](ConfigYaml::resolve)
 //! sees a fully-populated [`Config`] and never has to reason about defaults.
 
+use anyhow::Context as _;
+use hmodel::htaddr::Addr;
 use std::path::{Path, PathBuf};
 
 use crate::engine::RemoteCacheDef;
@@ -22,6 +24,10 @@ pub struct Config {
     ///
     /// [`Engine::skip_dirs`]: crate::engine::Engine::skip_dirs
     pub fs_skip: Vec<String>,
+    /// Workspace-level `defaultRunner:` — the exec environment applied to every
+    /// target that neither authored `runner =` nor opted out with
+    /// `runner = None`. See `docs/EXEC_RUNNERS.md` §6.
+    pub default_runner: Option<Addr>,
     pub parallelism: Option<usize>,
     /// In-memory tier fronting the durable (SQLite) local cache.
     pub mem_cache: MemCacheOptions,
@@ -60,6 +66,7 @@ impl Default for Config {
             root: PathBuf::new(),
             home_dir: PathBuf::new(),
             fs_skip: Vec::new(),
+            default_runner: None,
             parallelism: None,
             mem_cache: MemCacheOptions::default(),
             tmp_cache: MemCacheOptions::default_tmp(),
@@ -139,6 +146,17 @@ impl ConfigYamlExt for ConfigYaml {
                 .map(|p| root.join(p))
                 .unwrap_or_else(|| root.join(".heph3")),
             fs_skip: self.fs.as_ref().map(|f| f.skip.clone()).unwrap_or_default(),
+            // Parsed here rather than carried as a string so a typo fails at
+            // config load, naming the file — not at the first target that tried
+            // to use it, where it reads as a target problem.
+            default_runner: self
+                .default_runner
+                .as_deref()
+                .map(|s| {
+                    hmodel::htaddr::parse_addr_with_base(s, &hmodel::htpkg::PkgBuf::from(""))
+                        .with_context(|| format!("defaultRunner: {s:?} is not a target address"))
+                })
+                .transpose()?,
             parallelism: None,
             mem_cache: self
                 .mem_cache

--- a/crates/engine/src/engine/engine.rs
+++ b/crates/engine/src/engine/engine.rs
@@ -80,6 +80,18 @@ pub struct Engine {
     pub providers_by_name: HashMap<String, Arc<Provider>>,
     pub(crate) drivers: Vec<Arc<Driver>>,
     pub drivers_by_name: HashMap<String, Arc<Driver>>,
+    /// Exec runners by name. A runner is selected by the **driver name of the
+    /// runner target**: a plugin exporting a `devenv` driver (which builds the
+    /// environment artifact) exports a `devenv` runner alongside it (which reads
+    /// that artifact back).
+    pub exec_runners: HashMap<String, Arc<dyn hexec_runner::ExecRunner>>,
+    /// Open sessions, keyed by content — the runner target's hashouts.
+    ///
+    /// Engine-scoped rather than request-scoped so a long-lived process opens a
+    /// cold environment once, not once per invocation. Keyed by content and not
+    /// by addr so two runner targets with byte-identical artifacts correctly
+    /// share one session.
+    pub(crate) exec_sessions: Arc<crate::engine::exec_pool::ExecSessionPool>,
 
     /// Registered build-event hooks. Fed every emitted `BuildEvent` (see
     /// `RequestState::emit`); unlike providers/drivers they are never queried,
@@ -351,6 +363,17 @@ pub struct Provider {
 pub struct Driver {
     pub name: String,
     pub driver: Box<dyn SDKDriver>,
+    /// Whether this driver is served across the plugin ABI (a cdylib) rather
+    /// than linked into the host.
+    ///
+    /// Load-bearing, not informational: an ABI-served driver cannot yet be told
+    /// which environment to build in — the `runner_*` fields on
+    /// `pb::ManagedRunRequest` and their positive ack are Phase 2. Until then a
+    /// non-`local` runner on such a target would key the artifact as
+    /// runner-built while the plugin builds it in the host environment, and that
+    /// artifact goes to the shared remote cache. So the engine refuses the
+    /// combination outright rather than degrading (`docs/EXEC_RUNNERS.md` §8).
+    pub abi_served: bool,
 }
 
 impl Engine {
@@ -444,6 +467,8 @@ impl Engine {
             providers_by_name: HashMap::new(),
             drivers: vec![],
             drivers_by_name: HashMap::new(),
+            exec_runners: HashMap::new(),
+            exec_sessions: Arc::new(crate::engine::exec_pool::ExecSessionPool::default()),
             hooks: vec![],
             requests: Mutex::new(HashMap::new()),
             result_permits: {
@@ -608,9 +633,20 @@ impl Engine {
     /// Registers an already-constructed driver. Shared by [`Self::register_driver`]
     /// and [`Self::register_managed_driver`].
     fn insert_driver(&mut self, driver: Box<dyn SDKDriver>) -> anyhow::Result<()> {
+        self.insert_driver_with(driver, false)
+    }
+
+    /// [`Self::insert_driver`], recording whether the driver is served across
+    /// the plugin ABI. See [`Driver::abi_served`].
+    fn insert_driver_with(
+        &mut self,
+        driver: Box<dyn SDKDriver>,
+        abi_served: bool,
+    ) -> anyhow::Result<()> {
         let driver = Arc::new(Driver {
             name: driver.config(driver::ConfigRequest {})?.name,
             driver,
+            abi_served,
         });
 
         if self.drivers_by_name.contains_key(&driver.name) {
@@ -631,6 +667,34 @@ impl Engine {
         let managed = factory(&self.plugin_init_payload());
         let driver = self.new_managed_driver(managed);
         self.insert_driver(Box::new(driver))
+    }
+
+    /// [`Self::register_managed_driver`] for a driver loaded from a cdylib.
+    ///
+    /// The only difference is that the driver is marked [`Driver::abi_served`],
+    /// which the engine uses to refuse a non-`local` runner on its targets until
+    /// Phase 2 can actually carry one across the seam.
+    pub fn register_managed_driver_abi(
+        &mut self,
+        factory: impl FnOnce(&PluginInit) -> Box<dyn SDKManagedDriver>,
+    ) -> anyhow::Result<()> {
+        let managed = factory(&self.plugin_init_payload());
+        let driver = self.new_managed_driver(managed);
+        self.insert_driver_with(Box::new(driver), true)
+    }
+
+    /// Register an exec runner under `name`, matching the driver name of the
+    /// runner targets it serves.
+    pub fn register_exec_runner(
+        &mut self,
+        name: impl Into<String>,
+        runner: Arc<dyn hexec_runner::ExecRunner>,
+    ) -> anyhow::Result<()> {
+        let name = name.into();
+        if self.exec_runners.insert(name.clone(), runner).is_some() {
+            anyhow::bail!("exec runner already registered: {name}");
+        }
+        Ok(())
     }
 
     pub fn register_driver(

--- a/crates/engine/src/engine/exec_pool.rs
+++ b/crates/engine/src/engine/exec_pool.rs
@@ -1,0 +1,187 @@
+//! Open exec sessions, keyed by content.
+//!
+//! Not `hmemoizer`. That gives single-flight and panic-guarding and nothing else
+//! this needs: it has no TTL, no refcount, it memoizes *errors* for the process
+//! lifetime, and every instance in the tree is request-scoped. A pool that
+//! cached "devenv.nix doesn't evaluate" forever would keep failing after the
+//! user fixed it. So the single-flight is borrowed and the rest is here.
+
+use hcore::hasync::Cancellable;
+use hexec_runner::{ExecRunner, ExecSession, OpenRequest};
+use std::collections::HashMap;
+use std::sync::Arc;
+use tokio::sync::Mutex;
+
+/// One key's session, or the in-flight open of it. Named because the nesting
+/// is load-bearing and unreadable inline: the outer `Mutex` guards the map, the
+/// `OnceCell` collapses concurrent opens of the *same* key into one call, and
+/// the `Arc` lets a waiter hold the cell without holding the map lock across a
+/// 30-second `open`.
+type SessionCell = Arc<tokio::sync::OnceCell<Arc<dyn ExecSession>>>;
+
+/// Sessions by key, with the open of a cold key single-flighted.
+#[derive(Default)]
+pub struct ExecSessionPool {
+    entries: Mutex<HashMap<String, SessionCell>>,
+}
+
+impl std::fmt::Debug for ExecSessionPool {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("ExecSessionPool").finish_non_exhaustive()
+    }
+}
+
+impl ExecSessionPool {
+    /// The session for `req.key`, opening it once if this is the first ask.
+    ///
+    /// A failed open is **not** retained: the cell is removed so the next
+    /// request tries again. That matters most in a long-lived process, where
+    /// the alternative is a user fixing their environment and still being told
+    /// it is broken until they restart.
+    pub async fn get_or_open(
+        &self,
+        runner: &dyn ExecRunner,
+        req: OpenRequest,
+        ctoken: &(dyn Cancellable + Send + Sync),
+    ) -> anyhow::Result<Arc<dyn ExecSession>> {
+        let key = req.key.clone();
+        let cell = {
+            let mut entries = self.entries.lock().await;
+            Arc::clone(entries.entry(key.clone()).or_default())
+        };
+
+        let res = cell
+            .get_or_try_init(|| async { runner.open(req, ctoken).await })
+            .await;
+
+        match res {
+            Ok(s) => Ok(Arc::clone(s)),
+            Err(e) => {
+                self.entries.lock().await.remove(&key);
+                Err(e)
+            }
+        }
+    }
+}
+
+use crate::engine::Engine;
+use crate::engine::request_state::RequestState;
+use anyhow::Context as _;
+use hmodel::htaddr::Addr;
+
+/// Flatten a runner target's artifacts into the files its runner will parse.
+///
+/// Small by construction — an environment description, not a build output — so
+/// this reads them fully into memory rather than streaming.
+fn read_runner_artifacts(
+    res: &crate::engine::EResult,
+) -> anyhow::Result<Vec<hexec_runner::RunnerArtifact>> {
+    use hcore::hartifactcontent::WalkEntryKind;
+    use std::io::Read as _;
+
+    let mut out = Vec::new();
+    for content in &res.artifacts {
+        for entry in content.walk()? {
+            let entry = entry?;
+            if let WalkEntryKind::File { mut data, .. } = entry.kind {
+                let mut bytes = Vec::new();
+                data.read_to_end(&mut bytes)?;
+                out.push(hexec_runner::RunnerArtifact {
+                    path: entry.path.to_string_lossy().into_owned(),
+                    bytes,
+                });
+            }
+        }
+    }
+    // Stable order: a runner must not see its own inputs shuffled between runs.
+    out.sort_by(|a, b| a.path.cmp(&b.path));
+    Ok(out)
+}
+
+impl Engine {
+    /// The session a target's processes are created in.
+    ///
+    /// `None` runner ⇒ `LocalSession`, which is the identity transform and
+    /// contributes nothing to any cache key — the pre-runner behaviour, exactly.
+    pub(crate) async fn exec_session_for(
+        self: &Arc<Self>,
+        rs: &Arc<RequestState>,
+        runner: Option<&Addr>,
+        consumer_driver: &crate::engine::engine::Driver,
+    ) -> anyhow::Result<Arc<dyn ExecSession>> {
+        let Some(runner_addr) = runner else {
+            return Ok(Arc::new(hexec_runner::LocalSession::new()));
+        };
+
+        // Refuse rather than degrade. The runner's hashout is already folded
+        // into this target's `hashin` — that happened at def time — so building
+        // it in the host environment now would write an artifact whose key
+        // asserts an environment its bytes do not reflect, and push it to the
+        // shared remote cache. An older cdylib could not even warn about it:
+        // prost drops fields it was not compiled with before guest code runs.
+        if consumer_driver.abi_served {
+            anyhow::bail!(
+                "driver `{}` is served across the plugin ABI and cannot yet run targets under a \
+                 runner (`{}`). Set `runner = None` on this target, or drop `defaultRunner` for \
+                 it, until the driver can be told which environment to build in.",
+                consumer_driver.name,
+                runner_addr.format(),
+            );
+        }
+
+        // The runner's own result: its artifacts are the environment's
+        // description, and their hashouts are its identity.
+        let res = Arc::clone(self)
+            .result_addr(
+                Arc::clone(rs),
+                runner_addr,
+                crate::engine::OutputMatcher::All,
+                &crate::engine::ResultOptions::default(),
+            )
+            .await
+            .with_context(|| format!("resolving runner {}", runner_addr.format()))?;
+
+        // Which runner implementation? The runner target's own driver name —
+        // a plugin exporting a `devenv` driver exports a `devenv` runner beside
+        // it, so one name covers both halves.
+        let spec = Arc::clone(self)
+            .get_spec(Arc::clone(rs), runner_addr)
+            .await
+            .with_context(|| format!("resolving runner spec {}", runner_addr.format()))?;
+        let impl_name = spec.spec.driver.clone();
+        let runner_impl = self.exec_runners.get(&impl_name).cloned().ok_or_else(|| {
+            anyhow::anyhow!(
+                "no exec runner registered for `{impl_name}`, which is the driver of runner target \
+                 {}. A runner target's driver names the runner implementation that reads its \
+                 artifact.",
+                runner_addr.format(),
+            )
+        })?;
+
+        // Keyed by content, so two runner targets with byte-identical artifacts
+        // are one environment and share a session.
+        let mut key_parts: Vec<&str> = res
+            .artifacts_meta
+            .iter()
+            .map(|m| m.hashout.as_str())
+            .collect();
+        key_parts.sort_unstable();
+        let key = format!("{impl_name}:{}", key_parts.join("+"));
+
+        let artifacts = read_runner_artifacts(&res)
+            .with_context(|| format!("reading runner artifacts {}", runner_addr.format()))?;
+
+        self.exec_sessions
+            .get_or_open(
+                runner_impl.as_ref(),
+                OpenRequest {
+                    key,
+                    runner_addr: runner_addr.format(),
+                    artifacts,
+                },
+                rs.ctoken(),
+            )
+            .await
+            .with_context(|| format!("opening runner {}", runner_addr.format()))
+    }
+}

--- a/crates/engine/src/engine/execute.rs
+++ b/crates/engine/src/engine/execute.rs
@@ -38,6 +38,15 @@ impl Engine {
             .ok_or_else(|| anyhow::anyhow!("driver not found: {}", spec.driver))
             .cloned()?;
 
+        // Resolved here rather than threaded from `get_def`: `resolve_runner` is
+        // a pure function of (addr, spec, config), so recomputing it costs
+        // nothing and keeps the execute path from growing another parameter.
+        // The session itself is pooled and opened at most once per environment.
+        let runner_addr = self.resolve_runner(addr, spec);
+        let session = self
+            .exec_session_for(&rs, runner_addr.as_ref(), &driver)
+            .await?;
+
         hcore::hmemoizer::set_phase("execute:inputs_result_exec");
         let deps_result = self
             .clone()
@@ -158,7 +167,7 @@ impl Engine {
                     let hashin = hashin.to_owned();
 
                     let inner: InteractiveInner = Box::new(enclose!(
-                        (driver, def, rs, self => engine, sandbox_dir)
+                        (driver, def, rs, self => engine, sandbox_dir, session)
                         move |stdin, stdout, stderr| {
                             Box::pin(async move {
                                 let req = RunRequest {
@@ -171,6 +180,7 @@ impl Engine {
                                     stdout,
                                     stderr,
                                     sandbox_dir,
+                                    runner: Arc::clone(&session),
                                 };
                                 let res = if shell {
                                     driver.driver.run_shell(req, rs.ctoken()).await?

--- a/crates/engine/src/engine/meta.rs
+++ b/crates/engine/src/engine/meta.rs
@@ -104,7 +104,7 @@ impl Engine {
         // the link/execute path, but must not alter the cache key.
         let futures = inputs.iter().filter(|input| input.hashed).map(|input| {
             enclose!((self => engine, rc, input) async move {
-                engine
+                let res = engine
                     .clone()
                     .result_addr(
                         rc,
@@ -112,7 +112,32 @@ impl Engine {
                         OutputMatcher::None,
                         &ResultOptions::default(),
                     )
-                    .await
+                    .await?;
+
+                // A runner target that produces nothing is INVISIBLE to the
+                // cache key, and silently so: `hashin` folds input *hashouts*,
+                // and a zero-output target yields an empty `artifacts_meta`. Two
+                // runner targets describing completely different environments
+                // would then produce byte-identical `hashin` for every consumer,
+                // and an artifact built under one would be served for the other.
+                //
+                // Rejecting here rather than folding the runner's own `hashin`
+                // instead: that would be a second, runner-shaped hash component,
+                // and the design deliberately has exactly one way for anything to
+                // reach the key — through a dependency's hashout.
+                if input.origin_id == crate::engine::result::RUNNER_ORIGIN_ID
+                    && res.artifacts_meta.is_empty()
+                {
+                    anyhow::bail!(
+                        "runner {} produces no output artifacts, so it cannot describe an \
+                         environment: nothing of it would reach the cache key, and every target \
+                         using it would share a key with targets using a different runner. Give \
+                         the runner target an `out`.",
+                        input.r#ref.r#ref.format(),
+                    );
+                }
+
+                Ok(res)
             })
         });
 
@@ -157,6 +182,7 @@ mod tests {
         ExtendedTargetDef {
             target_def,
             applied_transitive: None,
+            runner: None,
             driver: driver.to_string(),
         }
     }

--- a/crates/engine/src/engine/mod.rs
+++ b/crates/engine/src/engine/mod.rs
@@ -29,6 +29,7 @@ pub use cwd::get_cwp;
 // The plugin contract (driver/provider/error + targetdef/eresult/htspec) now
 // lives in the `heph-plugin` crate; re-export at the original engine paths so
 // `crate::engine::driver::…` etc. resolve unchanged across engine + plugins.
+pub use hexec_runner as exec_runner;
 pub use hplugin::driver;
 pub use hplugin::error;
 pub use hplugin::hook;
@@ -69,6 +70,7 @@ pub use spec::EngineTargetSpec;
 pub use hdriver_bridge::driver_managed_fuse;
 pub use hdriver_support::driver_managed;
 pub use hdriver_support::driver_managed_os;
+pub(crate) mod exec_pool;
 mod execute;
 mod managed_register;
 mod result_lock;

--- a/crates/engine/src/engine/plugin_load.rs
+++ b/crates/engine/src/engine/plugin_load.rs
@@ -103,7 +103,9 @@ fn load_dylib_plugins(
             e.register_provider(|_| Box::new(p))?;
         }
         for (_name, drv) in drivers {
-            e.register_managed_driver(|_| Box::new(drv))?;
+            // `_abi`: these came from a cdylib, and a driver behind the seam
+            // cannot yet be told which environment to build in.
+            e.register_managed_driver_abi(|_| Box::new(drv))?;
         }
         for (_name, hook) in hooks {
             e.register_hook(std::sync::Arc::new(hook))?;

--- a/crates/engine/src/engine/result.rs
+++ b/crates/engine/src/engine/result.rs
@@ -1,4 +1,6 @@
 use crate::engine::Engine;
+use crate::engine::driver::TargetAddr;
+use crate::engine::driver::targetdef::InputMode;
 use crate::engine::driver::targetdef::{Input, TargetDef};
 use crate::engine::driver::{ApplyTransitiveRequest, ParseRequest, outputartifact};
 use crate::engine::error::{
@@ -18,6 +20,7 @@ use hcore::hmemoizer::{downcast_chain_ref, unwrap_arc_err};
 use hmodel::htaddr::Addr;
 use hmodel::htmatcher::MatchResult;
 use hmodel::htpkg::PkgBuf;
+use hplugin::provider::RunnerRef;
 
 use crate::engine::driver::sandbox::Sandbox;
 use crate::engine::link::LinkedTargetDef;
@@ -491,10 +494,48 @@ impl ProviderExecutor for EngineProviderExecutor {
 pub struct ExtendedTargetDef {
     pub target_def: Arc<TargetDef>,
     pub applied_transitive: Option<Sandbox>,
+    /// Resolved exec environment: `None` for `local`, else the runner target's
+    /// addr. Resolution order is per-target `runner =` → workspace
+    /// `defaultRunner` → local (`docs/EXEC_RUNNERS.md` §6).
+    ///
+    /// The addr is recorded for diagnostics and for execution to look the
+    /// session up. It does **not** feed the cache key directly — the runner
+    /// reaches `hashin` as an ordinary hashed input (see
+    /// [`Engine::resolve_runner`]), so two runner targets with byte-identical
+    /// artifacts are correctly the same environment.
+    pub runner: Option<Addr>,
     /// Registry name of the driver that produced `target_def`. Folded into
     /// `hashin` so swapping drivers under the same addr invalidates cache —
     /// even if the produced `TargetDef` bytes happen to match.
     pub driver: String,
+}
+
+/// The `origin_id` the runner input carries. Distinct and reserved so a driver
+/// cannot collide with it, and so diagnostics can name the edge.
+pub const RUNNER_ORIGIN_ID: &str = "@runner";
+
+/// The runner target, as an input of every target that uses it.
+///
+/// `hashed: true, runtime: false` — the existing `hash_deps` shape. That pair is
+/// the whole trick: the runner's `hashout` reaches the consumer's `hashin`, so
+/// changing the environment changes the key, while its bytes are **never**
+/// materialized into the consumer's sandbox. Materializing would cost a symlink,
+/// a list file and an `SRC_*`/`LIST_*` entry per target — 20k redundant file
+/// operations on a 20k-target build — and would change what an in-sandbox glob
+/// matches, which is a behaviour change nobody asked for.
+fn runner_input(addr: &Addr) -> Input {
+    Input {
+        r#ref: TargetAddr {
+            r#ref: addr.clone(),
+            output: None,
+            filters: vec![],
+        },
+        mode: InputMode::Standard,
+        origin_id: RUNNER_ORIGIN_ID.to_string(),
+        annotations: Default::default(),
+        hashed: true,
+        runtime: false,
+    }
 }
 
 /// Aggregate of a multi-target fanout. `errors` is non-empty only when the
@@ -3567,6 +3608,27 @@ impl Engine {
             .with_context(|| format!("get_def: {}", addr))
     }
 
+    /// Resolve which exec environment a target's processes are created in.
+    ///
+    /// Order: per-target `runner =` → workspace `defaultRunner` → local.
+    ///
+    /// The runner target itself is **excluded from the workspace default**. It
+    /// has to build under something, and letting it inherit the default makes it
+    /// its own dependency — which the cycle checker does catch, but reports as a
+    /// graph problem when it is really a config one. Excluding it up front means
+    /// the common case never reaches the checker at all.
+    fn resolve_runner(&self, addr: &Addr, spec: &TargetSpec) -> Option<Addr> {
+        match &spec.runner {
+            // `runner = None`: explicit opt-out, no default applies.
+            Some(RunnerRef::Local) => None,
+            Some(RunnerRef::Target(a)) => Some(a.clone()),
+            None => match &self.cfg.default_runner {
+                Some(d) if d == addr => None,
+                other => other.clone(),
+            },
+        }
+    }
+
     async fn get_def_inner(
         self: Arc<Self>,
         rs: Arc<RequestState>,
@@ -3658,6 +3720,25 @@ impl Engine {
             anyhow::bail!("missing hash");
         }
 
+        // Resolve the exec environment and wire it in as a hashed, non-runtime
+        // input.
+        //
+        // AFTER `apply_transitive`, deliberately. The runner is an engine-level
+        // concern that no driver is told about, and a driver's
+        // `apply_transitive` is free to rebuild `def.inputs` rather than push to
+        // it. Injecting earlier would leave the runner's presence in the cache
+        // key at the mercy of a driver that has no idea it exists — and its
+        // *absence* is silent, since a target that hashes as though it built in
+        // the host environment is exactly what it would then be.
+        //
+        // Nothing is lost by being late: `collect_transitive_deps` filters on
+        // `runtime`, which this input is not, so it would have been skipped
+        // there regardless.
+        let runner = self.resolve_runner(addr, &spec.spec);
+        if let Some(runner_addr) = &runner {
+            def.inputs.push(runner_input(runner_addr));
+        }
+
         // Validate approval notices against the finalized input set at definition
         // time — before any result resolution or execution — so a notice naming a
         // non-existent input group fails fast and identically on every path.
@@ -3667,6 +3748,7 @@ impl Engine {
         Ok(Arc::new(ExtendedTargetDef {
             target_def: Arc::new(def),
             applied_transitive: all_transitive,
+            runner,
             driver: spec.driver.clone(),
         }))
     }

--- a/crates/engine/src/engine/result.rs
+++ b/crates/engine/src/engine/result.rs
@@ -3617,7 +3617,7 @@ impl Engine {
     /// its own dependency — which the cycle checker does catch, but reports as a
     /// graph problem when it is really a config one. Excluding it up front means
     /// the common case never reaches the checker at all.
-    fn resolve_runner(&self, addr: &Addr, spec: &TargetSpec) -> Option<Addr> {
+    pub(crate) fn resolve_runner(&self, addr: &Addr, spec: &TargetSpec) -> Option<Addr> {
         match &spec.runner {
             // `runner = None`: explicit opt-out, no default applies.
             Some(RunnerRef::Local) => None,

--- a/crates/exec-runner/src/lib.rs
+++ b/crates/exec-runner/src/lib.rs
@@ -44,6 +44,7 @@ use hcore::hasync::Cancellable;
 use hproc::proc_exec::{self, Handle, Spec};
 use std::ffi::OsString;
 use std::process::Output;
+use std::sync::Arc;
 
 /// How well-pinned a session's environment is. Diagnostics only — it never
 /// changes whether heph caches a target. Choosing a weakly-pinned environment
@@ -248,6 +249,60 @@ pub trait ExecSession: Send + Sync {
     }
 }
 
+/// One file from the runner target's artifacts, handed to [`ExecRunner::open`].
+///
+/// Bytes rather than a path: the artifact **is** the description of the
+/// environment (§4.7 — "the canonicalized `ExecSessionSpec` *is* the runner
+/// target's output artifact"), it is small by construction, and passing bytes
+/// keeps `open` a pure parse of content the cache key already covers rather
+/// than a filesystem read the key knows nothing about.
+#[derive(Debug, Clone)]
+pub struct RunnerArtifact {
+    /// Path within the artifact tree.
+    pub path: String,
+    pub bytes: Vec<u8>,
+}
+
+/// What a runner needs to open a session.
+#[derive(Debug, Clone)]
+pub struct OpenRequest {
+    /// Content-addressed identity of this environment — the runner target's
+    /// hashouts. Two runner targets with byte-identical artifacts are the same
+    /// environment and share a session, which is the intended behaviour.
+    pub key: String,
+    /// The runner target's address, for diagnostics only.
+    pub runner_addr: String,
+    /// The runner target's output artifacts.
+    pub artifacts: Vec<RunnerArtifact>,
+}
+
+/// An environment in which target processes are created.
+///
+/// Registered on the engine under a name, and selected by the *driver name of
+/// the runner target*: a plugin that exports a `devenv` driver (which builds
+/// the environment artifact) exports a `devenv` runner alongside it (which
+/// parses that artifact). One name, two halves — the half that produces the
+/// description, and the half that reads it.
+#[async_trait::async_trait]
+pub trait ExecRunner: Send + Sync {
+    /// Acquire the session for `req.key`.
+    ///
+    /// Called at most once per distinct key per engine — the pool single-flights
+    /// it — and never on the per-target path. It may be slow: a cold devenv
+    /// evaluation is tens of seconds.
+    ///
+    /// **Must be a pure function of `req`.** Anything it reads that is not in
+    /// `req` is unhashed input: `open` runs after `hashin` is computed, and not
+    /// at all on a fully-cached build, so a value it discovers cannot reach the
+    /// key and cannot be validated on the build where a stale artifact is
+    /// served.
+    async fn open(
+        &self,
+        req: OpenRequest,
+        ctoken: &(dyn Cancellable + Send + Sync),
+    ) -> anyhow::Result<Arc<dyn ExecSession>>;
+}
+
 /// The zero-configuration session: the process is created exactly as it would
 /// have been before exec runners existed.
 ///
@@ -388,5 +443,152 @@ mod tests {
         .to_string();
         assert!(session.contains("runner `//:devenv`"), "{session}");
         assert!(session.contains("tools ="), "{session}");
+    }
+}
+
+/// A `Direct` session: processes are forked from this process, with a base
+/// environment applied beneath the caller's own.
+///
+/// This is the shape a devenv env-snapshot runner produces — the environment is
+/// a set of variables, and nothing else about process creation changes. It is
+/// also the reason `prepare` is the seam: there is no process to own here, only
+/// a spec to transform.
+#[derive(Debug)]
+pub struct EnvSession {
+    base_env: Vec<(OsString, OsString)>,
+    caps: SessionCaps,
+    description: SessionDescription,
+}
+
+impl EnvSession {
+    pub fn new(
+        base_env: Vec<(OsString, OsString)>,
+        caps: SessionCaps,
+        description: SessionDescription,
+    ) -> Self {
+        Self {
+            base_env,
+            caps,
+            description,
+        }
+    }
+}
+
+#[async_trait::async_trait]
+impl ExecSession for EnvSession {
+    /// Merge `base_env` **underneath** the spec's own entries.
+    ///
+    /// The caller wins on a collision: by the time a driver hands over a spec it
+    /// has already resolved the target's `env` / `pass_env` / `runtime_env` and
+    /// the sandbox's `$OUT`/`$SRC` routing, and none of that may be silently
+    /// replaced by an environment the target did not write.
+    ///
+    /// Pre-sized and built as a `Vec` rather than routed through a
+    /// `HashMap<String, String>`: the latter would clone every key and value and
+    /// then convert each again into `OsString`, which for a 60–150-variable dev
+    /// shell is hundreds of allocations per executed target.
+    fn prepare(&self, mut spec: Spec) -> Result<Spec, SpawnError> {
+        let mut env = Vec::with_capacity(self.base_env.len() + spec.env.len());
+        for (k, v) in &self.base_env {
+            if !spec.env.iter().any(|(sk, _)| sk == k) {
+                env.push((k.clone(), v.clone()));
+            }
+        }
+        env.append(&mut spec.env);
+        spec.env = env;
+        Ok(spec)
+    }
+
+    fn base_env(&self) -> Option<&[(OsString, OsString)]> {
+        Some(&self.base_env)
+    }
+
+    fn caps(&self) -> &SessionCaps {
+        &self.caps
+    }
+
+    fn describe(&self) -> &SessionDescription {
+        &self.description
+    }
+}
+
+#[cfg(test)]
+mod env_session_tests {
+    use super::*;
+    use std::path::PathBuf;
+
+    fn session(base: &[(&str, &str)]) -> EnvSession {
+        EnvSession::new(
+            base.iter()
+                .map(|(k, v)| (OsString::from(*k), OsString::from(*v)))
+                .collect(),
+            SessionCaps {
+                pty: true,
+                max_concurrent: None,
+                identity: Identity::Pinned {
+                    by: "test".to_string(),
+                },
+            },
+            SessionDescription {
+                runner: "test".to_string(),
+                key: "k".to_string(),
+                summary: "test".to_string(),
+            },
+        )
+    }
+
+    fn spec_with(env: &[(&str, &str)]) -> Spec {
+        Spec {
+            program: PathBuf::from("/bin/true"),
+            args: vec![],
+            env: env
+                .iter()
+                .map(|(k, v)| (OsString::from(*k), OsString::from(*v)))
+                .collect(),
+            cwd: PathBuf::from("/"),
+            stdin: proc_exec::StdioSpec::Null,
+            stdout: proc_exec::StdioSpec::Null,
+            stderr: proc_exec::StdioSpec::Null,
+            setsid: false,
+            ctty: false,
+        }
+    }
+
+    fn get<'a>(spec: &'a Spec, key: &str) -> Option<&'a OsString> {
+        spec.env.iter().find(|(k, _)| k == key).map(|(_, v)| v)
+    }
+
+    #[test]
+    fn base_env_is_applied_where_the_caller_said_nothing() {
+        let out = session(&[("PATH", "/nix/bin")])
+            .prepare(spec_with(&[]))
+            .expect("prepare");
+        assert_eq!(get(&out, "PATH"), Some(&OsString::from("/nix/bin")));
+    }
+
+    /// The caller wins. A driver has already resolved the target's own `env` and
+    /// the sandbox's `$OUT`/`$SRC` routing by this point; an environment the
+    /// target never wrote must not silently replace any of it.
+    #[test]
+    fn the_callers_entries_win_over_the_base() {
+        let out = session(&[("PATH", "/nix/bin"), ("CC", "clang")])
+            .prepare(spec_with(&[("PATH", "/sandbox/bin:/nix/bin")]))
+            .expect("prepare");
+        assert_eq!(
+            get(&out, "PATH"),
+            Some(&OsString::from("/sandbox/bin:/nix/bin"))
+        );
+        // …and a base entry the caller did not mention still arrives.
+        assert_eq!(get(&out, "CC"), Some(&OsString::from("clang")));
+    }
+
+    /// One entry per key: a duplicate would leave which value the child sees up
+    /// to `execve`, which is not a decision to leave to chance.
+    #[test]
+    fn no_duplicate_keys_survive_the_merge() {
+        let out = session(&[("A", "base")])
+            .prepare(spec_with(&[("A", "caller")]))
+            .expect("prepare");
+        assert_eq!(out.env.iter().filter(|(k, _)| k == "A").count(), 1);
     }
 }

--- a/crates/plugin-abi/src/convert.rs
+++ b/crates/plugin-abi/src/convert.rs
@@ -15,7 +15,7 @@ use hmodel::htpkg::PkgBuf;
 use hplugin::driver::TargetAddr;
 use hplugin::driver::sandbox::{Dep, Env, EnvValue, Mode, Sandbox, Tool};
 use hplugin::driver::targetdef::{RawDef, RawDefBytes};
-use hplugin::provider::{Approval, State, TargetSpec};
+use hplugin::provider::{Approval, RUNNER_LOCAL, RunnerRef, State, TargetSpec};
 use std::collections::BTreeMap;
 use std::sync::Arc;
 
@@ -500,7 +500,33 @@ pub fn target_spec_to_pb(t: &TargetSpec) -> pb::TargetSpec {
         labels: t.labels.clone(),
         transitive: Some(sandbox_to_pb(&t.transitive)),
         approval: Some(approval_to_pb(&t.approval)),
+        runner: runner_to_pb(t.runner.as_ref()),
     }
+}
+
+/// `runner =` crosses as a string: empty for "not authored" (inherit the
+/// workspace default), the reserved `"local"` for the explicit opt-out, and a
+/// formatted addr otherwise. A string rather than a message so the field is
+/// additive in the plainest possible way — an older peer sees an absent field
+/// and behaves exactly as it did before runners existed.
+fn runner_to_pb(r: Option<&RunnerRef>) -> String {
+    match r {
+        None => String::new(),
+        Some(RunnerRef::Local) => RUNNER_LOCAL.to_string(),
+        Some(RunnerRef::Target(addr)) => addr.format(),
+    }
+}
+
+fn runner_from_pb(s: &str, pkg: &PkgBuf) -> anyhow::Result<Option<RunnerRef>> {
+    if s.is_empty() {
+        return Ok(None);
+    }
+    if s == RUNNER_LOCAL {
+        return Ok(Some(RunnerRef::Local));
+    }
+    Ok(Some(RunnerRef::Target(
+        hmodel::htaddr::parse_addr_with_base(s, pkg)?,
+    )))
 }
 
 pub fn target_spec_from_pb(t: pb::TargetSpec) -> TargetSpec {
@@ -515,6 +541,11 @@ pub fn target_spec_from_pb(t: pb::TargetSpec) -> TargetSpec {
         labels: t.labels,
         transitive: sandbox_from_pb(t.transitive.unwrap_or_default()),
         approval: approval_from_pb(t.approval.unwrap_or_default()),
+        // A malformed runner addr from a peer is not worth failing the whole
+        // spec decode over; it degrades to "not authored" and the workspace
+        // default applies. The authoring side (`target()`) rejects it loudly,
+        // which is where a human can act on it.
+        runner: runner_from_pb(&t.runner, &PkgBuf::from("")).ok().flatten(),
     }
 }
 
@@ -896,6 +927,9 @@ mod tests {
                 required: true,
                 notice: vec!["plan".to_string()],
             },
+            runner: Some(RunnerRef::Target(
+                hmodel::htaddr::parse_addr_with_base("//pkg:devenv", &PkgBuf::from("")).unwrap(),
+            )),
         };
         spec.transitive.push_dep(Dep {
             r#ref: TargetAddr {

--- a/crates/plugin-buildfile/src/pluginbuildfile/provider.rs
+++ b/crates/plugin-buildfile/src/pluginbuildfile/provider.rs
@@ -619,6 +619,7 @@ impl EProvider for Provider {
                             labels: p.labels.clone(),
                             transitive: p.transitive.clone(),
                             approval: p.approval.clone(),
+                            runner: p.runner.clone(),
                         },
                     });
                 }

--- a/crates/plugin-buildfile/src/pluginbuildfile/run_file.rs
+++ b/crates/plugin-buildfile/src/pluginbuildfile/run_file.rs
@@ -10,6 +10,7 @@ use hplugin::driver::sandbox::{Dep, Env, EnvValue, Mode, Sandbox, Tool};
 use hplugin::driver::{DriverSchema, TargetAddr};
 use hplugin::provider::{
     Approval, FnArgs, FnCallContext, ProvenanceFrame, ProviderFn, ProviderFunctionRegistry,
+    RunnerRef,
 };
 use hwalk::{CachedWalker, EntryKind};
 use starlark::any::ProvidesStaticType;
@@ -464,10 +465,40 @@ pub(crate) struct OnTargetPayload {
     pub labels: Vec<String>,
     pub transitive: Sandbox,
     pub approval: Approval,
+    pub runner: Option<RunnerRef>,
     pub config: HashMap<String, htvalue::Value>,
     /// Source call sites that produced this target (innermost `target()` call
     /// first). See [`hplugin::provider::ProvenanceFrame`].
     pub provenance: Vec<ProvenanceFrame>,
+}
+
+/// Parse a BUILD-file `runner` value into a [`RunnerRef`].
+///
+/// Two spellings, and the asymmetry is deliberate: `runner = None` is the
+/// explicit opt-out, and everything else is an **addr**, not a name. That is
+/// the one place this differs from `driver =` sitting next to it, which is
+/// always a name — so a bare word here would be ambiguous with a target called
+/// `//:local`, and is rejected rather than guessed at.
+fn runner_from(v: htvalue::Value, pkg: &PkgBuf) -> anyhow::Result<Option<RunnerRef>> {
+    match v {
+        htvalue::Value::Null() => Ok(Some(RunnerRef::Local)),
+        htvalue::Value::String(s) if s == hplugin::provider::RUNNER_LOCAL => {
+            Ok(Some(RunnerRef::Local))
+        }
+        htvalue::Value::String(s) => {
+            if !s.contains("//") && !s.contains(':') {
+                anyhow::bail!(
+                    "runner must be a target address (e.g. `//:devenv`) or `None` to opt out; \
+                     got the bare name {s:?}. Unlike `driver`, `runner` names a target, because \
+                     the environment it describes has to reach the cache key."
+                );
+            }
+            Ok(Some(RunnerRef::Target(htaddr::parse_addr_with_base(
+                &s, pkg,
+            )?)))
+        }
+        other => anyhow::bail!("runner must be a target address string or `None`, got {other:?}"),
+    }
 }
 
 /// Parse a BUILD-file `approval` value into an [`Approval`]. Two spellings:
@@ -834,6 +865,12 @@ pub(crate) fn target_base_fields() -> Vec<hplugin::driver::DriverField> {
             false,
         ),
         f(
+            "runner",
+            ParamType::union(vec![ParamType::String, ParamType::Null]),
+            "Exec environment this target's processes run in: a runner target's addr, or `None` to opt out of the workspace `defaultRunner`.",
+            false,
+        ),
+        f(
             "approval",
             ParamType::union(vec![
                 ParamType::Bool,
@@ -874,6 +911,7 @@ fn starlark_module(builder: &mut GlobalsBuilder) {
         let mut labels: Vec<String> = vec![];
         let mut transitive: Sandbox = Default::default();
         let mut approval: Approval = Default::default();
+        let mut runner: Option<RunnerRef> = None;
         let config = m
             .iter()
             .map(|e| -> anyhow::Result<Option<(String, htvalue::Value)>> {
@@ -910,6 +948,11 @@ fn starlark_module(builder: &mut GlobalsBuilder) {
                             approval_from(starlark_to_rust(e.1)?).with_context(|| "approval")?;
                         Ok(None)
                     }
+                    "runner" => {
+                        runner = runner_from(starlark_to_rust(e.1)?, &PkgBuf::from(extra.pkg))
+                            .with_context(|| "runner")?;
+                        Ok(None)
+                    }
                     _ => Ok(Some((e.0.as_str().to_string(), starlark_to_rust(e.1)?))),
                 }
             })
@@ -938,6 +981,7 @@ fn starlark_module(builder: &mut GlobalsBuilder) {
             labels,
             transitive,
             approval,
+            runner,
             config,
             provenance,
         };

--- a/crates/plugin-exec/src/pluginexec/mod.rs
+++ b/crates/plugin-exec/src/pluginexec/mod.rs
@@ -2028,6 +2028,7 @@ mod tests {
             stdout: None,
             stderr: None,
             sandbox_dir: tmp.path().to_path_buf(),
+            runner: std::sync::Arc::new(hexec_runner::LocalSession::new()),
         };
 
         let res = tokio::time::timeout(
@@ -2352,6 +2353,7 @@ mod tests {
             stdout: Some(&mut stdout),
             stderr: None,
             sandbox_dir: tmp.path().to_path_buf(),
+            runner: std::sync::Arc::new(hexec_runner::LocalSession::new()),
         };
 
         let _res = driver.run(make_req(req), &ctoken).await?;
@@ -2409,6 +2411,7 @@ mod tests {
             stdout: None,
             stderr: None,
             sandbox_dir: tmp.path().to_path_buf(),
+            runner: std::sync::Arc::new(hexec_runner::LocalSession::new()),
         };
 
         let res = driver.run(make_req(req), &ctoken).await;
@@ -2479,6 +2482,7 @@ mod tests {
             stdout: Some(&mut stdout),
             stderr: None,
             sandbox_dir: tmp.path().to_path_buf(),
+            runner: std::sync::Arc::new(hexec_runner::LocalSession::new()),
         };
 
         // Use a timeout to detect the hang
@@ -2539,6 +2543,7 @@ mod tests {
             stdout: None,
             stderr: None,
             sandbox_dir: tmp.path().to_path_buf(),
+            runner: std::sync::Arc::new(hexec_runner::LocalSession::new()),
         };
 
         let run_fut = driver.run(make_req(req), &ctoken);
@@ -2606,6 +2611,7 @@ mod tests {
             stdout: None,
             stderr: None,
             sandbox_dir: tmp.path().to_path_buf(),
+            runner: std::sync::Arc::new(hexec_runner::LocalSession::new()),
         };
 
         let run_fut = driver.run(make_req(req), &ctoken);
@@ -2672,6 +2678,7 @@ mod tests {
             stdout: Some(&mut stdout),
             stderr: None,
             sandbox_dir: tmp.path().to_path_buf(),
+            runner: std::sync::Arc::new(hexec_runner::LocalSession::new()),
         };
 
         let res = tokio::time::timeout(
@@ -2847,6 +2854,7 @@ mod tests {
             stdout: Some(&mut out_handle),
             stderr: Some(&mut err_handle),
             sandbox_dir: tmp.path().to_path_buf(),
+            runner: std::sync::Arc::new(hexec_runner::LocalSession::new()),
         };
 
         tokio::time::timeout(MIDDLE * 10, driver.run(make_req(req), &ctoken))
@@ -2927,6 +2935,7 @@ mod tests {
             stdout: None,
             stderr: None,
             sandbox_dir: tmp.path().to_path_buf(),
+            runner: std::sync::Arc::new(hexec_runner::LocalSession::new()),
         };
 
         driver.run(make_req(req), &ctoken).await?;
@@ -3000,6 +3009,7 @@ mod tests {
             stdout: Some(&mut stdout),
             stderr: Some(&mut stderr),
             sandbox_dir: tmp.path().to_path_buf(),
+            runner: std::sync::Arc::new(hexec_runner::LocalSession::new()),
         };
 
         tokio::time::timeout(
@@ -3155,6 +3165,7 @@ mod tests {
             stdout: Some(&mut stdout),
             stderr: None,
             sandbox_dir: tmp.path().to_path_buf(),
+            runner: std::sync::Arc::new(hexec_runner::LocalSession::new()),
         };
 
         tokio::time::timeout(
@@ -3252,6 +3263,7 @@ mod tests {
             stdout: Some(&mut stdout),
             stderr: None,
             sandbox_dir: tmp.path().to_path_buf(),
+            runner: std::sync::Arc::new(hexec_runner::LocalSession::new()),
         };
         driver.run(make_req(req), &ctoken).await?;
         Ok(String::from_utf8(stdout)?.trim().to_string())
@@ -3433,6 +3445,7 @@ mod tests {
             stdout: Some(&mut stdout),
             stderr: None,
             sandbox_dir: tmp.path().to_path_buf(),
+            runner: std::sync::Arc::new(hexec_runner::LocalSession::new()),
         };
         driver.run(make_req(req), &ctoken).await?;
 
@@ -4129,6 +4142,7 @@ mod tests {
             stdout: None,
             stderr: None,
             sandbox_dir: tmp.path().to_path_buf(),
+            runner: std::sync::Arc::new(hexec_runner::LocalSession::new()),
         };
         driver
             .run(
@@ -4176,6 +4190,7 @@ mod tests {
             stdout: Some(&mut stdout),
             stderr: None,
             sandbox_dir: tmp.path().to_path_buf(),
+            runner: std::sync::Arc::new(hexec_runner::LocalSession::new()),
         };
         driver
             .run(
@@ -4255,6 +4270,7 @@ mod tests {
             stdout: Some(&mut stdout),
             stderr: None,
             sandbox_dir: tmp.path().to_path_buf(),
+            runner: std::sync::Arc::new(hexec_runner::LocalSession::new()),
         };
         driver
             .run(
@@ -4411,6 +4427,7 @@ mod tests {
             stdout: None,
             stderr: None,
             sandbox_dir: sandbox.clone(),
+            runner: std::sync::Arc::new(hexec_runner::LocalSession::new()),
         };
 
         os.run_inner(req, &ctoken, false).await?;
@@ -4507,6 +4524,7 @@ mod tests {
             stdout: None,
             stderr: None,
             sandbox_dir: tmp.path().to_path_buf(),
+            runner: std::sync::Arc::new(hexec_runner::LocalSession::new()),
         };
         driver
             .run(
@@ -4581,6 +4599,7 @@ mod tests {
             stdout: None,
             stderr: None,
             sandbox_dir: tmp.path().to_path_buf(),
+            runner: std::sync::Arc::new(hexec_runner::LocalSession::new()),
         };
         driver.run(make_req(req), &ctoken).await?;
 
@@ -4666,6 +4685,7 @@ mod tests {
             stdout: None,
             stderr: None,
             sandbox_dir: tmp.path().to_path_buf(),
+            runner: std::sync::Arc::new(hexec_runner::LocalSession::new()),
         };
         driver
             .run(
@@ -4768,6 +4788,7 @@ mod tests {
             stdout: None,
             stderr: None,
             sandbox_dir: tmp.path().to_path_buf(),
+            runner: std::sync::Arc::new(hexec_runner::LocalSession::new()),
         };
         driver
             .run(
@@ -4857,6 +4878,7 @@ mod tests {
             stdout: None,
             stderr: None,
             sandbox_dir: tmp.path().to_path_buf(),
+            runner: std::sync::Arc::new(hexec_runner::LocalSession::new()),
         };
 
         driver.run(make_req(req), &ctoken).await?;

--- a/crates/plugin-go/src/plugingo/driver_format.rs
+++ b/crates/plugin-go/src/plugingo/driver_format.rs
@@ -470,6 +470,7 @@ pub fn build_format_spec(p: FormatParams) -> TargetSpec {
         ],
         transitive: Default::default(),
         approval: Default::default(),
+        runner: None,
     }
 }
 
@@ -487,6 +488,7 @@ pub fn build_format_check_spec(p: FormatParams) -> TargetSpec {
         labels: vec!["go-format-check".to_string(), "format-check".to_string()],
         transitive: Default::default(),
         approval: Default::default(),
+        runner: None,
     }
 }
 

--- a/crates/plugin-go/src/plugingo/driver_lint.rs
+++ b/crates/plugin-go/src/plugingo/driver_lint.rs
@@ -1324,6 +1324,7 @@ pub fn build_lint_spec(p: LintParams) -> TargetSpec {
         labels: vec![],
         transitive: Default::default(),
         approval: Default::default(),
+        runner: None,
     }
 }
 
@@ -1366,6 +1367,7 @@ pub fn build_lint_gate_spec(
         labels: vec!["go-lint-check".to_string(), "lint-check".to_string()],
         transitive: Default::default(),
         approval: Default::default(),
+        runner: None,
     }
 }
 
@@ -1429,6 +1431,7 @@ pub fn build_lint_fix_spec(
         labels: vec!["go-lint".to_string(), "lint".to_string(), "fix".to_string()],
         transitive: Default::default(),
         approval: Default::default(),
+        runner: None,
     }
 }
 

--- a/crates/plugin-oci/src/pluginoci/mod.rs
+++ b/crates/plugin-oci/src/pluginoci/mod.rs
@@ -463,6 +463,7 @@ pub(crate) mod testfake {
                 stdout: None,
                 stderr: None,
                 sandbox_dir: sandbox.dir.path().to_path_buf(),
+                runner: std::sync::Arc::new(hexec_runner::LocalSession::new()),
             },
             sandbox_dir: sandbox.dir.path().to_path_buf(),
             sandbox_ws_dir: sandbox.ws.clone(),

--- a/crates/plugin-sdk/src/serve.rs
+++ b/crates/plugin-sdk/src/serve.rs
@@ -1268,6 +1268,7 @@ async fn run_once(
         stdout: Some(&mut stdout_sink),
         stderr: Some(&mut stderr_sink),
         sandbox_dir: sandbox_dir.clone(),
+        runner: std::sync::Arc::new(hexec_runner::LocalSession::new()),
     };
     let mrr = ManagedRunRequest {
         request: rr,

--- a/crates/plugin/Cargo.toml
+++ b/crates/plugin/Cargo.toml
@@ -10,6 +10,7 @@ workspace = true
 hcore = { package = "core", path = "../core" }
 hconfig = { package = "config", path = "../config" }
 hmodel = { package = "model", path = "../model" }
+hexec-runner = { package = "exec-runner", path = "../exec-runner" }
 hwalk = { package = "walk", path = "../walk" }
 htspec-derive = { path = "../htspec-derive" }
 anyhow = "1.0.102"

--- a/crates/plugin/src/driver.rs
+++ b/crates/plugin/src/driver.rs
@@ -1026,6 +1026,13 @@ pub struct RunRequest<'a, 'io> {
     pub stdout: Option<&'io mut (dyn tokio::io::AsyncWrite + Send + Sync + Unpin)>,
     pub stderr: Option<&'io mut (dyn tokio::io::AsyncWrite + Send + Sync + Unpin)>,
     pub sandbox_dir: std::path::PathBuf,
+    /// The environment this target's processes are created in. Always present;
+    /// `LocalSession` (an identity transform) unless a runner was selected.
+    ///
+    /// Resolved by the engine per target — a driver never chooses it. Drivers
+    /// create processes through this rather than calling `proc_exec` directly
+    /// (`docs/EXEC_RUNNERS.md` §4.2).
+    pub runner: std::sync::Arc<dyn hexec_runner::ExecSession>,
 }
 /// Cleanup closure a driver returns for the engine to run after `cache_locally`.
 /// The FUSE/OS sandbox layers each supply their own teardown; the engine's

--- a/crates/plugin/src/provider.rs
+++ b/crates/plugin/src/provider.rs
@@ -84,6 +84,37 @@ pub struct TargetSpec {
     pub labels: Vec<String>,
     pub transitive: Sandbox,
     pub approval: Approval,
+    /// Authored `runner =`: the exec environment this target's processes are
+    /// created in (`docs/EXEC_RUNNERS.md`).
+    ///
+    /// `None` means *not authored*, which is not the same as `local`: an
+    /// unauthored target inherits the workspace `defaultRunner`, while
+    /// [`RunnerRef::Local`] is an explicit opt-out that no default overrides.
+    /// Collapsing the two would make it impossible to opt a bootstrap target
+    /// out of a workspace default.
+    pub runner: Option<RunnerRef>,
+}
+
+/// The reserved, non-addr value of `runner =`: the explicit opt-out.
+///
+/// Spelled once here so the BUILD-file parser, the wire conversion and the
+/// engine's resolution cannot drift on it.
+pub const RUNNER_LOCAL: &str = "local";
+
+/// Where a target's processes are created.
+#[derive(Clone, Debug, PartialEq, Eq, Hash, Default, Serialize, Deserialize)]
+pub enum RunnerRef {
+    /// `runner = None` — the host process, exactly as before exec runners
+    /// existed. Never subject to `defaultRunner`; the runner target itself must
+    /// build under something, and letting it inherit the default would turn a
+    /// config mistake into a cycle error.
+    #[default]
+    Local,
+    /// `runner = //pkg:name` — a target whose artifact describes the
+    /// environment. A target reference rather than a config name so its
+    /// identity reaches the cache key through the ordinary dependency
+    /// mechanism (see `docs/EXEC_RUNNERS.md` §4.3).
+    Target(Addr),
 }
 
 pub trait ProviderExecutor: Send + Sync {

--- a/crates/testkit/src/lib.rs
+++ b/crates/testkit/src/lib.rs
@@ -17,6 +17,7 @@ pub struct WorkspaceBuilder {
     parallelism: Option<usize>,
     fs_skip: Vec<String>,
     default_runner: Option<Addr>,
+    exec_runners: Vec<(String, Arc<dyn heph::engine::exec_runner::ExecRunner>)>,
     setups: Vec<SetupFn>,
 }
 
@@ -27,6 +28,7 @@ impl WorkspaceBuilder {
             parallelism: None,
             fs_skip: vec![],
             default_runner: None,
+            exec_runners: vec![],
             setups: vec![],
         })
     }
@@ -37,6 +39,7 @@ impl WorkspaceBuilder {
             parallelism: None,
             fs_skip: vec![],
             default_runner: None,
+            exec_runners: vec![],
             setups: vec![],
         }
     }
@@ -61,6 +64,17 @@ impl WorkspaceBuilder {
         self
     }
 
+    /// Register an exec runner under `name`, which must match the *driver name*
+    /// of the runner targets it serves.
+    pub fn with_exec_runner(
+        mut self,
+        name: impl Into<String>,
+        runner: Arc<dyn heph::engine::exec_runner::ExecRunner>,
+    ) -> Self {
+        self.exec_runners.push((name.into(), runner));
+        self
+    }
+
     pub fn with_provider(
         mut self,
         factory: impl FnOnce(&PluginInit) -> Box<dyn SDKProvider> + 'static,
@@ -73,6 +87,16 @@ impl WorkspaceBuilder {
     pub fn with_managed_driver(mut self, driver: Box<dyn SDKManagedDriver>) -> Self {
         self.setups.push(Box::new(move |e: &mut Engine| {
             e.register_managed_driver(|_| driver)
+        }));
+        self
+    }
+
+    /// [`Self::with_managed_driver`], registered as though it were loaded from a
+    /// cdylib. Lets a test exercise the engine's refusal to run an ABI-served
+    /// driver under a runner without building an actual plugin.
+    pub fn with_managed_driver_abi(mut self, driver: Box<dyn SDKManagedDriver>) -> Self {
+        self.setups.push(Box::new(move |e: &mut Engine| {
+            e.register_managed_driver_abi(|_| driver)
         }));
         self
     }
@@ -93,6 +117,9 @@ impl WorkspaceBuilder {
             default_runner: self.default_runner,
             ..Default::default()
         })?;
+        for (name, runner) in self.exec_runners {
+            e.register_exec_runner(name, runner)?;
+        }
         for setup in self.setups {
             setup(&mut e)?;
         }

--- a/crates/testkit/src/lib.rs
+++ b/crates/testkit/src/lib.rs
@@ -16,6 +16,7 @@ pub struct WorkspaceBuilder {
     dir: TempDir,
     parallelism: Option<usize>,
     fs_skip: Vec<String>,
+    default_runner: Option<Addr>,
     setups: Vec<SetupFn>,
 }
 
@@ -25,6 +26,7 @@ impl WorkspaceBuilder {
             dir: tempfile::tempdir().context("create workspace tempdir")?,
             parallelism: None,
             fs_skip: vec![],
+            default_runner: None,
             setups: vec![],
         })
     }
@@ -34,6 +36,7 @@ impl WorkspaceBuilder {
             dir,
             parallelism: None,
             fs_skip: vec![],
+            default_runner: None,
             setups: vec![],
         }
     }
@@ -47,6 +50,14 @@ impl WorkspaceBuilder {
     /// plugin prunes. The engine splits these into literal dirs and globs.
     pub fn with_fs_skip(mut self, skip: impl IntoIterator<Item = impl Into<String>>) -> Self {
         self.fs_skip = skip.into_iter().map(Into::into).collect();
+        self
+    }
+
+    /// Mirrors the config file's `defaultRunner:` — the exec environment every
+    /// target inherits unless it authored `runner =` or opted out with
+    /// `runner = None`.
+    pub fn with_default_runner(mut self, addr: Addr) -> Self {
+        self.default_runner = Some(addr);
         self
     }
 
@@ -79,6 +90,7 @@ impl WorkspaceBuilder {
             home_dir: std::path::PathBuf::new(),
             parallelism: self.parallelism,
             fs_skip: self.fs_skip,
+            default_runner: self.default_runner,
             ..Default::default()
         })?;
         for setup in self.setups {

--- a/proto/plugin/v1/targetdef.proto
+++ b/proto/plugin/v1/targetdef.proto
@@ -21,6 +21,12 @@ message TargetSpec {
   repeated string labels = 4;
   Sandbox transitive = 5;
   Approval approval = 6;
+  // The exec environment this target's processes are created in
+  // (`docs/EXEC_RUNNERS.md`). Empty = not authored, so the workspace default
+  // applies; the reserved value "local" is the explicit opt-out. Additive: an
+  // older host ignores it and builds locally, which is the pre-runner
+  // behaviour.
+  string runner = 7;
 }
 
 // Opaque driver-specific config blob. The host never inspects this; it is


### PR DESCRIPTION
Phase 1a of #404, on top of #405. **The identity half of exec runners**: a target can say which environment it builds in, and that choice reaches `hashin`. Nothing executes differently yet — #413 opens sessions, #411 carries them across the plugin ABI.

Landing the key change alone is deliberate. It is the part that can silently produce a *wrong build*, and it is provable without a session existing.

## Surface

```yaml
defaultRunner: //:devenv          # .hephconfig — the expected way to use this
```
```python
target(name = "build", ..., runner = "//:devenv")   # per-target
target(name = "bootstrap", ..., runner = None)      # opt out
```

Resolution: per-target → `defaultRunner` → local. **Three levels, not four** — `runner` is deliberately *not* accepted in `transitive`, which is dependency-directional: as specified there, adding a dep would silently change a target's execution environment, and a scalar in an additive merge would pick an iteration-order winner.

`runner =` names a **target**, not a driver-style name — the one place it differs from `driver =` sitting beside it, so a bare word is rejected with an error saying why. That it must be a target is the load-bearing choice of the whole feature: only a target has a hashout, and only a hashout reaches the key without inventing a second hash component.

## Three decisions worth reviewing

**The runner is a `hashed: true, runtime: false` input** — the existing `hash_deps` shape. That pair is the trick: the environment's hashout reaches the consumer's `hashin` while its bytes are **never materialized** into the consumer's sandbox. Materializing would cost a symlink, a list file and an `SRC_*` entry per target — 20k redundant file ops on a 20k-target build — and would change what an in-sandbox glob matches.

**Injected *after* `apply_transitive`, not before.** A driver's `apply_transitive` may rebuild `def.inputs` rather than push to it, and the runner is an engine-level concern no driver is told about. Injecting earlier would leave its presence in the cache key at the mercy of a driver that doesn't know it exists — and its *absence* is silent, because a target that hashes as though it built on the host is exactly what it would then be. Nothing is lost by being late: `collect_transitive_deps` filters on `runtime`, which this input is not.

**A runner target with no outputs is rejected.** `hashin` folds input *hashouts*, and a zero-output target has none — so two runners describing completely different environments would give their consumers byte-identical keys, and an artifact built in one would be served for the other. Folding the runner's own `hashin` instead would have been a second, runner-shaped hash component; refusing keeps exactly one way for anything to reach the key.

## Compatibility

- `TargetSpec.runner` crosses the provider ABI as an **additive string** (empty = unauthored, `"local"` = opt-out, else an addr). A provider that knows nothing about runners is unaffected.
- `defaultRunner:` needs no rejection path — `ConfigYaml` is already `deny_unknown_fields`.
- **No cache entry is invalidated**: a target with no runner hashes byte-identically to today, asserted by a test.

## Tests (`crates/e2e/tests/exec_runner.rs`, 7 new)

- runner identity reaches the key; two runners ⇒ two keys
- `runner = None` and no-runner hash identically — the compatibility promise
- the runner artifact is **not** materialized (no `env.json` in the sandbox, `SRC_`/`LIST_` empty)
- zero-output runner ⇒ typed error naming the actual problem
- bare name ⇒ rejected with an error explaining a runner is a target
- workspace default applies, and `runner = None` survives it
- the runner target does not inherit the default (no cycle)

Full local run green: 545 e2e, 183 engine, 91 plugin-exec, plus buildfile/abi. `lint` clean.

## Not in this PR

`ExecRunner`/`open`, the session pool, wiring the resolved runner into execution, `inspect` output, and the devenv cdylib — those are #411 and #413.

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>
