### PR TITLE
feat(plugin-devenv): ship devenv as a cdylib plugin, not a builtin

### DIFF
--- a/.github/workflows/heph.yml
+++ b/.github/workflows/heph.yml
@@ -266,6 +266,7 @@ jobs:
           PLUGIN_GO_NAME="heph-go-plugin_${{ matrix.os }}_${{ matrix.arch }}.$ext"
           PLUGIN_GHA_NAME="heph-gha-plugin_${{ matrix.os }}_${{ matrix.arch }}.$ext"
           PLUGIN_OCI_NAME="heph-oci-plugin_${{ matrix.os }}_${{ matrix.arch }}.$ext"
+          PLUGIN_DEVENV_NAME="heph-devenv-plugin_${{ matrix.os }}_${{ matrix.arch }}.$ext"
           # heph-bench: the perf-regression harness (`perfbench` job). Publishing
           # it as a release asset alongside `heph` itself means that job never
           # builds anything to compare a PR against its baseline — both the
@@ -283,6 +284,7 @@ jobs:
           echo "plugin_go_name=$PLUGIN_GO_NAME" >> $GITHUB_OUTPUT
           echo "plugin_gha_name=$PLUGIN_GHA_NAME" >> $GITHUB_OUTPUT
           echo "plugin_oci_name=$PLUGIN_OCI_NAME" >> $GITHUB_OUTPUT
+          echo "plugin_devenv_name=$PLUGIN_DEVENV_NAME" >> $GITHUB_OUTPUT
           echo "bench_bin_name=$BENCH_BIN_NAME" >> $GITHUB_OUTPUT
           echo "debug_bin_name=$DEBUG_BIN_NAME" >> $GITHUB_OUTPUT
           OUT="target/${{ matrix.target }}/release"
@@ -313,12 +315,13 @@ jobs:
           # costs nothing extra). `heph-bench` links the same `heph` lib crate, so
           # adding it here is marginal — the expensive part (engine + deps) is
           # already being compiled for `heph` itself.
-          TARGETS="--bin heph --bin heph-bench --lib -p heph -p plugin-go-cdylib -p plugin-gha-cdylib -p plugin-oci-cdylib -p bench"
+          TARGETS="--bin heph --bin heph-bench --lib -p heph -p plugin-go-cdylib -p plugin-gha-cdylib -p plugin-oci-cdylib -p plugin-devenv-cdylib -p bench"
           if [ "${{ matrix.os }}" = "darwin" ]; then
             cargo build --release --locked --target ${{ matrix.target }} $TARGETS
             lib="$OUT/libplugin_go_cdylib.dylib"
             gha_lib="$OUT/libplugin_gha_cdylib.dylib"
             oci_lib="$OUT/libplugin_oci_cdylib.dylib"
+            devenv_lib="$OUT/libplugin_devenv_cdylib.dylib"
             # The nix toolchain hard-links libiconv against its /nix/store path,
             # which is absent on user machines (dyld aborts at launch). Rewrite
             # those load commands to the OS /usr/lib copies — for every artifact.
@@ -327,16 +330,19 @@ jobs:
             bash scripts/macos-portable.sh "$lib"
             bash scripts/macos-portable.sh "$gha_lib"
             bash scripts/macos-portable.sh "$oci_lib"
+            bash scripts/macos-portable.sh "$devenv_lib"
           else
             cargo zigbuild --release --locked --target ${{ matrix.target }} $TARGETS
             lib="$OUT/libplugin_go_cdylib.so"
             gha_lib="$OUT/libplugin_gha_cdylib.so"
             oci_lib="$OUT/libplugin_oci_cdylib.so"
+            devenv_lib="$OUT/libplugin_devenv_cdylib.so"
           fi
           cp "$OUT/heph-bench" $BENCH_BIN_NAME
           cp "$lib" $PLUGIN_GO_NAME
           cp "$gha_lib" $PLUGIN_GHA_NAME
           cp "$oci_lib" $PLUGIN_OCI_NAME
+          cp "$devenv_lib" $PLUGIN_DEVENV_NAME
 
           # The build version, stamped into every artifact below rather than
           # compiled in. Deliberately a plain shell variable and NOT exported:
@@ -355,7 +361,7 @@ jobs:
           # default govet target address from the version, so a dev-stamped
           # cdylib would resolve the wrong address at runtime.
           for artifact in \
-            $BENCH_BIN_NAME $PLUGIN_GO_NAME $PLUGIN_GHA_NAME $PLUGIN_OCI_NAME
+            $BENCH_BIN_NAME $PLUGIN_GO_NAME $PLUGIN_GHA_NAME $PLUGIN_OCI_NAME $PLUGIN_DEVENV_NAME
           do
             bash scripts/patch-slot.sh "$artifact" "version=$VERSION"
           done
@@ -485,6 +491,12 @@ jobs:
               name: ${{steps.build.outputs.plugin_oci_name}}
               path: ${{steps.build.outputs.plugin_oci_name}}
 
+      - name: Upload devenv plugin artifact
+        uses: actions/upload-artifact@v6
+        with:
+          name: ${{steps.build.outputs.plugin_devenv_name}}
+          path: ${{steps.build.outputs.plugin_devenv_name}}
+
       # Last, deliberately. This is the only job with steps after its compile,
       # and the drain must not sit in front of them: it would still be correct
       # today (nothing after `Build` compiles) but only by accident, and a
@@ -581,6 +593,14 @@ jobs:
               -out "$GITHUB_WORKSPACE/dist/heph-oci-plugin.json" )
           cat dist/heph-oci-plugin.json
           echo "manifest checksum: $(cat dist/heph-oci-plugin.json.sha256)"
