### PR TITLE
feat(cache): custom endpoint/region for s3 remote caches

### DIFF
--- a/crates/config/src/config_yaml.rs
+++ b/crates/config/src/config_yaml.rs
@@ -79,6 +79,10 @@ pub struct ConfigYaml {
 /// `file://` for tests/local use. `read`/`write` gate whether the cache is
 /// consulted on lookups and pushed to on writes; both default to `true`.
 ///
+/// `endpoint`/`region` point an `s3://` cache at an S3-compatible service that
+/// is not AWS — the URI still names the bucket and prefix, the endpoint names
+/// the host to talk to.
+///
 /// Produced from one or more layered [`RemoteCacheConfigPatch`]es — see
 /// [`ConfigYaml::resolved_caches`].
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -89,6 +93,14 @@ pub struct RemoteCacheConfig {
     /// Max in-flight requests to this cache (object_store `LimitStore`). Caps how
     /// many connections a wide build fan-out opens at once. Defaults to 10.
     pub concurrency: usize,
+    /// Base URL of an S3-compatible service to talk to instead of AWS, e.g.
+    /// `https://<account>.r2.cloudflarestorage.com` or `http://localhost:9000`.
+    /// `s3://` caches only; unset means AWS.
+    pub endpoint: Option<String>,
+    /// Region to sign S3 requests for. `s3://` caches only; unset leaves the
+    /// choice to the environment (`AWS_REGION`), which in turn defaults to
+    /// `us-east-1`.
+    pub region: Option<String>,
 }
 
 /// Parse/overlay shape for one named cache. Every field is optional so a profile
@@ -106,6 +118,10 @@ pub struct RemoteCacheConfigPatch {
     pub write: Option<bool>,
     #[serde(default)]
     pub concurrency: Option<usize>,
+    #[serde(default)]
+    pub endpoint: Option<String>,
+    #[serde(default)]
+    pub region: Option<String>,
 }
 
 impl RemoteCacheConfigPatch {
@@ -125,6 +141,12 @@ impl RemoteCacheConfigPatch {
         if other.concurrency.is_some() {
             self.concurrency = other.concurrency;
         }
+        if other.endpoint.is_some() {
+            self.endpoint = other.endpoint;
+        }
+        if other.region.is_some() {
+            self.region = other.region;
+        }
     }
 
     /// Finalize into a [`RemoteCacheConfig`], applying defaults for omitted
@@ -139,6 +161,8 @@ impl RemoteCacheConfigPatch {
             read: self.read.unwrap_or(true),
             write: self.write.unwrap_or(true),
             concurrency: self.concurrency.unwrap_or(DEFAULT_CACHE_CONCURRENCY),
+            endpoint: self.endpoint.clone(),
+            region: self.region.clone(),
         })
     }
 }
@@ -811,6 +835,37 @@ caches:
     }
 
     #[test]
