### PR TITLE
feat(plugin-abi): carry the exec environment across the seam, with an ack

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4140,6 +4140,7 @@ dependencies = [
  "core",
  "driver-support",
  "enclose",
+ "exec-runner",
  "flate2",
  "futures",
  "glob",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4322,6 +4322,7 @@ name = "plugingo-e2e"
 version = "0.1.0"
 dependencies = [
  "anyhow",
+ "async-trait",
  "core",
  "futures",
  "heph",

--- a/crates/e2e/tests/common/mod.rs
+++ b/crates/e2e/tests/common/mod.rs
@@ -46,62 +46,6 @@ impl std::ops::Deref for Workspace {
     }
 }
 
-/// A do-nothing managed driver registered as ABI-served, so a test can reach
-/// the engine's refusal without building a cdylib.
-pub struct AbiDriver;
-
-#[async_trait::async_trait]
-impl heph::engine::driver_managed::ManagedDriver for AbiDriver {
-    fn config(
-        &self,
-        _: heph::engine::driver::ConfigRequest,
-    ) -> anyhow::Result<heph::engine::driver::ConfigResponse> {
-        Ok(heph::engine::driver::ConfigResponse {
-            name: "abidriver".to_string(),
-        })
-    }
-    fn schema(&self) -> heph::engine::driver::DriverSchema {
-        Default::default()
-    }
-    async fn parse(
-        &self,
-        req: heph::engine::driver::ParseRequest,
-        _: &(dyn heph::hasync::Cancellable + Send + Sync),
-    ) -> anyhow::Result<heph::engine::driver::ParseResponse> {
-        use heph::engine::driver::targetdef::{CacheConfig, TargetDef};
-        Ok(heph::engine::driver::ParseResponse {
-            target_def: TargetDef {
-                addr: req.target_spec.addr.clone(),
-                labels: vec![],
-                raw_def: Arc::new(()),
-                inputs: vec![],
-                outputs: vec![],
-                support_files: vec![],
-                cache: CacheConfig::off(),
-                pty: false,
-                hash: vec![1],
-                transparent: false,
-            },
-        })
-    }
-    async fn apply_transitive(
-        &self,
-        req: heph::engine::driver::ApplyTransitiveRequest,
-        _: &(dyn heph::hasync::Cancellable + Send + Sync),
-    ) -> anyhow::Result<heph::engine::driver::ApplyTransitiveResponse> {
-        Ok(heph::engine::driver::ApplyTransitiveResponse {
-            target_def: req.target_def,
-        })
-    }
-    async fn run<'a, 'io>(
-        &self,
-        _: heph::engine::driver_managed::ManagedRunRequest<'a, 'io>,
-        _: &(dyn heph::hasync::Cancellable + Send + Sync),
-    ) -> anyhow::Result<heph::engine::driver_managed::ManagedRunResponse> {
-        Ok(heph::engine::driver_managed::ManagedRunResponse { artifacts: vec![] })
-    }
-}
-
 /// A test [`ExecRunner`] that counts its opens and hands back an environment.
 ///
 /// The open counter is the point: the whole premise of a session is "acquire
@@ -193,33 +137,6 @@ impl Workspace {
 
     pub fn new() -> Self {
         Self::with_parallelism(None)
-    }
-
-    /// Like [`Workspace::with_recording_runner`], plus an `abidriver` managed
-    /// driver registered as though it came from a cdylib.
-    pub fn with_recording_runner_abi_driver(opens: Arc<std::sync::atomic::AtomicUsize>) -> Self {
-        Self {
-            inner: WorkspaceBuilder::new()
-                .expect("workspace tempdir")
-                .with_provider(|init| {
-                    Box::new(pluginbuildfile::Provider::new(
-                        init.root.to_path_buf(),
-                        init.runtime.clone(),
-                    ))
-                })
-                .with_managed_driver(Box::new(pluginexec::Driver::new_bash()))
-                .with_managed_driver_abi(Box::new(AbiDriver))
-                .with_exec_runner(
-                    "bash",
-                    Arc::new(RecordingExecRunner {
-                        opens,
-                        var: ("V".to_string(), "1".to_string()),
-                    }),
-                )
-                .build()
-                .expect("build workspace"),
-            reopen_with: None,
-        }
     }
 
     /// A workspace with `defaultRunner:` set — the exec environment every

--- a/crates/e2e/tests/exec_runner.rs
+++ b/crates/e2e/tests/exec_runner.rs
@@ -320,35 +320,3 @@ target(name = "b", driver = "bash", run = "echo b > $OUT", out = "o", runner = "
     );
     Ok(())
 }
-
-/// A driver served across the plugin ABI cannot yet be told which environment
-/// to build in, so the engine **refuses** the combination rather than degrading.
-///
-/// Degrading is the dangerous option, not the safe one: the runner's hashout is
-/// folded into the target's `hashin` at def time, so a plugin that quietly built
-/// in the host environment would write an artifact whose key asserts an
-/// environment its bytes do not reflect — and push it to the shared remote
-/// cache. An older cdylib could not even warn: prost drops fields it was not
-/// compiled with before guest code runs.
-#[tokio::test]
-async fn abi_served_driver_refuses_a_runner() -> anyhow::Result<()> {
-    let opens = std::sync::Arc::new(std::sync::atomic::AtomicUsize::new(0));
-    let ws = Workspace::with_recording_runner_abi_driver(std::sync::Arc::clone(&opens));
-    ws.write_build_file(
-        "abi",
-        r#"
-target(name = "env", driver = "bash", run = "echo E > $OUT", out = "env.json")
-target(name = "c", driver = "abidriver", run = "true", runner = "//abi:env")
-"#,
-    );
-
-    let msg = match ws.run("//abi:c").await {
-        Ok(_) => panic!("an ABI-served driver must refuse a runner"),
-        Err(e) => format!("{e:#}"),
-    };
-    assert!(
-        msg.contains("plugin ABI") && msg.contains("abidriver"),
-        "error must name the driver and why, got: {msg}"
-    );
-    Ok(())
-}

--- a/crates/engine/src/engine/engine.rs
+++ b/crates/engine/src/engine/engine.rs
@@ -363,17 +363,6 @@ pub struct Provider {
 pub struct Driver {
     pub name: String,
     pub driver: Box<dyn SDKDriver>,
-    /// Whether this driver is served across the plugin ABI (a cdylib) rather
-    /// than linked into the host.
-    ///
-    /// Load-bearing, not informational: an ABI-served driver cannot yet be told
-    /// which environment to build in — the `runner_*` fields on
-    /// `pb::ManagedRunRequest` and their positive ack are Phase 2. Until then a
-    /// non-`local` runner on such a target would key the artifact as
-    /// runner-built while the plugin builds it in the host environment, and that
-    /// artifact goes to the shared remote cache. So the engine refuses the
-    /// combination outright rather than degrading (`docs/EXEC_RUNNERS.md` §8).
-    pub abi_served: bool,
 }
 
 impl Engine {
@@ -633,20 +622,9 @@ impl Engine {
     /// Registers an already-constructed driver. Shared by [`Self::register_driver`]
     /// and [`Self::register_managed_driver`].
     fn insert_driver(&mut self, driver: Box<dyn SDKDriver>) -> anyhow::Result<()> {
-        self.insert_driver_with(driver, false)
-    }
-
-    /// [`Self::insert_driver`], recording whether the driver is served across
-    /// the plugin ABI. See [`Driver::abi_served`].
-    fn insert_driver_with(
-        &mut self,
-        driver: Box<dyn SDKDriver>,
-        abi_served: bool,
-    ) -> anyhow::Result<()> {
         let driver = Arc::new(Driver {
             name: driver.config(driver::ConfigRequest {})?.name,
             driver,
-            abi_served,
         });
 
         if self.drivers_by_name.contains_key(&driver.name) {
@@ -667,20 +645,6 @@ impl Engine {
         let managed = factory(&self.plugin_init_payload());
         let driver = self.new_managed_driver(managed);
         self.insert_driver(Box::new(driver))
-    }
-
-    /// [`Self::register_managed_driver`] for a driver loaded from a cdylib.
-    ///
-    /// The only difference is that the driver is marked [`Driver::abi_served`],
-    /// which the engine uses to refuse a non-`local` runner on its targets until
-    /// Phase 2 can actually carry one across the seam.
-    pub fn register_managed_driver_abi(
-        &mut self,
-        factory: impl FnOnce(&PluginInit) -> Box<dyn SDKManagedDriver>,
-    ) -> anyhow::Result<()> {
-        let managed = factory(&self.plugin_init_payload());
-        let driver = self.new_managed_driver(managed);
-        self.insert_driver_with(Box::new(driver), true)
     }
 
     /// Register an exec runner under `name`, matching the driver name of the

--- a/crates/engine/src/engine/exec_pool.rs
+++ b/crates/engine/src/engine/exec_pool.rs
@@ -107,27 +107,10 @@ impl Engine {
         self: &Arc<Self>,
         rs: &Arc<RequestState>,
         runner: Option<&Addr>,
-        consumer_driver: &crate::engine::engine::Driver,
     ) -> anyhow::Result<Arc<dyn ExecSession>> {
         let Some(runner_addr) = runner else {
             return Ok(Arc::new(hexec_runner::LocalSession::new()));
         };
-
-        // Refuse rather than degrade. The runner's hashout is already folded
-        // into this target's `hashin` — that happened at def time — so building
-        // it in the host environment now would write an artifact whose key
-        // asserts an environment its bytes do not reflect, and push it to the
-        // shared remote cache. An older cdylib could not even warn about it:
-        // prost drops fields it was not compiled with before guest code runs.
-        if consumer_driver.abi_served {
-            anyhow::bail!(
-                "driver `{}` is served across the plugin ABI and cannot yet run targets under a \
-                 runner (`{}`). Set `runner = None` on this target, or drop `defaultRunner` for \
-                 it, until the driver can be told which environment to build in.",
-                consumer_driver.name,
-                runner_addr.format(),
-            );
-        }
 
         // The runner's own result: its artifacts are the environment's
         // description, and their hashouts are its identity.

--- a/crates/engine/src/engine/execute.rs
+++ b/crates/engine/src/engine/execute.rs
@@ -43,9 +43,7 @@ impl Engine {
         // nothing and keeps the execute path from growing another parameter.
         // The session itself is pooled and opened at most once per environment.
         let runner_addr = self.resolve_runner(addr, spec);
-        let session = self
-            .exec_session_for(&rs, runner_addr.as_ref(), &driver)
-            .await?;
+        let session = self.exec_session_for(&rs, runner_addr.as_ref()).await?;
 
         hcore::hmemoizer::set_phase("execute:inputs_result_exec");
         let deps_result = self

--- a/crates/engine/src/engine/plugin_load.rs
+++ b/crates/engine/src/engine/plugin_load.rs
@@ -103,9 +103,7 @@ fn load_dylib_plugins(
             e.register_provider(|_| Box::new(p))?;
         }
         for (_name, drv) in drivers {
-            // `_abi`: these came from a cdylib, and a driver behind the seam
-            // cannot yet be told which environment to build in.
-            e.register_managed_driver_abi(|_| Box::new(drv))?;
+            e.register_managed_driver(|_| Box::new(drv))?;
         }
         for (_name, hook) in hooks {
             e.register_hook(std::sync::Arc::new(hook))?;

--- a/crates/plugin-go/Cargo.toml
+++ b/crates/plugin-go/Cargo.toml
@@ -11,6 +11,7 @@ hcore = { package = "core", path = "../core" }
 hmodel = { package = "model", path = "../model" }
 hwalk = { package = "walk", path = "../walk" }
 hproc = { package = "proc", path = "../proc" }
+hexec-runner = { package = "exec-runner", path = "../exec-runner" }
 hplugin = { package = "plugin", path = "../plugin" }
 hbuiltins = { package = "builtins", path = "../builtins" }
 hdriver-support = { package = "driver-support", path = "../driver-support" }

--- a/crates/plugin-go/src/plugingo/driver_compile.rs
+++ b/crates/plugin-go/src/plugingo/driver_compile.rs
@@ -20,6 +20,7 @@ use async_trait::async_trait;
 use hcore::debug_hash::DebugHasher;
 use hcore::hasync::Cancellable;
 use hdriver_support::driver_managed::{ManagedDriver, ManagedRunRequest, ManagedRunResponse};
+use hexec_runner::ExecSession;
 use hplugin::driver::targetdef::path::{CodegenMode, Content, Path};
 use hplugin::driver::targetdef::{CacheConfig, Input, InputMode, Output, TargetDef};
 use hplugin::driver::{
@@ -489,6 +490,7 @@ impl ManagedDriver for GoCompileDriver {
                 args.push(format!("./{s}"));
             }
             self.exec_go(
+                &*req.runner,
                 &go_bin,
                 run_go(args),
                 &env,
@@ -533,8 +535,16 @@ impl ManagedDriver for GoCompileDriver {
         cargs.push("-o".to_string());
         cargs.push(def.out_file.clone());
         cargs.push(format!("@{}", rsp_path.to_string_lossy()));
-        self.exec_go(&go_bin, run_go(cargs), &env, pkg_dir, ctoken, "compile")
-            .await?;
+        self.exec_go(
+            &*req.runner,
+            &go_bin,
+            run_go(cargs),
+            &env,
+            pkg_dir,
+            ctoken,
+            "compile",
+        )
+        .await?;
 
         // 6. asm step 3+4: assemble each .s, then pack into the archive.
         if has_asm {
@@ -557,8 +567,16 @@ impl ManagedDriver for GoCompileDriver {
                 ];
                 args.extend(shared.map(str::to_string));
                 args.extend(["-o".to_string(), obj, format!("./{s}")]);
-                self.exec_go(&go_bin, run_go(args), &env, pkg_dir, ctoken, "asm")
-                    .await?;
+                self.exec_go(
+                    &*req.runner,
+                    &go_bin,
+                    run_go(args),
+                    &env,
+                    pkg_dir,
+                    ctoken,
+                    "asm",
+                )
+                .await?;
             }
             let mut pargs = vec![
                 "tool".to_string(),
@@ -569,8 +587,16 @@ impl ManagedDriver for GoCompileDriver {
             for s in &def.s_files {
                 pargs.push(format!("{}.o", s.trim_end_matches(".s")));
             }
-            self.exec_go(&go_bin, run_go(pargs), &env, pkg_dir, ctoken, "pack")
-                .await?;
+            self.exec_go(
+                &*req.runner,
+                &go_bin,
+                run_go(pargs),
+                &env,
+                pkg_dir,
+                ctoken,
+                "pack",
+            )
+            .await?;
         }
 
         Ok(ManagedRunResponse { artifacts: vec![] })
@@ -701,8 +727,13 @@ impl GoCompileDriver {
         Ok(rel)
     }
 
+    #[expect(
+        clippy::too_many_arguments,
+        reason = "one process invocation: binary, argv, env, cwd, session, cancellation, and the step name for diagnostics"
+    )]
     async fn exec_go(
         &self,
+        runner: &dyn ExecSession,
         go_bin: &std::path::Path,
         args: Vec<OsString>,
         env: &HashMap<String, String>,
@@ -725,7 +756,8 @@ impl GoCompileDriver {
             setsid: false,
             ctty: false,
         };
-        let output = proc_exec::output(spec, ctoken)
+        let output = runner
+            .output(spec, ctoken)
             .await
             .with_context(|| format!("wait for go {step}"))?;
         if !output.status.success() {

--- a/crates/plugin-go/src/plugingo/driver_format.rs
+++ b/crates/plugin-go/src/plugingo/driver_format.rs
@@ -18,6 +18,7 @@ use async_trait::async_trait;
 use hcore::debug_hash::DebugHasher;
 use hcore::hasync::Cancellable;
 use hdriver_support::driver_managed::{ManagedDriver, ManagedRunRequest, ManagedRunResponse};
+use hexec_runner::ExecSession;
 use hplugin::driver::targetdef::path::{CodegenMode, Content, Path as TPath};
 use hplugin::driver::targetdef::{CacheConfig, Input, InputMode, Output, TargetDef};
 use hplugin::driver::{
@@ -74,6 +75,7 @@ fn arg_file(pkg_dir: &std::path::Path, files: &[String]) -> anyhow::Result<OsStr
 /// Run `heph-govet` with `args`, returning (exit code or None-if-signal, stdout,
 /// stderr). Never fails on a non-zero exit — the caller interprets the code.
 async fn exec_govet(
+    runner: &dyn ExecSession,
     bin: &str,
     args: Vec<OsString>,
     env: &HashMap<String, String>,
@@ -95,7 +97,8 @@ async fn exec_govet(
         setsid: false,
         ctty: false,
     };
-    let output = proc_exec::output(spec, ctoken)
+    let output = runner
+        .output(spec, ctoken)
         .await
         .context("wait for heph-govet -format")?;
     Ok((output.status.code(), output.stdout, output.stderr))
@@ -277,7 +280,8 @@ impl ManagedDriver for GoFormatDriver {
         }
         let args = vec![OsString::from("-format"), arg_file(pkg_dir, &files)?];
 
-        let (code, _stdout, stderr) = exec_govet(&bin, args, &env, pkg_dir, ctoken).await?;
+        let (code, _stdout, stderr) =
+            exec_govet(&*req.runner, &bin, args, &env, pkg_dir, ctoken).await?;
         if code != Some(0) {
             anyhow::bail!(
                 "heph-govet -format failed ({code:?}):\n{}",
@@ -379,7 +383,8 @@ impl ManagedDriver for GoFormatCheckDriver {
             arg_file(pkg_dir, &files)?,
         ];
 
-        let (code, stdout, stderr) = exec_govet(&bin, args, &env, pkg_dir, ctoken).await?;
+        let (code, stdout, stderr) =
+            exec_govet(&*req.runner, &bin, args, &env, pkg_dir, ctoken).await?;
         match code {
             Some(0) => Ok(ManagedRunResponse { artifacts: vec![] }),
             // Exit 1 = files need formatting; the tool prints them to stdout.

--- a/crates/plugin-go/src/plugingo/driver_golist.rs
+++ b/crates/plugin-go/src/plugingo/driver_golist.rs
@@ -439,7 +439,13 @@ impl ManagedDriver for GoGolistDriver {
             ctty: false,
         };
 
-        let output = proc_exec::output(spec, ctoken)
+        // Through the session, like every other `go` invocation: a target whose
+        // `hashin` says it ran in a runner's environment must actually have run
+        // there. `LocalSession::prepare` is the identity, so this is free when
+        // no runner is configured.
+        let output = req
+            .runner
+            .output(spec, ctoken)
             .await
             .with_context(|| format!("wait for go list for {}", def.import_path))?;
 

--- a/crates/plugin-go/src/plugingo/driver_lint.rs
+++ b/crates/plugin-go/src/plugingo/driver_lint.rs
@@ -31,6 +31,7 @@ use async_trait::async_trait;
 use hcore::debug_hash::DebugHasher;
 use hcore::hasync::Cancellable;
 use hdriver_support::driver_managed::{ManagedDriver, ManagedRunRequest, ManagedRunResponse};
+use hexec_runner::ExecSession;
 use hplugin::driver::targetdef::path::{CodegenMode, Content, Path as TPath};
 use hplugin::driver::targetdef::{CacheConfig, Input, InputMode, Output, TargetDef};
 use hplugin::driver::{
@@ -415,6 +416,7 @@ impl ManagedDriver for GoLintDriver {
         // produced and cached regardless of findings.
         let report = self
             .exec_govet(
+                &*req.runner,
                 std::path::Path::new(&govet_bin),
                 vec![
                     OsString::from("-json"),
@@ -495,6 +497,7 @@ impl GoLintDriver {
     /// findings do NOT fail here, `-json` makes the tool exit 0 for those.
     async fn exec_govet(
         &self,
+        runner: &dyn ExecSession,
         govet_bin: &std::path::Path,
         args: Vec<OsString>,
         env: &HashMap<String, String>,
@@ -516,7 +519,8 @@ impl GoLintDriver {
             setsid: false,
             ctty: false,
         };
-        let output = proc_exec::output(spec, ctoken)
+        let output = runner
+            .output(spec, ctoken)
             .await
             .context("wait for heph-govet")?;
         if !output.status.success() {

--- a/crates/plugin-oci/src/pluginoci/docker_build.rs
+++ b/crates/plugin-oci/src/pluginoci/docker_build.rs
@@ -86,6 +86,7 @@ use async_trait::async_trait;
 use hcore::debug_hash::DebugHasher;
 use hcore::hasync::Cancellable;
 use hdriver_support::driver_managed::{ManagedDriver, ManagedRunRequest, ManagedRunResponse};
+use hexec_runner::ExecSession;
 use hplugin::driver::targetdef::path::{CodegenMode, Content, Path as OutPath};
 use hplugin::driver::targetdef::{Input, InputMode, Output, TargetDef};
 use hplugin::driver::{
@@ -1171,9 +1172,16 @@ impl ManagedDriver for Driver {
 
         let addr = req.request.target.addr.format();
         let mut io = ToolIo::from_request(&mut req.request);
-        run_tool(argv, &context_dir, "docker buildx build", &mut io, ctoken)
-            .await
-            .map_err(|e| build_error_hint(e, &def, &addr))?;
+        run_tool(
+            &*req.runner,
+            argv,
+            &context_dir,
+            "docker buildx build",
+            &mut io,
+            ctoken,
+        )
+        .await
+        .map_err(|e| build_error_hint(e, &def, &addr))?;
 
         let metadata = tokio::fs::read_to_string(&metadata_file)
             .await
@@ -1407,6 +1415,7 @@ async fn tee<'w>(
 ///
 /// Returns captured stdout.
 pub(crate) async fn run_tool(
+    runner: &dyn ExecSession,
     argv: Vec<String>,
     cwd: &Path,
     what: &'static str,
@@ -1432,7 +1441,9 @@ pub(crate) async fn run_tool(
         ctty: false,
     };
 
-    let mut handle = proc_exec::spawn(spec).map_err(|e| missing_tool_error(e, bin, what))?;
+    let mut handle = runner
+        .spawn(spec)
+        .map_err(|e| missing_tool_error(e, bin, what))?;
     let output_reader = handle.take_output();
 
     let out_tail = std::sync::Mutex::new(TailBuf::default());
@@ -1491,8 +1502,12 @@ pub(crate) async fn run_tool(
 /// something the reader can act on. `docker` is a host capability
 /// heph does not install, so "not found" is a routine first-run state, not an
 /// internal error.
-fn missing_tool_error(e: std::io::Error, bin: &str, what: &str) -> anyhow::Error {
-    if e.kind() == std::io::ErrorKind::NotFound {
+fn missing_tool_error(e: hexec_runner::SpawnError, bin: &str, what: &str) -> anyhow::Error {
+    let not_found = matches!(
+        &e,
+        hexec_runner::SpawnError::Io(io) if io.kind() == std::io::ErrorKind::NotFound,
+    ) || matches!(&e, hexec_runner::SpawnError::ProgramNotFound { .. });
+    if not_found {
         let hint = match Path::new(bin).file_name().and_then(|n| n.to_str()) {
             Some("docker") => " — install Docker (the `docker_build` driver needs `docker buildx`)",
             _ => "",

--- a/crates/plugin-oci/src/pluginoci/platform.rs
+++ b/crates/plugin-oci/src/pluginoci/platform.rs
@@ -285,6 +285,7 @@ impl ManagedDriver for Driver {
 
         let mut io = super::docker_build::ToolIo::from_request(&mut req.request);
         let stdout = super::docker_build::run_tool(
+            &*req.runner,
             argv,
             &cwd,
             "docker buildx inspect",

--- a/crates/plugin-sdk/src/serve.rs
+++ b/crates/plugin-sdk/src/serve.rs
@@ -1235,6 +1235,45 @@ impl tokio::io::AsyncWrite for FrameSink {
     }
 }
 
+/// Build the session the host asked for.
+///
+/// An empty `runner_key` means no runner was selected, and `LocalSession` — the
+/// identity transform — is what every driver behind this seam did before exec
+/// runners existed. A non-empty key means the host resolved an environment and
+/// is expecting it back in the ack.
+fn guest_session(req: &pb::ManagedRunRequest) -> Arc<dyn hexec_runner::ExecSession> {
+    use std::os::unix::ffi::OsStringExt as _;
+
+    if req.runner_key.is_empty() {
+        return Arc::new(hexec_runner::LocalSession::new());
+    }
+    Arc::new(hexec_runner::EnvSession::new(
+        req.runner_env
+            .iter()
+            .map(|kv| {
+                (
+                    std::ffi::OsString::from_vec(kv.key.to_vec()),
+                    std::ffi::OsString::from_vec(kv.value.to_vec()),
+                )
+            })
+            .collect(),
+        hexec_runner::SessionCaps {
+            pty: true,
+            max_concurrent: None,
+            // The host decided how well-pinned this is; the guest is only
+            // applying it, and must not claim more than it knows.
+            identity: hexec_runner::Identity::Asserted {
+                why: "supplied by the host for this run".to_string(),
+            },
+        },
+        hexec_runner::SessionDescription {
+            runner: req.runner_addr.clone(),
+            key: req.runner_key.clone(),
+            summary: "host-supplied environment".to_string(),
+        },
+    ))
+}
+
 async fn run_once(
     driver: Arc<dyn ManagedDriver>,
     req: pb::ManagedRunRequest,
@@ -1243,6 +1282,9 @@ async fn run_once(
 ) -> pb::RunOutFrame {
     // `shell` selects run_shell over run; it rides the request.
     let shell = req.shell;
+    // Both captured before `req` is consumed field-by-field below.
+    let runner_key = req.runner_key.clone();
+    let session = guest_session(&req);
     let target = match convert::target_def_from_pb(req.target.unwrap_or_default()) {
         Ok(t) => t,
         Err(e) => return run_out_err(err_message(&e)),
@@ -1276,18 +1318,10 @@ async fn run_once(
         sandbox_ws_dir: PathBuf::from(req.sandbox_ws_dir),
         sandbox_pkg_dir: PathBuf::from(req.sandbox_pkg_dir),
         inputs: managed_inputs,
-        // Guest-side `local`: an identity transform, matching what a cdylib
-        // driver did before the seam existed.
-        //
-        // A runner selected host-side does NOT reach a plugin driver yet — the
-        // `runner_*` fields on `pb::ManagedRunRequest` are Phase 2. Until they
-        // exist WITH the positive-ack handshake, the host refuses `runner !=
-        // local` for any ABI-served driver rather than letting it build in the
-        // host environment under a cache key that asserts the runner's. That
-        // refusal is the host's to make: an older cdylib has no field to notice
-        // and could not even log the discrepancy — prost drops unknown bytes
-        // before guest code runs.
-        runner: std::sync::Arc::new(hexec_runner::LocalSession::new()),
+        // The environment the host resolved for this target. Empty key ⇒ no
+        // runner was selected and this is `local`, the identity transform —
+        // exactly what a cdylib driver did before the seam existed.
+        runner: session,
     };
     let result = if shell {
         driver.run_shell(mrr, ct).await
@@ -1304,6 +1338,10 @@ async fn run_once(
             Ok(artifacts) => pb::RunOutFrame {
                 msg: Some(pb::run_out_frame::Msg::Response(pb::ManagedRunResponse {
                     artifacts,
+                    // The ack. Echoed only once the run has actually returned,
+                    // so it is evidence the environment was in force for the
+                    // whole run rather than a promise made up front.
+                    runner_key: runner_key.clone(),
                 })),
             },
             Err(e) => run_out_err(err_message(&e)),

--- a/crates/plugin-stabby/src/load_stable.rs
+++ b/crates/plugin-stabby/src/load_stable.rs
@@ -265,10 +265,73 @@ enum Chunk {
 /// request. Forwarding them as they arrive rather than at the end is the whole
 /// point — a `docker buildx build` or a `go build` should print while it runs,
 /// not in one burst after it finishes.
+/// Check a guest's runner **ack**: its echo of the environment key it was told
+/// to run under.
+///
+/// Positive confirmation, not absence of complaint. A guest compiled before
+/// `runner_env` existed cannot object to what it ignored — prost drops unknown
+/// fields before guest code runs — so silence has to read as failure. Otherwise
+/// the guest builds in the host environment while the target's `hashin` already
+/// asserts the runner's, and that artifact goes to the shared remote cache for
+/// every other machine to pick up.
+fn verify_runner_ack(expected: &str, got: &str, driver: &str) -> anyhow::Result<()> {
+    if expected.is_empty() || got == expected {
+        return Ok(());
+    }
+    anyhow::bail!(
+        "driver `{driver}` did not confirm it ran under the requested exec environment \
+         (expected key {expected:?}, got {got:?}). The target's cache key already asserts that \
+         environment, so the run is refused rather than producing an artifact whose key does not \
+         describe how it was built. Rebuild the plugin against a heph that understands exec \
+         runners, or set `runner = None` on this target."
+    )
+}
+
+#[cfg(test)]
+mod runner_ack_tests {
+    use super::verify_runner_ack;
+
+    /// No runner requested: every guest, old or new, echoes nothing and that is
+    /// correct. This is the path every existing plugin takes.
+    #[test]
+    fn no_runner_requested_needs_no_ack() {
+        verify_runner_ack("", "", "go").expect("no runner requested must pass");
+    }
+
+    #[test]
+    fn matching_ack_passes() {
+        verify_runner_ack("k1", "k1", "go").expect("a matching ack must pass");
+    }
+
+    /// The case this exists for: an older cdylib silently ignores the
+    /// environment and returns a result as though nothing happened.
+    #[test]
+    fn silence_from_an_older_guest_is_a_failure_not_a_pass() {
+        let err = verify_runner_ack("k1", "", "go").expect_err("silence must not pass");
+        let msg = format!("{err:#}");
+        assert!(msg.contains("did not confirm"), "{msg}");
+        assert!(msg.contains("go"), "{msg}");
+        assert!(msg.contains("runner = None"), "must name a way out: {msg}");
+    }
+
+    /// A guest that applied a *different* environment than the one the key
+    /// asserts is the same class of wrong, and is caught by the same check.
+    #[test]
+    fn a_mismatched_ack_is_a_failure() {
+        assert!(verify_runner_ack("k1", "k2", "go").is_err());
+    }
+}
+
+/// Drain a run's response stream, returning the result and the guest's
+/// **runner ack** — its echo of the environment key it was asked to use.
+///
+/// The ack rides out of here rather than on `ManagedRunResponse` so the Rust
+/// type every in-tree managed driver constructs stays as it was; only the
+/// seam that can actually be lied to needs to carry it.
 fn drain_run(
     stream: DynItemStream,
     chunks: &tokio::sync::mpsc::UnboundedSender<Chunk>,
-) -> anyhow::Result<ManagedRunResponse> {
+) -> anyhow::Result<(ManagedRunResponse, String)> {
     loop {
         let bytes = stream.next();
         if bytes.is_empty() {
@@ -276,13 +339,17 @@ fn drain_run(
         }
         match pb::RunOutFrame::decode(&bytes[..])?.msg {
             Some(pb::run_out_frame::Msg::Response(r)) => {
-                return Ok(ManagedRunResponse {
-                    artifacts: r
-                        .artifacts
-                        .into_iter()
-                        .map(convert::output_artifact_from_pb)
-                        .collect(),
-                });
+                let ack = r.runner_key.clone();
+                return Ok((
+                    ManagedRunResponse {
+                        artifacts: r
+                            .artifacts
+                            .into_iter()
+                            .map(convert::output_artifact_from_pb)
+                            .collect(),
+                    },
+                    ack,
+                ));
             }
             Some(pb::run_out_frame::Msg::Error(e)) => anyhow::bail!("{e}"),
             // A dropped receiver means the caller stopped reading; keep draining
@@ -723,7 +790,24 @@ impl StableRemoteManagedDriver {
             inputs: req.inputs.iter().map(managed_input_to_pb).collect(),
             shell,
             driver: self.name.clone(),
+            // The environment the guest must create its processes in. Sent as
+            // bytes because env values are bytes; see `pb::EnvVar`.
+            runner_env: req
+                .runner
+                .base_env()
+                .unwrap_or_default()
+                .iter()
+                .map(|(k, v)| pb::EnvVar {
+                    key: k.as_encoded_bytes().to_vec().into(),
+                    value: v.as_encoded_bytes().to_vec().into(),
+                })
+                .collect(),
+            runner_key: req.runner.describe().key.clone(),
+            runner_addr: req.runner.describe().runner.clone(),
         };
+        // Held for the ack check below: a guest that ignored the environment
+        // must not be able to pass by staying quiet.
+        let expect_runner_key = req.runner.describe().key.clone();
         // `run` is bidi: the request stream carries the run request (RunInFrame),
         // the response stream carries the result (RunOutFrame). `shell` rides pmrr.
         let in_frame = pb::RunInFrame {
@@ -783,10 +867,20 @@ impl StableRemoteManagedDriver {
                 futures::future::Either::Right((never, _)) => match never {},
             }
         };
-        match result {
-            Ok(result) => result,
+        let (response, ack) = match result {
+            Ok(result) => result?,
             Err(_canceled) => anyhow::bail!("run drain thread dropped"),
-        }
+        };
+
+        // Positive confirmation, not absence of complaint. A guest compiled
+        // before `runner_env` existed cannot object to what it ignored — prost
+        // drops unknown fields before guest code runs — so silence has to read
+        // as failure. Otherwise the guest builds in the host environment while
+        // the target's `hashin` already asserts the runner's, and that artifact
+        // goes to the shared remote cache for every other machine to pick up.
+        verify_runner_ack(&expect_runner_key, &ack, &self.name)?;
+
+        Ok(response)
     }
 }
 

--- a/crates/plugingo-e2e/Cargo.toml
+++ b/crates/plugingo-e2e/Cargo.toml
@@ -17,6 +17,7 @@ hmodel = { package = "model", path = "../model" }
 hplugin = { package = "plugin", path = "../plugin" }
 tokio = { version = "1", features = ["rt", "rt-multi-thread", "macros"] }
 anyhow = "1"
+async-trait = "0.1.89"
 tempfile = "3"
 futures = "0.3"
 # Reads the program headers of a linked Go binary, to assert its buildmode.

--- a/crates/plugingo-e2e/tests/build.rs
+++ b/crates/plugingo-e2e/tests/build.rs
@@ -348,3 +348,43 @@ async fn test_embed_generated_in_subpackage_of_the_embedder() -> anyhow::Result<
     );
     Ok(())
 }
+
+/// Every `go` invocation a build makes must be created **in the runner's
+/// session**, `go list` included.
+///
+/// `go_golist` used to call `proc_exec::output` directly while `go_compile`
+/// went through `req.runner`. With no runner configured the two are
+/// indistinguishable — `LocalSession::prepare` is the identity — so the whole
+/// existing suite passed while, under a real runner, `go build` ran in the
+/// environment and `go list` ran on the host. The target's `hashin` says
+/// otherwise, which makes it a wrong build rather than a slow one.
+///
+/// The recording runner is deliberately passive: it changes nothing and only
+/// notes what it was asked to start. A runner that *did* something would fail
+/// this for the wrong reason (a broken build), and a driver that bypasses the
+/// session is invisible to anything less passive.
+#[tokio::test]
+async fn every_go_invocation_is_created_in_the_runner_session() -> anyhow::Result<()> {
+    require_go!();
+    let dir = fixture("simple_lib")?;
+    let (ws, seen) = common::make_workspace_recording_runner(dir)?;
+    ws.run("//:build_lib@v=host").await?;
+
+    let seen = seen.lock().unwrap_or_else(|p| p.into_inner()).clone();
+    assert!(
+        !seen.is_empty(),
+        "the runner saw no process at all — the default runner is not wired up, \
+         so this test would pass vacuously"
+    );
+
+    let go_list = seen
+        .iter()
+        .filter(|(program, _)| std::path::Path::new(program).file_name() == Some("go".as_ref()))
+        .any(|(_, args)| args.first().map(String::as_str) == Some("list"));
+    assert!(
+        go_list,
+        "no `go list` reached the runner; the go_golist driver spawned it beside \
+         the session. Saw: {seen:#?}"
+    );
+    Ok(())
+}

--- a/crates/plugingo-e2e/tests/common/mod.rs
+++ b/crates/plugingo-e2e/tests/common/mod.rs
@@ -268,7 +268,7 @@ impl hplugin::provider::Provider for VariantInjector {
 /// the few tests that specifically exercise the hermetic toolchain use
 /// [`make_workspace_hermetic`]. Requires `go` on PATH (guard with `require_go!`).
 pub fn make_workspace(dir: TempDir) -> anyhow::Result<Workspace> {
-    make_workspace_ordered(dir, false, true, &[], HOST_GO)
+    make_workspace_ordered(dir, false, true, &[], HOST_GO, None)
 }
 
 /// Alias for [`make_workspace`] kept for call sites that spell the host toolchain
@@ -282,7 +282,7 @@ pub fn make_workspace_host(dir: TempDir) -> anyhow::Result<Workspace> {
 /// so reserve it for the *select few* tests that must prove the hermetic
 /// toolchain path itself; everything else uses [`make_workspace`] (host `go`).
 pub fn make_workspace_hermetic(dir: TempDir) -> anyhow::Result<Workspace> {
-    make_workspace_ordered(dir, false, true, &[], HERMETIC_GO)
+    make_workspace_ordered(dir, false, true, &[], HERMETIC_GO, None)
 }
 
 /// A published heph release whose `heph-govet_<goos>_<goarch>` assets the lint
@@ -299,7 +299,7 @@ pub fn govet_addr() -> String {
 /// `fs: { skip: [...] }`. Used to reproduce a codegen target whose generated Go
 /// package lives under a skipped subtree (e.g. a generated `gen/**` tree).
 pub fn make_workspace_fs_skip(dir: TempDir, skip: &[&str]) -> anyhow::Result<Workspace> {
-    make_workspace_ordered(dir, false, true, skip, HOST_GO)
+    make_workspace_ordered(dir, false, true, skip, HOST_GO, None)
 }
 
 /// Same as [`make_workspace`] but registers the **go provider before** the
@@ -314,7 +314,108 @@ pub fn make_workspace_go_first(
     dir: TempDir,
     foreign_name_guard: bool,
 ) -> anyhow::Result<Workspace> {
-    make_workspace_ordered(dir, true, foreign_name_guard, &[], HOST_GO)
+    make_workspace_ordered(dir, true, foreign_name_guard, &[], HOST_GO, None)
+}
+
+/// Addr of the stand-in runner target [`make_workspace_recording_runner`] adds.
+///
+/// A `bash` target, so the runner registered under `"bash"` serves it — the same
+/// wiring a real workspace uses for a `devenv` runner target built by the devenv
+/// driver.
+pub const RECORDING_RUNNER_ADDR: &str = "//@heph/runner:env";
+
+/// Every spec that reached the runner, as `(program, args)`.
+pub type SeenSpecs = std::sync::Arc<std::sync::Mutex<Vec<(String, Vec<String>)>>>;
+
+/// A runner that records what it was asked to start and otherwise changes
+/// nothing.
+///
+/// `prepare` is the identity, so a target behaves exactly as it does with no
+/// runner — which is the point. The question this answers is not *what* the
+/// environment does but *whether the driver asked it at all*, and a driver that
+/// calls `proc_exec` directly is invisible to a runner that does anything less
+/// passive.
+struct RecordingRunner {
+    seen: SeenSpecs,
+}
+
+struct RecordingSession {
+    seen: SeenSpecs,
+    caps: heph::engine::exec_runner::SessionCaps,
+    description: heph::engine::exec_runner::SessionDescription,
+}
+
+#[async_trait::async_trait]
+impl heph::engine::exec_runner::ExecRunner for RecordingRunner {
+    async fn open(
+        &self,
+        req: heph::engine::exec_runner::OpenRequest,
+        _ct: &(dyn heph::hasync::Cancellable + Send + Sync),
+    ) -> anyhow::Result<std::sync::Arc<dyn heph::engine::exec_runner::ExecSession>> {
+        Ok(std::sync::Arc::new(RecordingSession {
+            seen: std::sync::Arc::clone(&self.seen),
+            caps: heph::engine::exec_runner::SessionCaps {
+                pty: true,
+                max_concurrent: None,
+                identity: heph::engine::exec_runner::Identity::Pinned {
+                    by: req.key.clone(),
+                },
+            },
+            description: heph::engine::exec_runner::SessionDescription {
+                runner: req.runner_addr.clone(),
+                key: req.key.clone(),
+                summary: "recording (identity)".to_string(),
+            },
+        }))
+    }
+}
+
+#[async_trait::async_trait]
+impl heph::engine::exec_runner::ExecSession for RecordingSession {
+    fn prepare(
+        &self,
+        spec: heph::proc_exec::Spec,
+    ) -> Result<heph::proc_exec::Spec, heph::engine::exec_runner::SpawnError> {
+        self.seen.lock().unwrap_or_else(|p| p.into_inner()).push((
+            spec.program.to_string_lossy().into_owned(),
+            spec.args
+                .iter()
+                .map(|a| a.to_string_lossy().into_owned())
+                .collect(),
+        ));
+        Ok(spec)
+    }
+
+    fn base_env(&self) -> Option<&[(std::ffi::OsString, std::ffi::OsString)]> {
+        None
+    }
+
+    fn caps(&self) -> &heph::engine::exec_runner::SessionCaps {
+        &self.caps
+    }
+
+    fn describe(&self) -> &heph::engine::exec_runner::SessionDescription {
+        &self.description
+    }
+}
+
+/// [`make_workspace`] with every target routed through a recording runner.
+///
+/// Returns the specs the runner saw, so a test can assert that a given `go`
+/// invocation was actually created *in the session* rather than beside it.
+pub fn make_workspace_recording_runner(dir: TempDir) -> anyhow::Result<(Workspace, SeenSpecs)> {
+    let seen: SeenSpecs = Default::default();
+    let ws = make_workspace_ordered(
+        dir,
+        false,
+        true,
+        &[],
+        HOST_GO,
+        Some(std::sync::Arc::new(RecordingRunner {
+            seen: std::sync::Arc::clone(&seen),
+        })),
+    )?;
+    Ok((ws, seen))
 }
 
 fn make_workspace_ordered(
@@ -323,7 +424,9 @@ fn make_workspace_ordered(
     foreign_name_guard: bool,
     fs_skip: &[&str],
     gotool: &str,
+    exec_runner: Option<std::sync::Arc<dyn heph::engine::exec_runner::ExecRunner>>,
 ) -> anyhow::Result<Workspace> {
+    let wants_runner = exec_runner.is_some();
     let gotool = gotool.to_string();
     let go_bin = go_bin_path();
     let cc_bin = cc_bin_path();
@@ -390,6 +493,26 @@ fn make_workspace_ordered(
                     ..Default::default()
                 });
             }
+            // The runner target `defaultRunner` resolves to. It goes in this
+            // list rather than a second provider — only one
+            // `pluginstatictarget` may register per engine. The engine excludes
+            // a runner target from the default runner, so it does not chase its
+            // own tail.
+            if wants_runner {
+                targets.push(pluginstatictarget::Target {
+                    addr: RECORDING_RUNNER_ADDR.to_string(),
+                    driver: "bash".to_string(),
+                    run: Some("echo recording > env.json".to_string()),
+                    out: std::collections::HashMap::from([(
+                        String::new(),
+                        vec!["env.json".to_string()],
+                    )]),
+                    codegen: None,
+                    deps: Default::default(),
+                    labels: vec![],
+                    ..Default::default()
+                });
+            }
             Box::new(pluginstatictarget::Provider::new(targets).expect("static provider"))
         });
 
@@ -411,6 +534,12 @@ fn make_workspace_ordered(
                 .expect("plugingo provider"),
             )
         });
+    }
+
+    if let Some(runner) = exec_runner {
+        let addr = heph::htaddr::parse_addr(RECORDING_RUNNER_ADDR)
+            .context("parse the recording runner's addr")?;
+        b = b.with_default_runner(addr).with_exec_runner("bash", runner);
     }
 
     b.with_managed_driver(Box::new(pluginexec::Driver::new_bash()))

--- a/crates/testkit/src/lib.rs
+++ b/crates/testkit/src/lib.rs
@@ -91,16 +91,6 @@ impl WorkspaceBuilder {
         self
     }
 
-    /// [`Self::with_managed_driver`], registered as though it were loaded from a
-    /// cdylib. Lets a test exercise the engine's refusal to run an ABI-served
-    /// driver under a runner without building an actual plugin.
-    pub fn with_managed_driver_abi(mut self, driver: Box<dyn SDKManagedDriver>) -> Self {
-        self.setups.push(Box::new(move |e: &mut Engine| {
-            e.register_managed_driver_abi(|_| driver)
-        }));
-        self
-    }
-
     pub fn with_driver(mut self, driver: Box<dyn SDKDriver>) -> Self {
         self.setups.push(Box::new(move |e: &mut Engine| {
             e.register_driver(|_| driver)

--- a/proto/plugin/v1/driver.proto
+++ b/proto/plugin/v1/driver.proto
@@ -108,10 +108,48 @@ message ManagedRunRequest {
   // true => run_shell
   bool shell = 9;
   string driver = 10;
+
+  // ---- Exec runner (docs/EXEC_RUNNERS.md) ----
+  // The environment this target's processes must be created in. Absent/empty
+  // means the host process itself, which is what every driver did before exec
+  // runners existed — so an older guest that never reads these behaves exactly
+  // as it always has.
+  //
+  // A guest that DOES honour them must echo `runner_key` back in
+  // `ManagedRunResponse.runner_key`. See that field: the ack is not a courtesy,
+  // it is what stops a silently-degraded run from poisoning the shared cache.
+  repeated EnvVar runner_env = 11;
+  // Identity of the environment, echoed back to prove it was applied.
+  string runner_key = 12;
+  // Diagnostics: the runner target's address.
+  string runner_addr = 13;
+}
+
+// An environment variable. `bytes`, not `string`: env values are bytes
+// (`Spec.env` is `Vec<(OsString, OsString)>`) and proto3 `string` must be valid
+// UTF-8, so a non-UTF-8 `LANG` or store path would be dropped — a silently
+// wrong environment — or fail the encode outright.
+message EnvVar {
+  bytes key = 1;
+  bytes value = 2;
 }
 
 message ManagedRunResponse {
   repeated OutputArtifactRef artifacts = 1;
+  // Echo of `ManagedRunRequest.runner_key`, proving the guest created its
+  // processes in the environment the host asked for.
+  //
+  // The host REFUSES the run when a runner was requested and this does not
+  // match. Degrading is the dangerous option: the runner's hashout is folded
+  // into the target's `hashin` before the driver ever runs, so a guest that
+  // quietly built in the host environment produces an artifact whose key
+  // asserts an environment its bytes do not reflect — and that artifact goes to
+  // the shared remote cache, where every other machine gets it.
+  //
+  // An older guest cannot warn about what it ignored: prost drops fields it was
+  // not compiled with before guest code runs. So the check has to be the host's,
+  // and it has to be on evidence of success rather than absence of complaint.
+  string runner_key = 2;
 }
 
 // ---- Bidi run streams (DriverMethod RUN over StableManagedDriver::invoke_bidi) ----


### PR DESCRIPTION
Phase 2a of #404, on top of #409. **A driver served from a cdylib now runs in the environment the host chose — and proves it did.**

#409 carried an interim blanket refusal: an ABI-served driver could not be given a runner at all. That was right only while the guest had no way to *receive* an environment. This replaces it: evidence of success is a better check than a categorical ban, and it covers version skew the ban never could.

## The ack is the point

A guest that honours the environment echoes the session key back on the response; the host refuses the run when a runner was requested and the echo is missing or wrong.

It has to work this way round. **A guest compiled before these fields existed cannot object to ignoring them** — prost drops unknown fields before guest code runs — so silence must read as failure, not consent. Without that, an older plugin builds in the host environment while the target's `hashin` already asserts the runner's, and that artifact goes to the **shared remote cache** for every other machine to pick up. This is the blocker `compatibility` raised at design time, and it is why the check is on the *response*: that makes it evidence the environment was in force for the whole run, not a promise made up front.

## Wire changes — additive, no ABI bump

| Field | On | Note |
|---|---|---|
| `runner_env` | `pb.ManagedRunRequest` | **`bytes`, not `string`** — env values are bytes (`Spec.env` is `Vec<(OsString, OsString)>`) and proto3 `string` must be valid UTF-8, so a non-UTF-8 `LANG` or store path would be dropped (a silently wrong environment) or fail the encode |
| `runner_key`, `runner_addr` | `pb.ManagedRunRequest` | identity + diagnostics |
| `runner_key` | `pb.ManagedRunResponse` | the ack |

No `abi.rs` change, no `ABI_SEMVER` bump — the additive lane. An older guest ignores the fields and is caught by the ack rather than by hoping it noticed.

## Also

- **All five cdylib-only spawn sites converted** — `plugin-go`'s compile/golist/lint/format and `plugin-oci`'s `run_tool` — so all eight in-tree sites now create processes through the session.
  <br>_`golist` was in fact still calling `proc_exec::output` directly when this was first written; fixed in a later commit on this branch, with the test that proves it. With no runner configured `LocalSession::prepare` is the identity, so nothing in the suite could tell the two apart — hence a recording runner as the regression test._
- `missing_tool_error` matches the typed `SpawnError` instead of `io::ErrorKind`, which is what lets "not found" name the *runner's* PATH rather than one nobody set.
- **`Driver::abi_served` is removed.** It existed solely for the interim refusal in #409; a field nobody reads is the dead-code smell this feature has been careful about.

## Tests

`verify_runner_ack` is extracted as a pure function so the check is testable without a cdylib fixture — which keeps this class of test out of `bin-e2e`, where it would cost a release build on three platforms:

- no runner requested ⇒ no ack needed — **every existing plugin's path**
- matching ack passes
- mismatched ack fails
- **silence from an older guest fails rather than passes** — the case it exists for

Full local run green: 545 e2e, 481 engine, plus plugin-go/stabby/exec-runner. `lint` clean.

## Not in this PR

devenv session mode (`Agent` + `__runner-agent` + the fd-passing protocol) and the `Wrap` container runner — those are #414.

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>

