### PR TITLE
fix(go): copy with whatever `cp` the environment has

### DIFF
--- a/crates/plugin-go/src/plugingo/target_std.rs
+++ b/crates/plugin-go/src/plugingo/target_std.rs
@@ -73,17 +73,25 @@ pub fn install_spec(
         // populate pkg/. `-L` dereferences symlinks: staged dep files may be
         // symlinks into the read-only artifact cache, and a plain copy would
         // leave LGOROOT pointing back at it (so `chmod -R u+w` would try to
-        // mutate the cache). BSD/macOS `cp` also copies xattrs and trips EPERM
-        // on the FUSE overlay; `cp -X` suppresses that (GNU `cp -X` differs, so
-        // branch on uname). Use the absolute system `cp` (`/bin/cp`) so the flag
-        // set matches the platform regardless of `$PATH` — under the host
-        // toolchain (`gotool = "host"`) the sandbox inherits the host `PATH`,
-        // which may put a GNU `cp` (no `-X`) ahead of the BSD system one.
-        "if [ \"$(uname)\" = Darwin ]; then CP=\"/bin/cp -RLX\"; else CP=\"/bin/cp -RL\"; fi"
-            .to_string(),
+        // mutate the cache).
+        //
+        // No platform branch and no absolute path. This used to pick
+        // `/bin/cp -RLX` on Darwin, because BSD `cp` copies xattrs and trips
+        // EPERM on the FUSE overlay, and `-X` suppresses that.
+        //
+        // Both halves of that were wrong once an environment can be named. `-X`
+        // is BSD-only and GNU `cp` rejects it outright, while `uname` says
+        // Darwin for a Mac inside a devenv whose `PATH` leads with nixpkgs
+        // coreutils; and `/bin/cp` reaches outside the sandbox for a host
+        // binary a container image or a NixOS box need not have.
+        //
+        // So the flag goes. Its only exposure is macOS under `fuse.enabled`;
+        // elsewhere the copied xattrs are inert metadata on a scratch GOROOT,
+        // and Linux has none to copy. Deliberate call — see the matching note
+        // in `thirdparty::build_download_spec`.
         "LGOROOT=\"$PWD/goroot\"".to_string(),
         "rm -rf \"$LGOROOT\"".to_string(),
-        "$CP \"$GOROOT\" \"$LGOROOT\"".to_string(),
+        "cp -RL \"$GOROOT\" \"$LGOROOT\"".to_string(),
         "export GOROOT=\"$LGOROOT\"".to_string(),
         "chmod -R u+w \"$GOROOT\"".to_string(),
         // A throwaway module keeps `go` from reading the workspace go.mod.
@@ -254,6 +262,39 @@ mod tests {
 
     fn test_vref() -> VariantRef {
         VariantRef::new("dev", "")
+    }
+
+    /// The GOROOT copy must run under whatever `cp` the environment provides.
+    ///
+    /// It used to be `/bin/cp -RLX` on Darwin. `-X` (suppress xattr copy) is a
+    /// BSD flag that GNU `cp` rejects outright, and `uname` cannot tell the two
+    /// apart any more: a Mac inside a devenv reports Darwin while its `PATH`
+    /// leads with nixpkgs coreutils. `/bin/cp` answered the dialect by reaching
+    /// outside the sandbox for a host binary a container or a NixOS box need not
+    /// have.
+    ///
+    /// So neither may come back. Dropping `-X` is a deliberate trade: its only
+    /// exposure is macOS under `fuse.enabled`, where the EPERM it avoided may
+    /// return.
+    #[test]
+    fn test_install_copies_goroot_with_a_portable_cp() {
+        let spec = install_spec(
+            install_addr(&test_vref()),
+            &test_factors(),
+            V,
+            "//@heph/bin:cc",
+        );
+        let run = run_str(&spec);
+        assert!(
+            run.contains("cp -RL \"$GOROOT\" \"$LGOROOT\""),
+            "the GOROOT copy must be a plain, PATH-resolved `cp -RL`: {run}"
+        );
+        assert!(!run.contains("/bin/cp"), "must not name a host path: {run}");
+        assert!(
+            !run.contains("uname"),
+            "the OS does not determine the `cp` dialect once a runner supplies \
+             the environment: {run}"
+        );
     }
 
     #[test]

--- a/crates/plugin-go/src/plugingo/thirdparty.rs
+++ b/crates/plugin-go/src/plugingo/thirdparty.rs
@@ -32,11 +32,24 @@ pub fn build_download_spec(
     // Multi-line bash. `awk` parses `Dir` out of the JSON `go mod download`
     // emits. The stub go.mod blocks Go from reading the project go.mod.
     //
-    // `cp` choice: BSD/macOS cp copies xattrs (com.apple.quarantine on
-    // Go's mod cache files) by default, which fails with EPERM on FUSE
-    // overlays that reject xattr writes. `cp -X` on macOS suppresses
-    // xattr copy; on GNU cp `-X` means `--one-file-system`, so branch
-    // on `uname`.
+    // A plain `cp -R`, with no platform branch. This used to pick `cp -RX` on
+    // Darwin — BSD `cp` copies xattrs (`com.apple.quarantine` on Go's mod cache
+    // files), which EPERMs on a FUSE overlay that rejects xattr writes, and `-X`
+    // suppresses that.
+    //
+    // `-X` is BSD-only — GNU `cp` rejects it outright (`invalid option -- 'X'`)
+    // — and `uname` no longer tells you which `cp` you have: it says Darwin for
+    // a Mac inside a devenv, where `PATH` leads with nixpkgs coreutils and the
+    // build broke. `PATH` is the host's under `gotool = "host"` and entirely the
+    // runner's under a `runner:`, so nothing here can know the dialect. Naming
+    // `/bin/cp` would answer the dialect and lose the sandbox: it is a host path
+    // that a container image or a NixOS box need not have at all.
+    //
+    // So the flag goes. Its only exposure is macOS under `fuse.enabled`, where
+    // the EPERM may return; elsewhere the copied xattrs are inert metadata on
+    // scratch files, and Linux has none to copy. FUSE is already an untested
+    // gap for runners (`docs/EXEC_RUNNERS.md`). Deliberate call, taken to keep
+    // the copy hermetic and dialect-neutral.
     //
     // GOROOT/`go` come from the staged hermetic SDK. We use the GOROOT-only
     // prelude (no sandbox GOCACHE) because the `**/*` output glob would
@@ -54,8 +67,7 @@ pub fn build_download_spec(
            exit 1\n\
          fi"
         .to_string(),
-        "if [ \"$(uname)\" = Darwin ]; then CP=\"cp -RX\"; else CP=\"cp -R\"; fi".to_string(),
-        "$CP \"$MOD_DIR/.\" .".to_string(),
+        "cp -R \"$MOD_DIR/.\" .".to_string(),
         "rm mod.json".to_string(),
         "chmod -R u+w .".to_string(),
     ]);
@@ -271,6 +283,34 @@ mod tests {
     }
 
     // ---- download spec ----
+
+    /// The module copy must run under whatever `cp` the environment provides.
+    ///
+    /// It used to be `/bin/cp -RX` on Darwin. `-X` (suppress xattr copy) is a
+    /// BSD flag that GNU `cp` rejects outright, and `uname` cannot tell the two
+    /// apart any more: a Mac inside a devenv reports Darwin while its `PATH`
+    /// leads with nixpkgs coreutils. `/bin/cp` answered the dialect by reaching
+    /// outside the sandbox for a host binary a container or a NixOS box need not
+    /// have.
+    ///
+    /// So neither may come back. Dropping `-X` is a deliberate trade: its only
+    /// exposure is macOS under `fuse.enabled`, where the EPERM it avoided may
+    /// return.
+    #[test]
+    fn test_download_spec_copies_module_with_a_portable_cp() {
+        let spec = build_download_spec(download_addr(), "github.com/go-logr/logr", "v1.4.2", V);
+        let run = run_str(&spec);
+        assert!(
+            run.contains("cp -R \"$MOD_DIR/.\" ."),
+            "the module copy must be a plain, PATH-resolved `cp -R`: {run}"
+        );
+        assert!(!run.contains("/bin/cp"), "must not name a host path: {run}");
+        assert!(
+            !run.contains("uname"),
+            "the OS does not determine the `cp` dialect once a runner supplies \
+             the environment: {run}"
+        );
+    }
 
     #[test]
     fn test_download_spec_driver() {


### PR DESCRIPTION
The thirdparty download and the std install both picked `cp` flags from `uname`, and `-X` (suppress xattr copy) is BSD-only — GNU `cp` rejects it outright. A Mac inside a `devenv` breaks: `uname` says Darwin while `PATH` leads with nixpkgs coreutils.

Not a corner case. `PATH` is the host's under `gotool = "host"` and entirely the runner's under a `runner:`, so nothing in the sandbox can infer the dialect from the OS.

`target_std` had already hit this and answered with `/bin/cp` — trading the bug for a worse one: a host absolute path, in a sandbox, that a container image or NixOS box need not have. The download target copied the `uname` branch without the workaround.

Both are now a plain, PATH-resolved `cp -R` / `cp -RL`.

### The trade

`-X` was there for a reason: BSD `cp` copies xattrs (`com.apple.quarantine` on Go's mod cache files) and that EPERMs on a FUSE overlay rejecting xattr writes. Dropping it exposes **macOS under `fuse.enabled` only** — elsewhere the copied xattrs are inert metadata on scratch files, and Linux has none to copy. FUSE is already an untested gap here.

### Why not the obvious repairs

Both fail, and it's worth recording:

- **A shared `cp` flag** — there isn't one. GNU `cp` on APFS reflinks by default and `clonefile()` carries xattrs regardless of `--no-preserve=xattr`; only `--reflink=never` suppresses it, which BSD `cp` rejects.
- **`tar --no-xattrs`** — bsdtar accepts it but still carries mac metadata. The flag that works (`--no-mac-metadata`) is rejected by GNU tar.

### Tests

One per site, pinning the copy as a plain `cp` with no `/bin/cp` and no `uname`, so a platform branch cannot quietly return. 483 pass in `plugin-go`; lint clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01VaazTTm6xTUQxxpxhY9tJW