+    fn cache_endpoint_and_region_are_configurable() {
+        // An S3-compatible service that isn't AWS: the uri still names the
+        // bucket and prefix, the endpoint names the host.
+        let yaml = concat!(
+            "caches:\n",
+            "  remote:\n",
+            "    uri: s3://my-bucket/heph\n",
+            "    endpoint: https://accountid.r2.cloudflarestorage.com\n",
+            "    region: auto\n",
+        );
+        let cfg: ConfigYaml = serde_yaml::from_str(yaml).expect("parse");
+        let caches = cfg.resolved_caches().expect("resolve");
+        let remote = caches.get("remote").expect("present");
+        assert_eq!(
+            remote.endpoint.as_deref(),
+            Some("https://accountid.r2.cloudflarestorage.com")
+        );
+        assert_eq!(remote.region.as_deref(), Some("auto"));
+    }
+
+    #[test]
+    fn cache_endpoint_and_region_default_to_unset() {
+        let cfg: ConfigYaml =
+            serde_yaml::from_str("caches:\n  c:\n    uri: s3://b/p\n").expect("parse");
+        let caches = cfg.resolved_caches().expect("resolve");
+        let c = caches.get("c").expect("present");
+        assert_eq!(c.endpoint, None);
+        assert_eq!(c.region, None);
+    }
+
+    #[test]
     fn resolved_caches_errors_on_missing_uri() {
         // A cache that only ever sets read/write (no base uri) cannot resolve.
         let cfg: ConfigYaml =
@@ -1038,6 +1093,32 @@ caches:
         assert_eq!(caches.get("b").expect("b").uri, "s3://prof/b");
         // New key is added.
         assert_eq!(caches.get("c").expect("c").uri, "s3://prof/c");
+    }
+
+    #[test]
+    fn merge_deep_merges_cache_endpoint_and_region() {
+        // A profile can re-point a cache at a different S3-compatible service
+        // (e.g. a local MinIO) while inheriting the base bucket and prefix.
+        let mut base: ConfigYaml = serde_yaml::from_str(concat!(
+            "caches:\n",
+            "  remote:\n",
+            "    uri: s3://bucket/heph\n",
+            "    endpoint: https://accountid.r2.cloudflarestorage.com\n",
+            "    region: auto\n",
+        ))
+        .expect("parse base");
+        let overlay: ConfigYaml =
+            serde_yaml::from_str("caches:\n  remote:\n    endpoint: http://localhost:9000\n")
+                .expect("parse overlay");
+
+        base.merge(overlay);
+
+        let caches = base.resolved_caches().expect("resolve");
+        let remote = caches.get("remote").expect("present");
+        assert_eq!(remote.uri, "s3://bucket/heph");
+        assert_eq!(remote.endpoint.as_deref(), Some("http://localhost:9000"));
+        // Untouched by the overlay, so the base value survives.
+        assert_eq!(remote.region.as_deref(), Some("auto"));
     }
 
     #[test]

--- a/crates/e2e/tests/cache_load.rs
+++ b/crates/e2e/tests/cache_load.rs
@@ -105,6 +105,8 @@ fn build_engine(root: &Path, remote_uri: &str, parallelism: Option<usize>) -> Ar
             read: true,
             write: true,
             concurrency: 10,
+            endpoint: None,
+            region: None,
         }]
     };
     let mut e = Engine::new(Config {

--- a/crates/e2e/tests/remote_cache.rs
+++ b/crates/e2e/tests/remote_cache.rs
@@ -33,6 +33,8 @@ fn build_engine(root: &Path, remote_uri: &str) -> Arc<Engine> {
             read: true,
             write: true,
             concurrency: 10,
+            endpoint: None,
+            region: None,
         }],
         ..Default::default()
     })

--- a/crates/engine/src/engine/config.rs
+++ b/crates/engine/src/engine/config.rs
@@ -173,6 +173,8 @@ impl ConfigYamlExt for ConfigYaml {
                     read: c.read,
                     write: c.write,
                     concurrency: c.concurrency,
+                    endpoint: c.endpoint,
+                    region: c.region,
                 })
                 .collect(),
         })
@@ -219,6 +221,25 @@ mod tests {
         assert_eq!(r.uri, "s3://b/p");
         assert!(r.read);
         assert!(!r.write);
+    }
+
+    #[test]
+    fn resolve_carries_cache_endpoint_and_region() {
+        let yaml: ConfigYaml = serde_yaml::from_str(concat!(
+            "caches:\n",
+            "  r:\n",
+            "    uri: s3://b/p\n",
+            "    endpoint: https://accountid.r2.cloudflarestorage.com\n",
+            "    region: auto\n",
+        ))
+        .expect("parse");
+        let cfg = yaml.resolve(Path::new("/repo")).expect("resolve");
+        let r = &cfg.remote_caches[0];
+        assert_eq!(
+            r.endpoint.as_deref(),
+            Some("https://accountid.r2.cloudflarestorage.com")
+        );
+        assert_eq!(r.region.as_deref(), Some("auto"));
     }
 
     #[test]

--- a/crates/engine/src/engine/local_cache.rs
+++ b/crates/engine/src/engine/local_cache.rs
@@ -1208,6 +1208,8 @@ mod tests {
                 read: true,
                 write: true,
                 concurrency: 10,
+                endpoint: None,
+                region: None,
             }],
             ..Default::default()
         })

--- a/crates/engine/src/engine/remote_cache.rs
+++ b/crates/engine/src/engine/remote_cache.rs
@@ -66,7 +66,7 @@ use crate::engine::local_cache::{
     ManifestArtifactEncoding, ManifestArtifactType,
 };
 use crate::engine::remote_cache_latency::{UNREACHABLE, load_order, store_order};
