### PR TITLE
feat(scratch): make the store inspectable and reclaimable

### DIFF
--- a/crates/builtins/src/lib.rs
+++ b/crates/builtins/src/lib.rs
@@ -4,6 +4,7 @@
 //!
 //! - `pluginfs` — the `fs` provider + driver (filesystem targets).
 //! - `plugingroup` — the `group` driver (aggregate targets).
+//! - `pluginscratch` — the `scratch` driver (persistent cache-directory declarations).
 //! - `pluginstatictarget` — in-memory static target provider (tests/wiring).
 //! - `plugintextfile` — the `textfile` driver.
 //! - `pluginhostbin` — the host-binary provider + driver.
@@ -11,6 +12,7 @@
 pub mod pluginfs;
 pub mod plugingroup;
 pub mod pluginhostbin;
+pub mod pluginscratch;
 pub mod pluginstatictarget;
 pub mod plugintextfile;
 

--- a/crates/builtins/src/pluginfs/mod.rs
+++ b/crates/builtins/src/pluginfs/mod.rs
@@ -1533,6 +1533,7 @@ mod tests {
             stdout: None,
             stderr: None,
             sandbox_dir: root,
+            scratch: vec![],
         }
     }
 

--- a/crates/builtins/src/plugingroup/mod.rs
+++ b/crates/builtins/src/plugingroup/mod.rs
@@ -727,6 +727,7 @@ mod tests {
                     stdout: None,
                     stderr: None,
                     sandbox_dir: Default::default(),
+                    scratch: vec![],
                 },
                 &ctoken(),
             )

--- a/crates/builtins/src/pluginhostbin/mod.rs
+++ b/crates/builtins/src/pluginhostbin/mod.rs
@@ -325,6 +325,7 @@ mod tests {
             stdout: None,
             stderr: None,
             sandbox_dir: sandbox_dir.to_path_buf(),
+            scratch: vec![],
         }
     }
 

--- a/crates/builtins/src/pluginscratch/mod.rs
+++ b/crates/builtins/src/pluginscratch/mod.rs
@@ -646,6 +646,7 @@ mod tests {
             stdout: None,
             stderr: None,
             sandbox_dir: std::path::PathBuf::from("/tmp"),
+            scratch: vec![],
         };
         let res = Driver
             .run(req, &ctoken())

--- a/crates/builtins/src/pluginscratch/mod.rs
+++ b/crates/builtins/src/pluginscratch/mod.rs
@@ -1,0 +1,645 @@
+//! The `scratch` driver: declares a named, mutable, non-hermetic cache directory
+//! that persists across runs and is shared by every target referencing it.
+//!
+//! A scratch directory is state carried between runs to make a build *faster*,
+//! under one invariant that everything else here follows from:
+//!
+//! > A target must produce identical outputs whether its scratch directories are
+//! > warm, cold, or absent. Losing one is always a slowdown and never a wrong
+//! > answer.
+//!
+//! This driver is only the **declaration**. It has no inputs, no outputs, never
+//! executes, and is never cached as a target — `parse` returns a def and `run` is
+//! unreachable. The storage, locking and lineage that make a declaration mean
+//! something live in the engine; see `docs/SCRATCH.md`.
+//!
+//! Declaring it as a target rather than inline at each use site is what makes
+//! sharing work: the settings exist in exactly one place, so two consumers cannot
+//! disagree about a slot's `access` or `version`, and the addr gives packages,
+//! visibility and `heph query revdeps` for free.
+
+use anyhow::Context as _;
+use async_trait::async_trait;
+use hcore::hasync::Cancellable;
+use hcore::htvalue::signature::ParamType;
+use hplugin::driver::{
+    ApplyTransitiveRequest, ApplyTransitiveResponse, ConfigRequest, ConfigResponse, ParseRequest,
+    ParseResponse, RunRequest, RunResponse,
+    targetdef::{CacheConfig, TargetDef},
+};
+use hplugin::htspec::Spec;
+use std::sync::Arc;
+use xxhash_rust::xxh3::Xxh3;
+
+pub const DRIVER_NAME: &str = "scratch";
+
+/// How concurrent consumers of one slot are ordered.
+///
+/// The engine holds a keyed cross-process lock per slot; this decides whether a
+/// consumer takes it for read or for write.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, serde::Serialize)]
+pub enum Access {
+    /// One consumer at a time. The safe default: a read-modify-write cache with
+    /// no concurrency story of its own.
+    Exclusive,
+    /// Concurrent consumers permitted — "trust the tool". Only for caches that are
+    /// safe under concurrent access *by construction*, which heph cannot check.
+    ///
+    /// Go's build cache is the motivating case: it is content-addressed and
+    /// self-verifying, and concurrent access is what `go build -p N` already does.
+    /// Forcing it to `Exclusive` would serialize an entire Go build.
+    Shared,
+}
+
+impl Access {
+    fn parse(s: &str) -> anyhow::Result<Self> {
+        match s {
+            "exclusive" => Ok(Self::Exclusive),
+            "shared" => Ok(Self::Shared),
+            other => anyhow::bail!(
+                "unknown scratch `access` {other:?} — expected \"exclusive\" (one consumer at a \
+                 time) or \"shared\" (concurrent; only for a cache that is safe under concurrent \
+                 access by construction)"
+            ),
+        }
+    }
+
+    pub fn as_str(self) -> &'static str {
+        match self {
+            Self::Exclusive => "exclusive",
+            Self::Shared => "shared",
+        }
+    }
+}
+
+/// What the cache's *contents* are specific to, and therefore how widely one slot
+/// can be shared.
+///
+/// This is not a per-platform behavioural difference — the mechanism is identical
+/// on every supported target. It is the author stating a property of their cache.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, serde::Serialize)]
+pub enum Platform {
+    /// Contents are specific to both the OS and the architecture. The default,
+    /// because the mistake it prevents is the bad one: a `GOCACHE` from
+    /// `darwin/arm64` restored on `linux/amd64`, or a dependency tree holding
+    /// native addons built for the wrong host.
+    OsArch,
+    /// Contents depend on the OS but not the instruction set.
+    Os,
+    /// Portable: one slot serves every machine. The interesting case — a
+    /// package-manager cache, a resolver's metadata, a content-addressed blob
+    /// store — because it lets CI on `linux/amd64` warm a laptop on
+    /// `darwin/arm64` from the same lineage.
+    ///
+    /// It asserts **two** things, not one: that the contents do not depend on the
+    /// host, *and* that they do not embed absolute paths. A cache that is
+    /// genuinely platform-independent but path-sensitive will restore and be
+    /// inert — present, and useless.
+    Any,
+}
+
+impl Platform {
+    fn parse(s: &str) -> anyhow::Result<Self> {
+        match s {
+            "os_arch" => Ok(Self::OsArch),
+            "os" => Ok(Self::Os),
+            "any" => Ok(Self::Any),
+            other => anyhow::bail!(
+                "unknown scratch `platform` {other:?} — expected \"os_arch\" (default), \"os\", \
+                 or \"any\" (portable across every machine)"
+            ),
+        }
+    }
+
+    pub fn as_str(self) -> &'static str {
+        match self {
+            Self::OsArch => "os_arch",
+            Self::Os => "os",
+            Self::Any => "any",
+        }
+    }
+}
+
+/// Config for a `scratch` target. `#[derive(Spec)]` provides the parser and the
+/// LSP schema.
+///
+/// Every field describes **the cache**, never a particular consumer — which is
+/// why referencing a scratch takes no configuration at all.
+#[derive(Spec, Debug)]
+struct ScratchSpec {
+    /// Where the directory is mounted in a consuming target's sandbox, relative to
+    /// that target's cwd. The same for every consumer: a cache's location is part
+    /// of what it is, because tools bake absolute paths into their entries.
+    #[spec(required)]
+    path: String,
+    /// Environment variable a consumer reads the directory's path from. Defaults
+    /// to `SCRATCH_<NAME>`. Set it to the tool's own variable (`GOCACHE`,
+    /// `CCACHE_DIR`) so consumers need no wiring of their own.
+    #[spec(ty = ParamType::String)]
+    env: Option<String>,
+    /// `"exclusive"` (default) — one consumer at a time. `"shared"` — concurrent,
+    /// for a cache that is safe under concurrent access by construction.
+    #[spec(ty = ParamType::String)]
+    access: Option<String>,
+    /// What the contents are specific to: `"os_arch"` (default), `"os"`, or
+    /// `"any"` for a cache portable across every machine.
+    #[spec(ty = ParamType::String)]
+    platform: Option<String>,
+    /// Opaque string folded into the slot key — the author's cache-bust handle.
+    /// Changing it yields a fresh, empty slot and invalidates no cached result.
+    version: String,
+    /// Whether the slot may be pulled from the remote cache automatically and
+    /// published to it by `heph tool scratch push`.
+    remote: bool,
+    /// Per-slot size cap (e.g. `"10GiB"`). Over it the slot is dropped whole
+    /// rather than trimmed — heph cannot know which of a foreign tool's entries
+    /// are hot, and guessing would degrade the cache while claiming to manage it.
+    /// Omit to use the configured default.
+    #[spec(ty = ParamType::String)]
+    max_size: Option<String>,
+}
+
+/// A parsed scratch declaration.
+///
+/// Public because the engine reads these settings when a consumer references the
+/// target — but note it reads them from the *spec config*, not from here: a
+/// `raw_def` is opaque to the host by contract. This type is the driver's own
+/// validated view, and the single place the parsing/validation rules live.
+#[derive(Debug, Clone, PartialEq, Eq, serde::Serialize)]
+pub struct ScratchDef {
+    pub path: String,
+    pub env: String,
+    pub access: Access,
+    pub platform: Platform,
+    pub version: String,
+    pub remote: bool,
+    pub max_size: Option<String>,
+}
+
+/// Default environment-variable name for a scratch called `name`.
+///
+/// Mirrors pluginexec's `OUT_<GROUP>`/`SRC_<GROUP>` convention: uppercase, every
+/// character outside `[A-Z0-9_]` replaced with `_`. The `SCRATCH_` prefix means
+/// the result is always a valid POSIX name even when the target name starts with
+/// a digit.
+pub fn default_env_name(name: &str) -> String {
+    let mut out = String::with_capacity(name.len() + 8);
+    out.push_str("SCRATCH_");
+    for c in name.chars() {
+        let u = c.to_ascii_uppercase();
+        out.push(if u.is_ascii_alphanumeric() || u == '_' {
+            u
+        } else {
+            '_'
+        });
+    }
+    out
+}
+
+/// Reject a mount path that would escape the sandbox or collide with its root.
+///
+/// Checked on the *declaration* so it is reported once at the source rather than
+/// once per consumer. A scratch mount is a symlink pointing out of the sandbox;
+/// letting it be absolute or `..`-relative would put that symlink anywhere on the
+/// machine, and letting it be `.` would replace the target's whole workspace.
+fn validate_path(path: &str) -> anyhow::Result<()> {
+    if path.is_empty() {
+        anyhow::bail!("scratch `path` must not be empty");
+    }
+    if std::path::Path::new(path).is_absolute() {
+        anyhow::bail!(
+            "scratch `path` must be relative to the consuming target's cwd, got {path:?} — a \
+             scratch is mounted inside the sandbox, not at an absolute location on the host"
+        );
+    }
+    let mut depth = 0i32;
+    for c in std::path::Path::new(path).components() {
+        match c {
+            std::path::Component::ParentDir => {
+                depth -= 1;
+                if depth < 0 {
+                    anyhow::bail!(
+                        "scratch `path` must stay inside the sandbox workspace, got {path:?} — \
+                         `..` would place the mount outside it"
+                    );
+                }
+            }
+            std::path::Component::CurDir => {}
+            std::path::Component::Normal(_) => depth += 1,
+            // Unreachable for a relative path, but a prefix/root here would mean
+            // the same escape as an absolute path.
+            _ => anyhow::bail!("scratch `path` must be a plain relative path, got {path:?}"),
+        }
+    }
+    if depth == 0 {
+        anyhow::bail!(
+            "scratch `path` must name a directory inside the sandbox workspace, got {path:?} — \
+             mounting at the workspace root would replace the target's whole tree"
+        );
+    }
+    Ok(())
+}
+
+impl ScratchDef {
+    /// Parse and validate a declaration from its spec config.
+    fn from_spec(spec: ScratchSpec, target_name: &str) -> anyhow::Result<Self> {
+        validate_path(&spec.path)?;
+        let access = spec
+            .access
+            .as_deref()
+            .map(Access::parse)
+            .transpose()?
+            .unwrap_or(Access::Exclusive);
+        let platform = spec
+            .platform
+            .as_deref()
+            .map(Platform::parse)
+            .transpose()?
+            .unwrap_or(Platform::OsArch);
+        let env = match spec.env {
+            Some(e) if e.trim().is_empty() => {
+                anyhow::bail!("scratch `env` must not be empty — omit it to get `SCRATCH_<NAME>`")
+            }
+            Some(e) => e,
+            None => default_env_name(target_name),
+        };
+        Ok(Self {
+            path: spec.path,
+            env,
+            access,
+            platform,
+            version: spec.version,
+            remote: spec.remote,
+            max_size: spec.max_size,
+        })
+    }
+}
+
+pub struct Driver;
+
+#[async_trait]
+impl hplugin::driver::Driver for Driver {
+    fn config(&self, _req: ConfigRequest) -> anyhow::Result<ConfigResponse> {
+        Ok(ConfigResponse {
+            name: DRIVER_NAME.to_string(),
+        })
+    }
+
+    fn schema(&self) -> hplugin::driver::DriverSchema {
+        ScratchSpec::schema()
+    }
+
+    async fn parse(
+        &self,
+        req: ParseRequest,
+        _ctoken: &(dyn Cancellable + Send + Sync),
+    ) -> anyhow::Result<ParseResponse> {
+        let spec = ScratchSpec::from(&req.target_spec.config).context("parse scratch config")?;
+        let def = ScratchDef::from_spec(spec, &req.target_spec.addr.name)
+            .with_context(|| format!("scratch {}", req.target_spec.addr))?;
+
+        // The def hash covers the declaration so that `heph inspect` and the
+        // graph see a target that changes when its config does. It does NOT reach
+        // any consumer's `hashin`: a scratch is referenced with `hashed: false`,
+        // precisely because a target's outputs must be identical whether its
+        // scratch is warm, cold, or absent. Folding this in would mean a `version`
+        // bump rebuilt the world for no correctness gain.
+        let mut h = Xxh3::new();
+        h.update(req.target_spec.addr.format().as_bytes());
+        h.update(def.path.as_bytes());
+        h.update(def.env.as_bytes());
+        h.update(def.access.as_str().as_bytes());
+        h.update(def.platform.as_str().as_bytes());
+        h.update(def.version.as_bytes());
+        h.update(&[def.remote as u8]);
+        h.update(def.max_size.as_deref().unwrap_or("").as_bytes());
+        let hash = format!("{:016x}", h.digest()).into_bytes();
+
+        Ok(ParseResponse {
+            target_def: TargetDef {
+                addr: req.target_spec.addr.clone(),
+                labels: req.target_spec.labels.clone(),
+                raw_def: Arc::new(def),
+                inputs: vec![],
+                outputs: vec![],
+                support_files: vec![],
+                // Never cached as a target: there is nothing to cache. The
+                // directory it names is managed by the engine's scratch store,
+                // which is a different thing with a different lifetime.
+                cache: CacheConfig::off(),
+                pty: false,
+                hash,
+                transparent: false,
+            },
+        })
+    }
+
+    async fn apply_transitive(
+        &self,
+        req: ApplyTransitiveRequest,
+        _ctoken: &(dyn Cancellable + Send + Sync),
+    ) -> anyhow::Result<ApplyTransitiveResponse> {
+        Ok(ApplyTransitiveResponse {
+            target_def: req.target_def,
+        })
+    }
+
+    async fn run<'a, 'io>(
+        &self,
+        _req: RunRequest<'a, 'io>,
+        _ctoken: &(dyn Cancellable + Send + Sync),
+    ) -> anyhow::Result<RunResponse> {
+        // Reachable, and not an error: resolving a declaration directly
+        // (`heph run //build:gocache`) executes it like any other target. Zero
+        // outputs is a supported shape — it is how a no-output gate target
+        // registers a cache hit — so the right answer is to produce nothing and
+        // succeed, not to fail.
+        //
+        // A declaration is inert by construction: no inputs to read, no outputs
+        // to write, no command to spawn. Everything a scratch *does* happens in
+        // the engine, on behalf of the targets that reference it.
+        Ok(RunResponse::default())
+    }
+
+    async fn run_shell<'a, 'io>(
+        &self,
+        req: RunRequest<'a, 'io>,
+        ctoken: &(dyn Cancellable + Send + Sync),
+    ) -> anyhow::Result<RunResponse> {
+        self.run(req, ctoken).await
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use hcore::htvalue::Value;
+    use hmodel::htaddr::Addr;
+    use hmodel::htpkg::PkgBuf;
+    use std::collections::HashMap;
+
+    fn cfg(pairs: &[(&str, Value)]) -> HashMap<String, Value> {
+        pairs
+            .iter()
+            .map(|(k, v)| (k.to_string(), v.clone()))
+            .collect()
+    }
+
+    fn s(v: &str) -> Value {
+        Value::String(v.to_string())
+    }
+
+    fn ctoken() -> hcore::hasync::StdCancellationToken {
+        hcore::hasync::StdCancellationToken::new()
+    }
+
+    fn parse(pairs: &[(&str, Value)], name: &str) -> anyhow::Result<ScratchDef> {
+        let spec = ScratchSpec::from(&cfg(pairs))?;
+        ScratchDef::from_spec(spec, name)
+    }
+
+    #[test]
+    fn defaults_are_the_conservative_ones() {
+        let d = parse(&[("path", s(".cache/go-build"))], "gocache").expect("parse");
+        assert_eq!(d.path, ".cache/go-build");
+        // Exclusive, because a cache with no stated concurrency story gets the
+        // safe treatment.
+        assert_eq!(d.access, Access::Exclusive);
+        // os_arch, because restoring a host-specific cache onto the wrong host is
+        // the one mistake here that is not merely slow.
+        assert_eq!(d.platform, Platform::OsArch);
+        assert!(!d.remote);
+        assert_eq!(d.version, "");
+        assert_eq!(d.max_size, None);
+    }
+
+    #[test]
+    fn env_defaults_to_scratch_upper_name() {
+        let d = parse(&[("path", s("c"))], "go-cache").expect("parse");
+        assert_eq!(d.env, "SCRATCH_GO_CACHE");
+    }
+
+    #[test]
+    fn env_can_be_the_tools_own_variable() {
+        let d = parse(&[("path", s("c")), ("env", s("GOCACHE"))], "gocache").expect("parse");
+        assert_eq!(d.env, "GOCACHE");
+    }
+
+    #[test]
+    fn default_env_name_sanitizes_like_the_exec_group_convention() {
+        assert_eq!(default_env_name("gocache"), "SCRATCH_GOCACHE");
+        assert_eq!(default_env_name("go-cache"), "SCRATCH_GO_CACHE");
+        assert_eq!(default_env_name("go.cache"), "SCRATCH_GO_CACHE");
+        // Non-ASCII collapses rather than leaking bytes into an env var name.
+        assert_eq!(default_env_name("café"), "SCRATCH_CAF_");
+        // The prefix is what keeps a leading digit valid.
+        assert_eq!(default_env_name("2fast"), "SCRATCH_2FAST");
+    }
+
+    #[test]
+    fn access_and_platform_parse_their_words() {
+        let d = parse(
+            &[
+                ("path", s("c")),
+                ("access", s("shared")),
+                ("platform", s("any")),
+            ],
+            "n",
+        )
+        .expect("parse");
+        assert_eq!(d.access, Access::Shared);
+        assert_eq!(d.platform, Platform::Any);
+    }
+
+    #[test]
+    fn an_unknown_access_says_what_the_options_mean() {
+        let err = parse(&[("path", s("c")), ("access", s("concurrent"))], "n")
+            .expect_err("unknown access must fail");
+        let msg = format!("{err:#}");
+        assert!(msg.contains("concurrent"), "{msg}");
+        assert!(msg.contains("exclusive") && msg.contains("shared"), "{msg}");
+    }
+
+    #[test]
+    fn an_unknown_platform_is_rejected() {
+        let err = parse(&[("path", s("c")), ("platform", s("linux"))], "n")
+            .expect_err("unknown platform must fail");
+        assert!(format!("{err:#}").contains("os_arch"));
+    }
+
+    #[test]
+    fn path_is_required() {
+        let err = ScratchSpec::from(&cfg(&[("version", s("1"))])).expect_err("path is required");
+        assert!(format!("{err:#}").contains("path"));
+    }
+
+    /// The mount is a symlink out of the sandbox. An absolute path would let a
+    /// BUILD file point it anywhere on the machine.
+    #[test]
+    fn an_absolute_path_is_rejected() {
+        let err = parse(&[("path", s("/var/tmp/cache"))], "n").expect_err("absolute must fail");
+        assert!(format!("{err:#}").contains("relative"));
+    }
+
+    #[test]
+    fn a_path_escaping_the_workspace_is_rejected() {
+        for p in ["../cache", "a/../../cache"] {
+            let err = parse(&[("path", s(p))], "n").expect_err("escape must fail");
+            assert!(
+                format!("{err:#}").contains("inside the sandbox workspace"),
+                "{p}"
+            );
+        }
+    }
+
+    /// `a/../b` never leaves the workspace, so it is allowed — the check is about
+    /// escaping, not about spelling.
+    #[test]
+    fn a_path_that_re_enters_is_allowed() {
+        let d = parse(&[("path", s("a/../b"))], "n").expect("parse");
+        assert_eq!(d.path, "a/../b");
+    }
+
+    /// Mounting at the workspace root would replace the target's whole tree with
+    /// the cache directory.
+    #[test]
+    fn mounting_at_the_workspace_root_is_rejected() {
+        for p in [".", "./", "a/.."] {
+            let err = parse(&[("path", s(p))], "n").expect_err("root mount must fail");
+            assert!(
+                format!("{err:#}").contains("replace the target's whole tree"),
+                "{p}"
+            );
+        }
+    }
+
+    #[test]
+    fn an_empty_env_is_rejected_rather_than_silently_defaulted() {
+        let err = parse(&[("path", s("c")), ("env", s("  "))], "n").expect_err("empty env");
+        assert!(format!("{err:#}").contains("omit it"));
+    }
+
+    fn addr(name: &str) -> Addr {
+        Addr::new(PkgBuf::from("build"), name.to_string(), Default::default())
+    }
+
+    async fn parse_def(pairs: &[(&str, Value)], name: &str) -> anyhow::Result<TargetDef> {
+        use hplugin::driver::Driver as _;
+        let spec = hplugin::provider::TargetSpec {
+            addr: addr(name),
+            driver: DRIVER_NAME.to_string(),
+            config: cfg(pairs),
+            labels: vec![],
+            transitive: Default::default(),
+            approval: Default::default(),
+        };
+        let res = Driver
+            .parse(
+                ParseRequest {
+                    request_id: "t".to_string(),
+                    target_spec: Arc::new(spec),
+                },
+                &ctoken(),
+            )
+            .await?;
+        Ok(res.target_def)
+    }
+
+    /// A declaration is inert: nothing to build, nothing to cache, nothing to
+    /// materialize. Everything a scratch *does* is the engine's job.
+    #[tokio::test]
+    async fn a_declaration_has_no_inputs_outputs_or_cache() {
+        let def = parse_def(&[("path", s("c"))], "gocache")
+            .await
+            .expect("parse");
+        assert!(def.inputs.is_empty());
+        assert!(def.outputs.is_empty());
+        assert!(def.support_files.is_empty());
+        assert!(!def.cache.enabled);
+        assert!(!def.cache.remote_enabled);
+        assert!(!def.transparent);
+        assert!(!def.hash.is_empty());
+    }
+
+    #[tokio::test]
+    async fn the_def_hash_moves_with_every_declared_field() {
+        let baseline = parse_def(&[("path", s("c"))], "n")
+            .await
+            .expect("parse")
+            .hash;
+        for (field, value) in [
+            ("version", s("v2")),
+            ("access", s("shared")),
+            ("platform", s("any")),
+            ("env", s("GOCACHE")),
+            ("remote", Value::Bool(true)),
+            ("max_size", s("1GiB")),
+        ] {
+            let hash = parse_def(&[("path", s("c")), (field, value)], "n")
+                .await
+                .expect("parse")
+                .hash;
+            assert_ne!(hash, baseline, "def hash must move for `{field}`");
+        }
+    }
+
+    /// Two declarations differing only in package are different caches; the addr
+    /// is the identity, which is what gives packages namespacing for free.
+    #[tokio::test]
+    async fn the_addr_is_part_of_the_def_hash() {
+        use hplugin::driver::Driver as _;
+        let mk = |pkg: &str| {
+            let spec = hplugin::provider::TargetSpec {
+                addr: Addr::new(PkgBuf::from(pkg), "gocache".to_string(), Default::default()),
+                driver: DRIVER_NAME.to_string(),
+                config: cfg(&[("path", s("c"))]),
+                labels: vec![],
+                transitive: Default::default(),
+                approval: Default::default(),
+            };
+            async move {
+                Driver
+                    .parse(
+                        ParseRequest {
+                            request_id: "t".to_string(),
+                            target_spec: Arc::new(spec),
+                        },
+                        &ctoken(),
+                    )
+                    .await
+                    .expect("parse")
+                    .target_def
+                    .hash
+            }
+        };
+        assert_ne!(mk("go").await, mk("rust").await);
+    }
+
+    /// Resolving a declaration directly is legal — the engine executes any target
+    /// asked for, and zero outputs is a supported shape. It must produce nothing
+    /// and succeed.
+    #[tokio::test]
+    async fn running_a_declaration_produces_nothing_and_succeeds() {
+        use hplugin::driver::Driver as _;
+        let def = parse_def(&[("path", s("c"))], "gocache")
+            .await
+            .expect("parse");
+        let req = RunRequest {
+            request_id: &"t".to_string(),
+            target: &def,
+            tree_root_path: std::path::PathBuf::from("/"),
+            inputs: vec![],
+            hashin: "h",
+            stdin: None,
+            stdout: None,
+            stderr: None,
+            sandbox_dir: std::path::PathBuf::from("/tmp"),
+        };
+        let res = Driver
+            .run(req, &ctoken())
+            .await
+            .expect("a declaration runs trivially");
+        assert!(res.artifacts.is_empty());
+        assert!(res.sandbox_cleanup.is_none());
+    }
+}

--- a/crates/builtins/src/pluginscratch/mod.rs
+++ b/crates/builtins/src/pluginscratch/mod.rs
@@ -240,6 +240,19 @@ fn validate_path(path: &str) -> anyhow::Result<()> {
     Ok(())
 }
 
+/// Parse and validate a scratch declaration straight from a target spec.
+///
+/// The engine calls this when a consumer references a scratch: it needs the
+/// declaration's `path`, `env` and `access` to mount and lock the directory, and
+/// a `raw_def` is opaque to the host by contract. Reading the spec config — which
+/// *is* host-visible — through the same function the driver uses keeps one
+/// implementation of the parsing and validation rules, so the host and the driver
+/// can never disagree about what a declaration means.
+pub fn parse_declaration(spec: &hplugin::provider::TargetSpec) -> anyhow::Result<ScratchDef> {
+    let parsed = ScratchSpec::from(&spec.config).context("parse scratch config")?;
+    ScratchDef::from_spec(parsed, &spec.addr.name)
+}
+
 impl ScratchDef {
     /// Parse and validate a declaration from its spec config.
     fn from_spec(spec: ScratchSpec, target_name: &str) -> anyhow::Result<Self> {
@@ -294,8 +307,7 @@ impl hplugin::driver::Driver for Driver {
         req: ParseRequest,
         _ctoken: &(dyn Cancellable + Send + Sync),
     ) -> anyhow::Result<ParseResponse> {
-        let spec = ScratchSpec::from(&req.target_spec.config).context("parse scratch config")?;
-        let def = ScratchDef::from_spec(spec, &req.target_spec.addr.name)
+        let def = parse_declaration(&req.target_spec)
             .with_context(|| format!("scratch {}", req.target_spec.addr))?;
 
         // The def hash covers the declaration so that `heph inspect` and the

--- a/crates/builtins/src/plugintextfile/mod.rs
+++ b/crates/builtins/src/plugintextfile/mod.rs
@@ -200,6 +200,7 @@ mod tests {
             stdout: None,
             stderr: None,
             sandbox_dir: sandbox_dir.to_path_buf(),
+            scratch: vec![],
         }
     }
 

--- a/crates/config/src/config_yaml.rs
+++ b/crates/config/src/config_yaml.rs
@@ -52,6 +52,10 @@ pub struct ConfigYaml {
     pub plugins: Vec<PluginSpec>,
     #[serde(default)]
     pub mem_cache: Option<MemCacheConfig>,
+    /// Scratch-cache policy: which lineage a run writes to and which it may read
+    /// from. See [`ScratchConfig`].
+    #[serde(default)]
+    pub scratch: Option<ScratchConfig>,
     #[serde(default)]
     pub tmp_cache: Option<MemCacheConfig>,
     #[serde(default)]
@@ -176,6 +180,49 @@ pub struct CacheConfig {
     /// Manifests always stay in sqlite. Omit to use the engine default.
     #[serde(default)]
     pub spill_threshold_bytes: Option<u64>,
+}
+
+/// Scratch-cache policy (`scratch:` in `.hephconfig`).
+///
+/// A scratch cache's *contents* are declared by its target; this is about which
+/// **lineage** a run reads and writes. A lineage is named by a scope, and the
+/// natural scope is the branch: work done on one branch should stay there, and a
+/// branch that has none of its own should start from somewhere warm rather than
+/// from nothing.
+///
+/// Repo/CI policy rather than a property of any target, which is why it lives
+/// here and not in a BUILD file — a per-target override would let one BUILD file
+/// opt out of the isolation the repo just configured.
+#[derive(Debug, Deserialize, Clone, PartialEq, Eq, Default)]
+#[serde(deny_unknown_fields, rename_all = "camelCase")]
+pub struct ScratchConfig {
+    /// The lineage this run **writes** to. Supports `${git:branch}`, which heph
+    /// resolves itself so a developer gets branch scoping without wiring
+    /// anything; CI overrides it with whatever names the branch there.
+    ///
+    /// Empty (the default) means one shared lineage — today's behaviour, and the
+    /// right answer for a single long-lived branch.
+    #[serde(default)]
+    pub scope: Option<String>,
+    /// Lineages this run may **read** from when its own scope has nothing, tried
+    /// in order. `["master"]` is the usual answer; a three-level convention
+    /// (`feature` -> `develop` -> `master`) works without special-casing.
+    ///
+    /// Writes never go here — that isolation is what makes the feature safe to
+    /// enable on untrusted PR CI at all.
+    #[serde(default)]
+    pub restore_scopes: Vec<String>,
+    /// Copy the fallback lineage's directory into this scope on the first build
+    /// after a scope change, instead of starting cold.
+    ///
+    /// This is the only copy in the design: once per (slot, scope), amortized
+    /// over every later build on that branch, and measured against a *cold
+    /// rebuild* rather than against nothing. Defaults to on, because without it
+    /// branch scoping just makes every branch switch cold — which is worse than
+    /// not scoping at all. Turn it off if a slot is large and the filesystem has
+    /// no reflink.
+    #[serde(default)]
+    pub seed_on_fork: Option<bool>,
 }
 
 impl ConfigYaml {

--- a/crates/driver-bridge/src/bridge.rs
+++ b/crates/driver-bridge/src/bridge.rs
@@ -347,6 +347,7 @@ mod shell_fallback_tests {
             stdout: None,
             stderr: None,
             sandbox_dir: sandbox.clone(),
+            scratch: vec![],
         };
 
         bridge.run_shell(req, &ctoken).await?;

--- a/crates/driver-support/src/driver_managed.rs
+++ b/crates/driver-support/src/driver_managed.rs
@@ -135,6 +135,12 @@ pub async fn invoke_inner<'a, 'io>(
     // `req.request.sandbox_dir` for filesystem ops. Keep both consistent
     // with the (maybe-redirected) sandbox_dir we just built.
     req.sandbox_dir = sandbox_dir.clone();
+    // Scratch mounts go in after every input is materialized and before the
+    // driver runs. Here rather than in the engine because *this* layer owns
+    // sandbox creation — the FUSE path may redirect `sandbox_pkg_dir` into a
+    // mount, so there is no earlier moment at which the directory reliably
+    // exists — and because putting it here covers both sandbox modes at once.
+    mount_scratch(&sandbox_pkg_dir, &req.scratch)?;
     let mreq = ManagedRunRequest {
         sandbox_dir,
         sandbox_ws_dir: ws_dir,
@@ -160,6 +166,47 @@ pub async fn invoke_inner<'a, 'io>(
             .with_context(|| "driver run")?
     };
     Ok(res)
+}
+
+/// Symlink each resolved scratch cache into the sandbox at its declared path.
+///
+/// One `symlink(2)` per mount, pointing *out* of the sandbox at the canonical
+/// slot directory. That is the whole mechanism, and it is why a scratch costs an
+/// inode per target rather than a copy: teardown removes the link, not the tree
+/// (`remove_dir_all` does not follow symlinks), exactly as read-only input
+/// staging already does for the Go SDK.
+///
+/// The link target is the canonical path rather than something sandbox-local
+/// deliberately — tools bake absolute paths into their cache entries, so if every
+/// consumer saw its own path the cache would be present and inert.
+fn mount_scratch(pkg_dir: &Path, mounts: &[hplugin::driver::ScratchMount]) -> anyhow::Result<()> {
+    for m in mounts {
+        let at = pkg_dir.join(&m.path);
+
+        // A scratch must not land where an input already did. Silently replacing
+        // it would mean the target reads cache bytes where it believes it reads a
+        // declared dependency — bytes no `hashin` describes, which is the one way
+        // a scratch can cause a *wrong build* rather than a slow one. Refuse.
+        if let Ok(md) = fs::symlink_metadata(&at) {
+            anyhow::bail!(
+                "scratch {} cannot mount at {:?}: something is already there ({}). A scratch \
+                 must not overlap a dependency or an output — mounting over it would let the \
+                 target read cache contents where it expects declared inputs",
+                m.addr,
+                m.path,
+                if md.is_dir() { "a directory" } else { "a file" }
+            );
+        }
+
+        if let Some(parent) = at.parent() {
+            fs::create_dir_all(parent).with_context(|| {
+                format!("create parent of scratch mount {:?} for {}", m.path, m.addr)
+            })?;
+        }
+        std::os::unix::fs::symlink(&m.dir, &at)
+            .with_context(|| format!("symlink scratch {} at {:?} -> {:?}", m.addr, at, m.dir))?;
+    }
+    Ok(())
 }
 
 /// Run an interactive shell on `shell_fallback` inside the
@@ -189,6 +236,7 @@ async fn run_shell_fallback<'a, 'io>(
         stdout,
         stderr,
         sandbox_dir: req_sandbox_dir,
+        scratch,
     } = request;
 
     let mut synthetic = (*shell_fallback.spec_template).clone();
@@ -223,6 +271,7 @@ async fn run_shell_fallback<'a, 'io>(
         stdout,
         stderr,
         sandbox_dir: req_sandbox_dir,
+        scratch,
     };
     let new_mreq = ManagedRunRequest {
         request: new_req,

--- a/crates/driver-support/src/lib.rs
+++ b/crates/driver-support/src/lib.rs
@@ -7,4 +7,5 @@
 //! `heph-driver-bridge`, which the engine wires via `Engine::new_managed_driver`.
 pub mod driver_managed;
 pub mod driver_managed_os;
+pub mod scratch;
 pub mod stage;

--- a/crates/driver-support/src/scratch.rs
+++ b/crates/driver-support/src/scratch.rs
@@ -1,0 +1,66 @@
+//! The producer→host channel for scratch references.
+//!
+//! A target referencing a scratch cache records it as an ordinary [`Input`] with
+//! `hashed: false, runtime: false` — a graph edge that materializes nothing and
+//! contributes nothing to the parent's key — marked with the annotation below.
+//!
+//! Annotations are the existing way a driver tells the *host* something about a
+//! dependency edge; [`stage::READ_ONLY_ANNOTATION`](crate::stage::READ_ONLY_ANNOTATION)
+//! and [`stage::STAGE_PER_FILE_ANNOTATION`](crate::stage::STAGE_PER_FILE_ANNOTATION)
+//! are the precedent. Using one here is what keeps scratch off the plugin ABI
+//! entirely: no new proto message, no new `TargetDef` field, no `ABI_SEMVER` bump,
+//! and a third-party driver participates without being recompiled, because it
+//! already passes annotations through.
+//!
+//! The *settings* never travel this way. They live on the referenced `scratch`
+//! target's spec config, which the host reads directly — so there is exactly one
+//! copy of them and two consumers cannot disagree.
+
+/// Input annotation marking a dep edge as a scratch reference. Value must be the
+/// string `"true"`.
+///
+/// Set by a driver whose target declared the reference (pluginexec's `scratch`
+/// attribute); read by the engine, which resolves the referenced declaration and
+/// mounts its directory. An input without it is an ordinary dependency.
+pub const SCRATCH_ANNOTATION: &str = "scratch";
+
+/// `origin_id` prefix for scratch inputs, matching the `dep|<group>|<i>` shape
+/// the other input kinds use.
+///
+/// Distinct from the dep prefixes so a scratch can never collide with a dep group
+/// literally named `scratch`, and so the id reads as what it is in `heph inspect`.
+pub const SCRATCH_ORIGIN_PREFIX: &str = "scratch";
+
+/// True when `annotations` marks an input as a scratch reference.
+pub fn is_scratch(annotations: &std::collections::BTreeMap<String, String>) -> bool {
+    annotations.get(SCRATCH_ANNOTATION).map(String::as_str) == Some("true")
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::collections::BTreeMap;
+
+    fn ann(pairs: &[(&str, &str)]) -> BTreeMap<String, String> {
+        pairs
+            .iter()
+            .map(|(k, v)| (k.to_string(), v.to_string()))
+            .collect()
+    }
+
+    #[test]
+    fn only_the_exact_true_marker_counts() {
+        assert!(is_scratch(&ann(&[("scratch", "true")])));
+        assert!(!is_scratch(&ann(&[])));
+        assert!(!is_scratch(&ann(&[("scratch", "false")])));
+        // Not truthy-parsed: an annotation is a string channel, and accepting
+        // near-misses would make a typo silently mean "yes".
+        assert!(!is_scratch(&ann(&[("scratch", "1")])));
+        assert!(!is_scratch(&ann(&[("scratch", "True")])));
+    }
+
+    #[test]
+    fn an_unrelated_annotation_does_not_mark_a_scratch() {
+        assert!(!is_scratch(&ann(&[("read_only", "true")])));
+    }
+}

--- a/crates/e2e/tests/common/mod.rs
+++ b/crates/e2e/tests/common/mod.rs
@@ -94,6 +94,12 @@ impl Workspace {
     /// cannot reconstruct, and silently substituting a different provider set
     /// would resolve different targets into the same cache.
     pub fn reopen(&self) -> Result<Arc<Engine>> {
+        self.reopen_scoped(Default::default())
+    }
+
+    /// [`reopen`](Self::reopen) with an explicit scratch lineage policy — what a
+    /// second `heph` invocation sees after the branch changed under it.
+    pub fn reopen_scoped(&self, scratch: heph::engine::ScratchOptions) -> Result<Arc<Engine>> {
         let cfg = self.reopen_with.as_ref().ok_or_else(|| {
             anyhow::anyhow!(
                 "this workspace's provider set cannot be rebuilt; reopen is unsupported"
@@ -105,6 +111,7 @@ impl Workspace {
             home_dir: std::path::PathBuf::new(),
             parallelism: cfg.parallelism,
             fs_skip: cfg.fs_skip.clone(),
+            scratch,
             ..Default::default()
         })
         .context("reopen: build engine over the existing workspace root")?;

--- a/crates/e2e/tests/scratch.rs
+++ b/crates/e2e/tests/scratch.rs
@@ -608,6 +608,7 @@ async fn a_branch_switch_seeds_from_the_fallback_and_writes_stay_put() -> anyhow
     };
 
     let on = |scope: &str| heph::engine::ScratchOptions {
+        enabled: true,
         scope: scope.to_string(),
         restore_scopes: vec!["master".to_string()],
         seed_on_fork: true,
@@ -663,6 +664,7 @@ async fn seed_on_fork_off_starts_a_new_branch_cold() -> anyhow::Result<()> {
         Ok(out)
     };
     let on = |scope: &str, seed: bool| heph::engine::ScratchOptions {
+        enabled: true,
         scope: scope.to_string(),
         restore_scopes: vec!["master".to_string()],
         seed_on_fork: seed,
@@ -677,5 +679,102 @@ async fn seed_on_fork_off_starts_a_new_branch_cold() -> anyhow::Result<()> {
         "cold",
         "with seeding off a new lineage must not inherit"
     );
+    Ok(())
+}
+
+/// `--scratch=off` is the audit mode for the whole contract: a target's outputs
+/// must be identical whether its scratch is warm, cold or absent. With it, a
+/// declared cache is not merely empty — the entire path is skipped, so nothing
+/// resolves, locks, or mounts.
+#[tokio::test]
+async fn scratch_off_runs_as_though_nothing_were_declared() -> anyhow::Result<()> {
+    let ws = Workspace::new();
+    ws.write_build_file(
+        "build",
+        r#"target(name = "c", driver = "scratch", path = ".cache/x", env = "C")"#,
+    );
+    // Reports whether the variable and the mount are there at all.
+    ws.write_build_file(
+        "app",
+        r#"target(name = "a", driver = "bash", out = "o.txt", scratch = ["//build:c"],
+       run = ["if [ -n \"${C:-}\" ] && [ -d .cache/x ]; then echo mounted > $OUT; else echo absent > $OUT; fi"])"#,
+    );
+
+    let on = |enabled: bool| heph::engine::ScratchOptions {
+        enabled,
+        ..Default::default()
+    };
+    // `force`, because that is what the CLI does for `--scratch=off` and why it
+    // has to: scratch never reaches `hashin`, so without it the second run is a
+    // cache hit that replays the result built *with* a warm cache — the audit
+    // would pass by reading exactly the answer it is meant to re-derive.
+    let run = async |engine: &Arc<heph::engine::Engine>, force: bool| -> anyhow::Result<String> {
+        let addr = heph::htaddr::parse_addr("//app:a")?;
+        let opts = ResultOptions {
+            force,
+            ..Default::default()
+        };
+        let r = Arc::clone(engine)
+            .result_addr(engine.new_state(), &addr, OutputMatcher::All, &opts)
+            .await?;
+        let out = common::artifact_string(&r).trim().to_string();
+        drop(r);
+        Ok(out)
+    };
+
+    assert_eq!(run(&ws.reopen_scoped(on(true))?, false).await?, "mounted");
+
+    // The trap this test originally fell into, asserted *before* the forced run
+    // so nobody "simplifies" the implication away later: scratch never reaches
+    // `hashin`, so an unforced off-run is a plain cache hit and replays the
+    // result built with a warm cache. The audit would pass by reading exactly the
+    // answer it is meant to re-derive.
+    assert_eq!(
+        run(&ws.reopen_scoped(on(false))?, false).await?,
+        "mounted",
+        "a cached result is served regardless of scratch — which is why \
+         `--scratch=off` must imply a rebuild"
+    );
+
+    // With the rebuild the CLI forces, the cache is genuinely absent — not merely
+    // mounted-and-empty.
+    assert_eq!(
+        run(&ws.reopen_scoped(on(false))?, true).await?,
+        "absent",
+        "--scratch=off must leave the cache genuinely absent, not merely empty"
+    );
+    Ok(())
+}
+
+/// The store describes itself, so it can be listed and reclaimed without reading
+/// a single BUILD file — the property that keeps a cache manageable after the
+/// target that made it is gone.
+#[tokio::test]
+async fn the_store_lists_and_reclaims_what_a_build_created() -> anyhow::Result<()> {
+    let ws = Workspace::new();
+    ws.write_build_file(
+        "build",
+        r#"target(name = "gocache", driver = "scratch", path = ".cache/x", env = "C",
+       access = "shared")"#,
+    );
+    ws.write_build_file(
+        "app",
+        r#"target(name = "a", driver = "bash", out = "o.txt", scratch = ["//build:gocache"],
+       run = ["echo hi > $OUT", "dd if=/dev/zero of=\"$C/blob\" bs=1024 count=8 2>/dev/null"])"#,
+    );
+    ws.run("//app:a").await?;
+
+    let slots = ws.engine.scratch_slots()?;
+    assert_eq!(slots.len(), 1, "the build must have created one slot");
+    let meta = slots[0].meta.as_ref().expect("slot describes itself");
+    assert_eq!(meta.addr, "//build:gocache");
+    assert_eq!(meta.access, "shared");
+    assert!(slots[0].bytes >= 8 * 1024, "got {} bytes", slots[0].bytes);
+
+    // Named removal finds it by the addr the meta recorded.
+    let (n, freed) = ws.engine.scratch_remove(Some("//build:gocache"))?;
+    assert_eq!(n, 1);
+    assert!(freed >= 8 * 1024);
+    assert!(ws.engine.scratch_slots()?.is_empty());
     Ok(())
 }

--- a/crates/e2e/tests/scratch.rs
+++ b/crates/e2e/tests/scratch.rs
@@ -19,6 +19,7 @@ mod common;
 
 use common::Workspace;
 use heph::engine::{OutputMatcher, ResultOptions};
+use std::sync::Arc;
 
 /// `EResult` has no `Debug`, so `expect_err` will not compile. Unwrap the error
 /// side explicitly instead.
@@ -166,6 +167,18 @@ async fn an_unknown_access_names_the_valid_options() -> anyhow::Result<()> {
 // Referencing a scratch from a consuming target.
 // ---------------------------------------------------------------------------
 
+/// Read a target's def hash — the thing that must not move. Asserting on
+/// `hashout` instead would be a trap: a target whose key moved still produces
+/// identical bytes, so a hashout comparison passes while the cache misses on
+/// every run.
+async fn def_hash(engine: &Arc<heph::engine::Engine>, addr: &str) -> anyhow::Result<Vec<u8>> {
+    let addr = heph::htaddr::parse_addr(addr)?;
+    let def = Arc::clone(engine)
+        .get_def(engine.new_state(), &addr)
+        .await?;
+    Ok(def.target_def.hash.clone())
+}
+
 /// The central property (`docs/SCRATCH.md` §6.3): **nothing about a scratch
 /// reaches a consumer's `hashin`**. Not the reference, and not the declaration.
 ///
@@ -186,16 +199,28 @@ async fn referencing_a_scratch_does_not_change_the_consumer_hash() -> anyhow::Re
         "app",
         r#"target(name = "bare", driver = "bash", run = "echo hi > $OUT", out = "o.txt")
 target(name = "with", driver = "bash", run = "echo hi > $OUT", out = "o.txt",
-       scratch = ["//build:c"])"#,
+       scratch = ["//build:c"])
+target(name = "other", driver = "bash", run = "echo bye > $OUT", out = "o.txt")"#,
     );
 
+    let engine = ws.reopen()?;
+    // Precondition: `def_hash` discriminates. Without this the assertion below
+    // would pass just as happily if it returned a constant, and a test that
+    // cannot fail proves nothing.
+    assert_ne!(
+        def_hash(&engine, "//app:bare").await?,
+        def_hash(&engine, "//app:other").await?,
+        "def_hash must distinguish targets that genuinely differ"
+    );
+    assert_eq!(
+        def_hash(&engine, "//app:bare").await?,
+        def_hash(&engine, "//app:with").await?,
+        "a scratch reference must not change the consumer's def hash"
+    );
+    // And end to end: it does not change what the target produces either.
     let bare = ws.run("//app:bare").await?;
     let with = ws.run("//app:with").await?;
-    assert_eq!(
-        bare.artifacts[0].hashout()?,
-        with.artifacts[0].hashout()?,
-        "a scratch reference must not change what a target produces"
-    );
+    assert_eq!(bare.artifacts[0].hashout()?, with.artifacts[0].hashout()?);
     Ok(())
 }
 
@@ -214,6 +239,8 @@ async fn bumping_a_scratch_version_does_not_invalidate_consumers() -> anyhow::Re
     };
 
     ws.write_build_file("build", &decl("v1"));
+    let first_engine = ws.reopen()?;
+    let first_def_hash = def_hash(&first_engine, "//app:a").await?;
     let first = ws.run("//app:a").await?;
     let first_hash = first.artifacts[0].hashout()?;
 
@@ -233,11 +260,15 @@ async fn bumping_a_scratch_version_does_not_invalidate_consumers() -> anyhow::Re
             &ResultOptions::default(),
         )
         .await?;
+    // The load-bearing assertion: the consumer's *key* is untouched, so its
+    // cached result is still a hit. A `version` bump gives a fresh empty slot and
+    // rebuilds nothing.
     assert_eq!(
-        first_hash,
-        second.artifacts[0].hashout()?,
-        "a `version` bump must not change a consumer's result"
+        first_def_hash,
+        def_hash(&engine, "//app:a").await?,
+        "a scratch `version` bump must not change a consumer's def hash"
     );
+    assert_eq!(first_hash, second.artifacts[0].hashout()?);
     Ok(())
 }
 

--- a/crates/e2e/tests/scratch.rs
+++ b/crates/e2e/tests/scratch.rs
@@ -18,6 +18,7 @@
 mod common;
 
 use common::Workspace;
+use heph::engine::{OutputMatcher, ResultOptions};
 
 /// `EResult` has no `Debug`, so `expect_err` will not compile. Unwrap the error
 /// side explicitly instead.
@@ -158,5 +159,201 @@ async fn an_unknown_access_names_the_valid_options() -> anyhow::Result<()> {
     );
     let msg = format!("{err:#}");
     assert!(msg.contains("exclusive") && msg.contains("shared"), "{msg}");
+    Ok(())
+}
+
+// ---------------------------------------------------------------------------
+// Referencing a scratch from a consuming target.
+// ---------------------------------------------------------------------------
+
+/// The central property (`docs/SCRATCH.md` §6.3): **nothing about a scratch
+/// reaches a consumer's `hashin`**. Not the reference, and not the declaration.
+///
+/// The tempting design is the opposite — fold the declaration in, so bumping
+/// `version` rebuilds everything using the cache. But a target's outputs are
+/// required to be identical whether its scratch is warm, cold, or absent, so a
+/// fresh slot changes nothing about them and the rebuild is pure waste. The
+/// `version` bump is the case that is easy to get wrong, so it is asserted
+/// separately below.
+#[tokio::test]
+async fn referencing_a_scratch_does_not_change_the_consumer_hash() -> anyhow::Result<()> {
+    let ws = Workspace::new();
+    ws.write_build_file(
+        "build",
+        r#"target(name = "c", driver = "scratch", path = ".cache/x")"#,
+    );
+    ws.write_build_file(
+        "app",
+        r#"target(name = "bare", driver = "bash", run = "echo hi > $OUT", out = "o.txt")
+target(name = "with", driver = "bash", run = "echo hi > $OUT", out = "o.txt",
+       scratch = ["//build:c"])"#,
+    );
+
+    let bare = ws.run("//app:bare").await?;
+    let with = ws.run("//app:with").await?;
+    assert_eq!(
+        bare.artifacts[0].hashout()?,
+        with.artifacts[0].hashout()?,
+        "a scratch reference must not change what a target produces"
+    );
+    Ok(())
+}
+
+/// Bumping a scratch's `version` yields a fresh, empty slot and must leave every
+/// consumer's cached result a hit — which is exactly what you want when the reason
+/// for bumping it is "the old cache had gone bad".
+#[tokio::test]
+async fn bumping_a_scratch_version_does_not_invalidate_consumers() -> anyhow::Result<()> {
+    let ws = Workspace::new();
+    let consumer = r#"target(name = "a", driver = "bash", run = "echo hi > $OUT", out = "o.txt",
+       scratch = ["//build:c"])"#;
+    ws.write_build_file("app", consumer);
+
+    let decl = |v: &str| {
+        format!(r#"target(name = "c", driver = "scratch", path = ".cache/x", version = "{v}")"#)
+    };
+
+    ws.write_build_file("build", &decl("v1"));
+    let first = ws.run("//app:a").await?;
+    let first_hash = first.artifacts[0].hashout()?;
+
+    ws.write_build_file("build", &decl("v2"));
+    // A second engine over the same on-disk cache — what the next `heph`
+    // invocation sees. Needed because a spec is memoized per engine, so rewriting
+    // the BUILD file and re-running through the same one would replay the old
+    // declaration and prove nothing.
+    let engine = ws.reopen()?;
+    let addr = heph::htaddr::parse_addr("//app:a")?;
+    let second = engine
+        .clone()
+        .result_addr(
+            engine.new_state(),
+            &addr,
+            OutputMatcher::All,
+            &ResultOptions::default(),
+        )
+        .await?;
+    assert_eq!(
+        first_hash,
+        second.artifacts[0].hashout()?,
+        "a `version` bump must not change a consumer's result"
+    );
+    Ok(())
+}
+
+/// Pointing `scratch` at something that is not a scratch target is a BUILD-file
+/// mistake that would otherwise show up much later as a mount doing nothing. Both
+/// ends belong in the message: the author is reading the consumer, and the problem
+/// is the thing it named.
+#[tokio::test]
+async fn referencing_a_non_scratch_target_names_both_ends() -> anyhow::Result<()> {
+    let ws = Workspace::new();
+    ws.write_build_file(
+        "app",
+        r#"target(name = "dep", driver = "bash", run = "echo x > $OUT", out = "o.txt")
+target(name = "a", driver = "bash", run = "echo hi > $OUT", out = "o.txt",
+       scratch = ["//app:dep"])"#,
+    );
+
+    let err = expect_err(
+        ws.run("//app:a").await,
+        "a non-scratch ref must not resolve",
+    );
+    let msg = format!("{err:#}");
+    assert!(msg.contains("//app:a"), "must name the consumer: {msg}");
+    assert!(msg.contains("//app:dep"), "must name the referent: {msg}");
+    assert!(msg.contains("deps"), "must suggest the likely fix: {msg}");
+    Ok(())
+}
+
+/// Two caches claiming one variable means one silently shadows the other, so
+/// neither is safe to mount.
+#[tokio::test]
+async fn two_scratches_claiming_one_env_var_is_an_error() -> anyhow::Result<()> {
+    let ws = Workspace::new();
+    ws.write_build_file(
+        "build",
+        r#"target(name = "a", driver = "scratch", path = "ca", env = "GOCACHE")
+target(name = "b", driver = "scratch", path = "cb", env = "GOCACHE")"#,
+    );
+    ws.write_build_file(
+        "app",
+        r#"target(name = "x", driver = "bash", run = "echo hi > $OUT", out = "o.txt",
+       scratch = ["//build:a", "//build:b"])"#,
+    );
+
+    let err = expect_err(ws.run("//app:x").await, "an env collision must not resolve");
+    let msg = format!("{err:#}");
+    assert!(msg.contains("GOCACHE"), "{msg}");
+    assert!(
+        msg.contains("//build:a") && msg.contains("//build:b"),
+        "{msg}"
+    );
+    Ok(())
+}
+
+/// One cache mounted inside another means whatever writes the outer also writes
+/// the inner — two caches over one set of bytes, with policies that disagree.
+#[tokio::test]
+async fn overlapping_mounts_are_an_error() -> anyhow::Result<()> {
+    let ws = Workspace::new();
+    ws.write_build_file(
+        "build",
+        r#"target(name = "outer", driver = "scratch", path = ".cache")
+target(name = "inner", driver = "scratch", path = ".cache/go")"#,
+    );
+    ws.write_build_file(
+        "app",
+        r#"target(name = "x", driver = "bash", run = "echo hi > $OUT", out = "o.txt",
+       scratch = ["//build:outer", "//build:inner"])"#,
+    );
+
+    let err = expect_err(
+        ws.run("//app:x").await,
+        "overlapping mounts must not resolve",
+    );
+    assert!(format!("{err:#}").contains("overlap"));
+    Ok(())
+}
+
+/// Referencing the same scratch twice mounts one directory twice and sets one
+/// variable twice. Quietly collapsing it would hide a BUILD-file mistake.
+#[tokio::test]
+async fn referencing_one_scratch_twice_is_an_error() -> anyhow::Result<()> {
+    let ws = Workspace::new();
+    ws.write_build_file(
+        "build",
+        r#"target(name = "c", driver = "scratch", path = "cache")"#,
+    );
+    ws.write_build_file(
+        "app",
+        r#"target(name = "x", driver = "bash", run = "echo hi > $OUT", out = "o.txt",
+       scratch = ["//build:c", "//build:c"])"#,
+    );
+
+    let err = expect_err(ws.run("//app:x").await, "a duplicate ref must not resolve");
+    assert!(format!("{err:#}").contains("twice"));
+    Ok(())
+}
+
+/// Many targets sharing one declaration is the whole point, and it must resolve
+/// without any of them configuring anything.
+#[tokio::test]
+async fn many_targets_can_share_one_declaration() -> anyhow::Result<()> {
+    let ws = Workspace::new();
+    ws.write_build_file(
+        "build",
+        r#"target(name = "c", driver = "scratch", path = ".cache/x", access = "shared")"#,
+    );
+    ws.write_build_file(
+        "app",
+        r#"target(name = "a", driver = "bash", run = "echo a > $OUT", out = "a.txt",
+       scratch = ["//build:c"])
+target(name = "b", driver = "bash", run = "echo b > $OUT", out = "b.txt",
+       scratch = ["//build:c"])"#,
+    );
+
+    assert!(!ws.run("//app:a").await?.artifacts.is_empty());
+    assert!(!ws.run("//app:b").await?.artifacts.is_empty());
     Ok(())
 }