+          # The devenv plugin (the `devenv` driver) ships the same way. It is
+          # driver-only: the runner half is generic and lives in the host, so
+          # this cdylib carries no runner code and needed no ABI change.
+          ( cd tools/pluginmanifest && go run . -name devenv -version "$VERSION" \
+              -prefix heph-devenv-plugin -from-dir "$GITHUB_WORKSPACE/dist" -url-base "$BASE" \
+              -out "$GITHUB_WORKSPACE/dist/heph-devenv-plugin.json" )
+          cat dist/heph-devenv-plugin.json
+          echo "manifest checksum: $(cat dist/heph-devenv-plugin.json.sha256)"
 
       - name: Create Release in artifacts repo
         id: create_release

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2272,7 +2272,6 @@ dependencies = [
  "parking_lot",
  "plugin",
  "plugin-buildfile",
- "plugin-devenv",
  "plugin-exec",
  "plugin-http",
  "plugin-nix",
@@ -4101,6 +4100,18 @@ dependencies = [
  "tokio",
  "tracing",
  "xxhash-rust",
+]
+
+[[package]]
+name = "plugin-devenv-cdylib"
+version = "0.1.0"
+dependencies = [
+ "anyhow",
+ "driver-support",
+ "plugin-devenv",
+ "plugin-sdk",
+ "stabby",
+ "tracing",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,7 +4,7 @@ version = "0.1.0"
 edition = "2024"
 
 [workspace]
-members = ["gen/proto", "crates/e2e", "crates/bin-e2e", "crates/testkit", "crates/plugingo-e2e", "crates/htspec-derive", "crates/core", "crates/config", "crates/walk", "crates/proc", "crates/model", "crates/sandboxfuse", "crates/plugin", "crates/plugin-abi", "crates/plugin-stabby", "crates/plugin-sdk", "crates/plugin-go-cdylib", "crates/builtins", "crates/plugin-buildfile", "crates/driver-support", "crates/driver-bridge", "crates/exec-runner", "crates/plugin-exec", "crates/plugin-devenv", "crates/plugin-nix", "crates/plugin-http", "crates/plugin-oci", "crates/plugin-query", "crates/plugin-go", "crates/plugin-gha", "crates/plugin-gha-cdylib", "crates/plugin-oci-cdylib", "crates/telemetry", "crates/tui", "crates/lock", "crates/selfupdate", "crates/engine", "crates/xstarlark-fmt", "crates/bench-corpus", "crates/bench"]
+members = ["gen/proto", "crates/e2e", "crates/bin-e2e", "crates/testkit", "crates/plugingo-e2e", "crates/htspec-derive", "crates/core", "crates/config", "crates/walk", "crates/proc", "crates/model", "crates/sandboxfuse", "crates/plugin", "crates/plugin-abi", "crates/plugin-stabby", "crates/plugin-sdk", "crates/plugin-go-cdylib", "crates/builtins", "crates/plugin-buildfile", "crates/driver-support", "crates/driver-bridge", "crates/exec-runner", "crates/plugin-exec", "crates/plugin-devenv", "crates/plugin-devenv-cdylib", "crates/plugin-nix", "crates/plugin-http", "crates/plugin-oci", "crates/plugin-query", "crates/plugin-go", "crates/plugin-gha", "crates/plugin-gha-cdylib", "crates/plugin-oci-cdylib", "crates/telemetry", "crates/tui", "crates/lock", "crates/selfupdate", "crates/engine", "crates/xstarlark-fmt", "crates/bench-corpus", "crates/bench"]
 
 [profile.profiling]
 inherits = "release"
@@ -117,7 +117,6 @@ hbuiltins = { package = "builtins", path = "crates/builtins" }
 hplugin-buildfile = { package = "plugin-buildfile", path = "crates/plugin-buildfile" }
 hdriver-support = { package = "driver-support", path = "crates/driver-support" }
 hplugin-exec = { package = "plugin-exec", path = "crates/plugin-exec" }
-hplugin-devenv = { package = "plugin-devenv", path = "crates/plugin-devenv" }
 hplugin-nix = { package = "plugin-nix", path = "crates/plugin-nix" }
 hplugin-http = { package = "plugin-http", path = "crates/plugin-http" }
 hplugin-query = { package = "plugin-query", path = "crates/plugin-query" }

--- a/crates/bin-e2e/tests/plugin_dylib.rs
+++ b/crates/bin-e2e/tests/plugin_dylib.rs
@@ -285,3 +285,95 @@ fn shipped_oci_cdylib_parses_across_the_abi_without_aborting() {
         describe(&out)
     );
 }
+
+/// The `devenv` driver, served from a REAL cdylib.
+///
+/// This is the seam an in-process test structurally cannot reach: the plugin is
+/// `dlopen`ed, its `heph_plugin_create` runs behind the stable ABI, and the
+/// `devenv` driver it exports has to be registered by name and reachable from
+/// the engine — none of which happens when a test constructs the driver
+/// directly through generics.
+///
+/// It also pins the shape of the conversion: `plugin-devenv` is **driver-only**.
+/// The runner half is generic and lives in the host, which is what let this ship
+/// over the existing `drivers` lane with no runner lane and no `ABI_SEMVER`
+/// bump. If someone later tries to hand a runner across the seam, this is the
+/// test that keeps the driver lane honest.
+///
+/// The assertion is not that the target *builds* — that would run `devenv
+/// print-dev-env` against a workspace that has no `devenv.nix`, which is slow
+/// and not what is under test. It is that the driver resolves across the seam
+/// and comes back diagnosable rather than as a SIGABRT.
+#[test]
+fn shipped_devenv_cdylib_serves_its_driver_across_the_abi() {
+    let dist = Dist::locate();
+    let ws = Workspace::new().expect("workspace");
+    let dylib = dist.plugin("devenv");
+    assert!(dylib.is_file(), "missing {}", dylib.display());
+
+    let manifest = ws.root().join("heph-devenv-plugin.json");
+    let sum = sha256_file(&dylib).expect("hash devenv cdylib");
+    write_manifest(&manifest, "devenv", &dylib, Some(&sum)).expect("write manifest");
+    ws.config(&format!("{BASE_CONFIG}  - path: {}\n", manifest.display()))
+        .expect("write config");
+
+    ws.write("pkg/BUILD", "target(name = \"env\", driver = \"devenv\")\n")
+        .expect("write BUILD");
+
+    let out = ws
+        .run(&dist, &["inspect", "def", "//pkg:env"])
+        .expect("run");
+
+    let combined = format!(
+        "{}{}",
+        String::from_utf8_lossy(&out.stdout),
+        String::from_utf8_lossy(&out.stderr)
+    );
+    assert!(
+        out.status.code().is_some(),
+        "heph was killed by a signal — the plugin panicked across the ABI seam: {}",
+        describe(&out)
+    );
+    assert!(
+        !combined.contains("panic in a function that cannot unwind")
+            && !combined.contains("there is no reactor running"),
+        "plugin aborted across the seam: {}",
+        describe(&out)
+    );
+    // The driver has to be *known*. Before this crate existed, `devenv` was
+    // compiled into the binary; if the cdylib failed to register it, this is the
+    // error that would come back instead.
+    assert!(
+        !combined.contains("no driver named"),
+        "the cdylib did not register its `devenv` driver: {}",
+        describe(&out)
+    );
+    assert!(
+        out.status.success(),
+        "parsing a devenv target across the seam failed: {}",
+        describe(&out)
+    );
+}
+
+/// The host binary must NOT carry a compiled-in `devenv` driver any more.
+///
+/// Without this, the conversion silently half-lands: the builtin keeps
+/// answering, every fixture passes, and nobody notices the cdylib is dead
+/// weight that is never actually loaded.
+#[test]
+fn devenv_is_not_compiled_into_the_binary() {
+    let dist = Dist::locate();
+    let ws = Workspace::new().expect("workspace");
+    // BASE_CONFIG only: no devenv plugin entry at all.
+    ws.write("pkg/BUILD", "target(name = \"env\", driver = \"devenv\")\n")
+        .expect("write BUILD");
+
+    let out = ws
+        .run(&dist, &["inspect", "def", "//pkg:env"])
+        .expect("run");
+    assert!(
+        !out.status.success(),
+        "`devenv` resolved with no plugin configured — it is still a builtin: {}",
+        describe(&out)
+    );
+}

--- a/crates/plugin-devenv-cdylib/Cargo.toml
+++ b/crates/plugin-devenv-cdylib/Cargo.toml
@@ -1,0 +1,18 @@
+[package]
+name = "plugin-devenv-cdylib"
+version = "0.1.0"
+edition = "2024"
+
+[lib]
+crate-type = ["cdylib"]
+
+[lints]
+workspace = true
+
+[dependencies]
+hplugin-devenv = { package = "plugin-devenv", path = "../plugin-devenv" }
+hdriver-support = { package = "driver-support", path = "../driver-support" }
+plugin-sdk = { path = "../plugin-sdk", features = ["stabby"] }
+stabby = "72.1.8"
+anyhow = "1.0.102"
+tracing = "0.1"

--- a/crates/plugin-devenv-cdylib/src/lib.rs
+++ b/crates/plugin-devenv-cdylib/src/lib.rs
@@ -1,0 +1,100 @@
+//! The `devenv` driver as a loadable cdylib behind the stable ABI.
+//!
+//! Two components, both named `devenv`: a **driver** that builds the environment
+//! artifact, and an **exec runner** that serves sessions from it.
+//!
+//! They are separate components rather than one driver answering extra methods,
+//! because a runner is not a driver — it has no schema, parses nothing, and
+//! builds nothing. Being the runner is what makes this plugin the party that
+//! starts the process: `prepare_spec` is per target, so one `devenv shell` is
+//! opened once *inside this plugin* and every target's exec is routed into it.
+
+use std::path::PathBuf;
+use std::sync::Arc;
+
+use hdriver_support::driver_managed::ManagedDriver;
+use plugin_sdk::stabby::abi::{
+    DynLogSink, DynSupervisor, NamedDriver, NamedExecRunner, PluginComponents,
+};
+use plugin_sdk::stabby::{
+    create_config_from_bytes, install_log_sink, install_supervisor, make_dyn_exec_runner,
+    make_dyn_managed_driver,
+};
+
+/// Stable ABI create entry. `#[stabby::export]` emits the type-report symbols the
+/// host's `get_stabbied` checks for ABI compatibility. `cfg` is prost-encoded
+/// `pb::CreateConfig` bytes.
+#[stabby::export]
+pub extern "C" fn heph_plugin_create(cfg: stabby::vec::Vec<u8>) -> PluginComponents {
+    match build(&cfg) {
+        Ok(c) => c,
+        Err(e) => {
+            tracing::error!("heph-devenv-plugin: plugin construction failed: {e:#}");
+            std::process::abort();
+        }
+    }
+}
+
+/// Stable ABI log-sink entry: the host calls this right after `create` to hand the
+/// plugin a sink for its `tracing` events. Without it, this cdylib's
+/// statically-linked `tracing` has no subscriber and the driver's logs vanish —
+/// including the "dropped non-/nix/store PATH entries" line, which is the one a
+/// user needs when a tool goes missing.
+#[stabby::export]
+pub extern "C" fn heph_plugin_set_log_sink(sink: DynLogSink) {
+    install_log_sink(sink);
+}
+
+/// Stable ABI supervisor entry: the host hands the plugin its process-supervisor
+/// client, so the `devenv print-dev-env` child this driver spawns is tracked by
+/// the host's sidecar rather than by this cdylib's own (uninitialised) copy of
+/// the `proc` tracker.
+#[stabby::export]
+pub extern "C" fn heph_plugin_set_supervisor(sup: DynSupervisor) {
+    install_supervisor(sup);
+}
+
+fn build(cfg: &[u8]) -> anyhow::Result<PluginComponents> {
+    let cfg = create_config_from_bytes(cfg)?;
+    // The workspace root, from the engine — never discovered. `devenv` must run
+    // against the real tree because `devenv.nix` lives there, and a plugin is
+    // handed its locations rather than guessing them.
+    let root = PathBuf::from(cfg.root);
+
+    // What `mode = "session"` needs, assembled here rather than discovered:
+    // `current_exe` in a cdylib is the *host* binary, which is exactly the agent
+    // and per-target client this needs; `home` comes from the engine.
+    let home = PathBuf::from(cfg.home);
+    let session =
+        std::env::current_exe()
+            .ok()
+            .map(|heph_bin| hplugin_devenv::plugindevenv::SessionSupport {
+                heph_bin,
+                socket_dir: home.join("exec-agents"),
+                tree_root: root.clone(),
+            });
+    let driver: Arc<dyn ManagedDriver> = Arc::new(hplugin_devenv::plugindevenv::Driver::new(root));
+    let runner: Arc<dyn plugin_sdk::runner::ExecRunnerPlugin> =
+        Arc::new(hplugin_devenv::plugindevenv::Runner::new(session));
+    let mut drivers = stabby::vec::Vec::new();
+    drivers.push(NamedDriver {
+        name: hplugin_devenv::plugindevenv::NAME.into(),
+        driver: make_dyn_managed_driver(driver),
+    });
+
+    let mut runners = stabby::vec::Vec::new();
+    runners.push(NamedExecRunner {
+        name: hplugin_devenv::plugindevenv::NAME.into(),
+        runner: make_dyn_exec_runner(runner),
+    });
+
+    Ok(PluginComponents {
+        // No provider and no hooks — a driver and a runner.
+        provider_name: String::new().into(),
+        provider: stabby::option::Option::None(),
+        drivers,
+        hooks: stabby::vec::Vec::new(),
+        runners,
+        meta: stabby::vec::Vec::new(),
+    })
+}

--- a/crates/plugin-devenv-cdylib/src/lib.rs
+++ b/crates/plugin-devenv-cdylib/src/lib.rs
@@ -74,7 +74,7 @@ fn build(cfg: &[u8]) -> anyhow::Result<PluginComponents> {
                 tree_root: root.clone(),
             });
     let driver: Arc<dyn ManagedDriver> = Arc::new(hplugin_devenv::plugindevenv::Driver::new(root));