-use crate::engine::remote_cache_objstore::ObjStoreBackend;
+use crate::engine::remote_cache_objstore::{ObjStoreBackend, StoreOptions};
 use anyhow::Context;
 use async_trait::async_trait;
 use borsh::{BorshDeserialize, BorshSerialize};
@@ -375,6 +375,11 @@ pub struct RemoteCacheDef {
     pub write: bool,
     /// Max in-flight requests to this cache (object_store `LimitStore`).
     pub concurrency: usize,
+    /// Base URL of an S3-compatible service to talk to instead of AWS. `s3://`
+    /// caches only — see [`StoreOptions`].
+    pub endpoint: Option<String>,
+    /// Region to sign S3 requests for. `s3://` caches only.
+    pub region: Option<String>,
 }
 
 impl RemoteCacheDef {
@@ -883,8 +888,15 @@ impl RemoteCacheSet {
     pub fn new(defs: &[RemoteCacheDef], home: PathBuf) -> anyhow::Result<Arc<Self>> {
         let mut caches = Vec::with_capacity(defs.len());
         for def in defs {
-            let backend = ObjStoreBackend::from_uri(&def.uri, def.concurrency)
-                .with_context(|| format!("configure remote cache `{}`", def.name))?;
+            let backend = ObjStoreBackend::from_uri(
+                &def.uri,
+                def.concurrency,
+                &StoreOptions {
+                    endpoint: def.endpoint.as_deref(),
+                    region: def.region.as_deref(),
+                },
+            )
+            .with_context(|| format!("configure remote cache `{}`", def.name))?;
             caches.push(ConfiguredCache::new(def.clone(), Arc::new(backend)));
         }
         let config_hash = config_hash(defs);
@@ -908,6 +920,8 @@ impl RemoteCacheSet {
                     read: true,
                     write: true,
                     concurrency: 4,
+                    endpoint: None,
+                    region: None,
                 },
                 backend,
             )],
@@ -1506,7 +1520,9 @@ fn copy_file_to(src: &Path, mut writer: impl std::io::Write) -> anyhow::Result<(
 }
 
 /// Stable hash of the definition set (order-independent) used to invalidate the
-/// persisted latency order when caches are added, removed, or re-pointed.
+/// persisted latency order when caches are added, removed, or re-pointed —
+/// including re-pointed at a different `endpoint`/`region`, which changes what
+/// host a cache talks to and so what its measured latency means.
 /// `concurrency` is excluded — it does not affect which caches exist or how fast
 /// they are, so changing it must not force a re-measure.
 fn config_hash(defs: &[RemoteCacheDef]) -> String {
@@ -1517,6 +1533,10 @@ fn config_hash(defs: &[RemoteCacheDef]) -> String {
         h.update(d.name.as_bytes());
         h.update(&[0]);
         h.update(d.uri.as_bytes());
+        h.update(&[0]);
+        h.update(d.endpoint.as_deref().unwrap_or_default().as_bytes());
+        h.update(&[0]);
+        h.update(d.region.as_deref().unwrap_or_default().as_bytes());
         h.update(&[d.read as u8, d.write as u8]);
         h.update(&[0xff]);
     }
@@ -2072,6 +2092,8 @@ mod tests {
             read,
             write,
             concurrency: DEFAULT_CACHE_CONCURRENCY,
+            endpoint: None,
+            region: None,
         }
     }
 
@@ -2217,6 +2239,39 @@ mod tests {
             def("y", "memory:///CHANGED", true, false),
         ];
         assert_ne!(config_hash(&a), config_hash(&c), "uri change must matter");
+    }
+
+    /// Endpoint and region decide which host a cache actually talks to, so a
+    /// change to either has to invalidate the persisted latency order the same
+    /// way a uri change does — otherwise a cache re-pointed at a different
+    /// service keeps the read position it earned against the old one.
+    #[test]
+    fn config_hash_covers_endpoint_and_region() {
+        let base = vec![def("x", "s3://bucket/p", true, true)];
+
+        let mut with_endpoint = base.clone();
+        with_endpoint[0].endpoint = Some("https://accountid.r2.cloudflarestorage.com".to_string());
+        assert_ne!(
+            config_hash(&base),
+            config_hash(&with_endpoint),
+            "endpoint change must matter"
+        );
+
+        let mut other_endpoint = with_endpoint.clone();
+        other_endpoint[0].endpoint = Some("http://localhost:9000".to_string());
+        assert_ne!(
+            config_hash(&with_endpoint),
+            config_hash(&other_endpoint),
+            "a different endpoint must matter"
+        );
+
+        let mut with_region = base.clone();
+        with_region[0].region = Some("auto".to_string());
+        assert_ne!(
+            config_hash(&base),
+            config_hash(&with_region),
+            "region change must matter"
+        );
     }
 
     #[test]

