### PR TITLE
feat(scratch): mount the cache, lock the slot, set the env var

### DIFF
--- a/crates/builtins/src/pluginfs/mod.rs
+++ b/crates/builtins/src/pluginfs/mod.rs
@@ -1533,6 +1533,7 @@ mod tests {
             stdout: None,
             stderr: None,
             sandbox_dir: root,
+            scratch: vec![],
         }
     }
 

--- a/crates/builtins/src/plugingroup/mod.rs
+++ b/crates/builtins/src/plugingroup/mod.rs
@@ -727,6 +727,7 @@ mod tests {
                     stdout: None,
                     stderr: None,
                     sandbox_dir: Default::default(),
+                    scratch: vec![],
                 },
                 &ctoken(),
             )

--- a/crates/builtins/src/pluginhostbin/mod.rs
+++ b/crates/builtins/src/pluginhostbin/mod.rs
@@ -325,6 +325,7 @@ mod tests {
             stdout: None,
             stderr: None,
             sandbox_dir: sandbox_dir.to_path_buf(),
+            scratch: vec![],
         }
     }
 

--- a/crates/builtins/src/pluginscratch/mod.rs
+++ b/crates/builtins/src/pluginscratch/mod.rs
@@ -646,6 +646,7 @@ mod tests {
             stdout: None,
             stderr: None,
             sandbox_dir: std::path::PathBuf::from("/tmp"),
+            scratch: vec![],
         };
         let res = Driver
             .run(req, &ctoken())

--- a/crates/builtins/src/plugintextfile/mod.rs
+++ b/crates/builtins/src/plugintextfile/mod.rs
@@ -200,6 +200,7 @@ mod tests {
             stdout: None,
             stderr: None,
             sandbox_dir: sandbox_dir.to_path_buf(),
+            scratch: vec![],
         }
     }
 

--- a/crates/driver-bridge/src/bridge.rs
+++ b/crates/driver-bridge/src/bridge.rs
@@ -347,6 +347,7 @@ mod shell_fallback_tests {
             stdout: None,
             stderr: None,
             sandbox_dir: sandbox.clone(),
+            scratch: vec![],
         };
 
         bridge.run_shell(req, &ctoken).await?;