-    let runner: Arc<dyn plugin_sdk::runner::ExecRunnerPlugin> =
+    let runner: Arc<dyn plugin_sdk::runner::ExecRunner> =
         Arc::new(hplugin_devenv::plugindevenv::Runner::new(session));
     let mut drivers = stabby::vec::Vec::new();
     drivers.push(NamedDriver {

--- a/crates/plugin-devenv/src/plugindevenv/mod.rs
+++ b/crates/plugin-devenv/src/plugindevenv/mod.rs
@@ -431,14 +431,6 @@ pub struct Runner {
     /// and client. Absent in a host with no session support, which makes
     /// `mode = "session"` an error rather than a silent downgrade.
     session: Option<SessionSupport>,
-    /// Sessions this runner holds open, by the id it handed the host.
-    ///
-    /// Only the id crosses the seam. What a session owns — a live `devenv
-    /// shell`, its socket, its pid — cannot, which is exactly why the component
-    /// trait is id-shaped and the runner keeps the objects here.
-    sessions: std::sync::Mutex<std::collections::HashMap<String, Arc<dyn ExecSession>>>,
-    /// Monotonic, so two environments opened in one build never collide.
-    next_session: std::sync::atomic::AtomicU64,
 }
 
 #[derive(Clone, Debug)]
@@ -453,78 +445,7 @@ pub struct SessionSupport {
 
 impl Runner {
     pub fn new(session: Option<SessionSupport>) -> Self {
-        Self {
-            session,
-            sessions: std::sync::Mutex::new(std::collections::HashMap::new()),
-            next_session: std::sync::atomic::AtomicU64::new(0),
-        }
-    }
-
-    /// A panic while the map was locked must not wedge every later spawn: the
-    /// data is a plain `HashMap` and is still structurally sound, which is the
-    /// same call `ExecSessionPool::teardown_all` makes.
-    fn sessions(
-        &self,
-    ) -> std::sync::MutexGuard<'_, std::collections::HashMap<String, Arc<dyn ExecSession>>> {
-        self.sessions.lock().unwrap_or_else(|p| p.into_inner())
-    }
-}
-
-/// The plugin-facing half: the same runner, addressed by session id so it can be
-/// served across the ABI as a component.
-#[async_trait]
-impl hexec_runner::ExecRunnerPlugin for Runner {
-    async fn open_session(
-        &self,
-        req: OpenRequest,
-        ctoken: &(dyn Cancellable + Send + Sync),
-    ) -> anyhow::Result<hexec_runner::OpenedSession> {
-        let session = ExecRunner::open(self, req, ctoken).await?;
-        let id = format!(
-            "devenv-{}",
-            self.next_session
-                .fetch_add(1, std::sync::atomic::Ordering::SeqCst)
-        );
-        let opened = hexec_runner::OpenedSession {
-            session_id: id.clone(),
-            caps: session.caps().clone(),
-            description: session.describe().clone(),
-            base_env: session.base_env().map(<[_]>::to_vec),
-        };
-        self.sessions().insert(id, session);
-        Ok(opened)
-    }
-
-    async fn prepare_spec(
-        &self,
-        session_id: &str,
-        spec: hproc::proc_exec::Spec,
-    ) -> anyhow::Result<hproc::proc_exec::Spec> {
-        let session = self
-            .sessions()
-            .get(session_id)
-            .map(Arc::clone)
-            .ok_or_else(|| {
-                anyhow::anyhow!(
-                    "no devenv session {session_id}; it was closed, or never opened here"
-                )
-            })?;
-        session
-            .prepare(spec)
-            .await
-            .map_err(|e| anyhow::anyhow!("{e}"))
-    }
-
-    async fn close_session(&self, session_id: &str) -> anyhow::Result<()> {
-        // Removed first: close is reachable from more than one path and the
-        // shell must not be killed twice.
-        let Some(session) = self.sessions().remove(session_id) else {
-            return Ok(());
-        };
-        if let Some(job) = session.teardown() {
-            job()?;
-        }
-        Ok(())
+        Self { session }
     }
 }
 

--- a/crates/plugin-devenv/src/plugindevenv/mod.rs
+++ b/crates/plugin-devenv/src/plugindevenv/mod.rs
@@ -431,6 +431,14 @@ pub struct Runner {
     /// and client. Absent in a host with no session support, which makes
     /// `mode = "session"` an error rather than a silent downgrade.
     session: Option<SessionSupport>,
+    /// Sessions this runner holds open, by the id it handed the host.
+    ///
+    /// Only the id crosses the seam. What a session owns — a live `devenv
+    /// shell`, its socket, its pid — cannot, which is exactly why the component
+    /// trait is id-shaped and the runner keeps the objects here.
+    sessions: std::sync::Mutex<std::collections::HashMap<String, Arc<dyn ExecSession>>>,
+    /// Monotonic, so two environments opened in one build never collide.
+    next_session: std::sync::atomic::AtomicU64,
 }
 
 #[derive(Clone, Debug)]
@@ -445,7 +453,78 @@ pub struct SessionSupport {
 
 impl Runner {
     pub fn new(session: Option<SessionSupport>) -> Self {
-        Self { session }
+        Self {
+            session,
+            sessions: std::sync::Mutex::new(std::collections::HashMap::new()),
+            next_session: std::sync::atomic::AtomicU64::new(0),
+        }
+    }
+
+    /// A panic while the map was locked must not wedge every later spawn: the
+    /// data is a plain `HashMap` and is still structurally sound, which is the
+    /// same call `ExecSessionPool::teardown_all` makes.
+    fn sessions(
+        &self,
+    ) -> std::sync::MutexGuard<'_, std::collections::HashMap<String, Arc<dyn ExecSession>>> {
+        self.sessions.lock().unwrap_or_else(|p| p.into_inner())
+    }
+}
+
+/// The plugin-facing half: the same runner, addressed by session id so it can be
+/// served across the ABI as a component.
+#[async_trait]
+impl hexec_runner::ExecRunnerPlugin for Runner {
+    async fn open_session(
+        &self,
+        req: OpenRequest,
+        ctoken: &(dyn Cancellable + Send + Sync),
+    ) -> anyhow::Result<hexec_runner::OpenedSession> {
+        let session = ExecRunner::open(self, req, ctoken).await?;
+        let id = format!(
+            "devenv-{}",
+            self.next_session
+                .fetch_add(1, std::sync::atomic::Ordering::SeqCst)
+        );
+        let opened = hexec_runner::OpenedSession {
+            session_id: id.clone(),
+            caps: session.caps().clone(),
+            description: session.describe().clone(),
+            base_env: session.base_env().map(<[_]>::to_vec),
+        };
+        self.sessions().insert(id, session);
+        Ok(opened)
+    }
+
+    async fn prepare_spec(
+        &self,
+        session_id: &str,
+        spec: hproc::proc_exec::Spec,
+    ) -> anyhow::Result<hproc::proc_exec::Spec> {
+        let session = self
+            .sessions()
+            .get(session_id)
+            .map(Arc::clone)
+            .ok_or_else(|| {
+                anyhow::anyhow!(
+                    "no devenv session {session_id}; it was closed, or never opened here"
+                )
+            })?;
+        session
+            .prepare(spec)
+            .await
+            .map_err(|e| anyhow::anyhow!("{e}"))
+    }
+
+    async fn close_session(&self, session_id: &str) -> anyhow::Result<()> {
+        // Removed first: close is reachable from more than one path and the
+        // shell must not be killed twice.
+        let Some(session) = self.sessions().remove(session_id) else {
+            return Ok(());
+        };
+        if let Some(job) = session.teardown() {
+            job()?;
+        }
+        Ok(())
     }
 }
 

--- a/devenv.nix
+++ b/devenv.nix
@@ -53,7 +53,7 @@ let
   };
 
   binLocation = "$HOME/.local/bin/heph3";
-  qualityCrates = "-p heph -p e2e -p bin-e2e -p testkit -p plugingo-e2e -p htspec-derive -p core -p config -p walk -p proc -p model -p sandboxfuse -p plugin -p plugin-abi -p plugin-sdk -p plugin-stabby -p plugin-go-cdylib -p builtins -p plugin-buildfile -p driver-support -p driver-bridge -p exec-runner -p plugin-exec -p plugin-devenv -p plugin-nix -p plugin-http -p plugin-oci -p plugin-query -p plugin-go -p plugin-gha -p plugin-gha-cdylib -p plugin-oci-cdylib -p telemetry -p tui -p lock -p selfupdate -p engine -p xstarlark-fmt -p bench-corpus -p bench";
+  qualityCrates = "-p heph -p e2e -p bin-e2e -p testkit -p plugingo-e2e -p htspec-derive -p core -p config -p walk -p proc -p model -p sandboxfuse -p plugin -p plugin-abi -p plugin-sdk -p plugin-stabby -p plugin-go-cdylib -p builtins -p plugin-buildfile -p driver-support -p driver-bridge -p exec-runner -p plugin-exec -p plugin-devenv -p plugin-devenv-cdylib -p plugin-nix -p plugin-http -p plugin-oci -p plugin-query -p plugin-go -p plugin-gha -p plugin-gha-cdylib -p plugin-oci-cdylib -p telemetry -p tui -p lock -p selfupdate -p engine -p xstarlark-fmt -p bench-corpus -p bench";
 in
 {
   # https://devenv.sh/basics/
@@ -371,10 +371,11 @@ in
       cp "$src/heph-go-plugin_''${os}_''${arch}.$ext"  "$dist/heph-go-plugin.$ext"
       cp "$src/heph-gha-plugin_''${os}_''${arch}.$ext" "$dist/heph-gha-plugin.$ext"
       cp "$src/heph-oci-plugin_''${os}_''${arch}.$ext" "$dist/heph-oci-plugin.$ext"
+      cp "$src/heph-devenv-plugin_''${os}_''${arch}.$ext" "$dist/heph-devenv-plugin.$ext"
     else
       # Local: build the same artifacts the build job builds, the same way (one
       # invocation so cargo overlaps their LTO tails — see heph.yml).
-      cargo build --release --locked --bin heph --lib -p heph -p plugin-go-cdylib -p plugin-gha-cdylib -p plugin-oci-cdylib
+      cargo build --release --locked --bin heph --lib -p heph -p plugin-go-cdylib -p plugin-gha-cdylib -p plugin-oci-cdylib -p plugin-devenv-cdylib
       out="$target/release"
 
       # cargo's build lock covers the build but not the gap between it and the
@@ -391,14 +392,15 @@ in
       fingerprint() {
         stat -c '%i %s %Y' "$@" 2>/dev/null || stat -f '%i %z %m' "$@"
       }
-      before="$(fingerprint "$out/heph" "$out/libplugin_go_cdylib.$ext" "$out/libplugin_gha_cdylib.$ext" "$out/libplugin_oci_cdylib.$ext")"
+      before="$(fingerprint "$out/heph" "$out/libplugin_go_cdylib.$ext" "$out/libplugin_gha_cdylib.$ext" "$out/libplugin_oci_cdylib.$ext" "$out/libplugin_devenv_cdylib.$ext")"
 
       cp "$out/heph"                       "$dist/heph"
       cp "$out/libplugin_go_cdylib.$ext"   "$dist/heph-go-plugin.$ext"
       cp "$out/libplugin_gha_cdylib.$ext"  "$dist/heph-gha-plugin.$ext"
       cp "$out/libplugin_oci_cdylib.$ext"  "$dist/heph-oci-plugin.$ext"
+      cp "$out/libplugin_devenv_cdylib.$ext" "$dist/heph-devenv-plugin.$ext"
 
-      after="$(fingerprint "$out/heph" "$out/libplugin_go_cdylib.$ext" "$out/libplugin_gha_cdylib.$ext" "$out/libplugin_oci_cdylib.$ext")"
+      after="$(fingerprint "$out/heph" "$out/libplugin_go_cdylib.$ext" "$out/libplugin_gha_cdylib.$ext" "$out/libplugin_oci_cdylib.$ext" "$out/libplugin_devenv_cdylib.$ext")"
       if [ "$before" != "$after" ]; then
         echo "e2e: $out changed while staging — another build in this" >&2
         echo "e2e: worktree raced this one. Re-run." >&2
@@ -408,7 +410,7 @@ in
       if [ "$os" = "darwin" ]; then
         # Same post-processing the shipped macOS artifacts get, so a local run
         # tests the same bytes CI would publish.
-        for f in "$dist/heph" "$dist/heph-go-plugin.$ext" "$dist/heph-gha-plugin.$ext" "$dist/heph-oci-plugin.$ext"; do
+        for f in "$dist/heph" "$dist/heph-go-plugin.$ext" "$dist/heph-gha-plugin.$ext" "$dist/heph-oci-plugin.$ext" "$dist/heph-devenv-plugin.$ext"; do
           bash "$DEVENV_ROOT/scripts/macos-portable.sh" "$f"
         done
       fi
@@ -424,7 +426,7 @@ in
       # After macos-portable.sh, not before: both re-sign, and this one must
       # have the last word or the signature covers pre-patch bytes.
       version="$(bash "$DEVENV_ROOT/.github/workflows/version.sh")"
-      for f in "$dist/heph" "$dist/heph-go-plugin.$ext" "$dist/heph-gha-plugin.$ext" "$dist/heph-oci-plugin.$ext"; do
+      for f in "$dist/heph" "$dist/heph-go-plugin.$ext" "$dist/heph-gha-plugin.$ext" "$dist/heph-oci-plugin.$ext" "$dist/heph-devenv-plugin.$ext"; do
         bash "$DEVENV_ROOT/scripts/patch-slot.sh" "$f" "version=$version"
       done
     fi
@@ -533,6 +535,29 @@ in
     ( cd "$DEVENV_ROOT/tools/pluginmanifest" \
         && go run . -name gha -host-path "$name" -checksum-from "$dest/$name" -out "$dest/heph-gha-plugin.json" )
     echo "installed gha plugin -> $dest"
+  '';
+
+  # Build + install the devenv plugin (a cdylib + manifest), the same publish flow
+  # as `install-go-plugin`. It is driver-only: the runner half is generic and
+  # lives in the host, so this ships nothing but the `devenv` driver.
+  scripts.install-devenv-plugin.exec = ''
+    cargo build --release -p plugin-devenv-cdylib
+    target="$(target-dir)"
+    if [ "$(uname -s)" = "Darwin" ]; then
+      lib="$target/release/libplugin_devenv_cdylib.dylib"
+      name="heph-devenv-plugin.dylib"
+      bash "$DEVENV_ROOT/scripts/macos-portable.sh" "$lib"
+    else
+      lib="$target/release/libplugin_devenv_cdylib.so"
+      name="heph-devenv-plugin.so"
+    fi
+    dest="$HOME/.heph/plugins/devenv"
+    mkdir -p "$dest"
+    cp "$lib" "$dest/$name.new"
+    mv -f "$dest/$name.new" "$dest/$name"
+    ( cd "$DEVENV_ROOT/tools/pluginmanifest" \
+        && go run . -name devenv -host-path "$name" -checksum-from "$dest/$name" -out "$dest/heph-devenv-plugin.json" )
+    echo "installed devenv plugin -> $dest"
   '';
 
   scripts.install-dev-build.exec = ''

--- a/devenv.nix
+++ b/devenv.nix
@@ -167,14 +167,18 @@ in
     cd $DEVENV_ROOT/example/go/large && go mod tidy
   '';
   # Set up the example workspace end to end: regenerate the large go repo and
-  # install the go plugin (cdylib + manifest) into ~/.heph/plugins/go via
-  # `install-go-plugin`. example/.hephconfig2 loads it in-process behind the
+  # install the go and devenv plugins (cdylib + manifest) into ~/.heph/plugins
+  # via `install-go-plugin` / `install-devenv-plugin`. example/.hephconfig2
+  # loads them in-process behind the
   # stable ABI via `path: ~/.heph/plugins/go/heph-go-plugin.json` (native speed —
   # see ai-docs/PERFORMANCE.md).
   scripts.gen-example.exec = ''
     gen
     gen-go-large
     install-go-plugin
+    # The example workspace's `exec_runner` package uses `driver = "devenv"`,
+    # which is no longer compiled into the binary.
+    install-devenv-plugin
   '';
   # Three clippy passes — default features, `--all-features`, and
   # `--no-default-features` — then fmt-check all hand-written crates

--- a/example/.hephconfig2
+++ b/example/.hephconfig2
@@ -12,6 +12,11 @@ plugins:
   # The go plugin: one manifest names the cdylib for this host. The provider + its
   # go_* drivers all come from that one library. Installed to the user-global
   # ~/.heph by the `gen-example` script (which runs `install-go-plugin`).
+  # The devenv plugin: the `devenv` driver, which captures the dev shell as a
+  # runner target's artifact. Driver-only — the runner half is generic and lives
+  # in heph itself, so nothing here selects a runner implementation. Installed by
+  # the `gen-example` script (which runs `install-devenv-plugin`).
+  - path: ~/.heph/plugins/devenv/heph-devenv-plugin.json
   - path: ~/.heph/plugins/go/heph-go-plugin.json
     options:
       # Required. A pinned version → hermetic SDK download (reads nothing from

--- a/src/commands/bootstrap.rs
+++ b/src/commands/bootstrap.rs
@@ -8,8 +8,7 @@ use tokio::sync::mpsc;
 use crate::engine::config::ConfigYamlExt;
 use crate::engine::config_yaml;
 use crate::{
-    engine, pluginbuildfile, plugindevenv, pluginexec, pluginhostbin, pluginhttp, pluginnix,
-    plugintextfile,
+    engine, pluginbuildfile, pluginexec, pluginhostbin, pluginhttp, pluginnix, plugintextfile,
 };
 
 /// Builds the multi-thread runtime used by every command entry point.
@@ -137,21 +136,13 @@ pub fn new_engine() -> anyhow::Result<(Arc<engine::Engine>, ShutdownTrigger)> {
     // (`heph-oci-plugin.json`), under their own `docker_build` / `oci_pull` /
     // `oci_push` / `oci_load` names.
     e.register_managed_driver(|_| Box::new(pluginnix::Driver::new(home_dir.join("nix-driver"))))?;
-    // Two halves of one plugin: the `devenv` driver captures the environment as
-    // an artifact, the `devenv` runner reads it back. Registered under the same
-    // name, which is how a runner target's driver selects its runner.
-    let runner_root = root.clone();
-    {
-        let devenv_root = root.clone();
-        e.register_managed_driver(move |_| Box::new(plugindevenv::Driver::new(devenv_root)))?;
-    }
-    e.register_exec_runner(
-        plugindevenv::NAME,
-        std::sync::Arc::new(plugindevenv::Runner::new(session_support(
-            &home_dir,
-            &runner_root,
-        ))),
-    )?;
+    // The `devenv` driver is not compiled in: like the go, gha and oci plugins,
+    // it ships as a separate cdylib loaded from a `path:`/`url:` manifest entry
+    // (`heph-devenv-plugin.json`), under its own `devenv` name.
+    //
+    // It serves its own runner too, over the exec-runner ABI lane: a driver that
+    // answers `serves_exec_sessions` is registered as the runner for its own
+    // name at load. Nothing about devenv is compiled into heph.
 
     // Opt-in built-in factories — instantiated only when a `plugins: - { builtin:
     // <name> }` entry selects them. The go plugin is no longer compiled in: it
@@ -279,23 +270,6 @@ fn hard_abort(engine: Option<&engine::Engine>, exit: impl FnOnce(i32)) {
     exit(130);
 }
 
-/// What a `mode = "session"` runner needs: this binary (it is both the agent
-/// and the per-target client) and a directory for its sockets.
-///
-/// `None` when the current executable cannot be located — a session runner then
-/// fails saying so, rather than silently downgrading to a snapshot and running
-/// targets in an environment nobody asked for.
-fn session_support(
-    home_dir: &std::path::Path,
-    tree_root: &std::path::Path,
-) -> Option<plugindevenv::SessionSupport> {
-    Some(plugindevenv::SessionSupport {
-        heph_bin: std::env::current_exe().ok()?,
-        socket_dir: home_dir.join("exec-agents"),
-        tree_root: tree_root.to_path_buf(),
-    })
-}
-
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -322,8 +296,6 @@ mod tests {
             .as_ref()
             .map(|p| root.join(p))
             .unwrap_or_else(|| root.join(".heph3"));
-        let devenv_root = root.clone();
-        let runner_root = root.clone();
         let mut e = engine::Engine::new(engine::Config {
             root,
             home_dir: home_dir.clone(),
@@ -340,17 +312,7 @@ mod tests {
         e.register_managed_driver(|_| {
             Box::new(pluginnix::Driver::new(home_dir.join("nix-driver")))
         })?;
-        // Two halves of one plugin: the driver captures the environment as an
-        // artifact, the runner reads it back. Registered under the same name,
-        // which is how a runner target's driver selects its runner.
-        e.register_managed_driver(move |_| Box::new(plugindevenv::Driver::new(devenv_root)))?;
-        e.register_exec_runner(
-            plugindevenv::NAME,
-            std::sync::Arc::new(plugindevenv::Runner::new(session_support(
-                &home_dir,
-                &runner_root,
-            ))),
-        )?;
+        // The devenv plugin, and its runner, come from the cdylib.
 
         e.register_provider_factory("buildfile", |init, opts| {
             Ok(Box::new(

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -30,7 +30,6 @@ pub use hplugin::htspec;
 pub use hplugin_buildfile::pluginbuildfile;
 pub mod runner_agent;
 
-pub use hplugin_devenv::plugindevenv;
 pub use hplugin_exec::pluginexec;
 pub use hplugin_http::pluginhttp;
 pub use hplugin_nix::pluginnix;


### PR DESCRIPTION
On top of the generic-runner PR. **`devenv` is a real cdylib plugin now**, not a
builtin.

It was asked for as a loadable plugin during design and shipped as a builtin:
`crates/plugin-devenv` had no `[lib] crate-type`, and `bootstrap.rs` registered
both halves unconditionally into the host binary. My miss.

## What changed

`crates/plugin-devenv-cdylib` — `crate-type = ["cdylib"]`, loaded from a
`heph-devenv-plugin.json` manifest, exactly like go/gha/oci. The host binary no
longer links `plugin-devenv` at all.

**Two components, both named `devenv`**: a driver that builds the environment
artifact, and an **exec runner** (#418) that serves sessions from it. Separate
components, because a runner is not a driver — it has no schema, parses nothing,
builds nothing.

Being the runner is what makes this plugin the party that decides how the
process starts: `ExecSession::prepare` is per target, so one `devenv shell` is
opened once *inside the plugin* and every target's exec is routed into it.

Since #418 hands the host a live session object rather than an id, that shell —
its socket, its pid — simply lives on the session. `Runner` is a single field
again: the `Mutex<HashMap<String, Arc<dyn ExecSession>>>` and the `AtomicU64`
that minted ids existed only to answer the host by a name it had invented, and
both are deleted here.

`SessionSupport` moves into the plugin, where it belongs: `current_exe()` in a
cdylib is the *host* binary, which is exactly the agent and per-target client a
session needs, and `home`/`root` come from `CreateConfig`. The host no longer
assembles it.

## Packaging

Ships as a release artifact on all three targets, same flow as the others:

- one more package in the single `cargo build` — splitting it would serialize a
  fourth LTO tail
- staged into `dist/`, `macos-portable.sh`'d, version-slot patched, manifest
  generated by `tools/pluginmanifest`, published
- `pattern: "heph*"` and `files: dist/*` pick it up with no further change
- `install-devenv-plugin` for local use; `gen-example` runs it, since
  `example/exec_runner/BUILD` uses `driver = "devenv"`
- `qualityCrates` gains the crate — a new crate missing there lints green
  locally and red in CI, which has already cost time once on this stack

## Tests

Two in `bin-e2e`, which is the only place this seam exists — an in-process test
constructs the driver through generics and never crosses it:

| | |
|---|---|
| the shipped cdylib `dlopen`s and its `devenv` driver answers across the ABI | PASS |
| `devenv` no longer resolves with **no** plugin configured | PASS |

The second is the one that matters. Without it the conversion half-lands: the
builtin keeps answering, every fixture passes, and nobody notices the cdylib is
dead weight that is never loaded.

Verified against real staged release artifacts — `plugin_dylib` 12/12.
exec-runner 37, plugin-devenv 10, engine 545, heph 128, e2e/exec_runner 12.
`lint` clean.

## Note for reviewers

`e2e` is a devenv script and is **baked at shell start**, so an existing shell
still stages the old three-artifact list and this suite fails on a missing
`heph-devenv-plugin.dylib`. Re-enter the shell (or `direnv reload`) before
running `e2e` locally. CI is unaffected — it starts a fresh shell.

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>