--- a/crates/engine/src/engine/remote_cache_objstore.rs
+++ b/crates/engine/src/engine/remote_cache_objstore.rs
@@ -6,7 +6,9 @@
 //! `object_store::parse_url_opts`, which dispatches on the scheme and returns
 //! the right store. Credentials are read from the process environment (e.g.
 //! `AWS_ACCESS_KEY_ID`, `GOOGLE_SERVICE_ACCOUNT`) by feeding `std::env::vars()`
-//! to the builder, mirroring each builder's `from_env`.
+//! to the builder, mirroring each builder's `from_env`. An `s3://` cache can
+//! additionally be pointed at a non-AWS S3-compatible service from the config
+//! file — see [`StoreOptions`].
 //!
 //! All transfers are streamed: reads expose the object's byte stream as an
 //! [`AsyncRead`], and writes go through object_store's multipart [`BufWriter`],
@@ -176,6 +178,44 @@ fn transfer_opts(scheme: &str) -> Vec<(String, String)> {
     }
 }
 
+/// Per-cache connection settings that have no place in the cache URI, from
+/// `caches: { <name>: { endpoint, region } }`.
+///
+/// Both are S3-only: they exist to point an `s3://bucket/prefix` cache at an
+/// S3-compatible service that is not AWS (Cloudflare R2, MinIO, Ceph, …), where
+/// the URI still names the bucket and the prefix and the endpoint names the host
+/// to talk to. Setting either on any other scheme is rejected by
+/// [`ObjStoreBackend::from_uri`] rather than silently ignored.
+///
+/// Both override the corresponding environment variable (`AWS_ENDPOINT_URL`,
+/// `AWS_REGION`), which stays supported for the case where the endpoint is a
+/// property of the machine rather than of the repo.
+#[derive(Debug, Clone, Copy, Default)]
+pub struct StoreOptions<'a> {
+    /// Base URL of the service, e.g. `https://<account>.r2.cloudflarestorage.com`
+    /// or `http://localhost:9000`. An `http://` endpoint also lifts
+    /// object_store's plaintext-HTTP block, which otherwise rejects every
+    /// request to it — writing `http://` is the opt-in.
+    pub endpoint: Option<&'a str>,
+    /// Region to sign requests for. Unset leaves object_store's own resolution
+    /// (`AWS_REGION`, else `us-east-1`) in place.
+    pub region: Option<&'a str>,
+}
+
+impl StoreOptions<'_> {
+    /// Reject endpoint/region on a store that has no notion of them. Silently
+    /// dropping them would leave a cache pointed at the wrong host with nothing
+    /// in the output saying so; failing at startup names the field and the URI.
+    fn reject_non_s3(&self, uri: &str) -> anyhow::Result<()> {
+        let field = match (self.endpoint, self.region) {
+            (Some(_), _) => "endpoint",
+            (_, Some(_)) => "region",
+            _ => return Ok(()),
+        };
+        anyhow::bail!("`{field}` is only supported for s3:// remote caches, not {uri}")
+    }
+}
+
 /// One remote object store plus the path prefix carved out of its URI. Object
 /// keys handed to [`RemoteCacheBackend`] are joined under `prefix`, so two
 /// repos can share a bucket by pointing at distinct prefixes (`s3://b/repo-a`,
