### PR TITLE
ci: macOS build/test on blacksmith, artifacts uploaded in parallel

### DIFF
--- a/.github/workflows/heph.yml
+++ b/.github/workflows/heph.yml
@@ -226,10 +226,10 @@ jobs:
 #            runs-on: macos-latest-large
 #            target: x86_64-apple-darwin
 
-          # macOS ARM64 (Apple Silicon natively runs on macos-latest)
+          # macOS ARM64 (Apple Silicon natively runs on the blacksmith macOS runner)
           - os: darwin
             arch: arm64
-            runs-on: macos-latest
+            runs-on: blacksmith-6vcpu-macos-latest
             target: aarch64-apple-darwin
     steps:
       - name: Download repo
@@ -439,41 +439,51 @@ jobs:
           DEBUG_BIN_NAME: "heph_debug_${{ matrix.os }}_${{ matrix.arch }}"
           EXPECTED_VERSION: "${{needs.gen.outputs.version}}"
 
-      - name: Upload artifact
-        uses: actions/upload-artifact@v6
-        with:
-          name: ${{steps.build.outputs.bin_name}}
-          path: ${{steps.build.outputs.bin_name}}
+      # Six independent uploads of files already sitting on disk: none reads
+      # another's result, so they go up concurrently rather than one after the
+      # other. `parallel:` rather than `background: true` on each, because it
+      # waits at the end of the block — which is what keeps the drain step below
+      # genuinely last (see its comment). Backgrounded uploads would be free to
+      # still be running underneath it.
+      #
+      # Six is under the ten-concurrent-background-step cap, so none of them
+      # queues behind another.
+      - parallel:
+          - name: Upload artifact
+            uses: actions/upload-artifact@v6
+            with:
+              name: ${{steps.build.outputs.bin_name}}
+              path: ${{steps.build.outputs.bin_name}}
 
-      - name: Upload debug flavour artifact
-        uses: actions/upload-artifact@v6
-        with:
-          name: ${{steps.build.outputs.debug_bin_name}}
-          path: ${{steps.build.outputs.debug_bin_name}}
+          - name: Upload debug flavour artifact
+            uses: actions/upload-artifact@v6
+            with:
+              name: ${{steps.build.outputs.debug_bin_name}}
+              path: ${{steps.build.outputs.debug_bin_name}}
 
-      - name: Upload heph-bench artifact
-        uses: actions/upload-artifact@v6
-        with:
-          name: ${{steps.build.outputs.bench_bin_name}}
-          path: ${{steps.build.outputs.bench_bin_name}}
+          - name: Upload heph-bench artifact
+            uses: actions/upload-artifact@v6
+            with:
+              name: ${{steps.build.outputs.bench_bin_name}}
+              path: ${{steps.build.outputs.bench_bin_name}}
 
-      - name: Upload go plugin artifact
-        uses: actions/upload-artifact@v6
-        with:
-          name: ${{steps.build.outputs.plugin_go_name}}
-          path: ${{steps.build.outputs.plugin_go_name}}
+          - name: Upload go plugin artifact
+            uses: actions/upload-artifact@v6
+            with:
+              name: ${{steps.build.outputs.plugin_go_name}}
+              path: ${{steps.build.outputs.plugin_go_name}}
 
-      - name: Upload gha plugin artifact
-        uses: actions/upload-artifact@v6
-        with:
-          name: ${{steps.build.outputs.plugin_gha_name}}
-          path: ${{steps.build.outputs.plugin_gha_name}}
+          - name: Upload gha plugin artifact
+            uses: actions/upload-artifact@v6
+            with:
+              name: ${{steps.build.outputs.plugin_gha_name}}
+              path: ${{steps.build.outputs.plugin_gha_name}}
 
-      - name: Upload oci plugin artifact
-        uses: actions/upload-artifact@v6
-        with:
-          name: ${{steps.build.outputs.plugin_oci_name}}
-          path: ${{steps.build.outputs.plugin_oci_name}}
+          - name: Upload oci plugin artifact
+            uses: actions/upload-artifact@v6
+            with:
+              name: ${{steps.build.outputs.plugin_oci_name}}
+              path: ${{steps.build.outputs.plugin_oci_name}}
 
       # Last, deliberately. This is the only job with steps after its compile,
       # and the drain must not sit in front of them: it would still be correct
@@ -781,10 +791,10 @@ jobs:
             runs-on: ubuntu-24.04-arm
             target: aarch64-unknown-linux-gnu
 
-          # macOS ARM64 (Apple Silicon natively runs on macos-latest)
+          # macOS ARM64 (Apple Silicon natively runs on the blacksmith macOS runner)
           - os: darwin
             arch: arm64
-            runs-on: macos-latest
+            runs-on: blacksmith-6vcpu-macos-latest
             target: aarch64-apple-darwin
     steps:
       - name: Download repo


### PR DESCRIPTION
Scoped to the `build` and `test` jobs.

## Runner

- `macos-latest` → `blacksmith-6vcpu-macos-latest`, in `build` and `test`.

Linux stays on GitHub-hosted runners throughout — both jobs' `ubuntu-latest` and `ubuntu-24.04-arm` legs are unchanged, as are `gen`, `govet`, `upload_artifacts`, `abi`, `lint`, `bin_e2e_warm`, `bin_e2e`, `release`, `summary` and `cleanup`.

## Parallel artifact uploads

The six uploads at the end of `build` are independent — each publishes a file already on disk, none reads another's result — so they now go up concurrently in a `parallel:` block instead of one after another.

`parallel:` rather than `background: true` per step, because it waits at the end of the block. The drain step after it is deliberately last (it stops the kache daemon, and anything compiling after that stops being published); with backgrounded uploads that ordering would hold only by luck. Six is under the ten-concurrent-background-step cap, so none queues behind another.

### Verified rather than assumed

Every published example of the parallel-steps feature uses `run:` steps, and the reference docs don't say whether `uses:` is allowed inside a `parallel:` block. It is — checked on this branch's first run (`Build darwin/arm64`):

- all six `actions/upload-artifact@v6` steps ran, and all six artifacts are on the run;
- they overlapped — all six started within 10:41:11–10:41:12 and finished by 10:41:14;
- the block's implicit wait holds — the drain step started at 10:41:14, after the last upload.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01ALT9b7iKzgtHxsFWGD2EEU
