### PR TITLE
feat(model): give labels a grammar, and reject what falls outside it

### DIFF
--- a/crates/e2e/tests/plugin_buildfile.rs
+++ b/crates/e2e/tests/plugin_buildfile.rs
@@ -211,20 +211,42 @@ async fn test_spec_labels() -> anyhow::Result<()> {
     let ws = Workspace::new();
     ws.write_build_file(
         "pkg",
-        r#"target(name = "t", driver = "bash", run = "true", labels = ["//team:foo", "//ci:lint"])"#,
+        r#"target(name = "t", driver = "bash", run = "true", labels = ["team-foo", "ci_lint2"])"#,
     );
 
     let spec = ws.get_spec("//pkg:t").await?;
     assert!(
-        spec.labels.contains(&"//team:foo".to_string()),
+        spec.labels.contains(&"team-foo".to_string()),
         "labels: {:?}",
         spec.labels
     );
     assert!(
-        spec.labels.contains(&"//ci:lint".to_string()),
+        spec.labels.contains(&"ci_lint2".to_string()),
         "labels: {:?}",
         spec.labels
     );
+    Ok(())
+}
+
+/// A label outside `[A-Za-z0-9_-]+` is rejected where it is declared, not left
+/// as a tag no `label(...)` query can name.
+#[tokio::test]
+async fn test_spec_label_outside_the_grammar_is_rejected() -> anyhow::Result<()> {
+    for bad in [r#"["//team:foo"]"#, r#"["needs review"]"#, r#"[""]"#] {
+        let ws = Workspace::new();
+        ws.write_build_file(
+            "pkg",
+            &format!(r#"target(name = "t", driver = "bash", run = "true", labels = {bad})"#),
+        );
+
+        let err = ws
+            .get_spec("//pkg:t")
+            .await
+            .err()
+            .unwrap_or_else(|| panic!("labels = {bad} should not evaluate"));
+        let chain = format!("{err:#}");
+        assert!(chain.contains("label"), "labels = {bad}: {chain}");
+    }
     Ok(())
 }
 

--- a/crates/engine/src/engine/labels.rs
+++ b/crates/engine/src/engine/labels.rs
@@ -70,9 +70,9 @@ mod tests {
     #[tokio::test]
     async fn collects_unique_labels_across_matched_targets() -> anyhow::Result<()> {
         let engine = make_engine(vec![
-            target("foo/bar", "a", &["//labels:lint", "//labels:test"]),
-            target("foo/bar", "b", &["//labels:lint"]),
-            target("foo/baz", "c", &["//labels:fmt"]),
+            target("foo/bar", "a", &["lint", "test"]),
+            target("foo/bar", "b", &["lint"]),
+            target("foo/baz", "c", &["fmt"]),
         ])?;
 
         let rs = engine.new_state();
@@ -85,11 +85,7 @@ mod tests {
         // Sorted, deduped: lint appears on two targets but once here.
         assert_eq!(
             labels,
-            vec![
-                "//labels:fmt".to_string(),
-                "//labels:lint".to_string(),
-                "//labels:test".to_string(),
-            ]
+            vec!["fmt".to_string(), "lint".to_string(), "test".to_string(),]
         );
         Ok(())
     }
@@ -97,8 +93,8 @@ mod tests {
     #[tokio::test]
     async fn scopes_labels_to_the_matcher() -> anyhow::Result<()> {
         let engine = make_engine(vec![
-            target("foo", "a", &["//labels:lint"]),
-            target("other", "b", &["//labels:fmt"]),
+            target("foo", "a", &["lint"]),
+            target("other", "b", &["fmt"]),
         ])?;
 
         let rs = engine.new_state();
@@ -108,7 +104,7 @@ mod tests {
             .into_iter()
             .collect();
 
-        assert_eq!(labels, vec!["//labels:lint".to_string()]);
+        assert_eq!(labels, vec!["lint".to_string()]);
         Ok(())
     }
 

--- a/crates/engine/src/engine/matcher_spec.rs
+++ b/crates/engine/src/engine/matcher_spec.rs
@@ -139,15 +139,15 @@ mod tests {
 
     #[test]
     fn label_yes() {
-        let s = spec("foo/bar", "baz", &["//tag:release"]);
-        let m = Matcher::Label("//tag:release".to_string());
+        let s = spec("foo/bar", "baz", &["release"]);
+        let m = Matcher::Label("release".to_string());
         assert_eq!(match_spec(&m, &s), MatchResult::MatchYes);
     }
 
     #[test]
     fn label_no() {
         let s = spec("foo/bar", "baz", &[]);
-        let m = Matcher::Label("//tag:release".to_string());
+        let m = Matcher::Label("release".to_string());
         assert_eq!(match_spec(&m, &s), MatchResult::MatchNo);
     }
 

--- a/crates/engine/src/engine/matcher_target.rs
+++ b/crates/engine/src/engine/matcher_target.rs
@@ -243,13 +243,13 @@ mod tests {
 
     #[test]
     fn def_label_match() {
-        let d = def_with_labels("foo", "bar", &["//labels:lint"]);
+        let d = def_with_labels("foo", "bar", &["lint"]);
         assert_eq!(
-            match_target(&Matcher::Label("//labels:lint".to_string()), &d),
+            match_target(&Matcher::Label("lint".to_string()), &d),
             MatchResult::MatchYes
         );
         assert_eq!(
-            match_target(&Matcher::Label("//labels:other".to_string()), &d),
+            match_target(&Matcher::Label("other".to_string()), &d),
             MatchResult::MatchNo
         );
     }
@@ -292,15 +292,15 @@ mod tests {
 
     #[test]
     fn def_and_match() {
-        let d = def_with_labels("foo", "bar", &["//labels:lint"]);
+        let d = def_with_labels("foo", "bar", &["lint"]);
         let m = Matcher::And(vec![
             Matcher::Package(PkgBuf::from("foo")),
-            Matcher::Label("//labels:lint".to_string()),
+            Matcher::Label("lint".to_string()),
         ]);
         assert_eq!(match_target(&m, &d), MatchResult::MatchYes);
         let m2 = Matcher::And(vec![
             Matcher::Package(PkgBuf::from("foo")),
-            Matcher::Label("//labels:other".to_string()),
+            Matcher::Label("other".to_string()),
         ]);
         assert_eq!(match_target(&m2, &d), MatchResult::MatchNo);
     }

--- a/crates/engine/src/engine/query.rs
+++ b/crates/engine/src/engine/query.rs
@@ -497,8 +497,7 @@ mod tests {
             parallelism: None,
             ..Default::default()
         })?;
-        let provider =
-            pluginstatictarget::Provider::new(vec![target("foo", "a", &["//labels:lint"])])?;
+        let provider = pluginstatictarget::Provider::new(vec![target("foo", "a", &["lint"])])?;
         engine.register_provider(move |_| Box::new(provider))?;
         engine.register_provider(|_| Box::new(PhantomLister))?;
         let engine = Arc::new(engine);
@@ -691,14 +690,11 @@ mod tests {
 
     #[tokio::test]
     async fn query_by_label_calls_get_spec() -> anyhow::Result<()> {
-        let engine = make_engine(vec![
-            target("foo", "a", &["//labels:lint"]),
-            target("foo", "b", &[]),
-        ])?;
+        let engine = make_engine(vec![target("foo", "a", &["lint"]), target("foo", "b", &[])])?;
 
         let rs = engine.new_state();
         let addrs: Vec<Addr> = engine
-            .query(rs, &Matcher::Label("//labels:lint".to_string()))
+            .query(rs, &Matcher::Label("lint".to_string()))
             .try_collect()
             .await?;
 

--- a/crates/model/src/htlabel.rs
+++ b/crates/model/src/htlabel.rs
@@ -1,0 +1,135 @@
+//! The label grammar.
+//!
+//! A label is a free-form tag a target carries (`labels = ["lint", "go-test"]`)
+//! and the only thing `label(x)` in the query language selects on. Its
+//! alphabet is deliberately narrow — ASCII letters, digits, `-` and `_` — so
+//! that a label is never confused with the syntax that surrounds it:
+//!
+//! - `heph run <LABEL> <PACKAGE>` takes a bare label positionally, with no
+//!   delimiters. Without a grammar, `heph run 'lint && !go-lint' //...` is a
+//!   perfectly well-formed request for the label *literally spelled*
+//!   `lint && !go-lint`, which no target carries — so it selects nothing and
+//!   exits 0, reading exactly like a build that passed.
+//! - `//`, `:` and `@` are address syntax; a label shaped like `//tag:release`
+//!   invites the reader to believe labels and addresses share a namespace.
+//! - `&& || ! ( ) "` are query operators, and whitespace is the query
+//!   tokenizer's separator, so such a label is unselectable from `-e`.
+//!
+//! Rejecting these at the two ends — where a label is *declared* and where one
+//! is *selected* — keeps the set of labels a query can name equal to the set a
+//! target can carry.
+
+/// Characters a label may be built from: `A-Z`, `a-z`, `0-9`, `-`, `_`.
+fn is_label_char(c: char) -> bool {
+    c.is_ascii_alphanumeric() || c == '-' || c == '_'
+}
+
+/// Whether `s` is a well-formed label.
+pub fn is_valid(s: &str) -> bool {
+    !s.is_empty() && s.chars().all(is_label_char)
+}
+
+/// Validate a label, with an error naming the first offending character.
+///
+/// Callers that took the label from a positional CLI argument should surface
+/// [`looks_like_query_expr`] as a hint alongside this error.
+pub fn validate(s: &str) -> anyhow::Result<()> {
+    if s.is_empty() {
+        anyhow::bail!("empty label: a label must contain at least one character");
+    }
+    if let Some(bad) = s.chars().find(|c| !is_label_char(*c)) {
+        anyhow::bail!(
+            "invalid label {s:?}: {} is not allowed — a label may contain only \
+             ASCII letters, digits, `-` and `_`",
+            describe_char(bad),
+        );
+    }
+    Ok(())
+}
+
+/// Render an offending character for an error message. Whitespace and control
+/// characters have no useful printed form, so name them instead of emitting
+/// them raw into the terminal.
+fn describe_char(c: char) -> String {
+    match c {
+        ' ' => "a space".to_string(),
+        '\t' => "a tab".to_string(),
+        c if c.is_whitespace() || c.is_control() => format!("U+{:04X}", c as u32),
+        c => format!("`{c}`"),
+    }
+}
+
+/// Whether an invalid label reads like someone typed a query expression where a
+/// bare label was expected (`heph run 'lint && !go-lint' //...`). Used only to
+/// add a "did you mean `-e`?" hint to the error — never to accept the input.
+pub fn looks_like_query_expr(s: &str) -> bool {
+    s.chars()
+        .any(|c| matches!(c, '&' | '|' | '!' | '(' | ')') || c.is_whitespace())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn accepts_the_alphabet() {
+        for s in ["lint", "go-lint", "go_lint", "Lint2", "a", "0", "-", "_"] {
+            assert!(is_valid(s), "{s:?} should be valid");
+            assert!(validate(s).is_ok(), "{s:?} should validate");
+        }
+    }
+
+    #[test]
+    fn rejects_empty() {
+        assert!(!is_valid(""));
+        let err = validate("").unwrap_err().to_string();
+        assert!(err.contains("empty label"), "{err}");
+    }
+
+    #[test]
+    fn rejects_query_operators_and_whitespace() {
+        for s in [
+            "lint && !go-lint",
+            "lint&&go",
+            "a b",
+            "a|b",
+            "(a)",
+            "!a",
+            "a\tb",
+        ] {
+            assert!(!is_valid(s), "{s:?} should be invalid");
+            assert!(validate(s).is_err(), "{s:?} should fail validation");
+        }
+    }
+
+    #[test]
+    fn rejects_address_syntax() {
+        // Labels and addresses are separate namespaces; an addr-shaped label
+        // suggests otherwise.
+        for s in ["//tag:release", "tag:release", "//team/foo", "name@k=v"] {
+            assert!(!is_valid(s), "{s:?} should be invalid");
+        }
+    }
+
+    #[test]
+    fn rejects_non_ascii() {
+        assert!(!is_valid("café"));
+        assert!(!is_valid("日本語"));
+    }
+
+    #[test]
+    fn error_names_the_offending_character() {
+        let err = validate("go lint").unwrap_err().to_string();
+        assert!(err.contains("a space"), "{err}");
+        let err = validate("//tag:release").unwrap_err().to_string();
+        assert!(err.contains("`/`"), "{err}");
+    }
+
+    #[test]
+    fn query_expr_hint_fires_on_operators_not_on_plain_typos() {
+        assert!(looks_like_query_expr("lint && !go-lint"));
+        assert!(looks_like_query_expr("a b"));
+        assert!(!looks_like_query_expr("//tag:release"));
+        assert!(!looks_like_query_expr("café"));
+    }
+}

--- a/crates/model/src/htquery/mod.rs
+++ b/crates/model/src/htquery/mod.rs
@@ -7,7 +7,9 @@
 //!   ([`Matcher::PackagePrefix`]), `//pkg:name` ([`Matcher::Addr`]); relative
 //!   forms (`./x`, `../x`, `.`, `..`) resolve against the base package.
 //! - functions — `label(x)`, `tree_output(pkg)`, plus the explicit
-//!   `addr(x)`, `package(x)`, `package_prefix(x)` forms.
+//!   `addr(x)`, `package(x)`, `package_prefix(x)` forms. `label`'s argument
+//!   must be a well-formed label (`[A-Za-z0-9_-]+`, see [`crate::htlabel`]);
+//!   anything else is a parse error rather than a label nothing carries.
 //! - operators — `&&` ([`Matcher::And`]), `||` ([`Matcher::Or`]),
 //!   `!` ([`Matcher::Not`]), and `( … )` grouping.
 //!
@@ -17,6 +19,7 @@
 //! See [`parse`] for the entry point.
 
 use crate::htaddr::parse_addr_with_base;
+use crate::htlabel;
 use crate::htmatcher::Matcher;
 use crate::htpkg::{self, PkgBuf, join_rel_checked_pkg};
 use anyhow::{Context, Result, bail};
@@ -61,6 +64,8 @@ fn fmt_prec(m: &Matcher, parent_prec: u8, out: &mut String) {
                 out.push_str("/...");
             }
         }
+        // Never needs quoting: a label is `[A-Za-z0-9_-]+`, which contains no
+        // tokenizer metacharacter.
         Matcher::Label(l) => {
             out.push_str("label(");
             out.push_str(l);
@@ -135,7 +140,10 @@ impl Tok {
 
 /// Split a query into tokens. Words are runs of any character except
 /// whitespace and the operator metacharacters `( ) & | !`; `"…"` wraps a word
-/// that needs those characters (e.g. a label with a space).
+/// that needs those characters. Nothing in the grammar requires quoting today
+/// — labels exclude every metacharacter by construction — but a quoted word
+/// still tokenizes so that the resulting *validation* error names the label
+/// instead of a stray `"`.
 fn tokenize(input: &str) -> Result<Vec<Tok>> {
     let mut tokens = Vec::new();
     let mut chars = input.chars().peekable();
@@ -329,7 +337,10 @@ impl<'a> Parser<'a> {
 
     fn func_to_matcher(&self, name: &str, arg: &str) -> Result<Matcher> {
         match name {
-            "label" => Ok(Matcher::Label(arg.to_string())),
+            "label" => {
+                htlabel::validate(arg).with_context(|| format!("parsing label({arg})"))?;
+                Ok(Matcher::Label(arg.to_string()))
+            }
             "tree_output" | "tree_output_to" => Ok(Matcher::TreeOutputTo(
                 to_pkg(arg).with_context(|| format!("parsing {name}({arg})"))?,
             )),
@@ -426,10 +437,26 @@ mod tests {
     #[test]
     fn label_func() {
         assert_eq!(p("label(foo)"), Matcher::Label("foo".to_string()));
-        assert_eq!(
-            p("label(//tag:release)"),
-            Matcher::Label("//tag:release".to_string())
-        );
+        assert_eq!(p("label(go-lint)"), Matcher::Label("go-lint".to_string()));
+        assert_eq!(p("label(go_lint2)"), Matcher::Label("go_lint2".to_string()));
+    }
+
+    #[test]
+    fn err_label_outside_the_grammar() {
+        // A label is `[A-Za-z0-9_-]+`. Address-shaped and quoted-with-spaces
+        // forms used to parse into a label no target could ever carry.
+        for src in [
+            "label(//tag:release)",
+            "label(\"my label\")",
+            "label()",
+            "label(caf\u{e9})",
+        ] {
+            let err = parse(src, &base())
+                .err()
+                .unwrap_or_else(|| panic!("{src} should not parse"));
+            let chain = format!("{err:#}");
+            assert!(chain.contains("label"), "{chain}");
+        }
     }
 
     #[test]
@@ -590,14 +617,6 @@ mod tests {
             let m2 = parse(&rendered, &base).expect("parse rendered");
             assert_eq!(m1, m2, "round-trip mismatch: {src:?} -> {rendered:?}");
         }
-    }
-
-    #[test]
-    fn quoted_label_with_spaces() {
-        assert_eq!(
-            p("label(\"my label\")"),
-            Matcher::Label("my label".to_string())
-        );
     }
 
     #[test]

--- a/crates/model/src/lib.rs
+++ b/crates/model/src/lib.rs
@@ -1,6 +1,6 @@
 //! Target addressing + selection model: the `//package:name` address
-//! (`htaddr`), package paths (`htpkg`), and the composable matcher predicate
-//! (`htmatcher`). Self-contained — depends on no other heph crate. The
+//! (`htaddr`), package paths (`htpkg`), labels (`htlabel`), and the composable
+//! matcher predicate (`htmatcher`). Self-contained — depends on no other heph crate. The
 //! matcher-against-target-def evaluation lives in the engine
 //! (`engine::matcher_target`), keeping this crate free of the driver/target-def
 //! types.
@@ -14,6 +14,7 @@
 )]
 
 pub mod htaddr;
+pub mod htlabel;
 pub mod htmatcher;
 pub mod htpkg;
 pub mod htquery;

--- a/crates/plugin-buildfile/src/pluginbuildfile/run_file.rs
+++ b/crates/plugin-buildfile/src/pluginbuildfile/run_file.rs
@@ -923,6 +923,14 @@ fn starlark_module(builder: &mut GlobalsBuilder) {
                 "target name cannot be empty"
             )));
         }
+        // Reject a label outside the grammar here, where the BUILD file and
+        // target name are still in the error, rather than letting it become a
+        // tag no `label(...)` query can ever name.
+        for l in &labels {
+            hmodel::htlabel::validate(l)
+                .with_context(|| format!("target {name:?} labels"))
+                .map_err(starlark::Error::new_other)?;
+        }
         // An empty driver is allowed here: the provider resolves it against the
         // configured `defaultDriver` (and errors if neither is set).
 
@@ -2289,6 +2297,41 @@ target(name = "direct", driver = "exec")
         let result = run_pkg_blocking(&provider, pkg).unwrap();
         assert_eq!(result.targets.len(), 1);
         assert_eq!(result.targets[0].name, "t");
+    }
+
+    /// A label outside `[A-Za-z0-9_-]+` fails at declaration, naming the
+    /// target — not silently becoming a tag `label(...)` can never select.
+    #[test]
+    fn label_outside_the_grammar_fails_the_package() {
+        for bad in [
+            r#"["//team:foo"]"#,
+            r#"["needs review"]"#,
+            r#"[""]"#,
+            r#""a&b""#,
+        ] {
+            let tmp_dir = tempdir().unwrap();
+            let pkg_path = tmp_dir.path().join("mypkg");
+            fs::create_dir_all(&pkg_path).unwrap();
+            fs::write(
+                pkg_path.join("BUILD"),
+                format!(r#"target(name = "t", driver = "d", labels = {bad})"#),
+            )
+            .unwrap();
+
+            let provider = Provider {
+                root: tmp_dir.path().to_path_buf(),
+                ..Provider::default()
+            };
+            let err = run_pkg_blocking(&provider, "mypkg")
+                .err()
+                .unwrap_or_else(|| panic!("labels = {bad} should not evaluate"));
+            let chain = format!("{err:#}");
+            assert!(chain.contains("label"), "labels = {bad}: {chain}");
+            assert!(
+                chain.contains("\"t\""),
+                "error must name the target: {chain}"
+            );
+        }
     }
 
     #[test]

--- a/src/commands/run.rs
+++ b/src/commands/run.rs
@@ -21,6 +21,9 @@ Selecting targets:
   heph run <label> //pkg/...          all targets with <label> under //pkg
   heph run -e '<expr>'                a query expression (see below)
 
+  A label is [A-Za-z0-9_-]+ — the positional form takes one bare label, never
+  an expression. For &&, ||, ! or grouping, use -e.
+
 Query language (-e / --expr):
   Patterns:
     //pkg                package //pkg
@@ -28,7 +31,7 @@ Query language (-e / --expr):
     //pkg:name           one target address
     ./sub, ../x, .       relative to the current package
   Functions:
-    label(x)             targets carrying label x   (e.g. label(\"//tag:release\"))
+    label(x)             targets carrying label x   (e.g. label(go-lint))
     tree_output(pkg)     targets whose codegen tree writes into pkg
     addr(//pkg:name)     an explicit target address
     package(//pkg)       an explicit package

--- a/src/commands/utils.rs
+++ b/src/commands/utils.rs
@@ -3,7 +3,7 @@ use std::path::Path;
 use crate::htaddr::Addr;
 use crate::htmatcher::Matcher;
 use crate::htpkg::PkgBuf;
-use crate::{engine, htaddr, htpkg, htquery};
+use crate::{engine, htaddr, htlabel, htpkg, htquery};
 use anyhow::Context;
 
 /// Resolve a CLI target argument into an `Addr`, relative to package `cwp` under
@@ -85,6 +85,7 @@ pub fn matcher_from_args(
 
             htpkg::parse(package_matcher, &engine::get_cwp()?)
         } else {
+            validate_positional_label(label)?;
             Ok(Matcher::And(vec![
                 Matcher::Label(label.into()),
                 htpkg::parse(package_matcher, &engine::get_cwp()?)?,
@@ -96,6 +97,28 @@ pub fn matcher_from_args(
             .with_context(|| format!("parse {}", addr_str))?;
         Ok(Matcher::Addr(addr))
     }
+}
+
+/// Check the positional `<LABEL> <PACKAGE_MATCHER>` form's first argument
+/// against the label grammar.
+///
+/// The positional form has no delimiters, so before this check any string at
+/// all was a "label" — `heph run 'lint && !go-lint' //...` asked for the label
+/// literally spelled `lint && !go-lint`, matched nothing, and exited 0, which
+/// is indistinguishable from a build that passed. When the argument reads like
+/// a query expression, point at `-e`, which is where that syntax belongs.
+fn validate_positional_label(label: &str) -> anyhow::Result<()> {
+    let Err(err) = htlabel::validate(label) else {
+        return Ok(());
+    };
+    if htlabel::looks_like_query_expr(label) {
+        return Err(err).context(
+            "the first positional argument is a bare label, not a query expression — \
+             for `&&`, `||`, `!` or grouping use `-e`, e.g. \
+             -e 'label(lint) && !label(go-lint) && //...'",
+        );
+    }
+    Err(err)
 }
 
 /// Tally a parsed query matcher's nodes into telemetry counts. Walks the tree
@@ -266,6 +289,44 @@ mod tests {
             format!("{err:#}").contains("cannot combine"),
             "expected conflict message: {err:#}"
         );
+    }
+
+    #[test]
+    fn positional_label_outside_the_grammar_is_rejected() {
+        // The motivating bug: this is a well-formed request for the label
+        // literally spelled `lint && !go-lint`, which no target carries — so it
+        // used to select nothing and exit 0.
+        let pkg = PkgBuf::from("");
+        let err = matcher_from_args("lint && !go-lint", &Some("//...".to_string()), &pkg, false)
+            .err()
+            .expect("expected label validation error");
+        let chain = format!("{err:#}");
+        assert!(chain.contains("invalid label"), "{chain}");
+        assert!(chain.contains("-e"), "expected a pointer to -e: {chain}");
+    }
+
+    #[test]
+    fn positional_label_error_omits_the_query_hint_for_a_plain_typo() {
+        let pkg = PkgBuf::from("");
+        let err = matcher_from_args("go:lint", &Some("//...".to_string()), &pkg, false)
+            .err()
+            .expect("expected label validation error");
+        let chain = format!("{err:#}");
+        assert!(chain.contains("invalid label"), "{chain}");
+        assert!(
+            !chain.contains("query expression"),
+            "no operators typed, so no -e hint: {chain}"
+        );
+    }
+
+    #[test]
+    fn positional_label_within_the_grammar_is_accepted() {
+        // Checked directly: the accepting path goes on to resolve the package
+        // matcher against the ambient workspace root, which a unit test has no
+        // business depending on.
+        for l in ["lint", "go-lint", "go_lint2", "Lint"] {
+            validate_positional_label(l).unwrap_or_else(|e| panic!("{l:?}: {e:#}"));
+        }
     }
 
     #[test]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -25,7 +25,7 @@ pub use hcore::{
 };
 pub use hengine::engine;
 pub use hlock::hlock;
-pub use hmodel::{htaddr, htmatcher, htpkg, htquery};
+pub use hmodel::{htaddr, htlabel, htmatcher, htpkg, htquery};
 pub use hplugin::htspec;
 pub use hplugin_buildfile::pluginbuildfile;
 pub use hplugin_exec::pluginexec;

--- a/src/pluginquery_test.rs
+++ b/src/pluginquery_test.rs
@@ -39,13 +39,13 @@ mod tests {
     #[tokio::test]
     async fn query_by_label_returns_group_spec() -> anyhow::Result<()> {
         let engine = make_engine(vec![
-            labeled_target("foo", "a", &["//labels:lint"]),
+            labeled_target("foo", "a", &["lint"]),
             labeled_target("foo", "b", &[]),
-            labeled_target("bar", "c", &["//labels:lint"]),
+            labeled_target("bar", "c", &["lint"]),
         ])?;
 
         let rs = engine.new_state();
-        let addr = parse_addr(&format!("//{PACKAGE}:q@expr=label(//labels:lint)"))?;
+        let addr = parse_addr(&format!("//{PACKAGE}:q@expr=label(lint)"))?;
         let spec = engine.get_spec(rs, &addr).await?;
 
         assert_eq!(spec.driver, crate::plugingroup::DRIVER_NAME);
@@ -111,14 +111,14 @@ mod tests {
     #[tokio::test]
     async fn query_multiple_matchers_combined_as_and() -> anyhow::Result<()> {
         let engine = make_engine(vec![
-            labeled_target("src/foo", "a", &["//labels:lint"]),
+            labeled_target("src/foo", "a", &["lint"]),
             labeled_target("src/foo", "b", &[]),
-            labeled_target("other", "c", &["//labels:lint"]),
+            labeled_target("other", "c", &["lint"]),
         ])?;
 
         let rs = engine.new_state();
         let addr = parse_addr(&format!(
-            "//{PACKAGE}:q@expr=\"package(src/foo) && label(//labels:lint)\""
+            "//{PACKAGE}:q@expr=\"package(src/foo) && label(lint)\""
         ))?;
         let spec = engine.get_spec(rs, &addr).await?;
 
@@ -215,13 +215,13 @@ mod tests {
         // Single provider registered: pluginstatictarget. exclude_provider=
         // pluginstatictarget should yield an empty result.
         let engine = make_engine(vec![
-            labeled_target("foo", "a", &["//labels:lint"]),
-            labeled_target("foo", "b", &["//labels:lint"]),
+            labeled_target("foo", "a", &["lint"]),
+            labeled_target("foo", "b", &["lint"]),
         ])?;
 
         let rs = engine.new_state();
         let addr = parse_addr(&format!(
-            "//{PACKAGE}:q@expr=label(//labels:lint),exclude_provider=pluginstatictarget"
+            "//{PACKAGE}:q@expr=label(lint),exclude_provider=pluginstatictarget"
         ))?;
         let spec = engine.get_spec(rs, &addr).await?;
 


### PR DESCRIPTION
## The bug

A label had no grammar. Any string was one, which made the positional `heph run <LABEL> <PACKAGE>` form silently unfalsifiable:

```
heph run 'lint && !go-lint' //...
```

is a well-formed request for the label *literally spelled* `lint && !go-lint`. No target carries it, so the selection matched nothing and the command **exited 0** — indistinguishable from a build that passed.

## The grammar

A label is now `[A-Za-z0-9_-]+` — one definition, `hmodel::htlabel`.

The alphabet excludes exactly what would otherwise be ambiguous: `//`, `:` and `@` are address syntax; `&& || ! ( ) "` are query operators; whitespace is the query tokenizer's separator. A label containing any of them is unselectable from `-e` anyway.

## Where it is enforced

Both ends, so the set of labels a query can name equals the set a target can carry.

**Declaration** — `target(labels = [...])`, at the BUILD line:

```
 --> ws/pkg/BUILD:1:1
  |
1 | target(name = "a", driver = "bash", run = "true", labels = ["//team:foo"])
  | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  |
: invalid label "//team:foo": `/` is not allowed — a label may contain only ASCII letters, digits, `-` and `_`
```

**Selection** — `label(x)` in the query language, and the positional `<LABEL>` argument. The positional form adds a pointer to `-e` when the argument reads like an expression:

```
$ heph run 'lint && !go-lint' //...
× the first positional argument is a bare label, not a query expression — for `&&`, `||`, `!` or grouping use `-e`, e.g. -e 'label(lint) && !label(go-lint) && //...'
╰─▶ invalid label "lint && !go-lint": a space is not allowed — a label may contain only ASCII letters, digits, `-` and `_`
$ echo $?
1
```

The `-e` form the user actually wanted keeps working:

```
$ heph query -e 'label(lint) && !label(go-lint) && //...'
//pkg:b
```

## Breaking

Address-shaped labels (`labels = ["//team:foo"]`) and labels with spaces no longer evaluate. They were selectable only through the positional form or a quoted `label("…")`; both now error rather than matching nothing.

No in-tree provider used one — the go/oci/gha/http plugins all already emit `[a-z0-9-]` labels. The addr-shaped labels that existed were only in test fixtures and one `--help` example, updated here.

## Deliberately not done

Labels arriving from a plugin across the ABI are not re-validated: it would cost a walk per spec on the resolution path, and the two authoring surfaces that can produce one are covered above.

## Tests

- `crates/model/src/htlabel.rs` — the grammar itself (alphabet, empty, operators, address syntax, non-ASCII, error wording).
- `crates/model/src/htquery` — `label(…)` rejects what falls outside it; the quoted-label-with-spaces test is replaced by its rejection.
- `crates/plugin-buildfile` unit + `crates/e2e` — declaration is rejected, and the error names the target.
- `src/commands/utils.rs` — the positional form, including that the `-e` hint fires on an expression and not on a plain typo.

`lint` clean; `model`, `engine`, `heph`, `plugin-buildfile` unit suites and the `e2e` `query`/`clean`/`plugin_buildfile` tests pass locally.

## Unrelated, noticed while verifying

`example/.hephconfig2` still lists `builtin: sh`, which #397 removed — `heph` in `example/` fails to start on master. Not touched here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01YMk23DyFdAbqLjeDstFXBi