@@ -192,10 +232,16 @@ impl ObjStoreBackend {
     ///
     /// `max_concurrency` caps in-flight requests to this store via
     /// [`LimitStore`], so a wide build fan-out can't open thousands of
-    /// simultaneous connections.
-    pub fn from_uri(uri: &str, max_concurrency: usize) -> anyhow::Result<Self> {
+    /// simultaneous connections. `opts` carries the S3-only endpoint/region
+    /// overrides; see [`StoreOptions`].
+    pub fn from_uri(
+        uri: &str,
+        max_concurrency: usize,
+        opts_override: &StoreOptions<'_>,
+    ) -> anyhow::Result<Self> {
         let url = Url::parse(uri).with_context(|| format!("parse remote cache uri {uri}"))?;
         let (store, prefix): (Box<dyn ObjectStore>, ObjPath) = if url.scheme() == "gs" {
+            opts_override.reject_non_s3(uri)?;
             // Always drive GCS through the NegotiatingConnector so transfers use
             // HTTP/2 (falling back to HTTP/1.1) instead of object_store's
             // connection-storming HTTP/1.1-only default.
@@ -249,19 +295,41 @@ impl ObjStoreBackend {
                 .chain(transfer_opts(url.scheme()))
                 .collect();
             let store: Box<dyn ObjectStore> = match scheme {
-                ObjectStoreScheme::AmazonS3 => Box::new(
-                    build_with_opts!(AmazonS3Builder, uri, opts)
-                        .with_retry(retry_config())
-                        .build()
-                        .with_context(|| format!("build S3 store for {uri}"))?,
-                ),
-                ObjectStoreScheme::MicrosoftAzure => Box::new(
-                    build_with_opts!(MicrosoftAzureBuilder, uri, opts)
-                        .with_retry(retry_config())
-                        .build()
-                        .with_context(|| format!("build Azure store for {uri}"))?,
-                ),
+                ObjectStoreScheme::AmazonS3 => {
+                    let mut builder =
+                        build_with_opts!(AmazonS3Builder, uri, opts).with_retry(retry_config());
+                    // Applied *after* the env fold so an endpoint/region written
+                    // in `.hephconfig` wins over an ambient `AWS_ENDPOINT_URL` /
+                    // `AWS_REGION` — the repo's own config is the more specific
+                    // statement of where its cache lives.
+                    if let Some(endpoint) = opts_override.endpoint {
+                        builder = builder.with_endpoint(endpoint);
+                        if endpoint.starts_with("http://") {
+                            // object_store refuses plaintext HTTP unless asked;
+                            // spelling out `http://` in the config is the ask.
+                            builder = builder.with_allow_http(true);
+                        }
+                    }
+                    if let Some(region) = opts_override.region {
+                        builder = builder.with_region(region);
+                    }
+                    Box::new(
+                        builder
+                            .build()
+                            .with_context(|| format!("build S3 store for {uri}"))?,
+                    )
+                }
+                ObjectStoreScheme::MicrosoftAzure => {
+                    opts_override.reject_non_s3(uri)?;
+                    Box::new(
+                        build_with_opts!(MicrosoftAzureBuilder, uri, opts)
+                            .with_retry(retry_config())
+                            .build()
+                            .with_context(|| format!("build Azure store for {uri}"))?,
+                    )
+                }
                 ObjectStoreScheme::Http => {
+                    opts_override.reject_non_s3(uri)?;
                     let base = &url[..url::Position::BeforePath];
                     Box::new(
                         build_with_opts!(HttpBuilder, base, opts)
@@ -272,6 +340,7 @@ impl ObjStoreBackend {
                 }
                 // `file`/`memory`: no network client, no retry semantics.
                 _ => {
+                    opts_override.reject_non_s3(uri)?;
                     parse_url_opts(&url, opts)
                         .with_context(|| format!("open remote cache store for {uri}"))?
                         .0
@@ -732,7 +801,8 @@ mod tests {
 
     #[tokio::test]
     async fn memory_backend_streams_under_prefix() {
-        let backend = ObjStoreBackend::from_uri("memory:///repo-a", 10).expect("backend");
+        let backend = ObjStoreBackend::from_uri("memory:///repo-a", 10, &StoreOptions::default())
+            .expect("backend");
         assert!(!backend.exists("k/v").await.expect("exists"));
         assert!(get(&backend, "k/v").await.is_none());
 
@@ -759,7 +829,8 @@ mod tests {
     async fn file_backend_streams() {
         let dir = tempfile::tempdir().expect("tempdir");
         let uri = format!("file://{}", dir.path().display());
-        let backend = ObjStoreBackend::from_uri(&uri, 10).expect("backend");
+        let backend =
+            ObjStoreBackend::from_uri(&uri, 10, &StoreOptions::default()).expect("backend");
         put(&backend, "a/b/c", b"payload").await;
         assert_eq!(get(&backend, "a/b/c").await.expect("present"), b"payload");
     }
@@ -919,7 +990,9 @@ mod tests {
 
     #[test]
     fn s3_scheme_wires_retry_config_not_object_store_default() {
-        let backend = ObjStoreBackend::from_uri("s3://some-bucket/prefix", 10).expect("backend");
+        let backend =
+            ObjStoreBackend::from_uri("s3://some-bucket/prefix", 10, &StoreOptions::default())
+                .expect("backend");
         assert_wires_retry_config(&*backend.store, "S3");
     }
 
@@ -928,14 +1001,130 @@ mod tests {
         let backend = ObjStoreBackend::from_uri(
             "abfss://some-container@some-account.dfs.core.windows.net/prefix",
             10,
+            &StoreOptions::default(),
         )
         .expect("backend");
         assert_wires_retry_config(&*backend.store, "Azure");
     }
 
+    /// A custom endpoint has to reach the built client, not just the builder:
+    /// object_store folds it into `S3Config::bucket_endpoint`, which is what
+    /// every request URL is built from. Same Debug-introspection trick (and the
+    /// same never-print-the-string rule) as [`assert_wires_retry_config`].
+    #[test]
+    fn s3_endpoint_and_region_reach_the_built_store() {
+        let backend = ObjStoreBackend::from_uri(
+            "s3://some-bucket/prefix",
+            10,
+            &StoreOptions {
+                endpoint: Some("https://accountid.r2.cloudflarestorage.com"),
+                region: Some("auto"),
+            },
+        )
+        .expect("backend");
+        let debug = format!("{:?}", backend.store);
+        assert!(
+            debug.contains("https://accountid.r2.cloudflarestorage.com/some-bucket"),
+            "custom endpoint never reached the S3 client's request URL"
+        );
+        assert!(
+            !debug.contains("amazonaws.com"),
+            "S3 client still points at AWS despite a configured endpoint"
+        );
+        assert!(
+            debug.contains("auto"),
+            "configured region never reached the S3 client"
+        );
+    }
+
+    /// A plaintext endpoint (a local MinIO, a test double) is otherwise refused
+    /// by object_store's `allow_http` guard on the first request — writing
+    /// `http://` in the config is the opt-in, so nothing else has to be set.
+    #[test]
+    fn s3_http_endpoint_opts_into_plaintext() {
+        let backend = ObjStoreBackend::from_uri(
+            "s3://some-bucket/prefix",
+            10,
+            &StoreOptions {
+                endpoint: Some("http://localhost:9000"),
+                region: None,
+            },
+        )
+        .expect("backend");
+        let debug = format!("{:?}", backend.store);
+        assert!(
+            debug.contains("http://localhost:9000/some-bucket"),
+            "plaintext endpoint never reached the S3 client's request URL"
+        );
+        assert!(
+            debug.contains("allow_http: Parsed(true)"),
+            "an http:// endpoint must lift object_store's plaintext block"
+        );
+    }
+
+    /// An https endpoint must NOT lift the guard — the opt-in is scoped to the
+    /// scheme actually written, so a typo elsewhere can't silently downgrade a
+    /// TLS connection.
+    #[test]
+    fn s3_https_endpoint_leaves_plaintext_blocked() {
+        let backend = ObjStoreBackend::from_uri(
+            "s3://some-bucket/prefix",
+            10,
+            &StoreOptions {
+                endpoint: Some("https://accountid.r2.cloudflarestorage.com"),
+                region: None,
+            },
+        )
+        .expect("backend");
+        assert!(
+            !format!("{:?}", backend.store).contains("allow_http: Parsed(true)"),
+            "an https:// endpoint must leave plaintext HTTP blocked"
+        );
+    }
+
+    /// Endpoint/region are S3-only. On any other scheme they are a config
+    /// mistake, and silently dropping them would leave the cache pointed
+    /// somewhere the config does not say — fail at startup, naming the field.
+    #[test]
+    fn endpoint_or_region_on_a_non_s3_scheme_is_rejected() {
+        for uri in [
+            "gs://some-bucket/prefix",
+            "abfss://some-container@some-account.dfs.core.windows.net/prefix",
+            "https://example.com/prefix",
+            "memory:///repo-a",
+        ] {
+            let err = ObjStoreBackend::from_uri(
+                uri,
+                10,
+                &StoreOptions {
+                    endpoint: Some("https://example.invalid"),
+                    region: None,
+                },
+            )
+            .err()
+            .expect("endpoint on a non-s3 scheme must not be accepted");
+            let msg = format!("{err:#}");
+            assert!(msg.contains("endpoint") && msg.contains(uri), "{msg}");
+
+            let err = ObjStoreBackend::from_uri(
+                uri,
+                10,
+                &StoreOptions {
+                    endpoint: None,
+                    region: Some("auto"),
+                },
+            )
+            .err()
+            .expect("region on a non-s3 scheme must not be accepted");
+            assert!(format!("{err:#}").contains("region"), "{err:#}");
+        }
+    }
+
     #[test]
     fn http_scheme_wires_retry_config_not_object_store_default() {
-        let backend = ObjStoreBackend::from_uri("http://example.com/prefix", 10).expect("backend");
+        let backend =
+            ObjStoreBackend::from_uri("http://example.com/prefix", 10, &StoreOptions::default())
+                .expect("backend");
         assert_wires_retry_config(&*backend.store, "HTTP");
     }
 

--- a/crates/engine/src/engine/result.rs
+++ b/crates/engine/src/engine/result.rs
@@ -5181,6 +5181,8 @@ mod tests {
                 read: true,
                 write: true,
                 concurrency: 10,
+                endpoint: None,
+                region: None,
             }],
             ..Default::default()
         })?;
@@ -5403,6 +5405,8 @@ mod tests {
                 read: true,
                 write: true,
                 concurrency: 10,
+                endpoint: None,
+                region: None,
             }],
             ..Default::default()
         })?;


### PR DESCRIPTION
An `s3://` remote cache could only ever talk to AWS from the config file. Pointing one at an S3-compatible service that isn't AWS (Cloudflare R2, MinIO, Ceph) meant setting `AWS_ENDPOINT_URL` in the environment of every shell and CI job that runs a build — but the endpoint is a property of the repo's cache, not of the machine, so it belongs in `.hephconfig`.

```yaml
caches:
  remote:
    uri: s3://my-bucket/heph
    endpoint: https://<account>.r2.cloudflarestorage.com
    region: auto
```

The URI still names the bucket and the prefix; the endpoint names the host to talk to.

## Behaviour

- **Config beats env.** Both fields are applied *after* the environment fold, so a value in `.hephconfig` wins over an ambient `AWS_ENDPOINT_URL` / `AWS_REGION`. The env vars keep working untouched for the case where the endpoint really is a property of the host.
- **`http://` is the opt-in for plaintext.** An `http://` endpoint (a local MinIO, a test double) lifts object_store's plaintext-HTTP block, which would otherwise reject every request. Writing the scheme is the ask — an `https://` endpoint deliberately does not lift it, so a typo elsewhere can't silently downgrade a TLS connection.
- **S3-only, and loud about it.** Set on `gs://`, `az://`, `http(s)://`, `file://` or `memory://`, they fail at engine startup naming the field and the URI, rather than being silently dropped. A cache pointed somewhere the config doesn't say is exactly the failure that can't be diagnosed from the outside.
- **Both feed `config_hash`**, so re-pointing a cache at a different service invalidates the persisted latency order the same way a URI change does — a cache doesn't keep a read position it earned against a different host.

Nothing is R2-specific; R2 is just the case that prompted it.

## Compatibility

Purely additive: two optional fields on an existing cache entry. An existing config parses and resolves identically, and `RemoteCacheDef`'s new fields are `None` on every current path. `config_hash` for a cache with neither field set is unchanged in meaning but not in value — the persisted latency order re-measures once after upgrade, which is the same self-healing path a cache edit already takes.

## Tests

- `config`: parse endpoint/region, default-unset, and a profile overlay re-pointing the endpoint while inheriting the base `uri` and `region`.
- `engine::config`: the resolved config carries both into `RemoteCacheDef`.
- `remote_cache`: `config_hash` moves on an endpoint change, on a *different* endpoint, and on a region change.
- `remote_cache_objstore`: the endpoint and region reach the built S3 client's request URL (and it no longer points at `amazonaws.com`); `http://` sets `allow_http` while `https://` does not; endpoint or region on each non-S3 scheme is rejected with the field and URI in the message.

`lint` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011bEg3y3sxgnpmvZz7T6okx