--- a/crates/driver-support/src/driver_managed.rs
+++ b/crates/driver-support/src/driver_managed.rs
@@ -135,6 +135,12 @@ pub async fn invoke_inner<'a, 'io>(
     // `req.request.sandbox_dir` for filesystem ops. Keep both consistent
     // with the (maybe-redirected) sandbox_dir we just built.
     req.sandbox_dir = sandbox_dir.clone();
+    // Scratch mounts go in after every input is materialized and before the
+    // driver runs. Here rather than in the engine because *this* layer owns
+    // sandbox creation — the FUSE path may redirect `sandbox_pkg_dir` into a
+    // mount, so there is no earlier moment at which the directory reliably
+    // exists — and because putting it here covers both sandbox modes at once.
+    mount_scratch(&sandbox_pkg_dir, &req.scratch)?;
     let mreq = ManagedRunRequest {
         sandbox_dir,
         sandbox_ws_dir: ws_dir,
@@ -160,6 +166,47 @@ pub async fn invoke_inner<'a, 'io>(
             .with_context(|| "driver run")?
     };
     Ok(res)
+}
+
+/// Symlink each resolved scratch cache into the sandbox at its declared path.
+///
+/// One `symlink(2)` per mount, pointing *out* of the sandbox at the canonical
+/// slot directory. That is the whole mechanism, and it is why a scratch costs an
+/// inode per target rather than a copy: teardown removes the link, not the tree
+/// (`remove_dir_all` does not follow symlinks), exactly as read-only input
+/// staging already does for the Go SDK.
+///
+/// The link target is the canonical path rather than something sandbox-local
+/// deliberately — tools bake absolute paths into their cache entries, so if every
+/// consumer saw its own path the cache would be present and inert.
+fn mount_scratch(pkg_dir: &Path, mounts: &[hplugin::driver::ScratchMount]) -> anyhow::Result<()> {
+    for m in mounts {
+        let at = pkg_dir.join(&m.path);
+
+        // A scratch must not land where an input already did. Silently replacing
+        // it would mean the target reads cache bytes where it believes it reads a
+        // declared dependency — bytes no `hashin` describes, which is the one way
+        // a scratch can cause a *wrong build* rather than a slow one. Refuse.
+        if let Ok(md) = fs::symlink_metadata(&at) {
+            anyhow::bail!(
+                "scratch {} cannot mount at {:?}: something is already there ({}). A scratch \
+                 must not overlap a dependency or an output — mounting over it would let the \
+                 target read cache contents where it expects declared inputs",
+                m.addr,
+                m.path,
+                if md.is_dir() { "a directory" } else { "a file" }
+            );
+        }
+
+        if let Some(parent) = at.parent() {
+            fs::create_dir_all(parent).with_context(|| {
+                format!("create parent of scratch mount {:?} for {}", m.path, m.addr)
+            })?;
+        }
+        std::os::unix::fs::symlink(&m.dir, &at)
+            .with_context(|| format!("symlink scratch {} at {:?} -> {:?}", m.addr, at, m.dir))?;
+    }
+    Ok(())
 }
 
 /// Run an interactive shell on `shell_fallback` inside the
@@ -189,6 +236,7 @@ async fn run_shell_fallback<'a, 'io>(
         stdout,
         stderr,
         sandbox_dir: req_sandbox_dir,
+        scratch,
     } = request;
 
     let mut synthetic = (*shell_fallback.spec_template).clone();
@@ -223,6 +271,7 @@ async fn run_shell_fallback<'a, 'io>(
         stdout,
         stderr,
         sandbox_dir: req_sandbox_dir,
+        scratch,
     };
     let new_mreq = ManagedRunRequest {
         request: new_req,

--- a/crates/e2e/tests/scratch.rs
+++ b/crates/e2e/tests/scratch.rs
@@ -243,6 +243,9 @@ async fn bumping_a_scratch_version_does_not_invalidate_consumers() -> anyhow::Re
     let first_def_hash = def_hash(&first_engine, "//app:a").await?;
     let first = ws.run("//app:a").await?;
     let first_hash = first.artifacts[0].hashout()?;
+    // Released before the second engine opens — see the note in
+    // `a_scratch_carries_state_between_runs`.
+    drop(first);
 
     ws.write_build_file("build", &decl("v2"));
     // A second engine over the same on-disk cache — what the next `heph`
@@ -386,5 +389,184 @@ target(name = "b", driver = "bash", run = "echo b > $OUT", out = "b.txt",
 
     assert!(!ws.run("//app:a").await?.artifacts.is_empty());
     assert!(!ws.run("//app:b").await?.artifacts.is_empty());
+    Ok(())
+}
+
+// ---------------------------------------------------------------------------
+// Mounting: the point of the whole thing.
+// ---------------------------------------------------------------------------
+
+/// The feature, end to end: a target writes into its scratch, a later run with
+/// changed inputs (so it genuinely re-executes) reads back what the first wrote.
+///
+/// This is the property everything else exists to support — state carried between
+/// runs — and it is asserted through the real sandbox, symlink and env var.
+#[tokio::test]
+async fn a_scratch_carries_state_between_runs() -> anyhow::Result<()> {
+    let ws = Workspace::new();
+    ws.write_build_file(
+        "build",
+        r#"target(name = "c", driver = "scratch", path = ".cache/x", env = "MYCACHE")"#,
+    );
+    let build = |marker: &str| {
+        format!(
+            r#"target(name = "a", driver = "bash", out = "o.txt", scratch = ["//build:c"],
+       run = [
+         "if [ -f \"$MYCACHE/marker\" ]; then cat \"$MYCACHE/marker\" > $OUT; else echo cold > $OUT; fi",
+         "echo {marker} > \"$MYCACHE/marker\"",
+       ])"#
+        )
+    };
+
+    ws.write_build_file("app", &build("first"));
+    let first = ws.run("//app:a").await?;
+    let first_out = common::artifact_string(&first).trim().to_string();
+    // Drop before reopening. An `EResult`'s artifacts hold a *riding read guard*
+    // on their addr's result lock, and the second engine takes the **write** lock
+    // on the same lock files to re-execute — so holding this across `reopen()`
+    // deadlocks the two engines against each other. (A second run that were a
+    // cache *hit* would only take a read lock and would not notice.) Same idiom
+    // as `engine_core.rs`.
+    drop(first);
+    assert_eq!(first_out, "cold", "the first run must see an empty scratch");
+
+    // Change the target so the second run is a genuine miss, not a cache hit —
+    // a hit would never reach the sandbox and the test would prove nothing.
+    ws.write_build_file("app", &build("second"));
+    let engine = ws.reopen()?;
+    let addr = heph::htaddr::parse_addr("//app:a")?;
+    let second = engine
+        .clone()
+        .result_addr(
+            engine.new_state(),
+            &addr,
+            OutputMatcher::All,
+            &ResultOptions::default(),
+        )
+        .await?;
+    assert_eq!(
+        common::artifact_string(&second).trim(),
+        "first",
+        "the second run must see what the first wrote into the scratch"
+    );
+    Ok(())
+}
+
+/// The declaration's `env` is what makes a reference sufficient: the consumer
+/// wires nothing, and the variable holds the canonical slot path — an absolute
+/// path outside the sandbox, not the in-sandbox mount. Tools bake absolute paths
+/// into their cache entries, so every consumer must see the same string.
+#[tokio::test]
+async fn the_env_var_carries_the_canonical_path() -> anyhow::Result<()> {
+    let ws = Workspace::new();
+    ws.write_build_file(
+        "build",
+        r#"target(name = "c", driver = "scratch", path = ".cache/x", env = "MYCACHE")"#,
+    );
+    ws.write_build_file(
+        "app",
+        r#"target(name = "a", driver = "bash", out = "o.txt", scratch = ["//build:c"],
+       run = ["echo \"$MYCACHE\" > $OUT"])"#,
+    );
+
+    let out = common::artifact_string(&*ws.run("//app:a").await?);
+    let path = out.trim();
+    assert!(path.starts_with('/'), "must be absolute, got {path:?}");
+    assert!(
+        path.contains("/scratch/"),
+        "must point into the scratch store, got {path:?}"
+    );
+    assert!(
+        !path.contains("/sandbox/"),
+        "must be the canonical slot, not the in-sandbox mount, got {path:?}"
+    );
+    Ok(())
+}
+
+/// Two targets referencing one declaration must resolve to one directory —
+/// otherwise "sharing" is a word rather than a behaviour.
+#[tokio::test]
+async fn two_targets_sharing_a_declaration_get_one_directory() -> anyhow::Result<()> {
+    let ws = Workspace::new();
+    ws.write_build_file(
+        "build",
+        r#"target(name = "c", driver = "scratch", path = ".cache/x", env = "MYCACHE",
+       access = "shared")"#,
+    );
+    ws.write_build_file(
+        "app",
+        r#"target(name = "a", driver = "bash", out = "a.txt", scratch = ["//build:c"],
+       run = ["echo \"$MYCACHE\" > $OUT"])
+target(name = "b", driver = "bash", out = "b.txt", scratch = ["//build:c"],
+       run = ["echo \"$MYCACHE\" > $OUT"])"#,
+    );
+
+    let a = common::artifact_string(&*ws.run("//app:a").await?);
+    let b = common::artifact_string(&*ws.run("//app:b").await?);
+    assert_eq!(a.trim(), b.trim(), "one declaration is one slot");
+    Ok(())
+}
+
+/// Two declarations differing only in `version` are different caches — that is
+/// what makes `version` a bust handle rather than a label.
+#[tokio::test]
+async fn version_selects_a_different_slot() -> anyhow::Result<()> {
+    let ws = Workspace::new();
+    ws.write_build_file(
+        "build",
+        r#"target(name = "v1", driver = "scratch", path = ".cache/x", env = "C", version = "1")
+target(name = "v2", driver = "scratch", path = ".cache/x", env = "C", version = "2")"#,
+    );
+    ws.write_build_file(
+        "app",
+        r#"target(name = "a", driver = "bash", out = "o.txt", scratch = ["//build:v1"],
+       run = ["echo \"$C\" > $OUT"])
+target(name = "b", driver = "bash", out = "o.txt", scratch = ["//build:v2"],
+       run = ["echo \"$C\" > $OUT"])"#,
+    );
+
+    let a = common::artifact_string(&*ws.run("//app:a").await?);
+    let b = common::artifact_string(&*ws.run("//app:b").await?);
+    assert_ne!(
+        a.trim(),
+        b.trim(),
+        "a `version` bump must give a fresh slot"
+    );
+    Ok(())
+}
+
+/// A scratch mounting where an input already landed would let the target read
+/// cache contents where it believes it reads a declared dependency — bytes no
+/// `hashin` describes. That is the one way a scratch can cause a *wrong build*
+/// rather than a slow one, so it must fail rather than silently win.
+#[tokio::test]
+async fn a_scratch_cannot_mount_over_a_materialized_input() -> anyhow::Result<()> {
+    let ws = Workspace::new();
+    ws.write_build_file(
+        "build",
+        r#"target(name = "c", driver = "scratch", path = "depdir", env = "C")"#,
+    );
+    // The producer's output unpacks into the consumer's sandbox at `depdir/f.txt`,
+    // which is exactly where the scratch wants to mount.
+    ws.write_build_file(
+        "app",
+        r#"target(name = "producer", driver = "bash", out = "depdir/f.txt",
+       run = ["mkdir -p depdir && echo real > depdir/f.txt"])
+target(name = "a", driver = "bash", out = "o.txt",
+       scratch = ["//build:c"],
+       deps = {"src": ["//app:producer"]},
+       run = ["cat depdir/f.txt > $OUT"])"#,
+    );
+
+    let err = expect_err(
+        ws.run("//app:a").await,
+        "a scratch must not mount over a materialized input",
+    );
+    let msg = format!("{err:#}");
+    assert!(
+        msg.contains("already there"),
+        "must explain the collision: {msg}"
+    );
+    assert!(msg.contains("//build:c"), "must name the scratch: {msg}");
     Ok(())
 }

