### PR TITLE
ci: make the macOS runner label a repository variable

### DIFF
--- a/.github/workflows/heph.yml
+++ b/.github/workflows/heph.yml
@@ -226,10 +226,13 @@ jobs:
 #            runs-on: macos-latest-large
 #            target: x86_64-apple-darwin
 
-          # macOS ARM64 (Apple Silicon natively runs on the blacksmith macOS runner)
+          # macOS ARM64 (Apple Silicon). The runner label is the `MACOS_RUNNER`
+          # repository variable, so switching between the blacksmith runner and a
+          # GitHub-hosted one is a repo-settings change rather than a code change.
+          # There is no fallback: unset the variable and the job fails to start.
           - os: darwin
             arch: arm64
-            runs-on: blacksmith-6vcpu-macos-latest
+            runs-on: ${{ vars.MACOS_RUNNER }}
             target: aarch64-apple-darwin
     steps:
       - name: Download repo
@@ -791,10 +794,13 @@ jobs:
             runs-on: ubuntu-24.04-arm
             target: aarch64-unknown-linux-gnu
 
-          # macOS ARM64 (Apple Silicon natively runs on the blacksmith macOS runner)
+          # macOS ARM64 (Apple Silicon). The runner label is the `MACOS_RUNNER`
+          # repository variable, so switching between the blacksmith runner and a
+          # GitHub-hosted one is a repo-settings change rather than a code change.
+          # There is no fallback: unset the variable and the job fails to start.
           - os: darwin
             arch: arm64
-            runs-on: blacksmith-6vcpu-macos-latest
+            runs-on: ${{ vars.MACOS_RUNNER }}
             target: aarch64-apple-darwin
     steps:
       - name: Download repo


### PR DESCRIPTION
The `darwin/arm64` legs of `build` and `test` hardcoded `blacksmith-6vcpu-macos-latest` (#417), so switching macOS back to a GitHub-hosted runner — or to a different blacksmith size — meant a code change, a PR and a CI wait.

Both now resolve the label from a repository variable, with no in-workflow fallback:

```yaml
runs-on: ${{ vars.MACOS_RUNNER }}
```

The label lives in repo settings and nowhere else — one place to look, no stale default to drift out of sync with what CI actually runs on.

`MACOS_RUNNER` is already set to `blacksmith-6vcpu-macos-latest`, so behaviour is unchanged. Change it under *Settings → Secrets and variables → Actions → Variables* (e.g. to `macos-latest`) and the next run picks it up. **Unsetting it makes `runs-on` empty and the two darwin jobs fail to start** — that is deliberate: a missing runner label should be loud, not silently routed somewhere else.

`vars` is one of the contexts available in `jobs.<job_id>.strategy`, so it resolves inside the matrix rather than needing a separate job-level expression. `actionlint` reports nothing new on the file.

Only the two blacksmith legs changed; the `lint`, `bin_e2e` and `release` jobs that already run on `macos-latest` are untouched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01AHYSN1UyWgDpVeRJKeKbAm