### PR TITLE
feat(exec-runner): Agent and Wrap sessions

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1716,7 +1716,11 @@ dependencies = [
  "anyhow",
  "async-trait",
  "core",
+ "libc",
  "proc",
+ "serde",
+ "serde_json",
+ "tempfile",
  "tokio",
 ]
 
@@ -4084,12 +4088,14 @@ dependencies = [
  "driver-support",
  "exec-runner",
  "htspec-derive",
+ "libc",
  "model",
  "plugin",
  "proc",
  "serde",
  "serde_json",
  "tempfile",
+ "tokio",
  "tracing",
  "xxhash-rust",
 ]

--- a/crates/e2e/tests/common/mod.rs
+++ b/crates/e2e/tests/common/mod.rs
@@ -46,6 +46,40 @@ impl std::ops::Deref for Workspace {
     }
 }
 
+/// Wraps a session so its teardown can be observed.
+struct TeardownSession {
+    inner: heph::engine::exec_runner::EnvSession,
+    /// Taken on the first hand-over, so a second caller gets `None` — teardown
+    /// must not be runnable twice.
+    torn: std::sync::Mutex<Option<Arc<std::sync::atomic::AtomicUsize>>>,
+}
+
+#[async_trait::async_trait]
+impl heph::engine::exec_runner::ExecSession for TeardownSession {
+    fn prepare(
+        &self,
+        spec: heph::proc_exec::Spec,
+    ) -> Result<heph::proc_exec::Spec, heph::engine::exec_runner::SpawnError> {
+        self.inner.prepare(spec)
+    }
+    fn base_env(&self) -> Option<&[(std::ffi::OsString, std::ffi::OsString)]> {
+        self.inner.base_env()
+    }
+    fn caps(&self) -> &heph::engine::exec_runner::SessionCaps {
+        self.inner.caps()
+    }
+    fn describe(&self) -> &heph::engine::exec_runner::SessionDescription {
+        self.inner.describe()
+    }
+    fn teardown(&self) -> Option<heph::engine::exec_runner::TeardownJob> {
+        let torn = self.torn.lock().ok()?.take()?;
+        Some(Box::new(move || {
+            torn.fetch_add(1, std::sync::atomic::Ordering::SeqCst);
+            Ok(())
+        }))
+    }
+}
+
 /// A test [`ExecRunner`] that counts its opens and hands back an environment.
 ///
 /// The open counter is the point: the whole premise of a session is "acquire
@@ -57,6 +91,8 @@ pub struct RecordingExecRunner {
     /// When set, the session also supplies `PATH`, which must then REPLACE the
     /// driver's own rather than sit under it.
     pub path: Option<String>,
+    /// Incremented by the session's teardown job, so a test can prove it ran.
+    pub torn: Option<Arc<std::sync::atomic::AtomicUsize>>,
 }
 
 #[async_trait::async_trait]
@@ -95,6 +131,28 @@ impl heph::engine::exec_runner::ExecRunner for RecordingExecRunner {
                 std::ffi::OsString::from(from_artifact),
             ),
         ]);
