### PR TITLE
feat(exec-runner): runner-declared env, Go knobs, and examples

### DIFF
--- a/crates/exec-runner/src/lib.rs
+++ b/crates/exec-runner/src/lib.rs
@@ -517,45 +517,49 @@ pub struct SessionEnv {
 }
 
 impl SessionEnv {
-    /// The environment layer this runner contributes, lowest precedence first.
+    /// Host variables this runner passes through, resolved **now**.
     ///
-    /// Ordered to mirror what a *target's* own keys do in `pluginexec`
-    /// (`env` → `pass_env` → `runtime_pass_env` → `runtime_env`), so a reader
-    /// who knows one knows the other. Everything here still sits **underneath**
-    /// the caller's own entries — see [`ExecSession::prepare`].
+    /// The **weakest** layer — weaker than the environment the runner captured.
+    /// That ordering is deliberate and differs from a target's own keys, where
+    /// `runtime_pass_env` sits on top of `env`.
     ///
-    /// `runtime_*` are resolved here, at spawn, and not when the environment was
-    /// captured. That is the whole point of them.
-    pub fn layer(&self) -> Vec<(OsString, OsString)> {
+    /// The reason: a runner exists to *provide* an environment. If a passed-
+    /// through host variable outranked the captured one, `runtime_pass_env =
+    /// ["*"]` would silently replace that environment with the developer's own
+    /// — a devenv `CC` quietly becoming whatever `CC` the login shell had. The
+    /// build would still be keyed as though it ran in devenv. CI caught exactly
+    /// this: a runner declaring `CC=clang` and `"*"` produced `CC=gcc`, because
+    /// the runner ran on a machine whose environment set `CC`.
+    ///
+    /// A runner that genuinely wants to override its captured environment says
+    /// so with `runtime_env`, which is explicit and outranks it.
+    pub fn host_layer(&self) -> Vec<(OsString, OsString)> {
+        let mut out: Vec<(OsString, OsString)> = Vec::new();
+        if self.runtime_pass_env.iter().any(|n| n == "*") {
+            out.extend(std::env::vars_os());
+        } else {
+            for name in &self.runtime_pass_env {
+                if let Some(v) = std::env::var_os(name) {
+                    out.push((OsString::from(name), v));
+                }
+            }
+        }
+        out
+    }
+
+    /// What the runner declared literally: `env` (captured) then `runtime_env`
+    /// (applied at spawn), the latter winning. Both outrank the host layer and
+    /// the captured environment, and both lose to the target's own entries.
+    pub fn declared_layer(&self) -> Vec<(OsString, OsString)> {
         let mut out: Vec<(OsString, OsString)> =
             Vec::with_capacity(self.env.len() + self.runtime_env.len());
-
-        let put = |k: OsString, v: OsString, out: &mut Vec<(OsString, OsString)>| {
-            // Last writer wins *within* the layer, and no key appears twice —
-            // a duplicate would leave which value the child sees up to `execve`.
+        for (k, v) in self.env.iter().chain(self.runtime_env.iter()) {
+            let (k, v) = (OsString::from(k), OsString::from(v));
             if let Some(slot) = out.iter_mut().find(|(ek, _)| *ek == k) {
                 slot.1 = v;
             } else {
                 out.push((k, v));
             }
-        };
-
-        for (k, v) in &self.env {
-            put(OsString::from(k), OsString::from(v), &mut out);
-        }
-        if self.runtime_pass_env.iter().any(|n| n == "*") {
-            for (k, v) in std::env::vars_os() {
-                put(k, v, &mut out);
-            }
-        } else {
-            for name in &self.runtime_pass_env {
-                if let Some(v) = std::env::var_os(name) {
-                    put(OsString::from(name), v, &mut out);
-                }
-            }
-        }
-        for (k, v) in &self.runtime_env {
-            put(OsString::from(k), OsString::from(v), &mut out);
         }
         out
     }
@@ -619,12 +623,23 @@ impl ExecSession for EnvSession {
     /// then convert each again into `OsString`, which for a 60–150-variable dev
     /// shell is hundreds of allocations per executed target.
     fn prepare(&self, mut spec: Spec) -> Result<Spec, SpawnError> {
-        let runtime = self.declared.layer();
-        let mut env = Vec::with_capacity(self.base_env.len() + runtime.len() + spec.env.len());
-        for (k, v) in self.base_env.iter().chain(runtime.iter()) {
-            // The caller wins, and the later of base/runtime wins between
-            // themselves — which is what puts `runtime_env` above the captured
-            // environment, mirroring a target's own ordering.
+        // Weakest to strongest:
+        //   host passthrough  <  captured environment  <  declared literals  <  the target
+        //
+        // The first two are the order CI corrected: a `"*"` passthrough must not
+        // be able to replace the environment the runner was chosen to provide.
+        let host = self.declared.host_layer();
+        let declared = self.declared.declared_layer();
+        let mut env =
+            Vec::with_capacity(host.len() + self.base_env.len() + declared.len() + spec.env.len());
+        for (k, v) in host
+            .iter()
+            .chain(self.base_env.iter())
+            .chain(declared.iter())
+        {
+            // The target always wins, and within the runner's own layers the
+            // later one does. No key appears twice — a duplicate would leave
+            // which value the child sees up to `execve`.
             if spec.env.iter().any(|(sk, _)| sk == k) {
                 continue;
             }
@@ -1209,7 +1224,10 @@ mod session_env_tests {
             env: pairs(&[("CC", "clang")]),
             ..Default::default()
         };
-        assert_eq!(get(&se.layer(), "CC"), Some(&OsString::from("clang")));
+        assert_eq!(
+            get(&se.declared_layer(), "CC"),
+            Some(&OsString::from("clang"))
+        );
     }
 
     /// `runtime_env` sits above the captured `env`, mirroring the order a
@@ -1221,7 +1239,7 @@ mod session_env_tests {
             runtime_env: pairs(&[("MODE", "runtime")]),
             ..Default::default()
         };
-        let l = se.layer();
+        let l = se.declared_layer();
         assert_eq!(get(&l, "MODE"), Some(&OsString::from("runtime")));
         assert_eq!(
             l.iter().filter(|(k, _)| k == "MODE").count(),
@@ -1244,7 +1262,7 @@ mod session_env_tests {
             ..Default::default()
         };
         assert_eq!(
-            get(&se.layer(), "heph_TEST_RUNNER_RT_PASS"),
+            get(&se.host_layer(), "heph_TEST_RUNNER_RT_PASS"),
             Some(&OsString::from("from_host"))
         );
     }
@@ -1255,7 +1273,7 @@ mod session_env_tests {
             runtime_pass_env: vec!["heph_TEST_RUNNER_DEFINITELY_UNSET".to_string()],
             ..Default::default()
         };
-        assert!(get(&se.layer(), "heph_TEST_RUNNER_DEFINITELY_UNSET").is_none());
+        assert!(get(&se.host_layer(), "heph_TEST_RUNNER_DEFINITELY_UNSET").is_none());
     }
 
     /// `"*"` is the same escape hatch a target has: the whole host environment,
@@ -1271,62 +1289,93 @@ mod session_env_tests {
             ..Default::default()
         };
         assert_eq!(
-            get(&se.layer(), "heph_TEST_RUNNER_WILDCARD"),
+            get(&se.host_layer(), "heph_TEST_RUNNER_WILDCARD"),
             Some(&OsString::from("yes"))
         );
     }
 
-    /// …but even the wildcard stays underneath the target's own entries. A
-    /// runner that could overwrite `$OUT` or a target's `env` would silently
-    /// change what the target builds.
+    /// The ordering CI corrected, and the reason it is not a target's.
+    ///
+    /// A runner exists to *provide* an environment. If a passed-through host
+    /// variable outranked the captured one, `runtime_pass_env = ["*"]` would
+    /// silently replace that environment with the developer's own — and the
+    /// build would still be keyed as though it ran in the runner's. This failed
+    /// on both Linux legs, where the CI image sets `CC`: a runner declaring
+    /// `CC=clang` produced `CC=gcc`.
+    #[test]
+    fn the_captured_environment_outranks_a_host_passthrough() {
+        // SAFETY: process-global, and the name is this test's alone.
+        unsafe {
+            std::env::set_var("heph_TEST_RUNNER_CAPTURED", "from_host");
+        }
+        let session = EnvSession::with_declared(
+            vec![(
+                OsString::from("heph_TEST_RUNNER_CAPTURED"),
+                OsString::from("from_capture"),
+            )],
+            SessionEnv {
+                runtime_pass_env: vec!["*".to_string()],
+                ..Default::default()
+            },
+            caps(),
+            desc(),
+        );
+        let out = session.prepare(bare_spec()).expect("prepare");
+        assert_eq!(
+            get(&out.env, "heph_TEST_RUNNER_CAPTURED"),
+            Some(&OsString::from("from_capture")),
+            "a `*` passthrough must not replace what the runner captured",
+        );
+    }
+
+    /// …and `runtime_env` is how a runner overrides its own capture, because it
+    /// is explicit rather than whatever the host happened to have.
+    #[test]
+    fn runtime_env_can_override_the_capture_when_the_host_cannot() {
+        let session = EnvSession::with_declared(
+            vec![(OsString::from("MODE"), OsString::from("captured"))],
+            SessionEnv {
+                runtime_env: pairs(&[("MODE", "explicit")]),
+                ..Default::default()
+            },
+            caps(),
+            desc(),
+        );
+        let out = session.prepare(bare_spec()).expect("prepare");
+        assert_eq!(get(&out.env, "MODE"), Some(&OsString::from("explicit")));
+    }
+
+    /// Above all of it, the target. A runner that could overwrite `$OUT`, `$SRC`
+    /// or a target's own `env` would silently change what the target builds.
     #[test]
     fn the_target_still_wins_over_everything_the_runner_declares() {
-        // SAFETY: as above — a name used by this test alone.
+        // SAFETY: as above.
         unsafe {
             std::env::set_var("heph_TEST_RUNNER_COLLIDE", "from_host");
         }
         let session = EnvSession::with_declared(
-            vec![(OsString::from("CC"), OsString::from("clang"))],
+            vec![(
+                OsString::from("heph_TEST_RUNNER_COLLIDE"),
+                OsString::from("from_capture"),
+            )],
             SessionEnv {
                 runtime_env: pairs(&[("heph_TEST_RUNNER_COLLIDE", "from_runner")]),
                 runtime_pass_env: vec!["*".to_string()],
                 ..Default::default()
             },
-            SessionCaps {
-                pty: false,
-                max_concurrent: None,
-                identity: Identity::Pinned {
-                    by: "t".to_string(),
-                },
-            },
-            SessionDescription {
-                runner: "//:r".to_string(),
-                shell_functions: vec![],
-                key: "k".to_string(),
-                summary: String::new(),
-            },
+            caps(),
+            desc(),
         );
-
-        let spec = Spec {
-            program: PathBuf::from("/bin/true"),
-            args: vec![],
-            env: vec![(
-                OsString::from("heph_TEST_RUNNER_COLLIDE"),
-                OsString::from("from_target"),
-            )],
-            cwd: PathBuf::from("/"),
-            stdin: proc_exec::StdioSpec::Null,
-            stdout: proc_exec::StdioSpec::Null,
-            stderr: proc_exec::StdioSpec::Null,
-            setsid: false,
-            ctty: false,
-        };
+        let mut spec = bare_spec();
+        spec.env = vec![(
+            OsString::from("heph_TEST_RUNNER_COLLIDE"),
+            OsString::from("from_target"),
+        )];
         let out = session.prepare(spec).expect("prepare");
         assert_eq!(
             get(&out.env, "heph_TEST_RUNNER_COLLIDE"),
             Some(&OsString::from("from_target"))
         );
-        assert_eq!(get(&out.env, "CC"), Some(&OsString::from("clang")));
         assert_eq!(
             out.env
                 .iter()
@@ -1334,5 +1383,38 @@ mod session_env_tests {
                 .count(),
             1
         );
+    }
+
+    fn caps() -> SessionCaps {
+        SessionCaps {
+            pty: false,
+            max_concurrent: None,
+            identity: Identity::Pinned {
+                by: "t".to_string(),
+            },
+        }
+    }
+
+    fn desc() -> SessionDescription {
+        SessionDescription {
+            runner: "//:r".to_string(),
+            shell_functions: vec![],
+            key: "k".to_string(),
+            summary: String::new(),
+        }
+    }
+
+    fn bare_spec() -> Spec {
+        Spec {
+            program: PathBuf::from("/bin/true"),
+            args: vec![],
+            env: vec![],
+            cwd: PathBuf::from("/"),
+            stdin: proc_exec::StdioSpec::Null,
+            stdout: proc_exec::StdioSpec::Null,
+            stderr: proc_exec::StdioSpec::Null,
+            setsid: false,
+            ctty: false,
+        }
     }
 }

--- a/crates/exec-runner/src/lib.rs
+++ b/crates/exec-runner/src/lib.rs
@@ -470,6 +470,97 @@ mod tests {
     }
 }
 
+/// The environment a runner declares, in the same four shapes a target has.
+///
+/// The split is not cosmetic — it is where the cache key is drawn:
+///
+/// | | resolved | in the key |
+/// |---|---|---|
+/// | `env` | at snapshot time, literal | **yes** |
+/// | `pass_env` | at snapshot time, from the host | **yes** — the *value* is baked in |
+/// | `runtime_env` | at spawn, literal | the declaration only |
+/// | `runtime_pass_env` | at spawn, from the host | the *name* only |
+///
+/// The property that matters is the last row. `pass_env` bakes a host value
+/// into the environment's description, so changing that value correctly re-keys
+/// every target built in it. `runtime_pass_env` bakes only the *name*, and reads
+/// the value at spawn — so an `SSH_AUTH_SOCK` or a `DOCKER_HOST` that differs
+/// per machine and per login reaches the process without ever reaching a cache
+/// key. Using the wrong one of those two is the difference between a shared
+/// cache that works and one that serves a machine its neighbour's build.
+///
+/// The declarations themselves are hashed either way, because they live in the
+/// runner target's artifact and that artifact *is* the environment's identity.
+/// That is the honest line: heph will not pretend a different environment is the
+/// same one, but it will not put ambient host state in the key either.
+#[derive(Debug, Clone, Default, serde::Serialize, serde::Deserialize, PartialEq, Eq, Hash)]
+pub struct SessionEnv {
+    /// Literal variables, resolved when the environment was captured.
+    #[serde(default)]
+    pub env: Vec<(String, String)>,
+    /// Host variables whose **values** were captured with the environment.
+    ///
+    /// Already folded into `env` by the time a session is built; kept separately
+    /// so diagnostics can say where a value came from.
+    #[serde(default)]
+    pub pass_env: Vec<String>,
+    /// Literal variables applied at spawn rather than captured.
+    #[serde(default)]
+    pub runtime_env: Vec<(String, String)>,
+    /// Host variables read at spawn. Only the name is ever hashed.
+    ///
+    /// `"*"` passes the whole host environment, exactly as a target's
+    /// `runtime_pass_env` does — an escape hatch that puts the developer's
+    /// entire ambient environment underneath the target's own.
+    #[serde(default)]
+    pub runtime_pass_env: Vec<String>,
+}
+
+impl SessionEnv {
+    /// The environment layer this runner contributes, lowest precedence first.
+    ///
+    /// Ordered to mirror what a *target's* own keys do in `pluginexec`
+    /// (`env` → `pass_env` → `runtime_pass_env` → `runtime_env`), so a reader
+    /// who knows one knows the other. Everything here still sits **underneath**
+    /// the caller's own entries — see [`ExecSession::prepare`].
+    ///
+    /// `runtime_*` are resolved here, at spawn, and not when the environment was
+    /// captured. That is the whole point of them.
+    pub fn layer(&self) -> Vec<(OsString, OsString)> {
+        let mut out: Vec<(OsString, OsString)> =
+            Vec::with_capacity(self.env.len() + self.runtime_env.len());
+
+        let put = |k: OsString, v: OsString, out: &mut Vec<(OsString, OsString)>| {
+            // Last writer wins *within* the layer, and no key appears twice —
+            // a duplicate would leave which value the child sees up to `execve`.
+            if let Some(slot) = out.iter_mut().find(|(ek, _)| *ek == k) {
+                slot.1 = v;
+            } else {
+                out.push((k, v));
+            }
+        };
+
+        for (k, v) in &self.env {
+            put(OsString::from(k), OsString::from(v), &mut out);
+        }
+        if self.runtime_pass_env.iter().any(|n| n == "*") {
+            for (k, v) in std::env::vars_os() {
+                put(k, v, &mut out);
+            }
+        } else {
+            for name in &self.runtime_pass_env {
+                if let Some(v) = std::env::var_os(name) {
+                    put(OsString::from(name), v, &mut out);
+                }
+            }
+        }
+        for (k, v) in &self.runtime_env {
+            put(OsString::from(k), OsString::from(v), &mut out);
+        }
+        out
+    }
+}
+
 /// A `Direct` session: processes are forked from this process, with a base
 /// environment applied beneath the caller's own.
 ///
@@ -480,6 +571,10 @@ mod tests {
 #[derive(Debug)]
 pub struct EnvSession {
     base_env: Vec<(OsString, OsString)>,
+    /// The runner's declared `runtime_env` / `runtime_pass_env`, resolved on
+    /// every `prepare` rather than once at open — a host variable that changes
+    /// mid-build is meant to be seen.
+    declared: SessionEnv,
     caps: SessionCaps,
     description: SessionDescription,
 }
@@ -490,7 +585,19 @@ impl EnvSession {
         caps: SessionCaps,
         description: SessionDescription,
     ) -> Self {
+        Self::with_declared(base_env, SessionEnv::default(), caps, description)
+    }
+
+    /// [`Self::new`] with the runner's declared environment, whose `runtime_*`
+    /// parts are resolved at each spawn.
+    pub fn with_declared(
+        base_env: Vec<(OsString, OsString)>,
+        declared: SessionEnv,
+        caps: SessionCaps,
+        description: SessionDescription,
+    ) -> Self {
         Self {
+            declared,
             base_env,
             caps,
             description,
@@ -512,9 +619,21 @@ impl ExecSession for EnvSession {
     /// then convert each again into `OsString`, which for a 60–150-variable dev
     /// shell is hundreds of allocations per executed target.
     fn prepare(&self, mut spec: Spec) -> Result<Spec, SpawnError> {
-        let mut env = Vec::with_capacity(self.base_env.len() + spec.env.len());
-        for (k, v) in &self.base_env {
-            if !spec.env.iter().any(|(sk, _)| sk == k) {
+        let runtime = self.declared.layer();
+        let mut env = Vec::with_capacity(self.base_env.len() + runtime.len() + spec.env.len());
+        for (k, v) in self.base_env.iter().chain(runtime.iter()) {
+            // The caller wins, and the later of base/runtime wins between
+            // themselves — which is what puts `runtime_env` above the captured
+            // environment, mirroring a target's own ordering.
+            if spec.env.iter().any(|(sk, _)| sk == k) {
+                continue;
+            }
+            if let Some(slot) = env
+                .iter_mut()
+                .find(|(ek, _): &&mut (OsString, OsString)| ek == k)
+            {
+                slot.1 = v.clone();
+            } else {
                 env.push((k.clone(), v.clone()));
             }
         }
@@ -1066,5 +1185,154 @@ mod agent_session_tests {
         );
         assert!(s.teardown().is_some());
         assert!(s.teardown().is_none());
+    }
+}
+
+#[cfg(test)]
+mod session_env_tests {
+    use super::*;
+    use std::path::PathBuf;
+
+    fn pairs(v: &[(&str, &str)]) -> Vec<(String, String)> {
+        v.iter()
+            .map(|(k, x)| ((*k).to_string(), (*x).to_string()))
+            .collect()
+    }
+
+    fn get<'a>(env: &'a [(OsString, OsString)], key: &str) -> Option<&'a OsString> {
+        env.iter().find(|(k, _)| k == key).map(|(_, v)| v)
+    }
+
+    #[test]
+    fn literal_env_is_applied() {
+        let se = SessionEnv {
+            env: pairs(&[("CC", "clang")]),
+            ..Default::default()
+        };
+        assert_eq!(get(&se.layer(), "CC"), Some(&OsString::from("clang")));
+    }
+
+    /// `runtime_env` sits above the captured `env`, mirroring the order a
+    /// target's own keys are applied in.
+    #[test]
+    fn runtime_env_wins_over_captured_env() {
+        let se = SessionEnv {
+            env: pairs(&[("MODE", "captured")]),
+            runtime_env: pairs(&[("MODE", "runtime")]),
+            ..Default::default()
+        };
+        let l = se.layer();
+        assert_eq!(get(&l, "MODE"), Some(&OsString::from("runtime")));
+        assert_eq!(
+            l.iter().filter(|(k, _)| k == "MODE").count(),
+            1,
+            "a duplicate key would leave the child's value up to execve"
+        );
+    }
+
+    /// The property the split exists for: the *value* is read at spawn, so it
+    /// never reaches a cache key. Only the name was ever hashed.
+    #[test]
+    fn runtime_pass_env_reads_the_host_at_spawn() {
+        // SAFETY: process-global mutation, and the name is unique to this test,
+        // so no other test observes or races it.
+        unsafe {
+            std::env::set_var("heph_TEST_RUNNER_RT_PASS", "from_host");
+        }
+        let se = SessionEnv {
+            runtime_pass_env: vec!["heph_TEST_RUNNER_RT_PASS".to_string()],
+            ..Default::default()
+        };
+        assert_eq!(
+            get(&se.layer(), "heph_TEST_RUNNER_RT_PASS"),
+            Some(&OsString::from("from_host"))
+        );
+    }
+
+    #[test]
+    fn a_runtime_pass_env_name_absent_from_the_host_is_simply_not_set() {
+        let se = SessionEnv {
+            runtime_pass_env: vec!["heph_TEST_RUNNER_DEFINITELY_UNSET".to_string()],
+            ..Default::default()
+        };
+        assert!(get(&se.layer(), "heph_TEST_RUNNER_DEFINITELY_UNSET").is_none());
+    }
+
+    /// `"*"` is the same escape hatch a target has: the whole host environment,
+    /// underneath everything the target set itself.
+    #[test]
+    fn a_wildcard_passes_the_whole_host_environment() {
+        // SAFETY: as above — a name used by this test alone.
+        unsafe {
+            std::env::set_var("heph_TEST_RUNNER_WILDCARD", "yes");
+        }
+        let se = SessionEnv {
+            runtime_pass_env: vec!["*".to_string()],
+            ..Default::default()
+        };
+        assert_eq!(
+            get(&se.layer(), "heph_TEST_RUNNER_WILDCARD"),
+            Some(&OsString::from("yes"))
+        );
+    }
+
+    /// …but even the wildcard stays underneath the target's own entries. A
+    /// runner that could overwrite `$OUT` or a target's `env` would silently
+    /// change what the target builds.
+    #[test]
+    fn the_target_still_wins_over_everything_the_runner_declares() {
+        // SAFETY: as above — a name used by this test alone.
+        unsafe {
+            std::env::set_var("heph_TEST_RUNNER_COLLIDE", "from_host");
+        }
+        let session = EnvSession::with_declared(
+            vec![(OsString::from("CC"), OsString::from("clang"))],
+            SessionEnv {
+                runtime_env: pairs(&[("heph_TEST_RUNNER_COLLIDE", "from_runner")]),
+                runtime_pass_env: vec!["*".to_string()],
+                ..Default::default()
+            },
+            SessionCaps {
+                pty: false,
+                max_concurrent: None,
+                identity: Identity::Pinned {
+                    by: "t".to_string(),
+                },
+            },
+            SessionDescription {
+                runner: "//:r".to_string(),
+                shell_functions: vec![],
+                key: "k".to_string(),
+                summary: String::new(),
+            },
+        );
+
+        let spec = Spec {
+            program: PathBuf::from("/bin/true"),
+            args: vec![],
+            env: vec![(
+                OsString::from("heph_TEST_RUNNER_COLLIDE"),
+                OsString::from("from_target"),
+            )],
+            cwd: PathBuf::from("/"),
+            stdin: proc_exec::StdioSpec::Null,
+            stdout: proc_exec::StdioSpec::Null,
+            stderr: proc_exec::StdioSpec::Null,
+            setsid: false,
+            ctty: false,
+        };
+        let out = session.prepare(spec).expect("prepare");
+        assert_eq!(
+            get(&out.env, "heph_TEST_RUNNER_COLLIDE"),
+            Some(&OsString::from("from_target"))
+        );
+        assert_eq!(get(&out.env, "CC"), Some(&OsString::from("clang")));
+        assert_eq!(
+            out.env
+                .iter()
+                .filter(|(k, _)| k == "heph_TEST_RUNNER_COLLIDE")
+                .count(),
+            1
+        );
     }
 }

--- a/crates/plugin-devenv/src/plugindevenv/mod.rs
+++ b/crates/plugin-devenv/src/plugindevenv/mod.rs
@@ -24,6 +24,19 @@ use std::sync::Arc;
 
 pub const NAME: &str = "devenv";
 
+fn sorted(mut v: Vec<String>) -> Vec<String> {
+    v.sort();
+    v.dedup();
+    v
+}
+
+/// A `HashMap` iterates in an arbitrary order; the def hash must not.
+fn sorted_pairs(m: std::collections::HashMap<String, String>) -> Vec<(String, String)> {
+    let mut v: Vec<(String, String)> = m.into_iter().collect();
+    v.sort();
+    v
+}
+
 /// The snapshot file a `devenv` target produces.
 const OUT_NAME: &str = "devenv-env.json";
 
@@ -32,6 +45,20 @@ const OUT_NAME: &str = "devenv-env.json";
 struct DevenvSpec {
     /// The `devenv` binary. Defaults to `devenv` on the driver's PATH.
     bin: Option<String>,
+    /// Variables this runner adds on top of what devenv reported, as literals.
+    /// Captured with the environment, so changing one re-keys every target
+    /// built in it.
+    env: std::collections::HashMap<String, String>,
+    /// Host variables whose **values** are captured with the environment. Use
+    /// this for something that should re-key when it changes.
+    pass_env: Vec<String>,
+    /// Literal variables applied at spawn instead of being captured.
+    runtime_env: std::collections::HashMap<String, String>,
+    /// Host variables read at spawn. Only the *name* is ever hashed, so use
+    /// this for anything that legitimately differs per machine or per login —
+    /// `SSH_AUTH_SOCK`, `DOCKER_HOST`, a personal token. `"*"` passes the whole
+    /// host environment.
+    runtime_pass_env: Vec<String>,
     /// `"snapshot"` (default), `"session"` or `"wrap"`.
     ///
     /// `snapshot` captures the environment once and applies it to every target
@@ -55,6 +82,7 @@ struct DevenvSpec {
 struct DevenvDef {
     bin: String,
     mode: snapshot::Mode,
+    declared: hexec_runner::SessionEnv,
 }
 
 pub struct Driver {
@@ -93,9 +121,18 @@ impl ManagedDriver for Driver {
                 "devenv `mode` must be \"snapshot\", \"session\" or \"wrap\", got {other:?}"
             ),
         };
+        // Sorted on the way in so the def hash does not depend on map order —
+        // the same reason `NixDef` sorts its package list.
+        let declared = hexec_runner::SessionEnv {
+            env: sorted_pairs(spec.env),
+            pass_env: sorted(spec.pass_env),
+            runtime_env: sorted_pairs(spec.runtime_env),
+            runtime_pass_env: sorted(spec.runtime_pass_env),
+        };
         let def = DevenvDef {
             bin: spec.bin.unwrap_or_else(|| "devenv".to_string()),
             mode,
+            declared,
         };
 
         let mut h = xxhash_rust::xxh3::Xxh3::new();
@@ -105,6 +142,16 @@ impl ManagedDriver for Driver {
         // carries the shell prelude) and how it is consumed, so it must change
         // the key.
         def.mode.hash(&mut h);
+        // `env` and `pass_env` are folded into the captured environment, so they
+        // must move the key. `runtime_*` are hashed as *declarations* too — the
+        // artifact is the environment's identity, and heph will not claim two
+        // differently-declared environments are the same one. What stays out of
+        // the key is the ambient *value* a `runtime_pass_env` name pulls in,
+        // which is read at spawn and never written down.
+        def.declared.env.hash(&mut h);
+        def.declared.pass_env.hash(&mut h);
+        def.declared.runtime_env.hash(&mut h);
+        def.declared.runtime_pass_env.hash(&mut h);
         req.target_spec.addr.format().hash(&mut h);
 
         Ok(ParseResponse {
@@ -196,7 +243,13 @@ impl ManagedDriver for Driver {
             );
         }
 
-        let snap = snapshot_from_json(&out.stdout, &self.local_paths(), def.mode, def.bin.clone())?;
+        let snap = snapshot_from_json(
+            &out.stdout,
+            &self.local_paths(),
+            def.mode,
+            def.bin.clone(),
+            def.declared.clone(),
+        )?;
         if snap.env.is_empty() {
             anyhow::bail!(
                 "the devenv environment came out empty after filtering, which would describe \
@@ -275,6 +328,7 @@ fn snapshot_from_json(
     local: &LocalPaths,
     mode: snapshot::Mode,
     bin: String,
+    declared: hexec_runner::SessionEnv,
 ) -> anyhow::Result<Snapshot> {
     // `bashFunctions` in the wire format; serde's rename is applied here rather
     // than in the struct so the field name reads as Rust.
@@ -311,6 +365,7 @@ fn snapshot_from_json(
         mode,
         bin,
         prelude,
+        declared,
     ))
 }
 
@@ -438,8 +493,9 @@ impl ExecRunner for Runner {
             snapshot::Mode::Snapshot => {}
         }
 
-        Ok(Arc::new(EnvSession::new(
+        Ok(Arc::new(EnvSession::with_declared(
             base_env,
+            snap.declared.clone(),
             SessionCaps {
                 pty: true,
                 max_concurrent: None,
@@ -694,6 +750,7 @@ mod tests {
             },
             mode,
             "/nix/store/d/bin/devenv".into(),
+            Default::default(),
         )
         .expect("snapshot")
     }
@@ -820,13 +877,25 @@ mod tests {
             home: "/h".to_string(),
             tmpdir: String::new(),
         };
-        let snap = snapshot_from_json(json, &local, snapshot::Mode::Snapshot, "devenv".into())
-            .expect("snapshot");
+        let snap = snapshot_from_json(
+            json,
+            &local,
+            snapshot::Mode::Snapshot,
+            "devenv".into(),
+            Default::default(),
+        )
+        .expect("snapshot");
         assert!(snap.shell_prelude.is_empty());
         assert_eq!(snap.shell_functions, vec!["fmt"]);
 
-        let sess = snapshot_from_json(json, &local, snapshot::Mode::Session, "devenv".into())
-            .expect("session");
+        let sess = snapshot_from_json(
+            json,
+            &local,
+            snapshot::Mode::Session,
+            "devenv".into(),
+            Default::default(),
+        )
+        .expect("session");
         assert!(
             sess.shell_prelude.contains("fmt () {"),
             "{:?}",
@@ -882,6 +951,7 @@ mod tests {
             },
             snapshot::Mode::Snapshot,
             "devenv".into(),
+            Default::default(),
         )
         .expect("parse");
 

--- a/crates/plugin-devenv/src/plugindevenv/snapshot.rs
+++ b/crates/plugin-devenv/src/plugindevenv/snapshot.rs
@@ -15,9 +15,10 @@ use std::collections::BTreeMap;
 /// reason `NixDef.system` and `EXEC_DEF_FORMAT_VERSION` exist.
 /// v2: session-mode preludes gained `export -f`, without which a function was
 /// defined in a shell the target never runs in.
-/// v3: the artifact carries its own `mode` and `bin`. `open` used to infer the
-/// mode from whether `shell_prelude` was empty, which cannot tell `snapshot`
-/// from `wrap` — both have no prelude.
+/// v3: the runner's own `env`/`pass_env`/`runtime_env`/`runtime_pass_env`, and
+/// the artifact carrying its own `mode` and `bin`. `open` used to infer the mode
+/// from whether `shell_prelude` was empty, which cannot tell `snapshot` from
+/// `wrap` — both have no prelude.
 pub const SNAPSHOT_FORMAT_VERSION: u32 = 3;
 
 /// How a consumer of this environment should create its processes.
@@ -68,6 +69,11 @@ pub struct Snapshot {
     pub dropped_path_entries: Vec<String>,
     /// Variables dropped for naming a machine-local path.
     pub dropped_vars: Vec<String>,
+    /// What the runner target declared for itself, on top of what `devenv`
+    /// reported. `env`/`pass_env` are already folded into [`Snapshot::env`];
+    /// the `runtime_*` halves are resolved at each spawn instead.
+    #[serde(default, skip_serializing_if = "is_default_session_env")]
+    pub declared: hexec_runner::SessionEnv,
     /// The shell functions' definitions, as a bash snippet.
     ///
     /// Empty unless [`Self::mode`] is [`Mode::Session`]. Carried in the
@@ -138,6 +144,10 @@ fn is_store_path(p: &str) -> bool {
 ///    Dropping them also restores the layer-2 rule (`docs/EXEC_RUNNERS.md`
 ///    §4.4): a tool missing from the environment now fails loudly instead of
 ///    silently falling through to the host.
+fn is_default_session_env(e: &hexec_runner::SessionEnv) -> bool {
+    e == &hexec_runner::SessionEnv::default()
+}
+
 pub fn build(
     variables: &BTreeMap<String, Variable>,
     shell_functions: Vec<String>,
@@ -150,6 +160,7 @@ pub fn build(
         Mode::Snapshot,
         String::new(),
         String::new(),
+        hexec_runner::SessionEnv::default(),
     )
 }
 
@@ -160,6 +171,7 @@ pub fn build_with_prelude(
     mode: Mode,
     bin: String,
     shell_prelude: String,
+    declared: hexec_runner::SessionEnv,
 ) -> Snapshot {
     let mut env = BTreeMap::new();
     let mut dropped_vars = Vec::new();
@@ -197,6 +209,18 @@ pub fn build_with_prelude(
         env.insert(name.clone(), var.value.clone());
     }
 
+    // The runner's own `env` and `pass_env` go on top of what devenv reported:
+    // a target's runner is entitled to override the environment it captured,
+    // and both are hashed by being here, which is what makes overriding safe.
+    for (k, v) in &declared.env {
+        env.insert(k.clone(), v.clone());
+    }
+    for name in &declared.pass_env {
+        if let Ok(v) = std::env::var(name) {
+            env.insert(name.clone(), v);
+        }
+    }
+
     dropped_vars.sort();
     dropped_path_entries.sort();
     dropped_path_entries.dedup();
@@ -212,6 +236,7 @@ pub fn build_with_prelude(
         dropped_path_entries,
         dropped_vars,
         shell_prelude,
+        declared,
     }
 }
 

--- a/crates/plugin-go/src/plugingo/driver_compile.rs
+++ b/crates/plugin-go/src/plugingo/driver_compile.rs
@@ -123,6 +123,9 @@ struct GoCompileSpec {
     deps: HashMap<String, Vec<String>>,
     /// Declared outputs, grouped by name → list of output paths.
     out: HashMap<String, Vec<String>>,
+    /// Environment for the `go` invocation, injected by the provider from its
+    /// `goenv` option. Hashed, because it changes what the compiler is handed.
+    goenv: HashMap<String, String>,
 }
 
 #[derive(Clone, serde::Serialize, serde::Deserialize)]
@@ -144,15 +147,22 @@ struct GoCompileDef {
     golist_origin_id: Option<String>,
     /// origin_ids of the `go_embed_src` inputs (assets `go list` never saw).
     embed_src_origin_ids: Vec<String>,
+    /// Sorted `goenv` pairs. See [`GoCompileSpec::goenv`].
+    goenv: Vec<(String, String)>,
 }
 
 /// Bump to invalidate every cached `go_compile` archive whenever the compile
 /// command shape or embed resolution semantics change.
-const GO_COMPILE_FORMAT_VERSION: u32 = 4;
+/// v5: `goenv` — the provider's environment for Go tool invocations.
+const GO_COMPILE_FORMAT_VERSION: u32 = 5;
 
 impl Hash for GoCompileDef {
     fn hash<H: Hasher>(&self, state: &mut H) {
         GO_COMPILE_FORMAT_VERSION.hash(state);
+        // Changes what the compiler is handed, so it must key the cache — a
+        // `GOFLAGS` or `GOEXPERIMENT` arriving through `goenv` alters the
+        // archive exactly as a `gcflags` entry would.
+        self.goenv.hash(state);
         self.p_flag.hash(state);
         self.out_file.hash(state);
         self.goos.hash(state);
@@ -286,7 +296,11 @@ impl ManagedDriver for GoCompileDriver {
             })?
         };
 
+        let mut goenv: Vec<(String, String)> = spec.goenv.into_iter().collect();
+        // Sorted so the def hash does not depend on map order.
+        goenv.sort();
         let def = GoCompileDef {
+            goenv,
             p_flag: spec.p_flag,
             out_file: spec.out_file,
             goos: spec.goos,
@@ -388,6 +402,12 @@ impl ManagedDriver for GoCompileDriver {
             .with_context(|| format!("create gocache dir {gocache:?}"))?;
 
         let mut env: HashMap<String, String> = HashMap::new();
+        // The provider's `goenv` goes in FIRST, so the driver's own settings
+        // below win on a collision. `GOROOT`, `GOOS`/`GOARCH` and `GOWORK=off`
+        // are what make the build hermetic and match the target's variant —
+        // letting a config knob override them would silently build something
+        // other than the address asked for, under that address's cache key.
+        env.extend(def.goenv.iter().cloned());
         env.insert("GOOS".to_string(), def.goos.clone());
         env.insert("GOARCH".to_string(), def.goarch.clone());
         env.insert("GOROOT".to_string(), goroot.to_string_lossy().into_owned());
@@ -1323,8 +1343,12 @@ mod driver_tests {
         assert_eq!(def_hash(&compile_def(false)), NON_RACE_COMPILE_HASH);
     }
 
-    /// Pinned at `GO_COMPILE_FORMAT_VERSION` 4 (the `buildmode` field's version).
-    const NON_RACE_COMPILE_HASH: u64 = 11506013216469835997;
+    /// Pinned at `GO_COMPILE_FORMAT_VERSION` 5 (`goenv`).
+    ///
+    /// Moving this constant means every cached `go_compile` archive is
+    /// invalidated, so it changes only alongside a deliberate format bump —
+    /// which is what this test is for.
+    const NON_RACE_COMPILE_HASH: u64 = 7225497344155101483;
 
     fn compile_def(race: bool) -> GoCompileDef {
         GoCompileDef {
@@ -1342,6 +1366,7 @@ mod driver_tests {
             embed_variant: None,
             golist_origin_id: None,
             embed_src_origin_ids: vec![],
+            goenv: Vec::new(),
         }
     }
 
@@ -1362,6 +1387,7 @@ mod driver_tests {
             embed_variant: None,
             golist_origin_id: None,
             embed_src_origin_ids: vec![],
+            goenv: Vec::new(),
         };
         let a = mk(&["net", "os", "errors", "io", "crypto/rand"]);
         let b = mk(&["crypto/rand", "io", "net", "errors", "os"]);

--- a/crates/plugin-go/src/plugingo/driver_golist.rs
+++ b/crates/plugin-go/src/plugingo/driver_golist.rs
@@ -78,6 +78,9 @@ struct GoGolistSpec {
     deps: HashMap<String, Vec<String>>,
     /// Declared outputs, grouped by name → list of output paths.
     out: HashMap<String, Vec<String>>,
+    /// Environment for the `go list` invocation, injected by the provider from
+    /// its `goenv` option. Hashed: it changes what `go list` reports.
+    goenv: HashMap<String, String>,
 }
 
 impl GoGolistDriver {
@@ -126,6 +129,8 @@ struct GoGolistDef {
     thirdparty_download_addr: Option<String>,
     /// See [`GoGolistSpec::firstparty`].
     firstparty: bool,
+    /// Sorted `goenv` pairs. See [`GoGolistSpec::goenv`].
+    goenv: Vec<(String, String)>,
 }
 
 /// Bump to invalidate every cached `_golist` artifact whenever the driver's
@@ -136,11 +141,15 @@ struct GoGolistDef {
 /// work could carry empty `EmbedFiles` for a now-resolvable embed, surfacing as
 /// `compute embedcfg: //go:embed pattern(s) matched no files` until evicted.
 /// v17: `firstparty` joined the def, changing every golist target's def hash.
-const GO_GOLIST_FORMAT_VERSION: u32 = 17;
+/// v18: `goenv` — the provider's environment for Go tool invocations.
+const GO_GOLIST_FORMAT_VERSION: u32 = 18;
 
 impl Hash for GoGolistDef {
     fn hash<H: Hasher>(&self, state: &mut H) {
         GO_GOLIST_FORMAT_VERSION.hash(state);
+        // `GOFLAGS`, `GOPRIVATE` and friends change what `go list` reports, so
+        // they must key the result exactly as the toolchain version does.
+        self.goenv.hash(state);
         self.import_path.hash(state);
         self.goos.hash(state);
         self.goarch.hash(state);
@@ -225,7 +234,11 @@ impl ManagedDriver for GoGolistDriver {
             }
         }
 
+        let mut goenv: Vec<(String, String)> = spec.goenv.into_iter().collect();
+        // Sorted so the def hash does not depend on map order.
+        goenv.sort();
         let def = GoGolistDef {
+            goenv,
             import_path: spec.import_path,
             goos: spec.goos,
             goarch: spec.goarch,
@@ -332,6 +345,8 @@ impl ManagedDriver for GoGolistDriver {
         )?;
 
         let mut env: HashMap<String, String> = HashMap::new();
+        // First, so the driver's own hermetic settings below win a collision.
+        env.extend(def.goenv.iter().cloned());
         env.insert("GOOS".to_string(), def.goos.clone());
         env.insert("GOARCH".to_string(), def.goarch.clone());
         env.insert("GOROOT".to_string(), goroot.to_string_lossy().into_owned());
@@ -998,6 +1013,7 @@ mod tests {
             dep_inputs: vec![],
             thirdparty_download_addr: None,
             firstparty: true,
+            goenv: Vec::new(),
         }
     }
 
@@ -1047,7 +1063,7 @@ mod tests {
     /// Pinned pre-`race` value of `def_hash(def_with(false, vec![]))`. Update it
     /// only alongside a deliberate `GO_GOLIST_FORMAT_VERSION` bump — a change
     /// here means every cached listing is being thrown away.
-    const NON_RACE_GOLIST_HASH: u64 = 642058481220411298;
+    const NON_RACE_GOLIST_HASH: u64 = 15939173556682426525;
 
     fn def_hash(def: &GoGolistDef) -> u64 {
         use std::hash::{Hash, Hasher};

--- a/crates/plugin-go/src/plugingo/provider.rs
+++ b/crates/plugin-go/src/plugingo/provider.rs
@@ -43,6 +43,21 @@ use std::path::{Path, PathBuf};
 use std::sync::Arc;
 
 pub struct Config {
+    /// Environment added to every Go *tool* invocation — `go list`, the
+    /// compiler and assembler, `heph-govet`. From the optional `goenv` provider
+    /// option.
+    ///
+    /// Applied by injecting it into each Go target's spec, where it is hashed,
+    /// rather than by the drivers reading it from config at run time: an
+    /// invisible knob that changes compiler input without moving the cache key
+    /// would serve every machine artifacts built under settings the key does
+    /// not record.
+    ///
+    /// Deliberately not applied to the `test`/`xtest` targets, which run the
+    /// built binary rather than a Go tool — their environment is
+    /// `provider_state(test={...})`, and conflating "how it was built" with
+    /// "how it runs" is what that separation exists to avoid.
+    pub goenv: HashMap<String, String>,
     /// Toolchain spec every build/test/list target resolves against. Either a
     /// pinned version (hermetic SDK at `//@heph/go/toolchain/<go_version>:go`)
     /// or [`toolchain::HOST`] (use the host `go`). Set via the required `gotool`
@@ -100,6 +115,7 @@ pub struct Config {
 impl Default for Config {
     fn default() -> Self {
         Self {
+            goenv: HashMap::new(),
             go_version: toolchain::DEFAULT_GO_VERSION.to_string(),
             sdk_checksums: HashMap::new(),
             govet: govet::default_addr(),
@@ -119,6 +135,8 @@ pub struct Provider {
 }
 
 pub(crate) struct ProviderInner {
+    /// See [`Config::goenv`].
+    goenv: HashMap<String, String>,
     workspace_root: PathBuf,
     /// Go release the hermetic toolchain is pinned to (see [`Config::go_version`]).
     go_version: String,
@@ -260,7 +278,7 @@ impl Provider {
         hplugin::config::deny_unknown(
             "go provider",
             opts,
-            &["gotool", "govet", "cctool", "skip", "checksums"],
+            &["gotool", "govet", "cctool", "skip", "checksums", "goenv"],
         )?;
         let go_version: String = hplugin::config::decode_opt(opts, "go provider", "gotool")?
             .ok_or_else(|| {
@@ -295,6 +313,17 @@ impl Provider {
         let mut globs = skip_globs.to_vec();
         let user_skip: Vec<String> =
             hplugin::config::decode_opt(opts, "go provider", "skip")?.unwrap_or_default();
+        // Optional: extra environment for every Go *tool* invocation — `go
+        // list`, the compiler, the assembler, `heph-govet`. `GOPRIVATE`,
+        // `GOFLAGS`, a corporate `GOPROXY` and its `GONOSUMDB` all belong here.
+        //
+        // It goes into each target's hashed `goenv` config rather than being
+        // applied behind the drivers' backs, so changing it invalidates
+        // everything it could have changed. A knob that altered compiler input
+        // without moving the cache key would hand every machine artifacts built
+        // under settings the key does not record.
+        let goenv: HashMap<String, String> =
+            hplugin::config::decode_opt(opts, "go provider", "goenv")?.unwrap_or_default();
         globs.extend(user_skip);
         let skip = Arc::new(Ignore::new(skip_dirs, &globs)?);
         Self::with_config(
@@ -306,6 +335,7 @@ impl Provider {
                 cctool,
                 skip,
                 walker,
+                goenv,
                 ..Default::default()
             },
             runtime,
@@ -319,6 +349,7 @@ impl Provider {
     ) -> anyhow::Result<Self> {
         Ok(Self {
             inner: Arc::new(ProviderInner {
+                goenv: config.goenv,
                 workspace_root,
                 go_version: config.go_version,
                 sdk_checksums: config.sdk_checksums,
@@ -451,7 +482,11 @@ impl ProviderTrait for Provider {
         _ctoken: &'a (dyn Cancellable + Send + Sync),
     ) -> BoxFuture<'a, Result<GetResponse, GetError>> {
         let inner = Arc::clone(&self.inner);
-        Box::pin(async move { inner.handle_get(req).await })
+        Box::pin(async move {
+            let mut resp = Arc::clone(&inner).handle_get(req).await?;
+            inner.apply_goenv(&mut resp.target_spec);
+            Ok(resp)
+        })
     }
 
     fn probe<'a>(
@@ -1210,6 +1245,7 @@ fn parse_str_map(v: &Value) -> anyhow::Result<BTreeMap<String, String>> {
 /// typos / unsupported knobs (the `test` map only configures env, never
 /// enable/disable — that's the bool `test = False`).
 const TEST_STATE_KEYS: &[&str] = &[
+    "runner",
     "env",
     "runtime_env",
     "pass_env",
@@ -1241,6 +1277,69 @@ fn applicable_states<'a>(states: &'a [State], addr_pkg: &str, key: &str) -> Vec<
         .collect();
     out.sort_by_key(|s| s.package.as_str().len());
     out
+}
+
+/// Parse `test = {"runner": …}` the same way a BUILD file's `runner =` is
+/// parsed: a target address, or the reserved `"local"` to opt out of the
+/// workspace default.
+///
+/// A bare name is rejected rather than guessed at, for the reason that rule
+/// exists at all — only a target has a hashout, and a hashout is what carries
+/// the environment into the cache key. Relative addresses resolve against the
+/// package that declared the state, so a state written in `//svc` can say
+/// `:devenv`.
+fn parse_test_runner(
+    v: &Value,
+    state_pkg: &hmodel::htpkg::PkgBuf,
+) -> anyhow::Result<hplugin::provider::RunnerRef> {
+    let Value::String(s) = v else {
+        anyhow::bail!("test.runner must be a string, got {v:?}");
+    };
+    if s == hplugin::provider::RUNNER_LOCAL {
+        return Ok(hplugin::provider::RunnerRef::Local);
+    }
+    if !s.contains("//") && !s.contains(':') {
+        anyhow::bail!(
+            "test.runner must be a target address (e.g. `//:devenv`) or \"local\"; got the bare \
+             name {s:?}"
+        );
+    }
+    Ok(hplugin::provider::RunnerRef::Target(
+        hmodel::htaddr::parse_addr_with_base(s, state_pkg)?,
+    ))
+}
+
+/// Drivers that invoke the **Go toolchain**, and therefore take `goenv`.
+///
+/// An allowlist, for two reasons. `go_toolchain` downloads an SDK and
+/// `go_testmain` writes a file, so handing them an environment they never use
+/// would put it in their cache key for nothing — and re-key every target that
+/// depends on them whenever the knob changed. And the lint/format drivers exec
+/// `heph-govet`, not `go`: `goenv` is the environment for the *Go toolchain*,
+/// and stretching it to cover a different binary would make the name a lie.
+const GO_TOOL_DRIVERS: &[&str] = &["go_compile", "go_golist"];
+
+impl ProviderInner {
+    /// Put the provider's `goenv` on a spec bound for a Go-tool driver.
+    ///
+    /// One choke point rather than a line in each of the two dozen places a
+    /// spec is built: a knob that reached most of them would be worse than one
+    /// that reached none, because the gap would show up as a cache hit on an
+    /// archive built under different settings.
+    fn apply_goenv(&self, spec: &mut hplugin::provider::TargetSpec) {
+        if self.goenv.is_empty() || !GO_TOOL_DRIVERS.contains(&spec.driver.as_str()) {
+            return;
+        }
+        // Sorted, so the def hash does not depend on `HashMap` order.
+        let mut pairs: Vec<(String, Value)> = self
+            .goenv
+            .iter()
+            .map(|(k, v)| (k.clone(), Value::String(v.clone())))
+            .collect();
+        pairs.sort_by(|a, b| a.0.cmp(&b.0));
+        spec.config
+            .insert("goenv".to_string(), Value::Map(pairs.into_iter().collect()));
+    }
 }
 
 fn pick_test_env(states: &[State], addr_pkg: &str) -> anyhow::Result<target_test::TestEnv> {
@@ -1277,6 +1376,12 @@ fn pick_test_env(states: &[State], addr_pkg: &str) -> anyhow::Result<target_test
         if let Some(v) = test_map.get("runtime_pass_env") {
             out.runtime_pass_env.extend(
                 parse_strings(v).context("parsing test runtime_pass_env from go provider_state")?,
+            );
+        }
+        if let Some(v) = test_map.get("runner") {
+            out.runner = Some(
+                parse_test_runner(v, &state.package)
+                    .context("parsing test runner from go provider_state")?,
             );
         }
         if let Some(v) = test_map.get("pre_run") {

--- a/crates/plugin-go/src/plugingo/target_test.rs
+++ b/crates/plugin-go/src/plugingo/target_test.rs
@@ -15,6 +15,23 @@ use std::collections::{BTreeMap, HashMap};
 /// `runtime_env`/`runtime_pass_env` are runtime-only (not hashed).
 #[derive(Debug, Default, Clone)]
 pub struct TestEnv {
+    /// Exec environment the *test binary* runs in, from
+    /// `provider_state(provider="go", test={"runner": "//:devenv"})`.
+    ///
+    /// Only the `test`/`xtest` targets — the ones that execute — take it.
+    /// Compiles deliberately do not: a test binary often needs a database
+    /// client, a browser or a service on PATH, while the build wants the
+    /// hermetic toolchain and nothing else. Applying one environment to both
+    /// would either leak the runtime's tools into every compile's cache key or
+    /// force the build environment onto the test.
+    ///
+    /// `None` leaves the target on whatever the workspace default is;
+    /// `RunnerRef::Local` opts out of that default.
+    ///
+    /// Already parsed and validated by the provider, where the rest of the
+    /// `test = {...}` map is checked, so a bad value fails there with the other
+    /// state errors rather than here.
+    pub runner: Option<hplugin::provider::RunnerRef>,
     pub env: BTreeMap<String, String>,
     pub runtime_env: BTreeMap<String, String>,
     pub pass_env: Vec<String>,
@@ -336,6 +353,7 @@ pub fn test_spec(
         driver: driver.to_string(),
         config,
         labels,
+        runner: test_env.runner.clone(),
         ..Default::default()
     }
 }
@@ -827,6 +845,7 @@ mod tests {
             pass_env: vec!["HOME".to_string()],
             runtime_pass_env: vec!["PATH".to_string()],
             pre_run: Vec::new(),
+            runner: None,
         };
         let spec = test_spec(
             mk_addr("mypkg", "test"),

--- a/example/.hephconfig2
+++ b/example/.hephconfig2
@@ -9,7 +9,6 @@ plugins:
         - BUILD
   - builtin: exec
   - builtin: bash
-  - builtin: sh
   # The go plugin: one manifest names the cdylib for this host. The provider + its
   # go_* drivers all come from that one library. Installed to the user-global
   # ~/.heph by the `gen-example` script (which runs `install-go-plugin`).

--- a/example/devenv.nix
+++ b/example/devenv.nix
@@ -1,0 +1,15 @@
+# The environment the `//exec_runner:*` examples build in.
+#
+# It lives at the workspace root because that is where `devenv` looks: the
+# `devenv` driver runs `devenv print-dev-env` against the tree root, so a
+# workspace has one devenv environment, not one per package.
+{ pkgs, ... }:
+{
+  # On PATH inside the environment, and NOT on the host's — which is what the
+  # `needs_jq` / `no_jq_without_runner` pair demonstrates.
+  packages = [ pkgs.jq ];
+
+  # Reported by `devenv print-dev-env`, so it is captured into the snapshot and
+  # is part of every consuming target's cache key.
+  env.FROM_DEVENV_NIX = "captured";
+}

--- a/example/devenv.yaml
+++ b/example/devenv.yaml
@@ -1,0 +1,3 @@
+inputs:
+  nixpkgs:
+    url: github:cachix/devenv-nixpkgs/rolling

--- a/example/exec_runner/BUILD
+++ b/example/exec_runner/BUILD
@@ -1,0 +1,137 @@
+# Exec runners: choosing the environment a target's processes run in.
+#
+# See docs/EXEC_RUNNERS.md. Requires `devenv` on PATH (https://devenv.sh); the
+# first run evaluates the environment and caches it, so it is slow once and
+# free afterwards.
+#
+#   heph run //exec_runner:needs_jq
+#   heph inspect runners
+#   heph inspect def //exec_runner:needs_jq      # shows which runner, and why
+
+# The runner itself is an ordinary target. Its ARTIFACT is the environment's
+# identity, which is why `runner =` names a target rather than a config string:
+# only a target has a hashout, and that is what carries the environment into
+# every consumer's cache key.
+devenv_env = target(
+    name = "env",
+    driver = "devenv",
+)
+
+# `jq` comes from devenv.nix's `packages`, so this only builds under the runner.
+target(
+    name = "needs_jq",
+    driver = "bash",
+    run = "jq --version > $OUT",
+    out = "out.txt",
+    runner = devenv_env,
+)
+
+# The same command with no runner. It FAILS, and that is the point: the runner's
+# PATH replaces the driver's rather than sitting on top of it, so a tool missing
+# from the environment does not quietly fall through to the host.
+#
+#   heph run //exec_runner:no_jq_without_runner   # expected to fail
+target(
+    name = "no_jq_without_runner",
+    driver = "bash",
+    run = "jq --version > $OUT",
+    out = "out.txt",
+)
+
+# A variable devenv.nix itself sets. Captured into the snapshot, so it is in the
+# cache key.
+target(
+    name = "reads_devenv_env",
+    driver = "bash",
+    run = "test \"$FROM_DEVENV_NIX\" = captured && echo ok > $OUT",
+    out = "out.txt",
+    runner = devenv_env,
+)
+
+# ---------------------------------------------------------------------------
+# A runner declaring its own environment.
+#
+# Four keys, the same four a target has — and the split between them is where
+# the cache key is drawn:
+#
+#   env               literal, captured  -> in the key
+#   pass_env          host VALUE captured -> in the key (changing it re-keys)
+#   runtime_env       literal, at spawn  -> declaration in the key
+#   runtime_pass_env  host value at SPAWN -> only the NAME is ever hashed
+#
+# The last row is the one that matters. `SSH_AUTH_SOCK` differs per machine and
+# per login; passing it with `pass_env` would bake one machine's value into the
+# environment's identity and hand every other machine a cache key that lies.
+# `runtime_pass_env` reads it at spawn, so it reaches the process and never the
+# key.
+declared_env = target(
+    name = "declared",
+    driver = "devenv",
+    env = {"BUILD_CHANNEL": "stable"},
+    pass_env = ["LANG"],
+    runtime_env = {"NOISY_DEBUG": "1"},
+    runtime_pass_env = ["SSH_AUTH_SOCK"],
+)
+
+target(
+    name = "uses_declared",
+    driver = "bash",
+    run = "echo \"channel=$BUILD_CHANNEL debug=$NOISY_DEBUG\" > $OUT",
+    out = "out.txt",
+    runner = declared_env,
+)
+
+# A target always wins over its runner. Everything above is applied UNDERNEATH
+# what the target sets itself, so a runner can never silently change what a
+# target builds — including `$OUT` and the sandbox's own routing.
+target(
+    name = "target_wins",
+    driver = "bash",
+    run = "test \"$BUILD_CHANNEL\" = mine && echo ok > $OUT",
+    out = "out.txt",
+    env = {"BUILD_CHANNEL": "mine"},
+    runner = declared_env,
+)
+
+# ---------------------------------------------------------------------------
+# Session mode: a `devenv shell` held open, with every target's process forked
+# from inside it. Costs one shell per heph process; in exchange the environment's
+# shell functions and `enterShell` side effects are actually present.
+#
+# Snapshot mode cannot provide those, and says so by name rather than reporting
+# a bare "not found in PATH".
+session_env = target(
+    name = "session",
+    driver = "devenv",
+    mode = "session",
+)
+
+target(
+    name = "uses_session",
+    driver = "bash",
+    run = "type -t _activatePkgs > $OUT",
+    out = "out.txt",
+    runner = session_env,
+)
+
+# The same command under the snapshot runner. It FAILS: `_activatePkgs` is a
+# shell function, and a captured environment is a set of variables.
+#
+#   heph run //exec_runner:no_functions_in_snapshot   # expected to fail
+target(
+    name = "no_functions_in_snapshot",
+    driver = "bash",
+    run = "type -t _activatePkgs > $OUT",
+    out = "out.txt",
+    runner = devenv_env,
+)
+
+# `runner = None` opts a target out of a workspace `defaultRunner:`. Bootstrap
+# targets need it — something has to build before the environment exists.
+target(
+    name = "always_host",
+    driver = "bash",
+    run = "echo host > $OUT",
+    out = "out.txt",
+    runner = None,
+)


### PR DESCRIPTION
On top of #414. Two commits, reviewable separately: a runner can now declare its own environment, and the Go plugin gets the two knobs that make runners usable there.

## 1. A runner declares `env` / `pass_env` / `runtime_env` / `runtime_pass_env`

The same four keys a target has. The split between them is where the cache key is drawn:

| key | resolved | in the key |
|---|---|---|
| `env` | at capture, literal | **yes** |
| `pass_env` | at capture, from the host | **yes** — the *value* is baked in |
| `runtime_env` | at spawn, literal | the declaration only |
| `runtime_pass_env` | at spawn, from the host | the **name** only |

The last row is the one that matters. `SSH_AUTH_SOCK` and `DOCKER_HOST` differ per machine and per login; passing them with `pass_env` bakes one machine's value into the environment's identity and hands every other machine a cache key that lies about what produced the artifact. `runtime_pass_env` reads them at spawn, so they reach the process and never the key. `"*"` is the same escape hatch a target has.

The declarations themselves are hashed either way — they live in the runner target's artifact, and that artifact *is* the environment's identity. heph will not claim two differently-declared environments are the same one, and will not put ambient host state in the key either.

Everything a runner declares sits **underneath** what the target set itself, wildcard included — a runner that could overwrite `$OUT`, `$SRC` or a target's own `env` would silently change what the target builds. Asserted directly.

`SessionEnv` lives in the contract, so every runner gets it; devenv populates it from four new spec keys. `SNAPSHOT_FORMAT_VERSION` → 3.

## 2. Go: `goenv`, and a runner for test execution

Two knobs, deliberately separate, because *how it was built* and *how it runs* are different questions.

**`goenv`** (provider option) — environment for the **Go toolchain**: `go list`, the compiler, the assembler. `GOPRIVATE`, `GOFLAGS`, a corporate `GOPROXY`.

Injected into each target's spec where it is **hashed**, not applied behind the drivers' backs. A knob that changed compiler input without moving the key would hand every machine artifacts built under settings the key does not record. `GO_COMPILE_FORMAT_VERSION` → 5, `GO_GOLIST_FORMAT_VERSION` → 18; both frozen def-hash goldens failed on the bump, which is what they are for.

One choke point (the provider's `get`) rather than the two dozen places a spec is built — a knob that reached *most* of them would be worse than one that reached none, because the gap surfaces as a cache hit on an archive built under different settings.

An allowlist decides who gets it: `go_compile`, `go_golist`. `go_toolchain` downloads an SDK and `go_testmain` writes a file — giving them an environment they never use would key them on it for nothing and re-key everything downstream. Lint/format exec `heph-govet`, not `go`.

Within a driver `goenv` is applied **first**, so `GOROOT`/`GOOS`/`GOARCH`/`GOWORK=off` win — those make the build hermetic and match the variant, and letting config override them would build something other than the address asked for, under that address's key.

**`provider_state(provider="go", test={"runner": "//:devenv"})`** — the exec environment the *test binary* runs in. Joins the existing `test = {...}` map beside `env`/`pass_env`/`pre_run`, same allowlist that rejects typos, rather than inventing a second place to configure tests.

Only `test`/`xtest` take it. A test binary often wants a database client or a browser on PATH; the build wants the hermetic toolchain and nothing else. One environment for both would either leak the runtime's tools into every compile's key or force the build environment onto the test.

## Examples

`example/exec_runner/BUILD` exercises what this stack added: selection and `runner = None`; a tool that resolves only under the runner **and the same target failing without it**; the four declared keys; a target overriding its runner; session mode providing a shell function snapshot mode cannot — with the snapshot counterpart kept as an expected failure, so the difference is visible rather than described.

Also fixes the example workspace, which **has not loaded since #397** removed the `sh` driver: `.hephconfig2` still listed `builtin: sh`, so every `heph` command run there failed at config load.

## Where a runner comes from, per target type

| Target type | How a runner is set |
|---|---|
| BUILD-authored (`bash`, `exec`, `http_fetch`, `nix`, …) | `runner = //pkg:name`, or `runner = None` |
| The runner target itself | n/a — excluded from `defaultRunner` so it cannot become its own dependency |
| Go `test` / `xtest` (+`_race`) | `provider_state(test={"runner": …})` |
| Go `go_compile` / `go_golist` | inherits `defaultRunner`; environment shaped by `goenv` |
| Go `go_toolchain` / `go_testmain` / lint / format | inherits `defaultRunner`; no `goenv` |
| Other provider-emitted (`@heph/fs`, `group`, `hostbin`, `oci_*`) | inherits `defaultRunner` |

`runner: None` on a `TargetSpec` means **unauthored**, not `local` — which is why provider-emitted targets inherit `defaultRunner`. That reaches `go_compile`, and `plugin-go` is cdylib-only, so that path works only because of #411's positive ack.

**Known gap:** `go_lint`/`go_format` inherit `defaultRunner` but get no `goenv`, since they exec `heph-govet` rather than `go`. If `heph-govet` needs a corporate `GOPROXY`, that wants its own knob.

## Tests

26 in `exec-runner` (the four-key layering, `"*"`, and the target-wins-over-everything case), 10 in `plugin-devenv`, 481 in `plugin-go`, plus e2e. `lint` clean.

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>