### PR TITLE
feat(plugin-devenv): capture a devenv environment and run targets in it

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2267,6 +2267,7 @@ dependencies = [
  "parking_lot",
  "plugin",
  "plugin-buildfile",
+ "plugin-devenv",
  "plugin-exec",
  "plugin-http",
  "plugin-nix",
@@ -4071,6 +4072,26 @@ dependencies = [
  "tracing",
  "walk",
  "xstarlark-fmt",
+]
+
+[[package]]
+name = "plugin-devenv"
+version = "0.1.0"
+dependencies = [
+ "anyhow",
+ "async-trait",
+ "core",
+ "driver-support",
+ "exec-runner",
+ "htspec-derive",
+ "model",
+ "plugin",
+ "proc",
+ "serde",
+ "serde_json",
+ "tempfile",
+ "tracing",
+ "xxhash-rust",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,7 +4,7 @@ version = "0.1.0"
 edition = "2024"
 
 [workspace]
-members = ["gen/proto", "crates/e2e", "crates/bin-e2e", "crates/testkit", "crates/plugingo-e2e", "crates/htspec-derive", "crates/core", "crates/config", "crates/walk", "crates/proc", "crates/model", "crates/sandboxfuse", "crates/plugin", "crates/plugin-abi", "crates/plugin-stabby", "crates/plugin-sdk", "crates/plugin-go-cdylib", "crates/builtins", "crates/plugin-buildfile", "crates/driver-support", "crates/driver-bridge", "crates/exec-runner", "crates/plugin-exec", "crates/plugin-nix", "crates/plugin-http", "crates/plugin-oci", "crates/plugin-query", "crates/plugin-go", "crates/plugin-gha", "crates/plugin-gha-cdylib", "crates/plugin-oci-cdylib", "crates/telemetry", "crates/tui", "crates/lock", "crates/selfupdate", "crates/engine", "crates/xstarlark-fmt", "crates/bench-corpus", "crates/bench"]
+members = ["gen/proto", "crates/e2e", "crates/bin-e2e", "crates/testkit", "crates/plugingo-e2e", "crates/htspec-derive", "crates/core", "crates/config", "crates/walk", "crates/proc", "crates/model", "crates/sandboxfuse", "crates/plugin", "crates/plugin-abi", "crates/plugin-stabby", "crates/plugin-sdk", "crates/plugin-go-cdylib", "crates/builtins", "crates/plugin-buildfile", "crates/driver-support", "crates/driver-bridge", "crates/exec-runner", "crates/plugin-exec", "crates/plugin-devenv", "crates/plugin-nix", "crates/plugin-http", "crates/plugin-oci", "crates/plugin-query", "crates/plugin-go", "crates/plugin-gha", "crates/plugin-gha-cdylib", "crates/plugin-oci-cdylib", "crates/telemetry", "crates/tui", "crates/lock", "crates/selfupdate", "crates/engine", "crates/xstarlark-fmt", "crates/bench-corpus", "crates/bench"]
 
 [profile.profiling]
 inherits = "release"
@@ -117,6 +117,7 @@ hbuiltins = { package = "builtins", path = "crates/builtins" }
 hplugin-buildfile = { package = "plugin-buildfile", path = "crates/plugin-buildfile" }
 hdriver-support = { package = "driver-support", path = "crates/driver-support" }
 hplugin-exec = { package = "plugin-exec", path = "crates/plugin-exec" }
+hplugin-devenv = { package = "plugin-devenv", path = "crates/plugin-devenv" }
 hplugin-nix = { package = "plugin-nix", path = "crates/plugin-nix" }
 hplugin-http = { package = "plugin-http", path = "crates/plugin-http" }
 hplugin-query = { package = "plugin-query", path = "crates/plugin-query" }

--- a/crates/e2e/tests/common/mod.rs
+++ b/crates/e2e/tests/common/mod.rs
@@ -54,6 +54,9 @@ pub struct RecordingExecRunner {
     pub opens: Arc<std::sync::atomic::AtomicUsize>,
     /// Env var name/value the returned session applies to every process.
     pub var: (String, String),
+    /// When set, the session also supplies `PATH`, which must then REPLACE the
+    /// driver's own rather than sit under it.
+    pub path: Option<String>,
 }
 
 #[async_trait::async_trait]
@@ -75,17 +78,25 @@ impl heph::engine::exec_runner::ExecRunner for RecordingExecRunner {
             .map(|a| String::from_utf8_lossy(&a.bytes).trim().to_string())
             .unwrap_or_default();
 
+        let mut base = vec![];
+        if let Some(p) = &self.path {
+            base.push((
+                std::ffi::OsString::from("PATH"),
+                std::ffi::OsString::from(p.clone()),
+            ));
+        }
+        base.extend(vec![
+            (
+                std::ffi::OsString::from(self.var.0.clone()),
+                std::ffi::OsString::from(self.var.1.clone()),
+            ),
+            (
+                std::ffi::OsString::from("HEPH_TEST_RUNNER_ARTIFACT"),
+                std::ffi::OsString::from(from_artifact),
+            ),
+        ]);
         Ok(Arc::new(er::EnvSession::new(
-            vec![
-                (
-                    std::ffi::OsString::from(self.var.0.clone()),
-                    std::ffi::OsString::from(self.var.1.clone()),
-                ),
-                (
-                    std::ffi::OsString::from("HEPH_TEST_RUNNER_ARTIFACT"),
-                    std::ffi::OsString::from(from_artifact),
-                ),
-            ],
+            base,
             er::SessionCaps {
                 pty: true,
                 max_concurrent: None,
@@ -95,6 +106,7 @@ impl heph::engine::exec_runner::ExecRunner for RecordingExecRunner {
             },
             er::SessionDescription {
                 runner: req.runner_addr.clone(),
+                shell_functions: Vec::new(),
                 key: req.key,
                 summary: "recording test runner".to_string(),
             },
@@ -109,6 +121,16 @@ impl Workspace {
         opens: Arc<std::sync::atomic::AtomicUsize>,
         var: (&str, &str),
     ) -> Self {
+        Self::with_recording_runner_path(opens, var, None)
+    }
+
+    /// [`Self::with_recording_runner`] whose session also supplies `PATH`.
+    pub fn with_recording_runner_path(
+        opens: Arc<std::sync::atomic::AtomicUsize>,
+        var: (&str, &str),
+        path: Option<&str>,
+    ) -> Self {
+        let path = path.map(str::to_owned);
         Self {
             inner: WorkspaceBuilder::new()
                 .expect("workspace tempdir")
@@ -127,6 +149,7 @@ impl Workspace {
                     Arc::new(RecordingExecRunner {
                         opens,
                         var: (var.0.to_string(), var.1.to_string()),
+                        path,
                     }),
                 )
                 .build()
@@ -166,6 +189,7 @@ impl Workspace {
                     Arc::new(RecordingExecRunner {
                         opens: Arc::new(std::sync::atomic::AtomicUsize::new(0)),
                         var: ("FROM_DEFAULT_RUNNER".to_string(), "1".to_string()),
+                        path: None,
                     }),
                 )
                 .build()

--- a/crates/e2e/tests/exec_runner.rs
+++ b/crates/e2e/tests/exec_runner.rs
@@ -320,3 +320,52 @@ target(name = "b", driver = "bash", run = "echo b > $OUT", out = "o", runner = "
     );
     Ok(())
 }
+
+/// A session's `PATH` **replaces** the driver's, it does not sit under it.
+///
+/// This is §4.4's layer-2 rule, and it is the one that decides whether a runner
+/// means anything: with the driver's default appended, a tool missing from the
+/// environment silently falls through to the host — the exact ambient
+/// dependency a runner exists to remove — and does so under a cache key that
+/// asserts the runner's environment. Caught end to end, because it was
+/// documented and then not implemented.
+#[tokio::test]
+async fn session_path_replaces_the_drivers_default() -> anyhow::Result<()> {
+    let opens = std::sync::Arc::new(std::sync::atomic::AtomicUsize::new(0));
+    let ws = Workspace::with_recording_runner_path(
+        std::sync::Arc::clone(&opens),
+        ("V", "1"),
+        // Real enough to find `bash`, marked enough to prove which PATH won.
+        // Deliberately NOT `/usr/bin`, which is in the driver's default.
+        Some("/runner/only/bin:/bin"),
+    );
+    ws.write_build_file(
+        "p",
+        r#"
+target(name = "env", driver = "bash", run = "echo E > $OUT", out = "env.json")
+target(
+    name = "shows_path",
+    driver = "bash",
+    run = "echo \"$PATH\" > $OUT",
+    out = "o",
+    runner = "//p:env",
+)
+"#,
+    );
+
+    let res = ws.run("//p:shows_path").await?;
+    let path = common::artifact_string(&res);
+
+    assert!(
+        path.contains("/runner/only/bin"),
+        "the runner's PATH must be in force: {path:?}"
+    );
+    // The driver's default must not be appended behind it.
+    assert!(
+        !path.contains("/usr/bin"),
+        "the driver's default PATH must not survive under a runner: {path:?}"
+    );
+    // The sandbox `bin/` prepend still wins over everything — a hermetic
+    // `tools =` dep must never be shadowed by an ambient one.
+    Ok(())
+}

--- a/crates/engine/src/engine/engine.rs
+++ b/crates/engine/src/engine/engine.rs
@@ -649,6 +649,12 @@ impl Engine {
 
     /// Register an exec runner under `name`, matching the driver name of the
     /// runner targets it serves.
+    /// The workspace-level `defaultRunner:`, if set. Read by diagnostics to say
+    /// *how* a target's environment was chosen, not only which it was.
+    pub fn default_runner(&self) -> Option<&hmodel::htaddr::Addr> {
+        self.cfg.default_runner.as_ref()
+    }
+
     pub fn register_exec_runner(
         &mut self,
         name: impl Into<String>,

--- a/crates/exec-runner/src/lib.rs
+++ b/crates/exec-runner/src/lib.rs
@@ -93,6 +93,12 @@ pub struct SessionCaps {
 pub struct SessionDescription {
     /// The runner that opened it (`local`, or a runner target's addr).
     pub runner: String,
+    /// Names the environment defines as **shell functions** rather than
+    /// binaries. Diagnostics only, and the difference between a dead end and a
+    /// recoverable error: a target calling one of these otherwise fails with
+    /// "not found in PATH", which sends the reader hunting for a missing
+    /// package that is not missing.
+    pub shell_functions: Vec<String>,
     /// Content-addressed key this session was opened for. Empty for `local`,
     /// which contributes nothing to any cache key.
     pub key: String,
@@ -133,6 +139,14 @@ pub enum SpawnError {
         key: String,
         reason: String,
     },
+    /// The program is not a binary in this environment, but the environment
+    /// *does* define it as a shell function — which a snapshot runner cannot
+    /// provide. Named separately because the fix is different in kind: not
+    /// "install it" but "this runner mode cannot express it".
+    ShellFunctionNotABinary {
+        program: String,
+        runner: String,
+    },
     Io(std::io::Error),
 }
 
@@ -163,6 +177,13 @@ impl std::fmt::Display for SpawnError {
                      check that the working directory {cwd:?} exists."
                 ),
             },
+            SpawnError::ShellFunctionNotABinary { program, runner } => write!(
+                f,
+                "spawn child process {program:?}: runner `{runner}` defines {program:?} as a shell \
+                 function, not a binary on PATH. The snapshot runner cannot provide shell \
+                 functions — call the underlying command directly, or set `mode = \"session\"` on \
+                 the runner target."
+            ),
             SpawnError::SessionDied { key, reason } => write!(
                 f,
                 "exec session {key} died before the process could be created: {reason}"
@@ -176,7 +197,7 @@ impl std::error::Error for SpawnError {
     fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
         match self {
             SpawnError::Io(e) | SpawnError::ProgramNotFound { io: e, .. } => Some(e),
-            SpawnError::SessionDied { .. } => None,
+            SpawnError::SessionDied { .. } | SpawnError::ShellFunctionNotABinary { .. } => None,
         }
     }
 }
@@ -343,6 +364,7 @@ impl LocalSession {
             },
             description: SessionDescription {
                 runner: "local".to_string(),
+                shell_functions: Vec::new(),
                 key: String::new(),
                 summary: "host process, no environment applied".to_string(),
             },
@@ -531,6 +553,7 @@ mod env_session_tests {
             },
             SessionDescription {
                 runner: "test".to_string(),
+                shell_functions: Vec::new(),
                 key: "k".to_string(),
                 summary: "test".to_string(),
             },
@@ -590,5 +613,25 @@ mod env_session_tests {
             .prepare(spec_with(&[("A", "caller")]))
             .expect("prepare");
         assert_eq!(out.env.iter().filter(|(k, _)| k == "A").count(), 1);
+    }
+}
+
+#[cfg(test)]
+mod shell_function_diag_tests {
+    use super::*;
+
+    /// M1's one real limitation, made recoverable. Without this the reader sees
+    /// "not found in PATH" and goes looking for a package that is not missing.
+    #[test]
+    fn a_shell_function_says_so_rather_than_not_found() {
+        let msg = SpawnError::ShellFunctionNotABinary {
+            program: "fmt-all".to_string(),
+            runner: "//:devenv".to_string(),
+        }
+        .to_string();
+        assert!(msg.contains("shell function"), "{msg}");
+        assert!(msg.contains("//:devenv"), "{msg}");
+        // Names the way out, not just the problem.
+        assert!(msg.contains(r#"mode = "session""#), "{msg}");
     }
 }

--- a/crates/plugin-devenv/Cargo.toml
+++ b/crates/plugin-devenv/Cargo.toml
@@ -1,0 +1,25 @@
+[package]
+name = "plugin-devenv"
+version = "0.1.0"
+edition = "2024"
+
+[lints]
+workspace = true
+
+[dependencies]
+hcore = { package = "core", path = "../core" }
+hmodel = { package = "model", path = "../model" }
+hplugin = { package = "plugin", path = "../plugin" }
+hdriver-support = { package = "driver-support", path = "../driver-support" }
+hexec-runner = { package = "exec-runner", path = "../exec-runner" }
+hproc = { package = "proc", path = "../proc" }
+htspec-derive = { path = "../htspec-derive" }
+anyhow = "1.0.102"
+async-trait = "0.1.89"
+serde = { version = "1", features = ["derive"] }
+serde_json = "1.0"
+tracing = "0.1"
+xxhash-rust = { version = "0.8.15", features = ["xxh3", "std"] }
+
+[dev-dependencies]
+tempfile = "3"

--- a/crates/plugin-devenv/src/lib.rs
+++ b/crates/plugin-devenv/src/lib.rs
@@ -1,0 +1,10 @@
+//! The `devenv` plugin: a driver that captures a devenv.sh environment as an
+//! artifact, and an exec runner that reads it back.
+//!
+//! Design: `docs/EXEC_RUNNERS.md` §5. Two halves under one name, because that
+//! is how a runner is selected — by the driver name of the runner target.
+pub mod plugindevenv;
+
+// The `htspec` derive macros expand to `crate::htvalue` / `crate::htspec`.
+pub(crate) use hcore::htvalue;
+pub(crate) use hplugin::htspec;

--- a/crates/plugin-devenv/src/plugindevenv/mod.rs
+++ b/crates/plugin-devenv/src/plugindevenv/mod.rs
@@ -1,0 +1,378 @@
+//! The `devenv` driver (builds the environment artifact) and the `devenv` exec
+//! runner (reads it back). One name, two halves — see `docs/EXEC_RUNNERS.md` §5.
+
+pub mod snapshot;
+
+use anyhow::Context as _;
+use async_trait::async_trait;
+use hcore::hasync::Cancellable;
+use hdriver_support::driver_managed::{ManagedDriver, ManagedRunRequest, ManagedRunResponse};
+use hexec_runner::{
+    EnvSession, ExecRunner, ExecSession, Identity, OpenRequest, SessionCaps, SessionDescription,
+};
+use hplugin::driver::targetdef::path::{CodegenMode, Content, Path as TPath};
+use hplugin::driver::targetdef::{CacheConfig, Output, TargetDef};
+use hplugin::driver::{
+    ApplyTransitiveRequest, ApplyTransitiveResponse, ConfigRequest, ConfigResponse, ParseRequest,
+    ParseResponse,
+};
+use hplugin::htspec::Spec;
+use snapshot::{LocalPaths, Snapshot, Variable};
+use std::collections::BTreeMap;
+use std::hash::{Hash as _, Hasher as _};
+use std::sync::Arc;
+
+pub const NAME: &str = "devenv";
+
+/// The snapshot file a `devenv` target produces.
+const OUT_NAME: &str = "devenv-env.json";
+
+/// Config for a `devenv` target.
+#[derive(Spec)]
+struct DevenvSpec {
+    /// The `devenv` binary. Defaults to `devenv` on the driver's PATH.
+    bin: Option<String>,
+}
+
+#[derive(Clone, serde::Serialize, serde::Deserialize)]
+struct DevenvDef {
+    bin: String,
+}
+
+pub struct Driver {
+    tree_root: std::path::PathBuf,
+}
+
+impl Driver {
+    pub fn new(tree_root: std::path::PathBuf) -> Self {
+        Self { tree_root }
+    }
+}
+
+#[async_trait]
+impl ManagedDriver for Driver {
+    fn config(&self, _req: ConfigRequest) -> anyhow::Result<ConfigResponse> {
+        Ok(ConfigResponse {
+            name: NAME.to_string(),
+        })
+    }
+
+    fn schema(&self) -> hplugin::driver::DriverSchema {
+        DevenvSpec::schema()
+    }
+
+    async fn parse(
+        &self,
+        req: ParseRequest,
+        _ctoken: &(dyn Cancellable + Send + Sync),
+    ) -> anyhow::Result<ParseResponse> {
+        let spec = DevenvSpec::from(&req.target_spec.config).with_context(|| "devenv spec")?;
+        let def = DevenvDef {
+            bin: spec.bin.unwrap_or_else(|| "devenv".to_string()),
+        };
+
+        let mut h = xxhash_rust::xxh3::Xxh3::new();
+        snapshot::SNAPSHOT_FORMAT_VERSION.hash(&mut h);
+        def.bin.hash(&mut h);
+        req.target_spec.addr.format().hash(&mut h);
+
+        Ok(ParseResponse {
+            target_def: TargetDef {
+                addr: req.target_spec.addr.clone(),
+                labels: vec![],
+                raw_def: Arc::new(def),
+                inputs: vec![],
+                outputs: vec![Output {
+                    group: String::new(),
+                    // Declared output paths are workspace-relative, i.e.
+                    // package-prefixed — the same normalization `pluginexec`
+                    // applies to `out =`. A bare name would be looked for at the
+                    // workspace root and never found.
+                    paths: vec![TPath {
+                        content: Content::FilePath(hmodel::htpkg::join_rel_checked(
+                            req.target_spec.addr.package.as_str(),
+                            OUT_NAME,
+                        )?),
+                        codegen_tree: CodegenMode::None,
+                        collect: true,
+                    }],
+                }],
+                support_files: vec![],
+                // Local cache only. The snapshot's `PATH` is a list of
+                // host-local `/nix/store` paths, and `plugin-nix` already
+                // refuses to share the same kind of artifact for the same
+                // reason ("wrappers point at host-local /nix/store; remote cache
+                // must stay disabled"). A machine that pulled this from a shared
+                // cache without those store paths would get an environment of
+                // directories that do not exist.
+                cache: CacheConfig::on(false),
+                pty: false,
+                hash: h.finish().to_le_bytes().to_vec(),
+                transparent: false,
+            },
+        })
+    }
+
+    async fn apply_transitive(
+        &self,
+        req: ApplyTransitiveRequest,
+        _ctoken: &(dyn Cancellable + Send + Sync),
+    ) -> anyhow::Result<ApplyTransitiveResponse> {
+        Ok(ApplyTransitiveResponse {
+            target_def: req.target_def,
+        })
+    }
+
+    async fn run<'a, 'io>(
+        &self,
+        req: ManagedRunRequest<'a, 'io>,
+        ctoken: &(dyn Cancellable + Send + Sync),
+    ) -> anyhow::Result<ManagedRunResponse> {
+        let def = req.request.target.def_de::<DevenvDef>().clone();
+        let out_path = req.sandbox_pkg_dir.join(OUT_NAME);
+
+        // `devenv` must run against the real tree, not the sandbox: the
+        // environment it describes is the workspace's, and `devenv.nix` lives
+        // there. This is the one read outside the sandbox in the whole design,
+        // and it is why the *inputs* (devenv.nix/yaml/lock) must be declared on
+        // the target — they, not this directory, are what the cache key sees.
+        let spec = hproc::proc_exec::Spec {
+            program: std::path::PathBuf::from(&def.bin),
+            args: vec!["print-dev-env".into(), "--json".into()],
+            env: passthrough_env(),
+            cwd: self.tree_root.clone(),
+            stdin: hproc::proc_exec::StdioSpec::Null,
+            stdout: hproc::proc_exec::StdioSpec::Piped,
+            stderr: hproc::proc_exec::StdioSpec::Piped,
+            setsid: true,
+            ctty: false,
+        };
+
+        // `output`, not `spawn`: the JSON is collected in full after the wait,
+        // which needs the unbounded drain (a dev shell's dump is well past the
+        // streaming bound).
+        let out = req
+            .runner
+            .output(spec, ctoken)
+            .await
+            .with_context(|| format!("running `{} print-dev-env --json`", def.bin))?;
+        if !out.status.success() {
+            let stderr = String::from_utf8_lossy(&out.stderr);
+            anyhow::bail!(
+                "`{} print-dev-env --json` failed ({}):\n{stderr}",
+                def.bin,
+                out.status
+            );
+        }
+
+        let snap = snapshot_from_json(&out.stdout, &self.local_paths())?;
+        if snap.env.is_empty() {
+            anyhow::bail!(
+                "the devenv environment came out empty after filtering, which would describe \
+                 nothing and make every target using it share a cache key with targets using a \
+                 different runner"
+            );
+        }
+
+        let json = serde_json::to_vec_pretty(&snap).context("serialize devenv snapshot")?;
+        std::fs::write(&out_path, json).with_context(|| format!("write {}", out_path.display()))?;
+
+        if !snap.dropped_path_entries.is_empty() {
+            tracing::info!(
+                dropped = snap.dropped_path_entries.len(),
+                "devenv: dropped non-/nix/store PATH entries; targets needing those tools must \
+                 declare them as `tools =` deps"
+            );
+        }
+
+        Ok(ManagedRunResponse { artifacts: vec![] })
+    }
+}
+
+impl Driver {
+    fn local_paths(&self) -> LocalPaths {
+        LocalPaths {
+            tree_root: self.tree_root.to_string_lossy().into_owned(),
+            home: std::env::var("HOME").unwrap_or_default(),
+            tmpdir: std::env::var("TMPDIR").unwrap_or_default(),
+        }
+    }
+}
+
+/// What `devenv` itself needs to run: it shells out to nix, which needs the
+/// user's store, channels and TLS trust. Mirrors `plugin-nix`'s passthrough for
+/// the same reason — the spawn is `env_clear`ed, so anything nix needs must be
+/// named.
+fn passthrough_env() -> Vec<(std::ffi::OsString, std::ffi::OsString)> {
+    [
+        "HOME",
+        "USER",
+        "PATH",
+        "NIX_PATH",
+        "XDG_CACHE_HOME",
+        "XDG_CONFIG_HOME",
+        "NIX_SSL_CERT_FILE",
+        "SSL_CERT_FILE",
+        "SSL_CERT_DIR",
+        "CURL_CA_BUNDLE",
+        "HTTPS_PROXY",
+        "HTTP_PROXY",
+        "NO_PROXY",
+        "https_proxy",
+        "http_proxy",
+        "no_proxy",
+    ]
+    .iter()
+    .filter_map(|n| {
+        std::env::var(n)
+            .ok()
+            .map(|v| (std::ffi::OsString::from(n), std::ffi::OsString::from(v)))
+    })
+    .collect()
+}
+
+#[derive(serde::Deserialize)]
+struct PrintDevEnv {
+    #[serde(default)]
+    variables: BTreeMap<String, Variable>,
+    #[serde(default)]
+    bash_functions: BTreeMap<String, serde_json::Value>,
+}
+
+fn snapshot_from_json(stdout: &[u8], local: &LocalPaths) -> anyhow::Result<Snapshot> {
+    // `bashFunctions` in the wire format; serde's rename is applied here rather
+    // than in the struct so the field name reads as Rust.
+    let raw: serde_json::Value = serde_json::from_slice(stdout).with_context(|| {
+        // Show what actually came back. "expected value at line 1 column 1"
+        // alone cannot distinguish "empty output" from "devenv printed
+        // progress on stdout", and those have different fixes.
+        let head: String = String::from_utf8_lossy(stdout).chars().take(200).collect();
+        if stdout.is_empty() {
+            "`devenv print-dev-env --json` produced no output on stdout".to_string()
+        } else {
+            format!("parse `devenv print-dev-env --json` output; first bytes: {head:?}")
+        }
+    })?;
+    let parsed: PrintDevEnv = serde_json::from_value(serde_json::json!({
+        "variables": raw.get("variables").cloned().unwrap_or_default(),
+        "bash_functions": raw.get("bashFunctions").cloned().unwrap_or_default(),
+    }))
+    .context("decode devenv env")?;
+
+    Ok(snapshot::build(
+        &parsed.variables,
+        parsed.bash_functions.keys().cloned().collect(),
+        local,
+    ))
+}
+
+/// The runner half: a pure parse of the artifact the driver produced.
+///
+/// It reads nothing else. `open` runs after `hashin` is computed and does not
+/// run at all on a fully-cached build, so anything discovered here would be
+/// unhashed input that cannot be validated on the build where a stale artifact
+/// is served (`docs/EXEC_RUNNERS.md` §4.7).
+pub struct Runner;
+
+#[async_trait]
+impl ExecRunner for Runner {
+    async fn open(
+        &self,
+        req: OpenRequest,
+        _ctoken: &(dyn Cancellable + Send + Sync),
+    ) -> anyhow::Result<Arc<dyn ExecSession>> {
+        let artifact = req
+            .artifacts
+            .iter()
+            .find(|a| a.path.ends_with(OUT_NAME))
+            .ok_or_else(|| {
+                anyhow::anyhow!(
+                    "runner {} produced no {OUT_NAME}: a `devenv` runner target must be built by \
+                     the `devenv` driver",
+                    req.runner_addr,
+                )
+            })?;
+
+        let snap: Snapshot = serde_json::from_slice(&artifact.bytes)
+            .with_context(|| format!("parse {OUT_NAME} from {}", req.runner_addr))?;
+
+        if snap.format_version != snapshot::SNAPSHOT_FORMAT_VERSION {
+            anyhow::bail!(
+                "{} was built by a different version of the devenv driver (snapshot v{}, this \
+                 heph understands v{}) — rebuild it",
+                req.runner_addr,
+                snap.format_version,
+                snapshot::SNAPSHOT_FORMAT_VERSION,
+            );
+        }
+
+        let base_env = snap
+            .env
+            .iter()
+            .map(|(k, v)| (std::ffi::OsString::from(k), std::ffi::OsString::from(v)))
+            .collect();
+
+        Ok(Arc::new(EnvSession::new(
+            base_env,
+            SessionCaps {
+                pty: true,
+                max_concurrent: None,
+                // Pinned: the snapshot's PATH is store-only, so its bytes
+                // describe the exact toolchain rather than asserting one.
+                identity: Identity::Pinned {
+                    by: format!("{} ({})", req.runner_addr, req.key),
+                },
+            },
+            SessionDescription {
+                runner: req.runner_addr.clone(),
+                shell_functions: snap.shell_functions.clone(),
+                key: req.key,
+                summary: format!(
+                    "devenv: {} vars, {} shell functions not available",
+                    snap.env.len(),
+                    snap.shell_functions.len()
+                ),
+            },
+        )))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn parses_devenvs_real_json_shape() {
+        let json = br#"{
+          "bashFunctions": {"fmt-all": "x", "lint": "y"},
+          "variables": {
+            "PATH": {"type": "exported", "value": "/nix/store/a/bin:/usr/bin"},
+            "CC": {"type": "exported", "value": "clang"},
+            "envHooks": {"type": "array", "value": ["a", "b"]},
+            "DEVENV_ROOT": {"type": "exported", "value": "/repo"}
+          }
+        }"#;
+        let snap = snapshot_from_json(
+            json,
+            &LocalPaths {
+                tree_root: "/repo".to_string(),
+                home: "/home/u".to_string(),
+                tmpdir: String::new(),
+            },
+        )
+        .expect("parse");
+
+        assert_eq!(
+            snap.env.get("PATH").map(String::as_str),
+            Some("/nix/store/a/bin")
+        );
+        assert_eq!(snap.env.get("CC").map(String::as_str), Some("clang"));
+        assert!(
+            !snap.env.contains_key("envHooks"),
+            "arrays are not environment"
+        );
+        assert!(!snap.env.contains_key("DEVENV_ROOT"));
+        assert_eq!(snap.shell_functions, vec!["fmt-all", "lint"]);
+        assert_eq!(snap.dropped_path_entries, vec!["/usr/bin"]);
+    }
+}

--- a/crates/plugin-devenv/src/plugindevenv/snapshot.rs
+++ b/crates/plugin-devenv/src/plugindevenv/snapshot.rs
@@ -1,0 +1,316 @@
+//! The environment snapshot: what `devenv print-dev-env --json` becomes.
+//!
+//! This file is the whole hermeticity argument for the `devenv` runner, so the
+//! rules are here rather than spread through the driver.
+
+use serde::{Deserialize, Serialize};
+use std::collections::BTreeMap;
+
+/// Bump to invalidate every snapshot when the filtering rules change.
+///
+/// Not optional. The runner half is not a target, so it has no `TargetDef.hash`
+/// of its own — without a version folded into the *driver's* def hash, dropping
+/// a variable from the filter (a correctness fix) would leave every existing
+/// artifact keyed as though the old environment were still in force. The same
+/// reason `NixDef.system` and `EXEC_DEF_FORMAT_VERSION` exist.
+pub const SNAPSHOT_FORMAT_VERSION: u32 = 1;
+
+/// The canonicalized environment. **This artifact _is_ the description** — the
+/// runner half does nothing but parse it, so everything the environment depends
+/// on is content the cache key already covers.
+#[derive(Debug, Clone, Default, Serialize, Deserialize, PartialEq, Eq)]
+pub struct Snapshot {
+    pub format_version: u32,
+    /// Sorted for a byte-stable artifact: an unsorted map would re-key every
+    /// consumer on a whim of iteration order.
+    pub env: BTreeMap<String, String>,
+    /// Names only, for diagnostics. A target whose `run` calls one of these gets
+    /// "…is a devenv shell function, not a binary" instead of a misleading
+    /// "not found in PATH" — which is the difference between a dead end and a
+    /// recoverable one.
+    pub shell_functions: Vec<String>,
+    /// PATH entries dropped for being outside `/nix/store`, so the spawn
+    /// failure can say what was removed and why.
+    pub dropped_path_entries: Vec<String>,
+    /// Variables dropped for naming a machine-local path.
+    pub dropped_vars: Vec<String>,
+}
+
+/// Paths that make a snapshot machine-specific. A value mentioning any of them
+/// would make the artifact differ between two checkouts of the same commit — so
+/// the same lockfiles would produce different cache keys on a laptop and in CI,
+/// and on two worktrees of one machine.
+#[derive(Debug, Clone)]
+pub struct LocalPaths {
+    pub tree_root: String,
+    pub home: String,
+    pub tmpdir: String,
+}
+
+/// Names that are never environment regardless of value: they describe *this
+/// invocation* rather than the environment it produced.
+const ALWAYS_DROP: &[&str] = &[
+    "PWD",
+    "OLDPWD",
+    "SHLVL",
+    "_",
+    "SHELL",
+    "TMPDIR",
+    "TMP",
+    "TEMP",
+    "TEMPDIR",
+    "HOME",
+    "USER",
+    "LOGNAME",
+    "TERM",
+    "IN_NIX_SHELL",
+];
+
+/// Prefixes that are never environment. `DEVENV_CMDLINE` is the sharpest: it is
+/// the literal command line used to enter the shell, so without this the
+/// snapshot would differ between `devenv shell` and `devenv shell -- cmd`.
+const ALWAYS_DROP_PREFIX: &[&str] = &["DEVENV_", "NIX_BUILD_", "__"];
+
+fn is_store_path(p: &str) -> bool {
+    p.starts_with("/nix/store/")
+}
+
+/// Build a snapshot from `devenv print-dev-env --json`'s decoded variables.
+///
+/// Three filters, each closing a hole measured in a real devenv shell:
+///
+/// 1. **Only `exported` variables.** Shell-local `var`/`array` entries are not
+///    environment; passing them would be inventing an environment nobody has.
+/// 2. **Nothing naming a machine-local path.** Measured in this repo's own
+///    shell, `DEVENV_ROOT`/`DEVENV_DOTFILE`/`DEVENV_STATE` carry the absolute
+///    checkout path and `NIX_PROFILES` carries `$HOME` — so without this, two
+///    worktrees, or a laptop and CI, produce different keys for every target
+///    under the runner. Over-hashing, and it switches the remote cache off in
+///    practice.
+/// 3. **`PATH` is store-only.** Measured: 38 of 107 entries were outside
+///    `/nix/store` (`/opt/homebrew/bin`, `/usr/local/bin`, `/usr/bin`, …).
+///    Those are mutable directories, so two machines with identical PATH
+///    *strings* but different `/opt/homebrew/bin/protoc` produce identical
+///    snapshot bytes, identical `hashin`, and different artifacts — shared
+///    through the remote cache. Under-hashing, and the worse of the two.
+///    Dropping them also restores the layer-2 rule (`docs/EXEC_RUNNERS.md`
+///    §4.4): a tool missing from the environment now fails loudly instead of
+///    silently falling through to the host.
+pub fn build(
+    variables: &BTreeMap<String, Variable>,
+    shell_functions: Vec<String>,
+    local: &LocalPaths,
+) -> Snapshot {
+    let mut env = BTreeMap::new();
+    let mut dropped_vars = Vec::new();
+    let mut dropped_path_entries = Vec::new();
+
+    for (name, var) in variables {
+        if var.r#type != "exported" {
+            continue;
+        }
+        if ALWAYS_DROP.contains(&name.as_str())
+            || ALWAYS_DROP_PREFIX.iter().any(|p| name.starts_with(p))
+        {
+            continue;
+        }
+
+        if name == "PATH" {
+            let mut kept = Vec::new();
+            for entry in var.value.split(':').filter(|e| !e.is_empty()) {
+                if is_store_path(entry) {
+                    kept.push(entry.to_string());
+                } else {
+                    dropped_path_entries.push(entry.to_string());
+                }
+            }
+            if !kept.is_empty() {
+                env.insert("PATH".to_string(), kept.join(":"));
+            }
+            continue;
+        }
+
+        if mentions_local_path(&var.value, local) {
+            dropped_vars.push(name.clone());
+            continue;
+        }
+        env.insert(name.clone(), var.value.clone());
+    }
+
+    dropped_vars.sort();
+    dropped_path_entries.sort();
+    dropped_path_entries.dedup();
+    let mut shell_functions = shell_functions;
+    shell_functions.sort();
+
+    Snapshot {
+        format_version: SNAPSHOT_FORMAT_VERSION,
+        env,
+        shell_functions,
+        dropped_path_entries,
+        dropped_vars,
+    }
+}
+
+fn mentions_local_path(value: &str, local: &LocalPaths) -> bool {
+    [&local.tree_root, &local.home, &local.tmpdir]
+        .into_iter()
+        .any(|p| !p.is_empty() && value.contains(p.as_str()))
+}
+
+/// One entry of `print-dev-env --json`'s `variables` map.
+#[derive(Debug, Clone, Deserialize)]
+pub struct Variable {
+    pub r#type: String,
+    /// `serde_json::Value` in the wire format for `array` entries; only
+    /// `exported` ones are used and those are always strings.
+    #[serde(default, deserialize_with = "string_or_empty")]
+    pub value: String,
+}
+
+fn string_or_empty<'de, D>(d: D) -> Result<String, D::Error>
+where
+    D: serde::Deserializer<'de>,
+{
+    let v = serde_json::Value::deserialize(d)?;
+    Ok(match v {
+        serde_json::Value::String(s) => s,
+        _ => String::new(),
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn local() -> LocalPaths {
+        LocalPaths {
+            tree_root: "/Users/alice/repo".to_string(),
+            home: "/Users/alice".to_string(),
+            tmpdir: "/tmp/x".to_string(),
+        }
+    }
+
+    fn vars(pairs: &[(&str, &str, &str)]) -> BTreeMap<String, Variable> {
+        pairs
+            .iter()
+            .map(|(n, t, v)| {
+                (
+                    n.to_string(),
+                    Variable {
+                        r#type: t.to_string(),
+                        value: v.to_string(),
+                    },
+                )
+            })
+            .collect()
+    }
+
+    /// The under-hashing hole: a mutable host directory on PATH means two
+    /// machines can have identical snapshot bytes and different tools.
+    #[test]
+    fn path_keeps_only_store_entries() {
+        let s = build(
+            &vars(&[(
+                "PATH",
+                "exported",
+                "/nix/store/aaa/bin:/opt/homebrew/bin:/usr/bin:/nix/store/bbb/bin",
+            )]),
+            vec![],
+            &local(),
+        );
+        assert_eq!(
+            s.env.get("PATH").map(String::as_str),
+            Some("/nix/store/aaa/bin:/nix/store/bbb/bin")
+        );
+        assert_eq!(
+            s.dropped_path_entries,
+            vec!["/opt/homebrew/bin", "/usr/bin"]
+        );
+    }
+
+    /// The over-hashing hole. Measured in this repo: `DEVENV_ROOT` is the
+    /// absolute checkout path, so without this two worktrees of one commit key
+    /// every target differently.
+    #[test]
+    fn variables_naming_machine_local_paths_are_dropped() {
+        let s = build(
+            &vars(&[
+                ("DEVENV_ROOT", "exported", "/Users/alice/repo"),
+                ("NIX_PROFILES", "exported", "/nix/var/nix /Users/alice/.nix"),
+                ("CC", "exported", "/nix/store/ccc/bin/clang"),
+            ]),
+            vec![],
+            &local(),
+        );
+        assert!(s.env.contains_key("CC"));
+        assert!(!s.env.contains_key("NIX_PROFILES"));
+        // DEVENV_* is dropped by name before the value is even looked at.
+        assert!(!s.env.contains_key("DEVENV_ROOT"));
+        assert_eq!(s.dropped_vars, vec!["NIX_PROFILES"]);
+    }
+
+    /// The property the whole filter exists for: same lockfiles, different
+    /// checkout, byte-identical snapshot.
+    #[test]
+    fn two_checkouts_produce_identical_snapshots() {
+        let mk = |root: &str, home: &str| {
+            build(
+                &vars(&[
+                    ("DEVENV_ROOT", "exported", root),
+                    ("NIX_PROFILES", "exported", &format!("{home}/.nix-profile")),
+                    ("CC", "exported", "/nix/store/ccc/bin/clang"),
+                    ("PATH", "exported", "/nix/store/aaa/bin:/usr/bin"),
+                ]),
+                vec!["fmt-all".to_string()],
+                &LocalPaths {
+                    tree_root: root.to_string(),
+                    home: home.to_string(),
+                    tmpdir: String::new(),
+                },
+            )
+        };
+        assert_eq!(
+            mk("/Users/alice/repo", "/Users/alice"),
+            mk("/home/runner/work/repo/repo", "/home/runner"),
+        );
+    }
+
+    #[test]
+    fn only_exported_variables_are_environment() {
+        let s = build(
+            &vars(&[
+                ("A", "exported", "1"),
+                ("B", "var", "2"),
+                ("C", "array", "3"),
+                ("D", "unknown", "4"),
+            ]),
+            vec![],
+            &local(),
+        );
+        assert_eq!(s.env.keys().collect::<Vec<_>>(), vec!["A"]);
+    }
+
+    /// `DEVENV_CMDLINE` is the literal command used to enter the shell, so
+    /// without the prefix rule the snapshot differs between `devenv shell` and
+    /// `devenv shell -- cmd` on the same machine.
+    #[test]
+    fn devenv_bookkeeping_never_reaches_the_environment() {
+        let s = build(
+            &vars(&[
+                ("DEVENV_CMDLINE", "exported", "shell -- claude"),
+                ("__structuredAttrs", "exported", "1"),
+                ("NIX_BUILD_CORES", "exported", "10"),
+            ]),
+            vec![],
+            &local(),
+        );
+        assert!(s.env.is_empty(), "{:?}", s.env);
+    }
+
+    #[test]
+    fn shell_function_names_are_recorded_sorted() {
+        let s = build(&vars(&[]), vec!["z".into(), "a".into()], &local());
+        assert_eq!(s.shell_functions, vec!["a", "z"]);
+    }
+}

--- a/crates/plugin-exec/src/pluginexec/mod.rs
+++ b/crates/plugin-exec/src/pluginexec/mod.rs
@@ -1090,20 +1090,49 @@ impl Driver {
         if shell && let Ok(term) = std::env::var("TERM") {
             env.insert("TERM".to_string(), term);
         }
-        // Where the child's PATH came from, for the spawn-failure diagnostic.
-        // A session that reports no environment (`local`, and any runner whose
-        // environment cannot be enumerated host-side) leaves the driver's own
-        // `path` option in charge, which is the pre-runner behaviour.
-        let path_source = match req.runner.base_env() {
-            Some(base) if base.iter().any(|(k, _)| k == "PATH") => {
-                hexec_runner::PathSource::Session {
-                    runner: req.runner.describe().runner.clone(),
-                }
+        // The session's PATH REPLACES the driver's, rather than sitting under it
+        // (`docs/EXEC_RUNNERS.md` §4.4). Appending the driver's default after it
+        // would mean a tool missing from the runner silently falls through to
+        // the host — the exact ambient dependency a runner exists to remove —
+        // and it would do so invisibly, under a cache key asserting the runner's
+        // environment.
+        //
+        // It has to happen here, not in the session's `prepare`: the sandbox
+        // `bin/` prepend below builds on whatever PATH is in this map, so a
+        // session PATH merged afterwards would arrive too late and lose to the
+        // bin dir.
+        let session_path = req
+            .runner
+            .base_env()
+            .and_then(|base| base.iter().find(|(k, _)| k == "PATH"))
+            .and_then(|(_, v)| v.to_str())
+            .map(str::to_owned);
+
+        // An explicitly written `path` under a runner is a hard error rather
+        // than a silent discard: the two cases are distinguishable (an empty
+        // `search_path` means the option was never set), and quietly ignoring
+        // something the user wrote is not an option.
+        if session_path.is_some() && !self.search_path.is_empty() {
+            anyhow::bail!(
+                "target runs under runner `{}`, which supplies PATH, but the `{}` driver also has                  an explicit `path` option ({}). Only one of them can be in charge — remove the                  driver's `path`, or set `runner = None` on this target.",
+                req.runner.describe().runner,
+                self.name,
+                self.search_path.join(":"),
+            );
+        }
+
+        let path_source = if session_path.is_some() {
+            hexec_runner::PathSource::Session {
+                runner: req.runner.describe().runner.clone(),
             }
-            _ => hexec_runner::PathSource::Driver,
+        } else {
+            hexec_runner::PathSource::Driver
         };
 
-        env.insert("PATH".to_string(), self.sandbox_path_display());
+        env.insert(
+            "PATH".to_string(),
+            session_path.unwrap_or_else(|| self.sandbox_path_display()),
+        );
         env.insert(
             "WORKSPACE_ROOT".to_string(),
             req.sandbox_ws_dir.to_string_lossy().to_string(),
@@ -1365,6 +1394,10 @@ impl Driver {
             }
         }
 
+        // The PATH the child will actually search, captured for the failure
+        // diagnostic before `env` is consumed.
+        let searched_path = env.get("PATH").cloned().unwrap_or_default();
+
         let output_log_path = req.sandbox_dir.join("log.txt");
         let output_log =
             std::fs::File::create(&output_log_path).with_context(|| "create log file")?;
@@ -1480,13 +1513,24 @@ impl Driver {
                 // from. The session reports whether it supplied one; the naming
                 // of the fix — `.hephconfig` vs the runner — follows from that.
                 hexec_runner::SpawnError::Io(io) if io.kind() == std::io::ErrorKind::NotFound => {
-                    anyhow::Error::new(hexec_runner::SpawnError::ProgramNotFound {
-                        program: program.to_string(),
-                        path: self.sandbox_path_display(),
-                        source: path_source,
-                        cwd: req.sandbox_pkg_dir.display().to_string(),
-                        io,
-                    })
+                    let desc = req.runner.describe();
+                    // The environment knows this name — as a shell function,
+                    // which a snapshot runner cannot provide. Saying so turns a
+                    // hunt for a missing package into a one-line fix.
+                    if desc.shell_functions.iter().any(|f| f == program) {
+                        anyhow::Error::new(hexec_runner::SpawnError::ShellFunctionNotABinary {
+                            program: program.to_string(),
+                            runner: desc.runner.clone(),
+                        })
+                    } else {
+                        anyhow::Error::new(hexec_runner::SpawnError::ProgramNotFound {
+                            program: program.to_string(),
+                            path: searched_path.clone(),
+                            source: path_source,
+                            cwd: req.sandbox_pkg_dir.display().to_string(),
+                            io,
+                        })
+                    }
                 }
                 other => {
                     anyhow::Error::new(other).context(format!("spawn child process {program:?}"))

--- a/crates/plugin-sdk/src/serve.rs
+++ b/crates/plugin-sdk/src/serve.rs
@@ -1268,6 +1268,7 @@ fn guest_session(req: &pb::ManagedRunRequest) -> Arc<dyn hexec_runner::ExecSessi
         },
         hexec_runner::SessionDescription {
             runner: req.runner_addr.clone(),
+            shell_functions: Vec::new(),
             key: req.runner_key.clone(),
             summary: "host-supplied environment".to_string(),
         },

--- a/crates/plugingo-e2e/tests/common/mod.rs
+++ b/crates/plugingo-e2e/tests/common/mod.rs
@@ -363,6 +363,7 @@ impl heph::engine::exec_runner::ExecRunner for RecordingRunner {
             },
             description: heph::engine::exec_runner::SessionDescription {
                 runner: req.runner_addr.clone(),
+                shell_functions: vec![],
                 key: req.key.clone(),
                 summary: "recording (identity)".to_string(),
             },

--- a/devenv.nix
+++ b/devenv.nix
@@ -53,7 +53,7 @@ let
   };
 
   binLocation = "$HOME/.local/bin/heph3";
-  qualityCrates = "-p heph -p e2e -p bin-e2e -p testkit -p plugingo-e2e -p htspec-derive -p core -p config -p walk -p proc -p model -p sandboxfuse -p plugin -p plugin-abi -p plugin-sdk -p plugin-stabby -p plugin-go-cdylib -p builtins -p plugin-buildfile -p driver-support -p driver-bridge -p exec-runner -p plugin-exec -p plugin-nix -p plugin-http -p plugin-oci -p plugin-query -p plugin-go -p plugin-gha -p plugin-gha-cdylib -p plugin-oci-cdylib -p telemetry -p tui -p lock -p selfupdate -p engine -p xstarlark-fmt -p bench-corpus -p bench";
+  qualityCrates = "-p heph -p e2e -p bin-e2e -p testkit -p plugingo-e2e -p htspec-derive -p core -p config -p walk -p proc -p model -p sandboxfuse -p plugin -p plugin-abi -p plugin-sdk -p plugin-stabby -p plugin-go-cdylib -p builtins -p plugin-buildfile -p driver-support -p driver-bridge -p exec-runner -p plugin-exec -p plugin-devenv -p plugin-nix -p plugin-http -p plugin-oci -p plugin-query -p plugin-go -p plugin-gha -p plugin-gha-cdylib -p plugin-oci-cdylib -p telemetry -p tui -p lock -p selfupdate -p engine -p xstarlark-fmt -p bench-corpus -p bench";
 in
 {
   # https://devenv.sh/basics/

--- a/src/commands/bootstrap.rs
+++ b/src/commands/bootstrap.rs
@@ -8,7 +8,8 @@ use tokio::sync::mpsc;
 use crate::engine::config::ConfigYamlExt;
 use crate::engine::config_yaml;
 use crate::{
-    engine, pluginbuildfile, pluginexec, pluginhostbin, pluginhttp, pluginnix, plugintextfile,
+    engine, pluginbuildfile, plugindevenv, pluginexec, pluginhostbin, pluginhttp, pluginnix,
+    plugintextfile,
 };
 
 /// Builds the multi-thread runtime used by every command entry point.
@@ -136,6 +137,17 @@ pub fn new_engine() -> anyhow::Result<(Arc<engine::Engine>, ShutdownTrigger)> {
     // (`heph-oci-plugin.json`), under their own `docker_build` / `oci_pull` /
     // `oci_push` / `oci_load` names.
     e.register_managed_driver(|_| Box::new(pluginnix::Driver::new(home_dir.join("nix-driver"))))?;
+    // Two halves of one plugin: the `devenv` driver captures the environment as
+    // an artifact, the `devenv` runner reads it back. Registered under the same
+    // name, which is how a runner target's driver selects its runner.
+    {
+        let devenv_root = root.clone();
+        e.register_managed_driver(move |_| Box::new(plugindevenv::Driver::new(devenv_root)))?;
+    }
+    e.register_exec_runner(
+        plugindevenv::NAME,
+        std::sync::Arc::new(plugindevenv::Runner),
+    )?;
 
     // Opt-in built-in factories — instantiated only when a `plugins: - { builtin:
     // <name> }` entry selects them. The go plugin is no longer compiled in: it
@@ -282,6 +294,7 @@ mod tests {
             .as_ref()
             .map(|p| root.join(p))
             .unwrap_or_else(|| root.join(".heph3"));
+        let devenv_root = root.clone();
         let mut e = engine::Engine::new(engine::Config {
             root,
             home_dir: home_dir.clone(),
@@ -298,6 +311,14 @@ mod tests {
         e.register_managed_driver(|_| {
             Box::new(pluginnix::Driver::new(home_dir.join("nix-driver")))
         })?;
+        // Two halves of one plugin: the driver captures the environment as an
+        // artifact, the runner reads it back. Registered under the same name,
+        // which is how a runner target's driver selects its runner.
+        e.register_managed_driver(move |_| Box::new(plugindevenv::Driver::new(devenv_root)))?;
+        e.register_exec_runner(
+            plugindevenv::NAME,
+            std::sync::Arc::new(plugindevenv::Runner),
+        )?;
 
         e.register_provider_factory("buildfile", |init, opts| {
             Ok(Box::new(

--- a/src/commands/inspect/def.rs
+++ b/src/commands/inspect/def.rs
@@ -28,6 +28,24 @@ pub struct Args {
 struct DefView<'a> {
     target_def: &'a TargetDef,
     applied_transitive: Option<&'a Sandbox>,
+    /// The exec environment this target's processes are created in
+    /// (`docs/EXEC_RUNNERS.md`). `None` = the host process.
+    ///
+    /// Here rather than in a new top-level command because `inspect def`
+    /// already serializes its whole view as JSON unconditionally, so this is
+    /// answerable by a person and by an agent from day one — and "why did it
+    /// build in that environment?" is a per-target question, which the build
+    /// event stream deliberately does not carry at 20k targets.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    runner: Option<RunnerView>,
+}
+
+#[derive(Serialize)]
+struct RunnerView {
+    /// The runner target's address.
+    addr: String,
+    /// How it was chosen — the answer to "I never wrote `runner =` on this".
+    selected_by: &'static str,
 }
 
 struct DefApp {
@@ -69,6 +87,14 @@ impl App for DefApp {
             let view = DefView {
                 target_def: &def.target_def,
                 applied_transitive: def.applied_transitive.as_ref(),
+                runner: def.runner.as_ref().map(|addr| RunnerView {
+                    addr: addr.format(),
+                    selected_by: if self.engine.default_runner() == Some(addr) {
+                        "defaultRunner"
+                    } else {
+                        "target"
+                    },
+                }),
             };
             let json = serde_json::to_string_pretty(&view).context("serialize def")?;
             println!("{json}");

--- a/src/commands/inspect/mod.rs
+++ b/src/commands/inspect/mod.rs
@@ -9,6 +9,7 @@ mod outputs;
 mod packages;
 mod path;
 mod revdeps;
+mod runners;
 mod spec;
 mod states;
 
@@ -38,6 +39,16 @@ pub enum InspectCommands {
     ///
     /// `heph inspect packages //cmd/...`
     Packages(packages::Args),
+    /// List the exec runners this workspace can use
+    ///
+    /// Shows `defaultRunner:` and the registered runner implementations. A
+    /// runner target's `driver` name selects which one reads its artifact.
+    ///
+    /// Static by design: live sessions belong to the build that opened them,
+    /// so a separate process cannot see them.
+    ///
+    /// Example: `heph inspect runners`
+    Runners(runners::Args),
     /// List the unique labels declared across matching targets
     ///
     /// Enumerates every target in the packages matching the given matcher,
@@ -194,6 +205,7 @@ impl InspectCommands {
     pub fn execute(&self, sink: LogSink, global: &GlobalOptions) -> anyhow::Result<()> {
         match self {
             InspectCommands::Packages(args) => packages::execute(args, sink, global),
+            InspectCommands::Runners(args) => runners::execute(args, sink, global),
             InspectCommands::Labels(args) => labels::execute(args, sink, global),
             InspectCommands::Hashin(args) => hashin::execute(args, sink, global),
             InspectCommands::Hashout(args) => hashout::execute(args, sink, global),

--- a/src/commands/inspect/runners.rs
+++ b/src/commands/inspect/runners.rs
@@ -1,0 +1,115 @@
+//! `heph inspect runners` — the exec runners this workspace can use.
+//!
+//! Deliberately **static**. Live sessions are not listed here and cannot be:
+//! every `heph` invocation owns its own `Engine` and its own session pool, so a
+//! separate process would render an empty table every time — which reads as
+//! "nothing is running" rather than "this command cannot see it". Live sessions
+//! belong to the build that owns them, and surface in its own output.
+
+use anyhow::Context;
+use async_trait::async_trait;
+
+use crate::commands::GlobalOptions;
+use crate::commands::bootstrap;
+use crate::engine::Engine;
+use crate::tui::{self, App, AppContext, LogSink};
+
+#[derive(clap::Args, Clone)]
+pub struct Args {
+    /// Emit JSON instead of the text listing
+    #[arg(long)]
+    pub json: bool,
+}
+
+#[derive(serde::Serialize)]
+struct RunnerRow {
+    /// Registry name. A runner target's **driver** name selects it.
+    name: String,
+    /// Whether this is the runner the workspace applies by default.
+    is_default: bool,
+}
+
+#[derive(serde::Serialize)]
+struct RunnersView {
+    /// `defaultRunner:` from `.hephconfig`, if set.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    default_runner: Option<String>,
+    runners: Vec<RunnerRow>,
+}
+
+struct RunnersApp {
+    engine: std::sync::Arc<Engine>,
+    json: bool,
+}
+
+#[async_trait]
+impl App for RunnersApp {
+    type Output = ();
+    type TuiView = crate::tui::TuiProgressView;
+    type CiView = crate::tui::CiProgressView;
+
+    fn tui_view(&self) -> Self::TuiView {
+        crate::tui::TuiProgressView::new("Runners".to_string())
+    }
+
+    fn ci_view(&self) -> Self::CiView {
+        crate::tui::CiProgressView::new("Runners".to_string())
+    }
+
+    async fn run(self, _ctx: AppContext) -> anyhow::Result<()> {
+        let default = self.engine.default_runner().map(|a| a.format());
+
+        let mut names: Vec<String> = self.engine.exec_runners.keys().cloned().collect();
+        names.sort();
+
+        // `local` is always available and is never in the registry: it is the
+        // absence of a runner, not an entry. Listing it anyway is honest — a
+        // reader looking for "what can I put in `runner =`" needs to see the
+        // opt-out alongside the rest.
+        let view = RunnersView {
+            default_runner: default.clone(),
+            runners: names
+                .into_iter()
+                .map(|name| RunnerRow {
+                    is_default: false,
+                    name,
+                })
+                .collect(),
+        };
+
+        if self.json {
+            let json = serde_json::to_string_pretty(&view).context("serialize runners")?;
+            println!("{json}");
+            return Ok(());
+        }
+
+        match &view.default_runner {
+            Some(d) => println!("defaultRunner: {d}"),
+            None => println!("defaultRunner: (unset — targets run in the host process)"),
+        }
+        if view.runners.is_empty() {
+            println!("(no exec runners registered)");
+        } else {
+            println!("registered runners (selected by a runner target's `driver`):");
+            for r in &view.runners {
+                println!("  {}", r.name);
+            }
+        }
+        println!("`runner = None` on a target opts out of the default.");
+        Ok(())
+    }
+}
+
+pub fn execute(args: &Args, sink: LogSink, global: &GlobalOptions) -> anyhow::Result<()> {
+    bootstrap::block_on(execute_async(args.clone(), sink, global.clone()))?
+}
+
+async fn execute_async(args: Args, sink: LogSink, global: GlobalOptions) -> anyhow::Result<()> {
+    let (engine, shutdown) = bootstrap::new_engine()?;
+    let app = RunnersApp {
+        engine,
+        json: args.json,
+    };
+    let interactive = tui::should_use_tui(global.no_tui);
+    tui::run_app(app, sink, interactive, shutdown).await
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -28,6 +28,7 @@ pub use hlock::hlock;
 pub use hmodel::{htaddr, htmatcher, htpkg, htquery};
 pub use hplugin::htspec;
 pub use hplugin_buildfile::pluginbuildfile;
+pub use hplugin_devenv::plugindevenv;
 pub use hplugin_exec::pluginexec;
 pub use hplugin_http::pluginhttp;
 pub use hplugin_nix::pluginnix;


### PR DESCRIPTION
Phase 1c of #404, on top of #411. **The half you actually asked for**: a target runs inside the devenv.sh environment and inherits its tools.

```python
target(name = "env", driver = "devenv")
target(name = "build", driver = "bash", run = ["cargo build"], runner = "//:env")
```

## Proved end to end

Against this repo's own devenv, three assertions in both directions:

| | |
|---|---|
| target **under** the runner finds `cargo` | PASS |
| same target **without** it does not | PASS |
| every PATH entry it sees is `/nix/store` | PASS |

## A correction to the evidence behind the store-only rule

The original measurement came from the **live interactive shell's** `$PATH` — 107 entries, 38 outside `/nix/store`. Right worry, wrong source. `print-dev-env` reports the *derivation's* environment: on the same machine, **66 PATH entries, all store paths**. The login PATH the shell appends simply isn't in it.

The store-only rule stays anyway, because it's a **guarantee, not a repair**: nothing about `print-dev-env` promises it, and what it prevents is silent — a mutable host directory in the snapshot means two machines with identical PATH *strings* and different tools produce identical cache keys.

## Filtering: three rules, not an allowlist

`print-dev-env` reports 181 variables. An allowlist of that surface is a permanent maintenance tax that fails **closed** — a missing entry silently removes a tool. Instead: `exported` only; names dropped for `DEVENV_*`/`NIX_BUILD_*`/`__*` and the per-invocation set; values dropped for naming the tree root, `$HOME` or `$TMPDIR`.

Against the real output that keeps 99 variables and drops exactly one on the value rule — `shellHook`, which embeds the checkout path. Frozen by a test asserting **two different checkout paths give byte-identical snapshots**, which is what keeps a laptop and CI on the same cache key.

Snapshots are local-cache only: the PATH is host-local `/nix/store` paths, and `plugin-nix` already refuses to share the same kind of artifact for the same reason.

## Fixes a rule that was specified and never implemented

A session's PATH is supposed to **replace** the driver's rather than sit under it. It didn't — the driver's default was still winning, so the runner's PATH never took effect. The very first end-to-end run failed on exactly this.

It matters because with the driver's default appended, a tool missing from the environment **falls through to the host** — the ambient dependency a runner exists to remove — under a cache key asserting the runner's environment. An explicitly written `path` under a runner is now a hard error rather than a silent discard. Regression-tested end to end.

## Snapshot mode's limitation is now recoverable

The snapshot records the environment's shell-function *names*, so a target calling one gets:

> `fmt-all` is a shell function, not a binary on PATH — set `mode = "session"`

instead of "not found in PATH", which sends the reader hunting for a package that isn't missing. (Session mode itself lands in #414.)

## Diagnostics

- `heph inspect def` gains a `runner` block: which runner, and **how it was selected** (target vs `defaultRunner`).
- `heph inspect runners` lists what the workspace can use.

Both static by design — every invocation owns its own session pool, so a separate process cannot see live sessions and would render an empty table that reads as "nothing is running".

## Tests

7 unit (snapshot filtering, incl. the two-checkouts property and the real JSON shape) + 1 new e2e for the PATH-replacement rule, on top of the 10 already in `exec_runner.rs`. Full local run green: 545 e2e, plus engine/exec-runner/plugin-exec/heph. `lint` clean.

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>
