### PR TITLE
test(e2e): cover the exec-runner component through the engine, and drop the dangling doc refs

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1508,6 +1508,7 @@ dependencies = [
  "async-trait",
  "core",
  "heph",
+ "plugin",
  "plugin-oci",
  "serde_json",
  "sha2 0.10.9",

--- a/crates/config/src/config_yaml.rs
+++ b/crates/config/src/config_yaml.rs
@@ -45,7 +45,7 @@ pub struct ConfigYaml {
     #[serde(default)]
     pub home_dir: Option<PathBuf>,
     /// Exec environment every target's processes are created in unless the
-    /// target says otherwise (`docs/EXEC_RUNNERS.md` §6). A runner target's
+    /// target says otherwise (`docs/EXEC_RUNNERS.md`). A runner target's
     /// address, e.g. `//:devenv`.
     ///
     /// This is the expected way to use exec runners — "the whole repo builds

--- a/crates/driver-support/src/driver_managed.rs
+++ b/crates/driver-support/src/driver_managed.rs
@@ -58,7 +58,7 @@ pub struct ManagedRunRequest<'a, 'io> {
     ///
     /// A driver creates processes through this rather than calling
     /// `proc_exec::{spawn,output}` directly — that is the whole of the
-    /// exec-runner seam (`docs/EXEC_RUNNERS.md` §4.2). A driver that creates no
+    /// exec-runner seam (`docs/EXEC_RUNNERS.md`). A driver that creates no
     /// process ignores it.
     pub runner: Arc<dyn ExecSession>,
 }

--- a/crates/e2e/Cargo.toml
+++ b/crates/e2e/Cargo.toml
@@ -12,6 +12,7 @@ heph = { path = "../.." }
 htestkit = { package = "testkit", path = "../testkit" }
 hplugin-oci = { package = "plugin-oci", path = "../plugin-oci" }
 hcore = { package = "core", path = "../core" }
+hplugin = { package = "plugin", path = "../plugin" }
 tokio = { version = "1", features = ["rt", "rt-multi-thread", "macros"] }
 anyhow = "1"
 async-trait = "0.1.89"

--- a/crates/e2e/tests/common/mod.rs
+++ b/crates/e2e/tests/common/mod.rs
@@ -107,7 +107,7 @@ impl heph::engine::exec_runner::ExecRunner for RecordingExecRunner {
 
         // The environment is derived from the artifact, not invented: that is
         // the rule that keeps `open` a pure parse of content the cache key
-        // already covers (docs/EXEC_RUNNERS.md §4.7).
+        // already covers. See `docs/EXEC_RUNNERS.md`.
         let from_artifact = req
             .artifacts
             .first()
@@ -282,6 +282,31 @@ impl Workspace {
                         torn: None,
                     }),
                 )
+                .build()
+                .expect("build workspace"),
+            reopen_with: None,
+        }
+    }
+
+    /// A workspace whose runner targets built by `driver_name` are served by
+    /// `runner` — the shape a loaded cdylib gets, where a driver that answers
+    /// the exec-runner lane is registered as the runner for its own name.
+    pub fn with_exec_runner_named(
+        driver_name: &str,
+        runner: Arc<dyn heph::engine::exec_runner::ExecRunner>,
+    ) -> Self {
+        Self {
+            inner: WorkspaceBuilder::new()
+                .expect("workspace tempdir")
+                .with_provider(|init| {
+                    Box::new(pluginbuildfile::Provider::new(
+                        init.root.to_path_buf(),
+                        init.runtime.clone(),
+                    ))
+                })
+                .with_managed_driver(Box::new(pluginexec::Driver::new_exec()))
+                .with_managed_driver(Box::new(pluginexec::Driver::new_bash()))
+                .with_exec_runner(driver_name, runner)
                 .build()
                 .expect("build workspace"),
             reopen_with: None,

--- a/crates/e2e/tests/exec_runner.rs
+++ b/crates/e2e/tests/exec_runner.rs
@@ -5,7 +5,7 @@
 
 //! `runner =` selection and its effect on the cache key.
 //!
-//! Design: `docs/EXEC_RUNNERS.md`. The property under test throughout is §4.3's:
+//! Design: `docs/EXEC_RUNNERS.md`. The property under test throughout is:
 //! a runner reference is a *target* reference, so the environment reaches
 //! `hashin` through the ordinary dependency mechanism and not through a new
 //! hash component.
@@ -156,7 +156,7 @@ target(name = "c", driver = "bash", run = "echo x > $OUT", out = "o", runner = "
     Ok(())
 }
 
-/// The workspace default applies to targets that did not author one — which §6
+/// The workspace default applies to targets that did not author one — which the workspace default
 /// calls the expected way to use this ("the whole repo builds under devenv").
 #[tokio::test]
 async fn workspace_default_applies_and_can_be_opted_out_of() -> anyhow::Result<()> {
@@ -323,7 +323,7 @@ target(name = "b", driver = "bash", run = "echo b > $OUT", out = "o", runner = "
 
 /// A session's `PATH` **replaces** the driver's, it does not sit under it.
 ///
-/// This is §4.4's layer-2 rule, and it is the one that decides whether a runner
+/// This is the PATH-replacement rule, and it is the one that decides whether a runner
 /// means anything: with the driver's default appended, a tool missing from the
 /// environment silently falls through to the host — the exact ambient
 /// dependency a runner exists to remove — and does so under a cache key that

--- a/crates/e2e/tests/exec_runner_spec.rs
+++ b/crates/e2e/tests/exec_runner_spec.rs
@@ -29,8 +29,10 @@ use heph::htaddr::parse_addr;
 /// A runner that holds "one shell" open and routes every spawn through it —
 /// the shape of a devenv session runner, without needing devenv.
 ///
-/// Note what is absent: no `parse`, no `run`, no schema. A runner is its own
-/// component kind, so it implements three methods and nothing else.
+/// Note what is absent: no `parse`, no `run`, no schema, and no session id. A
+/// runner is its own component kind, and it implements the *same* `ExecRunner`
+/// a host-side runner does — the session it returns is an object, so what that
+/// session holds stays on the runner's side.
 ///
 /// It rewrites each spawn to `env FROM_RUNNER=… SEQ=<n> <program> <args>`, so a
 /// target's own `run` can observe both that the session reached it and that the
@@ -39,22 +41,31 @@ struct MuxRunner {
     opens: Arc<AtomicUsize>,
     prepares: Arc<AtomicUsize>,
     closes: Arc<AtomicUsize>,
-    /// Per-session environment, held **inside the runner**.
-    ///
-    /// Under this lane the host does not merge `base_env` for anyone: the
-    /// runner owns the whole transformation, because the runner is what starts
-    /// the process. `ExecSession::base_env` is what the host *reports*, not
-    /// what it applies.
-    envs: std::sync::Mutex<std::collections::HashMap<String, Vec<(OsString, OsString)>>>,
+}
+
+/// The mux's session. Its state lives here, on the plugin's side — there is no
+/// id, no lookup table, and nothing for the host to address it by.
+///
+/// Under this lane the host does not merge `base_env` for anyone: the runner
+/// owns the whole transformation, because the runner is what decides how the
+/// process starts. `ExecSession::base_env` is what the host *reports*, not what
+/// it applies.
+struct MuxSession {
+    base_env: Vec<(OsString, OsString)>,
+    seq: AtomicUsize,
+    caps: heph::engine::exec_runner::SessionCaps,
+    description: heph::engine::exec_runner::SessionDescription,
+    prepares: Arc<AtomicUsize>,
+    closes: Arc<AtomicUsize>,
 }
 
 #[async_trait::async_trait]
-impl heph::engine::exec_runner::ExecRunnerPlugin for MuxRunner {
-    async fn open_session(
+impl heph::engine::exec_runner::ExecRunner for MuxRunner {
+    async fn open(
         &self,
         req: heph::engine::exec_runner::OpenRequest,
         _ct: &(dyn heph::hasync::Cancellable + Send + Sync),
-    ) -> anyhow::Result<heph::engine::exec_runner::OpenedSession> {
+    ) -> anyhow::Result<Arc<dyn heph::engine::exec_runner::ExecSession>> {
         self.opens.fetch_add(1, Ordering::SeqCst);
         // Derived from the artifact, not invented — the runner target's bytes
         // are what the consumer's key already covers.
@@ -63,17 +74,12 @@ impl heph::engine::exec_runner::ExecRunnerPlugin for MuxRunner {
             .first()
             .map(|a| String::from_utf8_lossy(&a.bytes).trim().to_string())
             .unwrap_or_default();
-        let base_env = vec![(
-            OsString::from("FROM_RUNNER"),
-            OsString::from(from_artifact.clone()),
-        )];
-        let session_id = format!("mux-{}", req.key);
-        self.envs
-            .lock()
-            .unwrap_or_else(|p| p.into_inner())
-            .insert(session_id.clone(), base_env.clone());
-        Ok(heph::engine::exec_runner::OpenedSession {
-            session_id,
+        Ok(Arc::new(MuxSession {
+            base_env: vec![(
+                OsString::from("FROM_RUNNER"),
+                OsString::from(from_artifact.clone()),
+            )],
+            seq: AtomicUsize::new(0),
             caps: heph::engine::exec_runner::SessionCaps {
                 pty: true,
                 max_concurrent: Some(4),
@@ -87,38 +93,47 @@ impl heph::engine::exec_runner::ExecRunnerPlugin for MuxRunner {
                 key: req.key.clone(),
                 summary: format!("mux over {from_artifact}"),
             },
-            base_env: Some(base_env),
-        })
+            prepares: Arc::clone(&self.prepares),
+            closes: Arc::clone(&self.closes),
+        }))
     }
+}
 
-    async fn prepare_spec(
+#[async_trait::async_trait]
+impl heph::engine::exec_runner::ExecSession for MuxSession {
+    async fn prepare(
         &self,
-        session_id: &str,
         mut spec: heph::proc_exec::Spec,
-    ) -> anyhow::Result<heph::proc_exec::Spec> {
-        let n = self.prepares.fetch_add(1, Ordering::SeqCst);
+    ) -> Result<heph::proc_exec::Spec, heph::engine::exec_runner::SpawnError> {
+        self.prepares.fetch_add(1, Ordering::SeqCst);
+        let n = self.seq.fetch_add(1, Ordering::SeqCst);
         // The session's environment goes UNDER the caller's own — a runner
         // supplies the floor, or it could silently change what a target builds.
-        let base = self
-            .envs
-            .lock()
-            .unwrap_or_else(|p| p.into_inner())
-            .get(session_id)
-            .cloned()
-            .unwrap_or_default();
-        for (k, v) in base {
-            if !spec.env.iter().any(|(sk, _)| *sk == k) {
-                spec.env.push((k, v));
+        for (k, v) in &self.base_env {
+            if !spec.env.iter().any(|(sk, _)| sk == k) {
+                spec.env.push((k.clone(), v.clone()));
             }
         }
         // Per-SPAWN state. An environment described once at open could not
-        // produce this — it is the capability the ABI lane exists for.
+        // produce this — it is the capability a live session buys.
         spec.env
             .push((OsString::from("SEQ"), OsString::from(n.to_string())));
         Ok(spec)
     }
 
-    async fn close_session(&self, _session_id: &str) -> anyhow::Result<()> {
+    fn base_env(&self) -> Option<&[(OsString, OsString)]> {
+        Some(&self.base_env)
+    }
+
+    fn caps(&self) -> &heph::engine::exec_runner::SessionCaps {
+        &self.caps
+    }
+
+    fn describe(&self) -> &heph::engine::exec_runner::SessionDescription {
+        &self.description
+    }
+
+    async fn close(&self) -> anyhow::Result<()> {
         self.closes.fetch_add(1, Ordering::SeqCst);
         Ok(())
     }
@@ -130,26 +145,23 @@ struct Counts {
     closes: Arc<AtomicUsize>,
 }
 
-/// A workspace whose `bash` runner targets are served by a driver over the
-/// exec-runner lane — the same adapter a loaded cdylib gets on the host side.
+/// A workspace whose `bash` runner targets are served over the exec-runner
+/// lane. Registered exactly as a loaded cdylib's runner is: no adapter, because
+/// there is no separate plugin-side trait to adapt from.
 fn mux_workspace() -> (Workspace, Counts) {
     let c = Counts {
         opens: Arc::new(AtomicUsize::new(0)),
         prepares: Arc::new(AtomicUsize::new(0)),
         closes: Arc::new(AtomicUsize::new(0)),
     };
-    let plugin: Arc<dyn heph::engine::exec_runner::ExecRunnerPlugin> = Arc::new(MuxRunner {
+    let runner: Arc<dyn heph::engine::exec_runner::ExecRunner> = Arc::new(MuxRunner {
         opens: Arc::clone(&c.opens),
         prepares: Arc::clone(&c.prepares),
         closes: Arc::clone(&c.closes),
-        envs: std::sync::Mutex::new(std::collections::HashMap::new()),
     });
     // Registered under `bash`: a runner target's driver name selects the runner
     // that serves it, and the runner targets below are bash targets.
-    let ws = Workspace::with_exec_runner_named(
-        "bash",
-        Arc::new(heph::engine::exec_runner::PluginExecRunner::new(plugin)),
-    );
+    let ws = Workspace::with_exec_runner_named("bash", runner);
     (ws, c)
 }
 

--- a/crates/e2e/tests/exec_runner_spec.rs
+++ b/crates/e2e/tests/exec_runner_spec.rs
@@ -1,0 +1,277 @@
+#![expect(
+    clippy::panic_in_result_fn,
+    reason = "restriction/style lints scoped to production code; tests are exempt"
+)]
+
+//! The exec-runner **ABI lane**, through the real engine.
+//!
+//! `crates/plugin-sdk` covers the lane at the seam itself: a driver's
+//! `open_session` / `prepare_spec` / `close_session` crossing a real stabby
+//! vtable. What that cannot show is the half above it — that the engine
+//! resolves a runner target to its driver, opens one session for the
+//! environment, and routes every target's actual process through it.
+//!
+//! So these run a real BUILD graph. The runner is a `DriverExecRunner` over a
+//! `ManagedDriver`, which is exactly what a loaded cdylib plugin becomes on the
+//! host side.
+//!
+//! See `docs/EXEC_RUNNERS.md`.
+
+mod common;
+
+use std::ffi::OsString;
+use std::sync::Arc;
+use std::sync::atomic::{AtomicUsize, Ordering};
+
+use common::Workspace;
+use heph::htaddr::parse_addr;
+
+/// A runner that holds "one shell" open and routes every spawn through it —
+/// the shape of a devenv session runner, without needing devenv.
+///
+/// Note what is absent: no `parse`, no `run`, no schema. A runner is its own
+/// component kind, so it implements three methods and nothing else.
+///
+/// It rewrites each spawn to `env FROM_RUNNER=… SEQ=<n> <program> <args>`, so a
+/// target's own `run` can observe both that the session reached it and that the
+/// runner was consulted for *this* spawn rather than once for the environment.
+struct MuxRunner {
+    opens: Arc<AtomicUsize>,
+    prepares: Arc<AtomicUsize>,
+    closes: Arc<AtomicUsize>,
+    /// Per-session environment, held **inside the runner**.
+    ///
+    /// Under this lane the host does not merge `base_env` for anyone: the
+    /// runner owns the whole transformation, because the runner is what starts
+    /// the process. `ExecSession::base_env` is what the host *reports*, not
+    /// what it applies.
+    envs: std::sync::Mutex<std::collections::HashMap<String, Vec<(OsString, OsString)>>>,
+}
+
+#[async_trait::async_trait]
+impl heph::engine::exec_runner::ExecRunnerPlugin for MuxRunner {
+    async fn open_session(
+        &self,
+        req: heph::engine::exec_runner::OpenRequest,
+        _ct: &(dyn heph::hasync::Cancellable + Send + Sync),
+    ) -> anyhow::Result<heph::engine::exec_runner::OpenedSession> {
+        self.opens.fetch_add(1, Ordering::SeqCst);
+        // Derived from the artifact, not invented — the runner target's bytes
+        // are what the consumer's key already covers.
+        let from_artifact = req
+            .artifacts
+            .first()
+            .map(|a| String::from_utf8_lossy(&a.bytes).trim().to_string())
+            .unwrap_or_default();
+        let base_env = vec![(
+            OsString::from("FROM_RUNNER"),
+            OsString::from(from_artifact.clone()),
+        )];
+        let session_id = format!("mux-{}", req.key);
+        self.envs
+            .lock()
+            .unwrap_or_else(|p| p.into_inner())
+            .insert(session_id.clone(), base_env.clone());
+        Ok(heph::engine::exec_runner::OpenedSession {
+            session_id,
+            caps: heph::engine::exec_runner::SessionCaps {
+                pty: true,
+                max_concurrent: Some(4),
+                identity: heph::engine::exec_runner::Identity::Pinned {
+                    by: format!("{} ({})", req.runner_addr, req.key),
+                },
+            },
+            description: heph::engine::exec_runner::SessionDescription {
+                runner: req.runner_addr.clone(),
+                shell_functions: vec![],
+                key: req.key.clone(),
+                summary: format!("mux over {from_artifact}"),
+            },
+            base_env: Some(base_env),
+        })
+    }
+
+    async fn prepare_spec(
+        &self,
+        session_id: &str,
+        mut spec: heph::proc_exec::Spec,
+    ) -> anyhow::Result<heph::proc_exec::Spec> {
+        let n = self.prepares.fetch_add(1, Ordering::SeqCst);
+        // The session's environment goes UNDER the caller's own — a runner
+        // supplies the floor, or it could silently change what a target builds.
+        let base = self
+            .envs
+            .lock()
+            .unwrap_or_else(|p| p.into_inner())
+            .get(session_id)
+            .cloned()
+            .unwrap_or_default();
+        for (k, v) in base {
+            if !spec.env.iter().any(|(sk, _)| *sk == k) {
+                spec.env.push((k, v));
+            }
+        }
+        // Per-SPAWN state. An environment described once at open could not
+        // produce this — it is the capability the ABI lane exists for.
+        spec.env
+            .push((OsString::from("SEQ"), OsString::from(n.to_string())));
+        Ok(spec)
+    }
+
+    async fn close_session(&self, _session_id: &str) -> anyhow::Result<()> {
+        self.closes.fetch_add(1, Ordering::SeqCst);
+        Ok(())
+    }
+}
+
+struct Counts {
+    opens: Arc<AtomicUsize>,
+    prepares: Arc<AtomicUsize>,
+    closes: Arc<AtomicUsize>,
+}
+
+/// A workspace whose `bash` runner targets are served by a driver over the
+/// exec-runner lane — the same adapter a loaded cdylib gets on the host side.
+fn mux_workspace() -> (Workspace, Counts) {
+    let c = Counts {
+        opens: Arc::new(AtomicUsize::new(0)),
+        prepares: Arc::new(AtomicUsize::new(0)),
+        closes: Arc::new(AtomicUsize::new(0)),
+    };
+    let plugin: Arc<dyn heph::engine::exec_runner::ExecRunnerPlugin> = Arc::new(MuxRunner {
+        opens: Arc::clone(&c.opens),
+        prepares: Arc::clone(&c.prepares),
+        closes: Arc::clone(&c.closes),
+        envs: std::sync::Mutex::new(std::collections::HashMap::new()),
+    });
+    // Registered under `bash`: a runner target's driver name selects the runner
+    // that serves it, and the runner targets below are bash targets.
+    let ws = Workspace::with_exec_runner_named(
+        "bash",
+        Arc::new(heph::engine::exec_runner::PluginExecRunner::new(plugin)),
+    );
+    (ws, c)
+}
+
+/// The engine resolves a runner target to the runner registered for its driver
+/// name, the runner opens a session, and the environment reaches the target's
+/// real process.
+#[tokio::test]
+async fn a_plugin_served_session_reaches_the_target() -> anyhow::Result<()> {
+    let (ws, c) = mux_workspace();
+    ws.write_build_file(
+        "m",
+        r#"
+target(name = "env", driver = "bash", run = "echo SHELL_A > $OUT", out = "env.txt")
+target(
+    name = "consumer",
+    driver = "bash",
+    run = "echo \"$FROM_RUNNER|$SEQ\" > $OUT",
+    out = "o",
+    runner = "//m:env",
+)
+"#,
+    );
+
+    let res = ws.run("//m:consumer").await?;
+    let out = common::artifact_string(&res);
+    assert!(
+        out.contains("SHELL_A"),
+        "the session's environment, derived from the runner artifact, must reach \
+         the target: {out:?}"
+    );
+    assert_eq!(c.opens.load(Ordering::SeqCst), 1);
+    assert!(
+        c.prepares.load(Ordering::SeqCst) >= 1,
+        "the runner must be consulted for the spawn"
+    );
+    Ok(())
+}
+
+/// The reason this lives on the ABI rather than in the artifact: the runner is
+/// asked about **every** spawn, while the environment is opened once.
+#[tokio::test]
+async fn the_runner_is_consulted_per_target_not_per_environment() -> anyhow::Result<()> {
+    let (ws, c) = mux_workspace();
+    ws.write_build_file(
+        "p",
+        r#"
+target(name = "env", driver = "bash", run = "echo E > $OUT", out = "env.txt")
+target(name = "a", driver = "bash", run = "echo a > $OUT", out = "o", runner = "//p:env")
+target(name = "b", driver = "bash", run = "echo b > $OUT", out = "o", runner = "//p:env")
+target(name = "c", driver = "bash", run = "echo c > $OUT", out = "o", runner = "//p:env")
+"#,
+    );
+
+    for t in ["//p:a", "//p:b", "//p:c"] {
+        ws.run(t).await?;
+    }
+
+    assert_eq!(
+        c.opens.load(Ordering::SeqCst),
+        1,
+        "three targets sharing one environment must open it once",
+    );
+    assert!(
+        c.prepares.load(Ordering::SeqCst) >= 3,
+        "but every target's process must go through the runner, got {}",
+        c.prepares.load(Ordering::SeqCst),
+    );
+    Ok(())
+}
+
+/// A runner target whose driver has no runner registered must refuse, not
+/// degrade. Running the target in the host environment under a key asserting
+/// the runner's is the silently-wrong build this check exists to prevent.
+///
+/// With runners as a component, absence is structural — a plugin exporting no
+/// runners simply registers none — rather than a probe that could answer wrong.
+#[tokio::test]
+async fn a_runner_target_with_no_registered_runner_is_refused() -> anyhow::Result<()> {
+    let ws = Workspace::new();
+    ws.write_build_file(
+        "r",
+        r#"
+target(name = "env", driver = "bash", run = "echo E > $OUT", out = "env.txt")
+target(name = "c", driver = "bash", run = "echo x > $OUT", out = "o", runner = "//r:env")
+"#,
+    );
+
+    let msg = match ws.run("//r:c").await {
+        Ok(_) => panic!("a runner with no session-serving driver must not resolve"),
+        Err(e) => format!("{e:#}"),
+    };
+    assert!(
+        msg.contains("exec runner"),
+        "the error must name the actual problem, got: {msg}"
+    );
+    Ok(())
+}
+
+/// The runner's identity still reaches the cache key: it is a dependency, so
+/// swapping the environment re-keys every artifact built in it.
+#[tokio::test]
+async fn the_runner_still_reaches_the_cache_key() -> anyhow::Result<()> {
+    let (ws, _c) = mux_workspace();
+    ws.write_build_file(
+        "k",
+        r#"
+target(name = "a", driver = "bash", run = "echo ONE > $OUT", out = "env.txt")
+target(name = "b", driver = "bash", run = "echo TWO > $OUT", out = "env.txt")
+target(name = "ca", driver = "bash", run = "echo x > $OUT", out = "o", runner = "//k:a")
+target(name = "cb", driver = "bash", run = "echo x > $OUT", out = "o", runner = "//k:b")
+"#,
+    );
+
+    let hashin = async |addr: &str| -> anyhow::Result<String> {
+        let rs = ws.engine.new_state();
+        let meta = ws.engine.clone().meta(rs, &parse_addr(addr)?).await?;
+        Ok(meta.hashin)
+    };
+    assert_ne!(
+        hashin("//k:ca").await?,
+        hashin("//k:cb").await?,
+        "two different environments must not share a cache key"
+    );
+    Ok(())
+}

--- a/crates/engine/src/engine/config.rs
+++ b/crates/engine/src/engine/config.rs
@@ -26,7 +26,7 @@ pub struct Config {
     pub fs_skip: Vec<String>,
     /// Workspace-level `defaultRunner:` — the exec environment applied to every
     /// target that neither authored `runner =` nor opted out with
-    /// `runner = None`. See `docs/EXEC_RUNNERS.md` §6.
+    /// `runner = None`. See `docs/EXEC_RUNNERS.md`.
     pub default_runner: Option<Addr>,
     pub parallelism: Option<usize>,
     /// In-memory tier fronting the durable (SQLite) local cache.

--- a/crates/engine/src/engine/result.rs
+++ b/crates/engine/src/engine/result.rs
@@ -496,7 +496,7 @@ pub struct ExtendedTargetDef {
     pub applied_transitive: Option<Sandbox>,
     /// Resolved exec environment: `None` for `local`, else the runner target's
     /// addr. Resolution order is per-target `runner =` → workspace
-    /// `defaultRunner` → local (`docs/EXEC_RUNNERS.md` §6).
+    /// `defaultRunner` → local (`docs/EXEC_RUNNERS.md`).
     ///
     /// The addr is recorded for diagnostics and for execution to look the
     /// session up. It does **not** feed the cache key directly — the runner

--- a/crates/exec-runner/src/agent.rs
+++ b/crates/exec-runner/src/agent.rs
@@ -25,7 +25,7 @@
 //! The client is a real child, so `Handle`, the drain, the PTY and the
 //! supervisor all work unchanged. The child's stdio are the *same* file
 //! descriptors — passed, not proxied — so none of `pluginexec`'s bounded-drain
-//! and line-discipline handling is re-derived on a new transport, which §4.6 of
+//! and line-discipline handling is re-derived on a new transport, which the fd-passing protocol in
 //! the design exists to prevent. The client then exits with the child's status,
 //! so the exit code a driver sees is the real one.
 //!
@@ -241,7 +241,7 @@ pub fn request(socket: &Path, req: &ExecRequest, stdio: [RawFd; 3]) -> anyhow::R
 /// Where an agent for `key` listens.
 ///
 /// Under the runner's own directory rather than a shared `/tmp` name: two heph
-/// processes on one machine each open their own session (§10), and a fixed path
+/// processes on one machine each open their own session, and a fixed path
 /// would have them fight over one socket.
 pub fn socket_path(dir: &Path, key: &str) -> PathBuf {
     // The key is a hex hash, but it is not this function's business to assume

--- a/crates/plugin-devenv/src/lib.rs
+++ b/crates/plugin-devenv/src/lib.rs
@@ -1,7 +1,7 @@
 //! The `devenv` plugin: a driver that captures a devenv.sh environment as an
 //! artifact, and an exec runner that reads it back.
 //!
-//! Design: `docs/EXEC_RUNNERS.md` §5. Two halves under one name, because that
+//! Design: `docs/EXEC_RUNNERS.md`. Two halves under one name, because that
 //! is how a runner is selected — by the driver name of the runner target.
 pub mod plugindevenv;
 

--- a/crates/plugin-exec/src/pluginexec/mod.rs
+++ b/crates/plugin-exec/src/pluginexec/mod.rs
@@ -1091,7 +1091,7 @@ impl Driver {
             env.insert("TERM".to_string(), term);
         }
         // The session's PATH REPLACES the driver's, rather than sitting under it
-        // (`docs/EXEC_RUNNERS.md` §4.4). Appending the driver's default after it
+        // (`docs/EXEC_RUNNERS.md`, "Environment layering"). Appending the driver's default after it
         // would mean a tool missing from the runner silently falls through to
         // the host — the exact ambient dependency a runner exists to remove —
         // and it would do so invisibly, under a cache key asserting the runner's
@@ -1502,7 +1502,7 @@ impl Driver {
         // versions of their fields were moved into `spec` above), so no work
         // happens on the far more common spawn-succeeds path.
         // Through the session, not `proc_exec::spawn` directly: that is the
-        // whole exec-runner seam (`docs/EXEC_RUNNERS.md` §4.2). Under `local`
+        // whole exec-runner seam (`docs/EXEC_RUNNERS.md`). Under `local`
         // the session's `prepare` is the identity function, so this is the same
         // fork it always was.
         let mut handle = req.runner.spawn(spec).await.map_err(|e| {
@@ -3393,7 +3393,7 @@ mod tests {
 
     /// Golden freeze of the child process's environment.
     ///
-    /// The exec-runner design (`docs/EXEC_RUNNERS.md` §4.4) inserts a runner's
+    /// The exec-runner layering rules (`docs/EXEC_RUNNERS.md`) insert a runner's
     /// `base_env` beneath the driver's `PATH` and skips the driver's `path`
     /// default when a runner supplies one. Everything else about this sequence
     /// must stay byte-identical — and an earlier draft of that design stated a
@@ -3522,7 +3522,7 @@ mod tests {
             "child env drifted.\n got: {got:#?}\nwant: {want:#?}\n\
              If this is a deliberate change to env composition, it changes what \
              existing targets see under an unchanged cache key — see \
-             docs/EXEC_RUNNERS.md §4.4 before updating this golden."
+             docs/EXEC_RUNNERS.md (\"Environment layering\") before updating this golden."
         );
 
         Ok(())

--- a/crates/plugin-nix/src/pluginnix/mod.rs
+++ b/crates/plugin-nix/src/pluginnix/mod.rs
@@ -423,7 +423,7 @@ impl ManagedDriver for Driver {
             ctty: false,
         };
 
-        // Through the session — see `docs/EXEC_RUNNERS.md` §4.2. `output`, not
+        // Through the session — see `docs/EXEC_RUNNERS.md`. `output`, not
         // `spawn`: nix build output is collected in full after the wait, which
         // needs the unbounded drain.
         let output = req

--- a/crates/plugin/src/driver.rs
+++ b/crates/plugin/src/driver.rs
@@ -1031,7 +1031,7 @@ pub struct RunRequest<'a, 'io> {
     ///
     /// Resolved by the engine per target — a driver never chooses it. Drivers
     /// create processes through this rather than calling `proc_exec` directly
-    /// (`docs/EXEC_RUNNERS.md` §4.2).
+    /// (`docs/EXEC_RUNNERS.md`).
     pub runner: std::sync::Arc<dyn hexec_runner::ExecSession>,
 }
 /// Cleanup closure a driver returns for the engine to run after `cache_locally`.

--- a/crates/plugin/src/provider.rs
+++ b/crates/plugin/src/provider.rs
@@ -113,7 +113,7 @@ pub enum RunnerRef {
     /// `runner = //pkg:name` — a target whose artifact describes the
     /// environment. A target reference rather than a config name so its
     /// identity reaches the cache key through the ordinary dependency
-    /// mechanism (see `docs/EXEC_RUNNERS.md` §4.3).
+    /// mechanism (see `docs/EXEC_RUNNERS.md`, "How it reaches the cache key").
     Target(Addr),
 }
 


### PR DESCRIPTION
On top of #419. Test-only, plus a comment sweep.

## The gap

#418 covers the exec-runner component **at the seam** — `open` returning a live
session across a real stabby vtable, and that session's `prepare` reached per
spawn. What that cannot show is the half above it: that the engine resolves a runner target to its
driver, opens one session for the environment, and routes every target's actual
process through it.

`crates/e2e/tests/exec_runner_spec.rs` runs a real BUILD graph against a mock
registered exactly as a loaded cdylib's runner is — no adapter, because after
#418 there is no separate plugin-side trait to adapt from.

The fixture is worth a look for what it does *not* contain: no `parse`, no
`run`, no schema, and no session id. A runner is its own component kind, so the
mock implements `ExecRunner` and nothing else; its per-session environment and
its per-spawn counter sit on the session object it returns. An earlier draft
needed three `bail!("unused")` stubs and a `HashMap` keyed by an id the host
handed back.

| | |
|---|---|
| a plugin-served session reaches the target's real process | PASS |
| the runner is consulted **per target** while the environment opens **once** | PASS |
| a runner target with no registered runner is refused, not degraded | PASS |
| the runner's identity still reaches the cache key | PASS |

The second row is the one that justifies a runner owning process creation: an
environment described once at open cannot produce per-spawn state.

## A semantic worth stating

Writing these surfaced something the design should say out loud: the host does
**not** merge `base_env` for anyone. The runner owns the whole
transformation, because the runner is what starts the process;
`ExecSession::base_env` is what the host *reports* for diagnostics, not what it
applies. The first draft of the fixture assumed otherwise and failed with
`FROM_RUNNER: unbound variable` — which is the right failure, loudly.

## Comment sweep

17 `§N.N` references to the design doc's numbered sections have pointed at
nothing since #404 made it a short reference. Each now names a real heading
("Environment layering", "How it reaches the cache key") or drops the section.

`GHA_REPORTING.md` and `CONCURRENCY_MEASUREMENTS.md` refs are untouched — those
docs still have those sections.

## Tests

e2e 147 across 18 files, plus plugin-sdk 36 and the crate suites. `lint` clean.

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>