+        if let Some(torn) = self.torn.clone() {
+            return Ok(Arc::new(TeardownSession {
+                inner: er::EnvSession::new(
+                    base,
+                    er::SessionCaps {
+                        pty: true,
+                        max_concurrent: None,
+                        identity: er::Identity::Pinned {
+                            by: req.key.clone(),
+                        },
+                    },
+                    er::SessionDescription {
+                        runner: req.runner_addr.clone(),
+                        shell_functions: Vec::new(),
+                        key: req.key.clone(),
+                        summary: "teardown test runner".to_string(),
+                    },
+                ),
+                torn: std::sync::Mutex::new(Some(torn)),
+            }));
+        }
+
         Ok(Arc::new(er::EnvSession::new(
             base,
             er::SessionCaps {
@@ -150,6 +208,7 @@ impl Workspace {
                         opens,
                         var: (var.0.to_string(), var.1.to_string()),
                         path,
+                        torn: None,
                     }),
                 )
                 .build()
@@ -160,6 +219,36 @@ impl Workspace {
 
     pub fn new() -> Self {
         Self::with_parallelism(None)
+    }
+
+    /// A workspace whose session records that its teardown ran.
+    pub fn with_teardown_runner(
+        opens: Arc<std::sync::atomic::AtomicUsize>,
+        torn: Arc<std::sync::atomic::AtomicUsize>,
+    ) -> Self {
+        Self {
+            inner: WorkspaceBuilder::new()
+                .expect("workspace tempdir")
+                .with_provider(|init| {
+                    Box::new(pluginbuildfile::Provider::new(
+                        init.root.to_path_buf(),
+                        init.runtime.clone(),
+                    ))
+                })
+                .with_managed_driver(Box::new(pluginexec::Driver::new_bash()))
+                .with_exec_runner(
+                    "bash",
+                    Arc::new(RecordingExecRunner {
+                        opens,
+                        var: ("V".to_string(), "1".to_string()),
+                        path: None,
+                        torn: Some(torn),
+                    }),
+                )
+                .build()
+                .expect("build workspace"),
+            reopen_with: None,
+        }
     }
 
     /// A workspace with `defaultRunner:` set — the exec environment every
@@ -190,6 +279,7 @@ impl Workspace {
                         opens: Arc::new(std::sync::atomic::AtomicUsize::new(0)),
                         var: ("FROM_DEFAULT_RUNNER".to_string(), "1".to_string()),
                         path: None,
+                        torn: None,
                     }),
                 )
                 .build()

--- a/crates/e2e/tests/exec_runner.rs
+++ b/crates/e2e/tests/exec_runner.rs
@@ -369,3 +369,41 @@ target(
     // `tools =` dep must never be shadowed by an ambient one.
     Ok(())
 }
+
+/// A session's teardown runs when the pool goes away.
+///
+/// Without this, a `Wrap` session's `docker run -d` container — or a devenv
+/// shell — survives every build, and survives Ctrl-C in particular, which is
+/// the case it matters in. `Drop` is where it has to happen: an orderly-only
+/// teardown leaks exactly when things are not orderly.
+#[tokio::test]
+async fn a_sessions_teardown_runs_when_the_pool_is_dropped() -> anyhow::Result<()> {
+    let torn = std::sync::Arc::new(std::sync::atomic::AtomicUsize::new(0));
+    {
+        let opens = std::sync::Arc::new(std::sync::atomic::AtomicUsize::new(0));
+        let ws = Workspace::with_teardown_runner(
+            std::sync::Arc::clone(&opens),
+            std::sync::Arc::clone(&torn),
+        );
+        ws.write_build_file(
+            "td",
+            r#"
+target(name = "env", driver = "bash", run = "echo E > $OUT", out = "env.json")
+target(name = "a", driver = "bash", run = "echo a > $OUT", out = "o", runner = "//td:env")
+"#,
+        );
+        ws.run("//td:a").await?;
+        assert_eq!(
+            torn.load(std::sync::atomic::Ordering::SeqCst),
+            0,
+            "teardown must not run while the session is still in use",
+        );
+    }
+
+    assert_eq!(
+        torn.load(std::sync::atomic::Ordering::SeqCst),
+        1,
+        "the session must be torn down exactly once when the pool goes away",
+    );
+    Ok(())
+}

--- a/crates/e2e/tests/exec_runner.rs
+++ b/crates/e2e/tests/exec_runner.rs
@@ -370,40 +370,55 @@ target(
     Ok(())
 }
 
-/// A session's teardown runs when the pool goes away.
+/// A session's teardown runs on shutdown, and exactly once.
 ///
-/// Without this, a `Wrap` session's `docker run -d` container — or a devenv
-/// shell — survives every build, and survives Ctrl-C in particular, which is
-/// the case it matters in. `Drop` is where it has to happen: an orderly-only
-/// teardown leaks exactly when things are not orderly.
+/// Without it, a `Wrap` session's `docker run -d` container — or a devenv shell
+/// — survives every build, and survives Ctrl-C in particular, which is the case
+/// it matters in.
+///
+/// Exercised through the **explicit** shutdown rather than by dropping the
+/// engine, because that is the path production takes and the only one that is
+/// guaranteed to run: `Drop` fires only if the last `Arc<Engine>` is released,
+/// and heph's hard-abort path calls `std::process::exit`, which runs no
+/// destructors at all. An earlier version of this test relied on drop; it
+/// passed on darwin and failed on linux/arm64, where something still held the
+/// `Arc` — silence being exactly the failure mode teardown must not have.
 #[tokio::test]
-async fn a_sessions_teardown_runs_when_the_pool_is_dropped() -> anyhow::Result<()> {
+async fn a_sessions_teardown_runs_on_shutdown_exactly_once() -> anyhow::Result<()> {
     let torn = std::sync::Arc::new(std::sync::atomic::AtomicUsize::new(0));
-    {
-        let opens = std::sync::Arc::new(std::sync::atomic::AtomicUsize::new(0));
-        let ws = Workspace::with_teardown_runner(
-            std::sync::Arc::clone(&opens),
-            std::sync::Arc::clone(&torn),
-        );
-        ws.write_build_file(
-            "td",
-            r#"
+    let opens = std::sync::Arc::new(std::sync::atomic::AtomicUsize::new(0));
+    let ws = Workspace::with_teardown_runner(
+        std::sync::Arc::clone(&opens),
+        std::sync::Arc::clone(&torn),
+    );
+    ws.write_build_file(
+        "td",
+        r#"
 target(name = "env", driver = "bash", run = "echo E > $OUT", out = "env.json")
 target(name = "a", driver = "bash", run = "echo a > $OUT", out = "o", runner = "//td:env")
 "#,
-        );
-        ws.run("//td:a").await?;
-        assert_eq!(
-            torn.load(std::sync::atomic::Ordering::SeqCst),
-            0,
-            "teardown must not run while the session is still in use",
-        );
-    }
+    );
+    ws.run("//td:a").await?;
+    assert_eq!(
+        torn.load(std::sync::atomic::Ordering::SeqCst),
+        0,
+        "teardown must not run while the session is still in use",
+    );
 
+    ws.engine.shutdown_exec_sessions();
     assert_eq!(
         torn.load(std::sync::atomic::Ordering::SeqCst),
         1,
-        "the session must be torn down exactly once when the pool goes away",
+        "the session must be torn down on shutdown",
+    );
+
+    // Idempotent: a `Drop` backstop after an explicit shutdown must not run a
+    // container's `docker rm` — or a shell's kill — a second time.
+    ws.engine.shutdown_exec_sessions();
+    assert_eq!(
+        torn.load(std::sync::atomic::Ordering::SeqCst),
+        1,
+        "teardown must not run twice",
     );
     Ok(())
 }

--- a/crates/engine/src/engine/engine.rs
+++ b/crates/engine/src/engine/engine.rs
@@ -649,6 +649,15 @@ impl Engine {
 
     /// Register an exec runner under `name`, matching the driver name of the
     /// runner targets it serves.
+    /// Tear down every open exec session.
+    ///
+    /// Call this on any path that ends the process. It is idempotent, and it
+    /// cannot be left to `Drop`: heph's hard-abort path exits without running
+    /// destructors, which is exactly when a leaked container or shell matters.
+    pub fn shutdown_exec_sessions(&self) {
+        self.exec_sessions.teardown_all();
+    }
+
     /// The workspace-level `defaultRunner:`, if set. Read by diagnostics to say
     /// *how* a target's environment was chosen, not only which it was.
     pub fn default_runner(&self) -> Option<&hmodel::htaddr::Addr> {

--- a/crates/engine/src/engine/exec_pool.rs
+++ b/crates/engine/src/engine/exec_pool.rs
@@ -10,7 +10,7 @@ use hcore::hasync::Cancellable;
 use hexec_runner::{ExecRunner, ExecSession, OpenRequest};
 use std::collections::HashMap;
 use std::sync::Arc;
-use tokio::sync::Mutex;
+use std::sync::Mutex;
 
 /// One key's session, or the in-flight open of it. Named because the nesting
 /// is load-bearing and unreadable inline: the outer `Mutex` guards the map, the
@@ -23,6 +23,38 @@ type SessionCell = Arc<tokio::sync::OnceCell<Arc<dyn ExecSession>>>;
 #[derive(Default)]
 pub struct ExecSessionPool {
     entries: Mutex<HashMap<String, SessionCell>>,
+}
+
+impl Drop for ExecSessionPool {
+    /// Tear every open session down on the way out.
+    ///
+    /// Synchronous by necessity and by design: `Drop` cannot await, and a
+    /// teardown that only ran on the orderly path would leak exactly when it
+    /// matters — a `Wrap` session's `docker run -d` container, or a devenv
+    /// shell, surviving every Ctrl-C. See `hexec_runner::TeardownJob`.
+    ///
+    /// `try_lock` rather than `lock`: nothing else can hold this at drop time
+    /// (the pool is being destroyed, so no `Arc` to it remains), and blocking a
+    /// destructor on a lock that will never be released would hang exit instead
+    /// of cleaning up.
+    fn drop(&mut self) {
+        let Ok(mut entries) = self.entries.try_lock() else {
+            tracing::warn!("exec session pool busy at shutdown; sessions not torn down");
+            return;
+        };
+        for (key, cell) in entries.drain() {
+            let Some(session) = cell.get() else { continue };
+            let Some(job) = session.teardown() else {
+                continue;
+            };
+            if let Err(e) = job() {
+                // A failed teardown is a leak the user can act on — a container
+                // still running, a shell still holding a lock — so it is said
+                // out loud rather than swallowed.
+                tracing::warn!(key = %key, error = %format!("{e:#}"), "exec session teardown failed");
+            }
+        }
+    }
 }
 
 impl std::fmt::Debug for ExecSessionPool {
@@ -45,8 +77,14 @@ impl ExecSessionPool {
         ctoken: &(dyn Cancellable + Send + Sync),
     ) -> anyhow::Result<Arc<dyn ExecSession>> {
         let key = req.key.clone();
+        // The map lock is taken and released around the clone — never held
+        // across the `open` below, which can be tens of seconds for a cold
+        // environment and would serialize every other key behind it.
         let cell = {
-            let mut entries = self.entries.lock().await;
+            let mut entries = self
+                .entries
+                .lock()
+                .unwrap_or_else(std::sync::PoisonError::into_inner);
             Arc::clone(entries.entry(key.clone()).or_default())
         };
 
@@ -57,7 +95,10 @@ impl ExecSessionPool {
         match res {
             Ok(s) => Ok(Arc::clone(s)),
             Err(e) => {
-                self.entries.lock().await.remove(&key);
+                self.entries
+                    .lock()
+                    .unwrap_or_else(std::sync::PoisonError::into_inner)
+                    .remove(&key);
                 Err(e)
             }
         }

--- a/crates/engine/src/engine/exec_pool.rs
+++ b/crates/engine/src/engine/exec_pool.rs
@@ -25,22 +25,26 @@ pub struct ExecSessionPool {
     entries: Mutex<HashMap<String, SessionCell>>,
 }
 
-impl Drop for ExecSessionPool {
-    /// Tear every open session down on the way out.
+impl ExecSessionPool {
+    /// Tear every open session down, and forget them.
     ///
-    /// Synchronous by necessity and by design: `Drop` cannot await, and a
-    /// teardown that only ran on the orderly path would leak exactly when it
-    /// matters — a `Wrap` session's `docker run -d` container, or a devenv
-    /// shell, surviving every Ctrl-C. See `hexec_runner::TeardownJob`.
+    /// **Idempotent**, and must be called explicitly rather than left to
+    /// `Drop`. Two reasons, both learned the hard way:
     ///
-    /// `try_lock` rather than `lock`: nothing else can hold this at drop time
-    /// (the pool is being destroyed, so no `Arc` to it remains), and blocking a
-    /// destructor on a lock that will never be released would hang exit instead
-    /// of cleaning up.
-    fn drop(&mut self) {
-        let Ok(mut entries) = self.entries.try_lock() else {
-            tracing::warn!("exec session pool busy at shutdown; sessions not torn down");
-            return;
+    /// 1. `Drop` runs only if the last `Arc<Engine>` is actually released. Any
+    ///    retained handle — a spawned task, a diagnostic, a test holding one —
+    ///    silently disables teardown, and silence is the failure mode here.
+    /// 2. heph's second-Ctrl-C path calls `std::process::exit`, which **runs no
+    ///    destructors at all**. That is precisely the moment a leaked `docker
+    ///    run -d` container or devenv shell matters most.
+    ///
+    /// `Drop` still calls this, as a backstop for the ordinary path.
+    pub fn teardown_all(&self) {
+        let mut entries = match self.entries.lock() {
+            Ok(e) => e,
+            // A panic while the map was locked must not stop cleanup: the data
+            // is a plain `HashMap` and is still structurally sound.
+            Err(poisoned) => poisoned.into_inner(),
         };
         for (key, cell) in entries.drain() {
             let Some(session) = cell.get() else { continue };
@@ -54,6 +58,12 @@ impl Drop for ExecSessionPool {
                 tracing::warn!(key = %key, error = %format!("{e:#}"), "exec session teardown failed");
             }
         }
+    }
+}
+
+impl Drop for ExecSessionPool {
+    fn drop(&mut self) {
+        self.teardown_all();
     }
 }
 

--- a/crates/exec-runner/Cargo.toml
+++ b/crates/exec-runner/Cargo.toml
@@ -10,7 +10,11 @@ workspace = true
 hcore = { package = "core", path = "../core" }
 hproc = { package = "proc", path = "../proc" }
 anyhow = "1.0.102"
+libc = "0.2"
+serde = { version = "1", features = ["derive"] }
+serde_json = "1.0"
 async-trait = "0.1.89"
 
 [dev-dependencies]
+tempfile = "3"
 tokio = { version = "1.52.3", features = ["rt", "macros"] }

--- a/crates/exec-runner/src/agent.rs
+++ b/crates/exec-runner/src/agent.rs
@@ -1,0 +1,415 @@
+//! The agent protocol: create a process inside a long-lived environment.
+//!
+//! Used by `Agent` sessions — a devenv shell held open for the life of the
+//! build, with every target's process forked from inside it.
+//!
+//! ## Why a client process, and not a `spawn` override
+//!
+//! An earlier sketch had `ExecSession::spawn` overridden for this mode. It
+//! cannot be: `spawn` returns a `proc_exec::Handle`, which can only be built for
+//! a child of *this* process, and the whole point here is that the child is
+//! forked by something else. Making the return type a trait object would undo
+//! the reason `prepare` is the seam at all — `proc_exec` would lose its
+//! synchronous spawn, its "the spawn is the API" invariant and its OS-divergent
+//! reader discipline behind a `dyn`.
+//!
+//! So `Agent` is *also* a pure spec transformation. The spec is rewritten to run
+//! a small **client** which heph spawns as its own child in the ordinary way:
+//!
+//! ```text
+//!   heph ──spawn──> client ──unix socket──> agent (inside `devenv shell`)
+//!                     │         SCM_RIGHTS        │
+//!                     └── its own 0/1/2 ──────────┘──fork/exec──> the target's process
+//! ```
+//!
+//! The client is a real child, so `Handle`, the drain, the PTY and the
+//! supervisor all work unchanged. The child's stdio are the *same* file
+//! descriptors — passed, not proxied — so none of `pluginexec`'s bounded-drain
+//! and line-discipline handling is re-derived on a new transport, which §4.6 of
+//! the design exists to prevent. The client then exits with the child's status,
+//! so the exit code a driver sees is the real one.
+//!
+//! Cancellation falls out: heph kills the client's process group, the agent sees
+//! the socket close, and kills the child it forked.
+
+use std::io::{Read as _, Write as _};
+use std::os::fd::{AsRawFd, RawFd};
+use std::os::unix::net::{UnixListener, UnixStream};
+use std::path::{Path, PathBuf};
+
+/// One process-creation request, client → agent.
+#[derive(Debug, Clone, serde::Serialize, serde::Deserialize, PartialEq, Eq)]
+pub struct ExecRequest {
+    pub argv: Vec<String>,
+    /// The composed environment, applied with `env_clear` on the far side.
+    ///
+    /// Sent rather than inherited on purpose. The agent lives inside the devenv
+    /// shell, so *its* environment is the shell's — letting a child inherit that
+    /// would put the developer's ambient `GOFLAGS`, `RUSTFLAGS` and `PATH` tail
+    /// into every build, unhashed, under a cache key that reports as
+    /// lockfile-pinned. That is the hole the design's M2 analysis missed on the
+    /// first pass, and this field is the fix.
+    pub env: Vec<(String, String)>,
+    pub cwd: String,
+    /// `setsid()` in the child, so heph's supervisor can reap the whole tree.
+    pub setsid: bool,
+}
+
+/// The agent's reply once the child has exited.
+#[derive(Debug, Clone, serde::Serialize, serde::Deserialize, PartialEq, Eq)]
+pub enum ExecReply {
+    /// Exit status. `None` means killed by a signal.
+    Exited {
+        code: Option<i32>,
+    },
+    Error {
+        message: String,
+    },
+}
+
+/// Length-prefixed framing, so a reader knows when a message ends without
+/// needing the sender to close — the socket stays open for the reply.
+fn write_frame(s: &mut UnixStream, bytes: &[u8]) -> std::io::Result<()> {
+    s.write_all(&(bytes.len() as u32).to_le_bytes())?;
+    s.write_all(bytes)?;
+    s.flush()
+}
+
+fn read_frame(s: &mut UnixStream) -> std::io::Result<Vec<u8>> {
+    let mut len = [0u8; 4];
+    s.read_exact(&mut len)?;
+    let len = u32::from_le_bytes(len) as usize;
+    // A hostile or corrupt length must not become a multi-gigabyte allocation.
+    if len > 8 * 1024 * 1024 {
+        return Err(std::io::Error::other(format!(
+            "agent frame of {len} bytes is beyond anything this protocol sends"
+        )));
+    }
+    let mut buf = vec![0u8; len];
+    s.read_exact(&mut buf)?;
+    Ok(buf)
+}
+
+/// Send `fds` alongside one byte of payload.
+///
+/// `SCM_RIGHTS` needs at least one byte of ordinary data to ride with, so the
+/// byte is not decoration.
+fn send_fds(sock: &UnixStream, fds: &[RawFd]) -> std::io::Result<()> {
+    let mut byte = [0u8; 1];
+    let mut iov = libc::iovec {
+        iov_base: byte.as_mut_ptr().cast::<libc::c_void>(),
+        iov_len: 1,
+    };
+    let payload = std::mem::size_of_val(fds) as u32;
+    // SAFETY: a pure size computation over a length — reads no memory.
+    let space = unsafe { libc::CMSG_SPACE(payload) };
+    let mut cmsg_buf = vec![0u8; space as usize];
+
+    // SAFETY: `msghdr` is a plain C struct whose fields are all set below;
+    // zeroing is how the platform headers expect it to be initialized.
+    let mut msg: libc::msghdr = unsafe { std::mem::zeroed() };
+    msg.msg_iov = &raw mut iov;
+    msg.msg_iovlen = 1;
+    msg.msg_control = cmsg_buf.as_mut_ptr().cast::<libc::c_void>();
+    msg.msg_controllen = space as _;
+
+    // SAFETY: `msg.msg_control` points at `cmsg_buf`, which is alive here and
+    // `CMSG_SPACE(payload)` bytes long, so a first header fits.
+    let cmsg = unsafe { libc::CMSG_FIRSTHDR(&raw const msg) };
+    if cmsg.is_null() {
+        return Err(std::io::Error::other("no control message header"));
+    }
+
+    // SAFETY: `cmsghdr` is a plain C struct with platform-private padding;
+    // zeroing is the only way to initialize it before setting the public fields.
+    let mut hdr: libc::cmsghdr = unsafe { std::mem::zeroed() };
+    hdr.cmsg_level = libc::SOL_SOCKET;
+    hdr.cmsg_type = libc::SCM_RIGHTS;
+    // SAFETY: another pure size computation.
+    hdr.cmsg_len = unsafe { libc::CMSG_LEN(payload) } as _;
+
+    // SAFETY: `cmsg` is non-null (checked) and points into `cmsg_buf`, which has
+    // room for a header plus `payload` bytes.
+    unsafe { std::ptr::write(cmsg, hdr) };
+
+    // SAFETY: `cmsg` was just initialized as a valid header.
+    let data = unsafe { libc::CMSG_DATA(cmsg) }.cast::<RawFd>();
+    // SAFETY: `data` points at the header's payload area, sized by `CMSG_SPACE`
+    // for exactly `fds.len()` descriptors; source and destination do not overlap.
+    unsafe { std::ptr::copy_nonoverlapping(fds.as_ptr(), data, fds.len()) };
+
+    // SAFETY: `msg` describes `iov` and `cmsg_buf`, both alive for this call,
+    // with lengths matching what was written into them.
+    let sent = unsafe { libc::sendmsg(sock.as_raw_fd(), &raw const msg, 0) };
+    if sent < 0 {
+        return Err(std::io::Error::last_os_error());
+    }
+    Ok(())
+}
+
+/// Receive exactly `want` descriptors sent by [`send_fds`].
+fn recv_fds(sock: &UnixStream, want: usize) -> std::io::Result<Vec<RawFd>> {
+    let mut byte = [0u8; 1];
+    let mut iov = libc::iovec {
+        iov_base: byte.as_mut_ptr().cast::<libc::c_void>(),
+        iov_len: 1,
+    };
+    let payload = (std::mem::size_of::<RawFd>() * want) as u32;
+    // SAFETY: a pure size computation.
+    let space = unsafe { libc::CMSG_SPACE(payload) };
+    let mut cmsg_buf = vec![0u8; space as usize];
+
+    // SAFETY: as in `send_fds`.
+    let mut msg: libc::msghdr = unsafe { std::mem::zeroed() };
+    msg.msg_iov = &raw mut iov;
+    msg.msg_iovlen = 1;
+    msg.msg_control = cmsg_buf.as_mut_ptr().cast::<libc::c_void>();
+    msg.msg_controllen = space as _;
+
+    // SAFETY: `msg` describes `iov` and `cmsg_buf`, both alive for this call.
+    let n = unsafe { libc::recvmsg(sock.as_raw_fd(), &raw mut msg, 0) };
+    if n < 0 {
+        return Err(std::io::Error::last_os_error());
+    }
+    if n == 0 {
+        return Err(std::io::Error::other(
+            "agent client closed before sending fds",
+        ));
+    }
+
+    // SAFETY: `recvmsg` succeeded, so `msg_control` holds what the kernel wrote.
+    let cmsg = unsafe { libc::CMSG_FIRSTHDR(&raw const msg) };
+    if cmsg.is_null() {
+        return Err(std::io::Error::other("no descriptors in message"));
+    }
+
+    // Trust the kernel's length, not the request: a peer that sent fewer
+    // descriptors than asked would otherwise have us read uninitialized bytes
+    // out of the buffer and treat them as file descriptors.
+    // SAFETY: `cmsg` is non-null and points at a header the kernel wrote.
+    let got_len = unsafe { (*cmsg).cmsg_len };
+    // SAFETY: a pure size computation.
+    let want_len = unsafe { libc::CMSG_LEN(payload) };
+    if (got_len as usize) < want_len as usize {
+        return Err(std::io::Error::other(format!(
+            "expected {want} descriptors, message carries fewer"
+        )));
+    }
+
+    // SAFETY: `cmsg` is a valid header, checked above to carry `want`
+    // descriptors' worth of payload.
+    let data = unsafe { libc::CMSG_DATA(cmsg) }.cast::<RawFd>();
+    let mut out = vec![0 as RawFd; want];
+    // SAFETY: `data` has at least `want` descriptors (length checked above) and
+    // `out` has room for exactly that many; the regions do not overlap.
+    unsafe { std::ptr::copy_nonoverlapping(data, out.as_mut_ptr(), want) };
+    Ok(out)
+}
+
+/// Client side: ask the agent to create the process, and return its exit code.
+///
+/// `stdio` are the descriptors the child should use — normally this process's
+/// own 0/1/2, which heph already wired to the target's pipes or PTY.
+pub fn request(socket: &Path, req: &ExecRequest, stdio: [RawFd; 3]) -> anyhow::Result<ExecReply> {
+    let mut sock = UnixStream::connect(socket).map_err(|e| {
+        anyhow::anyhow!(
+            "connecting to exec agent at {}: {e} — the environment's session is gone",
+            socket.display()
+        )
+    })?;
+    let body = serde_json::to_vec(req)?;
+    write_frame(&mut sock, &body)?;
+    send_fds(&sock, &stdio)?;
+    let reply = read_frame(&mut sock)?;
+    Ok(serde_json::from_slice(&reply)?)
+}
+
+/// Where an agent for `key` listens.
+///
+/// Under the runner's own directory rather than a shared `/tmp` name: two heph
+/// processes on one machine each open their own session (§10), and a fixed path
+/// would have them fight over one socket.
+pub fn socket_path(dir: &Path, key: &str) -> PathBuf {
+    // The key is a hex hash, but it is not this function's business to assume
+    // that — anything that is not a plain filename component is replaced.
+    let safe: String = key
+        .chars()
+        .map(|c| if c.is_ascii_alphanumeric() { c } else { '_' })
+        .take(48)
+        .collect();
+    dir.join(format!("agent-{safe}.sock"))
+}
+
+/// Bind the agent's listener, replacing any stale socket left by a crash.
+///
+/// A leftover socket file is not a live agent: `bind` would fail with
+/// `EADDRINUSE` on a path nothing is listening to, so a crashed session would
+/// poison its own key until someone deleted the file by hand.
+pub fn bind(socket: &Path) -> std::io::Result<UnixListener> {
+    if let Some(parent) = socket.parent() {
+        std::fs::create_dir_all(parent)?;
+    }
+    match UnixStream::connect(socket) {
+        // Someone is already serving this key.
+        Ok(_) => Err(std::io::Error::new(
+            std::io::ErrorKind::AddrInUse,
+            format!("an exec agent is already listening at {}", socket.display()),
+        )),
+        Err(_) => {
+            // Best-effort: the file may not exist, which is the common case.
+            // A real removal failure surfaces as the `bind` error below, which
+            // is the more useful message anyway.
+            drop(std::fs::remove_file(socket));
+            UnixListener::bind(socket)
+        }
+    }
+}
+
+/// Serve one connection: read the request, take the descriptors, run the
+/// process, reply with its status.
+///
+/// `run` is the fork/exec, injected so the protocol can be tested without one.
+pub fn serve_one(
+    mut sock: UnixStream,
+    run: &dyn Fn(ExecRequest, [RawFd; 3]) -> anyhow::Result<Option<i32>>,
+) -> anyhow::Result<()> {
+    let body = read_frame(&mut sock)?;
+    let req: ExecRequest = serde_json::from_slice(&body)?;
+    let fds = recv_fds(&sock, 3)?;
+    // `recv_fds` returns exactly what was asked for or an error, so this cannot
+    // fail — but say so with a type rather than an index that "cannot panic".
+    let stdio: [RawFd; 3] = fds.clone().try_into().map_err(|got: Vec<RawFd>| {
+        std::io::Error::other(format!(
+            "agent expected exactly three descriptors, got {}",
+            got.len()
+        ))
+    })?;
+
+    let reply = match run(req, stdio) {
+        Ok(code) => ExecReply::Exited { code },
+        Err(e) => ExecReply::Error {
+            message: format!("{e:#}"),
+        },
+    };
+    // The descriptors were dup'd into this process by the kernel; the child has
+    // its own copies by now, so ours must not be leaked into the next request.
+    for fd in fds {
+        // SAFETY: each descriptor was created by `recvmsg` for this process and
+        // is owned by nothing else here — the child got duplicates across its
+        // own fork, so closing ours cannot affect it.
+        unsafe {
+            libc::close(fd);
+        }
+    }
+    write_frame(&mut sock, &serde_json::to_vec(&reply)?)?;
+    Ok(())
+}
+
+#[cfg(test)]
+#[expect(
+    clippy::panic_in_result_fn,
+    clippy::unwrap_in_result,
+    clippy::undocumented_unsafe_blocks,
+    reason = "restriction lints scoped to production code; tests are exempt"
+)]
+mod tests {
+    use super::*;
+    use std::sync::{Arc, Mutex};
+
+    fn req() -> ExecRequest {
+        ExecRequest {
+            argv: vec!["echo".to_string(), "hi".to_string()],
+            env: vec![("A".to_string(), "1".to_string())],
+            cwd: "/ws".to_string(),
+            setsid: true,
+        }
+    }
+
+    /// The round trip that matters: a request and three live descriptors reach
+    /// the far side intact, and the reply comes back on the same socket.
+    #[test]
+    fn a_request_and_its_descriptors_survive_the_socket() -> anyhow::Result<()> {
+        let dir = tempfile::tempdir()?;
+        let sock_path = socket_path(dir.path(), "abc123");
+        let listener = bind(&sock_path)?;
+
+        let seen: Arc<Mutex<Option<(ExecRequest, bool)>>> = Arc::new(Mutex::new(None));
+        let seen_c = Arc::clone(&seen);
+        let server = std::thread::spawn(move || -> anyhow::Result<()> {
+            let (conn, _) = listener.accept()?;
+            serve_one(conn, &move |r, fds| {
+                // Prove the descriptors are usable on this side, not just that
+                // three integers arrived: a number that happens to be a valid
+                // fd in this process would pass a weaker check.
+                let usable = fds
+                    .iter()
+                    .all(|&fd| unsafe { libc::fcntl(fd, libc::F_GETFD) } != -1);
+                *seen_c.lock().expect("lock") = Some((r, usable));
+                Ok(Some(7))
+            })
+        });
+
+        let f = std::fs::File::open("/dev/null")?;
+        let fd = f.as_raw_fd();
+        let reply = request(&sock_path, &req(), [fd, fd, fd])?;
+        server.join().expect("join")?;
+
+        assert_eq!(reply, ExecReply::Exited { code: Some(7) });
+        let (got, usable) = seen.lock().expect("lock").clone().expect("served");
+        assert_eq!(got, req());
+        assert!(usable, "descriptors must arrive open on the far side");
+        Ok(())
+    }
+
+    #[test]
+    fn an_error_on_the_far_side_comes_back_as_an_error() -> anyhow::Result<()> {
+        let dir = tempfile::tempdir()?;
+        let sock_path = socket_path(dir.path(), "err");
+        let listener = bind(&sock_path)?;
+        let server = std::thread::spawn(move || -> anyhow::Result<()> {
+            let (conn, _) = listener.accept()?;
+            serve_one(conn, &|_, _| anyhow::bail!("no such program"))
+        });
+
+        let f = std::fs::File::open("/dev/null")?;
+        let fd = f.as_raw_fd();
+        let reply = request(&sock_path, &req(), [fd, fd, fd])?;
+        server.join().expect("join")?;
+
+        match reply {
+            ExecReply::Error { message } => assert!(message.contains("no such program")),
+            other => panic!("expected an error reply, got {other:?}"),
+        }
+        Ok(())
+    }
+
+    /// A crash leaves the socket file behind. Without replacing it, `bind`
+    /// fails with `EADDRINUSE` on a path nothing is listening to and the
+    /// environment's key is poisoned until someone deletes it by hand.
+    #[test]
+    fn a_stale_socket_file_is_replaced() -> anyhow::Result<()> {
+        let dir = tempfile::tempdir()?;
+        let sock_path = socket_path(dir.path(), "stale");
+        std::fs::write(&sock_path, b"not a socket")?;
+        let _listener = bind(&sock_path)?;
+        Ok(())
+    }
+
+    /// …but a *live* agent is not replaced, or two sessions would silently
+    /// fight over one socket and each would serve half the build.
+    #[test]
+    fn a_live_agent_is_not_displaced() -> anyhow::Result<()> {
+        let dir = tempfile::tempdir()?;
+        let sock_path = socket_path(dir.path(), "live");
+        let _first = bind(&sock_path)?;
+        assert!(bind(&sock_path).is_err(), "the second bind must refuse");
+        Ok(())
+    }
+
+    #[test]
+    fn socket_paths_stay_inside_the_runners_directory() {
+        let p = socket_path(Path::new("/home/x/.heph/agents"), "../../etc/passwd");
+        assert_eq!(p.parent(), Some(Path::new("/home/x/.heph/agents")));
+        assert!(!p.to_string_lossy().contains(".."));
+    }
+}

--- a/crates/exec-runner/src/agent.rs
+++ b/crates/exec-runner/src/agent.rs
@@ -29,8 +29,22 @@
 //! the design exists to prevent. The client then exits with the child's status,
 //! so the exit code a driver sees is the real one.
 //!
-//! Cancellation falls out: heph kills the client's process group, the agent sees
-//! the socket close, and kills the child it forked.
+//! ## Cancellation
+//!
+//! heph kills the client. That alone cannot reach the target: the target was
+//! forked by the *agent*, in a different process tree, and then `setsid` into a
+//! session of its own — so no group kill heph can issue touches it, and the
+//! session teardown's `SIGTERM` to the `devenv shell` misses it for the same
+//! reason.
+//!
+//! So the agent watches the socket. [`serve_one`] hands `run` a descriptor to
+//! poll; when the client goes away the peer hangs up, and the agent kills the
+//! process group it created. The target *is* that group's leader, because
+//! `setsid` made it one — which is what makes a single `kill(-pid)` enough.
+//!
+//! This used to be documented as working and was not implemented: `serve_one`
+//! blocked in `child.wait()` with nothing watching, so a cancelled build left
+//! its targets running to completion.
 
 use std::io::{Read as _, Write as _};
 use std::os::fd::{AsRawFd, RawFd};
@@ -269,9 +283,12 @@ pub fn bind(socket: &Path) -> std::io::Result<UnixListener> {
 /// process, reply with its status.
 ///
 /// `run` is the fork/exec, injected so the protocol can be tested without one.
+/// Its third argument is a descriptor that becomes readable when the client
+/// disconnects — the implementation must stop watching it before returning,
+/// since it is borrowed from this connection.
 pub fn serve_one(
     mut sock: UnixStream,
-    run: &dyn Fn(ExecRequest, [RawFd; 3]) -> anyhow::Result<Option<i32>>,
+    run: &dyn Fn(ExecRequest, [RawFd; 3], RawFd) -> anyhow::Result<Option<i32>>,
 ) -> anyhow::Result<()> {
     let body = read_frame(&mut sock)?;
     let req: ExecRequest = serde_json::from_slice(&body)?;
@@ -285,7 +302,10 @@ pub fn serve_one(
         ))
     })?;
 
-    let reply = match run(req, stdio) {
+    // The socket itself is the liveness signal: the client sends nothing after
+    // the request, so anything readable on it means the peer is gone.
+    let hangup = sock.as_raw_fd();
+    let reply = match run(req, stdio, hangup) {
         Ok(code) => ExecReply::Exited { code },
         Err(e) => ExecReply::Error {
             message: format!("{e:#}"),
@@ -305,6 +325,69 @@ pub fn serve_one(
     Ok(())
 }
 
+/// Kills the target's process group if the client disconnects first.
+pub struct HangupWatch {
+    done: std::sync::Arc<std::sync::atomic::AtomicBool>,
+    thread: Option<std::thread::JoinHandle<()>>,
+}
+
+impl HangupWatch {
+    pub fn arm(hangup: RawFd, pid: u32) -> Self {
+        let done = std::sync::Arc::new(std::sync::atomic::AtomicBool::new(false));
+        let thread = std::thread::spawn({
+            let done = std::sync::Arc::clone(&done);
+            move || {
+                while !done.load(std::sync::atomic::Ordering::SeqCst) {
+                    let mut pfd = libc::pollfd {
+                        fd: hangup,
+                        events: libc::POLLIN,
+                        revents: 0,
+                    };
+                    // A 200 ms tick rather than an infinite wait, so the normal
+                    // path (child exits first) reaps this thread promptly
+                    // instead of leaving it on a descriptor about to close.
+                    // SAFETY: `pfd` is a live local, and `hangup` is owned by
+                    // the connection `serve_one` holds open across this call.
+                    let rc = unsafe { libc::poll(&raw mut pfd, 1, 200) };
+                    if rc <= 0 {
+                        continue;
+                    }
+                    // The client writes nothing after its request, so readable,
+                    // hung up and errored all mean the same thing: it is gone.
+                    if pfd.revents & (libc::POLLIN | libc::POLLHUP | libc::POLLERR) == 0 {
+                        continue;
+                    }
+                    if done.load(std::sync::atomic::Ordering::SeqCst) {
+                        return;
+                    }
+                    // SIGKILL, not SIGTERM: the client is already gone, so its
+                    // stdio is closed and there is nothing left to flush or
+                    // report. The negative pid is the process *group* — the
+                    // target leads one because it called `setsid`, so this also
+                    // takes down anything it spawned.
+                    // SAFETY: a kill of a group this agent created; ESRCH when
+                    // it has already exited is not an error here.
+                    unsafe {
+                        libc::kill(-(pid as libc::pid_t), libc::SIGKILL);
+                    }
+                    return;
+                }
+            }
+        });
+        Self {
+            done,
+            thread: Some(thread),
+        }
+    }
+
+    pub fn disarm(mut self) {
+        self.done.store(true, std::sync::atomic::Ordering::SeqCst);
+        if let Some(t) = self.thread.take() {
+            drop(t.join());
+        }
+    }
+}
+
 #[cfg(test)]
 #[expect(
     clippy::panic_in_result_fn,
@@ -315,6 +398,69 @@ pub fn serve_one(
 mod tests {
     use super::*;
     use std::sync::{Arc, Mutex};
+
+    /// A cancelled build must not leave its targets running.
+    ///
+    /// Nothing else can reap them: heph forked the *client*, and the target is
+    /// `setsid` into its own session, so neither a group kill from heph nor the
+    /// session teardown's `SIGTERM` to the `devenv shell` reaches it. The agent
+    /// noticing its client leave is the only signal there is — and it was
+    /// documented as working long before it existed.
+    #[test]
+    fn a_client_that_disappears_takes_its_target_with_it() {
+        use std::os::unix::process::CommandExt as _;
+
+        let (ours, theirs) = UnixStream::pair().expect("socketpair");
+
+        // Stands in for a target: long enough that finishing on its own would
+        // be indistinguishable from nothing, and its own session leader exactly
+        // as `redirect_and_detach` makes the real one.
+        let mut child = {
+            let mut c = std::process::Command::new("sleep");
+            c.arg("30")
+                .stdin(std::process::Stdio::null())
+                .stdout(std::process::Stdio::null())
+                .stderr(std::process::Stdio::null());
+            // Hoisted out of the `unsafe` block below so its own `unsafe` is
+            // not swallowed by the enclosing one, and each states its condition.
+            let detach = || {
+                // SAFETY: async-signal-safe, and the child is not yet a
+                // process-group leader, having just been forked.
+                let rc = unsafe { libc::setsid() };
+                if rc < 0 {
+                    return Err(std::io::Error::last_os_error());
+                }
+                Ok(())
+            };
+            // SAFETY: `detach` runs in the forked child before `exec` and
+            // touches only that child.
+            unsafe {
+                c.pre_exec(detach);
+            }
+            c.spawn().expect("spawn sleep")
+        };
+
+        let watch = HangupWatch::arm(theirs.as_raw_fd(), child.id());
+
+        // The client goes away — a Ctrl-C on the build, from the agent's side.
+        drop(ours);
+
+        let start = std::time::Instant::now();
+        let status = child.wait().expect("wait");
+        let elapsed = start.elapsed();
+        watch.disarm();
+        drop(theirs);
+
+        assert!(
+            elapsed < std::time::Duration::from_secs(10),
+            "the target outlived its client by {elapsed:?} — it ran to completion, \
+             which is the bug this watch exists to prevent"
+        );
+        assert!(
+            status.code().is_none(),
+            "expected death by signal, got {status:?}"
+        );
+    }
 
     fn req() -> ExecRequest {
         ExecRequest {
@@ -337,7 +483,7 @@ mod tests {
         let seen_c = Arc::clone(&seen);
         let server = std::thread::spawn(move || -> anyhow::Result<()> {
             let (conn, _) = listener.accept()?;
-            serve_one(conn, &move |r, fds| {
+            serve_one(conn, &move |r, fds, _hangup| {
                 // Prove the descriptors are usable on this side, not just that
                 // three integers arrived: a number that happens to be a valid
                 // fd in this process would pass a weaker check.
@@ -368,7 +514,7 @@ mod tests {
         let listener = bind(&sock_path)?;
         let server = std::thread::spawn(move || -> anyhow::Result<()> {
             let (conn, _) = listener.accept()?;
-            serve_one(conn, &|_, _| anyhow::bail!("no such program"))
+            serve_one(conn, &|_, _, _| anyhow::bail!("no such program"))
         });
 
         let f = std::fs::File::open("/dev/null")?;

--- a/crates/exec-runner/src/lib.rs
+++ b/crates/exec-runner/src/lib.rs
@@ -40,6 +40,8 @@
 //! darwin and passes on linux. So the batch/streaming drain policy stays inside
 //! `hproc`, and this trait exposes both.
 
+pub mod agent;
+
 use hcore::hasync::Cancellable;
 use hproc::proc_exec::{self, Handle, Spec};
 use std::ffi::OsString;
@@ -633,5 +635,436 @@ mod shell_function_diag_tests {
         assert!(msg.contains("//:devenv"), "{msg}");
         // Names the way out, not just the problem.
         assert!(msg.contains(r#"mode = "session""#), "{msg}");
+    }
+}
+
+/// How a `Wrap` session gets the environment to the *inner* process.
+///
+/// The distinction is not cosmetic: `chroot`, `bwrap` and `nix develop
+/// --command` exec the inner program in their own process, so it inherits the
+/// spec's environment. `docker exec` does not — the environment we set belongs
+/// to the `docker` CLI on this side of the socket, and the container process
+/// sees none of it. A wrapper of the second kind that used `Inherit` would run
+/// every target with an environment it never asked for and no error to show
+/// for it.
+#[derive(Debug, Clone)]
+pub enum WrapEnv {
+    /// The wrapper execs the inner program; the spec's env carries through.
+    Inherit,
+    /// The wrapper creates the process elsewhere. Each variable is rendered
+    /// into the wrapper's own argv using this template, where `{K}` and `{V}`
+    /// are replaced — e.g. `["-e", "{K}={V}"]` for `docker exec`.
+    Args(Vec<String>),
+}
+
+/// A `Wrap` session: the process is created by a wrapper command — a container
+/// exec, a `chroot`, a `nix develop --command`.
+///
+/// Still a pure spec transformation, which is the whole reason `prepare` is the
+/// seam: nothing here owns a process, so `proc_exec` keeps its synchronous
+/// spawn, its `Handle` invariants and its stdio handling untouched.
+#[derive(Debug)]
+pub struct WrapSession {
+    prefix_argv: Vec<OsString>,
+    env_mode: WrapEnv,
+    base_env: Vec<(OsString, OsString)>,
+    caps: SessionCaps,
+    description: SessionDescription,
+}
+
+impl WrapSession {
+    pub fn new(
+        prefix_argv: Vec<OsString>,
+        env_mode: WrapEnv,
+        base_env: Vec<(OsString, OsString)>,
+        caps: SessionCaps,
+        description: SessionDescription,
+    ) -> anyhow::Result<Self> {
+        if prefix_argv.is_empty() {
+            anyhow::bail!("a Wrap session needs a wrapper command; `prefix_argv` is empty");
+        }
+        Ok(Self {
+            prefix_argv,
+            env_mode,
+            base_env,
+            caps,
+            description,
+        })
+    }
+
+    fn merged_env(&self, spec_env: &[(OsString, OsString)]) -> Vec<(OsString, OsString)> {
+        let mut env = Vec::with_capacity(self.base_env.len() + spec_env.len());
+        for (k, v) in &self.base_env {
+            if !spec_env.iter().any(|(sk, _)| sk == k) {
+                env.push((k.clone(), v.clone()));
+            }
+        }
+        env.extend_from_slice(spec_env);
+        env
+    }
+}
+
+#[async_trait::async_trait]
+impl ExecSession for WrapSession {
+    fn prepare(&self, mut spec: Spec) -> Result<Spec, SpawnError> {
+        let merged = self.merged_env(&spec.env);
+
+        // prefix[0] becomes the program; everything else, then the env args (if
+        // this wrapper needs them), then the original program and its args.
+        // `split_first` rather than an index: the constructor already rejects an
+        // empty prefix, but a slice that "cannot be empty" is worth expressing
+        // in the type rather than in a comment.
+        let (wrapper, rest) = self
+            .prefix_argv
+            .split_first()
+            .ok_or_else(|| SpawnError::Io(std::io::Error::other("empty wrapper command")))?;
+        let mut args: Vec<OsString> = rest.to_vec();
+        if let WrapEnv::Args(template) = &self.env_mode {
+            for (k, v) in &merged {
+                for part in template {
+                    args.push(OsString::from(
+                        part.replace("{K}", &k.to_string_lossy())
+                            .replace("{V}", &v.to_string_lossy()),
+                    ));
+                }
+            }
+        }
+        args.push(spec.program.clone().into_os_string());
+        args.append(&mut spec.args);
+
+        spec.program = std::path::PathBuf::from(wrapper);
+        spec.args = args;
+        // The wrapper itself still needs an environment to run in — a `PATH` to
+        // find `docker` with, at minimum — so the merged env goes on the spec
+        // either way. Under `Args` it reaches the inner process through argv
+        // instead, and this is what the wrapper process sees.
+        spec.env = merged;
+        Ok(spec)
+    }
+
+    fn base_env(&self) -> Option<&[(OsString, OsString)]> {
+        match self.env_mode {
+            // The environment reaches the inner process, so reporting it is
+            // honest.
+            WrapEnv::Inherit => Some(&self.base_env),
+            // It does not describe what the inner process sees — the wrapper
+            // decides that. Saying `None` makes a caller degrade explicitly
+            // rather than print a confident, wrong answer.
+            WrapEnv::Args(_) => None,
+        }
+    }
+
+    fn caps(&self) -> &SessionCaps {
+        &self.caps
+    }
+
+    fn describe(&self) -> &SessionDescription {
+        &self.description
+    }
+}
+
+#[cfg(test)]
+mod wrap_session_tests {
+    use super::*;
+    use std::path::PathBuf;
+
+    fn caps() -> SessionCaps {
+        SessionCaps {
+            pty: false,
+            max_concurrent: None,
+            identity: Identity::Pinned {
+                by: "img@sha256:abc".to_string(),
+            },
+        }
+    }
+
+    fn desc() -> SessionDescription {
+        SessionDescription {
+            runner: "//:ctr".to_string(),
+            shell_functions: vec![],
+            key: "k".to_string(),
+            summary: "container".to_string(),
+        }
+    }
+
+    fn spec() -> Spec {
+        Spec {
+            program: PathBuf::from("cargo"),
+            args: vec![OsString::from("build")],
+            env: vec![(OsString::from("MINE"), OsString::from("1"))],
+            cwd: PathBuf::from("/ws"),
+            stdin: proc_exec::StdioSpec::Null,
+            stdout: proc_exec::StdioSpec::Null,
+            stderr: proc_exec::StdioSpec::Null,
+            setsid: false,
+            ctty: false,
+        }
+    }
+
+    fn argv(s: &Spec) -> Vec<String> {
+        std::iter::once(s.program.to_string_lossy().into_owned())
+            .chain(s.args.iter().map(|a| a.to_string_lossy().into_owned()))
+            .collect()
+    }
+
+    #[test]
+    fn the_wrapper_becomes_the_program_and_the_original_follows() {
+        let s = WrapSession::new(
+            vec![OsString::from("chroot"), OsString::from("/root")],
+            WrapEnv::Inherit,
+            vec![(OsString::from("CC"), OsString::from("clang"))],
+            caps(),
+            desc(),
+        )
+        .expect("wrap");
+        let out = s.prepare(spec()).expect("prepare");
+        assert_eq!(argv(&out), vec!["chroot", "/root", "cargo", "build"]);
+        // Base env still applies underneath the caller's own.
+        assert!(out.env.iter().any(|(k, v)| k == "CC" && v == "clang"));
+        assert!(out.env.iter().any(|(k, v)| k == "MINE" && v == "1"));
+    }
+
+    /// `docker exec` does not inherit our environment, so it has to be rendered
+    /// into the wrapper's argv or the inner process never sees it.
+    #[test]
+    fn args_mode_renders_the_environment_into_the_wrappers_argv() {
+        let s = WrapSession::new(
+            vec![
+                OsString::from("docker"),
+                OsString::from("exec"),
+                OsString::from("-i"),
+            ],
+            WrapEnv::Args(vec!["-e".to_string(), "{K}={V}".to_string()]),
+            vec![(OsString::from("CC"), OsString::from("clang"))],
+            caps(),
+            desc(),
+        )
+        .expect("wrap");
+        let out = s.prepare(spec()).expect("prepare");
+        let a = argv(&out);
+        assert_eq!(a[0], "docker");
+        assert!(
+            a.windows(2).any(|w| w[0] == "-e" && w[1] == "CC=clang"),
+            "{a:?}"
+        );
+        assert!(
+            a.windows(2).any(|w| w[0] == "-e" && w[1] == "MINE=1"),
+            "{a:?}"
+        );
+        // The inner command still comes last, after everything the wrapper needs.
+        assert_eq!(&a[a.len() - 2..], &["cargo", "build"]);
+    }
+
+    /// A `Wrap` runner whose environment lives inside the container cannot
+    /// honestly answer "what will this process see" — so it says so rather than
+    /// reporting the host-side map as if it were the answer.
+    #[test]
+    fn args_mode_reports_no_enumerable_environment() {
+        let s = WrapSession::new(
+            vec![OsString::from("docker")],
+            WrapEnv::Args(vec!["-e".to_string(), "{K}={V}".to_string()]),
+            vec![(OsString::from("CC"), OsString::from("clang"))],
+            caps(),
+            desc(),
+        )
+        .expect("wrap");
+        assert!(s.base_env().is_none());
+    }
+
+    #[test]
+    fn an_empty_wrapper_command_is_rejected() {
+        assert!(
+            WrapSession::new(vec![], WrapEnv::Inherit, vec![], caps(), desc()).is_err(),
+            "a Wrap session with nothing to wrap with is not a session"
+        );
+    }
+}
+
+/// An `Agent` session: processes are forked by a long-lived helper living
+/// inside the environment — a `devenv shell` held open for the build.
+///
+/// Like the other modes, this is a **pure spec transformation**: the spec is
+/// rewritten to run a client that heph spawns as its own ordinary child. See
+/// [`agent`] for why that indirection exists rather than an overridden `spawn`.
+pub struct AgentSession {
+    /// The heph binary, which is also the client (`__runner-exec`).
+    client_bin: std::path::PathBuf,
+    socket: std::path::PathBuf,
+    base_env: Vec<(OsString, OsString)>,
+    caps: SessionCaps,
+    description: SessionDescription,
+    teardown: std::sync::Mutex<Option<TeardownJob>>,
+}
+
+impl std::fmt::Debug for AgentSession {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("AgentSession")
+            .field("socket", &self.socket)
+            .field("runner", &self.description.runner)
+            .finish_non_exhaustive()
+    }
+}
+
+impl AgentSession {
+    pub fn new(
+        client_bin: std::path::PathBuf,
+        socket: std::path::PathBuf,
+        base_env: Vec<(OsString, OsString)>,
+        caps: SessionCaps,
+        description: SessionDescription,
+        teardown: Option<TeardownJob>,
+    ) -> Self {
+        Self {
+            client_bin,
+            socket,
+            base_env,
+            caps,
+            description,
+            teardown: std::sync::Mutex::new(teardown),
+        }
+    }
+}
+
+#[async_trait::async_trait]
+impl ExecSession for AgentSession {
+    fn prepare(&self, mut spec: Spec) -> Result<Spec, SpawnError> {
+        // Base env under the caller's own, exactly as `Direct` does. The client
+        // forwards its own environment to the agent, which applies it with
+        // `env_clear` — so the devenv shell's ambient variables never reach the
+        // target. That is the correction the design's M2 analysis needed: an
+        // agent that let its own environment through would put the developer's
+        // `GOFLAGS` into every build, unhashed, under a lockfile-pinned key.
+        let mut env = Vec::with_capacity(self.base_env.len() + spec.env.len());
+        for (k, v) in &self.base_env {
+            if !spec.env.iter().any(|(sk, _)| sk == k) {
+                env.push((k.clone(), v.clone()));
+            }
+        }
+        env.append(&mut spec.env);
+
+        let mut args: Vec<OsString> = vec![
+            OsString::from("__runner-exec"),
+            OsString::from("--socket"),
+            self.socket.clone().into_os_string(),
+            OsString::from("--"),
+        ];
+        args.push(spec.program.clone().into_os_string());
+        args.append(&mut spec.args);
+
+        spec.program = self.client_bin.clone();
+        spec.args = args;
+        spec.env = env;
+        Ok(spec)
+    }
+
+    fn base_env(&self) -> Option<&[(OsString, OsString)]> {
+        Some(&self.base_env)
+    }
+
+    fn caps(&self) -> &SessionCaps {
+        &self.caps
+    }
+
+    fn describe(&self) -> &SessionDescription {
+        &self.description
+    }
+
+    fn teardown(&self) -> Option<TeardownJob> {
+        self.teardown.lock().ok().and_then(|mut t| t.take())
+    }
+}
+
+#[cfg(test)]
+mod agent_session_tests {
+    use super::*;
+    use std::path::PathBuf;
+
+    fn session() -> AgentSession {
+        AgentSession::new(
+            PathBuf::from("/usr/bin/heph"),
+            PathBuf::from("/run/agent.sock"),
+            vec![(OsString::from("CC"), OsString::from("clang"))],
+            SessionCaps {
+                pty: true,
+                max_concurrent: None,
+                identity: Identity::Asserted {
+                    why: "live shell".to_string(),
+                },
+            },
+            SessionDescription {
+                runner: "//:devenv".to_string(),
+                shell_functions: vec!["fmt-all".to_string()],
+                key: "k".to_string(),
+                summary: "session".to_string(),
+            },
+            None,
+        )
+    }
+
+    fn spec() -> Spec {
+        Spec {
+            program: PathBuf::from("cargo"),
+            args: vec![OsString::from("build")],
+            env: vec![(OsString::from("MINE"), OsString::from("1"))],
+            cwd: PathBuf::from("/ws"),
+            stdin: proc_exec::StdioSpec::Null,
+            stdout: proc_exec::StdioSpec::Null,
+            stderr: proc_exec::StdioSpec::Null,
+            setsid: false,
+            ctty: false,
+        }
+    }
+
+    /// The rewrite heph then spawns as an ordinary child — which is what keeps
+    /// `Handle`, the drain and the PTY untouched.
+    #[test]
+    fn the_spec_becomes_a_client_invocation_wrapping_the_original() {
+        let out = session().prepare(spec()).expect("prepare");
+        assert_eq!(out.program, PathBuf::from("/usr/bin/heph"));
+        let args: Vec<String> = out
+            .args
+            .iter()
+            .map(|a| a.to_string_lossy().into_owned())
+            .collect();
+        assert_eq!(
+            args,
+            vec![
+                "__runner-exec",
+                "--socket",
+                "/run/agent.sock",
+                "--",
+                "cargo",
+                "build"
+            ]
+        );
+        // `--` matters: a target's own argv must never be read as client flags.
+        assert!(args.iter().any(|a| a == "--"));
+    }
+
+    #[test]
+    fn the_environment_is_merged_with_the_caller_winning() {
+        let mut s = spec();
+        s.env.push((OsString::from("CC"), OsString::from("gcc")));
+        let out = session().prepare(s).expect("prepare");
+        let cc: Vec<_> = out.env.iter().filter(|(k, _)| k == "CC").collect();
+        assert_eq!(cc.len(), 1, "no duplicate keys reach execve");
+        assert_eq!(cc[0].1, OsString::from("gcc"), "the caller wins");
+        assert!(out.env.iter().any(|(k, _)| k == "MINE"));
+    }
+
+    /// Teardown is handed over once — a second caller must not be able to run
+    /// `docker rm` (or kill the shell) a second time.
+    #[test]
+    fn teardown_is_handed_over_at_most_once() {
+        let s = AgentSession::new(
+            PathBuf::from("/usr/bin/heph"),
+            PathBuf::from("/run/a.sock"),
+            vec![],
+            session().caps.clone(),
+            session().description.clone(),
+            Some(Box::new(|| Ok(()))),
+        );
+        assert!(s.teardown().is_some());
+        assert!(s.teardown().is_none());
     }
 }

--- a/crates/plugin-devenv/Cargo.toml
+++ b/crates/plugin-devenv/Cargo.toml
@@ -15,6 +15,8 @@ hexec-runner = { package = "exec-runner", path = "../exec-runner" }
 hproc = { package = "proc", path = "../proc" }
 htspec-derive = { path = "../htspec-derive" }
 anyhow = "1.0.102"
+libc = "0.2"
+tokio = { version = "1.52.3", features = ["time"] }
 async-trait = "0.1.89"
 serde = { version = "1", features = ["derive"] }
 serde_json = "1.0"

--- a/crates/plugin-devenv/src/plugindevenv/mod.rs
+++ b/crates/plugin-devenv/src/plugindevenv/mod.rs
@@ -32,11 +32,21 @@ const OUT_NAME: &str = "devenv-env.json";
 struct DevenvSpec {
     /// The `devenv` binary. Defaults to `devenv` on the driver's PATH.
     bin: Option<String>,
+    /// `"snapshot"` (default) or `"session"`.
+    ///
+    /// `snapshot` captures the environment once and applies it to every target
+    /// — no live process, cacheable, and the environment's own bytes are its
+    /// cache identity. `session` additionally holds a `devenv shell` open and
+    /// forks every target's process from inside it, which is what makes
+    /// `enterShell` side effects and shell functions available. It costs one
+    /// shell per heph process, forever, and cannot amortize across machines.
+    mode: Option<String>,
 }
 
 #[derive(Clone, serde::Serialize, serde::Deserialize)]
 struct DevenvDef {
     bin: String,
+    session: bool,
 }
 
 pub struct Driver {
@@ -67,13 +77,24 @@ impl ManagedDriver for Driver {
         _ctoken: &(dyn Cancellable + Send + Sync),
     ) -> anyhow::Result<ParseResponse> {
         let spec = DevenvSpec::from(&req.target_spec.config).with_context(|| "devenv spec")?;
+        let session = match spec.mode.as_deref() {
+            None | Some("snapshot") => false,
+            Some("session") => true,
+            Some(other) => {
+                anyhow::bail!("devenv `mode` must be \"snapshot\" or \"session\", got {other:?}")
+            }
+        };
         let def = DevenvDef {
             bin: spec.bin.unwrap_or_else(|| "devenv".to_string()),
+            session,
         };
 
         let mut h = xxhash_rust::xxh3::Xxh3::new();
         snapshot::SNAPSHOT_FORMAT_VERSION.hash(&mut h);
         def.bin.hash(&mut h);
+        // The mode changes what the artifact contains (a session snapshot also
+        // carries the shell prelude), so it must change the key.
+        def.session.hash(&mut h);
         req.target_spec.addr.format().hash(&mut h);
 
         Ok(ParseResponse {
@@ -165,7 +186,7 @@ impl ManagedDriver for Driver {
             );
         }
 
-        let snap = snapshot_from_json(&out.stdout, &self.local_paths())?;
+        let snap = snapshot_from_json(&out.stdout, &self.local_paths(), def.session)?;
         if snap.env.is_empty() {
             anyhow::bail!(
                 "the devenv environment came out empty after filtering, which would describe \
@@ -239,7 +260,11 @@ struct PrintDevEnv {
     bash_functions: BTreeMap<String, serde_json::Value>,
 }
 
-fn snapshot_from_json(stdout: &[u8], local: &LocalPaths) -> anyhow::Result<Snapshot> {
+fn snapshot_from_json(
+    stdout: &[u8],
+    local: &LocalPaths,
+    with_prelude: bool,
+) -> anyhow::Result<Snapshot> {
     // `bashFunctions` in the wire format; serde's rename is applied here rather
     // than in the struct so the field name reads as Rust.
     let raw: serde_json::Value = serde_json::from_slice(stdout).with_context(|| {
@@ -259,11 +284,67 @@ fn snapshot_from_json(stdout: &[u8], local: &LocalPaths) -> anyhow::Result<Snaps
     }))
     .context("decode devenv env")?;
 
-    Ok(snapshot::build(
+    // Only in session mode: the definitions are large, and a snapshot runner
+    // cannot use them — carrying them anyway would bloat every consumer's cache
+    // key for something nothing reads.
+    let prelude = if with_prelude {
+        render_prelude(&parsed.bash_functions)
+    } else {
+        String::new()
+    };
+
+    Ok(snapshot::build_with_prelude(
         &parsed.variables,
         parsed.bash_functions.keys().cloned().collect(),
         local,
+        prelude,
     ))
+}
+
+/// Render devenv's function bodies as a bash snippet the agent sources before
+/// each command.
+///
+/// `print-dev-env` gives each body without the `name () {…}` wrapper, so it is
+/// rebuilt here — and every function is then **exported**.
+///
+/// The export is the part that makes this work at all. The agent sources this
+/// into one bash, but the command it runs is itself `bash -c …` (that is how
+/// `pluginexec` invokes a target), and a function defined in a parent shell is
+/// not visible to a child shell unless exported. Without `export -f`, the
+/// prelude is defined in a process the target never runs in — which is exactly
+/// how this failed the first time.
+fn render_prelude(functions: &BTreeMap<String, serde_json::Value>) -> String {
+    let mut out = String::new();
+    for (name, body) in functions {
+        if !is_exportable_function_name(name) {
+            continue;
+        }
+        if let Some(b) = body.as_str() {
+            out.push_str(name);
+            out.push_str(" () {");
+            out.push_str(b);
+            out.push_str("}\n");
+            out.push_str("export -f ");
+            out.push_str(name);
+            out.push('\n');
+        }
+    }
+    out
+}
+
+/// A name bash can both declare and `export -f`.
+///
+/// Stricter than "a name devenv used": bash accepts some punctuation in a
+/// function name but cannot export it, and a failed `export -f` in the prelude
+/// takes down every command in the session — so anything not a plain identifier
+/// is skipped rather than risked.
+fn is_exportable_function_name(name: &str) -> bool {
+    let mut chars = name.chars();
+    match chars.next() {
+        Some(c) if c.is_ascii_alphabetic() || c == '_' => {}
+        _ => return false,
+    }
+    chars.all(|c| c.is_ascii_alphanumeric() || c == '_')
 }
 
 /// The runner half: a pure parse of the artifact the driver produced.
@@ -272,7 +353,33 @@ fn snapshot_from_json(stdout: &[u8], local: &LocalPaths) -> anyhow::Result<Snaps
 /// run at all on a fully-cached build, so anything discovered here would be
 /// unhashed input that cannot be validated on the build where a stale artifact
 /// is served (`docs/EXEC_RUNNERS.md` §4.7).
-pub struct Runner;
+///
+/// In `session` mode it additionally *starts* something — a `devenv shell`
+/// holding an agent — but strictly from the artifact's contents. What it starts
+/// is decided by bytes the cache key already covers; only the socket path and
+/// the pid are new, and neither describes the environment.
+pub struct Runner {
+    /// Where agent sockets live, and the heph binary that serves as both agent
+    /// and client. Absent in a host with no session support, which makes
+    /// `mode = "session"` an error rather than a silent downgrade.
+    session: Option<SessionSupport>,
+}
+
+#[derive(Clone, Debug)]
+pub struct SessionSupport {
+    pub heph_bin: std::path::PathBuf,
+    pub socket_dir: std::path::PathBuf,
+    /// Where `devenv.nix` lives. `devenv shell` must run there — it was the
+    /// socket directory once, which has no `devenv.nix`, and the only symptom
+    /// was a five-minute wait for a socket that was never going to appear.
+    pub tree_root: std::path::PathBuf,
+}
+
+impl Runner {
+    pub fn new(session: Option<SessionSupport>) -> Self {
+        Self { session }
+    }
+}
 
 #[async_trait]
 impl ExecRunner for Runner {
@@ -306,11 +413,15 @@ impl ExecRunner for Runner {
             );
         }
 
-        let base_env = snap
+        let base_env: Vec<(std::ffi::OsString, std::ffi::OsString)> = snap
             .env
             .iter()
             .map(|(k, v)| (std::ffi::OsString::from(k), std::ffi::OsString::from(v)))
             .collect();
+
+        if !snap.shell_prelude.is_empty() {
+            return self.open_session(&req, &snap, base_env).await;
+        }
 
         Ok(Arc::new(EnvSession::new(
             base_env,
@@ -337,9 +448,197 @@ impl ExecRunner for Runner {
     }
 }
 
+impl Runner {
+    /// `mode = "session"`: hold a `devenv shell` open with an agent inside it,
+    /// and fork every target's process from there.
+    async fn open_session(
+        &self,
+        req: &OpenRequest,
+        snap: &Snapshot,
+        base_env: Vec<(std::ffi::OsString, std::ffi::OsString)>,
+    ) -> anyhow::Result<Arc<dyn ExecSession>> {
+        let support = self.session.as_ref().ok_or_else(|| {
+            anyhow::anyhow!(
+                "{} asks for `mode = \"session\"`, but this heph was built without session \
+                 support",
+                req.runner_addr,
+            )
+        })?;
+
+        let socket = hexec_runner::agent::socket_path(&support.socket_dir, &req.key);
+        std::fs::create_dir_all(&support.socket_dir)?;
+
+        // The prelude goes to a file rather than the command line: a dev shell's
+        // function bodies run to tens of kilobytes, well past what argv can
+        // carry, and `execve` would fail with E2BIG rather than anything that
+        // explains itself.
+        let prelude_path = socket.with_extension("prelude.sh");
+        std::fs::write(&prelude_path, &snap.shell_prelude)?;
+
+        // The agent runs INSIDE the shell — that is the whole difference from
+        // snapshot mode. `devenv shell -- <cmd>` is the supported way in.
+        let mut cmd = std::process::Command::new("devenv");
+        cmd.arg("shell")
+            .arg("--")
+            .arg(&support.heph_bin)
+            .arg("__runner-agent")
+            .arg("--socket")
+            .arg(&socket)
+            .arg("--prelude")
+            .arg(&prelude_path)
+            .current_dir(&support.tree_root)
+            .stdin(std::process::Stdio::null())
+            .stdout(std::process::Stdio::null());
+
+        // Its stderr goes to a file, not to /dev/null. A session that fails to
+        // start is otherwise a five-minute timeout with no reason attached, and
+        // the reason is always in what `devenv` said on the way down.
+        let log_path = socket.with_extension("log");
+        match std::fs::File::create(&log_path) {
+            Ok(f) => {
+                cmd.stderr(std::process::Stdio::from(f));
+            }
+            Err(_) => {
+                cmd.stderr(std::process::Stdio::null());
+            }
+        }
+        let mut child = cmd
+            .spawn()
+            .with_context(|| "starting `devenv shell` for a session runner")?;
+        let pid = child.id();
+
+        // Wait for the socket rather than assume it: a cold `devenv shell` is
+        // tens of seconds, and connecting too early would fail every target of
+        // the build for a reason that reads like the environment is broken.
+        let deadline = std::time::Instant::now() + std::time::Duration::from_secs(300);
+        while !socket.exists() {
+            if std::time::Instant::now() > deadline {
+                let tail = std::fs::read_to_string(&log_path)
+                    .map(|s| s.lines().rev().take(20).collect::<Vec<_>>().join("\n"))
+                    .unwrap_or_default();
+                anyhow::bail!(
+                    "`devenv shell` did not open its exec agent at {} within 5 minutes.\n\
+                     Its last output:\n{tail}",
+                    socket.display(),
+                );
+            }
+            // A shell that has already exited is never going to open it, and
+            // waiting out the deadline only delays the same failure.
+            if let Ok(Some(status)) = child.try_wait() {
+                let tail = std::fs::read_to_string(&log_path)
+                    .map(|s| s.lines().rev().take(20).collect::<Vec<_>>().join("\n"))
+                    .unwrap_or_default();
+                anyhow::bail!(
+                    "`devenv shell` exited ({status}) before opening its exec agent.\n\
+                     Its last output:\n{tail}"
+                );
+            }
+            tokio::time::sleep(std::time::Duration::from_millis(100)).await;
+        }
+
+        let teardown_socket = socket.clone();
+        let teardown: hexec_runner::TeardownJob = Box::new(move || {
+            // Killing the shell closes the agent with it. Sync and
+            // fire-and-forget by contract — `Drop` and process exit must both
+            // be able to reach it.
+            //
+            // SAFETY: `kill` with a pid this process spawned; the worst case is
+            // ESRCH if it is already gone, which is not an error here.
+            unsafe {
+                libc::kill(pid as libc::pid_t, libc::SIGTERM);
+            }
+            // Best-effort: the agent removes it on a clean exit, so it is
+            // usually already gone.
+            drop(std::fs::remove_file(&teardown_socket));
+            Ok(())
+        });
+
+        Ok(Arc::new(hexec_runner::AgentSession::new(
+            support.heph_bin.clone(),
+            socket,
+            base_env,
+            SessionCaps {
+                pty: true,
+                max_concurrent: None,
+                // Asserted, not Pinned: the environment is now whatever that
+                // live shell has. The lockfiles pin what it was *asked* to be,
+                // which is a claim rather than an observation — and
+                // `enterShell` side effects and running services are outside
+                // any key by construction.
+                identity: Identity::Asserted {
+                    why: "a live `devenv shell`; enterShell effects and services are outside the \
+                          cache key"
+                        .to_string(),
+                },
+            },
+            SessionDescription {
+                runner: req.runner_addr.clone(),
+                shell_functions: snap.shell_functions.clone(),
+                key: req.key.clone(),
+                summary: format!(
+                    "devenv session: {} vars, {} shell functions",
+                    snap.env.len(),
+                    snap.shell_functions.len()
+                ),
+            },
+            Some(teardown),
+        )))
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    /// Session mode carries function *definitions*, snapshot mode only their
+    /// names — the definitions are large and a snapshot runner cannot use them.
+    #[test]
+    fn only_session_mode_carries_the_prelude() {
+        let json = br#"{"bashFunctions":{"fmt":"  echo hi\n"},"variables":{"CC":{"type":"exported","value":"clang"}}}"#;
+        let local = LocalPaths {
+            tree_root: "/r".to_string(),
+            home: "/h".to_string(),
+            tmpdir: String::new(),
+        };
+        let snap = snapshot_from_json(json, &local, false).expect("snapshot");
+        assert!(snap.shell_prelude.is_empty());
+        assert_eq!(snap.shell_functions, vec!["fmt"]);
+
+        let sess = snapshot_from_json(json, &local, true).expect("session");
+        assert!(
+            sess.shell_prelude.contains("fmt () {"),
+            "{:?}",
+            sess.shell_prelude
+        );
+    }
+
+    /// A name that is not a shell identifier cannot be declared; pasting it
+    /// would produce a snippet that fails to parse and take every command in
+    /// the session down with it.
+    #[test]
+    fn a_non_identifier_function_name_is_skipped() {
+        let mut fns = BTreeMap::new();
+        fns.insert("ok_name".to_string(), serde_json::json!("  :\n"));
+        fns.insert("bad name; rm -rf /".to_string(), serde_json::json!("  :\n"));
+        // bash declares this one but cannot `export -f` it, and a failed export
+        // in the prelude takes down every command in the session.
+        fns.insert("has-dash".to_string(), serde_json::json!("  :\n"));
+        let out = render_prelude(&fns);
+        assert!(out.contains("ok_name () {"));
+        assert!(!out.contains("rm -rf"), "{out}");
+        assert!(!out.contains("has-dash"), "{out}");
+    }
+
+    /// Every function is exported, or it is defined in a shell the target never
+    /// runs in — `pluginexec` invokes the target through its own `bash -c`.
+    #[test]
+    fn functions_are_exported_to_child_shells() {
+        let mut fns = BTreeMap::new();
+        fns.insert("fmt_all".to_string(), serde_json::json!("  echo hi\n"));
+        let out = render_prelude(&fns);
+        assert!(out.contains("fmt_all () {"), "{out}");
+        assert!(out.contains("export -f fmt_all"), "{out}");
+    }
 
     #[test]
     fn parses_devenvs_real_json_shape() {
@@ -359,6 +658,7 @@ mod tests {
                 home: "/home/u".to_string(),
                 tmpdir: String::new(),
             },
+            false,
         )
         .expect("parse");
 

--- a/crates/plugin-devenv/src/plugindevenv/mod.rs
+++ b/crates/plugin-devenv/src/plugindevenv/mod.rs
@@ -32,7 +32,7 @@ const OUT_NAME: &str = "devenv-env.json";
 struct DevenvSpec {
     /// The `devenv` binary. Defaults to `devenv` on the driver's PATH.
     bin: Option<String>,
-    /// `"snapshot"` (default) or `"session"`.
+    /// `"snapshot"` (default), `"session"` or `"wrap"`.
     ///
     /// `snapshot` captures the environment once and applies it to every target
     /// — no live process, cacheable, and the environment's own bytes are its
@@ -40,13 +40,21 @@ struct DevenvSpec {
     /// forks every target's process from inside it, which is what makes
     /// `enterShell` side effects and shell functions available. It costs one
     /// shell per heph process, forever, and cannot amortize across machines.
+    ///
+    /// `wrap` prefixes every spawn with `devenv shell --`. It is a
+    /// **demonstration** of the generic `Wrap` lane, not a recommendation:
+    /// measured at 4.5 s per spawn on this repo's own shell, it re-runs
+    /// `enterShell` once per target rather than once per build, and it does
+    /// **not** make shell functions callable — `devenv shell -- prog` execs
+    /// `prog` directly, with no functions defined. Use it only for a runner a
+    /// handful of targets name.
     mode: Option<String>,
 }
 
 #[derive(Clone, serde::Serialize, serde::Deserialize)]
 struct DevenvDef {
     bin: String,
-    session: bool,
+    mode: snapshot::Mode,
 }
 
 pub struct Driver {
@@ -77,24 +85,26 @@ impl ManagedDriver for Driver {
         _ctoken: &(dyn Cancellable + Send + Sync),
     ) -> anyhow::Result<ParseResponse> {
         let spec = DevenvSpec::from(&req.target_spec.config).with_context(|| "devenv spec")?;
-        let session = match spec.mode.as_deref() {
-            None | Some("snapshot") => false,
-            Some("session") => true,
-            Some(other) => {
-                anyhow::bail!("devenv `mode` must be \"snapshot\" or \"session\", got {other:?}")
-            }
+        let mode = match spec.mode.as_deref() {
+            None | Some("snapshot") => snapshot::Mode::Snapshot,
+            Some("session") => snapshot::Mode::Session,
+            Some("wrap") => snapshot::Mode::Wrap,
+            Some(other) => anyhow::bail!(
+                "devenv `mode` must be \"snapshot\", \"session\" or \"wrap\", got {other:?}"
+            ),
         };
         let def = DevenvDef {
             bin: spec.bin.unwrap_or_else(|| "devenv".to_string()),
-            session,
+            mode,
         };
 
         let mut h = xxhash_rust::xxh3::Xxh3::new();
         snapshot::SNAPSHOT_FORMAT_VERSION.hash(&mut h);
         def.bin.hash(&mut h);
         // The mode changes what the artifact contains (a session snapshot also
-        // carries the shell prelude), so it must change the key.
-        def.session.hash(&mut h);
+        // carries the shell prelude) and how it is consumed, so it must change
+        // the key.
+        def.mode.hash(&mut h);
         req.target_spec.addr.format().hash(&mut h);
 
         Ok(ParseResponse {
@@ -186,7 +196,7 @@ impl ManagedDriver for Driver {
             );
         }
 
-        let snap = snapshot_from_json(&out.stdout, &self.local_paths(), def.session)?;
+        let snap = snapshot_from_json(&out.stdout, &self.local_paths(), def.mode, def.bin.clone())?;
         if snap.env.is_empty() {
             anyhow::bail!(
                 "the devenv environment came out empty after filtering, which would describe \
@@ -263,7 +273,8 @@ struct PrintDevEnv {
 fn snapshot_from_json(
     stdout: &[u8],
     local: &LocalPaths,
-    with_prelude: bool,
+    mode: snapshot::Mode,
+    bin: String,
 ) -> anyhow::Result<Snapshot> {
     // `bashFunctions` in the wire format; serde's rename is applied here rather
     // than in the struct so the field name reads as Rust.
@@ -287,7 +298,7 @@ fn snapshot_from_json(
     // Only in session mode: the definitions are large, and a snapshot runner
     // cannot use them — carrying them anyway would bloat every consumer's cache
     // key for something nothing reads.
-    let prelude = if with_prelude {
+    let prelude = if mode == snapshot::Mode::Session {
         render_prelude(&parsed.bash_functions)
     } else {
         String::new()
@@ -297,6 +308,8 @@ fn snapshot_from_json(
         &parsed.variables,
         parsed.bash_functions.keys().cloned().collect(),
         local,
+        mode,
+        bin,
         prelude,
     ))
 }
@@ -419,8 +432,10 @@ impl ExecRunner for Runner {
             .map(|(k, v)| (std::ffi::OsString::from(k), std::ffi::OsString::from(v)))
             .collect();
 
-        if !snap.shell_prelude.is_empty() {
-            return self.open_session(&req, &snap, base_env).await;
+        match snap.mode {
+            snapshot::Mode::Session => return self.open_session(&req, &snap, base_env).await,
+            snapshot::Mode::Wrap => return Self::open_wrap(&req, &snap, base_env),
+            snapshot::Mode::Snapshot => {}
         }
 
         Ok(Arc::new(EnvSession::new(
@@ -449,6 +464,78 @@ impl ExecRunner for Runner {
 }
 
 impl Runner {
+    /// `mode = "wrap"`: prefix every spawn with `devenv shell --`.
+    ///
+    /// This is the tree's demonstration that the generic [`WrapSession`] lane
+    /// works — it is the shape a `docker exec` or `chroot` runner has — and it
+    /// is deliberately *not* the recommended way to use devenv. Three measured
+    /// reasons, in the order they will bite:
+    ///
+    /// 1. **Cost.** `devenv shell -- true` is ~4.5 s warm on this repo. Snapshot
+    ///    mode pays `devenv print-dev-env --json` **once, as a cached target**;
+    ///    this pays a full shell entry per spawn. A Go build is thousands of
+    ///    processes.
+    /// 2. **`enterShell` runs per target**, not per build. A shell that starts a
+    ///    service or writes to the tree does it once per spawn, which is exactly
+    ///    the side-effect-freedom the target model asks for.
+    /// 3. **It does not buy shell functions.** `devenv shell -- prog` execs
+    ///    `prog` directly with no functions defined (`declare -F` reports none),
+    ///    so the one thing `session` mode exists for is still missing here.
+    ///
+    /// Identity is therefore `Asserted`, not `Pinned`: the snapshot's bytes no
+    /// longer describe what the target runs in — the live shell does, per spawn,
+    /// outside any key.
+    ///
+    /// [`WrapEnv::Inherit`], because `devenv shell` execs the inner program and
+    /// the spec's environment carries through — unlike `docker exec`, which is
+    /// what the `Args` half of that enum is for.
+    fn open_wrap(
+        req: &OpenRequest,
+        snap: &Snapshot,
+        base_env: Vec<(std::ffi::OsString, std::ffi::OsString)>,
+    ) -> anyhow::Result<Arc<dyn ExecSession>> {
+        // `snap.bin` rather than a bare "devenv": the driver captured this
+        // snapshot with a specific binary and the wrapper must be the same one.
+        // It is in the def hash, so the key covers it.
+        let bin = if snap.bin.is_empty() {
+            "devenv"
+        } else {
+            snap.bin.as_str()
+        };
+        let prefix = vec![
+            std::ffi::OsString::from(bin),
+            std::ffi::OsString::from("shell"),
+            std::ffi::OsString::from("--"),
+        ];
+
+        Ok(Arc::new(hexec_runner::WrapSession::new(
+            prefix,
+            hexec_runner::WrapEnv::Inherit,
+            base_env,
+            SessionCaps {
+                pty: true,
+                max_concurrent: None,
+                identity: Identity::Asserted {
+                    why: "a `devenv shell` entered per spawn; what it produces is outside the \
+                          cache key, and `enterShell` runs once per target"
+                        .to_string(),
+                },
+            },
+            SessionDescription {
+                runner: req.runner_addr.clone(),
+                // Named, but still not callable: `devenv shell -- prog` execs
+                // `prog` rather than sourcing anything, so the diagnostic that
+                // says "that is a shell function" stays useful here.
+                shell_functions: snap.shell_functions.clone(),
+                key: req.key.clone(),
+                summary: format!(
+                    "devenv wrap: `{bin} shell --` per spawn, {} vars",
+                    snap.env.len()
+                ),
+            },
+        )?))
+    }
+
     /// `mode = "session"`: hold a `devenv shell` open with an agent inside it,
     /// and fork every target's process from there.
     async fn open_session(
@@ -477,7 +564,13 @@ impl Runner {
 
         // The agent runs INSIDE the shell — that is the whole difference from
         // snapshot mode. `devenv shell -- <cmd>` is the supported way in.
-        let mut cmd = std::process::Command::new("devenv");
+        // The binary the driver captured with, not whatever `devenv` a PATH
+        // resolves to — a configured `bin` was previously ignored here.
+        let mut cmd = std::process::Command::new(if snap.bin.is_empty() {
+            "devenv"
+        } else {
+            snap.bin.as_str()
+        });
         cmd.arg("shell")
             .arg("--")
             .arg(&support.heph_bin)
@@ -590,6 +683,133 @@ impl Runner {
 mod tests {
     use super::*;
 
+    fn snap_for(mode: snapshot::Mode) -> Snapshot {
+        let json = br#"{"bashFunctions":{"fmt":"  echo hi\n"},"variables":{"CC":{"type":"exported","value":"clang"},"PATH":{"type":"exported","value":"/nix/store/a/bin"}}}"#;
+        snapshot_from_json(
+            json,
+            &LocalPaths {
+                tree_root: "/r".to_string(),
+                home: "/h".to_string(),
+                tmpdir: String::new(),
+            },
+            mode,
+            "/nix/store/d/bin/devenv".into(),
+        )
+        .expect("snapshot")
+    }
+
+    fn open_req() -> OpenRequest {
+        OpenRequest {
+            key: "k".to_string(),
+            runner_addr: "//:devenv".to_string(),
+            artifacts: vec![],
+        }
+    }
+
+    fn a_spec() -> hproc::proc_exec::Spec {
+        hproc::proc_exec::Spec {
+            program: std::path::PathBuf::from("go"),
+            args: vec![std::ffi::OsString::from("build")],
+            env: vec![(
+                std::ffi::OsString::from("CC"),
+                std::ffi::OsString::from("mine"),
+            )],
+            cwd: std::path::PathBuf::from("/ws"),
+            stdin: hproc::proc_exec::StdioSpec::Null,
+            stdout: hproc::proc_exec::StdioSpec::Piped,
+            stderr: hproc::proc_exec::StdioSpec::Piped,
+            setsid: false,
+            ctty: false,
+        }
+    }
+
+    /// `wrap` defers each spawn to `devenv shell --`, using the binary the
+    /// driver captured with rather than whatever a PATH resolves to.
+    #[test]
+    fn wrap_mode_prefixes_every_spawn_with_devenv_shell() {
+        let snap = snap_for(snapshot::Mode::Wrap);
+        let session = Runner::open_wrap(&open_req(), &snap, vec![]).expect("wrap session");
+
+        let out = session.prepare(a_spec()).expect("prepare");
+        assert_eq!(
+            out.program,
+            std::path::PathBuf::from("/nix/store/d/bin/devenv")
+        );
+        let args: Vec<String> = out
+            .args
+            .iter()
+            .map(|a| a.to_string_lossy().into_owned())
+            .collect();
+        assert_eq!(args, vec!["shell", "--", "go", "build"]);
+    }
+
+    /// The target still wins on a collision, exactly as under `snapshot`.
+    ///
+    /// Only up to the point where `devenv shell` runs: it re-derives the
+    /// variables it owns and those win over what is handed in, which is one of
+    /// the reasons this mode is a demonstration rather than a recommendation.
+    #[test]
+    fn wrap_mode_puts_the_environment_under_the_target() {
+        let snap = snap_for(snapshot::Mode::Wrap);
+        let base = vec![
+            (
+                std::ffi::OsString::from("CC"),
+                std::ffi::OsString::from("clang"),
+            ),
+            (
+                std::ffi::OsString::from("EXTRA"),
+                std::ffi::OsString::from("1"),
+            ),
+        ];
+        let session = Runner::open_wrap(&open_req(), &snap, base).expect("wrap session");
+
+        let out = session.prepare(a_spec()).expect("prepare");
+        let cc = out
+            .env
+            .iter()
+            .find(|(k, _)| k == "CC")
+            .map(|(_, v)| v.to_string_lossy().into_owned());
+        assert_eq!(cc.as_deref(), Some("mine"), "the target's own value wins");
+        assert!(out.env.iter().any(|(k, _)| k == "EXTRA"));
+    }
+
+    /// A live shell entered per spawn cannot claim what a captured snapshot can.
+    #[test]
+    fn wrap_mode_is_asserted_not_pinned() {
+        let snap = snap_for(snapshot::Mode::Wrap);
+        let session = Runner::open_wrap(&open_req(), &snap, vec![]).expect("wrap session");
+        assert!(
+            !session.caps().identity.is_pinned(),
+            "wrap re-enters the shell per spawn, outside any cache key"
+        );
+    }
+
+    /// `wrap` has no prelude — and that is not a bug, it is the reason the mode
+    /// buys nothing over `snapshot` for shell functions: `devenv shell -- prog`
+    /// execs `prog` with no functions defined.
+    #[test]
+    fn wrap_mode_carries_no_prelude_and_still_names_the_functions() {
+        let snap = snap_for(snapshot::Mode::Wrap);
+        assert!(snap.shell_prelude.is_empty());
+        assert_eq!(snap.shell_functions, vec!["fmt"]);
+    }
+
+    /// The mode travels in the artifact, because `open` never sees a def.
+    #[test]
+    fn the_mode_round_trips_through_the_artifact() {
+        for mode in [
+            snapshot::Mode::Snapshot,
+            snapshot::Mode::Session,
+            snapshot::Mode::Wrap,
+        ] {
+            let snap = snap_for(mode);
+            let bytes = serde_json::to_vec(&snap).expect("encode");
+            let back: Snapshot = serde_json::from_slice(&bytes).expect("decode");
+            assert_eq!(back.mode, mode);
+            assert_eq!(back.bin, "/nix/store/d/bin/devenv");
+        }
+    }
+
     /// Session mode carries function *definitions*, snapshot mode only their
     /// names — the definitions are large and a snapshot runner cannot use them.
     #[test]
@@ -600,11 +820,13 @@ mod tests {
             home: "/h".to_string(),
             tmpdir: String::new(),
         };
-        let snap = snapshot_from_json(json, &local, false).expect("snapshot");
+        let snap = snapshot_from_json(json, &local, snapshot::Mode::Snapshot, "devenv".into())
+            .expect("snapshot");
         assert!(snap.shell_prelude.is_empty());
         assert_eq!(snap.shell_functions, vec!["fmt"]);
 
-        let sess = snapshot_from_json(json, &local, true).expect("session");
+        let sess = snapshot_from_json(json, &local, snapshot::Mode::Session, "devenv".into())
+            .expect("session");
         assert!(
             sess.shell_prelude.contains("fmt () {"),
             "{:?}",
@@ -658,7 +880,8 @@ mod tests {
                 home: "/home/u".to_string(),
                 tmpdir: String::new(),
             },
-            false,
+            snapshot::Mode::Snapshot,
+            "devenv".into(),
         )
         .expect("parse");
 

--- a/crates/plugin-devenv/src/plugindevenv/snapshot.rs
+++ b/crates/plugin-devenv/src/plugindevenv/snapshot.rs
@@ -15,7 +15,30 @@ use std::collections::BTreeMap;
 /// reason `NixDef.system` and `EXEC_DEF_FORMAT_VERSION` exist.
 /// v2: session-mode preludes gained `export -f`, without which a function was
 /// defined in a shell the target never runs in.
-pub const SNAPSHOT_FORMAT_VERSION: u32 = 2;
+/// v3: the artifact carries its own `mode` and `bin`. `open` used to infer the
+/// mode from whether `shell_prelude` was empty, which cannot tell `snapshot`
+/// from `wrap` — both have no prelude.
+pub const SNAPSHOT_FORMAT_VERSION: u32 = 3;
+
+/// How a consumer of this environment should create its processes.
+///
+/// It lives in the artifact because [`ExecRunner::open`] receives only the
+/// runner target's artifacts — no def — so this is the only way the decision
+/// can reach it. Folded into the driver's def hash, so changing it re-keys.
+#[derive(Debug, Clone, Copy, Default, Serialize, Deserialize, PartialEq, Eq, Hash)]
+#[serde(rename_all = "lowercase")]
+pub enum Mode {
+    /// Capture the environment once; every target is forked by heph with it
+    /// applied. The default, and the only mode whose identity is `Pinned`.
+    #[default]
+    Snapshot,
+    /// Additionally hold a `devenv shell` open and fork every target from
+    /// inside it, which is what makes shell functions callable.
+    Session,
+    /// Prefix every spawn with `devenv shell --`. See the runner's `open_wrap`
+    /// for why this is a demonstration rather than a recommendation.
+    Wrap,
+}
 
 /// The canonicalized environment. **This artifact _is_ the description** — the
 /// runner half does nothing but parse it, so everything the environment depends
@@ -23,6 +46,15 @@ pub const SNAPSHOT_FORMAT_VERSION: u32 = 2;
 #[derive(Debug, Clone, Default, Serialize, Deserialize, PartialEq, Eq)]
 pub struct Snapshot {
     pub format_version: u32,
+    /// How the runner half should consume this. Settled by the driver at
+    /// `parse`, carried here because `open` sees no def.
+    #[serde(default)]
+    pub mode: Mode,
+    /// The `devenv` binary this snapshot was captured with, so `wrap` and
+    /// `session` invoke the same one the driver did rather than whatever
+    /// `devenv` a PATH happens to resolve.
+    #[serde(default)]
+    pub bin: String,
     /// Sorted for a byte-stable artifact: an unsorted map would re-key every
     /// consumer on a whim of iteration order.
     pub env: BTreeMap<String, String>,
@@ -38,7 +70,7 @@ pub struct Snapshot {
     pub dropped_vars: Vec<String>,
     /// The shell functions' definitions, as a bash snippet.
     ///
-    /// Empty unless the target asked for `mode = "session"`. Carried in the
+    /// Empty unless [`Self::mode`] is [`Mode::Session`]. Carried in the
     /// artifact rather than re-derived at `open` for the same reason as
     /// everything else here: `open` runs after `hashin` and not at all on a
     /// cached build, so a definition discovered there would be unhashed input.
@@ -111,13 +143,22 @@ pub fn build(
     shell_functions: Vec<String>,
     local: &LocalPaths,
 ) -> Snapshot {
-    build_with_prelude(variables, shell_functions, local, String::new())
+    build_with_prelude(
+        variables,
+        shell_functions,
+        local,
+        Mode::Snapshot,
+        String::new(),
+        String::new(),
+    )
 }
 
 pub fn build_with_prelude(
     variables: &BTreeMap<String, Variable>,
     shell_functions: Vec<String>,
     local: &LocalPaths,
+    mode: Mode,
+    bin: String,
     shell_prelude: String,
 ) -> Snapshot {
     let mut env = BTreeMap::new();
@@ -164,6 +205,8 @@ pub fn build_with_prelude(
 
     Snapshot {
         format_version: SNAPSHOT_FORMAT_VERSION,
+        mode,
+        bin,
         env,
         shell_functions,
         dropped_path_entries,

--- a/crates/plugin-devenv/src/plugindevenv/snapshot.rs
+++ b/crates/plugin-devenv/src/plugindevenv/snapshot.rs
@@ -13,7 +13,9 @@ use std::collections::BTreeMap;
 /// a variable from the filter (a correctness fix) would leave every existing
 /// artifact keyed as though the old environment were still in force. The same
 /// reason `NixDef.system` and `EXEC_DEF_FORMAT_VERSION` exist.
-pub const SNAPSHOT_FORMAT_VERSION: u32 = 1;
+/// v2: session-mode preludes gained `export -f`, without which a function was
+/// defined in a shell the target never runs in.
+pub const SNAPSHOT_FORMAT_VERSION: u32 = 2;
 
 /// The canonicalized environment. **This artifact _is_ the description** — the
 /// runner half does nothing but parse it, so everything the environment depends
@@ -34,6 +36,14 @@ pub struct Snapshot {
     pub dropped_path_entries: Vec<String>,
     /// Variables dropped for naming a machine-local path.
     pub dropped_vars: Vec<String>,
+    /// The shell functions' definitions, as a bash snippet.
+    ///
+    /// Empty unless the target asked for `mode = "session"`. Carried in the
+    /// artifact rather than re-derived at `open` for the same reason as
+    /// everything else here: `open` runs after `hashin` and not at all on a
+    /// cached build, so a definition discovered there would be unhashed input.
+    #[serde(default, skip_serializing_if = "String::is_empty")]
+    pub shell_prelude: String,
 }
 
 /// Paths that make a snapshot machine-specific. A value mentioning any of them
@@ -101,6 +111,15 @@ pub fn build(
     shell_functions: Vec<String>,
     local: &LocalPaths,
 ) -> Snapshot {
+    build_with_prelude(variables, shell_functions, local, String::new())
+}
+
+pub fn build_with_prelude(
+    variables: &BTreeMap<String, Variable>,
+    shell_functions: Vec<String>,
+    local: &LocalPaths,
+    shell_prelude: String,
+) -> Snapshot {
     let mut env = BTreeMap::new();
     let mut dropped_vars = Vec::new();
     let mut dropped_path_entries = Vec::new();
@@ -149,6 +168,7 @@ pub fn build(
         shell_functions,
         dropped_path_entries,
         dropped_vars,
+        shell_prelude,
     }
 }
 

--- a/docs/EXEC_RUNNERS.md
+++ b/docs/EXEC_RUNNERS.md
@@ -91,30 +91,77 @@ discard.
 
 ## Modes
 
-A runner plugin returns a *description*; the host creates every process. The
-plugin never spawns, holds a process, or touches a descriptor.
+A runner returns a **session**, and every mode is a pure transformation of the
+process spec — `prepare(spec) -> spec`. That is what keeps `proc_exec::spawn`
+synchronous, its `Handle` invariants intact and its PTY handling in one place:
+no mode owns a process type of its own.
 
-| mode | what it is | notes |
-|---|---|---|
-| `Direct` | a base environment applied to a local fork | the devenv snapshot; no live process |
-| `Wrap` | a wrapper command prepended | container, `chroot`, `nix develop --command` |
-| `Agent` | processes forked by a helper inside a live environment | `devenv shell` held open |
-
-All three are pure transformations of the process spec. `Agent` reaches its
-helper through a client heph spawns as an ordinary child, which passes its own
-stdio descriptors over `SCM_RIGHTS` — passed, not proxied, so the bounded drain,
-the PTY handling and the supervisor are untouched.
+| mode | who forks the target | what `prepare` does | used by |
+|---|---|---|---|
+| `Local` | heph | nothing — the identity | the default |
+| `Env` | heph | layers env under the target's own | devenv `mode = "snapshot"` |
+| `Wrap` | the wrapper | prepends wrapper argv | devenv `mode = "wrap"` |
+| `Agent` | a helper inside a live environment | rewrites argv to the client | devenv `mode = "session"` |
 
 Sessions are pooled per environment (keyed by content, so byte-identical
 artifacts share one) and opened at most once. Teardown is explicit and
 idempotent: heph's hard-abort path exits without running destructors, so a
 `Drop`-only teardown would leak a container or shell exactly when it matters.
 
+### `__runner-agent` and `__runner-exec`
+
+Two hidden `heph` subcommands, used only by `Agent` mode. They exist for one
+reason, so it is worth stating plainly.
+
+The goal is *one* `devenv shell` for the whole build, with every target's
+process created inside it. But a process can only be created inside that shell
+by something already living there — so heph starts one helper there and asks it.
+That helper is **`heph __runner-agent`**: `devenv shell -- heph __runner-agent
+--socket S` runs it inside the environment, where it listens on a unix socket
+and forks a target on request.
+
+Which raises the real problem: heph now has a target process it did not fork.
+It cannot wait on it, cannot put it in a process group, and cannot give it a
+pipe or a PTY — a `Handle` can only be built for a child of *this* process, and
+all of heph's output streaming and cancellation is built on that.
+
+**`heph __runner-exec`** is the answer. Per target, heph forks it as an
+ordinary child, exactly as it would have forked the target itself:
+
+```
+heph ──fork──> __runner-exec ──socket──> __runner-agent ──fork──> the target
+                    │          SCM_RIGHTS      │
+                    └──── its own 0,1,2 ───────┘
+```
+
+It sends the command and hands over its own **stdio descriptors** — the ones
+heph already wired to the target's pipes or PTY. Passed, not proxied: the agent
+`dup2`s them onto the target's 0/1/2, so the bytes never travel through this
+path and none of the bounded-drain or line-discipline handling is re-derived on
+a new transport. Then it waits and exits with the target's real status.
+
+So from heph's side an `Agent`-mode target looks like any other child: one
+process it forked, whose output it reads and whose exit code it trusts. The
+client is that illusion, and it costs one small process per target.
+
+Two details that are not obvious:
+
+- The client forwards **its own environment** in the request, and the agent
+  applies it with `env_clear`. The agent lives inside the dev shell, so letting
+  a target inherit *its* environment would put the developer's ambient
+  `GOFLAGS` into every build — unhashed, under a lockfile-pinned key.
+- The target is `setsid` into its own session, so no kill heph issues reaches
+  it. The agent therefore watches the socket: when the client goes away — a
+  cancelled build — the peer hangs up and the agent kills the target's process
+  group. Without that, cancelling a build left its targets running to
+  completion.
+
 ## devenv
 
 ```python
 target(name = "env", driver = "devenv")                  # snapshot (default)
 target(name = "live", driver = "devenv", mode = "session")
+target(name = "wrapped", driver = "devenv", mode = "wrap")
 ```
 
 **Snapshot** captures `devenv print-dev-env --json` once as an artifact:
@@ -129,6 +176,22 @@ gets an error saying so by name rather than a misleading "not found in PATH".
 **Session** additionally holds a `devenv shell` open and forks every target's
 process from inside it, which is what makes those available. It costs one shell
 per heph process and cannot amortize across machines.
+
+**Wrap** (`mode = "wrap"`) prefixes every spawn with `devenv shell --`. It is a
+**demonstration of the `Wrap` lane, not a recommendation** — measured before it
+was written:
+
+- `devenv shell -- true` is **~4.5 s warm**. Snapshot pays `devenv
+  print-dev-env --json` once, as a *cached target*; wrap pays a full shell entry
+  per spawn, and a Go build is thousands of processes.
+- `enterShell` runs once per target rather than once per build, so any side
+  effect it has happens N times.
+- It does **not** buy shell functions: `devenv shell -- bash -c 'declare -F'`
+  reports none, because `devenv shell -- prog` execs `prog` directly.
+
+So its identity is `Asserted`, not `Pinned`. Reach for it only for a runner a
+handful of targets name — and note that the snapshot's `PATH` is store-only, so
+`bin` usually has to be an absolute path for `devenv` itself to be found.
 
 ## Go
 

--- a/src/commands/bootstrap.rs
+++ b/src/commands/bootstrap.rs
@@ -140,13 +140,17 @@ pub fn new_engine() -> anyhow::Result<(Arc<engine::Engine>, ShutdownTrigger)> {
     // Two halves of one plugin: the `devenv` driver captures the environment as
     // an artifact, the `devenv` runner reads it back. Registered under the same
     // name, which is how a runner target's driver selects its runner.
+    let runner_root = root.clone();
     {
         let devenv_root = root.clone();
         e.register_managed_driver(move |_| Box::new(plugindevenv::Driver::new(devenv_root)))?;
     }
     e.register_exec_runner(
         plugindevenv::NAME,
-        std::sync::Arc::new(plugindevenv::Runner),
+        std::sync::Arc::new(plugindevenv::Runner::new(session_support(
+            &home_dir,
+            &runner_root,
+        ))),
     )?;
 
     // Opt-in built-in factories — instantiated only when a `plugins: - { builtin:
@@ -268,6 +272,23 @@ fn hard_abort(exit: impl FnOnce(i32)) {
     exit(130);
 }
 
+/// What a `mode = "session"` runner needs: this binary (it is both the agent
+/// and the per-target client) and a directory for its sockets.
+///
+/// `None` when the current executable cannot be located — a session runner then
+/// fails saying so, rather than silently downgrading to a snapshot and running
+/// targets in an environment nobody asked for.
+fn session_support(
+    home_dir: &std::path::Path,
+    tree_root: &std::path::Path,
+) -> Option<plugindevenv::SessionSupport> {
+    Some(plugindevenv::SessionSupport {
+        heph_bin: std::env::current_exe().ok()?,
+        socket_dir: home_dir.join("exec-agents"),
+        tree_root: tree_root.to_path_buf(),
+    })
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -295,6 +316,7 @@ mod tests {
             .map(|p| root.join(p))
             .unwrap_or_else(|| root.join(".heph3"));
         let devenv_root = root.clone();
+        let runner_root = root.clone();
         let mut e = engine::Engine::new(engine::Config {
             root,
             home_dir: home_dir.clone(),
@@ -317,7 +339,10 @@ mod tests {
         e.register_managed_driver(move |_| Box::new(plugindevenv::Driver::new(devenv_root)))?;
         e.register_exec_runner(
             plugindevenv::NAME,
-            std::sync::Arc::new(plugindevenv::Runner),
+            std::sync::Arc::new(plugindevenv::Runner::new(session_support(
+                &home_dir,
+                &runner_root,
+            ))),
         )?;
 
         e.register_provider_factory("buildfile", |init, opts| {

--- a/src/commands/bootstrap.rs
+++ b/src/commands/bootstrap.rs
@@ -252,7 +252,7 @@ fn spawn_shutdown_handler(engine: Weak<engine::Engine>, mut rx: mpsc::UnboundedR
             return;
         }
         tracing::error!("second ctrl-c, aborting");
-        hard_abort(|code| std::process::exit(code));
+        hard_abort(engine.upgrade().as_deref(), |code| std::process::exit(code));
     });
 }
 
@@ -267,8 +267,15 @@ fn spawn_shutdown_handler(engine: Weak<engine::Engine>, mut rx: mpsc::UnboundedR
 /// registered a restore closure, so a non-interactive run's second Ctrl-C
 /// still exits with no extra work and no stray writes to a redirected
 /// stdout/stderr.
-fn hard_abort(exit: impl FnOnce(i32)) {
+fn hard_abort(engine: Option<&engine::Engine>, exit: impl FnOnce(i32)) {
     hcore::shutdown::restore_terminal();
+    // For the same reason the terminal restore is here: `exit` runs no
+    // destructors, so anything that must happen before the process disappears
+    // has to happen on this line rather than in a `Drop`. A live `docker run
+    // -d` container or a `devenv shell` would otherwise outlive heph.
+    if let Some(e) = engine {
+        e.shutdown_exec_sessions();
+    }
     exit(130);
 }
 
@@ -536,7 +543,7 @@ fs:
         });
 
         let mut exit_code = None;
-        hard_abort(|code| exit_code = Some(code));
+        hard_abort(None, |code| exit_code = Some(code));
 
         assert!(
             restored.load(std::sync::atomic::Ordering::SeqCst),
@@ -557,7 +564,7 @@ fs:
         hcore::shutdown::clear_terminal_restore();
 
         let mut exit_code = None;
-        hard_abort(|code| exit_code = Some(code));
+        hard_abort(None, |code| exit_code = Some(code));
 
         assert_eq!(exit_code, Some(130));
     }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -28,6 +28,8 @@ pub use hlock::hlock;
 pub use hmodel::{htaddr, htmatcher, htpkg, htquery};
 pub use hplugin::htspec;
 pub use hplugin_buildfile::pluginbuildfile;
+pub mod runner_agent;
+
 pub use hplugin_devenv::plugindevenv;
 pub use hplugin_exec::pluginexec;
 pub use hplugin_http::pluginhttp;

--- a/src/main.rs
+++ b/src/main.rs
@@ -33,6 +33,13 @@ fn main() -> ExitCode {
         heph::process_supervisor::run_supervisor_main(fd);
     }
 
+    // The exec-agent pair, for `Agent` sessions. Parsed here for the same reason
+    // as the supervisor: neither should pull clap, logging or a runtime into a
+    // process whose whole job is to fork one child.
+    if let Some(cmd) = heph::runner_agent::parse(std::env::args().skip(1)) {
+        return heph::runner_agent::run(cmd);
+    }
+
     // Dynamic shell completion. A no-op unless the `COMPLETE` env var is set
     // (a tab press or `heph tool completions` registration), in which case it
     // emits candidates / the registration script and exits the process. Runs

--- a/src/runner_agent.rs
+++ b/src/runner_agent.rs
@@ -145,8 +145,8 @@ fn run_agent(socket: &std::path::Path, prelude: Option<&std::path::Path>) -> Exi
             // A failed request is reported to its own client over the socket;
             // there is nothing useful for the agent to do with it here, and a
             // panic would take the whole session down for one target.
-            drop(agent::serve_one(conn, &move |req, stdio| {
-                exec_and_wait(req, stdio, prelude.as_deref())
+            drop(agent::serve_one(conn, &move |req, stdio, hangup| {
+                exec_and_wait(req, stdio, prelude.as_deref(), hangup)
             }));
         });
     }
@@ -165,6 +165,7 @@ fn exec_and_wait(
     req: ExecRequest,
     stdio: [RawFd; 3],
     prelude: Option<&str>,
+    hangup: RawFd,
 ) -> anyhow::Result<Option<i32>> {
     use std::os::unix::process::CommandExt as _;
 
@@ -212,8 +213,17 @@ fn exec_and_wait(
             req.argv.first().map_or("", String::as_str)
         )
     })?;
-    let status = child.wait()?;
-    Ok(status.code())
+
+    // Nothing else can kill this child. heph forked the client, not the target,
+    // and `setsid` above put the target in a session of its own — so a group
+    // kill from heph cannot reach it and neither can the session teardown. The
+    // client disappearing is the only cancellation signal that arrives here.
+    let watch = agent::HangupWatch::arm(hangup, child.id());
+    let status = child.wait();
+    // Before returning either way: the watcher borrows this connection's
+    // descriptor, which `serve_one` still has to write the reply on.
+    watch.disarm();
+    Ok(status?.code())
 }
 
 /// The child's pre-exec setup: point 0/1/2 at the descriptors the client sent,

--- a/src/runner_agent.rs
+++ b/src/runner_agent.rs
@@ -1,0 +1,294 @@
+//! The two hidden subcommands behind `Agent` exec sessions.
+//!
+//! - `heph __runner-agent --socket <path> [--prelude <file>]` runs *inside* the
+//!   environment (a `devenv shell`) and forks every target's process from there.
+//! - `heph __runner-exec --socket <path> -- <argv…>` is the per-target client
+//!   heph spawns as its own ordinary child, which hands the agent its own stdio
+//!   descriptors and exits with the child's status.
+//!
+//! Both are parsed before clap, like `__supervisor`, so neither drags the CLI
+//! or a tokio runtime into a path that must stay small.
+//!
+//! See `hexec_runner::agent` for why the client exists at all rather than heph
+//! talking to the agent directly.
+
+use hexec_runner::agent::{self, ExecReply, ExecRequest};
+use std::os::fd::RawFd;
+use std::path::PathBuf;
+use std::process::ExitCode;
+
+pub enum HiddenCommand {
+    Agent {
+        socket: PathBuf,
+        prelude: Option<PathBuf>,
+    },
+    Exec {
+        socket: PathBuf,
+        argv: Vec<String>,
+    },
+}
+
+/// Recognize the hidden invocations without clap.
+pub fn parse(mut args: impl Iterator<Item = String>) -> Option<HiddenCommand> {
+    match args.next()?.as_str() {
+        "__runner-agent" => {
+            let mut socket = None;
+            let mut prelude = None;
+            while let Some(a) = args.next() {
+                match a.as_str() {
+                    "--socket" => socket = args.next().map(PathBuf::from),
+                    "--prelude" => prelude = args.next().map(PathBuf::from),
+                    _ => return None,
+                }
+            }
+            Some(HiddenCommand::Agent {
+                socket: socket?,
+                prelude,
+            })
+        }
+        "__runner-exec" => {
+            let mut socket = None;
+            let mut argv = Vec::new();
+            while let Some(a) = args.next() {
+                match a.as_str() {
+                    "--socket" => socket = args.next().map(PathBuf::from),
+                    // Everything after `--` is the target's own command, which
+                    // must never be read as a flag of ours.
+                    "--" => {
+                        argv.extend(args.by_ref());
+                        break;
+                    }
+                    _ => return None,
+                }
+            }
+            if argv.is_empty() {
+                return None;
+            }
+            Some(HiddenCommand::Exec {
+                socket: socket?,
+                argv,
+            })
+        }
+        _ => None,
+    }
+}
+
+pub fn run(cmd: HiddenCommand) -> ExitCode {
+    match cmd {
+        HiddenCommand::Agent { socket, prelude } => run_agent(&socket, prelude.as_deref()),
+        HiddenCommand::Exec { socket, argv } => run_client(&socket, argv),
+    }
+}
+
+/// Client: hand the agent this process's own stdio and the command to run, then
+/// exit with whatever the child exited with.
+fn run_client(socket: &std::path::Path, argv: Vec<String>) -> ExitCode {
+    let req = ExecRequest {
+        argv,
+        // This process's environment IS the composed one — heph's driver built
+        // it and `proc_exec` applied it with `env_clear`. Forwarding it means
+        // the agent can `env_clear` on its side too, so the shell's own ambient
+        // variables never reach the target.
+        env: std::env::vars().collect(),
+        cwd: std::env::current_dir()
+            .map(|p| p.to_string_lossy().into_owned())
+            .unwrap_or_default(),
+        setsid: true,
+    };
+
+    // 0/1/2 are already wired to the target's pipes or PTY by heph. Passing the
+    // descriptors themselves, rather than proxying bytes, is what keeps the
+    // bounded drain and the PTY line discipline out of this path entirely.
+    let stdio: [RawFd; 3] = [0, 1, 2];
+
+    match agent::request(socket, &req, stdio) {
+        Ok(ExecReply::Exited { code }) => match code {
+            Some(c) => ExitCode::from(u8::try_from(c).unwrap_or(1)),
+            // Killed by a signal. 128+n is the shell convention; the exact
+            // signal is not recoverable through `ExitCode`, so report the
+            // generic "died on a signal" rather than inventing success.
+            None => ExitCode::from(137),
+        },
+        Ok(ExecReply::Error { message }) => {
+            eprintln!("exec agent: {message}");
+            ExitCode::FAILURE
+        }
+        Err(e) => {
+            eprintln!("exec agent: {e:#}");
+            ExitCode::FAILURE
+        }
+    }
+}
+
+/// Agent: serve requests until the listener is closed.
+fn run_agent(socket: &std::path::Path, prelude: Option<&std::path::Path>) -> ExitCode {
+    let listener = match agent::bind(socket) {
+        Ok(l) => l,
+        Err(e) => {
+            eprintln!("exec agent: bind {}: {e}", socket.display());
+            return ExitCode::FAILURE;
+        }
+    };
+    let prelude = prelude.and_then(|p| std::fs::read_to_string(p).ok());
+
+    // Removed on the way out so a clean exit does not leave a socket file that
+    // the next session would have to recognize as stale.
+    let _cleanup = SocketCleanup(socket.to_path_buf());
+
+    for conn in listener.incoming() {
+        let Ok(conn) = conn else { continue };
+        let prelude = prelude.clone();
+        // One thread per request: a target's process can run for minutes, and a
+        // single-threaded agent would serialize the whole build behind it —
+        // which is the opposite of what a shared session is for.
+        std::thread::spawn(move || {
+            // A failed request is reported to its own client over the socket;
+            // there is nothing useful for the agent to do with it here, and a
+            // panic would take the whole session down for one target.
+            drop(agent::serve_one(conn, &move |req, stdio| {
+                exec_and_wait(req, stdio, prelude.as_deref())
+            }));
+        });
+    }
+    ExitCode::SUCCESS
+}
+
+struct SocketCleanup(PathBuf);
+impl Drop for SocketCleanup {
+    fn drop(&mut self) {
+        drop(std::fs::remove_file(&self.0));
+    }
+}
+
+/// Fork/exec the request in this process's environment and wait for it.
+fn exec_and_wait(
+    req: ExecRequest,
+    stdio: [RawFd; 3],
+    prelude: Option<&str>,
+) -> anyhow::Result<Option<i32>> {
+    use std::os::unix::process::CommandExt as _;
+
+    // With a prelude, the command runs through bash so the environment's shell
+    // functions are defined first — which is the whole reason a devenv user
+    // reaches for `mode = "session"` over a snapshot.
+    let mut cmd = match prelude {
+        Some(p) => {
+            let mut c = std::process::Command::new("bash");
+            c.arg("-c")
+                .arg(format!("{p}\n\"$@\""))
+                .arg("--")
+                .args(&req.argv);
+            c
+        }
+        None => {
+            let (program, rest) = req
+                .argv
+                .split_first()
+                .ok_or_else(|| anyhow::anyhow!("empty argv"))?;
+            let mut c = std::process::Command::new(program);
+            c.args(rest);
+            c
+        }
+    };
+
+    cmd.current_dir(&req.cwd);
+    // `env_clear` is the point: this agent lives inside the devenv shell, so
+    // inheriting its environment would put the developer's ambient variables
+    // into every build — unhashed, under a key that reports as lockfile-pinned.
+    cmd.env_clear().envs(req.env.iter().map(|(k, v)| (k, v)));
+
+    let setsid = req.setsid;
+    // SAFETY: the closure runs in the forked child before `exec`, where the only
+    // calls it makes — `dup2` and `setsid` — are async-signal-safe and touch
+    // just that child's own descriptor table and session. The descriptors came
+    // from `recvmsg` and are open in this process, so they survive the fork.
+    unsafe {
+        cmd.pre_exec(move || redirect_and_detach(stdio, setsid));
+    }
+
+    let mut child = cmd.spawn().map_err(|e| {
+        anyhow::anyhow!(
+            "spawn {:?} inside the exec session: {e}",
+            req.argv.first().map_or("", String::as_str)
+        )
+    })?;
+    let status = child.wait()?;
+    Ok(status.code())
+}
+
+/// The child's pre-exec setup: point 0/1/2 at the descriptors the client sent,
+/// and start a new session so heph's supervisor can reap the whole tree.
+///
+/// Split out so each `unsafe` call states its own safety condition rather than
+/// hiding behind one block around the whole closure.
+fn redirect_and_detach(stdio: [RawFd; 3], setsid: bool) -> std::io::Result<()> {
+    for (target, src) in stdio.iter().enumerate() {
+        // SAFETY: async-signal-safe, and in the forked child `target` (0, 1 or
+        // 2) is ours to replace. `src` was received over the socket and is open.
+        let rc = unsafe { libc::dup2(*src, target as RawFd) };
+        if rc < 0 {
+            return Err(std::io::Error::last_os_error());
+        }
+    }
+    if setsid {
+        // SAFETY: async-signal-safe; the child is not already a process-group
+        // leader, having just been forked.
+        let rc = unsafe { libc::setsid() };
+        if rc < 0 {
+            return Err(std::io::Error::last_os_error());
+        }
+    }
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn parse_args(v: &[&str]) -> Option<HiddenCommand> {
+        parse(v.iter().map(|s| (*s).to_string()))
+    }
+
+    #[test]
+    fn an_ordinary_invocation_is_not_a_hidden_command() {
+        assert!(parse_args(&["run", "//x:y"]).is_none());
+        assert!(parse_args(&[]).is_none());
+    }
+
+    #[test]
+    fn the_agent_form_parses() {
+        match parse_args(&["__runner-agent", "--socket", "/s.sock"]) {
+            Some(HiddenCommand::Agent { socket, prelude }) => {
+                assert_eq!(socket, PathBuf::from("/s.sock"));
+                assert!(prelude.is_none());
+            }
+            other => panic!("expected an agent command, got {}", other.is_some()),
+        }
+    }
+
+    /// Everything after `--` belongs to the target. Without this, a target
+    /// running `foo --socket bar` would silently retarget the client.
+    #[test]
+    fn the_targets_own_flags_are_not_read_as_ours() {
+        match parse_args(&[
+            "__runner-exec",
+            "--socket",
+            "/s.sock",
+            "--",
+            "cargo",
+            "--socket",
+            "nope",
+        ]) {
+            Some(HiddenCommand::Exec { socket, argv }) => {
+                assert_eq!(socket, PathBuf::from("/s.sock"));
+                assert_eq!(argv, vec!["cargo", "--socket", "nope"]);
+            }
+            other => panic!("expected an exec command, got {}", other.is_some()),
+        }
+    }
+
+    #[test]
+    fn an_exec_with_no_command_is_rejected() {
+        assert!(parse_args(&["__runner-exec", "--socket", "/s.sock", "--"]).is_none());
+    }
+}


### PR DESCRIPTION
Phase 2b of #404, on top of #413 — **the last of the stack's core work**. `mode = "session"` holds a `devenv shell` open and forks every target's process from inside it; `WrapSession` covers container/chroot runners.

## Proved end to end

Against this repo's own devenv, the distinction the second mode exists for:

| | |
|---|---|
| shell function under `mode = "snapshot"` | **NOT available** |
| shell function under `mode = "session"` | **available** |

## Agent mode is a spec transformation, not an overridden spawn

The first sketch had `ExecSession::spawn` **overridden** for `Agent`. It cannot be: `spawn` returns a `proc_exec::Handle`, which can only be built for a child of *this* process — and the whole point of an agent is that the child is forked by something else. Returning a trait object instead would undo the reason `prepare` is the seam at all.

So `Agent` is **also a pure spec transformation**. The spec is rewritten to run `heph __runner-exec`, which heph spawns as its own ordinary child:

```
  heph ──spawn──> client ──unix socket──> agent (inside `devenv shell`)
                    │        SCM_RIGHTS         │
                    └── its own 0/1/2 ──────────┴──fork/exec──> the target
```

`Handle`, the bounded drain, the PTY and the supervisor keep working unchanged, and the child's stdio are the *same* descriptors — **passed, not proxied**. That is the property the fd-passing protocol exists to protect: a proxy would insert a copy loop between the target and the terminal, breaking PTY semantics and interactive output. Cancellation falls out: heph kills the client's process group, the agent sees the socket close.

## Two bugs the first end-to-end run found

**The agent must `env_clear`.** It lives inside the devenv shell, so inheriting its environment would put the developer's ambient `GOFLAGS`/`RUSTFLAGS`/PATH tail into every build — unhashed, under a key reporting as lockfile-pinned. That hole was missed when session mode was first analysed.

**Shell functions must be `export -f`'d.** Otherwise they're defined in a shell the target never runs in: `pluginexec` invokes every target through its own `bash -c`, and functions aren't inherited by a child shell unless exported. The first run reported the function still missing.

`SNAPSHOT_FORMAT_VERSION` → 2 for the prelude change, and it earned its keep immediately: without the bump the fix was invisible behind a cached v1 snapshot.

## `WrapSession`

Prepends a wrapper command. `WrapEnv` distinguishes wrappers that **exec** the inner program (`chroot`, `bwrap`, `nix develop --command` — the spec's env carries through) from those that create it **elsewhere** (`docker exec` — the environment must be rendered into the wrapper's own argv, or the container process sees none of it). The second kind reports *no enumerable environment* rather than handing back the host-side map as if it described what the inner process will see.

## Teardown is now wired — it wasn't

Nothing called `teardown()`. `ExecSessionPool` now runs every session's teardown explicitly, and idempotently: an orderly-only teardown leaks exactly when things aren't orderly, which is the `docker run -d` container and the devenv shell surviving Ctrl-C. Regression-tested (runs once, and not while the session is still in use).

## Tests

20 in `exec-runner` (SCM_RIGHTS round-trip proving descriptors arrive *open* on the far side, stale-vs-live socket handling, `Wrap` argv/env rendering, `Agent` spec rewrite, teardown handed over at most once), 9 in `plugin-devenv`, 4 in `runner_agent` (the `--` boundary, so a target's own `--socket` can't retarget the client), 12 e2e. `lint` clean — the fd-passing code is one unsafe operation per block, each with its own safety condition.

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>
