### PR TITLE
feat(plugin-oci): run targets in containers with an `oci_runner`

### DIFF
--- a/crates/exec-runner/src/lib.rs
+++ b/crates/exec-runner/src/lib.rs
@@ -833,13 +833,44 @@ pub enum WrapEnv {
 /// Still a pure spec transformation, which is the whole reason `prepare` is the
 /// seam: nothing here owns a process, so `proc_exec` keeps its synchronous
 /// spawn, its `Handle` invariants and its stdio handling untouched.
-#[derive(Debug)]
 pub struct WrapSession {
     prefix_argv: Vec<OsString>,
     env_mode: WrapEnv,
+    /// Rendered into the wrapper's argv with `{CWD}` replaced, when the wrapper
+    /// does not take the spec's own working directory.
+    ///
+    /// `docker exec` is the case that forced this: the wrapper runs on the host
+    /// and `spec.cwd` is where *it* starts, which says nothing about where the
+    /// process inside the container starts. Without `-w` every target would run
+    /// in the image's `WORKDIR` — usually `/` — and a build that reads a
+    /// relative path would fail somewhere far from the cause. A wrapper that
+    /// execs the inner program (`chroot`, `nix develop`) leaves this empty and
+    /// inherits `spec.cwd` as before.
+    cwd_args: Vec<String>,
+    /// Operands between the options and the program — see
+    /// [`with_trailing_args`](Self::with_trailing_args).
+    trailing_args: Vec<OsString>,
     base_env: Vec<(OsString, OsString)>,
     caps: SessionCaps,
     description: SessionDescription,
+    /// See [`TeardownJob`]. A container outlives the build unless something
+    /// removes it, and the hard-abort path cannot await — which is exactly the
+    /// shape this type was written for, and was missing until a runner needed it.
+    teardown: std::sync::Mutex<Option<TeardownJob>>,
+}
+
+impl std::fmt::Debug for WrapSession {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        // Hand-rolled because `TeardownJob` is a boxed closure: same reason
+        // `AgentSession` writes its own.
+        f.debug_struct("WrapSession")
+            .field("prefix_argv", &self.prefix_argv)
+            .field("env_mode", &self.env_mode)
+            .field("cwd_args", &self.cwd_args)
+            .field("trailing_args", &self.trailing_args)
+            .field("runner", &self.description.runner)
+            .finish_non_exhaustive()
+    }
 }
 
 impl WrapSession {
@@ -856,10 +887,44 @@ impl WrapSession {
         Ok(Self {
             prefix_argv,
             env_mode,
+            cwd_args: Vec::new(),
+            trailing_args: Vec::new(),
             base_env,
             caps,
             description,
+            teardown: std::sync::Mutex::new(None),
         })
+    }
+
+    /// Argv that tells the wrapper where to start the inner process, with
+    /// `{CWD}` replaced per spawn — `["-w", "{CWD}"]` for `docker exec`.
+    ///
+    /// Builders rather than more constructor arguments: only a container-shaped
+    /// wrapper needs either of these, and a seven-argument `new` would make
+    /// every caller name the two it does not use.
+    #[must_use]
+    pub fn with_cwd_args(mut self, cwd_args: Vec<String>) -> Self {
+        self.cwd_args = cwd_args;
+        self
+    }
+
+    /// Argv rendered **after** the options and immediately before the program.
+    ///
+    /// `docker exec` is `[OPTIONS] CONTAINER COMMAND [ARG…]`, so the container
+    /// id is an operand, not an option: it cannot go in `prefix_argv` (which
+    /// precedes the options) and it must not be mistaken for the command. The
+    /// three builders here map onto exactly that grammar — `cwd_args` and the
+    /// [`WrapEnv::Args`] template are options, this is the operand.
+    #[must_use]
+    pub fn with_trailing_args(mut self, trailing_args: Vec<OsString>) -> Self {
+        self.trailing_args = trailing_args;
+        self
+    }
+
+    #[must_use]
+    pub fn with_teardown(self, teardown: TeardownJob) -> Self {
+        *self.teardown.lock().unwrap_or_else(|p| p.into_inner()) = Some(teardown);
+        self
     }
 
     fn merged_env(&self, spec_env: &[(OsString, OsString)]) -> Vec<(OsString, OsString)> {
@@ -876,6 +941,13 @@ impl WrapSession {
 
 #[async_trait::async_trait]
 impl ExecSession for WrapSession {
+    fn teardown(&self) -> Option<TeardownJob> {
+        self.teardown
+            .lock()
+            .unwrap_or_else(|p| p.into_inner())
+            .take()
+    }
+
     async fn prepare(&self, mut spec: Spec) -> Result<Spec, SpawnError> {
         let merged = self.merged_env(&spec.env);
 
@@ -889,6 +961,11 @@ impl ExecSession for WrapSession {
             .split_first()
             .ok_or_else(|| SpawnError::Io(std::io::Error::other("empty wrapper command")))?;
         let mut args: Vec<OsString> = rest.to_vec();
+        for part in &self.cwd_args {
+            args.push(OsString::from(
+                part.replace("{CWD}", &spec.cwd.to_string_lossy()),
+            ));
+        }
         if let WrapEnv::Args(template) = &self.env_mode {
             for (k, v) in &merged {
                 for part in template {
@@ -899,6 +976,7 @@ impl ExecSession for WrapSession {
                 }
             }
         }
+        args.extend(self.trailing_args.iter().cloned());
         args.push(spec.program.clone().into_os_string());
         args.append(&mut spec.args);
 
@@ -1039,6 +1117,39 @@ mod wrap_session_tests {
         )
         .expect("wrap");
         assert!(s.base_env().is_none());
+    }
+
+    /// A container outlives the build unless something removes it, and the
+    /// hard-abort path exits without running destructors — so the teardown must
+    /// be reachable synchronously, and exactly once.
+    #[test]
+    fn a_wrap_session_hands_its_teardown_over_once() {
+        let ran = std::sync::Arc::new(std::sync::atomic::AtomicUsize::new(0));
+        let s = WrapSession::new(
+            vec![OsString::from("docker")],
+            WrapEnv::Inherit,
+            vec![],
+            caps(),
+            desc(),
+        )
+        .expect("wrap")
+        .with_teardown(Box::new({
+            let ran = std::sync::Arc::clone(&ran);
+            move || {
+                ran.fetch_add(1, std::sync::atomic::Ordering::SeqCst);
+                Ok(())
+            }
+        }));
+
+        let job = s.teardown().expect("a teardown was handed over");
+        job().expect("run");
+        assert_eq!(ran.load(std::sync::atomic::Ordering::SeqCst), 1);
+        // Taken, not cloned: the orderly path and the abort path can both reach
+        // `teardown()`, and a container must not be removed twice.
+        assert!(
+            s.teardown().is_none(),
+            "a second caller must not get the same job"
+        );
     }
 
     #[test]

--- a/crates/plugin-oci-cdylib/src/lib.rs
+++ b/crates/plugin-oci-cdylib/src/lib.rs
@@ -18,19 +18,22 @@
 
 use hdriver_support::driver_managed::ManagedDriver;
 use hplugin_oci::pluginoci;
-use plugin_sdk::stabby::abi::{DynLogSink, DynSupervisor, NamedDriver, PluginComponents};
+use plugin_sdk::stabby::abi::{
+    DynLogSink, DynSupervisor, NamedDriver, NamedExecRunner, PluginComponents,
+};
 use plugin_sdk::stabby::{
-    install_log_sink, install_supervisor, make_dyn_managed_driver, make_dyn_provider,
+    create_config_from_bytes, install_log_sink, install_supervisor, make_dyn_exec_runner,
+    make_dyn_managed_driver, make_dyn_provider,
 };
 use std::sync::Arc;
 
 /// Stable ABI create entry. `#[stabby::export]` emits the type-report symbols the
 /// host's `get_stabbied` checks for ABI compatibility. `cfg` is prost-encoded
-/// `pb::CreateConfig` bytes; this plugin reads nothing out of it, but the
-/// parameter stays so config fields can be added without an ABI change.
+/// `pb::CreateConfig` bytes — the workspace root, which `oci_runner` needs to
+/// know which directory to mount into its containers.
 #[stabby::export]
-pub extern "C" fn heph_plugin_create(_cfg: stabby::vec::Vec<u8>) -> PluginComponents {
-    build()
+pub extern "C" fn heph_plugin_create(cfg: stabby::vec::Vec<u8>) -> PluginComponents {
+    build(&cfg)
 }
 
 /// Stable ABI log-sink entry: the host calls this right after `create` to hand
@@ -54,7 +57,16 @@ pub extern "C" fn heph_plugin_set_supervisor(sup: DynSupervisor) {
     install_supervisor(sup);
 }
 
-fn build() -> PluginComponents {
+fn build(cfg: &[u8]) -> PluginComponents {
+    // A root we could not decode leaves the runner with nothing to mount, which
+    // would fail every target under it with a dangling `$OUT`. The drivers are
+    // unaffected, so this degrades to "no runner exported" — the host then
+    // refuses an `oci_runner` target by name rather than running one wrongly.
+    let root = create_config_from_bytes(cfg)
+        .ok()
+        .map(|c| std::path::PathBuf::from(c.root))
+        .filter(|r| !r.as_os_str().is_empty());
+
     let mut drivers = stabby::vec::Vec::new();
 
     // Assembles target outputs into an image. No daemon, no execution.
@@ -105,6 +117,26 @@ fn build() -> PluginComponents {
         driver: make_dyn_managed_driver(platform),
     });
 
+    // Writes the image reference a container session is opened from.
+    let oci_runner: Arc<dyn ManagedDriver> = Arc::new(pluginoci::runner::Driver);
+    drivers.push(NamedDriver {
+        name: pluginoci::runner::DRIVER_NAME.into(),
+        driver: make_dyn_managed_driver(oci_runner),
+    });
+
+    // The runner half, under the same name — a target built by the `oci_runner`
+    // driver selects the `oci_runner` runner.
+    let mut runners = stabby::vec::Vec::new();
+    if let Some(root) = root {
+        let runner: Arc<dyn plugin_sdk::runner::ExecRunner> = Arc::new(
+            pluginoci::runner::Runner::new(root.join(".heph3").join("sandbox")),
+        );
+        runners.push(NamedExecRunner {
+            name: pluginoci::runner::DRIVER_NAME.into(),
+            runner: make_dyn_exec_runner(runner),
+        });
+    }
+
     let provider: Arc<dyn hplugin::provider::Provider> = Arc::new(pluginoci::platform::Provider);
 
     PluginComponents {
@@ -112,8 +144,7 @@ fn build() -> PluginComponents {
         provider: stabby::option::Option::Some(make_dyn_provider(provider)),
         drivers,
         hooks: stabby::vec::Vec::new(),
-        // No exec runner: this plugin serves no environments.
-        runners: stabby::vec::Vec::new(),
+        runners,
         meta: stabby::vec::Vec::new(),
     }
 }

--- a/crates/plugin-oci/src/pluginoci/mod.rs
+++ b/crates/plugin-oci/src/pluginoci/mod.rs
@@ -31,6 +31,7 @@ pub mod platform;
 pub mod pull;
 pub mod push;
 pub mod registry;
+pub mod runner;
 
 /// Archive format an image is built/consumed as.
 #[derive(Clone, Copy, Debug, PartialEq, Eq, serde::Serialize, serde::Deserialize)]

--- a/crates/plugin-oci/src/pluginoci/runner.rs
+++ b/crates/plugin-oci/src/pluginoci/runner.rs
@@ -1,0 +1,615 @@
+//! `oci_runner` — run a target's processes inside a container.
+//!
+//! Two halves, like every runner: a **driver** that resolves the image and
+//! writes it as the target's artifact, and a **runner** that reads that artifact
+//! and serves sessions from it.
+//!
+//! The container is started **once per environment** and every target is
+//! `docker exec`'d into it. The alternative — `docker run --rm` per spawn — is
+//! simpler and needs no teardown, but it pays a container create per process,
+//! which is the cost a session exists to amortize.
+//!
+//! ## Why this is `Wrap` and not `Agent`
+//!
+//! `docker exec` creates the process on the far side of the daemon socket, so
+//! the environment heph sets belongs to the `docker` CLI on *this* side and the
+//! container process sees none of it. That is exactly the distinction
+//! [`WrapEnv::Args`] exists for: each variable is rendered into the wrapper's
+//! own argv as `-e K=V`. A wrapper of this kind using `Inherit` would run every
+//! target with an environment it never asked for and no error to show for it.
+//!
+//! ## What is pinned, and what is not
+//!
+//! An image referenced by **digest** is content the cache key already covers, so
+//! the session reports `Identity::Pinned`. A tag is a claim — it can move under
+//! a build — so a tagged reference reports `Asserted` and says why. heph does
+//! not refuse a tag: choosing a weakly-pinned environment is the user's call,
+//! and reporting the tradeoff honestly is the job.
+
+use anyhow::Context as _;
+use async_trait::async_trait;
+use hcore::debug_hash::DebugHasher;
+use hcore::hasync::Cancellable;
+use hdriver_support::driver_managed::{ManagedDriver, ManagedRunRequest, ManagedRunResponse};
+use hexec_runner::{
+    ExecRunner, ExecSession, Identity, OpenRequest, SessionCaps, SessionDescription, WrapEnv,
+    WrapSession,
+};
+use hplugin::driver::targetdef::path::{CodegenMode, Content, Path as OutPath};
+use hplugin::driver::targetdef::{CacheConfig, Input, InputMode, Output, TargetDef};
+use hplugin::driver::{
+    ApplyTransitiveRequest, ApplyTransitiveResponse, ConfigRequest, ConfigResponse, ParseRequest,
+    ParseResponse, TargetAddr,
+};
+use hplugin::htspec::Spec;
+use std::collections::BTreeMap;
+use std::ffi::OsString;
+use std::hash::{Hash, Hasher};
+use std::sync::Arc;
+use xxhash_rust::xxh3::Xxh3Default;
+
+use super::{dep_single_file, ws_path};
+
+pub const DRIVER_NAME: &str = "oci_runner";
+
+/// Bump to invalidate every runner artifact when this file's meaning changes,
+/// for the same reason the devenv snapshot carries one: the runner half is not
+/// a target, so it has no `TargetDef.hash` of its own.
+const FORMAT_VERSION: u32 = 1;
+
+const IMAGE_ORIGIN: &str = "image";
+
+#[derive(Spec)]
+struct OciRunnerSpec {
+    /// The image to run in.
+    ///
+    /// Either a **literal reference** (`ubuntu@sha256:…`, or a tag) or the
+    /// **addr of a target** that writes one — an `oci_load` target's `.ref`
+    /// output. An addr is anything starting with `//` or `:`.
+    ///
+    /// Prefer a digest: it is the difference between `Pinned` and `Asserted`.
+    image: String,
+    /// The `docker` binary. Defaults to `docker` on the driver's PATH.
+    bin: Option<String>,
+    /// The command that holds the container open. Defaults to
+    /// `["sleep", "infinity"]`, which needs a `sleep` in the image — a
+    /// distroless or scratch image must name something it does have.
+    keepalive: Vec<String>,
+    /// Extra `docker run` arguments, applied when the container starts:
+    /// `["--network", "none"]`, `["-v", "/opt/toolchain:/opt/toolchain:ro"]`.
+    ///
+    /// The sandbox root is always mounted at the same path inside the container
+    /// — without it a target's `$OUT` and `$SRC` name paths that do not exist
+    /// there — so this is for anything *beyond* that.
+    run_args: Vec<String>,
+}
+
+#[derive(Clone, serde::Serialize, serde::Deserialize, Hash)]
+struct OciRunnerDef {
+    /// `None` when `image` was a literal; otherwise the ref is read from the
+    /// dep's output at run time.
+    literal_image: Option<String>,
+    bin: String,
+    keepalive: Vec<String>,
+    run_args: Vec<String>,
+    out: String,
+}
+
+/// The artifact. **This _is_ the description** — the runner half parses it and
+/// reads nothing else, so everything the environment depends on is content the
+/// consumer's cache key already covers.
+#[derive(Debug, Clone, serde::Serialize, serde::Deserialize, PartialEq, Eq)]
+pub struct RunnerArtifactFile {
+    pub format_version: u32,
+    pub image: String,
+    pub bin: String,
+    pub keepalive: Vec<String>,
+    pub run_args: Vec<String>,
+}
+
+/// What the `docker` CLI itself needs to run — a `PATH` to be found on, and the
+/// daemon/socket selection a developer's shell already carries.
+///
+/// Deliberately not the target's environment: nothing here reaches the process
+/// inside the container, which gets its environment through `-e` instead.
+fn docker_cli_env() -> Vec<(OsString, OsString)> {
+    [
+        "PATH",
+        "HOME",
+        "DOCKER_HOST",
+        "DOCKER_CONFIG",
+        "DOCKER_CONTEXT",
+    ]
+    .into_iter()
+    .filter_map(|k| std::env::var_os(k).map(|v| (OsString::from(k), v)))
+    .collect()
+}
+
+fn looks_like_addr(s: &str) -> bool {
+    s.starts_with("//") || s.starts_with(':')
+}
+
+/// Whether a reference names content rather than a moving label.
+fn is_digest_pinned(image: &str) -> bool {
+    image.contains("@sha256:") || image.contains("@sha512:")
+}
+
+pub struct Driver;
+
+#[async_trait]
+impl ManagedDriver for Driver {
+    fn config(&self, _req: ConfigRequest) -> anyhow::Result<ConfigResponse> {
+        Ok(ConfigResponse {
+            name: DRIVER_NAME.to_string(),
+        })
+    }
+
+    fn schema(&self) -> hplugin::driver::DriverSchema {
+        OciRunnerSpec::schema()
+    }
+
+    async fn parse(
+        &self,
+        req: ParseRequest,
+        _ctoken: &(dyn Cancellable + Send + Sync),
+    ) -> anyhow::Result<ParseResponse> {
+        let addr = &req.target_spec.addr;
+        let spec =
+            OciRunnerSpec::from(&req.target_spec.config).context("parse oci_runner config")?;
+
+        if spec.image.trim().is_empty() {
+            anyhow::bail!(
+                "`image` is required: an image reference, or the addr of a target that writes one"
+            );
+        }
+
+        let mut inputs = Vec::new();
+        let literal_image = if looks_like_addr(&spec.image) {
+            let image_ref = TargetAddr::parse(&spec.image, &addr.package)
+                .with_context(|| format!("parse image target {:?}", spec.image))?;
+            inputs.push(Input {
+                r#ref: image_ref,
+                mode: InputMode::Standard,
+                origin_id: IMAGE_ORIGIN.to_string(),
+                annotations: BTreeMap::new(),
+                hashed: true,
+                runtime: true,
+            });
+            None
+        } else {
+            Some(spec.image.clone())
+        };
+
+        let keepalive = if spec.keepalive.is_empty() {
+            vec!["sleep".to_string(), "infinity".to_string()]
+        } else {
+            spec.keepalive
+        };
+
+        let out = ws_path(addr.package.as_str(), &format!("{}.runner.json", addr.name));
+        let def = OciRunnerDef {
+            literal_image,
+            bin: spec.bin.unwrap_or_else(|| "docker".to_string()),
+            keepalive,
+            run_args: spec.run_args,
+            out: out.clone(),
+        };
+
+        let hash = {
+            let mut h = DebugHasher::new(Xxh3Default::new(), || {
+                format!("oci_runner_{}", addr.format())
+            });
+            FORMAT_VERSION.hash(&mut h);
+            def.hash(&mut h);
+            format!("{:x}", h.finish()).into_bytes()
+        };
+
+        Ok(ParseResponse {
+            target_def: TargetDef {
+                addr: addr.clone(),
+                labels: req.target_spec.labels.clone(),
+                raw_def: Arc::new(def),
+                inputs,
+                outputs: vec![Output {
+                    group: String::new(),
+                    paths: vec![OutPath {
+                        content: Content::FilePath(out),
+                        codegen_tree: CodegenMode::None,
+                        collect: true,
+                    }],
+                }],
+                support_files: vec![],
+                // Local cache only. The reference may name an image that
+                // exists solely in *this* machine's daemon — an `oci_load`
+                // target's output does — so handing it to another machine over
+                // a shared cache would hand it a name it cannot resolve. Same
+                // reason devenv snapshots are local-only.
+                cache: CacheConfig::on(false),
+                pty: false,
+                hash,
+                transparent: false,
+            },
+        })
+    }
+
+    async fn apply_transitive(
+        &self,
+        req: ApplyTransitiveRequest,
+        _ctoken: &(dyn Cancellable + Send + Sync),
+    ) -> anyhow::Result<ApplyTransitiveResponse> {
+        Ok(ApplyTransitiveResponse {
+            target_def: req.target_def,
+        })
+    }
+
+    async fn run<'a, 'io>(
+        &self,
+        req: ManagedRunRequest<'a, 'io>,
+        _ctoken: &(dyn Cancellable + Send + Sync),
+    ) -> anyhow::Result<ManagedRunResponse> {
+        let def = req.request.target.def_de::<OciRunnerDef>();
+
+        let image = match &def.literal_image {
+            Some(i) => i.clone(),
+            None => {
+                let path = dep_single_file(&req, IMAGE_ORIGIN)
+                    .context("locate the image target's ref output")?;
+                std::fs::read_to_string(&path)
+                    .with_context(|| format!("read image ref from {path:?}"))?
+                    .trim()
+                    .to_string()
+            }
+        };
+        if image.is_empty() {
+            anyhow::bail!("the image target produced an empty reference");
+        }
+
+        let artifact = RunnerArtifactFile {
+            format_version: FORMAT_VERSION,
+            image,
+            bin: def.bin.clone(),
+            keepalive: def.keepalive.clone(),
+            run_args: def.run_args.clone(),
+        };
+        let bytes = serde_json::to_vec_pretty(&artifact).context("encode the runner artifact")?;
+        let out = req.sandbox_ws_dir.join(&def.out);
+        if let Some(parent) = out.parent() {
+            std::fs::create_dir_all(parent)
+                .with_context(|| format!("create {}", parent.display()))?;
+        }
+        std::fs::write(&out, &bytes).with_context(|| format!("write {}", out.display()))?;
+
+        Ok(ManagedRunResponse { artifacts: vec![] })
+    }
+}
+
+/// The runner half: start one container per environment, `docker exec` into it.
+pub struct Runner {
+    /// Mounted into every container at the same path. Targets address `$OUT` and
+    /// `$SRC` by absolute path, so the path inside must equal the path outside
+    /// or every one of them dangles.
+    sandbox_root: std::path::PathBuf,
+}
+
+impl Runner {
+    pub fn new(sandbox_root: std::path::PathBuf) -> Self {
+        Self { sandbox_root }
+    }
+}
+
+#[async_trait]
+impl ExecRunner for Runner {
+    async fn open(
+        &self,
+        req: OpenRequest,
+        ctoken: &(dyn Cancellable + Send + Sync),
+    ) -> anyhow::Result<Arc<dyn ExecSession>> {
+        let artifact = req
+            .artifacts
+            .iter()
+            .find(|a| a.path.ends_with(".runner.json"))
+            .ok_or_else(|| {
+                anyhow::anyhow!(
+                    "runner {} produced no *.runner.json: an `oci_runner` runner target must be \
+                     built by the `oci_runner` driver",
+                    req.runner_addr,
+                )
+            })?;
+        let file: RunnerArtifactFile = serde_json::from_slice(&artifact.bytes)
+            .with_context(|| format!("parse the runner artifact from {}", req.runner_addr))?;
+
+        if file.format_version != FORMAT_VERSION {
+            anyhow::bail!(
+                "{} was built by a different version of the oci_runner driver (artifact v{}, this \
+                 heph understands v{}) — rebuild it",
+                req.runner_addr,
+                file.format_version,
+                FORMAT_VERSION,
+            );
+        }
+
+        let mount = format!(
+            "{}:{}",
+            self.sandbox_root.display(),
+            self.sandbox_root.display()
+        );
+        let mut args: Vec<OsString> = vec![
+            OsString::from("run"),
+            OsString::from("-d"),
+            // `--rm` so a container the teardown never reached (a hard abort,
+            // a killed daemon connection) still goes away when it stops.
+            OsString::from("--rm"),
+            // Reap zombies: a target that spawns children inside the container
+            // would otherwise leave them parented to a pid 1 that never waits.
+            OsString::from("--init"),
+            OsString::from("-v"),
+            OsString::from(&mount),
+        ];
+        args.extend(file.run_args.iter().map(OsString::from));
+        // The image's own entrypoint would run instead of the keepalive, and
+        // most images have one that exits.
+        //
+        // `split_first` rather than an index: the driver never writes an empty
+        // keepalive, but this artifact is a file on disk and a corrupt one must
+        // say so rather than panic across the plugin seam, where a panic is a
+        // non-unwinding abort of the whole build.
+        let (entrypoint, keepalive_args) = file.keepalive.split_first().ok_or_else(|| {
+            anyhow::anyhow!(
+                "{}: the runner artifact has an empty `keepalive`, so nothing would hold the \
+                 container open",
+                req.runner_addr
+            )
+        })?;
+        args.push(OsString::from("--entrypoint"));
+        args.push(OsString::from(entrypoint));
+        args.push(OsString::from(&file.image));
+        args.extend(keepalive_args.iter().map(OsString::from));
+
+        let spec = hproc::proc_exec::Spec {
+            program: std::path::PathBuf::from(&file.bin),
+            args,
+            env: docker_cli_env(),
+            cwd: std::env::current_dir().unwrap_or_else(|_| std::path::PathBuf::from("/")),
+            stdin: hproc::proc_exec::StdioSpec::Null,
+            stdout: hproc::proc_exec::StdioSpec::Piped,
+            stderr: hproc::proc_exec::StdioSpec::Piped,
+            setsid: true,
+            ctty: false,
+        };
+        let out = hproc::proc_exec::output(spec, ctoken)
+            .await
+            .with_context(|| format!("start a container for {}", req.runner_addr))?;
+        if !out.status.success() {
+            let stderr = String::from_utf8_lossy(&out.stderr);
+            anyhow::bail!(
+                "`{} run` failed for image {} ({}):\n{stderr}",
+                file.bin,
+                file.image,
+                out.status
+            );
+        }
+        let cid = String::from_utf8_lossy(&out.stdout).trim().to_string();
+        if cid.is_empty() {
+            anyhow::bail!("`{} run -d` printed no container id", file.bin);
+        }
+
+        let teardown_bin = file.bin.clone();
+        let teardown_cid = cid.clone();
+        let teardown: hexec_runner::TeardownJob = Box::new(move || {
+            // Blocking and fire-and-forget by contract: `Drop` and the
+            // hard-abort path must both be able to reach it, and the latter
+            // exits without running destructors.
+            let status = std::process::Command::new(&teardown_bin)
+                .args(["rm", "-f", &teardown_cid])
+                .stdin(std::process::Stdio::null())
+                .stdout(std::process::Stdio::null())
+                .stderr(std::process::Stdio::null())
+                .status()
+                .with_context(|| format!("`{teardown_bin} rm -f {teardown_cid}`"))?;
+            if !status.success() {
+                anyhow::bail!("`{teardown_bin} rm -f {teardown_cid}` exited {status}");
+            }
+            Ok(())
+        });
+
+        let identity = if is_digest_pinned(&file.image) {
+            Identity::Pinned {
+                by: file.image.clone(),
+            }
+        } else {
+            Identity::Asserted {
+                why: format!(
+                    "image {} is referenced by tag, not digest — the tag can move between builds",
+                    file.image
+                ),
+            }
+        };
+
+        Ok(Arc::new(
+            WrapSession::new(
+                vec![OsString::from(&file.bin), OsString::from("exec")],
+                // `-e K=V`: the environment heph sets belongs to the `docker`
+                // CLI on this side of the socket, and the container process
+                // sees none of it.
+                WrapEnv::Args(vec!["-e".to_string(), "{K}={V}".to_string()]),
+                Vec::new(),
+                SessionCaps {
+                    // `docker exec -t` would allocate one, but the spec's stdio
+                    // is already a PTY slave heph owns; asking docker for a
+                    // second is how a build ends up with two line disciplines.
+                    pty: false,
+                    max_concurrent: None,
+                    identity,
+                },
+                SessionDescription {
+                    runner: req.runner_addr.clone(),
+                    shell_functions: Vec::new(),
+                    key: req.key.clone(),
+                    // `chars().take` rather than a byte slice: a container id
+                    // is hex today, and a summary line is not the place to
+                    // learn that assumption was wrong.
+                    summary: format!(
+                        "oci: {} in container {}",
+                        file.image,
+                        cid.chars().take(12).collect::<String>()
+                    ),
+                },
+            )?
+            .with_cwd_args(vec!["-w".to_string(), "{CWD}".to_string()])
+            .with_trailing_args(vec![OsString::from(&cid)])
+            .with_teardown(teardown),
+        ))
+    }
+}
+
+#[cfg(test)]
+#[expect(
+    clippy::panic_in_result_fn,
+    reason = "restriction lints scoped to production code; tests are exempt"
+)]
+mod tests {
+    use super::*;
+
+    fn session(image: &str) -> anyhow::Result<Arc<dyn ExecSession>> {
+        // The session is built from the artifact and a container id; the
+        // `docker run` that produces that id is the only part needing a daemon,
+        // so it is the one part these tests do not exercise.
+        let file = RunnerArtifactFile {
+            format_version: FORMAT_VERSION,
+            image: image.to_string(),
+            bin: "docker".to_string(),
+            keepalive: vec!["sleep".to_string(), "infinity".to_string()],
+            run_args: vec![],
+        };
+        let identity = if is_digest_pinned(&file.image) {
+            Identity::Pinned {
+                by: file.image.clone(),
+            }
+        } else {
+            Identity::Asserted {
+                why: format!("image {} is referenced by tag", file.image),
+            }
+        };
+        Ok(Arc::new(
+            WrapSession::new(
+                vec![OsString::from(&file.bin), OsString::from("exec")],
+                WrapEnv::Args(vec!["-e".to_string(), "{K}={V}".to_string()]),
+                Vec::new(),
+                SessionCaps {
+                    pty: false,
+                    max_concurrent: None,
+                    identity,
+                },
+                SessionDescription {
+                    runner: "//:ctr".to_string(),
+                    shell_functions: Vec::new(),
+                    key: "k".to_string(),
+                    summary: "test".to_string(),
+                },
+            )?
+            .with_cwd_args(vec!["-w".to_string(), "{CWD}".to_string()])
+            .with_trailing_args(vec![OsString::from("cid123")]),
+        ))
+    }
+
+    fn a_spec() -> hproc::proc_exec::Spec {
+        hproc::proc_exec::Spec {
+            program: std::path::PathBuf::from("cc"),
+            args: vec![OsString::from("-c"), OsString::from("a.c")],
+            env: vec![(OsString::from("OUT"), OsString::from("/sbx/out"))],
+            cwd: std::path::PathBuf::from("/sbx/ws"),
+            stdin: hproc::proc_exec::StdioSpec::Null,
+            stdout: hproc::proc_exec::StdioSpec::Piped,
+            stderr: hproc::proc_exec::StdioSpec::Piped,
+            setsid: false,
+            ctty: false,
+        }
+    }
+
+    async fn argv_of(image: &str) -> anyhow::Result<Vec<String>> {
+        let out = session(image)?
+            .prepare(a_spec())
+            .await
+            .map_err(|e| anyhow::anyhow!("{e}"))?;
+        let mut v = vec![out.program.to_string_lossy().into_owned()];
+        v.extend(out.args.iter().map(|a| a.to_string_lossy().into_owned()));
+        Ok(v)
+    }
+
+    /// `docker exec [OPTIONS] CONTAINER COMMAND [ARG…]` — in that order.
+    ///
+    /// The grammar is the test: an option after the container id is read as
+    /// part of the command, so a wrong order does not fail loudly, it runs the
+    /// wrong thing inside the container.
+    #[tokio::test]
+    async fn the_spawn_becomes_a_docker_exec_in_the_right_order() -> anyhow::Result<()> {
+        let argv = argv_of("ubuntu@sha256:abc").await?;
+        assert_eq!(
+            argv,
+            vec![
+                "docker",
+                "exec", // options first
+                "-w",
+                "/sbx/ws",
+                "-e",
+                "OUT=/sbx/out",
+                // then the operand
+                "cid123", // then the command
+                "cc",
+                "-c",
+                "a.c",
+            ]
+        );
+        Ok(())
+    }
+
+    /// The target's working directory must reach the container.
+    ///
+    /// Without `-w` every target runs in the image's `WORKDIR` — usually `/` —
+    /// and a build reading a relative path fails a long way from the cause.
+    #[tokio::test]
+    async fn the_targets_cwd_reaches_the_container() -> anyhow::Result<()> {
+        let argv = argv_of("ubuntu@sha256:abc").await?;
+        let w = argv.iter().position(|a| a == "-w").expect("-w is present");
+        assert_eq!(argv[w + 1], "/sbx/ws");
+        assert!(w < argv.iter().position(|a| a == "cid123").expect("cid"));
+        Ok(())
+    }
+
+    /// The environment must ride argv, not the spec.
+    ///
+    /// `docker exec` creates the process on the far side of the daemon socket,
+    /// so anything set on the `docker` CLI's own environment is invisible to it.
+    #[tokio::test]
+    async fn the_environment_rides_argv_because_the_daemon_is_in_the_way() -> anyhow::Result<()> {
+        let argv = argv_of("ubuntu@sha256:abc").await?;
+        assert!(
+            argv.windows(2)
+                .any(|w| w[0] == "-e" && w[1] == "OUT=/sbx/out"),
+            "{argv:?}"
+        );
+        Ok(())
+    }
+
+    /// A digest is content the cache key covers; a tag is a claim.
+    #[test]
+    fn only_a_digest_pinned_image_reports_pinned() -> anyhow::Result<()> {
+        assert!(session("ubuntu@sha256:abc")?.caps().identity.is_pinned());
+
+        let tagged = session("ubuntu:24.04")?;
+        assert!(!tagged.caps().identity.is_pinned());
+        match &tagged.caps().identity {
+            Identity::Asserted { why } => assert!(why.contains("tag"), "{why}"),
+            Identity::Pinned { .. } => panic!("a tag is not pinned"),
+        }
+        Ok(())
+    }
+
+    #[test]
+    fn an_addr_is_told_apart_from_a_literal_reference() {
+        assert!(looks_like_addr("//app:load"));
+        assert!(looks_like_addr(":load"));
+        assert!(!looks_like_addr("ubuntu@sha256:abc"));
+        assert!(!looks_like_addr("ghcr.io/x/y:1.2"));
+    }
+}

--- a/docs/EXEC_RUNNERS.md
+++ b/docs/EXEC_RUNNERS.md
@@ -214,6 +214,43 @@ So its identity is `Asserted`, not `Pinned`. Reach for it only for a runner a
 handful of targets name — and note that the snapshot's `PATH` is store-only, so
 `bin` usually has to be an absolute path for `devenv` itself to be found.
 
+## OCI — targets in containers
+
+```python
+oci_runner(name = "ctr", image = "ubuntu@sha256:...")     # a literal reference
+oci_runner(name = "ctr", image = "//app:load")            # or an oci_load target
+target(name = "build", driver = "bash", run = "...", runner = ":ctr")
+```
+
+One container per environment, started at `open` and `docker exec`'d per target
+— the shape `WrapEnv::Args` was written for. `docker exec` creates the process
+on the far side of the daemon socket, so the environment heph sets belongs to
+the `docker` CLI on this side and the container sees none of it; each variable
+is rendered into argv as `-e K=V` instead. The spawn becomes:
+
+```
+docker exec -w <target cwd> -e K=V … <container> <program> <args…>
+```
+
+`-w` matters: without it every target runs in the image's `WORKDIR`, usually
+`/`. The sandbox root is bind-mounted **at the same path inside the container**,
+because targets address `$OUT` and `$SRC` absolutely and a different path inside
+would dangle every one of them.
+
+An image referenced by **digest** is content the cache key already covers, so
+the session reports `Pinned`. A tag reports `Asserted` and says why — heph does
+not refuse a tag, it reports the tradeoff. The artifact is local-cache only: the
+reference may name an image that exists solely in this machine's daemon.
+
+The container is removed at teardown (`docker rm -f`), with `--rm` as the
+backstop for an abort that never reaches it, and `--init` so a target's own
+children are reaped inside.
+
+**Today this serves targets built by heph's built-in drivers (`exec`, `bash`).**
+A target built by a *plugin* driver — `go_*`, `oci_*` — under this runner is
+refused, because only the environment crosses the plugin seam and a container is
+not an environment. See the note above.
+
 ## Go
 
 | knob | applies to |


### PR DESCRIPTION
A runner target naming an image; every target under it is `docker exec`'d into
one container started for that environment.

```python
oci_runner(name = "ctr", image = "ubuntu@sha256:…")
target(name = "build", driver = "bash", run = "…", runner = ":ctr")
```

The second real user of the `Wrap` lane, and the one it was designed for:
`WrapEnv::Args` exists precisely because `docker exec` creates the process on
the far side of the daemon socket, so the environment heph sets belongs to the
CLI on this side and the container sees none of it. Each variable is rendered
into argv as `-e K=V`.

Building it surfaced three things `WrapSession` could not express, each added
here as a builder rather than a fourth and fifth constructor argument:

- `with_cwd_args` — `docker exec -w <cwd>`. `spec.cwd` is where the *wrapper*
  starts, which says nothing about the process inside the container. Without it
  every target runs in the image's `WORKDIR`, usually `/`, and a build reading a
  relative path fails a long way from the cause.
- `with_trailing_args` — `docker exec` is `[OPTIONS] CONTAINER COMMAND`, so the
  container id is an operand: it cannot sit in `prefix_argv`, which precedes the
  options. The three knobs now map onto exactly that grammar.
- `with_teardown` — a container outlives the build unless something removes it.
  `TeardownJob` was written for this case and `WrapSession` had no way to carry
  one.

Hermeticity: a digest is content the cache key already covers, so the session
reports `Pinned`; a tag reports `Asserted` and says why, rather than being
refused — choosing a weakly-pinned environment is the user's call. The sandbox
root is mounted at the *same path* inside the container, because targets address
`$OUT`/`$SRC` absolutely. The artifact is local-cache only: an `oci_load` ref
names an image in this machine's daemon and would not resolve on another.

Teardown is `docker rm -f`, with `--rm` as the backstop for an abort that never
reaches it and `--init` so a target's own children are reaped inside.

**Scope:** serves **any** driver. A plugin driver asks the host to create its
processes (#418), so `go_*` targets build inside the container like anything
else.

Tests cover the argv grammar, the cwd, env-through-argv, the digest/tag identity
split, and that a container session does not flatten to an environment. The one
part needing a daemon — `docker run` producing a container id — is the one part
they do not exercise.

Co-Authored-By: Claude Opus 5 (1M context) <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01RC5ykWRMPjRKGk1Tz1KTja

---

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>