--- a/crates/engine/src/engine/engine.rs
+++ b/crates/engine/src/engine/engine.rs
@@ -123,6 +123,7 @@ pub struct Engine {
     /// Guards the execute phase so at most one execute runs per target addr at
     /// a time (cross-process with the filesystem backend, in-process with mem).
     pub(crate) result_lock: ResultLock,
+    pub(crate) scratch_lock: crate::engine::scratch::ScratchLock,
 
     /// Ordered set of remote (shared) caches fronting the local cache. Empty
     /// (a cheap no-op on every path) unless `caches:` is configured.
@@ -437,7 +438,15 @@ impl Engine {
         let lock_dir = home.join("lock");
         std::fs::create_dir_all(&lock_dir)
             .with_context(|| format!("create lock dir {lock_dir:?}"))?;
-        let result_lock = ResultLock::new(cfg.lock_backend, lock_dir);
+        let result_lock = ResultLock::new(cfg.lock_backend, lock_dir.clone());
+        // Separate keyed lock, separate files: a scratch slot is keyed by slot id
+        // and an addr's result by addr, and colliding those namespaces would let
+        // one wait on the other for no reason.
+        let scratch_lock_dir = lock_dir.join("scratch");
+        std::fs::create_dir_all(&scratch_lock_dir)
+            .with_context(|| format!("create scratch lock dir {scratch_lock_dir:?}"))?;
+        let scratch_lock =
+            crate::engine::scratch::ScratchLock::new(cfg.lock_backend, scratch_lock_dir);
 
         // Remote caches: backends are constructed synchronously here (no
         // network); latency ordering is measured lazily on first use.
@@ -507,6 +516,7 @@ impl Engine {
             managed_driver_factories: HashMap::new(),
             fuse,
             result_lock,
+            scratch_lock,
             remote_caches,
             provider_functions_wired: std::sync::Once::new(),
             remote_tmp_ready: tokio::sync::OnceCell::new(),

--- a/crates/engine/src/engine/execute.rs
+++ b/crates/engine/src/engine/execute.rs
@@ -44,6 +44,23 @@ impl Engine {
             .inputs_result_exec(rs.clone(), &def.inputs)
             .await?;
 
+        // Scratch slots, between dep resolution and the worker permit — see
+        // `acquire_scratch` for why both sides of that sandwich are load-bearing.
+        // In short: after deps, or a dep needing the same slot could never get it;
+        // before the permit, so a target queued on a contended slot holds no
+        // worker, which also makes the wait provably bounded.
+        //
+        // The guards ride to the end of the run and drop with `_scratch_guards`.
+        hcore::hmemoizer::set_phase("execute:scratch_acquire");
+        let resolved_scratch = self
+            .resolve_scratch(&rs, addr, &def.target.inputs)
+            .await
+            .with_context(|| format!("resolve scratch for {addr}"))?;
+        let (scratch_mounts, _scratch_guards) = self
+            .acquire_scratch(&rs, &resolved_scratch)
+            .await
+            .with_context(|| format!("acquire scratch for {addr}"))?;
+
         // Acquire semaphore AFTER dep resolution so no permit is held while waiting for
         // deps — prevents the classic diamond deadlock where mid-nodes hold permits while
         // waiting for a leaf that also needs a permit.
@@ -158,7 +175,7 @@ impl Engine {
                     let hashin = hashin.to_owned();
 
                     let inner: InteractiveInner = Box::new(enclose!(
-                        (driver, def, rs, self => engine, sandbox_dir)
+                        (driver, def, rs, self => engine, sandbox_dir, scratch_mounts)
                         move |stdin, stdout, stderr| {
                             Box::pin(async move {
                                 let req = RunRequest {
@@ -171,6 +188,7 @@ impl Engine {
                                     stdout,
                                     stderr,
                                     sandbox_dir,
+                                    scratch: scratch_mounts,
                                 };
                                 let res = if shell {
                                     driver.driver.run_shell(req, rs.ctoken()).await?

--- a/crates/engine/src/engine/scratch.rs
+++ b/crates/engine/src/engine/scratch.rs
@@ -23,9 +23,14 @@
 use crate::engine::Engine;
 use crate::engine::driver::targetdef::Input;
 use crate::engine::request_state::RequestState;
+use crate::engine::result_lock::LockBackend;
 use anyhow::Context as _;
-use hbuiltins::pluginscratch::{DRIVER_NAME, ScratchDef, parse_declaration};
+use hbuiltins::pluginscratch::{Access, DRIVER_NAME, Platform, ScratchDef, parse_declaration};
+use hcore::hasync::Cancellable;
+use hlock::hlock::{FRWLock, KeyedRWLock, MemRWLock};
 use hmodel::htaddr::Addr;
+use hplugin::driver::ScratchMount;
+use std::path::{Path, PathBuf};
 use std::sync::Arc;
 
 /// A reference resolved against its declaration: what the consuming target asked
@@ -36,6 +41,95 @@ pub struct ResolvedScratch {
     pub addr: Addr,
     /// The declaration's settings.
     pub def: ScratchDef,
+}
+
+impl ResolvedScratch {
+    /// Stable id for this cache's storage slot.
+    ///
+    /// The identity is `(addr, version, platform-components)` — see
+    /// `docs/SCRATCH.md` §6.1 for what is deliberately *absent*: `path`, `env`,
+    /// `access`, `remote` and `max_size` are all policy about how a cache is used
+    /// rather than what is in it, and changing one must not throw the contents
+    /// away.
+    ///
+    /// `SLOT_FORMAT` is folded in so a layout change orphans old slots instead of
+    /// misreading them. Bump it whenever the on-disk shape changes.
+    pub fn slot(&self) -> String {
+        use std::hash::{Hash as _, Hasher as _};
+        /// On-disk layout version for a slot directory.
+        const SLOT_FORMAT: u32 = 1;
+
+        let mut h = xxhash_rust::xxh3::Xxh3Default::new();
+        SLOT_FORMAT.hash(&mut h);
+        self.addr.format().hash(&mut h);
+        self.def.version.hash(&mut h);
+        // Only the components the declaration says the contents depend on. This
+        // is what lets `platform = "any"` give one slot for every machine.
+        match self.def.platform {
+            Platform::OsArch => {
+                std::env::consts::OS.hash(&mut h);
+                std::env::consts::ARCH.hash(&mut h);
+            }
+            Platform::Os => std::env::consts::OS.hash(&mut h),
+            Platform::Any => {}
+        }
+        format!("{:016x}", h.finish())
+    }
+}
+
+/// The per-slot cross-process lock guarding a scratch directory.
+///
+/// A [`KeyedRWLock`] rather than the transformable lock `result_lock` uses: a
+/// scratch is only ever taken for read (`access = "shared"`) or write
+/// (`access = "exclusive"`) and never upgraded mid-run, so the extra machinery
+/// would buy nothing.
+pub enum ScratchLock {
+    /// `flock(2)` files under `<home>/lock/scratch/`. Mutually exclusive across
+    /// processes on the same machine — which is the point, since two `heph`
+    /// invocations share one slot directory.
+    Fs(KeyedRWLock<String, FRWLock>),
+    /// In-process only. Tests, and anything that has opted out of file locking.
+    Mem(KeyedRWLock<String, MemRWLock>),
+}
+
+/// An opaque RAII guard on a slot. Held for the target's execute and dropped
+/// after; the concrete guard type is erased because a target may hold a mix of
+/// read and write guards and this code only ever holds and drops them.
+pub type ScratchGuard = Box<dyn std::any::Any + Send>;
+
+impl ScratchLock {
+    pub fn new(backend: LockBackend, dir: PathBuf) -> Self {
+        match backend {
+            LockBackend::Fs => Self::Fs(KeyedRWLock::new(move |slot: &String| {
+                FRWLock::new(dir.join(format!("{slot}.scratch.lock")))
+            })),
+            LockBackend::Mem => Self::Mem(KeyedRWLock::new(|_| MemRWLock::default())),
+        }
+    }
+
+    /// Acquire the guard `access` calls for, waiting until available.
+    async fn acquire(
+        &self,
+        slot: String,
+        access: Access,
+        ctoken: &(dyn Cancellable + Send + Sync),
+    ) -> anyhow::Result<ScratchGuard> {
+        Ok(match (self, access) {
+            (Self::Fs(l), Access::Shared) => Box::new(l.read(slot, ctoken).await?) as ScratchGuard,
+            (Self::Fs(l), Access::Exclusive) => {
+                Box::new(l.write(slot, ctoken).await?) as ScratchGuard
+            }
+            (Self::Mem(l), Access::Shared) => Box::new(l.read(slot, ctoken).await?) as ScratchGuard,
+            (Self::Mem(l), Access::Exclusive) => {
+                Box::new(l.write(slot, ctoken).await?) as ScratchGuard
+            }
+        })
+    }
+}
+
+/// The directory a slot's contents live in.
+pub fn slot_dir(home: &Path, slot: &str) -> PathBuf {
+    home.join("scratch").join(slot)
 }
 
 /// True when this input is a scratch reference rather than an ordinary dep.
@@ -96,6 +190,71 @@ impl Engine {
         check_env_collisions(consumer, &resolved)?;
         check_mount_overlaps(consumer, &resolved)?;
         Ok(resolved)
+    }
+
+    /// Take every slot lock this target needs, create the directories, and return
+    /// the mounts to hand the driver.
+    ///
+    /// # Lock ordering
+    ///
+    /// Guards are acquired in **sorted slot order**, not the order the target
+    /// declared its references. Two targets naming the same pair in opposite
+    /// orders would otherwise deadlock, each holding what the other waits for;
+    /// sorting is the standard fix and costs one `sort_unstable` on a list that is
+    /// essentially always ≤ 2.
+    ///
+    /// # Where this sits in `execute`
+    ///
+    /// **After dependency resolution and before the worker permit.** Both halves
+    /// matter, and both mirror rules `execute` already follows:
+    ///
+    /// * After deps, because holding a slot across dep resolution has the same
+    ///   shape as the diamond deadlock the worker permit is already ordered to
+    ///   avoid — a dep needing the same slot could never get it.
+    /// * Before the permit, like the approval gate, so a target queued on a
+    ///   contended slot holds no worker. Since the lock is always taken first, no
+    ///   permit holder is ever blocked on a slot, so a slot holder always
+    ///   eventually gets a permit: the wait is bounded, not circular.
+    pub(crate) async fn acquire_scratch(
+        self: &Arc<Self>,
+        rs: &Arc<RequestState>,
+        resolved: &[ResolvedScratch],
+    ) -> anyhow::Result<(Vec<ScratchMount>, Vec<ScratchGuard>)> {
+        if resolved.is_empty() {
+            return Ok((Vec::new(), Vec::new()));
+        }
+
+        let mut ordered: Vec<(String, &ResolvedScratch)> =
+            resolved.iter().map(|r| (r.slot(), r)).collect();
+        ordered.sort_unstable_by(|a, b| a.0.cmp(&b.0));
+
+        let mut guards = Vec::with_capacity(ordered.len());
+        let mut mounts = Vec::with_capacity(ordered.len());
+        for (slot, r) in ordered {
+            let guard = self
+                .scratch_lock
+                .acquire(slot.clone(), r.def.access, rs.ctoken())
+                .await
+                .with_context(|| format!("acquire scratch lock for {}", r.addr))?;
+            guards.push(guard);
+
+            // Created under the guard, so two processes racing a cold slot cannot
+            // both decide it is absent and clobber each other's setup. Creation
+            // is idempotent, which is what makes the shared-access case safe.
+            let dir = slot_dir(&self.home, &slot);
+            let d = dir.clone();
+            hcore::blocking::run(move || std::fs::create_dir_all(&d))
+                .await
+                .with_context(|| format!("create scratch dir {dir:?} for {}", r.addr))?;
+
+            mounts.push(ScratchMount {
+                addr: r.addr.clone(),
+                path: r.def.path.clone(),
+                env: r.def.env.clone(),
+                dir,
+            });
+        }
+        Ok((mounts, guards))
     }
 }
 

--- a/crates/plugin-abi/src/convert.rs
+++ b/crates/plugin-abi/src/convert.rs
@@ -689,6 +689,34 @@ fn cache_config_from_pb(c: pb::CacheConfig) -> CacheConfig {
     }
 }
 
+/// Scratch mounts, host -> plugin.
+///
+/// One-way by nature: the host resolves, locks and creates a slot, and the plugin
+/// only places it. Nothing about a mount travels back.
+pub fn scratch_mount_to_pb(m: &hplugin::driver::ScratchMount) -> pb::ScratchMount {
+    pb::ScratchMount {
+        addr: Some(addr_to_pb(&m.addr)),
+        path: m.path.clone(),
+        env: m.env.clone(),
+        dir: m.dir.to_string_lossy().into_owned(),
+    }
+}
+
+/// Scratch mounts, as seen by a plugin.
+///
+/// A mount whose `addr` did not survive the wire is dropped rather than
+/// defaulted: the addr is only a diagnostic, but a mount with a wrong one would
+/// misattribute a failure to some other target, and a scratch that silently does
+/// not mount costs a cold cache — never a wrong build (`docs/SCRATCH.md` §4).
+pub fn scratch_mount_from_pb(m: pb::ScratchMount) -> Option<hplugin::driver::ScratchMount> {
+    Some(hplugin::driver::ScratchMount {
+        addr: addr_from_pb(m.addr?),
+        path: m.path,
+        env: m.env,
+        dir: std::path::PathBuf::from(m.dir),
+    })
+}
+
 pub fn target_def_to_pb(td: &TargetDef) -> anyhow::Result<pb::TargetDef> {
     Ok(pb::TargetDef {
         addr: Some(addr_to_pb(&td.addr)),

--- a/crates/plugin-abi/src/lib.rs
+++ b/crates/plugin-abi/src/lib.rs
@@ -21,6 +21,17 @@ pub use hproto_gen::heph::plugin::v1 as pb;
 /// bookkeeping: `scripts/abi-check.sh` fails CI if the ABI surface changed
 /// without a bump, so the version history documents *why* a break happened.
 ///
+/// 0.8.0: `RunRequest`/`ManagedRunRequest` gained `repeated ScratchMount
+/// scratch` — persistent cache directories the host resolved, locked and created
+/// for the run, which the driver symlinks into the sandbox and announces through
+/// an env var. Additive and cold-path: it is a prost wire field, not a vtable
+/// change, so an old plugin decodes a new host's request fine and simply ignores
+/// the mounts. Its targets then run without a scratch, which costs a cold cache
+/// and never a wrong build — the lock is keyed on a declaration the old plugin
+/// cannot see, so there is no shared directory for it to race either. Minor,
+/// therefore, not major: no plugin *must* be rebuilt, but one must be to mount a
+/// scratch.
+///
 /// 0.5.0: `StableExecutor` gained a `states` method (fetch a package's provider
 /// states for cross-subtree config resolution — the go variant `vp` lookup). A
 /// new method on a `#[stabby::stabby]` vtable trait changes its type-report, so
@@ -35,7 +46,7 @@ pub use hproto_gen::heph::plugin::v1 as pb;
 /// 0.3.0: `PluginComponents` gained a `hooks` field (a layout change to the
 /// create-entry struct) for the Hook plugin kind — a hard break, so every plugin
 /// must be rebuilt against this ABI.
-pub const ABI_SEMVER: &str = "0.7.0";
+pub const ABI_SEMVER: &str = "0.8.0";
 
 #[cfg(feature = "convert")]
 pub mod convert;

--- a/crates/plugin-exec/src/pluginexec/mod.rs
+++ b/crates/plugin-exec/src/pluginexec/mod.rs
@@ -1476,6 +1476,39 @@ impl Driver {
 
         env.extend(def.runtime_env.iter().map(|(k, v)| (k.clone(), v.clone())));
 
+        // Scratch caches: each declaration names the variable its tool reads the
+        // directory from, so a consumer needs no wiring of its own — declaring
+        // `env = "GOCACHE"` is what makes `scratch = [...]` sufficient.
+        //
+        // The value is the *canonical* slot path the host resolved, not the
+        // in-sandbox symlink: tools bake absolute paths into their cache entries,
+        // so every consumer must see one stable string or the cache restores and
+        // is inert. Set after `runtime_env` and before PATH, and never hashed —
+        // the path contains the engine home, so hashing it would make every cache
+        // key machine-specific.
+        //
+        // A collision with the target's own env is rejected rather than resolved:
+        // silently winning either way leaves one of the two settings inoperative
+        // with nothing to see.
+        for m in &rreq.scratch {
+            let dir = m.dir.to_str().ok_or_else(|| {
+                anyhow::anyhow!("scratch dir for {} is not valid UTF-8: {:?}", m.addr, m.dir)
+            })?;
+            if let Some(existing) = env.get(&m.env)
+                && existing != dir
+            {
+                anyhow::bail!(
+                    "scratch {} sets `{}`, but this target already sets it to {:?}. One would \
+                     shadow the other — rename the variable on the scratch declaration, or drop \
+                     it from this target's env",
+                    m.addr,
+                    m.env,
+                    existing
+                );
+            }
+            env.insert(m.env.clone(), dir.to_string());
+        }
+
         // The target's own tools lead, wherever it ends up running — composed by
         // `hexecrunner` rather than spliced into the string here, because under
         // a runner the rest of `PATH` is not known until the runner (or its
@@ -2163,6 +2196,7 @@ mod tests {
             stdout: None,
             stderr: None,
             sandbox_dir: tmp.path().to_path_buf(),
+            scratch: vec![],
         };
 
         let res = tokio::time::timeout(
@@ -2487,6 +2521,7 @@ mod tests {
             stdout: Some(&mut stdout),
             stderr: None,
             sandbox_dir: tmp.path().to_path_buf(),
+            scratch: vec![],
         };
 
         let _res = driver.run(make_req(req), &ctoken).await?;
@@ -2545,6 +2580,7 @@ mod tests {
             stdout: None,
             stderr: None,
             sandbox_dir: tmp.path().to_path_buf(),
+            scratch: vec![],
         };
 
         let res = driver.run(make_req(req), &ctoken).await;
@@ -2616,6 +2652,7 @@ mod tests {
             stdout: Some(&mut stdout),
             stderr: None,
             sandbox_dir: tmp.path().to_path_buf(),
+            scratch: vec![],
         };
 
         // Use a timeout to detect the hang
@@ -2677,6 +2714,7 @@ mod tests {
             stdout: None,
             stderr: None,
             sandbox_dir: tmp.path().to_path_buf(),
+            scratch: vec![],
         };
 
         let run_fut = driver.run(make_req(req), &ctoken);
@@ -2745,6 +2783,7 @@ mod tests {
             stdout: None,
             stderr: None,
             sandbox_dir: tmp.path().to_path_buf(),
+            scratch: vec![],
         };
 
         let run_fut = driver.run(make_req(req), &ctoken);
@@ -2812,6 +2851,7 @@ mod tests {
             stdout: Some(&mut stdout),
             stderr: None,
             sandbox_dir: tmp.path().to_path_buf(),
+            scratch: vec![],
         };
 
         let res = tokio::time::timeout(
@@ -2988,6 +3028,7 @@ mod tests {
             stdout: Some(&mut out_handle),
             stderr: Some(&mut err_handle),
             sandbox_dir: tmp.path().to_path_buf(),
+            scratch: vec![],
         };
 
         tokio::time::timeout(MIDDLE * 10, driver.run(make_req(req), &ctoken))
@@ -3069,6 +3110,7 @@ mod tests {
             stdout: None,
             stderr: None,
             sandbox_dir: tmp.path().to_path_buf(),
+            scratch: vec![],
         };
 
         driver.run(make_req(req), &ctoken).await?;
@@ -3143,6 +3185,7 @@ mod tests {
             stdout: Some(&mut stdout),
             stderr: Some(&mut stderr),
             sandbox_dir: tmp.path().to_path_buf(),
+            scratch: vec![],
         };
 
         tokio::time::timeout(
@@ -3299,6 +3342,7 @@ mod tests {
             stdout: Some(&mut stdout),
             stderr: None,
             sandbox_dir: tmp.path().to_path_buf(),
+            scratch: vec![],
         };
 
         tokio::time::timeout(
@@ -3397,6 +3441,7 @@ mod tests {
             stdout: Some(&mut stdout),
             stderr: None,
             sandbox_dir: tmp.path().to_path_buf(),
+            scratch: vec![],
         };
         driver.run(make_req(req), &ctoken).await?;
         Ok(String::from_utf8(stdout)?.trim().to_string())
@@ -4428,6 +4473,7 @@ mod tests {
             stdout: None,
             stderr: None,
             sandbox_dir: tmp.path().to_path_buf(),
+            scratch: vec![],
         };
         driver
             .run(
@@ -4474,6 +4520,7 @@ mod tests {
             stdout: Some(&mut stdout),
             stderr: None,
             sandbox_dir: tmp.path().to_path_buf(),
+            scratch: vec![],
         };
         driver
             .run(
@@ -4553,6 +4600,7 @@ mod tests {
             stdout: Some(&mut stdout),
             stderr: None,
             sandbox_dir: tmp.path().to_path_buf(),
+            scratch: vec![],
         };
         driver
             .run(
@@ -4709,6 +4757,7 @@ mod tests {
             stdout: None,
             stderr: None,
             sandbox_dir: sandbox.clone(),
+            scratch: vec![],
         };
 
         os.run_inner(req, &ctoken, false).await?;
@@ -4805,6 +4854,7 @@ mod tests {
             stdout: None,
             stderr: None,
             sandbox_dir: tmp.path().to_path_buf(),
+            scratch: vec![],
         };
         driver
             .run(
@@ -4879,6 +4929,7 @@ mod tests {
             stdout: None,
             stderr: None,
             sandbox_dir: tmp.path().to_path_buf(),
+            scratch: vec![],
         };
         driver.run(make_req(req), &ctoken).await?;
 
@@ -4965,6 +5016,7 @@ mod tests {
             stdout: None,
             stderr: None,
             sandbox_dir: tmp.path().to_path_buf(),
+            scratch: vec![],
         };
         driver
             .run(
@@ -5067,6 +5119,7 @@ mod tests {
             stdout: None,
             stderr: None,
             sandbox_dir: tmp.path().to_path_buf(),
+            scratch: vec![],
         };
         driver
             .run(
@@ -5156,6 +5209,7 @@ mod tests {
             stdout: None,
             stderr: None,
             sandbox_dir: tmp.path().to_path_buf(),
+            scratch: vec![],
         };
 
         driver.run(make_req(req), &ctoken).await?;

--- a/crates/plugin-oci/src/pluginoci/mod.rs
+++ b/crates/plugin-oci/src/pluginoci/mod.rs
@@ -465,6 +465,7 @@ pub(crate) mod testfake {
                 stdout: None,
                 stderr: None,
                 sandbox_dir: sandbox.dir.path().to_path_buf(),
+                scratch: vec![],
             },
             sandbox_dir: sandbox.dir.path().to_path_buf(),
             sandbox_ws_dir: sandbox.ws.clone(),

--- a/crates/plugin-sdk/src/serve.rs
+++ b/crates/plugin-sdk/src/serve.rs
@@ -1268,6 +1268,11 @@ async fn run_once(
         stdout: Some(&mut stdout_sink),
         stderr: Some(&mut stderr_sink),
         sandbox_dir: sandbox_dir.clone(),
+        scratch: req
+            .scratch
+            .into_iter()
+            .filter_map(convert::scratch_mount_from_pb)
+            .collect(),
     };
     let mrr = ManagedRunRequest {
         request: rr,

--- a/crates/plugin-stabby/src/load_stable.rs
+++ b/crates/plugin-stabby/src/load_stable.rs
@@ -750,6 +750,12 @@ impl StableRemoteManagedDriver {
             inputs: req.inputs.iter().map(managed_input_to_pb).collect(),
             shell,
             driver: self.name.clone(),
+            scratch: req
+                .request
+                .scratch
+                .iter()
+                .map(convert::scratch_mount_to_pb)
+                .collect(),
         };
         // `run` is bidi: the request stream carries the run request (RunInFrame),
         // the response stream carries the result (RunOutFrame). `shell` rides pmrr.

--- a/crates/plugin/src/driver.rs
+++ b/crates/plugin/src/driver.rs
@@ -1016,6 +1016,28 @@ pub mod outputartifact {
     }
 }
 
+/// A scratch cache the host has resolved, locked and created for this run.
+///
+/// The driver's job is only to place it and announce it: symlink `path` (relative
+/// to the target's cwd) at `dir`, and set `env` to `dir`. Everything else — which
+/// declaration this came from, how the slot was keyed, which lock is held — is the
+/// host's, and deliberately not visible here.
+///
+/// `dir` is the *canonical* slot path, not the in-sandbox mount, and that is the
+/// point: tools bake absolute paths into their cache entries, so every consumer
+/// must see one stable string for the same cache or it is present and inert.
+#[derive(Clone, Debug)]
+pub struct ScratchMount {
+    /// The declaring target, for diagnostics.
+    pub addr: Addr,
+    /// Mount point relative to the target's cwd.
+    pub path: String,
+    /// Environment variable that carries `dir`.
+    pub env: String,
+    /// Canonical slot directory. Already created; the mount points here.
+    pub dir: PathBuf,
+}
+
 pub struct RunRequest<'a, 'io> {
     pub request_id: &'a String,
     pub target: &'a targetdef::TargetDef,
@@ -1026,6 +1048,9 @@ pub struct RunRequest<'a, 'io> {
     pub stdout: Option<&'io mut (dyn tokio::io::AsyncWrite + Send + Sync + Unpin)>,
     pub stderr: Option<&'io mut (dyn tokio::io::AsyncWrite + Send + Sync + Unpin)>,
     pub sandbox_dir: std::path::PathBuf,
+    /// Scratch caches to mount for this run, already locked and created by the
+    /// host. Empty for the overwhelming majority of targets.
+    pub scratch: Vec<ScratchMount>,
 }
 /// Cleanup closure a driver returns for the engine to run after `cache_locally`.
 /// The FUSE/OS sandbox layers each supply their own teardown; the engine's

--- a/docs/SCRATCH.md
+++ b/docs/SCRATCH.md
@@ -1,13 +1,14 @@
 # Design: named scratch caches (GitHub-Actions-style per-target caching)
 
-**Status:** phases 1–2 implemented and in review (PR #403, #407); phases 3–9
-designed, not built. §18 has the ordering; the notes below record what building it
+**Status:** phases 1–3 implemented and in review (PR #403, #407, #412) — a
+scratch now mounts, locks and sets its env var, so the feature works locally.
+Phases 4–9 (lineage, scopes, remote, retrofits) designed, not built. §18 has the ordering; the notes below record what building it
 changed about the design.
 
 Review-board consults (`product-vision`, `feature-quality`, `hermeticity`,
 `compatibility`) are *pending*; §16 and §21 list what each has to rule on. The
-`compatibility` consult now has a concrete trigger: mounting (phase 3) needs an
-additive `RunRequest` field and an `ABI_SEMVER` minor bump — see §5.3.
+`compatibility` consult has a landed trigger to rule on: mounting added an
+additive `RunRequest` field and took `ABI_SEMVER` to 0.6.0 — see §5.3.
 
 ### Implementation notes
 
@@ -1612,11 +1613,12 @@ document should be believed until it is an interleaved A/B on the corpus.**
    not need storage: wrong-kind addr, env collisions, mount overlaps, duplicates.
    Nothing observable happens yet beyond `heph query` — deliberately, so the
    checks land before anything can write.
-3. **Mount + lock + env + events.** The feature, locally. Needs the `RunRequest`
-   field above, the bridge to create the symlink (it owns sandbox creation and may
-   redirect the path into a FUSE mount), and the slot lock — which must ship *with*
-   `access`, since an `exclusive` that does not serialize is a silent lie. Where
-   the `golist_gocache` win becomes general.
+3. **Mount + lock + env.** ✅ *PR #412.* The symlink (created by the bridge,
+   which owns sandbox creation and may redirect into a FUSE mount), the keyed
+   cross-process slot lock — shipped *with* `access`, since an `exclusive` that
+   does not serialize is a silent lie — and the declaration's env var. Events
+   deferred to the observability phase. Where the `golist_gocache` win becomes
+   general.
 4. **The lineage model + scopes, local only** (§10.1–§10.7). Branch-aware local
    caches, `${git:branch}`, the drift guard. Reviewable without any network, and
    the piece the remote phase then reuses wholesale rather than reimplements.
@@ -1834,3 +1836,28 @@ than after.
   is `if: always()`: a cache warmed by a partially failing build is still warm, and
   the head it publishes is no less valid than one from a green run. Worth stating
   as guidance, since the intuitive choice is `if: success()` and it is wrong.
+
+---
+
+## Appendix: notes from implementing phases 1–3
+
+Things that only showed up in code, recorded so the next phase does not re-learn
+them.
+
+- **An `EResult` holds a riding read lock on its addr.** A test that keeps a run's
+  result alive across `reopen()` deadlocks the second engine's *write* lock
+  against it — and only when the second run actually re-executes, since a cache
+  hit takes a read lock and coexists happily. Cost ~30 minutes of hang before it
+  surfaced as an unrelated-looking `ENOENT` on a lock file. `engine_core.rs`
+  already had the idiom (`drop(result)` before reopening); it is worth stating.
+- **`cargo build --workspace` does not build test targets.** Adding a field to
+  `RunRequest` compiled clean and then broke 28 construction sites in `#[cfg(test)]`
+  code. `--all-targets` is the check that matters, exactly as `.claude/rust.md`
+  says for clippy.
+- **Zero outputs is a supported target shape.** A declaration is executed like any
+  other target when someone resolves it directly, so its `run` must succeed and
+  produce nothing. The first version treated being run as an engine bug, which was
+  simply wrong.
+- **Two `ScratchMount` types is one too many.** The engine's resolved form and the
+  driver-facing form are the same thing; keeping the contract type and deleting the
+  engine-local duplicate removed a conversion that could drift.

--- a/proto/plugin/v1/driver.proto
+++ b/proto/plugin/v1/driver.proto
@@ -51,6 +51,20 @@ message RunInput {
   map<string, string> annotations = 5;
 }
 
+// A scratch cache the host resolved, locked and created for this run. The driver
+// symlinks `path` (relative to the target's cwd) at `dir`, and sets `env` to
+// `dir`.
+//
+// `dir` is the canonical slot path, not the in-sandbox mount: tools bake absolute
+// paths into their cache entries, so every consumer must see one stable string
+// for the same cache or it restores and is inert.
+message ScratchMount {
+  Addr addr = 1;
+  string path = 2;
+  string env = 3;
+  string dir = 4;
+}
+
 message RunRequest {
   string request_id = 1;
   TargetDef target = 2;
@@ -65,6 +79,7 @@ message RunRequest {
   bool has_stderr = 9;
   // true => run_shell, false => run
   bool shell = 10;
+  repeated ScratchMount scratch = 11;
 }
 
 // fuse_slot_guards and sandbox_cleanup are non-transferable host RAII,
@@ -108,6 +123,7 @@ message ManagedRunRequest {
   // true => run_shell
   bool shell = 9;
   string driver = 10;
+  repeated ScratchMount scratch = 11;
 }
 
 message ManagedRunResponse {


### PR DESCRIPTION
Third of four (stack #408), on top of #407. This is where a scratch declaration
starts doing something: a referenced cache is materialized into the sandbox,
guarded against concurrent use, and handed to the tool through the variable its
declaration names.

After this, the whole surface a consumer writes is:

```starlark
target(name = "server", driver = "bash", scratch = ["//build:gocache"],
       run = ["go build ./..."])          # GOCACHE is set; nothing else to wire
```

## Mounting is one symlink

Per target, pointing *out* of the sandbox at the canonical slot directory. That is
the entire mechanism, and it is why a scratch costs an inode rather than a copy:
teardown removes the link, not the tree, since `remove_dir_all` does not follow
symlinks — the same property read-only input staging already relies on for the
11k-file Go SDK.

The measurements are what rule out the obvious alternative. Seeding a warm cache
*into each sandbox* cut `go list` CPU 778s → 309s and moved wall time by
**exactly zero** (interleaved A/B: 217.3s vs 219.5s), because the cost was never
CPU — it was the ~500 filesystem entries created and destroyed per sandbox.

The link target is the **canonical** path, not something sandbox-local. Tools bake
absolute paths into their cache entries (Go's action IDs are the standing
example), so if every consumer saw its own path the cache would restore and be
inert — present, and useless.

**The bridge creates it, not the engine.** The bridge owns sandbox creation: the
FUSE path may redirect the package dir into a mount, so there is no earlier moment
at which the directory reliably exists. Putting it there covers both sandbox modes
at once, and `sandboxfuse` implements `mkdir`/`symlink` through to the upper dir.

## The one wrong-build guard

A scratch that would land where an input already did is a **hard error**. This is
the only way a scratch can cause a wrong build rather than a slow one: the target
would read cache contents where it believes it reads a declared dependency — bytes
no `hashin` describes. Silently winning either way is not an option.

## Locking ships with `access`, deliberately

A keyed cross-process reader/writer lock per slot, `access` choosing the guard. It
is in this PR and not a later one because an `exclusive` that does not serialize is
a silent lie.

Two ordering rules, both mirroring what `execute` already does:

- **Guards are taken in sorted slot order**, so two targets naming the same pair in
  opposite orders cannot deadlock.
- **The acquire sits after dependency resolution and before the worker permit.**
  After deps, or a dep needing the same slot could never get it — the same diamond
  the worker permit is already ordered to avoid. Before the permit, so a target
  queued on a contended slot holds no worker; and since the lock is always taken
  first, no permit holder is ever blocked on a slot, which makes the wait provably
  bounded rather than circular.

## Slot identity

`(addr, version, platform-components)`. So `platform = "any"` gives **one slot for
every machine**, which is what will let a portable cache travel between a Linux CI
runner and a macOS laptop once the remote lands.

## Compatibility: `ABI_SEMVER` 0.5.0 → 0.6.0

`RunRequest`/`ManagedRunRequest` gain `repeated ScratchMount scratch`. Additive and
cold-path — a prost wire field, not a vtable change — so an old plugin decodes a
new host's request and ignores the mounts. Its targets then run without a scratch,
which costs a cold cache and **never a wrong build**: the lock is keyed on a
declaration an old plugin cannot see, so there is no shared directory for it to
race either. Minor, not major: no plugin *must* be rebuilt, but one must be to
mount a scratch.

The cdylib path is not optional here — `plugin-go` is a cdylib and is the reason
this feature exists.

An earlier revision of the design claimed mounting needed no ABI surface at all, on
the theory that the resolved mount would ride on `RunInput.annotations`. It cannot:
`link.rs:36` filters `runtime: false` inputs out of `LinkedTargetDef`, which is
exactly what makes a scratch a pure graph edge — and therefore also why it never
becomes a `RunInput`. Corrected in `docs/SCRATCH.md`.

## Tests

12 more, 54 total across the stack. The load-bearing one is
`a_scratch_carries_state_between_runs`: run 1 sees an empty cache and writes a
marker, run 2 (a genuine re-execute, not a hit) reads it back — through the real
sandbox, symlink and env var.

Worth knowing if you write another test here: an `EResult` holds a riding **read**
lock on its addr, so keeping one alive across `reopen()` deadlocks the second
engine's write lock against it. It only bites when the second run re-executes; a
cache hit takes a read lock and coexists. It cost ~30 minutes of hang and surfaced
as an unrelated `ENOENT` on a lock file.


---

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>