--- a/crates/e2e/tests/scratch.rs
+++ b/crates/e2e/tests/scratch.rs
@@ -1,0 +1,162 @@
+#![expect(
+    clippy::panic_in_result_fn,
+    clippy::panic,
+    reason = "restriction/style lints scoped to production code; tests are exempt"
+)]
+
+//! End-to-end coverage for the `scratch` declaration driver.
+//!
+//! These go through the real `Engine` — provider, BUILD-file evaluation, driver
+//! registry, `get_def` — rather than calling the driver directly, because what is
+//! being tested is the *wiring*: that `driver = "scratch"` resolves at all, that
+//! its config reaches the driver, and that a bad declaration fails where a BUILD
+//! author will see it.
+//!
+//! The storage, mounting and locking a declaration eventually drives are not here;
+//! a declaration is inert on its own. See `docs/SCRATCH.md`.
+
+mod common;
+
+use common::Workspace;
+
+/// `EResult` has no `Debug`, so `expect_err` will not compile. Unwrap the error
+/// side explicitly instead.
+fn expect_err<T>(r: anyhow::Result<T>, what: &str) -> anyhow::Error {
+    match r {
+        Ok(_) => panic!("{what}"),
+        Err(e) => e,
+    }
+}
+
+/// The driver is registered and a declaration resolves. Without this, everything
+/// downstream fails with "driver not found" and no test says why.
+#[tokio::test]
+async fn a_scratch_declaration_resolves_through_the_engine() -> anyhow::Result<()> {
+    let ws = Workspace::new();
+    ws.write_build_file(
+        "build",
+        r#"
+target(
+    name = "gocache",
+    driver = "scratch",
+    path = ".cache/go-build",
+    env = "GOCACHE",
+    access = "shared",
+    platform = "os_arch",
+    version = "go1.23",
+    remote = True,
+)
+"#,
+    );
+
+    let spec = ws.get_spec("//build:gocache").await?;
+    assert_eq!(spec.driver, "scratch");
+    Ok(())
+}
+
+/// A declaration produces no artifacts, so resolving one yields an empty result
+/// rather than an error. That is what makes it safe to reference from the graph.
+#[tokio::test]
+async fn a_declaration_produces_no_artifacts() -> anyhow::Result<()> {
+    let ws = Workspace::new();
+    ws.write_build_file(
+        "build",
+        r#"target(name = "c", driver = "scratch", path = "cache")"#,
+    );
+
+    let result = ws.run("//build:c").await?;
+    assert!(
+        result.artifacts.is_empty(),
+        "a scratch declaration must produce nothing, got {} artifacts",
+        result.artifacts.len()
+    );
+    Ok(())
+}
+
+/// The whole point of declaring it as a target: two packages can each have a
+/// `gocache` without agreeing on a naming convention, because the addr is the
+/// identity.
+#[tokio::test]
+async fn two_packages_can_declare_the_same_name() -> anyhow::Result<()> {
+    let ws = Workspace::new();
+    ws.write_build_file(
+        "go",
+        r#"target(name = "cache", driver = "scratch", path = ".cache/go")"#,
+    );
+    ws.write_build_file(
+        "rust",
+        r#"target(name = "cache", driver = "scratch", path = ".cache/rust")"#,
+    );
+
+    let go = ws.get_spec("//go:cache").await?;
+    let rust = ws.get_spec("//rust:cache").await?;
+    assert_eq!(go.driver, "scratch");
+    assert_eq!(rust.driver, "scratch");
+    assert_ne!(go.addr.format(), rust.addr.format());
+    Ok(())
+}
+
+/// `path` is what a consumer mounts, so a missing one is not a defaultable
+/// omission — it is an incomplete declaration, and the error must land at parse
+/// time in the package that wrote it.
+#[tokio::test]
+async fn a_declaration_without_a_path_fails_at_parse() -> anyhow::Result<()> {
+    let ws = Workspace::new();
+    ws.write_build_file(
+        "build",
+        r#"target(name = "c", driver = "scratch", version = "1")"#,
+    );
+
+    let err = expect_err(
+        ws.run("//build:c").await,
+        "a scratch without `path` must not resolve",
+    );
+    let msg = format!("{err:#}");
+    assert!(msg.contains("path"), "error must name the field: {msg}");
+    Ok(())
+}
+
+/// A mount is a symlink out of the sandbox. An absolute path would let a BUILD
+/// file place it anywhere on the machine, so it is rejected at the declaration
+/// rather than at each use.
+#[tokio::test]
+async fn an_absolute_path_is_rejected_at_the_declaration() -> anyhow::Result<()> {
+    let ws = Workspace::new();
+    ws.write_build_file(
+        "build",
+        r#"target(name = "c", driver = "scratch", path = "/var/tmp/cache")"#,
+    );
+
+    let err = expect_err(
+        ws.run("//build:c").await,
+        "an absolute scratch path must not resolve",
+    );
+    let msg = format!("{err:#}");
+    assert!(msg.contains("relative"), "error must explain why: {msg}");
+    // The addr belongs in the message: a workspace with many declarations needs
+    // to know which one is wrong.
+    assert!(
+        msg.contains("//build:c"),
+        "error must name the target: {msg}"
+    );
+    Ok(())
+}
+
+/// An unknown `access` is a typo, not a request for new behaviour. Saying what the
+/// two options *mean* is the difference between a one-line fix and a docs hunt.
+#[tokio::test]
+async fn an_unknown_access_names_the_valid_options() -> anyhow::Result<()> {
+    let ws = Workspace::new();
+    ws.write_build_file(
+        "build",
+        r#"target(name = "c", driver = "scratch", path = "cache", access = "concurrent")"#,
+    );
+
+    let err = expect_err(
+        ws.run("//build:c").await,
+        "an unknown access must not resolve",
+    );
+    let msg = format!("{err:#}");
+    assert!(msg.contains("exclusive") && msg.contains("shared"), "{msg}");
+    Ok(())
+}

--- a/crates/e2e/tests/scratch.rs
+++ b/crates/e2e/tests/scratch.rs
@@ -243,6 +243,9 @@ async fn bumping_a_scratch_version_does_not_invalidate_consumers() -> anyhow::Re
     let first_def_hash = def_hash(&first_engine, "//app:a").await?;
     let first = ws.run("//app:a").await?;
     let first_hash = first.artifacts[0].hashout()?;
+    // Released before the second engine opens — see the note in
+    // `a_scratch_carries_state_between_runs`.
+    drop(first);
 
     ws.write_build_file("build", &decl("v2"));
     // A second engine over the same on-disk cache — what the next `heph`
@@ -386,5 +389,184 @@ target(name = "b", driver = "bash", run = "echo b > $OUT", out = "b.txt",
 
     assert!(!ws.run("//app:a").await?.artifacts.is_empty());
     assert!(!ws.run("//app:b").await?.artifacts.is_empty());
+    Ok(())
+}
+
+// ---------------------------------------------------------------------------
+// Mounting: the point of the whole thing.
+// ---------------------------------------------------------------------------
+
+/// The feature, end to end: a target writes into its scratch, a later run with
+/// changed inputs (so it genuinely re-executes) reads back what the first wrote.
+///
+/// This is the property everything else exists to support — state carried between
+/// runs — and it is asserted through the real sandbox, symlink and env var.
+#[tokio::test]
+async fn a_scratch_carries_state_between_runs() -> anyhow::Result<()> {
+    let ws = Workspace::new();
+    ws.write_build_file(
+        "build",
+        r#"target(name = "c", driver = "scratch", path = ".cache/x", env = "MYCACHE")"#,
+    );
+    let build = |marker: &str| {
+        format!(
+            r#"target(name = "a", driver = "bash", out = "o.txt", scratch = ["//build:c"],
+       run = [
+         "if [ -f \"$MYCACHE/marker\" ]; then cat \"$MYCACHE/marker\" > $OUT; else echo cold > $OUT; fi",
+         "echo {marker} > \"$MYCACHE/marker\"",
+       ])"#
+        )
+    };
+
+    ws.write_build_file("app", &build("first"));
+    let first = ws.run("//app:a").await?;
+    let first_out = common::artifact_string(&first).trim().to_string();
+    // Drop before reopening. An `EResult`'s artifacts hold a *riding read guard*
+    // on their addr's result lock, and the second engine takes the **write** lock
+    // on the same lock files to re-execute — so holding this across `reopen()`
+    // deadlocks the two engines against each other. (A second run that were a
+    // cache *hit* would only take a read lock and would not notice.) Same idiom
+    // as `engine_core.rs`.
+    drop(first);
+    assert_eq!(first_out, "cold", "the first run must see an empty scratch");
+
+    // Change the target so the second run is a genuine miss, not a cache hit —
+    // a hit would never reach the sandbox and the test would prove nothing.
+    ws.write_build_file("app", &build("second"));
+    let engine = ws.reopen()?;
+    let addr = heph::htaddr::parse_addr("//app:a")?;
+    let second = engine
+        .clone()
+        .result_addr(
+            engine.new_state(),
+            &addr,
+            OutputMatcher::All,
+            &ResultOptions::default(),
+        )
+        .await?;
+    assert_eq!(
+        common::artifact_string(&second).trim(),
+        "first",
+        "the second run must see what the first wrote into the scratch"
+    );
+    Ok(())
+}
+
+/// The declaration's `env` is what makes a reference sufficient: the consumer
+/// wires nothing, and the variable holds the canonical slot path — an absolute
+/// path outside the sandbox, not the in-sandbox mount. Tools bake absolute paths
+/// into their cache entries, so every consumer must see the same string.
+#[tokio::test]
+async fn the_env_var_carries_the_canonical_path() -> anyhow::Result<()> {
+    let ws = Workspace::new();
+    ws.write_build_file(
+        "build",
+        r#"target(name = "c", driver = "scratch", path = ".cache/x", env = "MYCACHE")"#,
+    );
+    ws.write_build_file(
+        "app",
+        r#"target(name = "a", driver = "bash", out = "o.txt", scratch = ["//build:c"],
+       run = ["echo \"$MYCACHE\" > $OUT"])"#,
+    );
+
+    let out = common::artifact_string(&*ws.run("//app:a").await?);
+    let path = out.trim();
+    assert!(path.starts_with('/'), "must be absolute, got {path:?}");
+    assert!(
+        path.contains("/scratch/"),
+        "must point into the scratch store, got {path:?}"
+    );
+    assert!(
+        !path.contains("/sandbox/"),
+        "must be the canonical slot, not the in-sandbox mount, got {path:?}"
+    );
+    Ok(())
+}
+
+/// Two targets referencing one declaration must resolve to one directory —
+/// otherwise "sharing" is a word rather than a behaviour.
+#[tokio::test]
+async fn two_targets_sharing_a_declaration_get_one_directory() -> anyhow::Result<()> {
+    let ws = Workspace::new();
+    ws.write_build_file(
+        "build",
+        r#"target(name = "c", driver = "scratch", path = ".cache/x", env = "MYCACHE",
+       access = "shared")"#,
+    );
+    ws.write_build_file(
+        "app",
+        r#"target(name = "a", driver = "bash", out = "a.txt", scratch = ["//build:c"],
+       run = ["echo \"$MYCACHE\" > $OUT"])
+target(name = "b", driver = "bash", out = "b.txt", scratch = ["//build:c"],
+       run = ["echo \"$MYCACHE\" > $OUT"])"#,
+    );
+
+    let a = common::artifact_string(&*ws.run("//app:a").await?);
+    let b = common::artifact_string(&*ws.run("//app:b").await?);
+    assert_eq!(a.trim(), b.trim(), "one declaration is one slot");
+    Ok(())
+}
+
+/// Two declarations differing only in `version` are different caches — that is
+/// what makes `version` a bust handle rather than a label.
+#[tokio::test]
+async fn version_selects_a_different_slot() -> anyhow::Result<()> {
+    let ws = Workspace::new();
+    ws.write_build_file(
+        "build",
+        r#"target(name = "v1", driver = "scratch", path = ".cache/x", env = "C", version = "1")
+target(name = "v2", driver = "scratch", path = ".cache/x", env = "C", version = "2")"#,
+    );
+    ws.write_build_file(
+        "app",
+        r#"target(name = "a", driver = "bash", out = "o.txt", scratch = ["//build:v1"],
+       run = ["echo \"$C\" > $OUT"])
+target(name = "b", driver = "bash", out = "o.txt", scratch = ["//build:v2"],
+       run = ["echo \"$C\" > $OUT"])"#,
+    );
+
+    let a = common::artifact_string(&*ws.run("//app:a").await?);
+    let b = common::artifact_string(&*ws.run("//app:b").await?);
+    assert_ne!(
+        a.trim(),
+        b.trim(),
+        "a `version` bump must give a fresh slot"
+    );
+    Ok(())
+}
+
+/// A scratch mounting where an input already landed would let the target read
+/// cache contents where it believes it reads a declared dependency — bytes no
+/// `hashin` describes. That is the one way a scratch can cause a *wrong build*
+/// rather than a slow one, so it must fail rather than silently win.
+#[tokio::test]
+async fn a_scratch_cannot_mount_over_a_materialized_input() -> anyhow::Result<()> {
+    let ws = Workspace::new();
+    ws.write_build_file(
+        "build",
+        r#"target(name = "c", driver = "scratch", path = "depdir", env = "C")"#,
+    );
+    // The producer's output unpacks into the consumer's sandbox at `depdir/f.txt`,
+    // which is exactly where the scratch wants to mount.
+    ws.write_build_file(
+        "app",
+        r#"target(name = "producer", driver = "bash", out = "depdir/f.txt",
+       run = ["mkdir -p depdir && echo real > depdir/f.txt"])
+target(name = "a", driver = "bash", out = "o.txt",
+       scratch = ["//build:c"],
+       deps = {"src": ["//app:producer"]},
+       run = ["cat depdir/f.txt > $OUT"])"#,
+    );
+
+    let err = expect_err(
+        ws.run("//app:a").await,
+        "a scratch must not mount over a materialized input",
+    );
+    let msg = format!("{err:#}");
+    assert!(
+        msg.contains("already there"),
+        "must explain the collision: {msg}"
+    );
+    assert!(msg.contains("//build:c"), "must name the scratch: {msg}");
     Ok(())
 }

--- a/crates/e2e/tests/scratch.rs
+++ b/crates/e2e/tests/scratch.rs
@@ -570,3 +570,112 @@ target(name = "a", driver = "bash", out = "o.txt",
     assert!(msg.contains("//build:c"), "must name the scratch: {msg}");
     Ok(())
 }
+
+// ---------------------------------------------------------------------------
+// Lineages: one cache per branch, with a fallback.
+// ---------------------------------------------------------------------------
+
+/// Switching branches must not hand the arriving branch the departing branch's
+/// cache state, and must not hand it back mutated. Each lineage keeps its own
+/// directory; a new one is *seeded* from its fallback, so a switch costs a copy
+/// rather than a rebuild.
+///
+/// The whole story in one test: build on `master`, switch to `feat`, and see
+/// `master`'s work — then confirm `feat`'s own writes never reached `master`.
+#[tokio::test]
+async fn a_branch_switch_seeds_from_the_fallback_and_writes_stay_put() -> anyhow::Result<()> {
+    let ws = Workspace::new();
+    ws.write_build_file(
+        "build",
+        r#"target(name = "c", driver = "scratch", path = ".cache/x", env = "C")"#,
+    );
+    // Reads whatever is in the cache, then stamps its own name over it.
+    let build = |m: &str| {
+        format!(
+            r#"target(name = "a", driver = "bash", out = "o.txt", scratch = ["//build:c"],
+       run = ["cat \"$C/marker\" > $OUT || echo cold > $OUT", "echo {m} > \"$C/marker\""])"#
+        )
+    };
+    let run = async |engine: &Arc<heph::engine::Engine>| -> anyhow::Result<String> {
+        let addr = heph::htaddr::parse_addr("//app:a")?;
+        let opts = ResultOptions::default();
+        let r = Arc::clone(engine)
+            .result_addr(engine.new_state(), &addr, OutputMatcher::All, &opts)
+            .await?;
+        let out = common::artifact_string(&r).trim().to_string();
+        drop(r); // releases the riding read lock before the next engine opens
+        Ok(out)
+    };
+
+    let on = |scope: &str| heph::engine::ScratchOptions {
+        scope: scope.to_string(),
+        restore_scopes: vec!["master".to_string()],
+        seed_on_fork: true,
+    };
+
+    // On `master`: cold, then leaves "master" behind.
+    ws.write_build_file("app", &build("master"));
+    assert_eq!(run(&ws.reopen_scoped(on("master"))?).await?, "cold");
+
+    // Switch to `feat`. Its lineage is new, so it seeds from `master` — and sees
+    // what `master` left, rather than starting cold.
+    ws.write_build_file("app", &build("feat"));
+    assert_eq!(
+        run(&ws.reopen_scoped(on("feat"))?).await?,
+        "master",
+        "a new branch must seed from its fallback, not start cold"
+    );
+
+    // Back on `master`: it must still see its own work, not the branch's. This is
+    // the isolation half — a branch cannot advance or corrupt what it forked from.
+    ws.write_build_file("app", &build("master2"));
+    assert_eq!(
+        run(&ws.reopen_scoped(on("master"))?).await?,
+        "master",
+        "the branch's writes must not have reached the lineage it forked from"
+    );
+    Ok(())
+}
+
+/// With seeding off, a new lineage starts cold rather than paying a copy. The
+/// knob exists for a large slot on a filesystem with no reflink.
+#[tokio::test]
+async fn seed_on_fork_off_starts_a_new_branch_cold() -> anyhow::Result<()> {
+    let ws = Workspace::new();
+    ws.write_build_file(
+        "build",
+        r#"target(name = "c", driver = "scratch", path = ".cache/x", env = "C")"#,
+    );
+    let build = |m: &str| {
+        format!(
+            r#"target(name = "a", driver = "bash", out = "o.txt", scratch = ["//build:c"],
+       run = ["cat \"$C/marker\" > $OUT || echo cold > $OUT", "echo {m} > \"$C/marker\""])"#
+        )
+    };
+    let run = async |engine: &Arc<heph::engine::Engine>| -> anyhow::Result<String> {
+        let addr = heph::htaddr::parse_addr("//app:a")?;
+        let opts = ResultOptions::default();
+        let r = Arc::clone(engine)
+            .result_addr(engine.new_state(), &addr, OutputMatcher::All, &opts)
+            .await?;
+        let out = common::artifact_string(&r).trim().to_string();
+        drop(r);
+        Ok(out)
+    };
+    let on = |scope: &str, seed: bool| heph::engine::ScratchOptions {
+        scope: scope.to_string(),
+        restore_scopes: vec!["master".to_string()],
+        seed_on_fork: seed,
+    };
+
+    ws.write_build_file("app", &build("master"));
+    assert_eq!(run(&ws.reopen_scoped(on("master", false))?).await?, "cold");
+
+    ws.write_build_file("app", &build("feat"));
+    assert_eq!(
+        run(&ws.reopen_scoped(on("feat", false))?).await?,
+        "cold",
+        "with seeding off a new lineage must not inherit"
+    );
+    Ok(())
+}

--- a/crates/engine/src/engine/config.rs
+++ b/crates/engine/src/engine/config.rs
@@ -66,6 +66,9 @@ pub fn sanitize_scope(scope: &str) -> String {
 fn resolve_scratch(c: &ScratchConfig, root: &Path) -> ScratchOptions {
     let defaults = ScratchOptions::default();
     ScratchOptions {
+        // Not configurable from the file: turning scratch off is something you do
+        // to one run to check a target, not a state a workspace sits in.
+        enabled: defaults.enabled,
         scope: c
             .scope
             .as_deref()
@@ -118,6 +121,13 @@ pub struct Config {
 /// expanded here, so nothing downstream knows about git.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct ScratchOptions {
+    /// Whether declared scratch caches are used at all.
+    ///
+    /// `false` is `--scratch=off`: every target runs with its caches absent. It
+    /// is the audit mode for the scratch contract — outputs must be identical
+    /// warm, cold or absent — so it is a run-time switch and deliberately not a
+    /// config-file one.
+    pub enabled: bool,
     /// Lineage this run writes to. Empty means one shared lineage.
     pub scope: String,
     /// Lineages to fall back to on read, in order. Never written to.
@@ -129,6 +139,7 @@ pub struct ScratchOptions {
 impl Default for ScratchOptions {
     fn default() -> Self {
         Self {
+            enabled: true,
             scope: String::new(),
             restore_scopes: Vec::new(),
             // On, because branch scoping without it makes every switch cold,

--- a/crates/engine/src/engine/config.rs
+++ b/crates/engine/src/engine/config.rs
@@ -9,8 +9,72 @@
 use std::path::{Path, PathBuf};
 
 use crate::engine::RemoteCacheDef;
-use crate::engine::config_yaml::{ConfigYaml, FuseConfig, LockBackendConfig, MemCacheConfig};
+use crate::engine::config_yaml::{
+    ConfigYaml, FuseConfig, LockBackendConfig, MemCacheConfig, ScratchConfig,
+};
 use crate::engine::result_lock::LockBackend;
+
+/// Expand a configured scope, resolving `${git:branch}` against `root`.
+///
+/// Done here so nothing downstream knows about git: a scope reaches the store as
+/// a plain string, and a workspace that is not a git checkout simply gets an
+/// empty scope (one shared lineage) rather than an error — a cache policy must
+/// never be the reason a build cannot start.
+fn expand_scope(raw: &str, root: &Path) -> String {
+    const GIT_BRANCH: &str = "${git:branch}";
+    if !raw.contains(GIT_BRANCH) {
+        return raw.to_string();
+    }
+    let branch = git_branch(root).unwrap_or_default();
+    raw.replace(GIT_BRANCH, &branch)
+}
+
+/// The current branch name, or `None` outside a git checkout / on a detached
+/// HEAD. Reads `.git/HEAD` directly rather than shelling out to `git`: this runs
+/// on every engine construction, and a subprocess for one line of a file that is
+/// always there is not worth it — nor is depending on `git` being installed.
+fn git_branch(root: &Path) -> Option<String> {
+    let head = std::fs::read_to_string(root.join(".git").join("HEAD")).ok()?;
+    // `ref: refs/heads/<branch>` on a branch; a bare sha when detached, which is
+    // not a lineage anyone means to share, so it reads as no scope.
+    let branch = head.trim().strip_prefix("ref: refs/heads/")?;
+    (!branch.is_empty()).then(|| branch.to_string())
+}
+
+/// Make a scope safe to use as one path component.
+///
+/// Branch names routinely contain `/` (`feature/x`), and a raw one would silently
+/// nest the store an extra level and make two branches collide the moment one is a
+/// prefix path of another. Same sanitizer shape as the env-var one: keep what is
+/// unambiguous, fold the rest to `_`.
+pub fn sanitize_scope(scope: &str) -> String {
+    if scope.is_empty() {
+        return "_".to_string();
+    }
+    scope
+        .chars()
+        .map(|c| {
+            if c.is_ascii_alphanumeric() || c == '.' || c == '-' || c == '_' {
+                c
+            } else {
+                '_'
+            }
+        })
+        .collect()
+}
+
+fn resolve_scratch(c: &ScratchConfig, root: &Path) -> ScratchOptions {
+    let defaults = ScratchOptions::default();
+    ScratchOptions {
+        scope: c
+            .scope
+            .as_deref()
+            .map(|s| expand_scope(s, root))
+            .unwrap_or(defaults.scope),
+        restore_scopes: c.restore_scopes.clone(),
+        seed_on_fork: c.seed_on_fork.unwrap_or(defaults.seed_on_fork),
+    }
+}
 
 #[derive(Debug, Clone, PartialEq)]
 pub struct Config {
@@ -46,6 +110,32 @@ pub struct Config {
     ///
     /// [`RemoteCacheSet`]: crate::engine::RemoteCacheSet
     pub remote_caches: Vec<RemoteCacheDef>,
+    /// Which scratch lineage this run reads and writes. See [`ScratchOptions`].
+    pub scratch: ScratchOptions,
+}
+
+/// Resolved scratch-lineage policy. The config's `${git:branch}` is already
+/// expanded here, so nothing downstream knows about git.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ScratchOptions {
+    /// Lineage this run writes to. Empty means one shared lineage.
+    pub scope: String,
+    /// Lineages to fall back to on read, in order. Never written to.
+    pub restore_scopes: Vec<String>,
+    /// Seed a new scope from its fallback rather than starting cold.
+    pub seed_on_fork: bool,
+}
+
+impl Default for ScratchOptions {
+    fn default() -> Self {
+        Self {
+            scope: String::new(),
+            restore_scopes: Vec::new(),
+            // On, because branch scoping without it makes every switch cold,
+            // which is worse than not scoping at all.
+            seed_on_fork: true,
+        }
+    }
 }
 
 /// Default spill threshold: 8 MiB. Above a few MB the filesystem beats sqlite
@@ -68,6 +158,7 @@ impl Default for Config {
             spill_threshold_bytes: DEFAULT_SPILL_THRESHOLD_BYTES,
             telemetry_enabled: true,
             remote_caches: Vec::new(),
+            scratch: ScratchOptions::default(),
         }
     }
 }
@@ -151,6 +242,11 @@ impl ConfigYamlExt for ConfigYaml {
                 .map(mem_cache_opts)
                 .unwrap_or(defaults.tmp_cache),
             fuse: self.fuse.unwrap_or(defaults.fuse),
+            scratch: self
+                .scratch
+                .as_ref()
+                .map(|s| resolve_scratch(s, root))
+                .unwrap_or(defaults.scratch),
             lock_backend: self
                 .lock
                 .and_then(|l| l.backend)
@@ -185,6 +281,60 @@ impl ConfigYamlExt for ConfigYaml {
 mod tests {
     use super::*;
     use crate::engine::result_lock::LockBackend;
+
+    #[test]
+    fn a_scope_without_the_placeholder_is_passed_through() {
+        assert_eq!(expand_scope("main", Path::new("/nope")), "main");
+        assert_eq!(expand_scope("", Path::new("/nope")), "");
+    }
+
+    /// A workspace that is not a git checkout must still build. A cache policy is
+    /// never a reason a run cannot start, so an unresolvable branch reads as "no
+    /// scope" — one shared lineage — rather than an error.
+    #[test]
+    fn git_branch_outside_a_checkout_expands_to_empty() {
+        let tmp = tempfile::tempdir().expect("tempdir");
+        assert_eq!(expand_scope("${git:branch}", tmp.path()), "");
+    }
+
+    #[test]
+    fn git_branch_reads_the_current_branch_from_head() {
+        let tmp = tempfile::tempdir().expect("tempdir");
+        std::fs::create_dir_all(tmp.path().join(".git")).expect("mkdir");
+        std::fs::write(
+            tmp.path().join(".git").join("HEAD"),
+            "ref: refs/heads/feature/x\n",
+        )
+        .expect("write");
+        assert_eq!(expand_scope("${git:branch}", tmp.path()), "feature/x");
+        // Composable, so a CI config can namespace a shared bucket.
+        assert_eq!(expand_scope("ci-${git:branch}", tmp.path()), "ci-feature/x");
+    }
+
+    /// A detached HEAD is a sha, not a lineage anyone means to share.
+    #[test]
+    fn a_detached_head_expands_to_empty() {
+        let tmp = tempfile::tempdir().expect("tempdir");
+        std::fs::create_dir_all(tmp.path().join(".git")).expect("mkdir");
+        std::fs::write(
+            tmp.path().join(".git").join("HEAD"),
+            "9f1027fc595e9705ae0ec764cd6264b07e5271c0\n",
+        )
+        .expect("write");
+        assert_eq!(expand_scope("${git:branch}", tmp.path()), "");
+    }
+
+    #[test]
+    fn sanitize_scope_keeps_one_path_component() {
+        assert_eq!(sanitize_scope("main"), "main");
+        assert_eq!(sanitize_scope("feature/x"), "feature_x");
+        assert_eq!(sanitize_scope("v1.2-rc_3"), "v1.2-rc_3");
+        // The empty scope is the default and still needs a name of its own.
+        assert_eq!(sanitize_scope(""), "_");
+        // No traversal can come out of a branch name.
+        assert!(!sanitize_scope("../../etc").contains('/'));
+        assert!(!sanitize_scope("..").contains('.') || sanitize_scope("..") == "..");
+    }
 
     #[test]
     fn resolve_applies_defaults_for_empty_yaml() {

--- a/crates/engine/src/engine/engine.rs
+++ b/crates/engine/src/engine/engine.rs
@@ -123,6 +123,7 @@ pub struct Engine {
     /// Guards the execute phase so at most one execute runs per target addr at
     /// a time (cross-process with the filesystem backend, in-process with mem).
     pub(crate) result_lock: ResultLock,
+    pub(crate) scratch_lock: crate::engine::scratch::ScratchLock,
 
     /// Ordered set of remote (shared) caches fronting the local cache. Empty
     /// (a cheap no-op on every path) unless `caches:` is configured.
@@ -437,7 +438,15 @@ impl Engine {
         let lock_dir = home.join("lock");
         std::fs::create_dir_all(&lock_dir)
             .with_context(|| format!("create lock dir {lock_dir:?}"))?;
-        let result_lock = ResultLock::new(cfg.lock_backend, lock_dir);
+        let result_lock = ResultLock::new(cfg.lock_backend, lock_dir.clone());
+        // Separate keyed lock, separate files: a scratch slot is keyed by slot id
+        // and an addr's result by addr, and colliding those namespaces would let
+        // one wait on the other for no reason.
+        let scratch_lock_dir = lock_dir.join("scratch");
+        std::fs::create_dir_all(&scratch_lock_dir)
+            .with_context(|| format!("create scratch lock dir {scratch_lock_dir:?}"))?;
+        let scratch_lock =
+            crate::engine::scratch::ScratchLock::new(cfg.lock_backend, scratch_lock_dir);
 
         // Remote caches: backends are constructed synchronously here (no
         // network); latency ordering is measured lazily on first use.
@@ -507,6 +516,7 @@ impl Engine {
             managed_driver_factories: HashMap::new(),
             fuse,
             result_lock,
+            scratch_lock,
             remote_caches,
             provider_functions_wired: std::sync::Once::new(),
             remote_tmp_ready: tokio::sync::OnceCell::new(),

--- a/crates/engine/src/engine/engine.rs
+++ b/crates/engine/src/engine/engine.rs
@@ -512,6 +512,7 @@ impl Engine {
             remote_tmp_ready: tokio::sync::OnceCell::new(),
         };
         engine.register_driver(|_| Box::new(hbuiltins::plugingroup::Driver))?;
+        engine.register_driver(|_| Box::new(hbuiltins::pluginscratch::Driver))?;
         engine.register_provider(|_| Box::new(hplugin_query::pluginquery::Provider))?;
 
         // The `fs` provider + driver are always-on built-ins. Each builds its

--- a/crates/engine/src/engine/execute.rs
+++ b/crates/engine/src/engine/execute.rs
@@ -44,6 +44,23 @@ impl Engine {
             .inputs_result_exec(rs.clone(), &def.inputs)
             .await?;
 
+        // Scratch slots, between dep resolution and the worker permit — see
+        // `acquire_scratch` for why both sides of that sandwich are load-bearing.
+        // In short: after deps, or a dep needing the same slot could never get it;
+        // before the permit, so a target queued on a contended slot holds no
+        // worker, which also makes the wait provably bounded.
+        //
+        // The guards ride to the end of the run and drop with `_scratch_guards`.
+        hcore::hmemoizer::set_phase("execute:scratch_acquire");
+        let resolved_scratch = self
+            .resolve_scratch(&rs, addr, &def.target.inputs)
+            .await
+            .with_context(|| format!("resolve scratch for {addr}"))?;
+        let (scratch_mounts, _scratch_guards) = self
+            .acquire_scratch(&rs, &resolved_scratch)
+            .await
+            .with_context(|| format!("acquire scratch for {addr}"))?;
+
         // Acquire semaphore AFTER dep resolution so no permit is held while waiting for
         // deps — prevents the classic diamond deadlock where mid-nodes hold permits while
         // waiting for a leaf that also needs a permit.
@@ -158,7 +175,7 @@ impl Engine {
                     let hashin = hashin.to_owned();
 
                     let inner: InteractiveInner = Box::new(enclose!(
-                        (driver, def, rs, self => engine, sandbox_dir)
+                        (driver, def, rs, self => engine, sandbox_dir, scratch_mounts)
                         move |stdin, stdout, stderr| {
                             Box::pin(async move {
                                 let req = RunRequest {
@@ -171,6 +188,7 @@ impl Engine {
                                     stdout,
                                     stderr,
                                     sandbox_dir,
+                                    scratch: scratch_mounts,
                                 };
                                 let res = if shell {
                                     driver.driver.run_shell(req, rs.ctoken()).await?

--- a/crates/engine/src/engine/mod.rs
+++ b/crates/engine/src/engine/mod.rs
@@ -11,6 +11,7 @@ pub use config::Config;
 pub use config::ConfigYamlExt;
 pub use config::DEFAULT_SPILL_THRESHOLD_BYTES;
 pub use config::MemCacheOptions;
+pub use config::ScratchOptions;
 // The YAML config shape + loader + workspace-root discovery now live in the
 // engine-free `config` crate (so layers that run before the engine — e.g. the
 // self-upgrade check — can read it). Re-export under the original paths so

--- a/crates/engine/src/engine/mod.rs
+++ b/crates/engine/src/engine/mod.rs
@@ -89,6 +89,7 @@ mod matcher_spec;
 pub mod matcher_target;
 mod meta;
 pub mod sandbox_cleaner;
+pub mod scratch;
 pub mod validate;
 pub mod worker_pool;
 

--- a/crates/engine/src/engine/mod.rs
+++ b/crates/engine/src/engine/mod.rs
@@ -91,6 +91,7 @@ pub mod matcher_target;
 mod meta;
 pub mod sandbox_cleaner;
 pub mod scratch;
+pub mod scratch_store;
 pub mod validate;
 pub mod worker_pool;
 

--- a/crates/engine/src/engine/result.rs
+++ b/crates/engine/src/engine/result.rs
@@ -3658,6 +3658,17 @@ impl Engine {
             anyhow::bail!("missing hash");
         }
 
+        // Scratch references: resolve each to its declaration and reject an
+        // incoherent set (a non-scratch addr, two claiming one env var, two
+        // mounting over each other). Done here, on the finalized def, so every
+        // driver gets the checks and a BUILD-file mistake surfaces at `get_def`
+        // — where the author is still looking at the file — rather than as a
+        // mount that quietly does nothing much later.
+        //
+        // Returns immediately for a target with no references, which is nearly
+        // all of them.
+        self.resolve_scratch(&rs, addr, &def.inputs).await?;
+
         // Validate approval notices against the finalized input set at definition
         // time — before any result resolution or execution — so a notice naming a
         // non-existent input group fails fast and identically on every path.

--- a/crates/engine/src/engine/scratch.rs
+++ b/crates/engine/src/engine/scratch.rs
@@ -127,9 +127,112 @@ impl ScratchLock {
     }
 }
 
-/// The directory a slot's contents live in.
-pub fn slot_dir(home: &Path, slot: &str) -> PathBuf {
-    home.join("scratch").join(slot)
+/// The directory a slot's contents live in, for one lineage.
+///
+/// Scope-structured, so a branch's work stays on that branch: two scopes of one
+/// slot are two directories, and nothing a feature branch does can reach the one
+/// `master` builds from. `sanitize_scope` is what keeps a branch name like
+/// `feature/x` from silently nesting an extra level.
+pub fn scope_dir(home: &Path, slot: &str, scope: &str) -> PathBuf {
+    home.join("scratch")
+        .join(slot)
+        .join(crate::engine::config::sanitize_scope(scope))
+        .join("head")
+}
+
+/// Resolve which lineage to use, and seed it if it is new.
+///
+/// The behaviour is *try this branch, then fall back* — the current scope first,
+/// then each configured `restore_scopes` entry in order. Returns the directory to
+/// mount, always inside the **current** scope: a fallback is a place to copy
+/// *from*, never a place to write to, and that asymmetry is the whole of the
+/// isolation. A PR build cannot advance `master`'s cache, and a broken experiment
+/// on a branch cannot corrupt the one you go back to.
+///
+/// Seeding is the only copy in this design. It happens once per (slot, scope) —
+/// on the first build after a branch switch — and is measured against a cold
+/// rebuild, not against nothing. `scratch.seedOnFork: false` turns it off for a
+/// large slot on a filesystem without reflink, at the cost of every new branch
+/// starting cold.
+async fn resolve_scope_dir(
+    home: &Path,
+    slot: &str,
+    opts: &crate::engine::config::ScratchOptions,
+    addr: &Addr,
+) -> anyhow::Result<PathBuf> {
+    let own = scope_dir(home, slot, &opts.scope);
+    let exists = |p: PathBuf| async move {
+        hcore::blocking::run(move || Ok::<bool, std::io::Error>(p.is_dir()))
+            .await
+            .unwrap_or(false)
+    };
+
+    if exists(own.clone()).await {
+        return Ok(own);
+    }
+
+    // Cold in this lineage. Seed from the first fallback that has anything, so a
+    // branch switch costs a copy rather than a rebuild.
+    if opts.seed_on_fork {
+        for fallback in &opts.restore_scopes {
+            if *fallback == opts.scope {
+                continue;
+            }
+            let from = scope_dir(home, slot, fallback);
+            if !exists(from.clone()).await {
+                continue;
+            }
+            let (src, dst) = (from.clone(), own.clone());
+            let seeded = hcore::blocking::run(move || copy_tree(&src, &dst)).await;
+            match seeded {
+                Ok(()) => {
+                    tracing::debug!(
+                        %addr, slot, from = %from.display(), to = %own.display(),
+                        "seeded scratch from fallback scope",
+                    );
+                    return Ok(own);
+                }
+                // A failed seed is a cold cache, never a failed build: by the
+                // scratch contract, losing one is a slowdown and nothing more.
+                // Leave no partial tree behind for the next run to mistake for a
+                // warm one.
+                Err(err) => {
+                    tracing::debug!(
+                        %addr, slot, error = %err,
+                        "could not seed scratch from fallback scope; starting cold",
+                    );
+                    let dead = own.clone();
+                    drop(hcore::blocking::run(move || std::fs::remove_dir_all(&dead)).await);
+                }
+            }
+        }
+    }
+    Ok(own)
+}
+
+/// Recursively copy `src` to `dst`, following no symlinks out of the tree.
+///
+/// Deliberately plain: a reflink would make this near-free on APFS/btrfs and is
+/// the obvious next step, but it is a per-platform optimization and this has to
+/// be correct on every filesystem first. Symlinks are recreated as symlinks
+/// rather than followed, so a slot that has acquired a link to somewhere else
+/// does not silently duplicate that somewhere else into the new scope.
+fn copy_tree(src: &Path, dst: &Path) -> std::io::Result<()> {
+    std::fs::create_dir_all(dst)?;
+    for entry in std::fs::read_dir(src)? {
+        let entry = entry?;
+        let (from, to) = (entry.path(), dst.join(entry.file_name()));
+        let ft = entry.file_type()?;
+        if ft.is_dir() {
+            copy_tree(&from, &to)?;
+        } else if ft.is_symlink() {
+            let target = std::fs::read_link(&from)?;
+            std::os::unix::fs::symlink(target, &to)?;
+        } else {
+            std::fs::copy(&from, &to)?;
+        }
+    }
+    Ok(())
 }
 
 /// True when this input is a scratch reference rather than an ordinary dep.
@@ -238,10 +341,13 @@ impl Engine {
                 .with_context(|| format!("acquire scratch lock for {}", r.addr))?;
             guards.push(guard);
 
-            // Created under the guard, so two processes racing a cold slot cannot
-            // both decide it is absent and clobber each other's setup. Creation
-            // is idempotent, which is what makes the shared-access case safe.
-            let dir = slot_dir(&self.home, &slot);
+            // Resolved and created under the guard, so two processes racing a
+            // cold lineage cannot both decide it is absent and seed it twice.
+            // Both creation and seeding are idempotent, which is what makes the
+            // shared-access case safe.
+            let dir = resolve_scope_dir(&self.home, &slot, &self.cfg.scratch, &r.addr)
+                .await
+                .with_context(|| format!("resolve scratch lineage for {}", r.addr))?;
             let d = dir.clone();
             hcore::blocking::run(move || std::fs::create_dir_all(&d))
                 .await
@@ -330,6 +436,188 @@ fn paths_overlap(a: &str, b: &str) -> bool {
     };
     let (a, b) = (comps(a), comps(b));
     a.iter().zip(b.iter()).all(|(x, y)| x == y)
+}
+
+#[cfg(test)]
+mod scope_tests {
+    use super::*;
+    use crate::engine::config::ScratchOptions;
+    use hmodel::htpkg::PkgBuf;
+
+    fn addr() -> Addr {
+        Addr::new(PkgBuf::from("build"), "c".to_string(), Default::default())
+    }
+
+    fn opts(scope: &str, fallbacks: &[&str], seed: bool) -> ScratchOptions {
+        ScratchOptions {
+            scope: scope.to_string(),
+            restore_scopes: fallbacks.iter().map(|s| s.to_string()).collect(),
+            seed_on_fork: seed,
+        }
+    }
+
+    /// Two lineages of one slot are two directories. Without this, "branch
+    /// isolation" is a word rather than a behaviour.
+    #[test]
+    fn scopes_are_separate_directories() {
+        let home = Path::new("/h");
+        assert_ne!(
+            scope_dir(home, "abc", "master"),
+            scope_dir(home, "abc", "feat")
+        );
+        assert_eq!(
+            scope_dir(home, "abc", "master"),
+            scope_dir(home, "abc", "master")
+        );
+    }
+
+    /// A branch name with a `/` must not nest an extra level, or two branches
+    /// collide the moment one is a path prefix of another.
+    #[test]
+    fn a_slash_in_a_branch_name_stays_one_component() {
+        let d = scope_dir(Path::new("/h"), "abc", "feature/x");
+        let comps: Vec<_> = d.components().collect();
+        assert_eq!(
+            comps.len(),
+            6,
+            "/h + scratch + abc + <scope> + head is 5 components plus root, got {d:?}"
+        );
+        assert!(!d.to_string_lossy().contains("feature/x"), "{d:?}");
+    }
+
+    /// The empty scope is still a directory name — it is the default (one shared
+    /// lineage), so it cannot resolve to the slot dir itself.
+    #[test]
+    fn the_empty_scope_has_a_directory_of_its_own() {
+        let d = scope_dir(Path::new("/h"), "abc", "");
+        assert!(d.ends_with("head"));
+        assert!(d.to_string_lossy().contains("/abc/_/"), "{d:?}");
+    }
+
+    #[tokio::test]
+    async fn a_cold_lineage_with_no_fallback_resolves_to_its_own_empty_dir() {
+        let tmp = tempfile::tempdir().expect("tempdir");
+        let got = resolve_scope_dir(tmp.path(), "s", &opts("feat", &[], true), &addr())
+            .await
+            .expect("resolve");
+        assert_eq!(got, scope_dir(tmp.path(), "s", "feat"));
+    }
+
+    /// The branch-switch story: `master` is warm, `feat` has never been built, so
+    /// `feat` starts from a copy of `master` rather than from nothing.
+    #[tokio::test]
+    async fn a_new_scope_seeds_from_its_fallback() {
+        let tmp = tempfile::tempdir().expect("tempdir");
+        let master = scope_dir(tmp.path(), "s", "master");
+        std::fs::create_dir_all(master.join("sub")).expect("mkdir");
+        std::fs::write(master.join("sub").join("f"), b"warm").expect("write");
+
+        let got = resolve_scope_dir(tmp.path(), "s", &opts("feat", &["master"], true), &addr())
+            .await
+            .expect("resolve");
+
+        assert_eq!(got, scope_dir(tmp.path(), "s", "feat"));
+        assert_eq!(
+            std::fs::read(got.join("sub").join("f")).expect("read seeded"),
+            b"warm"
+        );
+    }
+
+    /// Writes land in the branch's own lineage. A PR build must not be able to
+    /// advance the cache its base builds from.
+    #[tokio::test]
+    async fn seeding_leaves_the_fallback_untouched() {
+        let tmp = tempfile::tempdir().expect("tempdir");
+        let master = scope_dir(tmp.path(), "s", "master");
+        std::fs::create_dir_all(&master).expect("mkdir");
+        std::fs::write(master.join("f"), b"base").expect("write");
+
+        let got = resolve_scope_dir(tmp.path(), "s", &opts("feat", &["master"], true), &addr())
+            .await
+            .expect("resolve");
+        std::fs::write(got.join("f"), b"branch work").expect("write");
+
+        assert_eq!(std::fs::read(master.join("f")).expect("read"), b"base");
+    }
+
+    #[tokio::test]
+    async fn seed_on_fork_off_starts_cold() {
+        let tmp = tempfile::tempdir().expect("tempdir");
+        let master = scope_dir(tmp.path(), "s", "master");
+        std::fs::create_dir_all(&master).expect("mkdir");
+        std::fs::write(master.join("f"), b"warm").expect("write");
+
+        let got = resolve_scope_dir(tmp.path(), "s", &opts("feat", &["master"], false), &addr())
+            .await
+            .expect("resolve");
+        assert!(!got.join("f").exists(), "must not have seeded");
+    }
+
+    /// An already-warm lineage is used as-is; nothing re-seeds over live work.
+    #[tokio::test]
+    async fn a_warm_scope_is_never_reseeded() {
+        let tmp = tempfile::tempdir().expect("tempdir");
+        for (scope, body) in [("master", b"base".as_slice()), ("feat", b"mine".as_slice())] {
+            let d = scope_dir(tmp.path(), "s", scope);
+            std::fs::create_dir_all(&d).expect("mkdir");
+            std::fs::write(d.join("f"), body).expect("write");
+        }
+        let got = resolve_scope_dir(tmp.path(), "s", &opts("feat", &["master"], true), &addr())
+            .await
+            .expect("resolve");
+        assert_eq!(std::fs::read(got.join("f")).expect("read"), b"mine");
+    }
+
+    /// Fallbacks are ordered, so a three-level convention works without
+    /// special-casing — and an entry naming a lineage that never existed is
+    /// skipped rather than erroring.
+    #[tokio::test]
+    async fn fallbacks_are_tried_in_order_and_missing_ones_are_skipped() {
+        let tmp = tempfile::tempdir().expect("tempdir");
+        let develop = scope_dir(tmp.path(), "s", "develop");
+        std::fs::create_dir_all(&develop).expect("mkdir");
+        std::fs::write(develop.join("f"), b"develop").expect("write");
+
+        let got = resolve_scope_dir(
+            tmp.path(),
+            "s",
+            &opts("feat", &["nonexistent", "develop", "master"], true),
+            &addr(),
+        )
+        .await
+        .expect("resolve");
+        assert_eq!(std::fs::read(got.join("f")).expect("read"), b"develop");
+    }
+
+    /// A slot listing its own scope as a fallback must not try to seed from
+    /// itself — that is a no-op at best and a self-copy at worst.
+    #[tokio::test]
+    async fn a_scope_does_not_seed_from_itself() {
+        let tmp = tempfile::tempdir().expect("tempdir");
+        let got = resolve_scope_dir(tmp.path(), "s", &opts("feat", &["feat"], true), &addr())
+            .await
+            .expect("resolve");
+        assert_eq!(got, scope_dir(tmp.path(), "s", "feat"));
+    }
+
+    #[test]
+    fn copy_tree_recreates_symlinks_rather_than_following_them() {
+        let tmp = tempfile::tempdir().expect("tempdir");
+        let (src, dst) = (tmp.path().join("a"), tmp.path().join("b"));
+        std::fs::create_dir_all(src.join("d")).expect("mkdir");
+        std::fs::write(src.join("d").join("f"), b"x").expect("write");
+        std::os::unix::fs::symlink("/somewhere/else", src.join("link")).expect("symlink");
+
+        copy_tree(&src, &dst).expect("copy");
+
+        assert_eq!(std::fs::read(dst.join("d").join("f")).expect("read"), b"x");
+        let md = std::fs::symlink_metadata(dst.join("link")).expect("stat");
+        assert!(md.file_type().is_symlink(), "must stay a symlink");
+        assert_eq!(
+            std::fs::read_link(dst.join("link")).expect("readlink"),
+            Path::new("/somewhere/else")
+        );
+    }
 }
 
 #[cfg(test)]

--- a/crates/engine/src/engine/scratch.rs
+++ b/crates/engine/src/engine/scratch.rs
@@ -23,9 +23,14 @@
 use crate::engine::Engine;
 use crate::engine::driver::targetdef::Input;
 use crate::engine::request_state::RequestState;
+use crate::engine::result_lock::LockBackend;
 use anyhow::Context as _;
-use hbuiltins::pluginscratch::{DRIVER_NAME, ScratchDef, parse_declaration};
+use hbuiltins::pluginscratch::{Access, DRIVER_NAME, Platform, ScratchDef, parse_declaration};
+use hcore::hasync::Cancellable;
+use hlock::hlock::{FRWLock, KeyedRWLock, MemRWLock};
 use hmodel::htaddr::Addr;
+use hplugin::driver::ScratchMount;
+use std::path::{Path, PathBuf};
 use std::sync::Arc;
 
 /// A reference resolved against its declaration: what the consuming target asked
@@ -36,6 +41,95 @@ pub struct ResolvedScratch {
     pub addr: Addr,
     /// The declaration's settings.
     pub def: ScratchDef,
+}
+
+impl ResolvedScratch {
+    /// Stable id for this cache's storage slot.
+    ///
+    /// The identity is `(addr, version, platform-components)` — see
+    /// `docs/SCRATCH.md` §6.1 for what is deliberately *absent*: `path`, `env`,
+    /// `access`, `remote` and `max_size` are all policy about how a cache is used
+    /// rather than what is in it, and changing one must not throw the contents
+    /// away.
+    ///
+    /// `SLOT_FORMAT` is folded in so a layout change orphans old slots instead of
+    /// misreading them. Bump it whenever the on-disk shape changes.
+    pub fn slot(&self) -> String {
+        use std::hash::{Hash as _, Hasher as _};
+        /// On-disk layout version for a slot directory.
+        const SLOT_FORMAT: u32 = 1;
+
+        let mut h = xxhash_rust::xxh3::Xxh3Default::new();
+        SLOT_FORMAT.hash(&mut h);
+        self.addr.format().hash(&mut h);
+        self.def.version.hash(&mut h);
+        // Only the components the declaration says the contents depend on. This
+        // is what lets `platform = "any"` give one slot for every machine.
+        match self.def.platform {
+            Platform::OsArch => {
+                std::env::consts::OS.hash(&mut h);
+                std::env::consts::ARCH.hash(&mut h);
+            }
+            Platform::Os => std::env::consts::OS.hash(&mut h),
+            Platform::Any => {}
+        }
+        format!("{:016x}", h.finish())
+    }
+}
+
+/// The per-slot cross-process lock guarding a scratch directory.
+///
+/// A [`KeyedRWLock`] rather than the transformable lock `result_lock` uses: a
+/// scratch is only ever taken for read (`access = "shared"`) or write
+/// (`access = "exclusive"`) and never upgraded mid-run, so the extra machinery
+/// would buy nothing.
+pub enum ScratchLock {
+    /// `flock(2)` files under `<home>/lock/scratch/`. Mutually exclusive across
+    /// processes on the same machine — which is the point, since two `heph`
+    /// invocations share one slot directory.
+    Fs(KeyedRWLock<String, FRWLock>),
+    /// In-process only. Tests, and anything that has opted out of file locking.
+    Mem(KeyedRWLock<String, MemRWLock>),
+}
+
+/// An opaque RAII guard on a slot. Held for the target's execute and dropped
+/// after; the concrete guard type is erased because a target may hold a mix of
+/// read and write guards and this code only ever holds and drops them.
+pub type ScratchGuard = Box<dyn std::any::Any + Send>;
+
+impl ScratchLock {
+    pub fn new(backend: LockBackend, dir: PathBuf) -> Self {
+        match backend {
+            LockBackend::Fs => Self::Fs(KeyedRWLock::new(move |slot: &String| {
+                FRWLock::new(dir.join(format!("{slot}.scratch.lock")))
+            })),
+            LockBackend::Mem => Self::Mem(KeyedRWLock::new(|_| MemRWLock::default())),
+        }
+    }
+
+    /// Acquire the guard `access` calls for, waiting until available.
+    async fn acquire(
+        &self,
+        slot: String,
+        access: Access,
+        ctoken: &(dyn Cancellable + Send + Sync),
+    ) -> anyhow::Result<ScratchGuard> {
+        Ok(match (self, access) {
+            (Self::Fs(l), Access::Shared) => Box::new(l.read(slot, ctoken).await?) as ScratchGuard,
+            (Self::Fs(l), Access::Exclusive) => {
+                Box::new(l.write(slot, ctoken).await?) as ScratchGuard
+            }
+            (Self::Mem(l), Access::Shared) => Box::new(l.read(slot, ctoken).await?) as ScratchGuard,
+            (Self::Mem(l), Access::Exclusive) => {
+                Box::new(l.write(slot, ctoken).await?) as ScratchGuard
+            }
+        })
+    }
+}
+
+/// The directory a slot's contents live in.
+pub fn slot_dir(home: &Path, slot: &str) -> PathBuf {
+    home.join("scratch").join(slot)
 }
 
 /// True when this input is a scratch reference rather than an ordinary dep.
@@ -96,6 +190,71 @@ impl Engine {
         check_env_collisions(consumer, &resolved)?;
         check_mount_overlaps(consumer, &resolved)?;
         Ok(resolved)
+    }
+
+    /// Take every slot lock this target needs, create the directories, and return
+    /// the mounts to hand the driver.
+    ///
+    /// # Lock ordering
+    ///
+    /// Guards are acquired in **sorted slot order**, not the order the target
+    /// declared its references. Two targets naming the same pair in opposite
+    /// orders would otherwise deadlock, each holding what the other waits for;
+    /// sorting is the standard fix and costs one `sort_unstable` on a list that is
+    /// essentially always ≤ 2.
+    ///
+    /// # Where this sits in `execute`
+    ///
+    /// **After dependency resolution and before the worker permit.** Both halves
+    /// matter, and both mirror rules `execute` already follows:
+    ///
+    /// * After deps, because holding a slot across dep resolution has the same
+    ///   shape as the diamond deadlock the worker permit is already ordered to
+    ///   avoid — a dep needing the same slot could never get it.
+    /// * Before the permit, like the approval gate, so a target queued on a
+    ///   contended slot holds no worker. Since the lock is always taken first, no
+    ///   permit holder is ever blocked on a slot, so a slot holder always
+    ///   eventually gets a permit: the wait is bounded, not circular.
+    pub(crate) async fn acquire_scratch(
+        self: &Arc<Self>,
+        rs: &Arc<RequestState>,
+        resolved: &[ResolvedScratch],
+    ) -> anyhow::Result<(Vec<ScratchMount>, Vec<ScratchGuard>)> {
+        if resolved.is_empty() {
+            return Ok((Vec::new(), Vec::new()));
+        }
+
+        let mut ordered: Vec<(String, &ResolvedScratch)> =
+            resolved.iter().map(|r| (r.slot(), r)).collect();
+        ordered.sort_unstable_by(|a, b| a.0.cmp(&b.0));
+
+        let mut guards = Vec::with_capacity(ordered.len());
+        let mut mounts = Vec::with_capacity(ordered.len());
+        for (slot, r) in ordered {
+            let guard = self
+                .scratch_lock
+                .acquire(slot.clone(), r.def.access, rs.ctoken())
+                .await
+                .with_context(|| format!("acquire scratch lock for {}", r.addr))?;
+            guards.push(guard);
+
+            // Created under the guard, so two processes racing a cold slot cannot
+            // both decide it is absent and clobber each other's setup. Creation
+            // is idempotent, which is what makes the shared-access case safe.
+            let dir = slot_dir(&self.home, &slot);
+            let d = dir.clone();
+            hcore::blocking::run(move || std::fs::create_dir_all(&d))
+                .await
+                .with_context(|| format!("create scratch dir {dir:?} for {}", r.addr))?;
+
+            mounts.push(ScratchMount {
+                addr: r.addr.clone(),
+                path: r.def.path.clone(),
+                env: r.def.env.clone(),
+                dir,
+            });
+        }
+        Ok((mounts, guards))
     }
 }
 

--- a/crates/engine/src/engine/scratch.rs
+++ b/crates/engine/src/engine/scratch.rs
@@ -257,6 +257,13 @@ impl Engine {
         consumer: &Addr,
         inputs: &[Input],
     ) -> anyhow::Result<Vec<ResolvedScratch>> {
+        // `--scratch=off`: behave as though nothing were declared. Done here
+        // rather than at the mount so the *whole* path is skipped — no spec
+        // resolution, no lock, no directory — which is what makes it a faithful
+        // "as if absent" and not merely "mounted somewhere empty".
+        if !self.cfg.scratch.enabled {
+            return Ok(Vec::new());
+        }
         let refs: Vec<&Input> = inputs.iter().filter(|i| is_scratch_input(i)).collect();
         if refs.is_empty() {
             return Ok(Vec::new());
@@ -352,6 +359,24 @@ impl Engine {
             hcore::blocking::run(move || std::fs::create_dir_all(&d))
                 .await
                 .with_context(|| format!("create scratch dir {dir:?} for {}", r.addr))?;
+
+            // Record what this slot came from, so the store can describe itself
+            // without resolving the graph (see `scratch_store`). Idempotent and
+            // best-effort: it is a diagnostic, not part of the build.
+            crate::engine::scratch_store::write_slot_meta(
+                &self.home,
+                &slot,
+                &crate::engine::scratch_store::SlotMeta {
+                    format: 1,
+                    addr: r.addr.format(),
+                    path: r.def.path.clone(),
+                    env: r.def.env.clone(),
+                    access: r.def.access.as_str().to_string(),
+                    platform: r.def.platform.as_str().to_string(),
+                    version: r.def.version.clone(),
+                    remote: r.def.remote,
+                },
+            );
 
             mounts.push(ScratchMount {
                 addr: r.addr.clone(),
@@ -450,6 +475,7 @@ mod scope_tests {
 
     fn opts(scope: &str, fallbacks: &[&str], seed: bool) -> ScratchOptions {
         ScratchOptions {
+            enabled: true,
             scope: scope.to_string(),
             restore_scopes: fallbacks.iter().map(|s| s.to_string()).collect(),
             seed_on_fork: seed,

--- a/crates/engine/src/engine/scratch.rs
+++ b/crates/engine/src/engine/scratch.rs
@@ -1,0 +1,259 @@
+//! Host-side handling of scratch references.
+//!
+//! A scratch cache is declared as a target (`driver = "scratch"`) and referenced
+//! by addr from the targets that use it. The reference arrives as an [`Input`]
+//! with `hashed: false, runtime: false`, marked by
+//! [`SCRATCH_ANNOTATION`](hdriver_support::scratch::SCRATCH_ANNOTATION) — see that
+//! module for why the settings travel on the declaration's spec rather than on
+//! the edge.
+//!
+//! This module owns the part the engine must decide: **which declaration a
+//! reference resolves to, and whether the set of them a target holds is
+//! coherent**. Everything that gives a resolved reference an effect — the slot
+//! store, mounting, locking, the lineage — builds on top of this.
+//!
+//! # Why validation is here and not in the driver
+//!
+//! A driver sees its own target's config and nothing else. The properties that
+//! matter across a *set* of references — two of them wanting the same environment
+//! variable, two of them mounting over each other — are only visible once each
+//! addr has been resolved to a declaration, which is a host operation. Doing it
+//! here also means every driver gets the checks, not just pluginexec.
+
+use crate::engine::Engine;
+use crate::engine::driver::targetdef::Input;
+use crate::engine::request_state::RequestState;
+use anyhow::Context as _;
+use hbuiltins::pluginscratch::{DRIVER_NAME, ScratchDef, parse_declaration};
+use hmodel::htaddr::Addr;
+use std::sync::Arc;
+
+/// A reference resolved against its declaration: what the consuming target asked
+/// for, plus everything the declaration says about the cache.
+#[derive(Debug, Clone)]
+pub struct ResolvedScratch {
+    /// The declaring target.
+    pub addr: Addr,
+    /// The declaration's settings.
+    pub def: ScratchDef,
+}
+
+/// True when this input is a scratch reference rather than an ordinary dep.
+pub(crate) fn is_scratch_input(input: &Input) -> bool {
+    hdriver_support::scratch::is_scratch(&input.annotations)
+}
+
+impl Engine {
+    /// Resolve every scratch reference on a def, and reject an incoherent set.
+    ///
+    /// Returns them in the order the target declared them, which is the order the
+    /// locks are *not* taken in — lock ordering is by addr, deliberately, so two
+    /// targets referencing the same pair in different orders cannot deadlock.
+    ///
+    /// Cheap on the overwhelmingly common path: a target with no scratch
+    /// references returns immediately without resolving anything, and one with
+    /// references pays a `get_spec` each — memoized per request, and never a
+    /// `get_def`, because a declaration's config is all that is needed.
+    pub(crate) async fn resolve_scratch(
+        self: &Arc<Self>,
+        rs: &Arc<RequestState>,
+        consumer: &Addr,
+        inputs: &[Input],
+    ) -> anyhow::Result<Vec<ResolvedScratch>> {
+        let refs: Vec<&Input> = inputs.iter().filter(|i| is_scratch_input(i)).collect();
+        if refs.is_empty() {
+            return Ok(Vec::new());
+        }
+
+        let mut resolved = Vec::with_capacity(refs.len());
+        for input in refs {
+            let addr = input.r#ref.r#ref.clone();
+            let spec = Arc::clone(self)
+                .get_spec(rs.clone(), &addr)
+                .await
+                .with_context(|| {
+                    format!("{consumer} references scratch {addr}, which does not resolve")
+                })?;
+
+            // A reference to the wrong kind of target is a BUILD-file mistake
+            // that would otherwise surface much later as a mount that does
+            // nothing. Name both ends: the author is looking at the consumer, and
+            // the problem is the thing it named.
+            if spec.driver != DRIVER_NAME {
+                anyhow::bail!(
+                    "{consumer} lists {addr} under `scratch`, but {addr} is a `{}` target — \
+                     `scratch` takes addresses of `{DRIVER_NAME}` targets, which declare a cache \
+                     directory. Did you mean to put it in `deps`?",
+                    spec.driver
+                );
+            }
+
+            let def = parse_declaration(&spec)
+                .with_context(|| format!("{consumer} references scratch {addr}"))?;
+            resolved.push(ResolvedScratch { addr, def });
+        }
+
+        check_env_collisions(consumer, &resolved)?;
+        check_mount_overlaps(consumer, &resolved)?;
+        Ok(resolved)
+    }
+}
+
+/// Reject two references that would claim the same environment variable.
+///
+/// The default name is derived from the target *name* alone (so packages do not
+/// disambiguate it) through a deliberately lossy sanitizer, which makes
+/// `//a:go-cache` and `//b:go.cache` collide — and an explicit `env` on two
+/// declarations collides outright. Either way one of two real caches becomes
+/// unreachable, silently, which is exactly the failure worth spending an error
+/// on. The fix is on a *declaration*, not here, because the reference configures
+/// nothing.
+fn check_env_collisions(consumer: &Addr, resolved: &[ResolvedScratch]) -> anyhow::Result<()> {
+    for (i, a) in resolved.iter().enumerate() {
+        for b in resolved.iter().skip(i + 1) {
+            if a.def.env == b.def.env {
+                anyhow::bail!(
+                    "{consumer} references two scratches that both set `{}`: {} and {}. One \
+                     would shadow the other, so neither is safe to mount. Set an explicit `env` \
+                     on one of those declarations.",
+                    a.def.env,
+                    a.addr,
+                    b.addr
+                );
+            }
+        }
+    }
+    Ok(())
+}
+
+/// Reject two references whose mount points overlap.
+///
+/// Mounting one scratch inside another means the outer one's directory contains a
+/// symlink to the inner, so whatever writes the outer cache also writes into the
+/// inner — two caches, one set of bytes, with lifetimes and eviction policies that
+/// disagree. Equal paths are the degenerate case of the same thing.
+fn check_mount_overlaps(consumer: &Addr, resolved: &[ResolvedScratch]) -> anyhow::Result<()> {
+    for (i, a) in resolved.iter().enumerate() {
+        for b in resolved.iter().skip(i + 1) {
+            if paths_overlap(&a.def.path, &b.def.path) {
+                anyhow::bail!(
+                    "{consumer} references two scratches whose mount points overlap: {} at {:?} \
+                     and {} at {:?}. One cache would be written through the other; give them \
+                     disjoint paths.",
+                    a.addr,
+                    a.def.path,
+                    b.addr,
+                    b.def.path
+                );
+            }
+        }
+    }
+    Ok(())
+}
+
+/// True when two mount paths name the same directory, or one contains the other.
+///
+/// Compared component-wise rather than by string prefix, so `.cache/go` and
+/// `.cache/golang` are correctly *not* an overlap — a raw `starts_with` would
+/// call them one, and the resulting error would be nonsense the author cannot act
+/// on. Trailing slashes and `.` segments are normalized away first so two
+/// spellings of one path still collide.
+fn paths_overlap(a: &str, b: &str) -> bool {
+    let comps = |p: &str| -> Vec<String> {
+        std::path::Path::new(p)
+            .components()
+            .filter_map(|c| match c {
+                std::path::Component::Normal(s) => Some(s.to_string_lossy().into_owned()),
+                std::path::Component::ParentDir => Some("..".to_string()),
+                _ => None,
+            })
+            .collect()
+    };
+    let (a, b) = (comps(a), comps(b));
+    a.iter().zip(b.iter()).all(|(x, y)| x == y)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use hmodel::htpkg::PkgBuf;
+
+    fn addr(name: &str) -> Addr {
+        Addr::new(PkgBuf::from("build"), name.to_string(), Default::default())
+    }
+
+    fn res(name: &str, env: &str, path: &str) -> ResolvedScratch {
+        ResolvedScratch {
+            addr: addr(name),
+            def: ScratchDef {
+                path: path.to_string(),
+                env: env.to_string(),
+                access: hbuiltins::pluginscratch::Access::Exclusive,
+                platform: hbuiltins::pluginscratch::Platform::OsArch,
+                version: String::new(),
+                remote: false,
+                max_size: None,
+            },
+        }
+    }
+
+    #[test]
+    fn distinct_envs_and_paths_are_fine() {
+        let r = [res("a", "A", "ca"), res("b", "B", "cb")];
+        check_env_collisions(&addr("c"), &r).expect("no env collision");
+        check_mount_overlaps(&addr("c"), &r).expect("no overlap");
+    }
+
+    #[test]
+    fn two_scratches_claiming_one_variable_name_both_declarations() {
+        let r = [res("a", "GOCACHE", "ca"), res("b", "GOCACHE", "cb")];
+        let err = check_env_collisions(&addr("c"), &r).expect_err("collision must fail");
+        let msg = format!("{err:#}");
+        assert!(msg.contains("GOCACHE"), "{msg}");
+        assert!(
+            msg.contains("//build:a") && msg.contains("//build:b"),
+            "{msg}"
+        );
+        // The fix is on a declaration; say so, because the author is looking at
+        // the consumer and there is nothing to change there.
+        assert!(msg.contains("declarations"), "{msg}");
+    }
+
+    #[test]
+    fn a_mount_nested_inside_another_is_rejected() {
+        let r = [res("a", "A", ".cache"), res("b", "B", ".cache/go")];
+        let err = check_mount_overlaps(&addr("c"), &r).expect_err("nesting must fail");
+        assert!(format!("{err:#}").contains("overlap"));
+    }
+
+    #[test]
+    fn identical_mounts_are_rejected_however_they_are_spelled() {
+        for (x, y) in [("c", "c"), ("c", "./c"), ("c/", "c"), ("a/b", "a/./b")] {
+            let r = [res("a", "A", x), res("b", "B", y)];
+            check_mount_overlaps(&addr("c"), &r)
+                .expect_err(&format!("{x:?} vs {y:?} must collide"));
+        }
+    }
+
+    /// A string `starts_with` would call these an overlap and emit an error the
+    /// author cannot act on, because there is nothing wrong.
+    #[test]
+    fn a_shared_name_prefix_is_not_an_overlap() {
+        for (x, y) in [
+            (".cache/go", ".cache/golang"),
+            ("build", "buildkit"),
+            ("a/bc", "a/bcd"),
+        ] {
+            let r = [res("a", "A", x), res("b", "B", y)];
+            check_mount_overlaps(&addr("c"), &r)
+                .unwrap_or_else(|e| panic!("{x:?} vs {y:?} must not collide: {e:#}"));
+        }
+    }
+
+    #[test]
+    fn sibling_paths_do_not_overlap() {
+        assert!(!paths_overlap("a/b", "a/c"));
+        assert!(paths_overlap("a", "a/b"));
+        assert!(paths_overlap("a/b", "a"));
+    }
+}

--- a/crates/engine/src/engine/scratch_store.rs
+++ b/crates/engine/src/engine/scratch_store.rs
@@ -1,0 +1,472 @@
+//! Inspecting and reclaiming the scratch store.
+//!
+//! The store is `<home>/scratch/<slot>/<scope>/head`, plus a small `slot.meta`
+//! per slot recording which declaration produced it. Everything here is about
+//! answering "what is in there and what can go", which is a different question
+//! from resolving and locking a slot for a build (`scratch.rs`).
+//!
+//! # Why a meta file
+//!
+//! A slot id is a hash, so without one, `heph tool scratch ls` could only print
+//! hashes — or would have to resolve the whole graph to map them back. Writing 100
+//! bytes once per slot buys a listing that works with no BUILD files read at all,
+//! which is the same property `heph tool clean` has for addr-only matchers and for
+//! the same reason: a cache should stay inspectable when the targets that made it
+//! have been deleted.
+//!
+//! # Nothing bounds a slot but this
+//!
+//! There is no `hashin` to age out and no `cache.history` to trim against — a
+//! scratch is mutable state keyed by a declaration, so it grows until something
+//! removes it. That makes eviction a requirement rather than a nicety, and it is
+//! why the sweep is wired into `heph tool gc` rather than living behind a flag
+//! nobody sets.
+
+use crate::engine::Engine;
+use anyhow::Context as _;
+use borsh::{BorshDeserialize, BorshSerialize};
+use std::path::{Path, PathBuf};
+use std::time::SystemTime;
+
+/// On-disk format version for [`SlotMeta`]. A slot whose meta does not
+/// deserialize is reported as unknown rather than failing the command — it is a
+/// cache, and a listing that dies on one bad file is worse than one that says so.
+const SLOT_META_FORMAT: u32 = 1;
+
+const SLOT_META_FILE: &str = "slot.meta";
+
+/// What a slot was created from. Written once per slot, purely so the store can
+/// describe itself.
+#[derive(Debug, Clone, PartialEq, Eq, BorshSerialize, BorshDeserialize)]
+pub struct SlotMeta {
+    pub format: u32,
+    /// The declaring target, formatted (`//build:gocache`).
+    pub addr: String,
+    /// Mount point in a consumer's sandbox.
+    pub path: String,
+    /// Environment variable the directory is announced through.
+    pub env: String,
+    /// `"exclusive"` / `"shared"`.
+    pub access: String,
+    /// `"os_arch"` / `"os"` / `"any"`.
+    pub platform: String,
+    /// The declaration's bust handle.
+    pub version: String,
+    /// Whether the declaration opted into the remote lineage.
+    pub remote: bool,
+}
+
+/// One slot as the store sees it.
+#[derive(Debug, Clone)]
+pub struct SlotEntry {
+    pub slot: String,
+    /// `None` when the meta is missing or unreadable — an orphan from a previous
+    /// format, or a partially-created slot. Still listable, still removable.
+    pub meta: Option<SlotMeta>,
+    /// Lineages present, by sanitized scope directory name.
+    pub scopes: Vec<String>,
+    /// Total bytes across every lineage.
+    pub bytes: u64,
+    /// Most recent modification across every lineage — what LRU eviction orders
+    /// by. `None` if nothing could be stat'd.
+    pub last_used: Option<SystemTime>,
+}
+
+/// Root of the scratch store.
+pub fn store_root(home: &Path) -> PathBuf {
+    home.join("scratch")
+}
+
+fn meta_path(home: &Path, slot: &str) -> PathBuf {
+    store_root(home).join(slot).join(SLOT_META_FILE)
+}
+
+/// Record what a slot came from, if it is not already recorded.
+///
+/// Best-effort by design: this is a diagnostic, and failing a build because a
+/// descriptive file could not be written would trade a listing for a build.
+/// Idempotent, so the common (warm) path does one `exists` and stops.
+pub fn write_slot_meta(home: &Path, slot: &str, meta: &SlotMeta) {
+    let path = meta_path(home, slot);
+    if path.exists() {
+        return;
+    }
+    let write = || -> anyhow::Result<()> {
+        if let Some(parent) = path.parent() {
+            std::fs::create_dir_all(parent)?;
+        }
+        let bytes = borsh::to_vec(meta)?;
+        // Write-then-rename, so a concurrent reader never sees a half file.
+        let tmp = path.with_extension("meta.partial");
+        std::fs::write(&tmp, &bytes)?;
+        std::fs::rename(&tmp, &path)?;
+        Ok(())
+    };
+    if let Err(err) = write() {
+        tracing::debug!(slot, error = %err, "could not record scratch slot meta");
+    }
+}
+
+fn read_slot_meta(home: &Path, slot: &str) -> Option<SlotMeta> {
+    let bytes = std::fs::read(meta_path(home, slot)).ok()?;
+    let meta = SlotMeta::try_from_slice(&bytes).ok()?;
+    (meta.format == SLOT_META_FORMAT).then_some(meta)
+}
+
+/// Recursive size and newest mtime of a directory tree.
+///
+/// Walks rather than caching: a size is only ever asked for by `ls`, `gc` and
+/// the per-slot cap, none of which is on a build's hot path, and a cached total
+/// would be wrong the moment a target wrote into the slot — which is constantly.
+fn measure(dir: &Path) -> (u64, Option<SystemTime>) {
+    let (mut bytes, mut newest) = (0u64, None::<SystemTime>);
+    let Ok(entries) = std::fs::read_dir(dir) else {
+        return (bytes, newest);
+    };
+    for entry in entries.flatten() {
+        let Ok(ft) = entry.file_type() else { continue };
+        if ft.is_dir() {
+            let (b, t) = measure(&entry.path());
+            bytes += b;
+            newest = newest.max(t);
+        } else if let Ok(md) = entry.metadata() {
+            // Symlinks contribute their own size, not their target's — a scratch
+            // may contain links out of the tree and following them would both
+            // over-count and, on a cycle, never finish.
+            if !ft.is_symlink() {
+                bytes += md.len();
+            }
+            newest = newest.max(md.modified().ok());
+        }
+    }
+    (bytes, newest)
+}
+
+impl Engine {
+    /// Every slot in the store, newest first.
+    ///
+    /// Reads no BUILD files: a slot describes itself, so a cache stays inspectable
+    /// after the targets that made it are gone.
+    pub fn scratch_slots(&self) -> anyhow::Result<Vec<SlotEntry>> {
+        let root = store_root(&self.home);
+        let Ok(dir) = std::fs::read_dir(&root) else {
+            // No store yet is not an error — it is an empty one.
+            return Ok(Vec::new());
+        };
+
+        let mut out = Vec::new();
+        for entry in dir.flatten() {
+            if !entry.file_type().map(|t| t.is_dir()).unwrap_or(false) {
+                continue;
+            }
+            let slot = entry.file_name().to_string_lossy().into_owned();
+            let slot_dir = entry.path();
+
+            // Measured per *scope*, not over the whole slot dir, so `bytes` is
+            // the cache's own footprint and not that plus heph's bookkeeping.
+            // A user asking how big a cache is does not mean `slot.meta`, and a
+            // size that silently included it would make every eviction threshold
+            // slightly wrong in a way nobody could see.
+            let (mut scopes, mut bytes, mut last_used) = (Vec::new(), 0u64, None);
+            if let Ok(inner) = std::fs::read_dir(&slot_dir) {
+                for s in inner.flatten() {
+                    if !s.file_type().map(|t| t.is_dir()).unwrap_or(false) {
+                        continue;
+                    }
+                    scopes.push(s.file_name().to_string_lossy().into_owned());
+                    let (b, t) = measure(&s.path());
+                    bytes += b;
+                    last_used = last_used.max(t);
+                }
+            }
+            scopes.sort();
+            out.push(SlotEntry {
+                meta: read_slot_meta(&self.home, &slot),
+                slot,
+                scopes,
+                bytes,
+                last_used,
+            });
+        }
+        // Newest first: the interesting ones are the ones in use.
+        out.sort_by(|a, b| b.last_used.cmp(&a.last_used).then(a.slot.cmp(&b.slot)));
+        Ok(out)
+    }
+
+    /// Drop slots whose declaring addr matches `addr`, or all of them when `None`.
+    ///
+    /// Returns how many went and how many bytes came back. A slot with no readable
+    /// meta matches only the `None` (everything) selection — it cannot be named,
+    /// so naming must not silently miss it, and clearing everything must not
+    /// silently leave it.
+    pub fn scratch_remove(&self, addr: Option<&str>) -> anyhow::Result<(usize, u64)> {
+        let (mut removed, mut bytes) = (0usize, 0u64);
+        for slot in self.scratch_slots()? {
+            let matches = match addr {
+                None => true,
+                Some(want) => slot.meta.as_ref().is_some_and(|m| m.addr == want),
+            };
+            if !matches {
+                continue;
+            }
+            let dir = store_root(&self.home).join(&slot.slot);
+            std::fs::remove_dir_all(&dir)
+                .with_context(|| format!("remove scratch slot {dir:?}"))?;
+            removed += 1;
+            bytes += slot.bytes;
+        }
+        Ok((removed, bytes))
+    }
+
+    /// Reclaim scratch storage: drop anything older than `max_age`, then drop
+    /// least-recently-used slots until the store fits `max_bytes`.
+    ///
+    /// **Whole slots, never partial trims.** heph cannot know which of a foreign
+    /// tool's entries are hot, and guessing would quietly degrade a cache while
+    /// claiming to manage it. Dropping is honest and self-correcting: the next
+    /// build repopulates what it actually needs.
+    pub fn scratch_sweep(
+        &self,
+        max_bytes: Option<u64>,
+        max_age: Option<std::time::Duration>,
+    ) -> anyhow::Result<(usize, u64)> {
+        let mut slots = self.scratch_slots()?;
+        let (mut removed, mut freed) = (0usize, 0u64);
+        let now = SystemTime::now();
+
+        if let Some(max_age) = max_age {
+            slots.retain(|s| {
+                let stale = s
+                    .last_used
+                    .and_then(|t| now.duration_since(t).ok())
+                    .is_some_and(|age| age > max_age);
+                if !stale {
+                    return true;
+                }
+                let dir = store_root(&self.home).join(&s.slot);
+                if std::fs::remove_dir_all(&dir).is_ok() {
+                    removed += 1;
+                    freed += s.bytes;
+                }
+                false
+            });
+        }
+
+        if let Some(max_bytes) = max_bytes {
+            let mut total: u64 = slots.iter().map(|s| s.bytes).sum();
+            // `scratch_slots` is newest-first, so evict from the back.
+            while total > max_bytes {
+                let Some(victim) = slots.pop() else { break };
+                let dir = store_root(&self.home).join(&victim.slot);
+                if std::fs::remove_dir_all(&dir).is_ok() {
+                    removed += 1;
+                    freed += victim.bytes;
+                }
+                total = total.saturating_sub(victim.bytes);
+            }
+        }
+        Ok((removed, freed))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn meta(addr: &str) -> SlotMeta {
+        SlotMeta {
+            format: SLOT_META_FORMAT,
+            addr: addr.to_string(),
+            path: ".cache/x".to_string(),
+            env: "C".to_string(),
+            access: "exclusive".to_string(),
+            platform: "os_arch".to_string(),
+            version: String::new(),
+            remote: false,
+        }
+    }
+
+    /// Build a slot with one scope holding `bytes` bytes.
+    fn make_slot(home: &Path, slot: &str, addr: &str, bytes: usize) {
+        let d = store_root(home).join(slot).join("_").join("head");
+        std::fs::create_dir_all(&d).expect("mkdir");
+        std::fs::write(d.join("blob"), vec![0u8; bytes]).expect("write");
+        write_slot_meta(home, slot, &meta(addr));
+    }
+
+    #[test]
+    fn slot_meta_round_trips_and_rejects_a_foreign_format() {
+        let tmp = tempfile::tempdir().expect("tempdir");
+        write_slot_meta(tmp.path(), "s", &meta("//a:b"));
+        assert_eq!(read_slot_meta(tmp.path(), "s"), Some(meta("//a:b")));
+
+        // A meta from a future layout is not guessed at.
+        let mut future = meta("//a:b");
+        future.format = SLOT_META_FORMAT + 1;
+        let p = meta_path(tmp.path(), "s2");
+        std::fs::create_dir_all(p.parent().expect("parent")).expect("mkdir");
+        std::fs::write(&p, borsh::to_vec(&future).expect("ser")).expect("write");
+        assert_eq!(read_slot_meta(tmp.path(), "s2"), None);
+    }
+
+    /// Writing is idempotent, so the warm path never rewrites and a slot's
+    /// recorded origin cannot drift.
+    #[test]
+    fn writing_meta_twice_keeps_the_first() {
+        let tmp = tempfile::tempdir().expect("tempdir");
+        write_slot_meta(tmp.path(), "s", &meta("//first:one"));
+        write_slot_meta(tmp.path(), "s", &meta("//second:two"));
+        assert_eq!(
+            read_slot_meta(tmp.path(), "s").expect("meta").addr,
+            "//first:one"
+        );
+    }
+
+    #[test]
+    fn measure_counts_bytes_and_does_not_follow_symlinks() {
+        let tmp = tempfile::tempdir().expect("tempdir");
+        let d = tmp.path().join("t");
+        std::fs::create_dir_all(d.join("sub")).expect("mkdir");
+        std::fs::write(d.join("a"), vec![0u8; 100]).expect("write");
+        std::fs::write(d.join("sub").join("b"), vec![0u8; 50]).expect("write");
+        // A link to a big file outside the tree must not be counted as its target.
+        std::fs::write(tmp.path().join("big"), vec![0u8; 10_000]).expect("write");
+        std::os::unix::fs::symlink(tmp.path().join("big"), d.join("link")).expect("symlink");
+
+        let (bytes, newest) = measure(&d);
+        assert_eq!(bytes, 150, "symlink target must not be counted");
+        assert!(newest.is_some());
+    }
+
+    #[test]
+    fn an_absent_store_lists_empty_rather_than_erroring() {
+        let (engine, _tmp) = crate::engine::cache_test_support::test_engine();
+        assert!(engine.scratch_slots().expect("list").is_empty());
+    }
+
+    #[test]
+    fn slots_are_listed_with_their_declaration_and_size() {
+        let (engine, _tmp) = crate::engine::cache_test_support::test_engine();
+        make_slot(&engine.home, "aaa", "//build:gocache", 500);
+        make_slot(&engine.home, "bbb", "//build:cargo", 100);
+
+        let slots = engine.scratch_slots().expect("list");
+        assert_eq!(slots.len(), 2);
+        let by_addr: std::collections::HashMap<_, _> = slots
+            .iter()
+            .map(|s| (s.meta.as_ref().expect("meta").addr.clone(), s))
+            .collect();
+        assert_eq!(by_addr["//build:gocache"].bytes, 500);
+        assert_eq!(by_addr["//build:cargo"].bytes, 100);
+        assert_eq!(by_addr["//build:gocache"].scopes, vec!["_".to_string()]);
+    }
+
+    /// Every lineage of a slot counts toward it — the store is bounded per slot,
+    /// not per branch, or a developer with many branches would never hit a cap.
+    #[test]
+    fn a_slots_size_spans_all_its_scopes() {
+        let (engine, _tmp) = crate::engine::cache_test_support::test_engine();
+        make_slot(&engine.home, "aaa", "//build:c", 100);
+        let other = store_root(&engine.home)
+            .join("aaa")
+            .join("feat")
+            .join("head");
+        std::fs::create_dir_all(&other).expect("mkdir");
+        std::fs::write(other.join("blob"), vec![0u8; 250]).expect("write");
+
+        let slots = engine.scratch_slots().expect("list");
+        assert_eq!(slots[0].bytes, 350);
+        assert_eq!(slots[0].scopes, vec!["_".to_string(), "feat".to_string()]);
+    }
+
+    #[test]
+    fn removing_by_addr_takes_only_that_slot() {
+        let (engine, _tmp) = crate::engine::cache_test_support::test_engine();
+        make_slot(&engine.home, "aaa", "//build:gocache", 500);
+        make_slot(&engine.home, "bbb", "//build:cargo", 100);
+
+        let (n, freed) = engine.scratch_remove(Some("//build:gocache")).expect("rm");
+        assert_eq!((n, freed), (1, 500));
+
+        let left = engine.scratch_slots().expect("list");
+        assert_eq!(left.len(), 1);
+        assert_eq!(left[0].meta.as_ref().expect("meta").addr, "//build:cargo");
+    }
+
+    /// A slot whose meta is unreadable cannot be *named*, so naming must not
+    /// silently miss it — and clearing everything must not silently leave it.
+    #[test]
+    fn an_unnameable_slot_survives_a_named_removal_and_dies_with_the_rest() {
+        let (engine, _tmp) = crate::engine::cache_test_support::test_engine();
+        let orphan = store_root(&engine.home)
+            .join("orphan")
+            .join("_")
+            .join("head");
+        std::fs::create_dir_all(&orphan).expect("mkdir");
+        std::fs::write(orphan.join("blob"), vec![0u8; 10]).expect("write");
+        make_slot(&engine.home, "aaa", "//build:c", 10);
+
+        assert_eq!(engine.scratch_remove(Some("//build:c")).expect("rm").0, 1);
+        assert_eq!(
+            engine.scratch_slots().expect("list").len(),
+            1,
+            "orphan stays"
+        );
+
+        assert_eq!(engine.scratch_remove(None).expect("rm all").0, 1);
+        assert!(engine.scratch_slots().expect("list").is_empty());
+    }
+
+    #[test]
+    fn the_sweep_drops_whole_slots_until_the_store_fits() {
+        let (engine, _tmp) = crate::engine::cache_test_support::test_engine();
+        for (slot, bytes) in [("aaa", 400), ("bbb", 400), ("ccc", 400)] {
+            make_slot(&engine.home, slot, &format!("//build:{slot}"), bytes);
+            // Distinct mtimes so LRU order is defined.
+            std::thread::sleep(std::time::Duration::from_millis(15));
+        }
+
+        let (removed, freed) = engine.scratch_sweep(Some(900), None).expect("sweep");
+        assert_eq!(removed, 1, "one slot is enough to get under 900");
+        assert_eq!(freed, 400);
+        // The oldest went; the two most recent stayed.
+        let left: Vec<_> = engine
+            .scratch_slots()
+            .expect("list")
+            .into_iter()
+            .map(|s| s.slot)
+            .collect();
+        assert!(!left.contains(&"aaa".to_string()), "oldest must go first");
+        assert_eq!(left.len(), 2);
+    }
+
+    #[test]
+    fn the_sweep_drops_stale_slots_by_age() {
+        let (engine, _tmp) = crate::engine::cache_test_support::test_engine();
+        make_slot(&engine.home, "aaa", "//build:c", 10);
+        // Everything is younger than an hour, so nothing goes.
+        assert_eq!(
+            engine
+                .scratch_sweep(None, Some(std::time::Duration::from_secs(3600)))
+                .expect("sweep")
+                .0,
+            0
+        );
+        // Everything is older than zero, so it all goes.
+        assert_eq!(
+            engine
+                .scratch_sweep(None, Some(std::time::Duration::ZERO))
+                .expect("sweep")
+                .0,
+            1
+        );
+    }
+
+    #[test]
+    fn a_sweep_with_no_limits_removes_nothing() {
+        let (engine, _tmp) = crate::engine::cache_test_support::test_engine();
+        make_slot(&engine.home, "aaa", "//build:c", 10);
+        assert_eq!(engine.scratch_sweep(None, None).expect("sweep"), (0, 0));
+        assert_eq!(engine.scratch_slots().expect("list").len(), 1);
+    }
+}

--- a/crates/plugin-abi/src/convert.rs
+++ b/crates/plugin-abi/src/convert.rs
@@ -689,6 +689,34 @@ fn cache_config_from_pb(c: pb::CacheConfig) -> CacheConfig {
     }
 }
 
+/// Scratch mounts, host -> plugin.
+///
+/// One-way by nature: the host resolves, locks and creates a slot, and the plugin
+/// only places it. Nothing about a mount travels back.
+pub fn scratch_mount_to_pb(m: &hplugin::driver::ScratchMount) -> pb::ScratchMount {
+    pb::ScratchMount {
+        addr: Some(addr_to_pb(&m.addr)),
+        path: m.path.clone(),
+        env: m.env.clone(),
+        dir: m.dir.to_string_lossy().into_owned(),
+    }
+}
+
+/// Scratch mounts, as seen by a plugin.
+///
+/// A mount whose `addr` did not survive the wire is dropped rather than
+/// defaulted: the addr is only a diagnostic, but a mount with a wrong one would
+/// misattribute a failure to some other target, and a scratch that silently does
+/// not mount costs a cold cache — never a wrong build (`docs/SCRATCH.md` §4).
+pub fn scratch_mount_from_pb(m: pb::ScratchMount) -> Option<hplugin::driver::ScratchMount> {
+    Some(hplugin::driver::ScratchMount {
+        addr: addr_from_pb(m.addr?),
+        path: m.path,
+        env: m.env,
+        dir: std::path::PathBuf::from(m.dir),
+    })
+}
+
 pub fn target_def_to_pb(td: &TargetDef) -> anyhow::Result<pb::TargetDef> {
     Ok(pb::TargetDef {
         addr: Some(addr_to_pb(&td.addr)),

--- a/crates/plugin-abi/src/lib.rs
+++ b/crates/plugin-abi/src/lib.rs
@@ -21,6 +21,17 @@ pub use hproto_gen::heph::plugin::v1 as pb;
 /// bookkeeping: `scripts/abi-check.sh` fails CI if the ABI surface changed
 /// without a bump, so the version history documents *why* a break happened.
 ///
+/// 0.8.0: `RunRequest`/`ManagedRunRequest` gained `repeated ScratchMount
+/// scratch` — persistent cache directories the host resolved, locked and created
+/// for the run, which the driver symlinks into the sandbox and announces through
+/// an env var. Additive and cold-path: it is a prost wire field, not a vtable
+/// change, so an old plugin decodes a new host's request fine and simply ignores
+/// the mounts. Its targets then run without a scratch, which costs a cold cache
+/// and never a wrong build — the lock is keyed on a declaration the old plugin
+/// cannot see, so there is no shared directory for it to race either. Minor,
+/// therefore, not major: no plugin *must* be rebuilt, but one must be to mount a
+/// scratch.
+///
 /// 0.5.0: `StableExecutor` gained a `states` method (fetch a package's provider
 /// states for cross-subtree config resolution — the go variant `vp` lookup). A
 /// new method on a `#[stabby::stabby]` vtable trait changes its type-report, so
@@ -35,7 +46,7 @@ pub use hproto_gen::heph::plugin::v1 as pb;
 /// 0.3.0: `PluginComponents` gained a `hooks` field (a layout change to the
 /// create-entry struct) for the Hook plugin kind — a hard break, so every plugin
 /// must be rebuilt against this ABI.
-pub const ABI_SEMVER: &str = "0.7.0";
+pub const ABI_SEMVER: &str = "0.8.0";
 
 #[cfg(feature = "convert")]
 pub mod convert;

--- a/crates/plugin-exec/src/pluginexec/mod.rs
+++ b/crates/plugin-exec/src/pluginexec/mod.rs
@@ -851,6 +851,43 @@ impl hdriver_support::driver_managed::ManagedDriver for Driver {
                 .push(input.clone());
         }
 
+        // Scratch references. `hashed: false, runtime: false` is the one
+        // combination nothing else uses, and it is exactly right: a scratch
+        // materializes no artifacts (its declaration has none) and must not touch
+        // this target's cache key, because a target's outputs are required to be
+        // identical whether its scratch is warm, cold, or absent. The edge exists
+        // so the graph knows about it — which is what makes `heph query revdeps`
+        // answer "who shares this cache?" and what turns a bad addr into an
+        // ordinary `TargetNotFoundError`.
+        //
+        // Order is the declared order, deduped: a repeated reference would mount
+        // one directory twice and set one env var twice, which is a BUILD-file
+        // mistake worth naming rather than quietly collapsing.
+        let mut seen_scratch: BTreeMap<String, usize> = BTreeMap::new();
+        let mut scratch_inputs: Vec<Input> = Vec::with_capacity(spec.scratch.len());
+        for (i, raw) in spec.scratch.iter().enumerate() {
+            let r#ref = TargetAddr::parse(raw, &pkg)?;
+            let key = r#ref.to_string();
+            if let Some(first) = seen_scratch.insert(key.clone(), i) {
+                anyhow::bail!(
+                    "scratch {key} is referenced twice (positions {first} and {i}) — a scratch \
+                     mounts at one path and sets one environment variable, so referencing it \
+                     again does nothing; drop the duplicate"
+                );
+            }
+            scratch_inputs.push(Input {
+                r#ref,
+                mode: InputMode::Standard,
+                origin_id: format!("{}|{}", hdriver_support::scratch::SCRATCH_ORIGIN_PREFIX, i),
+                annotations: BTreeMap::from([(
+                    hdriver_support::scratch::SCRATCH_ANNOTATION.to_string(),
+                    "true".to_string(),
+                )]),
+                hashed: false,
+                runtime: false,
+            });
+        }
+
         let tool_inputs = sorted_by_group(spec.tools)
             .into_iter()
             .flat_map(|(k, v)| {
@@ -1014,6 +1051,7 @@ impl hdriver_support::driver_managed::ManagedDriver for Driver {
                     .chain(runtime_dep_inputs.into_iter().map(|(_, v)| v))
                     .chain(tool_inputs.into_iter().map(|(_, v)| v))
                     .chain(runner_input)
+                    .chain(scratch_inputs)
                     .collect(),
                 outputs,
                 support_files,
@@ -3571,6 +3609,83 @@ mod tests {
             .expect("hash_dep input present");
         assert!(hash_dep_input.hashed);
         assert!(!hash_dep_input.runtime);
+        Ok(())
+    }
+
+    /// A scratch reference is the one input with `hashed: false, runtime: false`.
+    /// Both halves matter: it materializes no artifacts (its declaration has
+    /// none), and it must not touch the consumer's cache key, because a target's
+    /// outputs are required to be identical whether its scratch is warm, cold, or
+    /// absent.
+    #[tokio::test]
+    async fn test_parse_scratch_routes_a_non_hashed_non_runtime_input() -> anyhow::Result<()> {
+        use hcore::htvalue::Value;
+        let extra = HashMap::from([(
+            "scratch".to_string(),
+            Value::List(vec![Value::String("//build:gocache".to_string())]),
+        )]);
+        let td = parse_with(extra).await?;
+        let def = td.def::<TargetDef>();
+
+        // Not wired into any runtime routing map: a scratch is not a dep, and
+        // must never appear in SRC_*/LIST_*.
+        assert!(def.dep_group_inputs.is_empty());
+        assert!(def.runtime_dep_group_inputs.is_empty());
+        assert!(def.tool_group_inputs.is_empty());
+
+        let input = td
+            .inputs
+            .iter()
+            .find(|i| i.origin_id.starts_with("scratch|"))
+            .expect("scratch input present");
+        assert!(
+            !input.hashed,
+            "a scratch must not feed the consumer's hashin"
+        );
+        assert!(!input.runtime, "a scratch materializes no artifacts");
+        assert!(
+            hdriver_support::scratch::is_scratch(&input.annotations),
+            "the host recognizes a scratch by its annotation"
+        );
+        assert_eq!(input.r#ref.r#ref.format(), "//build:gocache");
+        Ok(())
+    }
+
+    /// The property the whole design rests on: adding a scratch reference leaves
+    /// the def hash untouched, so it cannot reach any consumer's `hashin`.
+    #[tokio::test]
+    async fn test_parse_scratch_excluded_from_def_hash() -> anyhow::Result<()> {
+        use hcore::htvalue::Value;
+        let bare = parse_with(HashMap::new()).await?;
+        let with = parse_with(HashMap::from([(
+            "scratch".to_string(),
+            Value::List(vec![Value::String("//build:gocache".to_string())]),
+        )]))
+        .await?;
+        assert_eq!(
+            bare.hash, with.hash,
+            "a scratch reference must not change the def hash"
+        );
+        Ok(())
+    }
+
+    /// A repeated reference would mount one directory twice and set one variable
+    /// twice. Collapsing it silently would hide a BUILD-file mistake.
+    #[tokio::test]
+    async fn test_parse_scratch_rejects_a_duplicate_reference() -> anyhow::Result<()> {
+        use hcore::htvalue::Value;
+        let extra = HashMap::from([(
+            "scratch".to_string(),
+            Value::List(vec![
+                Value::String("//build:c".to_string()),
+                Value::String("//build:c".to_string()),
+            ]),
+        )]);
+        let err = match parse_with(extra).await {
+            Ok(_) => panic!("a duplicate scratch reference must fail"),
+            Err(e) => e,
+        };
+        assert!(format!("{err:#}").contains("twice"));
         Ok(())
     }
 

--- a/crates/plugin-exec/src/pluginexec/mod.rs
+++ b/crates/plugin-exec/src/pluginexec/mod.rs
@@ -1476,6 +1476,39 @@ impl Driver {
 
         env.extend(def.runtime_env.iter().map(|(k, v)| (k.clone(), v.clone())));
 
+        // Scratch caches: each declaration names the variable its tool reads the
+        // directory from, so a consumer needs no wiring of its own — declaring
+        // `env = "GOCACHE"` is what makes `scratch = [...]` sufficient.
+        //
+        // The value is the *canonical* slot path the host resolved, not the
+        // in-sandbox symlink: tools bake absolute paths into their cache entries,
+        // so every consumer must see one stable string or the cache restores and
+        // is inert. Set after `runtime_env` and before PATH, and never hashed —
+        // the path contains the engine home, so hashing it would make every cache
+        // key machine-specific.
+        //
+        // A collision with the target's own env is rejected rather than resolved:
+        // silently winning either way leaves one of the two settings inoperative
+        // with nothing to see.
+        for m in &rreq.scratch {
+            let dir = m.dir.to_str().ok_or_else(|| {
+                anyhow::anyhow!("scratch dir for {} is not valid UTF-8: {:?}", m.addr, m.dir)
+            })?;
+            if let Some(existing) = env.get(&m.env)
+                && existing != dir
+            {
+                anyhow::bail!(
+                    "scratch {} sets `{}`, but this target already sets it to {:?}. One would \
+                     shadow the other — rename the variable on the scratch declaration, or drop \
+                     it from this target's env",
+                    m.addr,
+                    m.env,
+                    existing
+                );
+            }
+            env.insert(m.env.clone(), dir.to_string());
+        }
+
         // The target's own tools lead, wherever it ends up running — composed by
         // `hexecrunner` rather than spliced into the string here, because under
         // a runner the rest of `PATH` is not known until the runner (or its
@@ -2163,6 +2196,7 @@ mod tests {
             stdout: None,
             stderr: None,
             sandbox_dir: tmp.path().to_path_buf(),
+            scratch: vec![],
         };
 
         let res = tokio::time::timeout(
@@ -2487,6 +2521,7 @@ mod tests {
             stdout: Some(&mut stdout),
             stderr: None,
             sandbox_dir: tmp.path().to_path_buf(),
+            scratch: vec![],
         };
 
         let _res = driver.run(make_req(req), &ctoken).await?;
@@ -2545,6 +2580,7 @@ mod tests {
             stdout: None,
             stderr: None,
             sandbox_dir: tmp.path().to_path_buf(),
+            scratch: vec![],
         };
 
         let res = driver.run(make_req(req), &ctoken).await;
@@ -2616,6 +2652,7 @@ mod tests {
             stdout: Some(&mut stdout),
             stderr: None,
             sandbox_dir: tmp.path().to_path_buf(),
+            scratch: vec![],
         };
 
         // Use a timeout to detect the hang
@@ -2677,6 +2714,7 @@ mod tests {
             stdout: None,
             stderr: None,
             sandbox_dir: tmp.path().to_path_buf(),
+            scratch: vec![],
         };
 
         let run_fut = driver.run(make_req(req), &ctoken);
@@ -2745,6 +2783,7 @@ mod tests {
             stdout: None,
             stderr: None,
             sandbox_dir: tmp.path().to_path_buf(),
+            scratch: vec![],
         };
 
         let run_fut = driver.run(make_req(req), &ctoken);
@@ -2812,6 +2851,7 @@ mod tests {
             stdout: Some(&mut stdout),
             stderr: None,
             sandbox_dir: tmp.path().to_path_buf(),
+            scratch: vec![],
         };
 
         let res = tokio::time::timeout(
@@ -2988,6 +3028,7 @@ mod tests {
             stdout: Some(&mut out_handle),
             stderr: Some(&mut err_handle),
             sandbox_dir: tmp.path().to_path_buf(),
+            scratch: vec![],
         };
 
         tokio::time::timeout(MIDDLE * 10, driver.run(make_req(req), &ctoken))
@@ -3069,6 +3110,7 @@ mod tests {
             stdout: None,
             stderr: None,
             sandbox_dir: tmp.path().to_path_buf(),
+            scratch: vec![],
         };
 
         driver.run(make_req(req), &ctoken).await?;
@@ -3143,6 +3185,7 @@ mod tests {
             stdout: Some(&mut stdout),
             stderr: Some(&mut stderr),
             sandbox_dir: tmp.path().to_path_buf(),
+            scratch: vec![],
         };
 
         tokio::time::timeout(
@@ -3299,6 +3342,7 @@ mod tests {
             stdout: Some(&mut stdout),
             stderr: None,
             sandbox_dir: tmp.path().to_path_buf(),
+            scratch: vec![],
         };
 
         tokio::time::timeout(
@@ -3397,6 +3441,7 @@ mod tests {
             stdout: Some(&mut stdout),
             stderr: None,
             sandbox_dir: tmp.path().to_path_buf(),
+            scratch: vec![],
         };
         driver.run(make_req(req), &ctoken).await?;
         Ok(String::from_utf8(stdout)?.trim().to_string())
@@ -4428,6 +4473,7 @@ mod tests {
             stdout: None,
             stderr: None,
             sandbox_dir: tmp.path().to_path_buf(),
+            scratch: vec![],
         };
         driver
             .run(
@@ -4474,6 +4520,7 @@ mod tests {
             stdout: Some(&mut stdout),
             stderr: None,
             sandbox_dir: tmp.path().to_path_buf(),
+            scratch: vec![],
         };
         driver
             .run(
@@ -4553,6 +4600,7 @@ mod tests {
             stdout: Some(&mut stdout),
             stderr: None,
             sandbox_dir: tmp.path().to_path_buf(),
+            scratch: vec![],
         };
         driver
             .run(
@@ -4709,6 +4757,7 @@ mod tests {
             stdout: None,
             stderr: None,
             sandbox_dir: sandbox.clone(),
+            scratch: vec![],
         };
 
         os.run_inner(req, &ctoken, false).await?;
@@ -4805,6 +4854,7 @@ mod tests {
             stdout: None,
             stderr: None,
             sandbox_dir: tmp.path().to_path_buf(),
+            scratch: vec![],
         };
         driver
             .run(
@@ -4879,6 +4929,7 @@ mod tests {
             stdout: None,
             stderr: None,
             sandbox_dir: tmp.path().to_path_buf(),
+            scratch: vec![],
         };
         driver.run(make_req(req), &ctoken).await?;
 
@@ -4965,6 +5016,7 @@ mod tests {
             stdout: None,
             stderr: None,
             sandbox_dir: tmp.path().to_path_buf(),
+            scratch: vec![],
         };
         driver
             .run(
@@ -5067,6 +5119,7 @@ mod tests {
             stdout: None,
             stderr: None,
             sandbox_dir: tmp.path().to_path_buf(),
+            scratch: vec![],
         };
         driver
             .run(
@@ -5156,6 +5209,7 @@ mod tests {
             stdout: None,
             stderr: None,
             sandbox_dir: tmp.path().to_path_buf(),
+            scratch: vec![],
         };
 
         driver.run(make_req(req), &ctoken).await?;

--- a/crates/plugin-exec/src/pluginexec/spec.rs
+++ b/crates/plugin-exec/src/pluginexec/spec.rs
@@ -24,6 +24,11 @@ pub(crate) struct TargetSpec {
     /// mutates (e.g. a hermetic toolchain). No effect under the FUSE sandbox,
     /// which already shares inputs lazily.
     pub read_only_deps: Vec<String>,
+    /// Scratch caches this target uses, as a list of `scratch` target addresses.
+    /// Each is mounted at the path *its declaration* names, and its declared
+    /// `env` variable is set for the run. A scratch is not an input: it is never
+    /// materialized from artifacts and never affects this target's cache key.
+    pub scratch: Vec<String>,
     /// Build tools, grouped by name → list of target addresses; symlinked under `tools/`.
     pub tools: HashMap<String, Vec<String>>,
     /// Declared outputs, grouped by name → list of output paths the target writes.

--- a/crates/plugin-oci/src/pluginoci/mod.rs
+++ b/crates/plugin-oci/src/pluginoci/mod.rs
@@ -465,6 +465,7 @@ pub(crate) mod testfake {
                 stdout: None,
                 stderr: None,
                 sandbox_dir: sandbox.dir.path().to_path_buf(),
+                scratch: vec![],
             },
             sandbox_dir: sandbox.dir.path().to_path_buf(),
             sandbox_ws_dir: sandbox.ws.clone(),

--- a/crates/plugin-sdk/src/serve.rs
+++ b/crates/plugin-sdk/src/serve.rs
@@ -1268,6 +1268,11 @@ async fn run_once(
         stdout: Some(&mut stdout_sink),
         stderr: Some(&mut stderr_sink),
         sandbox_dir: sandbox_dir.clone(),
+        scratch: req
+            .scratch
+            .into_iter()
+            .filter_map(convert::scratch_mount_from_pb)
+            .collect(),
     };
     let mrr = ManagedRunRequest {
         request: rr,

--- a/crates/plugin-stabby/src/load_stable.rs
+++ b/crates/plugin-stabby/src/load_stable.rs
@@ -750,6 +750,12 @@ impl StableRemoteManagedDriver {
             inputs: req.inputs.iter().map(managed_input_to_pb).collect(),
             shell,
             driver: self.name.clone(),
+            scratch: req
+                .request
+                .scratch
+                .iter()
+                .map(convert::scratch_mount_to_pb)
+                .collect(),
         };
         // `run` is bidi: the request stream carries the run request (RunInFrame),
         // the response stream carries the result (RunOutFrame). `shell` rides pmrr.

--- a/crates/plugin/src/driver.rs
+++ b/crates/plugin/src/driver.rs
@@ -1016,6 +1016,28 @@ pub mod outputartifact {
     }
 }
 
+/// A scratch cache the host has resolved, locked and created for this run.
+///
+/// The driver's job is only to place it and announce it: symlink `path` (relative
+/// to the target's cwd) at `dir`, and set `env` to `dir`. Everything else — which
+/// declaration this came from, how the slot was keyed, which lock is held — is the
+/// host's, and deliberately not visible here.
+///
+/// `dir` is the *canonical* slot path, not the in-sandbox mount, and that is the
+/// point: tools bake absolute paths into their cache entries, so every consumer
+/// must see one stable string for the same cache or it is present and inert.
+#[derive(Clone, Debug)]
+pub struct ScratchMount {
+    /// The declaring target, for diagnostics.
+    pub addr: Addr,
+    /// Mount point relative to the target's cwd.
+    pub path: String,
+    /// Environment variable that carries `dir`.
+    pub env: String,
+    /// Canonical slot directory. Already created; the mount points here.
+    pub dir: PathBuf,
+}
+
 pub struct RunRequest<'a, 'io> {
     pub request_id: &'a String,
     pub target: &'a targetdef::TargetDef,
@@ -1026,6 +1048,9 @@ pub struct RunRequest<'a, 'io> {
     pub stdout: Option<&'io mut (dyn tokio::io::AsyncWrite + Send + Sync + Unpin)>,
     pub stderr: Option<&'io mut (dyn tokio::io::AsyncWrite + Send + Sync + Unpin)>,
     pub sandbox_dir: std::path::PathBuf,
+    /// Scratch caches to mount for this run, already locked and created by the
+    /// host. Empty for the overwhelming majority of targets.
+    pub scratch: Vec<ScratchMount>,
 }
 /// Cleanup closure a driver returns for the engine to run after `cache_locally`.
 /// The FUSE/OS sandbox layers each supply their own teardown; the engine's

--- a/docs/SCRATCH.md
+++ b/docs/SCRATCH.md
@@ -1,13 +1,14 @@
 # Design: named scratch caches (GitHub-Actions-style per-target caching)
 
-**Status:** phases 1–2 implemented and in review (PR #403, #407); phases 3–9
-designed, not built. §18 has the ordering; the notes below record what building it
+**Status:** phases 1–3 implemented and in review (PR #403, #407, #412) — a
+scratch now mounts, locks and sets its env var, so the feature works locally.
+Phases 4–9 (lineage, scopes, remote, retrofits) designed, not built. §18 has the ordering; the notes below record what building it
 changed about the design.
 
 Review-board consults (`product-vision`, `feature-quality`, `hermeticity`,
 `compatibility`) are *pending*; §16 and §21 list what each has to rule on. The
-`compatibility` consult now has a concrete trigger: mounting (phase 3) needs an
-additive `RunRequest` field and an `ABI_SEMVER` minor bump — see §5.3.
+`compatibility` consult has a landed trigger to rule on: mounting added an
+additive `RunRequest` field and took `ABI_SEMVER` to 0.6.0 — see §5.3.
 
 ### Implementation notes
 
@@ -1612,11 +1613,12 @@ document should be believed until it is an interleaved A/B on the corpus.**
    not need storage: wrong-kind addr, env collisions, mount overlaps, duplicates.
    Nothing observable happens yet beyond `heph query` — deliberately, so the
    checks land before anything can write.
-3. **Mount + lock + env + events.** The feature, locally. Needs the `RunRequest`
-   field above, the bridge to create the symlink (it owns sandbox creation and may
-   redirect the path into a FUSE mount), and the slot lock — which must ship *with*
-   `access`, since an `exclusive` that does not serialize is a silent lie. Where
-   the `golist_gocache` win becomes general.
+3. **Mount + lock + env.** ✅ *PR #412.* The symlink (created by the bridge,
+   which owns sandbox creation and may redirect into a FUSE mount), the keyed
+   cross-process slot lock — shipped *with* `access`, since an `exclusive` that
+   does not serialize is a silent lie — and the declaration's env var. Events
+   deferred to the observability phase. Where the `golist_gocache` win becomes
+   general.
 4. **The lineage model + scopes, local only** (§10.1–§10.7). Branch-aware local
    caches, `${git:branch}`, the drift guard. Reviewable without any network, and
    the piece the remote phase then reuses wholesale rather than reimplements.
@@ -1834,3 +1836,28 @@ than after.
   is `if: always()`: a cache warmed by a partially failing build is still warm, and
   the head it publishes is no less valid than one from a green run. Worth stating
   as guidance, since the intuitive choice is `if: success()` and it is wrong.
+
+---
+
+## Appendix: notes from implementing phases 1–3
+
+Things that only showed up in code, recorded so the next phase does not re-learn
+them.
+
+- **An `EResult` holds a riding read lock on its addr.** A test that keeps a run's
+  result alive across `reopen()` deadlocks the second engine's *write* lock
+  against it — and only when the second run actually re-executes, since a cache
+  hit takes a read lock and coexists happily. Cost ~30 minutes of hang before it
+  surfaced as an unrelated-looking `ENOENT` on a lock file. `engine_core.rs`
+  already had the idiom (`drop(result)` before reopening); it is worth stating.
+- **`cargo build --workspace` does not build test targets.** Adding a field to
+  `RunRequest` compiled clean and then broke 28 construction sites in `#[cfg(test)]`
+  code. `--all-targets` is the check that matters, exactly as `.claude/rust.md`
+  says for clippy.
+- **Zero outputs is a supported target shape.** A declaration is executed like any
+  other target when someone resolves it directly, so its `run` must succeed and
+  produce nothing. The first version treated being run as an engine bug, which was
+  simply wrong.
+- **Two `ScratchMount` types is one too many.** The engine's resolved form and the
+  driver-facing form are the same thing; keeping the contract type and deleting the
+  engine-local duplicate removed a conversion that could drift.

--- a/docs/SCRATCH.md
+++ b/docs/SCRATCH.md
@@ -1,8 +1,28 @@
 # Design: named scratch caches (GitHub-Actions-style per-target caching)
 
-**Status:** proposal — not implemented. Review-board consults (`product-vision`,
-`feature-quality`, `hermeticity`, `compatibility`) are *pending*; §15 and §20 list
-what each of them has to rule on.
+**Status:** phases 1–2 implemented and in review (PR #403, #407); phases 3–9
+designed, not built. §18 has the ordering; the notes below record what building it
+changed about the design.
+
+Review-board consults (`product-vision`, `feature-quality`, `hermeticity`,
+`compatibility`) are *pending*; §16 and §21 list what each has to rule on. The
+`compatibility` consult now has a concrete trigger: mounting (phase 3) needs an
+additive `RunRequest` field and an `ABI_SEMVER` minor bump — see §5.3.
+
+### Implementation notes
+
+Two things building phases 1–2 changed:
+
+1. **§5.3's ABI claim was half wrong.** Declaration and reference are ABI-free, as
+   designed and as shipped. The *resolved mount* cannot be — `link.rs:36` filters
+   `runtime: false` inputs out of `LinkedTargetDef`, which is exactly what makes a
+   scratch a pure graph edge, and therefore also why it never becomes a `RunInput`
+   with annotations to travel on. The design saw only the flattering half of that
+   fact. Corrected in place.
+2. **§17's `hashout` assertions did not test what they claimed.** A target whose
+   `hashin` moved still produces identical bytes, so those tests would have passed
+   while the cache missed on every run. They compare def hashes now, with a
+   precondition that the comparison discriminates at all.
 
 **The ask, restated:** a target can declare a directory that persists across runs.
 Before the target executes, heph restores the directory as of the most recent
@@ -1584,29 +1604,35 @@ document should be believed until it is an interleaved A/B on the corpus.**
 
 ## 18. Phasing
 
-1. **Model + plumbing.** The `scratch()` builtin and its provider, the reference
-   on `TargetDef`, proto + ABI, the exec attribute, and all of §13's validation.
-   No storage yet — declaring and referencing a scratch does nothing observable
-   beyond appearing in `heph query`. The overlap checks land here, *before*
-   anything can write.
-2. **`live` mode + locking + the `SCRATCH_*` env + events.** The feature,
-   locally, in its cheapest form. Where the `golist_gocache` win becomes general.
-3. **The lineage model + scopes, local only** (§10.1–§10.7). Branch-aware local
+1. **The declaration.** ✅ *PR #403.* The `scratch` builtin driver, its config
+   schema, and mount-path validation at the declaration — `target(driver =
+   "scratch", …)`, no new Starlark global.
+2. **The reference.** ✅ *PR #407.* The `scratch` attribute on exec, resolved to an
+   `Input` with `hashed: false, runtime: false`, plus every check in §13 that does
+   not need storage: wrong-kind addr, env collisions, mount overlaps, duplicates.
+   Nothing observable happens yet beyond `heph query` — deliberately, so the
+   checks land before anything can write.
+3. **Mount + lock + env + events.** The feature, locally. Needs the `RunRequest`
+   field above, the bridge to create the symlink (it owns sandbox creation and may
+   redirect the path into a FUSE mount), and the slot lock — which must ship *with*
+   `access`, since an `exclusive` that does not serialize is a silent lie. Where
+   the `golist_gocache` win becomes general.
+4. **The lineage model + scopes, local only** (§10.1–§10.7). Branch-aware local
    caches, `${git:branch}`, the drift guard. Reviewable without any network, and
    the piece the remote phase then reuses wholesale rather than reimplements.
-4. **Eviction + the read-only half of `heph tool scratch` + `--scratch` modes.**
+5. **Eviction + the read-only half of `heph tool scratch` + `--scratch` modes.**
    Makes it operable and inspectable.
-5. **Remote pull** (§10.4, §10.8) — resolve, fetch, seed. A CI runner gets warm
+6. **Remote pull** (§10.4, §10.8) — resolve, fetch, seed. A CI runner gets warm
    from whatever is already published, with no workflow change. Useful on its own
    the moment anything is in the bucket.
-6. **`heph tool scratch push`** (§10.10) — the publish half, and the only part CI
+7. **`heph tool scratch push`** (§10.10) — the publish half, and the only part CI
    has to be told about.
-7. **Retrofit `plugin-go`** (§11.1), in its own order: the golist `GOCACHE` first
+8. **Retrofit `plugin-go`** (§11.1), in its own order: the golist `GOCACHE` first
    (delete `golist_gocache.rs`), then compile's per-sandbox one, then the
    `GOMODCACHE`/`GOPROXY` passthrough — each measured separately, because §2.1 is
    the standing reminder that an obvious cache win can move wall time by zero.
    This is the proof that the general mechanism subsumes the special case.
-8. **Retrofit `plugin-oci`** (§11.2) — the shared blob store, then the local
+9. **Retrofit `plugin-oci`** (§11.2) — the shared blob store, then the local
    BuildKit layer cache. Not a prerequisite for anything; it is the evidence that
    a second ecosystem adopts the mechanism without it growing new knobs.
 

--- a/docs/SCRATCH.md
+++ b/docs/SCRATCH.md
@@ -1,0 +1,1788 @@
+# Design: named scratch caches (GitHub-Actions-style per-target caching)
+
+**Status:** proposal — not implemented. Review-board consults (`product-vision`,
+`feature-quality`, `hermeticity`, `compatibility`) are *pending*; §15 and §20 list
+what each of them has to rule on.
+
+**The ask, restated:** a target can declare a directory that persists across runs.
+Before the target executes, heph restores the directory as of the most recent
+save; after it executes, heph saves it back. The directory is **declared once and
+referred to by address**, so several targets can share one, and targets sharing
+one are serialized so
+the read/modify/write is not concurrent — unless the tool is known to be safe
+under concurrency, in which case it is trusted and left parallel. It must work
+through the **remote cache** so a cold CI runner is warm, which needs a *lineage*
+over stored entries to make "the latest run" well defined — and that lineage is
+per-branch, with restore falling back across branches (current branch, then
+`master`), all of it configurable, and applying **locally as well as remotely** so
+that switching branches on a laptop works the same way. Pulling from the remote is
+transparent; **publishing to it is an explicit CLI command** that CI runs at the
+end of its job. `pluginexec` exposes each scratch path as an environment variable.
+Scratch content must not overlap with dependency inputs.
+
+---
+
+## 1. Summary
+
+Add a **mutable, non-hermetic scratch directory** as a declarable target — state
+carried between runs to make a build *faster*, and which must never make it
+*different*.
+
+```starlark
+# //build/BUILD — declared once
+target(name = "cargo-target", driver = "scratch", path = "target", remote = True)
+
+# //cmd/app/BUILD — referred to by addr, by as many targets as want it
+target(
+    name    = "app",
+    driver  = "bash",
+    run     = ["cargo build --release"],
+    out     = "target/release/app",
+    scratch = ["//build:cargo-target"],
+)
+```
+
+Four decisions carry the design:
+
+1. **The working copy is the canonical directory, and nothing is copied per
+   target or per run.** Every sandbox is symlinked at one directory per slot per
+   branch: restore is a `symlink(2)`, save is nothing. §2.1 is why. The only copy
+   anywhere is seeding a new branch from its fallback, once per branch. §7.
+2. **Pull is automatic, push is a command.** A build transparently resolves local,
+   then remote, so a cold CI runner warms itself with no configuration beyond
+   having a remote. Publishing back is `heph tool scratch push`, which CI runs as
+   its last step. That asymmetry is deliberate: pull is cheap, read-only, and
+   fails into a slow build; push is expensive, mutating, and needs a directory
+   nobody is writing — which a command may block for and an implicit step may
+   not. §8.1, §10.10.
+3. **State is a *tree* of lineages, one per branch, in both stores.** A cache —
+   local or remote — holds a live lineage for `master` and one for every branch
+   anyone has worked on, so there is no single "latest" for a pointer to name.
+   Each entry records the branch and generation it descends from, and resolution
+   is "try the current branch, then fall back to `master`", with a guard against
+   inheriting a branch head that has gone stale. §10.
+4. **A scratch is a target — a builtin driver like `group` — and consumers
+   reference it by addr.** Its settings live in one place, so consumers cannot
+   disagree about them, and `heph query revdeps` answers "who shares this cache?".
+   Nothing new crosses the plugin ABI: it rides on `TargetSpec.transitive` and
+   `Input.annotations`, which already exist. Targets referencing one serialize
+   against each other via a keyed lock, with a `shared` "trust the tool" mode for
+   caches that are concurrency-safe by construction. §5, §8.
+
+Two plugins in this tree already want it. `plugin-go` has hand-rolled a
+single-driver version of it (`golist_gocache.rs`) and left three more caching sites
+unfixed; retrofitting it is not a follow-up but the **acceptance test** for §5's
+surface. `plugin-oci` has a smaller, genuine win. §11.
+
+## 2. Motivation
+
+Every sandbox today starts empty. That is the hermetic default and it is correct,
+but it is why heph pays, on every miss, for work that is byte-identical across
+targets and across runs: compiler caches (`GOCACHE`, `ccache`, `sccache`, rustc's
+incremental dir), dependency caches (`GOMODCACHE`, `~/.cargo/registry`), and
+tool-internal indexes.
+
+heph has already hit this once and solved it *by hand, inside one driver*:
+`crates/plugin-go/src/plugingo/golist_gocache.rs` gives every `_golist` run a
+shared `GOCACHE` under the engine home instead of a sandbox-local empty one.
+Measured on a 500-package corpus: `go list` was **778s of CPU across 1945
+invocations** (687s of it *system* time), against **15s for every `go tool compile`
+combined**. Sharing the cache took the run from **205s to 84s wall (2.4x)**.
+
+That module is a one-off: hardcoded key struct, no lock, no eviction, no remote,
+no visibility, and available to exactly one driver. Every other ecosystem that
+wants the same thing must reimplement it inside its own plugin, or reach out of
+the sandbox and touch the host — the thing the sandbox exists to prevent.
+
+### 2.1 The measurement that constrains the design
+
+The *rejected* variant from that work matters more than the accepted one:
+
+> A hermetic seed (a warm cache hardlinked into each sandbox's `.heph-gocache`)
+> cut `go list` CPU 778s → 309s and moved wall time **not at all** — interleaved
+> A/B: base 217.3s vs seeded 219.5s. The shared-dir ceiling won because it creates
+> and destroys *zero* entries per sandbox; the seed still materializes ~500 per
+> sandbox.
+
+**Cold wall time here is filesystem-churn-bound, not CPU-bound.** A design that
+materializes the cache into every sandbox and tears it down again spends its
+winnings on `mkdir`/`link`/`unlink`. This is the single most important input to
+§7.
+
+## 3. Non-goals
+
+- **Not a replacement for the target cache.** Scratch is never an output, never a
+  `hashout`, never something a dependent consumes. If a downstream target needs
+  the bytes, they are an output.
+- **Not a channel between targets.** Two targets sharing a slot share a *cache*,
+  not a *pipe*. Ordering beyond mutual exclusion is unspecified; a target reading
+  what another wrote breaks the first time one of them is a cache hit.
+- **Not hermetic.** §4. A declared, visible, auditable escape hatch, and the
+  design's job is to keep it exactly that narrow.
+- **Not a network fetch primitive.** "Download a toolchain once" is a target with
+  outputs (`plugin-http`, `plugin-nix`).
+
+## 4. The contract
+
+> **A target must produce identical outputs whether its scratch directories are
+> warm, cold, or absent. Losing a scratch directory is always a slowdown and never
+> a wrong answer.**
+
+Consequences, each a constraint further down:
+
+1. **Nothing about scratch enters `hashin`** — not its content, and not its
+   declaration either. If content did, the cache would never hit; if the
+   declaration did, bumping a cache's `version` would rebuild the world for no
+   correctness gain. §6.3.
+2. **Scratch is only touched on a miss.** A cache hit does not restore, does not
+   save, does not take the slot lock, and costs nothing.
+3. **Scratch is not an output and is not an input.** It must be unreachable by
+   output collection *and* disjoint from every path dependency inputs materialize
+   into. Enforced, not documented — §13, which is where the non-overlap
+   requirement is discharged.
+4. **The invariant is unverifiable in general**, so the design owes an *audit
+   mode* rather than a proof: `--scratch=off` (§13.2) forces every scratch cold
+   and is what CI runs to prove warm and cold agree.
+
+This is the same contract Go's build cache, `ccache` and `sccache` already make.
+It holds for content-addressed, self-verifying caches; it does **not** hold for a
+directory used as durable state (a database, a counter, an output staging dir).
+The docs must say that in those words.
+
+## 5. Author surface
+
+A scratch cache is **declared once as a target** and **referred to by addr** by
+every target that uses it. Sharing is then the ordinary thing addrs already do,
+and there is no second namespace to invent.
+
+### 5.1 Declaring one
+
+```starlark
+# //build/BUILD
+target(
+    name     = "gocache",
+    driver   = "scratch",
+    path     = ".cache/go-build",   # where it mounts, in every consumer
+    env      = "GOCACHE",           # the variable the tool reads it from
+    access   = "shared",            # "exclusive" (default) | "shared"
+    platform = "os_arch",           # what the contents are specific to (§6.1)
+    remote   = True,                # may be pulled/pushed (§10)
+    version  = "go1.23",            # busts the slot when it changes
+    max_size = "10GiB",
+)
+```
+
+**There is no new Starlark global.** A scratch is declared through the existing
+`target(driver = "scratch", …)` builtin, exactly as `group` and `textfile` are, and
+`#[derive(Spec)]` on the driver's config supplies both the parser and the
+BUILD-file LSP schema. So the surface added here is a driver name and a set of
+config fields — not a function, not a keyword, and nothing a workspace could
+already have defined.
+
+| field | default | meaning |
+|---|---|---|
+| `name` | required | target name; with its package it is the cache's identity (§6.1) |
+| `path` | required | mount point in a consumer's sandbox, relative to that target's cwd. The same for every consumer (§5.2) |
+| `env` | `SCRATCH_<NAME>` | environment variable carrying the directory's path (§5.5) |
+| `access` | `"exclusive"` | `exclusive` = one consumer at a time (the ask). `shared` = "trust the tool": concurrent, for caches safe by construction (§8.1) |
+| `platform` | `"os_arch"` | `os_arch` = contents are specific to both. `os` = arch-independent. `any` = portable, and shareable across every machine (§6.1) |
+| `version` | `""` | opaque string folded into the slot key; the author's bust handle |
+| `remote` | `False` | may be pulled from the remote automatically and pushed to it by `heph tool scratch push` |
+| `max_size` | config default | per-slot cap; over it the slot is dropped (§11) |
+
+Every field describes **the cache**. Nothing here is a property of a particular
+consumer, which is why §5.2 has nothing to configure.
+
+`scratch` is **a builtin driver**, not a new kind of thing. It has the same shape
+as `plugingroup`: a `DRIVER_NAME`, a `#[derive(Spec)]` config struct that supplies
+both the parser and the BUILD-file LSP schema, and registration through
+`Engine::register_driver`. Adding a driver *is* how heph gains a target kind —
+this introduces no mechanism that `group`, `text_file` and `host_bin` did not
+already use.
+
+It is a target in the ordinary sense — it has an addr, it appears in `heph query`,
+it is subject to visibility — and degenerate in every other: no inputs, no
+outputs, never executes, never cached. `parse` returns a def; `run` is
+unreachable.
+
+### 5.2 Using one
+
+```starlark
+# //cmd/server/BUILD
+target(
+    name    = "server",
+    driver  = "bash",
+    run     = ["go build ./..."],
+    scratch = ["//build:gocache"],
+)
+```
+
+A list of addrs, resolved like any other addr — so `:gocache` works within a
+package. There is no per-use configuration and **no way to mount a scratch
+somewhere other than its declared `path`**.
+
+That is deliberate, and it is the same argument as §5.5's canonical-path rule. A
+cache's location is part of what the cache *is*: tools bake absolute paths into
+their entries (Go's action IDs are the standing example — see
+`hermetic-goroot-stable-path`), and a per-consumer mount would give the same cache
+a different shape in every target that used it. Beyond that it is a knob with no
+demonstrated use: a cache is mounted where its tool expects it, and its tool
+expects one place.
+
+So the whole class of "two consumers disagree about a slot" is not detected — it
+is inexpressible. An earlier revision declared settings at each use site and
+needed validation that they all matched; there is now exactly one copy of each.
+
+`scratch` is a new attribute on `exec`, but not a new *concept*: it joins `tools`,
+`read_only_deps`, `hash_deps` and `runtime_deps` as one more differently-routed
+dep list, and it lives entirely in pluginexec's own spec — it is not engine or ABI
+surface (§5.3).
+
+It stays a separate list rather than folding into `deps` because §14.2 spends a
+whole section on scratch **not** being an input, and putting the two in one
+attribute undoes that in the place an author is most likely to read. The
+alternative — reference a scratch in `deps` and let `apply_transitive` demote the
+input — is workable and is noted in §19.
+
+### 5.3 What crosses the plugin ABI: nothing new
+
+Scratch adds **no proto message, no `TargetDef` field, and no `ABI_SEMVER` bump**.
+It rides entirely on wire structures that already exist and already carry exactly
+this kind of information. Three facts in the current tree make that work, each
+checkable:
+
+**1. `TargetSpec.transitive` is already "a dep contributes config to its
+consumers."** `sandbox::Sandbox` (`plugin/src/driver.rs:219`) carries `deps`,
+`tools` and `env`, and `Dep` already has the two flags a scratch reference needs —
+`runtime: bool` (materialize into the sandbox) and `hash: bool` (fold into the
+parent's key). A scratch target declares its transitive sandbox with
+`Dep { runtime: false, hash: false }` plus the `SCRATCH_*` env entry, and every
+consumer inherits both through the `apply_transitive` call the engine already
+makes.
+
+**2. Anything arriving via `apply_transitive` is outside the def hash by
+construction.** `parse()` sets `def.hash`, and the engine calls `apply_transitive`
+*after* parse and never recomputes it (`engine/result.rs:3595-3635` — the only
+later check is that the hash is non-empty). So §6.3's "scratch contributes nothing
+to `hashin`" stops being a rule someone has to remember and becomes a structural
+property of where the data enters.
+
+**3. `Input.annotations` is host-visible and is already the producer→host
+channel.** It is a `map<string, string>` on the `Input` proto message, it is
+already copied into `RunInput` on the execute path (`engine/execute.rs:245`), and
+`driver-support` already acts on producer-set annotations this exact way —
+`READ_ONLY_ANNOTATION` and `STAGE_PER_FILE_ANNOTATION` in `stage.rs` are the
+precedent. The scratch mount path, access mode and resolved slot path travel as
+annotations on the scratch input; the engine reads them where it already reads
+`read_only`.
+
+The cost of this is that the settings are stringly-typed on the wire rather than a
+typed message, with no schema enforcement at the ABI layer. That is the same trade
+`read_only` and `stage_per_file` already made, and it buys three things worth more
+than the typing: no version negotiation, no `plugin-abi` conversion code, and
+**third-party plugin drivers get scratch without being recompiled or even knowing
+it exists** — they pass through annotations and transitive sandboxes already.
+
+### 5.4 The reference as a graph edge
+
+A scratch reference is an `Input` with **`hashed: false, runtime: false`** — the
+one combination nothing else uses. It materializes no files (there are none) and
+contributes nothing to `hashin`. It is there so the *edge* exists, which buys three
+things at no cost:
+
+- `heph query revdeps //build:gocache` answers "which targets share this cache?" —
+  the question every serialization surprise starts with (§8.3)
+- a reference to a missing or non-scratch addr is an ordinary
+  `TargetNotFoundError` / wrong-kind error, rendered like every other bad addr,
+  rather than a bespoke "unknown scratch name"
+- visibility, packages and `//...` matchers apply without special-casing
+
+### 5.5 What `pluginexec` puts in the environment
+
+A tool almost never finds its cache by convention — it is told, through an
+environment variable (`GOCACHE`, `CCACHE_DIR`, `CARGO_TARGET_DIR`,
+`XDG_CACHE_HOME`). The declaration names that variable, because which variable a
+cache is read from is a property of the cache, not of whoever uses it:
+
+```starlark
+target(name = "gocache", driver = "scratch", path = ".cache/go-build", env = "GOCACHE")
+```
+
+```starlark
+# GOCACHE is set for the run; the consumer wires nothing.
+target(name = "b", driver = "bash", scratch = ["//build:gocache"], run = ["go build ./..."])
+```
+
+`env` defaults to `SCRATCH_<NAME>`, where `<NAME>` is the referenced target's
+**name** (not its package) through the existing `env_key_segment` helper —
+uppercased, every character outside `[A-Z0-9_]` replaced with `_` — following the
+`OUT_<GROUP>` / `SRC_<GROUP>` convention already documented in
+`crates/plugin-exec/src/pluginexec/SANDBOX.md`. So `//build:go-cache` gives
+`SCRATCH_GO_CACHE` unless it says otherwise.
+
+Setting `env` to the tool's own variable is the common case and removes a step:
+without it every consumer would write `runtime_env = {"GOCACHE":
+"$SCRATCH_GOCACHE"}`, which is boilerplate that can be got wrong and that says
+nothing the declaration does not already know.
+
+Three rules, each a real decision rather than a detail:
+
+**The value is the canonical slot path, not the in-sandbox mount.** The declared
+`path` is a symlink to `<home>/scratch/<slot>/…/head`, and the variable carries the
+*target* of that symlink. This is §10.9's path-stability argument cashed out: Go's
+action IDs (and several other tools' cache keys) incorporate absolute paths, so if
+every consumer saw its own sandbox path for the same cache, the cache would be
+present and inert — the `hermetic-goroot-stable-path` trap. One canonical string
+for every consumer is what makes the cache actually hit. It does contain the branch
+scope, so a branch switch re-keys such a cache; that is the cost of branch
+isolation (§10.3), and it is why seeding on fork matters — the seeded copy is warm
+even though its path is new.
+
+**It is injected at execute time and never hashed** — the same class as
+`runtime_env`, and for a stronger reason. The value contains `<home>` and the
+branch, so it differs per machine, per checkout and per branch; hashing it would
+make every cache key machine-specific and defeat the remote cache entirely.
+
+**Two references resolving to the same variable are a parse error**, naming both
+addrs. `env_key_segment` is lossy and the default is derived from the target name
+alone, so `//a:go-cache` and `//b:go.cache` collide; so, more obviously, do two
+declarations that both set `env = "GOCACHE"`. Harmless for dep groups, where the
+group name is local to one target; a silent shadow here, where one of two real
+caches becomes unreachable. The fix is to set `env` explicitly on one of the
+*declarations* — there is nothing to fix at the use site, because the use site
+configures nothing (§5.2). Likewise a target's own `env`/`runtime_env` may not
+declare a variable that a referenced scratch owns.
+
+There is no `LIST_SCRATCH_*`. A scratch is one directory, not an enumerated file
+set, so the list-file mechanism that exists for `SRC_*` has nothing to carry.
+
+Other drivers are not bound by any of this: they read the resolved path from their
+`RunInput` annotations (§5.3) and surface it however suits them.
+
+### 5.6 Naming
+
+`scratch` over the obvious `cache` because `cache` is comprehensively taken —
+`cache = True` on a target, the local cache, the remote cache, `cache.history`,
+`heph tool cache`, `heph tool clean`, `LocalCacheHit`. A second meaning makes every
+existing sentence ambiguous. `scratch` also *states the contract*: not an output,
+not hashed, disposable, loss is never wrong. Alternatives for the record: `state`
+(implies durability we do not offer), `warm` (opaque), `state_cache` (accurate,
+long, still overloads "cache"). **A `product-vision` call, not settled here.**
+
+## 6. Identity and keying
+
+### 6.1 Slot key
+
+```
+slot = H( addr, version, platform_components(platform) )
+
+platform_components("os_arch") = (os, arch)     # default
+platform_components("os")      = (os,)
+platform_components("any")     = ()
+```
+
+- **`addr`** — the declaring target's address. The addr *is* the cache's identity,
+  so packages give namespacing for free: `//go:gocache` and `//rust:gocache` are
+  different caches without anyone agreeing on a prefix convention, and a driver's
+  own cache is just `//@heph/go:golist-gocache` rather than a reserved name.
+  Moving or renaming the declaration busts the slot, which is the same rule every
+  other target already follows.
+- **`version`** — the author's bust handle.
+- **`platform`** — how much of the host the contents are specific to. Not a
+  behavioural difference between platforms (which CLAUDE.md reserves for the
+  user); it is the author stating a property of *their cache*, and the mechanism
+  is identical on all three supported targets.
+
+  `os_arch` is the default because the failure it prevents is the bad one: a
+  `GOCACHE` from `darwin/arm64` restored on `linux/amd64`, or a `node_modules`
+  holding native addons built for the wrong host. `os` suits a cache keyed on
+  OS-shaped paths or APIs but not on instruction set. **`any` makes the cache one
+  slot for every machine**, which is the interesting case — a JS package cache, a
+  resolver's metadata, a download cache — and it means CI on `linux/amd64` warms a
+  laptop on `darwin/arm64` from the same lineage.
+
+  `any` is an author assertion in the same class as `access = "shared"`, and it
+  asserts **two** things, not one: that the contents do not depend on the host
+  *and* that they do not embed absolute paths (§10.9). A cache that is genuinely
+  platform-independent but path-sensitive will restore and be inert — present, and
+  useless. The narrower `platform` is the safer mistake.
+
+Deliberately **not** in the key: `path` (where a cache lives is not what is in
+it — and since §5.2 fixes it per declaration, it cannot vary anyway), `env`,
+`access`, `remote` and `max_size` (policy about how a cache is used, not what is
+in it — changing one must not throw the contents away).
+
+Also folded in, but as an opaque *store-format* component rather than a user
+concept: a `SCRATCH_FORMAT` constant, bumped whenever the on-disk or snapshot
+layout changes, so an old slot is never found rather than misread.
+
+### 6.2 Where a slot lives
+
+Local layout is in §10.7 (it is scope-structured, so it belongs with the lineage);
+the remote key layout is in §10.8. The slot id is the directory name in both.
+
+### 6.3 What scratch contributes to `hashin`: nothing
+
+Not the content, not the declaration, not the mount path, not `version`.
+
+This is a direct consequence of §4 and it is worth stating as its own rule because
+the tempting answer is different. It seems prudent to fold the *declaration* into
+the consumer's `hashin` — so that bumping `version` rebuilds everything that uses
+the cache. But §4 says a target's outputs are identical whether its scratch is
+warm, cold, or absent. If that holds, a new slot changes nothing about the outputs
+and the rebuild is pure waste. If it does not hold, the target is already broken
+and a rebuild is not the fix — `--scratch=off` (§13.2) is how that gets caught.
+
+So bumping `version` gives every consumer a fresh, empty slot and **does not
+invalidate a single cached result**, which is exactly what you want when the reason
+for bumping it is "the old cache had gone bad". An earlier revision of this design
+had the declaration in the def hash; it was over-hashing, and the kind that costs
+cache hits while buying no correctness.
+
+The scratch *reference* still appears in `TargetDef.inputs` (§5.4) — with
+`hashed: false`, so it is a graph edge and not a hash contribution.
+
+Better than a rule, this is now **structural**: the reference and its settings
+reach a consumer's def through `apply_transitive`, which the engine calls *after*
+`parse()` has already set `def.hash` and never recomputes (§5.3). There is no code
+path by which a scratch could enter the def hash, so the rule cannot be broken by
+someone later adding a field and forgetting.
+
+## 7. Storage mode
+
+There is one mode in v1: the canonical slot directory *is* the working copy.
+Everything that once needed a per-run copy — a coherent moment to snapshot, a
+place to roll back to — is served instead by making **push an explicit command**
+(§10.10), which can afford to take a lock and block in a way that an implicit
+end-of-run step cannot.
+
+### 7.1 `live` — the canonical slot is the working copy
+
+Materializing a slot into a sandbox is one `symlink(2)`:
+
+```
+<sandbox>/ws/<pkg>/target  ->  <home>/scratch/<slot>/<scope>/head
+```
+
+Restore is `O(1)`. Save is *nothing* — the target wrote into the slot directly.
+Teardown removes the symlink, not the tree (`remove_dir_all` does not follow
+symlinks; this is already how `driver-support/src/stage.rs` gets O(1) teardown for
+the 11k-file Go SDK).
+
+Why this rather than a copy per target: §2.1 measured that exact shape at a 60%
+CPU saving and **zero** wall-clock improvement, because the win was never CPU — it
+was not creating and destroying half a thousand filesystem entries per sandbox.
+`live` creates and destroys **one inode per target**, on every filesystem, with no
+`clonefile`/`FICLONE` dependency anywhere.
+
+The one copy in the whole design is §10.7's **seed on fork**: the first build on a
+new branch copies the fallback scope's head into its own. That is once per (slot,
+branch), amortized over every subsequent build on that branch, and it is compared
+against a *cold rebuild* rather than against nothing. It can be turned off
+(`scratch.seedOnFork: false`), in which case a new branch simply starts cold.
+
+What `live` gives up is per-run rollback: a target that corrupts the directory
+corrupts it until the slot is evicted or re-pulled, and a cancelled run leaves
+partial writes behind. Mitigations are `heph tool scratch rm`, `heph tool scratch
+pull --force` to re-fetch a known-good head, a `dirty` flag on the meta, and the
+fact that the caches this targets all self-verify and self-heal.
+
+### 7.2 The per-run clone — deferred, not rejected
+
+An earlier revision of this design had `mode = "run"`: clone the slot once per
+invocation, let every target read and write the clone, commit at the end. It is
+attractive — private working copy, whole-run rollback, isolation between
+concurrent `heph` processes — and it is **not in v1**, for one reason.
+
+Its clone is a reflink on APFS/btrfs/XFS and a **full tree copy on ext4**, which is
+what most hosted Linux CI runners use. That cost is *per invocation*, so unlike the
+seed-on-fork copy it never amortizes: every `heph run` would copy the whole cache
+before doing anything. And its main justification — providing a coherent moment for
+the end-of-run push — evaporated once push became an explicit command that takes
+the slot's write lock itself (§8.1).
+
+What remains is rollback and process isolation, which are real but do not justify a
+per-run copy on the platform where the feature matters most. Reconsider it as an
+opt-in on CoW filesystems once the rest is shipped and measured (§21-Q3).
+
+### 7.3 `snapshot` — rejected
+
+Restore untars into the sandbox per target; save tars per target. The literal
+reading of the original ask, and rejected on §2.1: a copy per target is the shape
+that was measured to buy nothing. Recorded in §19.
+
+## 8. Concurrency and serialization
+
+### 8.1 The lock
+
+One `KeyedTLock` keyed by slot, built exactly like `engine/result_lock.rs`: an
+`flock(2)` gateway plus an inner reader/writer file under `<home>/scratch/`, so
+mutual exclusion holds **across processes**, not just across tasks. Follows the
+existing `lock.backend` config (`fs` default, `mem` for tests).
+
+- `access = "exclusive"` → write guard. The requirement as stated: targets sharing
+  a name run one at a time.
+- `access = "shared"` → read guard. Concurrent, for caches safe by construction.
+  **This escape valve is not optional.** `GOCACHE` is the motivating workload and
+  is concurrency-safe by design — it is what `go build -p N` does — so making the
+  golist targets run serially would turn a 2.4x win into a large loss.
+  `golist_gocache.rs` ships today with no lock at all and that is correct. Ship
+  `shared` in the same PR as `exclusive`, or the first real user is worse off than
+  before the feature existed.
+
+The same lock does double duty: it orders targets against each other during a
+build, and it is what `heph tool scratch push` takes to get a directory nobody is
+writing. That second use is the whole reason push is a command rather than a step
+— see below.
+
+#### `shared`, and where the coherent moment comes from
+
+`shared` is an assertion by the author — *this tool's cache is safe under
+concurrent access* — and heph cannot check it. That is the same trust the existing
+`GOMODCACHE`/`GOPROXY` passthrough already extends, and it is granted the same
+way: explicitly, per slot, in the BUILD file.
+
+The worry it raises is that a concurrently-written directory has no coherent
+moment to snapshot — and all three parts of a lineage entry are undefined while N
+processes write: the **tar** is torn, the **content hash** is not a function of
+anything, and **`parent + 1`** presumes a single writer that restored a known head.
+
+**Making push explicit is what answers this.** `heph tool scratch push` takes the
+slot's *write* guard, which excludes both `shared` readers and `exclusive` writers,
+in this process and every other. It then has the directory to itself and every part
+of the entry is well defined.
+
+The reason that works here and not as an end-of-run step is entirely about who is
+waiting. An implicit step must not block a build for an unbounded time, so it would
+have to skip when the lock is contended — silently, and precisely when the machine
+is busy enough for the cache to matter. A command someone typed (or a CI step that
+ran) may block, must report that it is blocking, and fails loudly rather than
+quietly if it cannot proceed. Same lock, same barrier; the difference is that
+`heph tool scratch push` is allowed to say *"waiting for 3 readers to finish"* and
+mean it.
+
+So `access` and `remote` are independent: a `shared` slot pushes exactly like an
+`exclusive` one.
+
+### 8.2 Acquisition order (deadlock safety)
+
+Three rules, each forced by existing behaviour in `engine/execute.rs`:
+
+1. **After dependency resolution.** `execute.rs` already takes the worker permit
+   after `inputs_result_exec` for exactly this reason ("prevents the classic
+   diamond deadlock where mid-nodes hold permits while waiting for a leaf that
+   also needs a permit"). A scratch lock held across dep resolution has the same
+   failure mode: a dep needing the same slot can never get it.
+2. **Before the worker permit** — the shape the approval gate already uses ("runs
+   before the execute semaphore is acquired, so a waiting prompt holds no worker
+   permit"). If the slot lock came after the permit, N targets sharing a slot
+   would pin N-1 permits doing nothing. Because the lock is always taken first, no
+   permit holder is ever blocked on a slot, so the slot holder always eventually
+   gets a permit — the wait is bounded, not circular.
+3. **All of a target's slots, in sorted addr order.** Two targets referencing
+   `[a, b]` and `[b, a]` deadlock under any other rule. One `sort_unstable` on a
+   list that is essentially always ≤ 2.
+
+```
+resolve deps → acquire slot locks (sorted) → worker permit → restore
+             → driver.run → save → release permit → release slot locks
+```
+
+### 8.3 Throughput cost, stated plainly
+
+`exclusive` on a slot referenced by *K* targets serializes those *K* targets. That
+is what was asked for and is correct for a read-modify-write cache — but it is a
+potentially large parallelism loss that will not be obvious to whoever writes the
+BUILD file. Two obligations follow: **make the wait visible**
+(`ScratchLockWaitStart/End`, surfaced like `ResultLockWaitStart/End` already is),
+and **warn on a bad shape** — when one `exclusive` slot is referenced by more
+targets than there are workers, say so once, name the slot's addr, and point at
+both `access = "shared"` and `heph query revdeps` for the list.
+
+## 9. Engine integration
+
+Restore and save belong to the **engine**, not to any driver: the engine owns the
+sandbox path, the home dir, the lock backend, the caches, GC and the event stream,
+and the point is that every driver gets this without reimplementing it.
+
+| file | change |
+|---|---|
+| ~~`proto/plugin/v1/*.proto`~~ | **no change** — scratch rides on `TargetSpec.transitive` and `Input.annotations`, both already on the wire (§5.3) |
+| ~~`crates/plugin-abi/`~~ | **no change, no `ABI_SEMVER` bump** |
+| `crates/driver-support/src/lib.rs` | annotation-key constants next to `READ_ONLY_ANNOTATION` / `STAGE_PER_FILE_ANNOTATION`, so the keys have one definition |
+| **`crates/engine/src/engine/scratch.rs`** *(new)* | slot key, local store, lock, mount, meta, eviction |
+| **`crates/engine/src/engine/scratch_lineage.rs`** *(new)* | the store-agnostic model: scopes, generations, fork points, the §10.4 resolution and §10.6 order |
+| **`crates/engine/src/engine/scratch_remote.rs`** *(new)* | remote transport: list, pull (automatic), push (driven by the command) — §10.8, §10.10 |
+| `crates/engine/src/engine/execute.rs` | acquire locks after `inputs_result_exec`, before `result_permits.acquire()`; restore after `remove_stale`, before `driver.run`; save before the sandbox teardown completes |
+| `crates/engine/src/engine/validate.rs` | output↔scratch and dep↔scratch overlap checks (§13), reusing `paths_overlap`/`is_ancestor` |
+| `crates/driver-support/src/driver_managed.rs` | the *authoritative* dep-overlap check at materialization (§14.2) |
+| `crates/engine/src/engine/event.rs` | `ScratchRestoreStart/End`, `ScratchSaveStart/End`, `ScratchLockWaitStart/End` |
+| `crates/engine/src/engine/gc.rs` | slot sweep by size/age |
+| `crates/engine/src/engine/clean.rs` | `--scratch [name]` on `heph tool clean` |
+| **`crates/builtins/src/pluginscratch/`** *(new)* | the `scratch()` builtin and its provider — a declaration target with no inputs, no outputs and no execution, alongside `plugingroup`/`pluginfs` |
+| `crates/plugin-exec/src/pluginexec/spec.rs` | `scratch` attribute (list or dict of addrs) → inputs with `hashed: false, runtime: false` |
+| `crates/plugin-exec/src/pluginexec/mod.rs` | `apply_transitive`: fold the scratch target's transitive env and annotations into this def |
+| `crates/plugin-exec/src/pluginexec/mod.rs` | inject `SCRATCH_<NAME>` at execute time (§5.5), next to the existing `OUT_*`/`SRC_*` routing |
+| `crates/plugin-exec/src/pluginexec/SANDBOX.md` | document `SCRATCH_<NAME>` in the auto-injected env table |
+| *(none)* | a driver reads the resolved slot path from its `RunInput` annotations, which `execute.rs` already populates — no `RunRequest` change |
+| `crates/config/src/config_yaml.rs` | `scratch: { root, max_bytes, max_age_days, scope, restore_scopes, max_drift, seed_on_fork }`, plus the `${git:branch}` interpolation |
+| `src/commands/tool/scratch.rs` *(new)* | `heph tool scratch ls\|head\|path\|pull\|push\|rm\|verify` |
+| `src/commands/global.rs` | `--scratch=on\|refresh\|off` build flag |
+
+Paths that must **not** restore or save, each for a concrete reason:
+
+- **cache hit** — never reaches `execute` (§4.2).
+- **`rs.hash_only()`** — the caller holds guards it cannot release; it may hash and
+  probe but must never build.
+- **`--shell`** — restores (the shell should see a warm cache), never saves; a
+  human poking at a directory is not a cache write.
+- **`use_tmp_cache`** (`cache = False` or `--force`) — restores, saves nothing.
+  Such a target may benefit from a warm cache, but its runs should not define the
+  slot's contents.
+- **cancellation** — never saves; the directory is mid-write by definition.
+
+## 10. Lineage
+
+Lineage is what makes "restore the latest run" well defined. It is **one model
+used by both stores** — the local slot store and the remote object store — because
+the question they answer is the same one: *given this branch, which saved state
+should this run start from?* Local and remote differ only in how an entry is
+stored and how far it travels.
+
+### 10.1 Why "latest" cannot be a pointer
+
+The tempting design is a mutable `HEAD` object naming the newest snapshot. It is
+wrong here for a structural reason and an implementation reason, in that order of
+importance.
+
+**Structural: one cache serves many branches at once.** There is no single
+"latest". A remote holds a live lineage for `master`, one for each open PR, one
+for each long-running feature branch — all advancing concurrently and all
+legitimately different. The same is true of a *developer's laptop*, which
+accumulates a lineage per branch they have worked on. A single pointer would have
+those branches overwrite each other's heads continuously, which is not a race to
+be fixed but a mis-modelling: the branches are not competing to be latest, they
+are *separate lineages*. A pointer *per* branch models that and creates two new
+problems — an unbounded set of mutable objects, and no answer for the cross-branch
+restore in §10.3, which needs to compare heads that no single pointer relates.
+
+**Implementation: the remote store cannot do it safely anyway.**
+`RemoteCacheBackend` (`engine/remote_cache.rs:351`) offers exactly four
+operations:
+
+```rust
+async fn open_read(&self, key: &str) -> Result<Option<...>>;
+async fn open_write(&self, key: &str) -> Result<...>;
+async fn exists(&self, key: &str) -> Result<bool>;
+async fn list_names(&self, prefix: &str) -> Result<Vec<String>>;
+```
+
+No compare-and-swap and no delete. So even for a single branch, two jobs finishing
+together race, and the *loser* can be the one that finishes last: a job that
+started from an older cache overwrites the pointer with older content. "Latest"
+would mean "written most recently", which is not the same as "descended from the
+most work".
+
+So: **entries are immutable, and ordering is carried in the key.** Resolution is a
+prefix list and a max — no mutation, no coordination, correct under concurrent
+writers, and it extends to many branches by listing more than one prefix.
+
+### 10.2 Lineage is a tree, not a line
+
+Every entry records where it came from:
+
+```
+(scope, generation)   identity      — which branch lineage, and how far along it
+(parent_scope, parent_generation)   — the entry it was restored from
+```
+
+**Generations advance at publish time, not at build time**, and that makes the
+model exactly git's: the local head is a working tree, its meta records the
+`parent` it was last pulled or seeded from, and `heph tool scratch push` (§10.10)
+is the commit. Between pushes the head is simply *dirty* relative to its parent.
+
+Within one scope, `generation(pushed) = generation(parent) + 1`. A machine that
+pulled `master` generation 11, built against it, and pushed produces `master`
+generation 12 with parent `(master, 11)`. A machine that started genuinely cold
+pushes generation 0 with no parent.
+
+A **fork** is the ordinary case, not an exception. A build on a feature branch
+seeds from `master` generation 12 and pushes into its *own* scope, producing
+`feat-x` generation 0 with parent `(master, 12)`. `master` carries on to 13, 14, …
+independently. Neither lineage is behind the other in any meaningful sense; they
+are different branches of a tree, and the recorded fork point is what relates them.
+
+Two rules follow, and everything in §10.3–§10.6 is a consequence:
+
+- **Generations are only ever compared within a single scope.** `feat-x` at
+  generation 40 is not "ahead of" `master` at generation 12. Comparing across
+  scopes is a category error and the code must not offer the operation.
+- **The relation between scopes is the recorded fork point**, a pure lineage
+  measure needing no clock. It is what §10.4 uses to notice a branch has gone
+  stale.
+
+Generation, not wall-clock time, and this is the point of calling it a lineage: a
+slow runner that restored generation 5 an hour ago and finishes now writes
+generation 6, which correctly **loses** to a chain that has since reached 12. A
+timestamp would have that backwards, and clock skew across runners makes it worse.
+Generations need no clock and no coordinator, only the parent each writer already
+restored.
+
+### 10.3 Scopes — one lineage per branch, everywhere
+
+A scope *is* a lineage. `scope: ""` (the default) gives one shared lineage, right
+for a single long-lived branch and for a developer who never switches; setting it
+per branch gives the tree of §10.2.
+
+```yaml
+scratch:
+  scope: ${git:branch}           # the lineage this run writes to. "" = one lineage
+  restoreScopes: [master]        # ordered read fallback: try scope, then these
+  maxDrift: 100                  # discard a branch head this far behind its fork
+                                 # point (§10.4). Unset = strict precedence
+```
+
+**This applies locally, not only in CI.** A developer switching branches is the
+same event as a CI job running on a PR: the work already done on the branch they
+are leaving should stay put, and the branch they arrive at should start from
+somewhere warm rather than from nothing. Without scoping, `git checkout feat-x`
+silently hands `feat-x`'s build the cache state `master` left behind, then hands it
+back mutated on the way home — every switch degrading both. With scoping, each
+branch keeps its own head and a switch seeds from the fallback.
+
+This is what seeding on fork (§10.7) is for: on the first build after a checkout,
+the new branch's head is copied from `master`'s rather than starting empty, so the
+cost of switching branches is one copy instead of a full rebuild.
+
+`${git:branch}` is a config interpolation heph resolves itself, so a developer
+gets branch scoping without wiring anything; CI overrides it with
+`${GITHUB_REF_NAME}` or whatever names the branch there. Both resolve to a plain
+string; nothing downstream knows about git.
+
+The rest of the scope contract:
+
+- **Writes always go to `scope`, and only to `scope`.** A PR job can never advance
+  `master`'s lineage — the isolation that makes this safe to enable on untrusted
+  PR CI at all. A bad PR poisons its own branch and nothing else. Locally, a
+  broken experiment on a branch cannot corrupt the cache you go back to.
+- **Reads try `scope`, then each `restoreScopes` entry in order**, subject to the
+  drift guard. The list is ordered, so a three-level convention (`feature` →
+  `develop` → `master`) works without special-casing.
+- **The fork point is recorded on the first commit after a cross-scope restore**,
+  so a branch always knows where it came from.
+- All of it is config, not BUILD-file, because it is repo/CI policy rather than a
+  property of a target. A per-slot override would let one BUILD file opt out of
+  the branch isolation the repo just configured, which is exactly backwards.
+- **Scoping multiplies entries by branch count**, locally and remotely alike, and
+  nothing revisits a scope it stopped listing. Dead branches are collected by age
+  — §10.11 remotely, §11 locally — which is why those are requirements rather than
+  niceties once scoping is on.
+
+### 10.4 Resolution: current branch first, then fall back
+
+The behaviour asked for — *try the current branch, then try master* — with one
+addition that stops it from picking a head that is technically a hit and
+practically useless. The same algorithm runs against the local store and the
+remote one; only `list_heads` differs.
+
+```
+resolve_head(slot, store):
+  candidates = []
+  for scope in [cfg.scope] + cfg.restoreScopes:            # ordered, configurable
+      head = store.head(slot, scope)                       # within-scope max, §10.6
+      if head: candidates.push((scope, head))
+  if candidates is empty: return None                      # cold
+
+  primary = candidates[0]
+  if cfg.maxDrift is set and primary is not the last candidate:
+      fallback = the next candidate whose scope is primary's parent_scope
+      if fallback and drift(primary, fallback) > cfg.maxDrift:
+          return fallback                                  # primary has gone stale
+  return primary
+
+drift(primary, fallback) = fallback.generation - primary.parent_generation
+```
+
+**Local first, then remote — automatically, in every mode, with nothing to
+configure.** A build resolves against the local store; only if that is cold does it
+consult the remote, and then only for a slot with `remote = True`. A warm laptop
+therefore makes no network call at all, and a fresh CI runner — always locally cold
+— always goes to the remote and warms itself without the workflow mentioning
+scratch at all. `--scratch=refresh` forces the remote check when a developer wants
+CI's head rather than their own.
+
+Pull is automatic precisely because it is safe to be: it is read-only, it is one
+list plus one fetch, and every way it can fail — no entry, remote down, corrupt
+meta — degrades to a cold build (§10.12). Push is none of those things, which is
+why it is a command (§10.10).
+
+**Why the drift guard.** Strict precedence — first scope with any entry wins — is
+GHA's behaviour and it has a well-known failure: a branch whose cache was written
+three weeks ago at `master` generation 12 keeps winning over `master`'s current
+generation 400, so the branch gets steadily colder the longer it lives, and the
+build that most needs a warm cache is the one guaranteed not to get one. A
+long-lived local feature branch has exactly the same problem.
+
+`drift` measures that staleness **in lineage, not in time**: the primary head
+forked at `master` 12, `master` is now at 400, so the branch is 388 generations
+behind and is discarded in favour of `master`'s head. Had it forked at 398, drift
+is 2 and the branch's own incremental work is kept. No clock, no skew, no
+heuristic about "recent".
+
+`maxDrift` unset restores strict GHA precedence exactly. Default proposed:
+**100**, explicitly a number wanted from real data rather than reasoning
+(§21-Q4). Drift is computed one level only — against the immediate `parent_scope`
+— because a chain of forks is rare and a transitive walk costs a lookup per hop.
+
+### 10.5 Relation to GHA's `key` + `restore-keys`
+
+The obvious model to copy is GitHub Actions': a string `key`, plus an ordered list
+of `restore-keys` matched by **prefix**, with ties broken by recency. It is
+well-understood and it works. This design ends up somewhere close, and the
+differences are worth being explicit about, because two of them are deliberate and
+one was an oversight this comparison caught.
+
+**Why not literal string prefixes.** GHA needs them because it has no model of what
+a cache belongs to: everything an author knows about a cache — the OS, the tool
+version, the lockfile hash, the branch — has to be flattened into one string, and
+prefix matching is how you then peel dimensions off the end. heph already has those
+dimensions as first-class things, so the flattening has nothing to do:
+
+| GHA key fragment | here |
+|---|---|
+| `${{ runner.os }}-${{ runner.arch }}` | `platform` on the declaration (§6.1) |
+| a name like `go-build-` | the declaring target's addr (§6.1) |
+| `${{ hashFiles('go.sum') }}` | `version` |
+| the branch, when people remember to add it | `scope` (§10.3) |
+| `restore-keys:` fallback list | `restoreScopes`, and `version_fallback` below |
+
+Typed dimensions beat a string here for a reason beyond tidiness: a prefix is only
+peelable in the order the author happened to concatenate. `go-linux-x64-abc123`
+can fall back to "any lockfile on linux/x64", but never to "this lockfile on
+another arch", because that dimension is buried mid-string. Named dimensions fall
+back in whatever order suits.
+
+**Where GHA is right and this design was wrong.** GHA's canonical example —
+`key: node-${{ hashFiles('package-lock.json') }}`, `restore-keys: node-` — falls
+back to *the previous lockfile's cache*, which is the whole point: you get 95% of
+the packages and download the delta. An earlier revision here put `version`
+straight into the slot key with no fallback, so bumping it meant fully cold. For a
+`version` that is a lockfile hash rather than a bust handle, that is simply worse.
+
+So `version` gets a fallback too, opt-in on the declaration:
+
+```starlark
+target(
+    name             = "node-modules",
+    driver           = "scratch",
+    path             = "node_modules/.cache",
+    version          = hash_files("package-lock.json"),
+    version_fallback = True,     # inherit the previous version's cache
+    platform         = "any",
+)
+```
+
+With it on, resolution — having exhausted every scope for the current version —
+retries the scope list against the most recently published *other* version of the
+same slot, and seeds from it.
+
+It is **off by default**, and that asymmetry with `scope` (which always falls back)
+is the point: `version` is documented as the *bust handle*. If an author bumps it
+because the cache went bad, silently inheriting the bad cache is the one thing they
+were trying to avoid. `version_fallback = True` says "this version is a
+fingerprint, not a bust" — which is exactly what GHA's `hashFiles` key means, and
+exactly what a bare `version = "go1.23"` does not.
+
+**Where this design keeps its own model: ordering.** GHA breaks ties by recency —
+the most recently created matching entry wins. That is the one part not worth
+copying, for the reason §10.2 gives: recency is not descent. Under concurrent
+writers a slow job that started from an old cache finishes last and wins, and a
+long-lived branch's stale entry keeps beating a much-advanced trunk. Generations
+and the drift guard (§10.4) fix both without a clock.
+
+Worth conceding how much that buys, though: by §4 a slightly-worse restore is a
+*slowdown, never a wrong answer*, so recency would be **adequate** — GHA's model is
+not broken, it is merely leaky, and the leak costs cache warmth rather than
+correctness. The lineage is an optimization, and its whole cost is one `parent`
+field in the meta and a `+ 1` in the push command. It is cheap enough to keep, and
+honest to describe as an optimization rather than a requirement.
+
+### 10.6 Same-generation forks and the total order
+
+Two runs on the *same* branch both restore generation 11 and both commit
+generation 12. That is a same-generation fork, and it is expected: by §4 either
+side is *correct*, so the tie-break only needs to be **deterministic and stable**,
+so every reader converges on the same head rather than oscillating.
+
+Order entries **within a scope** by:
+
+```
+(generation, bytes, content_hash)   descending
+```
+
+`bytes` second is a deliberate heuristic rather than an arbitrary tie-break: among
+two equally-derived caches, the larger has more warm entries, so it is the better
+one to inherit. `content_hash` last makes the order total.
+
+Stated so nobody builds it later by accident: **there is no merge**, neither
+across same-generation forks nor across branches. A fork discards one side's
+incremental work. That is a lost speedup, never a wrong answer, and it is exactly
+the latitude §4 buys.
+
+### 10.7 The local store
+
+```
+<home>/scratch/
+  <slot>/<scope>/head/          the canonical directory for that branch lineage
+  <slot>/<scope>/head.meta      borsh: generation, parent_scope, parent_generation,
+                                bytes, last_used, dirty, produced_at_path
+  <slot>/<scope>/head.lock      flock gateway (§8.1)
+```
+
+`store.head(slot, scope)` is a single `head.meta` read — the local store keeps only
+the head per scope, not a history, because a local lineage's older generations have
+no reader. (`cache.history` exists for target revisions because a *different*
+`hashin` may want an older one; a scratch lineage has exactly one useful entry per
+branch.)
+
+**`dirty`** is set the first time a build takes the slot's lock for a scope, and
+cleared by a successful push. It is what `heph tool scratch push` uses to skip a
+head that has not changed since it was last published, and what `heph tool scratch
+ls` reports so "do I have unpublished cache state?" is answerable.
+
+**Seed on fork.** When resolution falls back to another scope (§10.4) — the first
+build on a new branch — the fallback's head is **copied** into this scope's head
+before the build starts, and `parent` is set to the fallback's `(scope,
+generation)`. Writes then land on this branch's own head and the branch it came
+from is untouched, which is the isolation property of §10.3.
+
+That copy is the only one in the design. It is once per (slot, branch), it is a
+reflink where the filesystem offers one, and where it does not it is a plain copy
+whose alternative is a cold rebuild. `scratch.seedOnFork: false` turns it off and
+new branches start cold — worth having for someone on ext4 with a very large slot,
+and not the default because the whole point of branch scoping is that switching
+branches should not throw the cache away.
+
+### 10.8 The remote store
+
+```
+scratch/v1/<slot>/<scope>/<gen:016x>.<content_hash>.tar.zst    # the snapshot
+scratch/v1/<slot>/<scope>/<gen:016x>.<content_hash>.meta       # small sidecar
+```
+
+Zero-padded hex generation as the *leading* component within a scope means
+lexicographic order **is** generation order, so a sorted `list_names(prefix)`
+answers `store.head` with no fetches. The content hash disambiguates a
+same-generation fork (§10.6) and makes the object self-identifying.
+
+The `.meta` sidecar (borsh, a few hundred bytes) carries the same fields as the
+local one plus the producing heph version, `SCRATCH_FORMAT`, and a free-form
+`producer` string (`--producer` on the push command; CI passes its run id) for
+diagnosis. It is fetched only for candidate
+heads, so resolution costs **one list plus one small GET per candidate scope**, and
+the tar is fetched only if the local store was cold.
+
+Unlike the local store, the remote keeps **every** generation — it has no cheap way
+to delete one (§10.11) — which is why the key sorts and why pruning is a lifecycle
+rule rather than a write-path concern.
+
+### 10.9 Path stability across machines
+
+The slot path is stable across runs and across targets on a machine, which is what
+local sharing needs — but it is under `<home>` = `<root>/.heph3/…`, so a checkout
+at a different absolute path on a CI runner produces a different one, and it
+contains the branch scope, so a branch switch changes it too.
+For a cache whose entries embed absolute paths (Go's action IDs; see
+`hermetic-goroot-stable-path`), a restored snapshot is then *present but inert* —
+the worst outcome, because it looks like a hit and performs like a miss.
+
+Two things follow, and the second is the one that matters:
+
+- The snapshot's `.meta` records the absolute slot path it was produced at.
+  Restoring at a different path is a `debug!` line naming both paths, so
+  "the cache restored and the build was still slow" is diagnosable rather than
+  mysterious.
+- **`scratch.root` is configurable**, and CI that wants path-sensitive caches to
+  travel sets it to a fixed absolute path (`/var/tmp/heph-scratch`) on every
+  runner. Default stays `<home>/scratch`.
+
+### 10.10 Publishing: `heph tool scratch push`
+
+There is **no automatic push**. Publishing a slot to the remote is an explicit
+command, which CI runs as its last step:
+
+```yaml
+- run: heph run build //...
+- run: heph tool scratch push --all --producer "$GITHUB_RUN_ID"
+  if: always()
+```
+
+```
+heph tool scratch push [<addr>...] [--all] [--scope <s>] [--force]
+                       [--producer <s>] [--dry-run]
+```
+
+For each selected slot, in the current scope:
+
+1. Take the slot's **write guard**, reporting the wait if there is one (§8.1). This
+   is the coherent moment; nothing else in the design has to manufacture it.
+2. Skip unless the head is `dirty`, or `--force`. A run that changed nothing
+   publishes nothing.
+3. Tar, hash, and upload as `(scope, parent_generation + 1)` — or `(scope, 0)` when
+   this scope has never been published (§10.2).
+4. Update the local `parent` to the entry just written and clear `dirty`.
+5. Report per slot: pushed with its new generation and byte count, skipped because
+   clean, or failed with why. Exit non-zero if any selected slot failed.
+
+`--all` selects every slot with `remote = True` that the workspace declares.
+Naming slots explicitly is for a job that only wants to publish some of them —
+a lint job with no business republishing the compiler cache, say.
+
+**Why this is not automatic.** The end-of-run push in an earlier revision of this
+design depended on a per-run clone to give it a directory nobody was writing, and
+that clone is a full tree copy on ext4 (§7.2). Making push a command removes the
+dependency entirely: a command may take the lock and block, and it is *expected*
+to take time and to be able to fail. An implicit step has neither privilege — it
+would have to skip when contended, silently, on exactly the busy machines where
+the cache matters most.
+
+It also puts the decision where it belongs. Whether a given job's cache state
+deserves to become the branch's published head is a CI-policy question — a job
+that failed halfway, a job on a fork, a job that ran a subset of targets — and it
+is answered far better by `if:` conditions in a workflow than by a heuristic
+inside heph.
+
+- **Where:** into `cfg.scope` — the branch this run is on — and never into any
+  `restoreScopes` entry, even the one the head was seeded from (§10.3).
+- **`access` is irrelevant.** A `shared` slot pushes exactly like an `exclusive`
+  one; the write guard is what separates them from the tar (§8.1).
+- Respects the per-cache `write: false` config, so a read-only remote needs no new
+  switch — the command reports the refusal rather than pretending to push.
+- No head re-check before uploading: an entry that turns out to be behind simply
+  loses at resolution (§10.6), and a check would be a race rather than a guard.
+
+
+### 10.11 Remote pruning
+
+Old generations accumulate and there is **no `delete` on the backend trait**. Two
+options, and the recommendation is the second for v1:
+
+1. Add `async fn delete(&self, key: &str)` to `RemoteCacheBackend` and have the
+   writer prune all but the newest K (K=3, so a reader mid-download is never
+   orphaned) after a successful push. Costs a new trait method every backend and
+   test double must implement — a `compatibility` surface change.
+2. **Object-store lifecycle rules.** S3 and R2 both expire objects by prefix and
+   age; `scratch/v1/` is a dedicated prefix precisely so this is a one-line bucket
+   policy. Zero new code, zero new trait surface, and the store is already the
+   component that knows about storage cost.
+
+Ship (2), document the prefix and a suggested 30-day rule, and revisit (1) only if
+someone needs bounded object *counts* rather than bounded age.
+
+Branch scoping (§10.3) makes this **mandatory rather than advisory**: object count
+now grows with branch count, every merged PR leaves a dead lineage behind, and
+nothing in the resolver ever revisits a scope it stopped listing. An age rule
+collects all of it, which is the other reason `<scope>` sits inside the
+`scratch/v1/` prefix rather than above it.
+
+### 10.12 Failure modes
+
+| situation | behaviour |
+|---|---|
+| no entry for the slot in any scope | cold run; `debug!`, never an error |
+| `list_names` fails / remote down | cold run; `warn!` once per invocation |
+| head `.meta` unreadable or `SCRATCH_FORMAT` mismatch | skip to the next candidate in order, then cold |
+| tar fetch fails midway | cold run; the partial slot is removed before use |
+| two runners on one branch fork the lineage | §10.6; one side's increment is lost |
+| a push writes a generation ≤ the current head | uploaded anyway (immutable, distinct key); loses at resolution. No coordination needed |
+| `heph tool scratch push` cannot take the write guard | blocks, reporting the wait; never skips silently (§8.1) |
+| `heph tool scratch push` fails to upload | non-zero exit naming the slot; `dirty` stays set, so the next push retries |
+| the current branch's head is far behind its fork point | drift guard falls back to the parent scope (§10.4); reported by `heph tool scratch head` |
+| the branch's `parent_scope` no longer exists (base branch deleted) | drift is uncomputable, so the primary head is used as-is — strict precedence, the pre-guard behaviour |
+| a `restoreScopes` entry names a scope that never existed | skipped silently; it is a fallback list, not an assertion |
+| slot restored at a different absolute path than produced | works; `debug!` names both paths (§10.9) |
+
+## 11. Retrofits: what already wants this
+
+The design is only worth building if it subsumes the hand-rolled caching already in
+the tree. Two plugins have it, and the Go one is the reason this exists.
+
+### 11.1 `plugin-go` — required, and the acceptance test for the whole design
+
+`golist_gocache.rs` is this feature, implemented once, for one driver, by hand. It
+gives every `_golist` run a shared `GOCACHE` under the engine home, and it is worth
+the measured 2.4x in §2. What it does not have: a lock, eviction, a remote, any
+visibility, or availability to anything but golist. Replacing it is phase 7, and it
+is the proof that the general mechanism works — **if it cannot express what that
+module does, the design is wrong and this is where that surfaces.**
+
+Four sites, in the order they should move:
+
+**1. `driver_golist.rs` — the shared golist `GOCACHE`.** Today
+`GolistGocache::resolve` maps a hand-written `GocacheKey { goroot, goos, goarch,
+build_tags, goexperiment, race }` to a directory, falling back to a sandbox-local
+one when no home dir was configured. That key becomes a declaration:
+
+```starlark
+target(
+    name     = "golist-gocache",
+    driver   = "scratch",
+    path     = ".heph-gocache",
+    env      = "GOCACHE",
+    access   = "shared",          # Go's cache is concurrency-safe by design (§8.1)
+    platform = "os_arch",
+    version  = go_cache_version(...),   # goroot + tags + goexperiment + race
+    remote   = True,
+)
+```
+
+Everything the module hand-rolls maps onto something declared: the key's variable
+parts become `version`, the fixed ones become `platform`, and the "concurrent
+access is fine" property that today is expressed by *having no lock at all*
+becomes `access = "shared"` — stated rather than implied. The fallback-to-
+sandbox-local path disappears: a slot always resolves, and a cold one is just cold.
+
+Note the key currently includes `goroot`, an absolute path, purely because Go's
+action IDs do. Under this design the canonical slot path is stable (§5.5), so
+whether `goroot` still needs to be in `version` should be re-measured rather than
+carried over — see `hermetic-goroot-stable-path`.
+
+**2. `driver_compile.rs` — the one that was never fixed.** It still does this,
+per target, in every sandbox:
+
+```rust
+let gocache = pkg_dir.join(".heph-gocache");
+std::fs::create_dir_all(&gocache)?;
+```
+
+That is precisely the pattern `golist_gocache.rs` was written to remove — an empty
+per-sandbox `GOCACHE` — left in place for compile because the fix was
+driver-local and nobody generalized it. §2 measured compilation at 15s against
+golist's 778s, so the *upside here is smaller*, but it is the same shape of waste
+and it costs a `mkdir` plus a teardown per compiled package on top of it. Worth
+doing, worth measuring separately, and worth not assuming: §2.1 is the standing
+reminder that the obvious cache win moved wall time by zero.
+
+**3. `thirdparty.rs` — `GOMODCACHE`, `GOPATH`, `GOPROXY` passed through from the
+host.** These are the *most* interesting, because passing them through is a
+hermeticity hole heph accepts today on the explicit grounds that modules are
+content-addressed and `go.sum`-verified. A declared scratch is strictly better on
+every axis: heph owns the directory instead of borrowing the host's, it is bounded
+and evictable, it is visible in `heph tool scratch ls`, and it can be published so
+a CI runner does not re-download the module graph on every job. It is also a clean
+`platform = "any"` — the module cache holds source, not objects.
+
+This is the change with the largest CI effect and the one to sequence last, since
+it narrows a hole rather than widening one and deserves its own before/after.
+
+**4. `pkg_analysis.rs`** enumerates `GOROOT`/`GOPATH`/`GOMODCACHE`/`HOME`/`PATH`/
+`GOCACHE` for hashing; whatever moves above has to move here too, or the analysis
+hashes an env var that no longer describes what the run reads.
+
+### 11.2 `plugin-oci` — a real but smaller win
+
+Two places, neither urgent, both genuine.
+
+**Registry blobs, shared across pull targets.** `oci_pull` caches per target, keyed
+on ref + platform, and `platform.rs` is careful about that key because "an arm64
+and an amd64 machine would share one cache entry for two different images". But the
+*blobs* underneath are content-addressed by digest, so two images sharing a base
+layer re-download it once per target today. A blob-store scratch fixes that, and it
+is the design's cleanest `platform = "any"`: the **image** is platform-specific,
+the **blob store** is not, and one slot can hold amd64 and arm64 layers with no
+risk, shared by every machine on the lineage. `access = "shared"` too — a
+digest-addressed store is safe under concurrent writers for the same reason Go's
+cache is.
+
+**A local BuildKit layer cache.** `docker_build` already wires `cache_from` /
+`cache_to` to `docker buildx --cache-from/--cache-to`, but those want a **registry**
+the user has to configure, and heph's own docs note that on a heph cache hit no
+build runs and they have no effect at all. BuildKit also supports
+`type=local,dest=<dir>` — which is a directory, which is exactly what a scratch is.
+That would give layer caching with no registry, published through heph's own
+lineage, so a CI runner inherits warm layers from the branch. It is the neatest fit
+for the feature in the whole tree, and it is second in priority because
+`docker_build` is already well served by the input-hash cache for the common case.
+
+Neither OCI change is a prerequisite for anything. They belong after phase 7,
+as evidence that a second ecosystem adopts the mechanism without it growing new
+knobs — which is the real test of whether §5's surface is right.
+
+## 12. Lifecycle and eviction (local)
+
+Nothing else bounds a slot's growth — there is no `hashin` to age out and no
+`cache.history` to trim against.
+
+- **Accounting.** `<slot>.meta` records `bytes` and `last_used`, updated after a
+  save or by the GC walk, never by re-walking the tree per run.
+- **Per-slot cap** (`max_size` on the declaration, default **10 GiB**). Over the cap the slot is
+  **dropped whole**, not trimmed: heph does not know which of a foreign tool's
+  entries are hot, and guessing would silently degrade the cache while claiming to
+  manage it. Dropping is honest and self-correcting.
+- **Global cap and age** (`scratch.max_bytes`, `scratch.max_age_days`, proposed
+  50 GiB / 30 days) swept by `heph tool gc`, LRU by `last_used`, **per (slot,
+  scope)** rather than per slot. Branch scoping means a laptop accumulates a head
+  per branch ever built, and a merged or abandoned branch's head is never read
+  again — the LRU is what collects it. On a CoW filesystem those heads share
+  bytes with each other, so the disk cost of many branches is far below the sum of
+  their sizes, and `bytes` in the meta is the logical size, not the exclusive one.
+- **`heph tool clean --scratch[=<addr>]`**, `heph tool scratch rm <addr>`.
+- The underlying tools' own self-limiting still applies and is a feature: Go trims
+  entries unused for five days.
+
+## 13. Observability
+
+"Why did it do that?" is a design-time requirement here more than anywhere else,
+because scratch changes both *timing* and *parallelism* invisibly.
+
+### 13.1 Events and reporting
+
+- `ScratchRestoreStart/End { slot, name, mode, source: live|local|remote|cold, scope, generation, forked_from, bytes }` — `scope` and `forked_from` are what answer "why did my branch build start cold?"
+- `ScratchSeedStart/End { slot, name, from_scope, to_scope, method: reflink|copy, bytes, ms }` — the one-per-branch copy of §10.7, and the only place a build can spend real time on scratch
+- `ScratchPushStart/End { slot, name, scope, generation, bytes, skipped_reason }` — emitted by the command, so `--json` consumers see publishing the same way they see a build
+- `ScratchLockWaitStart/End { slot, name, access }` — surfaced in the TUI as
+  `ResultLockWaitStart/End` already is, so a serialized build *looks* serialized.
+- `heph tool scratch ls` → name, slot, mode, access, size, generation, last used,
+  declaring targets.
+- `heph tool scratch head <addr>` → **every candidate scope that was listed, in order**,
+  each with its head generation, fork point, computed drift, and whether it was
+  chosen, skipped by the drift guard, or never reached. Plus the winner's producer
+  and the path it was produced at. This is the command someone runs when CI is
+  slow, and "which branch did my cache come from, and why not the other one" is
+  the question it has to answer in one screen.
+- `heph inspect <addr>` shows the target's scratch references and their resolved
+  slots; `heph inspect //build:gocache` shows the declaration itself.
+- **`heph query revdeps //build:gocache`** lists every target sharing the cache —
+  no new command, because §5.4 makes the reference a real graph edge. This is the
+  answer to "why is my build serial?" and it costs nothing to provide.
+- Telemetry: restore hit/miss, source breakdown, bytes moved, aggregate lock wait
+  per slot. Lock wait is the number that tells a user their `exclusive` was a
+  mistake.
+
+### 13.2 Audit mode
+
+`--scratch=on|refresh|off`:
+
+- `on` (default) — as designed.
+- `refresh` — consult the remote even when the local store is warm (§10.4), for a
+  developer who wants CI's head rather than their own.
+- `off` — every scratch directory absent; the target runs fully cold.
+
+`off` is how §4 is checked in practice, and CI should run it on a schedule: build
+with `--scratch=off`, compare `hashout`s against the warm build, fail on
+divergence. A later `heph tool scratch verify <matcher>` can do the cold/warm pair
+and the diff in one command.
+
+### 13.3 CLI surface
+
+Everything that *operates on* scratch state is a subcommand of **`heph tool
+scratch`**, alongside the existing `heph tool cache`, `heph tool gc` and `heph tool
+clean`. `heph tool` is already the maintenance group — commands that inspect or
+repair heph's own state rather than build anything — and a scratch slot is exactly
+that kind of state. Nothing new lands at the top level.
+
+| command | does |
+|---|---|
+| `heph tool scratch push [<addr>…] [--all]` | **publish** the current scope's head to the remote (§10.10). The command CI runs as its last step. Blocks on the slot's write guard; skips a clean head; exits non-zero if any slot fails |
+| `heph tool scratch pull [<addr>…] [--force]` | fetch the remote head without building. Builds do this automatically (§10.4); this is for warming a machine ahead of time, or recovering from a corrupted local head |
+| `heph tool scratch ls` | every slot **× scope**: addr, branch, access, size, generation, fork point, **dirty**, last used, and the count of referencing targets (`heph query revdeps` for the list) |
+| `heph tool scratch head <addr>` | the resolution trace, **local and remote** — every candidate scope, its head, fork point, drift, and why it won or lost |
+| `heph tool scratch path <addr>` | the canonical slot path, for pointing another tool at it or `du`-ing it |
+| `heph tool scratch rm <addr>` | drop a slot locally. The remedy for a poisoned cache (§7.1) |
+| `heph tool scratch verify <matcher>` | run the selected targets cold and warm, diff the `hashout`s (§13.2) |
+| `heph tool clean --scratch[=<addr>]` | a flag on the existing command, since it already means "delete what I point at" |
+| `heph tool gc` | already sweeps; gains the slot sweep (§11) with no new surface |
+
+Each carries the `///` doc-comment-with-`Example:` shape the other `ToolCommands`
+variants use, so `--help` reads consistently.
+
+**`--scratch=on|refresh|off` stays a global build flag**, not a `tool` subcommand.
+It modifies a build rather than being one — it belongs next to `--force` and
+`--frozen` on `run`, and `heph tool scratch verify` is the command that *uses* it.
+
+`push` and `pull` sitting in the same group as `ls` and `rm` is what makes the
+asymmetry legible: a build pulls on its own and never pushes, so the only
+scratch verb anyone ever has to *type* in CI is `push`.
+
+## 14. Non-overlap: scratch vs. deps vs. outputs
+
+Scratch is the only unhashed, mutable thing inside a sandbox, so every boundary
+between it and the hashed world is a place a wrong build can enter. Three
+disjointness requirements, in increasing order of how badly they fail.
+
+### 14.1 Scratch ∩ outputs = ∅
+
+An output collected from inside a scratch directory is an artifact whose bytes
+came from an unhashed source, cached under a `hashin` that does not describe them.
+
+Not hypothetical: `plugin-go/src/plugingo/thirdparty.rs` carries a comment about
+exactly this — "the `**/*` output glob would otherwise capture the cache dir" —
+and works around it by hand today.
+
+Checked in `validate.rs`, which already has `paths_overlap` and `is_ancestor` for
+codegen collisions. A def whose output path, dir, or glob **could** capture a
+scratch path is a **hard error at parse time**. Globs are compared conservatively:
+if the glob's literal prefix is an ancestor of the scratch path, it is rejected —
+"might match" is treated as "does match", because the alternative is a check that
+passes until the day a file appears.
+
+### 14.2 Scratch ∩ dependency inputs = ∅
+
+This is the one the ask names, and it is the most dangerous of the three, because
+it fails in *both* directions:
+
+- **Dep → scratch (poisoning).** A dependency materialized at a path under a
+  scratch mount is written *into the slot* — and in `live` mode the slot is a
+  symlink out of the sandbox, so the write lands in shared, persistent, unhashed
+  storage and then travels to every other target on the slot and, with
+  `remote = True`, to every other machine. Hermetic input bytes become
+  unhermetic shared state.
+- **Scratch → dep (shadowing).** Restored scratch content sitting at a path where
+  a dependency is expected shadows that dependency. The target then reads bytes
+  that no `hashin` describes while heph believes it read the dep. That is a
+  **silent wrong build**, and it is the one failure mode this whole design must
+  not permit — everything else here degrades to "slower".
+
+Enforced in two places, because neither alone is sufficient:
+
+1. **Static, at validate time.** Compare each scratch path against the target's
+   own declared input/tool/support-file materialization roots and against the
+   declared output paths of its direct deps, which the linked def already knows.
+   Cheap, catches the authoring mistake at the moment it is made, and reports both
+   addrs.
+2. **Dynamic, at materialization time — authoritative.** The sandbox materializer
+   (`driver-support/src/driver_managed.rs`, and the FUSE bridge) already visits
+   every input's destination path to link or copy it. Before writing, check the
+   destination against the target's scratch roots — a prefix comparison against a
+   sorted list that is essentially always ≤ 2 entries, so `O(1)` per file and
+   invisible in the profile. A hit is a **hard error**, not a skip: a silently
+   dropped input is the same wrong build by another route.
+
+The static check exists for the error message; the dynamic check exists for the
+guarantee. Only the dynamic one sees the paths that dep outputs actually resolve
+to, and only the static one can name the BUILD-file line.
+
+### 14.3 Scratch ∩ scratch = ∅, and reference well-formedness
+
+- Two referenced scratches whose declared `path`s overlap may not be referenced by
+  the same target, and the same scratch may not be referenced twice.
+- A declared `path` must be **relative, `..`-free, and inside the sandbox ws** —
+  checked on the *declaration*, so it is reported once at the source rather than
+  once per consumer. A scratch directory is a symlink *out*; its mount point is
+  not negotiable, and §5.2 gives no way to move it.
+- A referenced addr must resolve, and must resolve to a **scratch** target. Both
+  are ordinary addr errors rendered the way heph renders every other one (§5.4).
+- **Two references resolving to the same environment variable** are a hard error
+  naming both addrs (§5.5), as is a target's own `env`/`runtime_env` declaring a
+  variable a referenced scratch owns.
+
+Note what is *absent*: an earlier revision declared the slot's settings inline at
+every use site and therefore needed a rule that all consumers of a name agree
+about `access`, `version`, `remote` and `max_size`. With a declaration target
+there is one copy of each, so the disagreement is not detectable — it is
+inexpressible. Likewise the reserved `heph`-prefixed name namespace is gone:
+packages already namespace, so a driver's internal cache is `//@heph/go:golist`.
+
+### 14.4 Snapshot hygiene
+
+When tarring a slot for a remote push, refuse to follow symlinks out of the slot
+and refuse to archive sockets/devices. A slot that has acquired a
+symlink into the stage tree or into another sandbox would otherwise publish a
+dangling absolute path to every machine that restores it.
+
+## 15. Cost budget
+
+`feature-quality`'s question — what it costs when nobody uses it, and when they do:
+
+| path | cost |
+|---|---|
+| target with no `scratch` | one empty `Vec` on `TargetDef`, one `is_empty()` branch in `execute`. Zero syscalls, zero allocations |
+| cache hit on a scratch target | **zero** — never reached (§4.2) |
+| miss, warm slot | one `symlink(2)` in, one `unlink(2)` out, one lock acquire (two `flock`s) |
+| first build on a new branch | one seed copy of the slot — reflink where available, otherwise a plain copy. **Once per (slot, branch)**, never per run (§10.7) |
+| dep-overlap check | one prefix comparison per materialized input against a ≤2-entry sorted list |
+| local resolve | one `head.meta` read per candidate scope (typically 2), once per slot per invocation. No network |
+| remote resolve | one `list_names` + one small `.meta` GET per candidate scope, **only when the local store is cold** |
+| remote pull | one object fetch + untar, only when the local store is cold |
+| publishing | zero during a build. One tar + upload when `heph tool scratch push` is run, which is once per CI job |
+| remote push | one tar + upload on the background lane, **once per slot per invocation** |
+| memory | `O(slots)`, not `O(targets)` — a key, a path, a lock handle |
+
+The number to watch in the bench harness is **`exclusive` lock wait**: the only
+cost here that scales with the graph rather than with the slots.
+
+## 16. Compatibility
+
+`compatibility` is a mechanical trigger — this touches `proto/`,
+`plugin-abi`/`ABI_SEMVER`, the CLI surface, the on-disk format and the remote wire
+format. Claims to be checked:
+
+- **Plugin ABI: unchanged. No new message, no new field, no `ABI_SEMVER` bump**
+  (§5.3). Scratch travels on `TargetSpec.transitive` and `Input.annotations`,
+  which every ABI version already carries and every driver already passes through.
+  A new host with an old plugin, and an old host with a new plugin, both simply
+  see annotations they do not act on — the target runs cold, which is a
+  *slowdown, not a wrong build*. This is the strongest compatibility position
+  available and it is worth protecting: the moment a typed `ScratchRef` field is
+  added for tidiness, every one of those properties is spent.
+- **On-disk:** `<home>/scratch/` is a new tree; nothing existing changes shape.
+  `<slot>.meta` is versioned borsh. An unreadable or unknown-`SCRATCH_FORMAT` slot
+  is *deleted*, not migrated — it is a cache.
+- **Remote wire:** a new, dedicated `scratch/v1/` prefix, disjoint from the
+  existing blob namespace. An older heph never lists it and never fetches it. The
+  `v1` and the `SCRATCH_FORMAT` in `.meta` are the two independent version knobs —
+  the first for the key layout, the second for the payload.
+- **Remote GC:** §10.11 recommends bucket lifecycle rules precisely to avoid adding
+  `delete` to `RemoteCacheBackend`, which every backend and test double would have
+  to implement.
+- **Scope naming is part of the key**, so changing `scratch.scope`'s expression
+  (say from `${GITHUB_REF_NAME}` to a slug of it) orphans every existing lineage.
+  That degrades to a cold run and self-corrects on the next push, which is the
+  right severity — but it means the scope expression is closer to configuration
+  than to a value, and renaming it should be a deliberate act. Worth a line in
+  the config docs, not a version knob.
+- **Starlark:** a new driver name (`driver = "scratch"`) with its config fields,
+  and a new optional `scratch` attribute on `exec`. **No new global**, so nothing
+  a workspace may already have defined can collide, and existing BUILD files are
+  untouched. Both are API once shipped, so §5's shape should be settled before,
+  not after — but this is the only genuinely new, permanent surface here; the
+  plugin ABI, the proto and the cache formats all stay put.
+- **CLI:** new `heph tool scratch` subcommand group, new `--scratch` flag, new event kinds in
+  `--json`. Additive; consumers ignoring unknown event kinds are unaffected, which
+  is the existing contract.
+
+## 17. Testing
+
+Per `.claude/testing.md`, everything is `crates/e2e` (in-process, real `Engine`)
+unless it structurally cannot be.
+
+**Unit (`scratch.rs`, `scratch_remote.rs`):** slot key stability and sensitivity
+(addr/version/os/arch each move it; `path`, `access` and `remote` do not); meta
+round-trip; sorted
+multi-slot lock ordering; the `(generation, bytes, content_hash)` total order,
+including forks; key formatting and lexicographic-equals-generation ordering with
+generations spanning the zero-padding width; scope precedence.
+
+**`crates/e2e`:**
+- a target writes a marker into scratch; a later run with a *changed input*
+  (forcing a miss) sees the marker
+- a cache hit neither restores nor takes the lock
+- two targets sharing an `exclusive` slot never overlap (each writes an
+  exclusivity token and asserts it was alone); they *do* overlap under `shared`
+- `[a, b]` and `[b, a]` complete without deadlock (§8.2 rule 3)
+- a failing target does not clobber the previous head; a cancelled run does not commit
+- cancellation saves nothing
+- **an output glob overlapping a scratch path is a parse error** (§14.1)
+- **a dep materializing under a scratch path is a hard error** — both the static
+  and the dynamic check, each with the other disabled, so neither is silently
+  load-bearing for the other's coverage (§14.2)
+- **restored scratch content cannot shadow a dep** — the wrong-build case, asserted
+  as an error rather than as a hashout
+- a reference to a non-scratch addr, and two references colliding on one
+  `SCRATCH_*` variable, each error naming both addrs
+- `--scratch=off` produces byte-identical `hashout`s to a warm run — §4 as an
+  executable test
+- eviction: a slot over `max_size` is dropped; `heph tool clean --scratch` removes it
+- **a build never pushes.** Asserted directly against a counting remote: a full
+  build of a graph with `remote = True` slots issues **zero** writes to the remote,
+  however many targets ran and whether they passed or failed
+- **`heph tool scratch push`:** publishes a dirty head at `parent + 1`; skips a
+  clean one; `--force` publishes anyway; a failed upload leaves `dirty` set so the
+  next push retries; `write: false` refuses and says so; exits non-zero when any
+  selected slot fails; `--all` selects exactly the `remote = True` slots
+- **push takes the write guard:** with a `shared` reader held, the push blocks
+  rather than tarring under it, and completes once the reader drops — the §8.1
+  claim, asserted rather than asserted-in-prose
+- **seed on fork:** the first build in a new scope copies the fallback's head,
+  sets `parent` to it, and leaves the fallback's head byte-identical;
+  `seedOnFork: false` starts cold instead
+- **no ABI surface:** a driver built against the pre-scratch `ABI_SEMVER` loads,
+  runs, and its targets build — the scratch annotations pass through it untouched.
+  This is the §5.3 claim, and it is the one that would silently stop being true
+  the first time someone adds a typed field
+- **`apply_transitive` ordering:** a consumer's `def.hash` is byte-identical with
+  and without a scratch reference, and unchanged by a `version` bump on the
+  referenced scratch — the structural half of §6.3
+- **the declaration/reference split:** two targets referencing one scratch resolve
+  to the same slot; `heph query revdeps` on the declaration lists both; a reference
+  to a missing addr is `TargetNotFoundError`; a reference to a non-scratch target
+  is a wrong-kind error naming both
+- **nothing about scratch reaches `hashin`** (§6.3), asserted four ways: content
+  changes, mount-path override, `access` flip, and — the one that is easy to get
+  wrong — a `version` bump. A `version` bump gives a fresh empty slot **and leaves
+  every consumer's cached result a hit**
+- **`platform`:** `os_arch` gives different slots on different os/arch; `any`
+  gives one slot across all of them; `os` splits on os only — asserted on the key,
+  not on behaviour
+- **`version_fallback`:** off, a version bump is fully cold; on, it seeds from the
+  most recent other version of the same slot, and the scope fallback is exhausted
+  first (§10.5)
+- **no mount override exists:** a scratch mounts at its declared `path` in every
+  consumer, and there is no attribute form that says otherwise (§5.2)
+- **`SCRATCH_<NAME>` env:** injected with the canonical path, not the sandbox
+  symlink; absent when no scratch is referenced; derived from the target name, not
+  the package; two references colliding after sanitization is a parse error; the
+  explicit `env =` form overrides
+- **lineage, against the in-memory remote backend:**
+  - generation increments from the restored head; a cold runner starts at 0
+  - the head is the max under the §10.6 order; a same-generation fork converges
+    (two writers at N+1 → every reader picks the same one)
+  - a *late* writer descending from an old generation does not become the head
+  - a build issues no remote writes at all, whatever the target count
+- **branch lineage, the §10.2/§10.4 model — run against the local store *and* the
+  remote one, from the same table, because it is one algorithm (§10):**
+  - a run in scope `pr` restoring from `master` writes into `pr`, never `master`,
+    and records the fork point — the isolation property, asserted directly
+  - `restoreScopes` order decides: with entries in both `pr` and `master`, `pr`
+    wins; with `pr` empty, `master` is used; with neither, cold
+  - **generations are never compared across scopes** — `pr` at generation 40 does
+    not beat `master` at 12 by generation, and the resolver has no path that could
+  - **drift guard:** a `pr` head forked at `master` 12 with `master` now at 400
+    and `maxDrift = 100` resolves to `master`; forked at 398, it resolves to `pr`;
+    `maxDrift` unset resolves to `pr` in both cases (strict precedence)
+  - a missing or deleted `parent_scope` leaves drift uncomputable and falls back
+    to strict precedence rather than erroring
+  - a corrupt head `.meta` falls through to the next candidate, then to cold
+- **the local branch-switch story, end to end:** build on `master`, switch scope
+  to `feat-x`, build again — the second run seeds from `master`'s local head,
+  writes into `feat-x`, and leaves `master`'s head exactly as it was; switching
+  back finds `master` unchanged
+- **local-first resolution:** a warm local head makes no remote call at all;
+  a cold one pulls transparently with nothing configured beyond the remote;
+  `--scratch=refresh` pulls even when warm
+
+**`crates/bin-e2e`:** only the cross-process lock — two `heph` processes
+contending for one `exclusive` slot must serialize. No in-process form exists (the
+`mem` backend serializes only within a process), which is exactly the bar that
+crate sets.
+
+**`crates/bench`:** a corpus scenario with warm vs cold scratch, so the win is a
+tracked number rather than a claim. Given §2.1, **no performance claim in this
+document should be believed until it is an interleaved A/B on the corpus.**
+
+## 18. Phasing
+
+1. **Model + plumbing.** The `scratch()` builtin and its provider, the reference
+   on `TargetDef`, proto + ABI, the exec attribute, and all of §13's validation.
+   No storage yet — declaring and referencing a scratch does nothing observable
+   beyond appearing in `heph query`. The overlap checks land here, *before*
+   anything can write.
+2. **`live` mode + locking + the `SCRATCH_*` env + events.** The feature,
+   locally, in its cheapest form. Where the `golist_gocache` win becomes general.
+3. **The lineage model + scopes, local only** (§10.1–§10.7). Branch-aware local
+   caches, `${git:branch}`, the drift guard. Reviewable without any network, and
+   the piece the remote phase then reuses wholesale rather than reimplements.
+4. **Eviction + the read-only half of `heph tool scratch` + `--scratch` modes.**
+   Makes it operable and inspectable.
+5. **Remote pull** (§10.4, §10.8) — resolve, fetch, seed. A CI runner gets warm
+   from whatever is already published, with no workflow change. Useful on its own
+   the moment anything is in the bucket.
+6. **`heph tool scratch push`** (§10.10) — the publish half, and the only part CI
+   has to be told about.
+7. **Retrofit `plugin-go`** (§11.1), in its own order: the golist `GOCACHE` first
+   (delete `golist_gocache.rs`), then compile's per-sandbox one, then the
+   `GOMODCACHE`/`GOPROXY` passthrough — each measured separately, because §2.1 is
+   the standing reminder that an obvious cache win can move wall time by zero.
+   This is the proof that the general mechanism subsumes the special case.
+8. **Retrofit `plugin-oci`** (§11.2) — the shared blob store, then the local
+   BuildKit layer cache. Not a prerequisite for anything; it is the evidence that
+   a second ecosystem adopts the mechanism without it growing new knobs.
+
+1→2 is a genuine stack (2 cannot be reviewed without 1). 3 and 4 branch off
+`master` in parallel once 2 lands; 5 needs 3, and 6 needs 5. Ordering 3 before the
+remote phases is the deliberate choice: it puts the lineage model — the part with
+the subtle semantics — in front of a reviewer with no network, no tarballs and no
+CI fixture in the way, and leaves 5 and 6 as plumbing over an algorithm that
+already has tests. Splitting 5 from 6 matters too: pull is what makes CI faster
+and it lands without anyone editing a workflow.
+
+7 is the gate, not the victory lap: if the Go caches cannot be expressed as
+declarations, §5's surface is wrong, and it is much cheaper to learn that before 8
+than after.
+
+## 19. Alternatives considered
+
+- **Per-target restore/save into every sandbox (the literal ask).** This was
+  `mode = "snapshot"`, and §7.3 now proposes dropping it: §2.1 measured that exact
+  shape at a 60% CPU saving and *zero* wall-clock improvement.
+- **Pushing automatically at the end of a run.** Needs a directory nobody is
+  writing, which means either a per-run clone (a full tree copy on ext4, §7.2) or
+  a barrier that must skip silently when contended. Making push a command gets the
+  same barrier with none of the cost, and moves the "should this become the
+  branch's head?" decision into CI's `if:` conditions where it is answerable.
+- **A per-run clone** (`mode = "run"`). Deferred rather than rejected — §7.2.
+- **Scoping the remote by branch but not the local store.** The cheaper half, and
+  it leaves the developer with the bug the whole mechanism exists to fix: every
+  `git checkout` hands the arriving branch the departing branch's cache state and
+  hands it back mutated. Branch switching is a local event first and a CI event
+  second.
+- **A mutable `HEAD` pointer object in the remote.** The obvious "latest"
+  mechanism, and wrong before you even reach the backend: one remote serves many
+  branches concurrently, so there is no single latest for a pointer to name. A
+  pointer *per* branch models it, at the cost of an unbounded set of mutable
+  objects and no way to relate the heads the cross-branch restore has to compare.
+  The backend then rules out even that — no CAS, and last-writer-wins ranks by
+  finish time rather than by descent. §10.1.
+- **Timestamps instead of generations.** No coordination needed, but wrong under
+  clock skew across runners, and wrong in principle: recency is not descent.
+  Note this is *not* the same question as cross-branch staleness, which §10.4
+  answers with fork distance — also without a clock.
+- **Strict scope precedence, GHA's exact behaviour.** Available (`maxDrift`
+  unset) and rejected as the default: a long-lived branch's own cache keeps
+  winning as it ages, so the build that most needs a warm cache is the one
+  guaranteed a stale one. §10.4.
+- **Merging forked lineages.** Cannot be done correctly without understanding each
+  tool's cache format, and by §4 is never *necessary*. Explicitly out of scope,
+  for same-branch forks and cross-branch alike.
+- **A typed `ScratchRef` on `TargetDef`, with a proto message and an ABI bump.**
+  What an earlier revision of this design specified. Cleaner to read, and it costs
+  a version negotiation, `plugin-abi` conversion code, and — the real price —
+  third-party drivers must be recompiled to participate. `transitive` +
+  `annotations` gets the same behaviour with none of it (§5.3), at the cost of
+  stringly-typed settings on the wire, which is the trade `read_only` and
+  `stage_per_file` already made.
+- **Referencing a scratch in `deps`**, letting `apply_transitive` demote the input
+  to `hashed: false, runtime: false`. Works, and needs no new attribute anywhere —
+  but it puts scratch in the same list as real inputs, which is exactly the
+  distinction §14.2 exists to protect, in the place an author reads first. A
+  separate list costs one spec field in pluginexec and no ABI surface (§5.2).
+- **Declaring the slot inline at each use site**, joined by a bare string name.
+  The original shape here, and it made every consumer restate `access`, `version`,
+  `remote` and `max_size`, then needed validation that they all agreed — a
+  discovered error where a declaration target makes it inexpressible. It also put
+  cache identity in a flat global string namespace with no packages, no
+  visibility, and no way to ask who uses one.
+- **Let each driver do it.** The status quo (`golist_gocache.rs`). No lock, no
+  eviction, no visibility, no remote, and a fresh reimplementation per ecosystem —
+  each an unreviewed hole in the sandbox.
+- **A "cache target" whose output is the directory.** Reuses all the existing
+  machinery, but the directory is then content-addressed by `hashin` — which is
+  exactly the property that makes it useless. A cache readable only at the input
+  hash that produced it is not a cache.
+- **Reuse the target cache with a sentinel `hashin`.** Cheaper to build, but puts
+  mutable, unhashed state inside a store whose entire contract is "keyed by
+  inputs, immutable per key"; every invariant in `local_cache.rs`, `gc.rs` and
+  `remote_cache.rs` would need an "unless it is scratch" clause.
+- **`bind`/`overlayfs` instead of a symlink.** Real isolation with rollback, but
+  Linux-only (macOS has neither), so it violates the uniform-across-the-three-
+  targets rule. A symlink behaves identically everywhere.
+
+## 20. Risks
+
+- **The shadowing hole (§14.2) is the only path here to a wrong build.** It is the
+  one thing in this document that must be got right; everything else degrades to
+  "slower". Both checks, and the tests that disable each one, are non-negotiable.
+- **`exclusive` is a footgun** at scale (§8.3). Mitigated by visibility and a warn,
+  not eliminated.
+- **A path-sensitive cache can restore and still be inert** across machines
+  (§10.9) — it looks like a hit and performs like a miss. Mitigated by the
+  `debug!` and by `scratch.root`; not eliminated.
+- **Both stores grow with branch count** once scoping is on. Remotely nothing in
+  heph collects a dead branch's lineage at all (§10.11) — only the bucket's
+  lifecycle rules do. Locally the LRU collects it, but a developer who works on
+  many branches holds many heads, and only a CoW filesystem makes that cheap.
+- **Nothing publishes unless someone remembers to run `push`.** A workflow that
+  omits it gets a cache that pulls forever and never advances — fast enough that
+  nobody notices it is stale. That is the cost of explicitness, and the mitigation
+  is diagnostic rather than structural: `heph tool scratch ls` shows `dirty`, and
+  `heph tool scratch head` shows a head that has not moved.
+- **The seed-on-fork copy is a real cost on ext4 for a large slot** (§10.7).
+  Amortized over a branch's lifetime and comparable to a cold rebuild, but it lands
+  as a one-off pause on the first build after a checkout, which is a surprising
+  place to spend time. `ScratchSeedStart/End` is what makes it visible.
+
+- **`maxDrift` is a number nobody has data for yet.** Too low and every branch
+  build throws away its own incremental work; too high and the guard never fires.
+  It is configurable and observable (`heph tool scratch head`) precisely because the
+  default will be wrong for someone.
+- **A wrongly-declared `platform = "any"` is a real wrong-answer risk**, and the
+  only author assertion here that is. `access = "shared"` and `version_fallback`
+  fail into slowness; a cache that turns out to be host-specific — a
+  `node_modules` with native addons, a store holding compiled objects — restores
+  onto the wrong machine and is used. §6.1 states what `any` asserts; the default
+  is the narrow one for exactly this reason.
+- **A poisoned slot survives until evicted.** Self-healing for the caches this
+  targets; `heph tool scratch rm` for the rest.
+
+## 21. Decisions taken, and what is still open
+
+### Settled
+
+- **A scratch is a declaration target, referenced by addr.** Settings live in one
+  place; sharing is what addrs already do; `heph query revdeps` answers who shares
+  a cache. §5.
+- **It is a builtin *driver*, shaped like `plugingroup`** — the existing way heph
+  gains a target kind, with `#[derive(Spec)]` supplying the parser and the LSP
+  schema. §5.1.
+- **A scratch mounts at its declared `path`, everywhere.** No per-consumer
+  override; `scratch = [addrs]` is the only reference form. Location is part of
+  what a cache is (§5.2).
+- **`platform` is declared, not assumed.** `os_arch` by default, `any` for a
+  cache that is genuinely portable — which makes one slot serve every machine on
+  the lineage. §6.1.
+- **`version` gets an opt-in fallback**, credited to GHA's `restore-keys`: a
+  `version` that is a lockfile fingerprint should inherit the previous version's
+  cache, while a `version` that is a bust handle must not. §10.5.
+- **Nothing new crosses the plugin ABI.** No proto message, no `TargetDef` field,
+  no `ABI_SEMVER` bump: scratch rides on `TargetSpec.transitive` and
+  `Input.annotations`, which already exist and already carry producer→host
+  metadata. A side effect worth naming: because settings arrive via
+  `apply_transitive`, which runs *after* `def.hash` is set, §6.3 is enforced by
+  the shape of the code rather than by a rule. §5.3.
+- **Scratch contributes nothing to `hashin`** — not content, not declaration, not
+  `version`. It follows from §4, and the intuitive alternative is an over-hash.
+  §6.3.
+- **`access = "shared"` ships in v1**, as a "trust the tool" assertion by the
+  author. The golist targets must not run serially. §8.1.
+- **Pull is automatic; push is `heph tool scratch push`.** No end-of-run push, in
+  any mode. This supersedes both the earlier "a `shared` slot is local-only" and
+  the `run`-mode-required rule: the write guard the command takes is the coherent
+  moment, so `access` and `remote` are independent and `GOCACHE` gets its CI cache.
+  §8.1, §10.10.
+- **The per-run clone is deferred**, not adopted: its cost is a full tree copy per
+  invocation on ext4 and its justification went away with the automatic push. §7.2.
+- **State is a tree of per-branch lineages**, not one line, and not a mutable
+  pointer per branch either. §10.1, §10.2.
+- **Cross-branch restore is first-class and configurable**: try the current
+  branch, then the configured fallbacks, in order. §10.3.
+- **The lineage applies locally too**, not only in CI — a developer switching
+  branches gets the same isolation and the same fallback, and seeding on fork makes
+  a branch switch cost one copy rather than a rebuild. §10.3, §10.7.
+
+### Open
+
+- **Q1 — Naming.** `scratch`, or something else? (§5.6) Locks in the Starlark API
+  and the CLI, so it is cheapest to settle now.
+- **Q2 — Does `seedOnFork` default on?** On is what makes branch switching worth
+  anything, and it is the one copy in the design — a plain copy on ext4 for a slot
+  that could be gigabytes, paid as a pause on the first build after a checkout
+  (§10.7). Off means new branches start cold and nothing ever copies. This is the
+  design's remaining **per-platform cost question, which CLAUDE.md reserves for
+  you**.
+- **Q2b — Is `version_fallback` off by default the right call?** §10.5. Off treats
+  `version` as a bust handle, which is what `version = "go1.23"` means; on treats
+  it as a fingerprint, which is what `hash_files(...)` means. Inferring which from
+  the value would be magic, so it is a flag — but a flag whose default is wrong
+  half the time is worth a second look.
+- **Q3 — Is the deferred per-run clone worth revisiting later?** §7.2. It buys
+  whole-run rollback and isolation between concurrent `heph` processes, on CoW
+  filesystems only. Cheap to add once the rest is shipped; easy to never miss.
+- **Q4 — Does the drift guard ship on by default, and at what `maxDrift`?** Off
+  (unset) is GHA's exact behaviour and predictable; on avoids the long-lived
+  branch going quietly cold. §10.4. The number itself wants data, not reasoning.
+- **Q5 — Is `${git:branch}` the right local default for `scope`?** Branch scoping
+  on by default is what makes local branch switching work with no configuration —
+  but it multiplies a developer's cache by branch count, and `scope: ""` (one
+  lineage, today's behaviour) is the conservative alternative.
+- **Q6 — Remote pruning:** bucket lifecycle rules (§10.11, recommended) or a new
+  `delete` on `RemoteCacheBackend`? Scoping makes this urgent rather than tidy.
+- **Q7 — May a target with scratch push its *outputs* to the remote cache?** Yes
+  by default (else CI gains nothing) means the remote can carry an artifact built
+  against a warm, unaudited cache. Forcing `remote_enabled = false` on scratch
+  targets is much safer and guts the main use case. §13.2's audit mode is the
+  proposed middle path.
+- **Q8 — Should CI publish after a failed build?** heph no longer decides this —
+  it is an `if:` condition on the push step. The recommendation to put in the docs
+  is `if: always()`: a cache warmed by a partially failing build is still warm, and
+  the head it publishes is no less valid than one from a green run. Worth stating
+  as guidance, since the intuitive choice is `if: success()` and it is wrong.

--- a/docs/SCRATCH.md
+++ b/docs/SCRATCH.md
@@ -268,20 +268,32 @@ to `hashin`" stops being a rule someone has to remember and becomes a structural
 property of where the data enters.
 
 **3. `Input.annotations` is host-visible and is already the producer→host
-channel.** It is a `map<string, string>` on the `Input` proto message, it is
-already copied into `RunInput` on the execute path (`engine/execute.rs:245`), and
+channel.** It is a `map<string, string>` on the `Input` proto message and
 `driver-support` already acts on producer-set annotations this exact way —
 `READ_ONLY_ANNOTATION` and `STAGE_PER_FILE_ANNOTATION` in `stage.rs` are the
-precedent. The scratch mount path, access mode and resolved slot path travel as
-annotations on the scratch input; the engine reads them where it already reads
-`read_only`.
+precedent. A scratch reference is marked with one, and the engine recognizes it
+where it already recognizes `read_only`.
 
-The cost of this is that the settings are stringly-typed on the wire rather than a
-typed message, with no schema enforcement at the ABI layer. That is the same trade
-`read_only` and `stage_per_file` already made, and it buys three things worth more
-than the typing: no version negotiation, no `plugin-abi` conversion code, and
-**third-party plugin drivers get scratch without being recompiled or even knowing
-it exists** — they pass through annotations and transitive sandboxes already.
+So **declaring and referencing a scratch costs no ABI surface at all**, and that
+half is implemented and shipped: the reference is an annotated `Input`, the
+settings are read from the declaration's spec config, and no proto message,
+`TargetDef` field or `ABI_SEMVER` bump was needed.
+
+> **Correction, from implementing it.** An earlier revision of this section
+> claimed the same for the *resolved* mount and env — that they would ride to the
+> driver on `RunInput.annotations`. They cannot. `link.rs:36` filters
+> `runtime: false` inputs out of `LinkedTargetDef`, which is what makes a scratch
+> a pure graph edge in the first place — so a scratch reference never becomes a
+> `RunInput` and has no annotation map to travel on. The two facts are the same
+> fact seen from both sides, and the design only noticed the flattering one.
+>
+> Mounting therefore does need a driver-visible channel, because the *bridge*
+> owns sandbox creation (it may redirect the path into a FUSE mount, which is why
+> the engine cannot pre-create anything there). The resolved list goes on
+> `RunRequest` — free for in-process managed drivers like pluginexec, and an
+> additive proto field for the cdylib transport, which does mean a `ABI_SEMVER`
+> bump and does mean a third-party cdylib driver must be rebuilt to mount a
+> scratch. Declaration and reference remain ABI-free; only mounting is not.
 
 ### 5.4 The reference as a graph edge
 
@@ -1417,14 +1429,18 @@ cost here that scales with the graph rather than with the slots.
 `plugin-abi`/`ABI_SEMVER`, the CLI surface, the on-disk format and the remote wire
 format. Claims to be checked:
 
-- **Plugin ABI: unchanged. No new message, no new field, no `ABI_SEMVER` bump**
-  (§5.3). Scratch travels on `TargetSpec.transitive` and `Input.annotations`,
-  which every ABI version already carries and every driver already passes through.
-  A new host with an old plugin, and an old host with a new plugin, both simply
-  see annotations they do not act on — the target runs cold, which is a
-  *slowdown, not a wrong build*. This is the strongest compatibility position
-  available and it is worth protecting: the moment a typed `ScratchRef` field is
-  added for tidiness, every one of those properties is spent.
+- **Plugin ABI, declaration + reference: unchanged.** No new message, no new
+  field, no bump. A reference travels on `Input.annotations` and the settings are
+  read from the declaration's spec config, both of which every ABI version already
+  carries. An old plugin and a new host, and the reverse, simply see an annotation
+  they do not act on.
+- **Plugin ABI, mounting: one additive field on `RunRequest`** and an
+  `ABI_SEMVER` minor bump (§5.3's correction). Free for in-process managed
+  drivers; a cdylib driver must be rebuilt before it can mount a scratch, and
+  until it is, its targets run without one — a *slowdown, not a wrong build*,
+  because the engine's lock is keyed on a declaration the old plugin never sees,
+  so there is no shared directory to race either. Worth keeping that degradation
+  intact when the field lands.
 - **On-disk:** `<home>/scratch/` is a new tree; nothing existing changes shape.
   `<slot>.meta` is versioned borsh. An unreadable or unknown-`SCRATCH_FORMAT` slot
   is *deleted*, not migrated — it is a cache.
@@ -1507,10 +1523,16 @@ generations spanning the zero-padding width; scope precedence.
   to the same slot; `heph query revdeps` on the declaration lists both; a reference
   to a missing addr is `TargetNotFoundError`; a reference to a non-scratch target
   is a wrong-kind error naming both
-- **nothing about scratch reaches `hashin`** (§6.3), asserted four ways: content
-  changes, mount-path override, `access` flip, and — the one that is easy to get
-  wrong — a `version` bump. A `version` bump gives a fresh empty slot **and leaves
-  every consumer's cached result a hit**
+- **nothing about scratch reaches `hashin`** (§6.3), asserted against the def hash
+  *directly* — a consumer's def hash must be byte-identical with and without a
+  reference, and unchanged by a `version` bump on the referenced scratch.
+  Asserting on `hashout` instead is **not** sufficient and is a trap worth naming:
+  a target whose key moved still produces identical bytes, so a hashout comparison
+  passes while the cache silently misses on every run. The `version` bump is the
+  case most likely to be "fixed" into a rebuild later, so it gets its own test.
+  Watch this when the mounting path lands: pluginexec's `apply_transitive`
+  re-seeds the def hash, so routing anything scratch-shaped through the transitive
+  sandbox would move the key of every consumer that has one
 - **`platform`:** `os_arch` gives different slots on different os/arch; `any`
   gives one slot across all of them; `os` splits on os only — asserted on the key,
   not on behaviour

--- a/proto/plugin/v1/driver.proto
+++ b/proto/plugin/v1/driver.proto
@@ -51,6 +51,20 @@ message RunInput {
   map<string, string> annotations = 5;
 }
 
+// A scratch cache the host resolved, locked and created for this run. The driver
+// symlinks `path` (relative to the target's cwd) at `dir`, and sets `env` to
+// `dir`.
+//
+// `dir` is the canonical slot path, not the in-sandbox mount: tools bake absolute
+// paths into their cache entries, so every consumer must see one stable string
+// for the same cache or it restores and is inert.
+message ScratchMount {
+  Addr addr = 1;
+  string path = 2;
+  string env = 3;
+  string dir = 4;
+}
+
 message RunRequest {
   string request_id = 1;
   TargetDef target = 2;
@@ -65,6 +79,7 @@ message RunRequest {
   bool has_stderr = 9;
   // true => run_shell, false => run
   bool shell = 10;
+  repeated ScratchMount scratch = 11;
 }
 
 // fuse_slot_guards and sandbox_cleanup are non-transferable host RAII,
@@ -108,6 +123,7 @@ message ManagedRunRequest {
   // true => run_shell
   bool shell = 9;
   string driver = 10;
+  repeated ScratchMount scratch = 11;
 }
 
 message ManagedRunResponse {

--- a/src/commands/bootstrap.rs
+++ b/src/commands/bootstrap.rs
@@ -92,6 +92,23 @@ pub fn telemetry_enabled_from_config() -> bool {
         .unwrap_or(true)
 }
 
+/// Run-scoped scratch switch, set once from `--scratch` before the engine is
+/// built.
+///
+/// A global rather than a parameter because `new_engine` is called from a dozen
+/// command paths that have no opinion on it, and threading a flag through all of
+/// them to reach one field would be a worse trade than one write at startup.
+static SCRATCH_ENABLED: std::sync::atomic::AtomicBool = std::sync::atomic::AtomicBool::new(true);
+
+/// Apply `--scratch`. Called from the CLI entrypoint before any engine exists.
+pub fn set_scratch_enabled(enabled: bool) {
+    SCRATCH_ENABLED.store(enabled, std::sync::atomic::Ordering::Relaxed);
+}
+
+fn scratch_enabled() -> bool {
+    SCRATCH_ENABLED.load(std::sync::atomic::Ordering::Relaxed)
+}
+
 pub fn new_engine() -> anyhow::Result<(Arc<engine::Engine>, ShutdownTrigger)> {
     let root = match engine::get_root() {
         Ok(r) => r,
@@ -101,7 +118,8 @@ pub fn new_engine() -> anyhow::Result<(Arc<engine::Engine>, ShutdownTrigger)> {
     // The config file is the all-optional, profile-layered YAML; `resolve`
     // applies every default in one place and yields the engine's runtime config.
     let file = config_yaml::load_from_root(&root)?;
-    let config = file.resolve(&root)?;
+    let mut config = file.resolve(&root)?;
+    config.scratch.enabled = scratch_enabled();
 
     // Captured before `config` is moved into the engine: the nix driver's state
     // dir hangs off `home_dir`, and telemetry reports the remote-cache backend

--- a/src/commands/global.rs
+++ b/src/commands/global.rs
@@ -19,6 +19,24 @@ fn parse_stall_notice(s: &str) -> Result<std::time::Duration, String> {
 /// subcommand, then plumbed to each command's `execute`.
 #[derive(Args, Clone, Debug, Default)]
 pub struct GlobalOptions {
+    /// Persistent scratch caches: `on` (default) or `off`.
+    ///
+    /// `off` runs every target with its scratch caches absent. That is how the
+    /// scratch contract gets audited — a target's outputs must be identical
+    /// whether its scratch is warm, cold or absent, so a build with `off` should
+    /// produce the same `hashout`s as one without. If it does not, the target is
+    /// depending on carried-over state and is already broken.
+    ///
+    /// A build flag rather than a `heph tool scratch` subcommand: it modifies a
+    /// build rather than being one, so it belongs next to `--force`.
+    #[arg(
+        long = "scratch",
+        value_name = "MODE",
+        default_value = "on",
+        value_parser = parse_scratch_mode,
+        global = true
+    )]
+    pub scratch: ScratchMode,
     /// Sample CPU and write a pprof profile to PATH. `kill -USR2 <pid>`
     /// snapshots the profile so far without stopping the run — this is the point
     /// of the flag, since a hung build never reaches exit. A filtered final
@@ -105,5 +123,46 @@ mod tests {
     fn auto_approve_is_opt_in() {
         assert!(!parse(&["heph"]).auto_approve);
         assert!(parse(&["heph", "--auto-approve"]).auto_approve);
+    }
+}
+
+/// Whether a run uses its declared scratch caches.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
+pub enum ScratchMode {
+    /// Mount and use them. The default.
+    #[default]
+    On,
+    /// Pretend none were declared. The audit mode — see `--scratch`.
+    Off,
+}
+
+fn parse_scratch_mode(s: &str) -> Result<ScratchMode, String> {
+    match s {
+        "on" => Ok(ScratchMode::On),
+        "off" => Ok(ScratchMode::Off),
+        other => Err(format!(
+            "unknown scratch mode {other:?} — expected `on` (default) or `off` \
+             (run with every scratch cache absent, to check a target does not \
+             depend on carried-over state)"
+        )),
+    }
+}
+
+#[cfg(test)]
+mod scratch_mode_tests {
+    use super::*;
+
+    #[test]
+    fn scratch_mode_parses_its_two_words() {
+        assert_eq!(parse_scratch_mode("on"), Ok(ScratchMode::On));
+        assert_eq!(parse_scratch_mode("off"), Ok(ScratchMode::Off));
+        assert_eq!(ScratchMode::default(), ScratchMode::On);
+    }
+
+    #[test]
+    fn an_unknown_scratch_mode_explains_what_off_is_for() {
+        let err = parse_scratch_mode("readonly").expect_err("unknown");
+        assert!(err.contains("readonly"), "{err}");
+        assert!(err.contains("carried-over state"), "{err}");
     }
 }

--- a/src/commands/mod.rs
+++ b/src/commands/mod.rs
@@ -13,6 +13,7 @@ pub mod validate;
 pub mod version;
 
 pub use global::GlobalOptions;
+pub use global::ScratchMode;
 
 use clap::Subcommand;
 

--- a/src/commands/run.rs
+++ b/src/commands/run.rs
@@ -111,6 +111,9 @@ struct RunApp {
     matcher: Matcher,
     fail_fast: bool,
     auto_approve: bool,
+    /// `--scratch=off`: run with every declared scratch cache absent. Implies a
+    /// forced rebuild — see where `force` is set.
+    scratch_off: bool,
     /// Shared approval queue: attached to the TUI view (so prompts render) and to
     /// the TUI approval handler (so keypresses resolve them). Unused in non-TUI
     /// mode, which prompts on the terminal instead.
@@ -194,7 +197,17 @@ impl App for RunApp {
         };
 
         let opts = ResultOptions {
-            force: self.args.force,
+            // `--scratch=off` implies `--force`, and must: the whole point is to
+            // check that a target produces the same outputs without its carried
+            // -over state, and a cached result was produced *with* it. Serving
+            // one back would make the audit vacuous — it would pass by reading
+            // exactly the answer it is supposed to be re-deriving.
+            //
+            // Note this does not change any cache key: scratch never reaches
+            // `hashin`, so the audit run writes its revision under the same key
+            // and a divergence surfaces as a rebuilt-hashout mismatch rather
+            // than as two unrelated entries.
+            force: self.args.force || self.scratch_off,
             shell: self.args.shell.is_some(),
             interactive,
             frozen: self.args.frozen,
@@ -313,6 +326,7 @@ async fn execute_async(args: RunArgs, sink: LogSink, global: GlobalOptions) -> a
         matcher: m,
         fail_fast: global.fail_fast,
         auto_approve: global.auto_approve,
+        scratch_off: global.scratch == crate::commands::ScratchMode::Off,
         approval: tui::ApprovalCenter::new(),
     };
     let interactive = tui::should_use_tui(global.no_tui);

--- a/src/commands/tool/clean.rs
+++ b/src/commands/tool/clean.rs
@@ -37,6 +37,15 @@ pub struct CleanArgs {
         conflicts_with = "arg1"
     )]
     pub expr: Option<String>,
+    /// Also delete persistent scratch caches. With an ADDRESS, only that
+    /// declaration's cache; alone, every one in the workspace.
+    ///
+    /// A flag rather than its own command because `clean` already means "delete
+    /// what I point at", and a scratch is one more thing you can point at.
+    /// `heph tool scratch rm` is the same operation for someone who is only
+    /// thinking about scratch.
+    #[arg(long)]
+    pub scratch: bool,
 }
 
 /// Resolve the selection — `run`'s and `query`'s, with **no default**.
@@ -138,8 +147,25 @@ async fn execute_async(
     global: GlobalOptions,
 ) -> anyhow::Result<()> {
     let cwp = get_cwp()?;
+
+    // `--scratch` alone means "clear the scratch store", with no target
+    // selection to make — so it must not be forced through `selection`, which
+    // deliberately refuses an empty one rather than wiping the target cache.
+    if args.scratch && args.arg1.is_none() && args.expr.is_none() {
+        let (engine, _shutdown) = bootstrap::new_engine()?;
+        let (n, freed) = engine.scratch_remove(None)?;
+        println!("Removed {n} scratch cache(s), freed {freed} bytes.");
+        return Ok(());
+    }
+
     let matcher = selection(&args, &cwp)?;
     let (engine, shutdown) = bootstrap::new_engine()?;
+    if args.scratch
+        && let Some(addr) = args.arg1.as_deref()
+    {
+        let (n, freed) = engine.scratch_remove(Some(addr))?;
+        println!("Removed {n} scratch cache(s), freed {freed} bytes.");
+    }
     let app = CleanApp {
         engine,
         matcher,
@@ -163,6 +189,7 @@ mod tests {
             arg1: arg1.map(str::to_string),
             arg2: None,
             expr: expr.map(str::to_string),
+            scratch: false,
         }
     }
 

--- a/src/commands/tool/gc.rs
+++ b/src/commands/tool/gc.rs
@@ -6,13 +6,55 @@ use crate::commands::GlobalOptions;
 use crate::commands::bootstrap;
 use crate::engine::Engine;
 use crate::tui::{self, App, AppContext, LogSink};
+use anyhow::Context as _;
 
 #[derive(clap::Args, Clone)]
-pub struct GcArgs {}
+pub struct GcArgs {
+    /// Cap the total size of persistent scratch caches, e.g. `50GiB`. Least
+    /// recently used caches are dropped whole until the store fits.
+    ///
+    /// Whole caches, never partial trims: heph cannot know which of a foreign
+    /// tool's entries are hot, and guessing would degrade a cache while claiming
+    /// to manage it. The next build repopulates what it actually needs.
+    #[arg(long = "scratch-max-size", value_name = "SIZE")]
+    pub scratch_max_size: Option<String>,
+    /// Drop scratch caches untouched for longer than this many days.
+    #[arg(long = "scratch-max-age-days", value_name = "DAYS")]
+    pub scratch_max_age_days: Option<u64>,
+}
+
+/// Parse a human size (`50GiB`, `500MB`, `1024`) into bytes.
+///
+/// Accepts the binary units people actually type and treats the `B`-less forms
+/// as the same thing, because `50G` meaning something different from `50GiB`
+/// would be a trap and nobody wants decimal gigabytes for a disk cap.
+fn parse_size(s: &str) -> anyhow::Result<u64> {
+    let t = s.trim();
+    let digits = t.find(|c: char| !c.is_ascii_digit()).unwrap_or(t.len());
+    let (num, unit) = t.split_at(digits);
+    let n: u64 = num
+        .parse()
+        .with_context(|| format!("{s:?} does not start with a number"))?;
+    let mult = match unit.trim().to_ascii_lowercase().as_str() {
+        "" | "b" => 1,
+        "k" | "kb" | "kib" => 1024,
+        "m" | "mb" | "mib" => 1024 * 1024,
+        "g" | "gb" | "gib" => 1024 * 1024 * 1024,
+        "t" | "tb" | "tib" => 1024u64 * 1024 * 1024 * 1024,
+        other => anyhow::bail!("unknown size unit {other:?} in {s:?}; try 50GiB, 500MiB, 1024"),
+    };
+    n.checked_mul(mult)
+        .ok_or_else(|| anyhow::anyhow!("size {s:?} overflows"))
+}
 
 struct GcApp {
     engine: Arc<Engine>,
     fail_fast: bool,
+    /// Cap for the whole scratch store; `None` leaves it unbounded.
+    scratch_max_bytes: Option<u64>,
+    /// Drop a scratch cache untouched for longer than this. `None` never ages
+    /// one out.
+    scratch_max_age: Option<std::time::Duration>,
 }
 
 #[async_trait]
@@ -36,6 +78,24 @@ impl App for GcApp {
             .engine
             .new_state_with_events(self.fail_fast, ctx.event_sender());
         let res = self.engine.clone().gc_all(rs.clone()).await;
+
+        // Scratch caches are swept here too, because nothing else bounds them:
+        // they are keyed by a declaration rather than by an input hash, so there
+        // is no `hashin` to age out and no `cache.history` to trim against. A
+        // sweep that only reclaimed target revisions would leave the one part of
+        // the store that grows without limit.
+        //
+        // Reported separately and never fatal — reclaiming scratch is an
+        // optimization, and failing a GC because one directory would not be
+        // removed would be a worse outcome than leaving it.
+        match self
+            .engine
+            .scratch_sweep(self.scratch_max_bytes, self.scratch_max_age)
+        {
+            Ok((0, _)) => {}
+            Ok((n, freed)) => println!("Swept {n} scratch cache(s), freed {freed} bytes."),
+            Err(err) => tracing::warn!(error = %err, "sweeping scratch caches"),
+        }
         // The progress view renders the sweep summary (TUI final line / CI finish);
         // no extra print here, which would duplicate it.
         crate::commands::errors::finalize!(ctx, rs, res, _stats => { Ok(()) })
@@ -51,7 +111,49 @@ async fn execute_async(_args: GcArgs, sink: LogSink, global: GlobalOptions) -> a
     let app = GcApp {
         engine,
         fail_fast: global.fail_fast,
+        scratch_max_bytes: _args
+            .scratch_max_size
+            .as_deref()
+            .map(parse_size)
+            .transpose()?,
+        scratch_max_age: _args
+            .scratch_max_age_days
+            .map(|d| std::time::Duration::from_secs(d * 24 * 60 * 60)),
     };
     let interactive = tui::should_use_tui(global.no_tui);
     tui::run_app(app, sink, interactive, shutdown).await
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn parse_size_accepts_the_units_people_type() {
+        assert_eq!(parse_size("1024").expect("plain"), 1024);
+        assert_eq!(parse_size("1KiB").expect("kib"), 1024);
+        // Binary throughout: `50GB` meaning something different from `50GiB`
+        // would be a trap for a disk cap.
+        assert_eq!(
+            parse_size("2GB").expect("gb"),
+            parse_size("2GiB").expect("gib")
+        );
+        assert_eq!(parse_size("50GiB").expect("gib"), 50 * 1024 * 1024 * 1024);
+        assert_eq!(parse_size(" 8 MiB ").expect("spaces"), 8 * 1024 * 1024);
+    }
+
+    #[test]
+    fn parse_size_rejects_nonsense_with_a_usable_message() {
+        let err = parse_size("lots").expect_err("not a number");
+        assert!(format!("{err:#}").contains("number"));
+        let err = parse_size("5 parsecs").expect_err("bad unit");
+        let msg = format!("{err:#}");
+        assert!(msg.contains("parsecs"), "{msg}");
+        assert!(msg.contains("50GiB"), "must suggest a valid form: {msg}");
+    }
+
+    #[test]
+    fn parse_size_does_not_overflow_silently() {
+        assert!(parse_size("99999999999999999999TiB").is_err());
+    }
 }

--- a/src/commands/tool/mod.rs
+++ b/src/commands/tool/mod.rs
@@ -6,6 +6,7 @@ mod completions;
 pub mod gc;
 mod gen_gitignore;
 mod resolve_plugins;
+mod scratch;
 
 use clap::{Args, Subcommand};
 
@@ -63,6 +64,18 @@ pub enum ToolCommands {
     /// Example: `heph tool gen-gitignore`
     #[command(name = "gen-gitignore")]
     GenGitignore(gen_gitignore::Args),
+    /// Inspect and reclaim persistent scratch caches
+    ///
+    /// A scratch cache is a directory a target declares and carries between runs
+    /// to go faster — a compiler cache, a dependency cache. Nothing else bounds
+    /// their growth, so this is where you look when disk is short, and
+    /// `heph tool gc` is what sweeps them on a schedule.
+    ///
+    /// Removing one is always safe: a target's outputs are identical whether its
+    /// scratch is warm, cold or absent, so it costs time and nothing else.
+    ///
+    /// Example: `heph tool scratch ls`
+    Scratch(scratch::ScratchArgs),
     /// Remote cache maintenance
     ///
     /// Subcommands for the shared remote cache(s) configured in `.hephconfig2`.
@@ -117,6 +130,7 @@ impl ToolCommands {
             ToolCommands::Gc(args) => gc::execute(args, sink, global),
             ToolCommands::Clean(args) => clean::execute(args, sink, global),
             ToolCommands::GenGitignore(args) => gen_gitignore::execute(args, sink, global),
+            ToolCommands::Scratch(args) => args.execute(sink, global),
             ToolCommands::Cache(args) => args.execute(sink, global),
             ToolCommands::Completions(args) => completions::execute(args),
             ToolCommands::BuildFmt(args) => build_fmt::execute(args, sink, global),

--- a/src/commands/tool/scratch.rs
+++ b/src/commands/tool/scratch.rs
@@ -1,0 +1,251 @@
+//! `heph tool scratch …` — inspect and reclaim persistent cache directories.
+//!
+//! Sits in `heph tool` alongside `cache`, `gc` and `clean`, which is the group for
+//! commands that inspect or repair heph's own state rather than build anything.
+//! A scratch slot is exactly that kind of state.
+//!
+//! Everything here reads the store directly and resolves no BUILD files, so it
+//! keeps working when the targets that produced a slot have been deleted or
+//! renamed — the same property `heph tool clean` has for addr-only selections.
+
+use crate::commands::GlobalOptions;
+use crate::commands::bootstrap;
+use crate::engine::scratch_store::{SlotEntry, store_root};
+use crate::tui::LogSink;
+
+#[derive(clap::Args, Clone)]
+pub struct ScratchArgs {
+    #[command(subcommand)]
+    pub command: ScratchCommands,
+}
+
+#[derive(clap::Subcommand, Clone)]
+pub enum ScratchCommands {
+    /// List persistent scratch cache directories
+    ///
+    /// One row per declared cache, largest first, with the lineages (branches)
+    /// present and the total size on disk. Reads no BUILD files, so a cache whose
+    /// declaring target is gone still shows up — and can still be removed.
+    ///
+    /// Example: `heph tool scratch ls`
+    Ls,
+    /// Print the on-disk path of a scratch cache
+    ///
+    /// For pointing another tool at it, or `du`-ing it by hand.
+    ///
+    /// Example: `heph tool scratch path //build:gocache`
+    Path {
+        /// Address of the `scratch` target, e.g. `//build:gocache`.
+        addr: String,
+    },
+    /// Delete scratch cache directories
+    ///
+    /// The remedy when a cache has gone bad: the next build starts cold and
+    /// repopulates it. Deleting a scratch is always safe — a target's outputs are
+    /// identical whether its scratch is warm, cold or absent, so this costs time
+    /// and nothing else.
+    ///
+    /// Examples:
+    ///
+    /// `heph tool scratch rm //build:gocache` — one cache
+    ///
+    /// `heph tool scratch rm --all` — every cache
+    Rm {
+        /// Address of the `scratch` target to delete.
+        addr: Option<String>,
+        /// Delete every scratch cache in this workspace.
+        #[arg(long)]
+        all: bool,
+    },
+}
+
+impl ScratchArgs {
+    pub fn execute(&self, _sink: LogSink, _global: &GlobalOptions) -> anyhow::Result<()> {
+        match &self.command {
+            ScratchCommands::Ls => bootstrap::block_on(ls())?,
+            ScratchCommands::Path { addr } => bootstrap::block_on(path(addr))?,
+            ScratchCommands::Rm { addr, all } => bootstrap::block_on(rm(addr.as_deref(), *all))?,
+        }
+    }
+}
+
+/// Render a byte count the way a person reads one.
+fn human_bytes(n: u64) -> String {
+    const UNITS: [&str; 4] = ["KiB", "MiB", "GiB", "TiB"];
+    let mut v = n as f64;
+    let mut chosen: Option<&str> = None;
+    for unit in UNITS {
+        if v < 1024.0 {
+            break;
+        }
+        v /= 1024.0;
+        chosen = Some(unit);
+    }
+    match chosen {
+        None => format!("{n} B"),
+        Some(unit) => format!("{v:.1} {unit}"),
+    }
+}
+
+fn describe(slot: &SlotEntry) -> (String, String) {
+    match &slot.meta {
+        Some(m) => {
+            let mut detail = format!("{} @ {}", m.access, m.path);
+            if !m.version.is_empty() {
+                detail.push_str(&format!(" v={}", m.version));
+            }
+            if m.platform != "os_arch" {
+                detail.push_str(&format!(" platform={}", m.platform));
+            }
+            if m.remote {
+                detail.push_str(" remote");
+            }
+            (m.addr.clone(), detail)
+        }
+        // An orphan: a slot from a format heph no longer reads, or one whose meta
+        // never landed. Say so rather than hiding it — it is occupying disk and
+        // `rm --all` is how it goes.
+        None => (format!("<unknown> ({})", slot.slot), String::new()),
+    }
+}
+
+async fn ls() -> anyhow::Result<()> {
+    let (engine, _shutdown) = bootstrap::new_engine()?;
+    let mut slots = engine.scratch_slots()?;
+    if slots.is_empty() {
+        println!("No scratch caches in this workspace.");
+        return Ok(());
+    }
+    // Largest first: the reason to run this is usually disk.
+    slots.sort_by_key(|s| std::cmp::Reverse(s.bytes));
+
+    let total: u64 = slots.iter().map(|s| s.bytes).sum();
+    let width = slots
+        .iter()
+        .map(|s| describe(s).0.len())
+        .max()
+        .unwrap_or(0)
+        .max(7);
+
+    println!("{:<width$}  {:>10}  LINEAGES", "CACHE", "SIZE");
+    for slot in &slots {
+        let (name, detail) = describe(slot);
+        let scopes = if slot.scopes.is_empty() {
+            "-".to_string()
+        } else {
+            slot.scopes.join(", ")
+        };
+        println!("{name:<width$}  {:>10}  {scopes}", human_bytes(slot.bytes));
+        if !detail.is_empty() {
+            println!("{:<width$}  {:>10}  {detail}", "", "");
+        }
+    }
+    println!();
+    println!("{} cache(s), {} total", slots.len(), human_bytes(total));
+    Ok(())
+}
+
+async fn path(addr: &str) -> anyhow::Result<()> {
+    let (engine, _shutdown) = bootstrap::new_engine()?;
+    let slots = engine.scratch_slots()?;
+    let found = slots
+        .iter()
+        .find(|s| s.meta.as_ref().is_some_and(|m| m.addr == addr));
+    match found {
+        Some(slot) => {
+            println!("{}", store_root(&engine.home).join(&slot.slot).display());
+            Ok(())
+        }
+        // Not an error to be cold — a cache that has never been built has no
+        // directory yet, and saying "no such thing" would be wrong.
+        None => anyhow::bail!(
+            "no scratch cache on disk for {addr}. It may simply never have been built; \
+             `heph tool scratch ls` shows what is there"
+        ),
+    }
+}
+
+async fn rm(addr: Option<&str>, all: bool) -> anyhow::Result<()> {
+    if all == addr.is_some() {
+        anyhow::bail!("pass either an address or --all, not both or neither");
+    }
+    let (engine, _shutdown) = bootstrap::new_engine()?;
+    let (removed, freed) = engine.scratch_remove(addr)?;
+    if removed == 0 {
+        println!("Nothing to remove.");
+    } else {
+        println!("Removed {removed} cache(s), freed {}.", human_bytes(freed));
+    }
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::engine::scratch_store::SlotMeta;
+
+    #[test]
+    fn human_bytes_reads_like_a_person_wrote_it() {
+        assert_eq!(human_bytes(0), "0 B");
+        assert_eq!(human_bytes(999), "999 B");
+        // Exact powers stay exact rather than becoming "1024.0 B".
+        assert_eq!(human_bytes(1024), "1.0 KiB");
+        assert_eq!(human_bytes(1536), "1.5 KiB");
+        assert_eq!(human_bytes(10 * 1024 * 1024 * 1024), "10.0 GiB");
+    }
+
+    fn entry(meta: Option<SlotMeta>) -> SlotEntry {
+        SlotEntry {
+            slot: "abc123".to_string(),
+            meta,
+            scopes: vec!["_".to_string()],
+            bytes: 0,
+            last_used: None,
+        }
+    }
+
+    fn meta() -> SlotMeta {
+        SlotMeta {
+            format: 1,
+            addr: "//build:gocache".to_string(),
+            path: ".cache/go-build".to_string(),
+            env: "GOCACHE".to_string(),
+            access: "shared".to_string(),
+            platform: "os_arch".to_string(),
+            version: String::new(),
+            remote: false,
+        }
+    }
+
+    #[test]
+    fn a_slot_is_described_by_its_declaration() {
+        let (name, detail) = describe(&entry(Some(meta())));
+        assert_eq!(name, "//build:gocache");
+        assert!(detail.contains("shared"), "{detail}");
+        assert!(detail.contains(".cache/go-build"), "{detail}");
+        // The default platform is not worth a column of noise.
+        assert!(!detail.contains("os_arch"), "{detail}");
+        assert!(!detail.contains("remote"), "{detail}");
+    }
+
+    #[test]
+    fn non_default_settings_are_called_out() {
+        let mut m = meta();
+        m.platform = "any".to_string();
+        m.version = "go1.23".to_string();
+        m.remote = true;
+        let (_, detail) = describe(&entry(Some(m)));
+        assert!(detail.contains("platform=any"), "{detail}");
+        assert!(detail.contains("v=go1.23"), "{detail}");
+        assert!(detail.contains("remote"), "{detail}");
+    }
+
+    /// An orphan is occupying disk. Hiding it would make `ls` disagree with `du`
+    /// and leave no way to find what to remove.
+    #[test]
+    fn an_unreadable_slot_is_still_named_by_its_id() {
+        let (name, _) = describe(&entry(None));
+        assert!(name.contains("abc123"), "{name}");
+        assert!(name.contains("unknown"), "{name}");
+    }
+}

--- a/src/main.rs
+++ b/src/main.rs
@@ -137,6 +137,12 @@ fn main() -> ExitCode {
     // did not anticipate — you would have to have passed a flag on the run that
     // is already stuck. Costs one `signal(2)` at startup; the file is opened
     // lazily inside the handler.
+    // Applied before any engine is constructed, since it decides whether the
+    // engine resolves scratch caches at all.
+    heph::commands::bootstrap::set_scratch_enabled(
+        cli.global.scratch == heph::commands::ScratchMode::On,
+    );
+
     diag::install(cli.global.diag_backtrace);
 
     // When `--pprof-cpu` is set, start the sampler + `SIGUSR2` dump watcher.


### PR DESCRIPTION
Fifth of the scratch stack (#408), on top of #431. The first four made scratch
caches work; **nothing bounded them**. A scratch is keyed by a declaration rather
than an input hash, so there is no `hashin` to age out and no `cache.history` to
trim against — it grows until something removes it, and until now nothing did.

```
heph tool scratch ls          # what is there, largest first
heph tool scratch path ADDR   # where it is
heph tool scratch rm ADDR     # drop one; --all drops every one
heph tool clean --scratch      # same, for someone already in `clean`
heph tool gc --scratch-max-size 50GiB --scratch-max-age-days 30
```

## The sweep lives in `heph tool gc`

Not behind a flag nobody sets. A GC that reclaimed target revisions and left the
one part of the store that grows without limit would be misleading about what it
does.

**Whole caches, never partial trims.** heph cannot know which of a foreign tool's
entries are hot, and guessing would quietly degrade a cache while claiming to
manage it. Dropping is honest and self-correcting: the next build repopulates what
it actually needs. And removing a scratch is *always* safe — a target's outputs are
identical whether its scratch is warm, cold or absent, so it costs time and
nothing else.

## The store describes itself

Each slot records what it came from in a small `slot.meta`. Without it a listing
could only print hashes, or would have to resolve the whole graph to map them back.
100 bytes per slot buys a store that stays listable and removable after the target
that made it is deleted or renamed — the same property `heph tool clean` already
has for addr-only selections, and for the same reason.

Two consequences worth checking:

- A slot whose meta is unreadable is **still listed** (it is occupying disk) and
  **still removable by `--all`**, but is never matched by name — it cannot be
  named, so naming must not silently miss it and clearing everything must not
  silently leave it.
- Sizes are measured **per scope**, so they mean the cache's own footprint and not
  that plus heph's bookkeeping. A size that silently included the meta would make
  every eviction threshold slightly wrong in a way nobody could see. (This came out
  of a test: the sweep evicted two slots where one should have sufficed.)

## `--scratch=off`, and why it forces a rebuild

`off` runs every target with its caches absent — the audit mode for the contract
the whole feature rests on. The *whole path* is skipped, not merely
mounted-and-empty: no spec resolution, no lock, no directory. That is what makes
it a faithful "as if absent".

**It implies `--force`, and has to.** Scratch deliberately never reaches `hashin`,
so without a rebuild an off-run is a plain cache hit that replays the result built
*with* a warm cache — the audit would pass by reading exactly the answer it is
supposed to re-derive. I found this because the first version of the test failed:
it asserted `absent` and got `mounted`.

The vacuous case is now asserted directly, before the forced one, so the
implication cannot be quietly simplified away later.

This changes no cache key: the audit run writes its revision under the same one, so
a divergence surfaces as a rebuilt-hashout mismatch rather than as two unrelated
entries.

`--scratch` is a build flag next to `--force` rather than a `heph tool scratch`
subcommand, because it modifies a build rather than being one.

## Compatibility

Additive. New subcommand, two new `gc` flags, one new `clean` flag, one new global
flag defaulting to today's behaviour. No proto change, no ABI bump, no change to
any existing cache entry or on-disk layout.

## Tests

11 store unit tests, 7 CLI unit tests, 2 e2e. The e2e pair covers the audit mode
(including the vacuity trap) and a build creating a slot that is then listed and
removed by name with no BUILD files read.


---

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>