### PR TITLE
feat(scratch): publish a cache to the remote, pick one up cold

### DIFF
--- a/crates/e2e/tests/scratch.rs
+++ b/crates/e2e/tests/scratch.rs
@@ -778,3 +778,256 @@ async fn the_store_lists_and_reclaims_what_a_build_created() -> anyhow::Result<(
     assert!(ws.engine.scratch_slots()?.is_empty());
     Ok(())
 }
+
+// ---------------------------------------------------------------------------
+// The remote lineage: publish here, pick it up cold there.
+// ---------------------------------------------------------------------------
+
+/// Build an engine rooted at `root` with one read+write remote cache and an
+/// explicit lineage policy — a stand-in for one CI runner.
+fn remote_engine(
+    root: &std::path::Path,
+    remote_uri: &str,
+    scope: &str,
+    fallbacks: &[&str],
+) -> Arc<heph::engine::Engine> {
+    use heph::engine::{Config, Engine, RemoteCacheDef, ScratchOptions};
+    let mut e = Engine::new(Config {
+        root: root.to_path_buf(),
+        home_dir: std::path::PathBuf::new(),
+        remote_caches: vec![RemoteCacheDef {
+            name: "shared".to_string(),
+            uri: remote_uri.to_string(),
+            read: true,
+            write: true,
+            concurrency: 10,
+            endpoint: None,
+            region: None,
+        }],
+        scratch: ScratchOptions {
+            enabled: true,
+            scope: scope.to_string(),
+            restore_scopes: fallbacks.iter().map(|s| s.to_string()).collect(),
+            seed_on_fork: true,
+        },
+        ..Default::default()
+    })
+    .expect("engine");
+    e.register_provider(|init| {
+        Box::new(heph::pluginbuildfile::Provider::new(
+            init.root.to_path_buf(),
+            init.runtime.clone(),
+        ))
+    })
+    .expect("provider");
+    e.register_managed_driver(|_| Box::new(heph::pluginexec::Driver::new_bash()))
+        .expect("bash driver");
+    Arc::new(e)
+}
+
+const REMOTE_DECL: &str = r#"target(name = "c", driver = "scratch", path = ".cache/x", env = "C",
+       remote = True)"#;
+
+fn remote_target(marker: &str) -> String {
+    format!(
+        r#"target(name = "a", driver = "bash", out = "o.txt", scratch = ["//build:c"],
+       run = ["cat \"$C/marker\" > $OUT || echo cold > $OUT", "echo {marker} > \"$C/marker\""])"#
+    )
+}
+
+async fn build(engine: &Arc<heph::engine::Engine>) -> anyhow::Result<String> {
+    let addr = heph::htaddr::parse_addr("//app:a")?;
+    let opts = ResultOptions::default();
+    let r = Arc::clone(engine)
+        .result_addr(engine.new_state(), &addr, OutputMatcher::All, &opts)
+        .await?;
+    let out = common::artifact_string(&r).trim().to_string();
+    drop(r);
+    Ok(out)
+}
+
+/// The CI story end to end: one machine builds and publishes; a second machine,
+/// cold in every lineage, picks the snapshot up automatically and sees the first
+/// machine's work.
+///
+/// Publishing is explicit; picking up is not. That asymmetry is the design —
+/// a pull is read-only, cheap, and degrades to a cold build, so it is safe to do
+/// on its own. A push is none of those.
+#[tokio::test]
+async fn a_published_snapshot_warms_a_cold_machine() -> anyhow::Result<()> {
+    let remote = tempfile::tempdir()?;
+    let uri = format!("file://{}", remote.path().display());
+
+    // Machine one: build, then publish.
+    let a = tempfile::tempdir()?;
+    std::fs::create_dir_all(a.path().join("build"))?;
+    std::fs::create_dir_all(a.path().join("app"))?;
+    std::fs::write(a.path().join("build").join("BUILD"), REMOTE_DECL)?;
+    std::fs::write(
+        a.path().join("app").join("BUILD"),
+        remote_target("machine-one"),
+    )?;
+
+    let e1 = remote_engine(a.path(), &uri, "master", &[]);
+    assert_eq!(build(&e1).await?, "cold", "the first machine starts cold");
+
+    let slots = e1.scratch_slots()?;
+    assert_eq!(slots.len(), 1);
+    let slot = slots[0].slot.clone();
+    let dir = heph::engine::scratch_remote::scope_head_dir(&e1.home, &slot, "master");
+    let (generation, bytes) = e1
+        .scratch_push(&slot, "master", &dir, None, "run-1")
+        .await?;
+    assert_eq!(generation, 0, "a first publish starts the lineage at 0");
+    assert!(bytes > 0);
+
+    // Machine two: a different root, nothing local at all.
+    let b = tempfile::tempdir()?;
+    std::fs::create_dir_all(b.path().join("build"))?;
+    std::fs::create_dir_all(b.path().join("app"))?;
+    std::fs::write(b.path().join("build").join("BUILD"), REMOTE_DECL)?;
+    std::fs::write(
+        b.path().join("app").join("BUILD"),
+        remote_target("machine-two"),
+    )?;
+
+    let e2 = remote_engine(b.path(), &uri, "master", &[]);
+    assert_eq!(
+        build(&e2).await?,
+        "machine-one",
+        "a cold machine must pick up the published snapshot without being asked"
+    );
+    Ok(())
+}
+
+/// Generations advance at publish time and are `parent + 1` within a lineage, so
+/// a later publish wins — and republishing identical contents adds nothing.
+#[tokio::test]
+async fn publishing_advances_the_lineage_and_skips_unchanged_contents() -> anyhow::Result<()> {
+    let remote = tempfile::tempdir()?;
+    let uri = format!("file://{}", remote.path().display());
+    let ws = tempfile::tempdir()?;
+    std::fs::create_dir_all(ws.path().join("build"))?;
+    std::fs::create_dir_all(ws.path().join("app"))?;
+    std::fs::write(ws.path().join("build").join("BUILD"), REMOTE_DECL)?;
+    std::fs::write(ws.path().join("app").join("BUILD"), remote_target("one"))?;
+
+    let e = remote_engine(ws.path(), &uri, "master", &[]);
+    build(&e).await?;
+    let slot = e.scratch_slots()?[0].slot.clone();
+    let dir = heph::engine::scratch_remote::scope_head_dir(&e.home, &slot, "master");
+
+    let (g0, _) = e.scratch_push(&slot, "master", &dir, None, "r1").await?;
+    assert_eq!(g0, 0);
+
+    // Nothing changed on disk, so there is nothing to say. Publishing anyway
+    // would grow the chain with every no-op CI run.
+    let parent = heph::engine::scratch_remote::read_local_meta(&e.home, &slot, "master");
+    let (g_same, bytes) = e
+        .scratch_push(&slot, "master", &dir, parent.as_ref(), "r2")
+        .await?;
+    assert_eq!(
+        (g_same, bytes),
+        (0, 0),
+        "unchanged contents must not publish"
+    );
+
+    // Change the contents, and the lineage advances.
+    std::fs::write(dir.join("marker"), b"two\n")?;
+    let parent = heph::engine::scratch_remote::read_local_meta(&e.home, &slot, "master");
+    let (g1, _) = e
+        .scratch_push(&slot, "master", &dir, parent.as_ref(), "r3")
+        .await?;
+    assert_eq!(g1, 1, "a changed publish is parent + 1");
+
+    let head = e
+        .scratch_remote_head(&slot, "master", &[])
+        .await
+        .expect("a head");
+    assert_eq!(head.meta.generation, 1, "the newest generation wins");
+    Ok(())
+}
+
+/// Reads fall back across branches; writes never do. A PR job picks up `master`'s
+/// snapshot and publishes into its own lineage, leaving `master`'s head where it
+/// was — the isolation that makes this safe on untrusted CI.
+#[tokio::test]
+async fn a_branch_reads_from_master_and_publishes_to_itself() -> anyhow::Result<()> {
+    let remote = tempfile::tempdir()?;
+    let uri = format!("file://{}", remote.path().display());
+    let mk = |marker: &str| -> anyhow::Result<tempfile::TempDir> {
+        let d = tempfile::tempdir()?;
+        std::fs::create_dir_all(d.path().join("build"))?;
+        std::fs::create_dir_all(d.path().join("app"))?;
+        std::fs::write(d.path().join("build").join("BUILD"), REMOTE_DECL)?;
+        std::fs::write(d.path().join("app").join("BUILD"), remote_target(marker))?;
+        Ok(d)
+    };
+
+    // `master` publishes.
+    let m = mk("from-master")?;
+    let em = remote_engine(m.path(), &uri, "master", &[]);
+    build(&em).await?;
+    let slot = em.scratch_slots()?[0].slot.clone();
+    let mdir = heph::engine::scratch_remote::scope_head_dir(&em.home, &slot, "master");
+    em.scratch_push(&slot, "master", &mdir, None, "master-run")
+        .await?;
+
+    // A PR runner, cold, on `pr-1` with `master` as its fallback.
+    let p = mk("from-pr")?;
+    let ep = remote_engine(p.path(), &uri, "pr-1", &["master"]);
+    assert_eq!(
+        build(&ep).await?,
+        "from-master",
+        "a branch must pick up its base's snapshot"
+    );
+
+    let pdir = heph::engine::scratch_remote::scope_head_dir(&ep.home, &slot, "pr-1");
+    let parent = heph::engine::scratch_remote::read_local_meta(&ep.home, &slot, "pr-1");
+    ep.scratch_push(&slot, "pr-1", &pdir, parent.as_ref(), "pr-run")
+        .await?;
+
+    // `master`'s lineage is untouched: still generation 0, still its own bytes.
+    let master_head = em
+        .scratch_remote_head(&slot, "master", &[])
+        .await
+        .expect("master head");
+    assert_eq!(master_head.meta.scope, "master");
+    assert_eq!(
+        master_head.meta.generation, 0,
+        "a PR publish must not advance master's lineage"
+    );
+
+    // And the branch has a lineage of its own.
+    let pr_head = ep
+        .scratch_remote_head(&slot, "pr-1", &[])
+        .await
+        .expect("pr head");
+    assert_eq!(pr_head.meta.scope, "pr-1");
+    Ok(())
+}
+
+/// A remote that is unreachable is a cold build, never a failed one — the scratch
+/// contract in its most load-bearing form.
+#[tokio::test]
+async fn an_unreachable_remote_degrades_to_a_cold_build() -> anyhow::Result<()> {
+    let ws = tempfile::tempdir()?;
+    std::fs::create_dir_all(ws.path().join("build"))?;
+    std::fs::create_dir_all(ws.path().join("app"))?;
+    std::fs::write(ws.path().join("build").join("BUILD"), REMOTE_DECL)?;
+    std::fs::write(ws.path().join("app").join("BUILD"), remote_target("x"))?;
+
+    // A path that does not exist and cannot be created.
+    let e = remote_engine(
+        ws.path(),
+        "file:///nonexistent/heph-scratch-test",
+        "master",
+        &[],
+    );
+    assert_eq!(
+        build(&e).await?,
+        "cold",
+        "a dead remote must not fail a build"
+    );
+    Ok(())
+}

--- a/crates/engine/src/engine/engine.rs
+++ b/crates/engine/src/engine/engine.rs
@@ -561,6 +561,16 @@ impl Engine {
     }
 
     /// The per-addr execute-phase lock.
+    /// The scratch lineage this run writes to.
+    pub fn scratch_scope(&self) -> &str {
+        &self.cfg.scratch.scope
+    }
+
+    /// Lineages this run may read from when its own has nothing.
+    pub fn scratch_restore_scopes(&self) -> &[String] {
+        &self.cfg.scratch.restore_scopes
+    }
+
     pub fn result_lock(&self) -> &ResultLock {
         &self.result_lock
     }

--- a/crates/engine/src/engine/mod.rs
+++ b/crates/engine/src/engine/mod.rs
@@ -91,6 +91,7 @@ pub mod matcher_target;
 mod meta;
 pub mod sandbox_cleaner;
 pub mod scratch;
+pub mod scratch_remote;
 pub mod scratch_store;
 pub mod validate;
 pub mod worker_pool;

--- a/crates/engine/src/engine/remote_cache.rs
+++ b/crates/engine/src/engine/remote_cache.rs
@@ -941,6 +941,31 @@ impl RemoteCacheSet {
         })
     }
 
+    /// Readable caches, fastest-first, as `(name, backend)`.
+    ///
+    /// Exposed for the scratch lineage, which lives in its own key namespace
+    /// (`scratch/v1/…`) and cannot go through the revision/manifest paths above —
+    /// a scratch is keyed by a declaration and a branch, not by an input hash, so
+    /// none of the addr/hashin plumbing applies to it.
+    pub async fn readable_backends(&self) -> Vec<(String, Arc<dyn RemoteCacheBackend>)> {
+        let order = self.read_order().await;
+        order
+            .iter()
+            .filter_map(|&i| self.caches.get(i))
+            .map(|c| (c.def.name.clone(), Arc::clone(&c.backend)))
+            .collect()
+    }
+
+    /// Writable caches, as `(name, backend)`. Same rationale as
+    /// [`readable_backends`](Self::readable_backends).
+    pub fn writable_backends(&self) -> Vec<(String, Arc<dyn RemoteCacheBackend>)> {
+        self.caches
+            .iter()
+            .filter(|c| c.def.write)
+            .map(|c| (c.def.name.clone(), Arc::clone(&c.backend)))
+            .collect()
+    }
+
     pub fn is_empty(&self) -> bool {
         self.caches.is_empty()
     }

--- a/crates/engine/src/engine/scratch.rs
+++ b/crates/engine/src/engine/scratch.rs
@@ -360,6 +360,19 @@ impl Engine {
                 .await
                 .with_context(|| format!("create scratch dir {dir:?} for {}", r.addr))?;
 
+            // Still cold after the local fallbacks? Try the remote lineage. This
+            // is the CI case and the reason `remote` exists: a fresh runner is
+            // cold in every lineage, so without it every job starts from nothing.
+            //
+            // Pull is automatic — and safe to be, because it is read-only, costs
+            // one list plus one fetch, and every way it can fail degrades to a
+            // cold build. Publishing is the opposite on all three counts and is
+            // therefore a command (`heph tool scratch push`), never a side effect
+            // of building.
+            if r.def.remote {
+                self.pull_if_cold(&slot, &dir, &r.addr).await;
+            }
+
             // Record what this slot came from, so the store can describe itself
             // without resolving the graph (see `scratch_store`). Idempotent and
             // best-effort: it is a diagnostic, not part of the build.
@@ -386,6 +399,63 @@ impl Engine {
             });
         }
         Ok((mounts, guards))
+    }
+}
+
+impl Engine {
+    /// Seed a locally-cold lineage from the remote, if there is anything to seed
+    /// from.
+    ///
+    /// Never fails a build. A remote that is down, a head that will not decode, a
+    /// transfer that dies halfway — every one of them means "cold", which by the
+    /// scratch contract is a slowdown and nothing more. A partial unpack is
+    /// cleared rather than left for the next run to mistake for a warm cache.
+    async fn pull_if_cold(&self, slot: &str, dir: &Path, addr: &Addr) {
+        // Unreadable counts as cold: if the directory cannot be listed, nothing
+        // useful is in it either way.
+        let cold = std::fs::read_dir(dir).map_or(true, |mut d| d.next().is_none());
+        if !cold {
+            return;
+        }
+        let opts = &self.cfg.scratch;
+        let Some(head) = self
+            .scratch_remote_head(slot, &opts.scope, &opts.restore_scopes)
+            .await
+        else {
+            return;
+        };
+
+        match self.scratch_pull(&head, dir).await {
+            Ok(bytes) => {
+                // A cache whose entries embed absolute paths restores fine at a
+                // different path and is then inert — present, and useless, which
+                // looks exactly like a hit. Naming both paths is what makes that
+                // diagnosable rather than mysterious.
+                if head.meta.produced_at != dir.to_string_lossy() {
+                    tracing::debug!(
+                        %addr, produced_at = %head.meta.produced_at, restored_at = %dir.display(),
+                        "scratch snapshot restored at a different path than it was produced at; \
+                         a path-sensitive cache will be inert",
+                    );
+                }
+                tracing::debug!(
+                    %addr, slot, scope = %head.meta.scope, generation = head.meta.generation, bytes,
+                    "pulled scratch snapshot",
+                );
+                crate::engine::scratch_remote::write_local_meta(
+                    &self.home,
+                    slot,
+                    &opts.scope,
+                    &head.meta,
+                );
+            }
+            Err(err) => {
+                tracing::debug!(%addr, slot, error = %err, "could not pull scratch snapshot");
+                let dead = dir.to_path_buf();
+                drop(hcore::blocking::run(move || std::fs::remove_dir_all(&dead)).await);
+                drop(std::fs::create_dir_all(dir));
+            }
+        }
     }
 }
 

--- a/crates/engine/src/engine/scratch_remote.rs
+++ b/crates/engine/src/engine/scratch_remote.rs
@@ -1,0 +1,568 @@
+//! The remote scratch lineage: publishing a cache and picking one up.
+//!
+//! This is what makes scratch worth anything in CI, where every runner starts
+//! cold. A slot's contents are published as immutable snapshots under
+//! `scratch/v1/<slot>/<scope>/<gen>.<hash>.tar.gz`, and a cold runner picks the
+//! newest one for its branch — falling back to the branch it forked from.
+//!
+//! # Why "latest" is not a pointer
+//!
+//! The tempting design is a mutable `HEAD` object naming the newest snapshot. It
+//! is wrong here twice over, and the first reason is the one that matters:
+//!
+//! **One cache serves many branches at once.** A remote holds a live lineage for
+//! `master`, one for each open PR, one for each long-running branch — all
+//! advancing concurrently and all legitimately different. There is no single
+//! "latest" for a pointer to name. A pointer *per* branch models that and creates
+//! two new problems: an unbounded set of mutable objects, and no way to relate the
+//! heads that a cross-branch restore has to compare.
+//!
+//! **And the store could not maintain one safely anyway.** [`RemoteCacheBackend`]
+//! has `open_read`, `open_write`, `exists` and `list_names` — no compare-and-swap
+//! and no delete. So even for a single branch, two jobs finishing together race,
+//! and the *loser* can be the one that finishes last: a job that started from an
+//! older cache would overwrite the pointer with older content. "Latest" would mean
+//! "written most recently", which is not the same as "descended from the most
+//! work".
+//!
+//! So entries are **immutable and ordering is carried in the key**. Resolution is
+//! a prefix list and a max: no mutation, no coordination, correct under concurrent
+//! writers, and it extends to many branches by listing more than one prefix.
+//!
+//! # Generations, not timestamps
+//!
+//! A snapshot records the generation it descends from, and a publish is
+//! `parent + 1`. That is deliberately not a clock. A slow runner that picked up
+//! generation 5 an hour ago and finishes now publishes 6, which correctly *loses*
+//! to a chain that has since reached 12 — a timestamp would have that backwards,
+//! and clock skew across runners makes it worse. Generations need no clock and no
+//! coordinator, only the parent each writer already picked up.
+//!
+//! Generations advance at **publish** time, not build time, which makes the model
+//! exactly git's: the local directory is a working tree, its meta records the
+//! parent it was last seeded from, and `heph tool scratch push` is the commit.
+
+use crate::engine::Engine;
+use crate::engine::remote_cache::RemoteCacheBackend;
+use crate::engine::scratch_store::store_root;
+use anyhow::Context as _;
+use borsh::{BorshDeserialize, BorshSerialize};
+use std::path::{Path, PathBuf};
+
+/// Key-layout version. Bumping it makes every older entry invisible rather than
+/// misread, which is the right failure for a cache.
+const KEY_PREFIX: &str = "scratch/v1";
+
+/// Payload-format version, independent of the key layout above: one covers where
+/// entries live, the other what is inside them.
+const SNAPSHOT_FORMAT: u32 = 1;
+
+/// What a published snapshot is, beside its bytes.
+///
+/// Small (a few hundred bytes) and fetched on its own, so resolving a head costs
+/// one list plus one tiny GET and never pulls a tarball to find out it is the
+/// wrong one.
+#[derive(Debug, Clone, PartialEq, Eq, BorshSerialize, BorshDeserialize)]
+pub struct SnapshotMeta {
+    pub format: u32,
+    /// Lineage this entry belongs to.
+    pub scope: String,
+    /// How far along that lineage.
+    pub generation: u64,
+    /// Lineage the entry descended from — the same scope in the ordinary case, a
+    /// different one on the first publish after a branch fork.
+    pub parent_scope: String,
+    /// Generation within `parent_scope` this descended from.
+    pub parent_generation: u64,
+    /// Uncompressed size, for reporting.
+    pub bytes: u64,
+    /// Producing heph version, for diagnosis.
+    pub heph_version: String,
+    /// Free-form producer id (`--producer`, typically a CI run id).
+    pub producer: String,
+    /// Hash of the packed bytes. Recorded locally so a re-publish of unchanged
+    /// contents can be skipped — the archive is deterministic (entries are
+    /// sorted), so identical contents hash identically.
+    pub content_hash: String,
+    /// Absolute path the snapshot was produced at.
+    ///
+    /// Recorded because a cache whose entries embed absolute paths — Go's action
+    /// IDs are the standing example — restores fine at a different path and is
+    /// then *inert*: present, and useless. That is the worst failure mode
+    /// available here, because it looks like a hit. Naming both paths in a log
+    /// line is what makes it diagnosable instead of mysterious.
+    pub produced_at: String,
+}
+
+/// A candidate head: its key stem, its meta, and which cache it came from.
+#[derive(Debug, Clone)]
+pub struct RemoteHead {
+    pub cache: String,
+    /// Key stem, i.e. everything before `.tar.gz` / `.meta`.
+    pub stem: String,
+    pub meta: SnapshotMeta,
+}
+
+fn scope_prefix(slot: &str, scope: &str) -> String {
+    format!(
+        "{KEY_PREFIX}/{slot}/{}/",
+        crate::engine::config::sanitize_scope(scope)
+    )
+}
+
+/// Order two entries in one lineage, best first.
+///
+/// `(generation, bytes, stem)` descending. Generation is the real order; `bytes`
+/// breaks a same-generation fork — two runners both publishing `parent + 1` — by
+/// preferring the fuller cache, which among two equally-derived ones has more
+/// warm entries and is the better inheritance. `stem` last makes the order total,
+/// so every reader converges on the same head instead of oscillating.
+fn better(a: &RemoteHead, b: &RemoteHead) -> std::cmp::Ordering {
+    b.meta
+        .generation
+        .cmp(&a.meta.generation)
+        .then(b.meta.bytes.cmp(&a.meta.bytes))
+        .then(a.stem.cmp(&b.stem))
+}
+
+/// Pack a directory tree into a gzipped tar.
+///
+/// Symlinks are archived as symlinks rather than followed, so a slot that has
+/// acquired a link out of the tree does not publish whatever it points at to
+/// every machine that picks the snapshot up.
+fn pack(dir: &Path) -> anyhow::Result<(Vec<u8>, u64)> {
+    let mut bytes = 0u64;
+    let buf = Vec::new();
+    let enc = flate2::write::GzEncoder::new(buf, flate2::Compression::default());
+    let mut tar = tar::Builder::new(enc);
+    tar.follow_symlinks(false);
+
+    append_dir(&mut tar, dir, Path::new(""), &mut bytes)?;
+    let enc = tar.into_inner().context("finish scratch tar")?;
+    Ok((enc.finish().context("finish scratch gzip")?, bytes))
+}
+
+/// Recursively append `dir`'s contents to `tar` under `rel`.
+///
+/// Hand-rolled rather than pulling in a directory walker: this needs symlinks
+/// archived *as symlinks* and everything that is not a file, dir or symlink
+/// skipped, which is a per-entry decision either way.
+fn append_dir<W: std::io::Write>(
+    tar: &mut tar::Builder<W>,
+    dir: &Path,
+    rel: &Path,
+    bytes: &mut u64,
+) -> anyhow::Result<()> {
+    let mut entries: Vec<_> = std::fs::read_dir(dir)
+        .with_context(|| format!("read scratch dir {dir:?}"))?
+        .collect::<Result<_, _>>()?;
+    // Sorted, so the same tree always produces the same archive — and therefore
+    // the same content hash, which is what makes a re-publish of unchanged
+    // contents recognizable rather than a fresh blob every time.
+    entries.sort_by_key(std::fs::DirEntry::file_name);
+
+    for entry in entries {
+        let path = entry.path();
+        let rel = rel.join(entry.file_name());
+        let ft = entry.file_type()?;
+        if ft.is_symlink() {
+            // Checked first: a symlink to a directory reports as a directory
+            // under `metadata`, and following it is exactly what must not happen.
+            let target = std::fs::read_link(&path)?;
+            let mut header = tar::Header::new_gnu();
+            header.set_entry_type(tar::EntryType::Symlink);
+            header.set_size(0);
+            header.set_mode(0o777);
+            tar.append_link(&mut header, &rel, target)?;
+        } else if ft.is_dir() {
+            tar.append_dir(&rel, &path)?;
+            append_dir(tar, &path, &rel, bytes)?;
+        } else if ft.is_file() {
+            let mut f = std::fs::File::open(&path)?;
+            *bytes += entry.metadata().map(|m| m.len()).unwrap_or(0);
+            tar.append_file(&rel, &mut f)?;
+        }
+        // Sockets, fifos and devices are skipped: they are not cache contents,
+        // and a tar member for one is meaningless where it is unpacked.
+    }
+    Ok(())
+}
+
+/// Unpack a gzipped tar into `dir`, which is created if absent.
+fn unpack(bytes: &[u8], dir: &Path) -> anyhow::Result<()> {
+    std::fs::create_dir_all(dir)?;
+    let dec = flate2::read::GzDecoder::new(bytes);
+    let mut archive = tar::Archive::new(dec);
+    archive.set_overwrite(true);
+    archive
+        .unpack(dir)
+        .with_context(|| format!("unpack scratch snapshot into {dir:?}"))
+}
+
+impl Engine {
+    /// The best head available for `slot`, trying `scope` then each fallback.
+    ///
+    /// First lineage with anything wins, then the best entry within it — mirroring
+    /// GitHub Actions' `key`-then-`restore-keys` precedence, so the behaviour is
+    /// one a CI author already knows. Generations are compared **only within a
+    /// scope**: `feat` at generation 40 is not "ahead of" `master` at 12, and
+    /// asking would be a category error.
+    pub async fn scratch_remote_head(
+        &self,
+        slot: &str,
+        scope: &str,
+        fallbacks: &[String],
+    ) -> Option<RemoteHead> {
+        let backends = self.remote_caches().readable_backends().await;
+        if backends.is_empty() {
+            return None;
+        }
+        let mut scopes = vec![scope.to_string()];
+        scopes.extend(fallbacks.iter().cloned());
+
+        for scope in scopes {
+            let mut best: Option<RemoteHead> = None;
+            for (name, backend) in &backends {
+                for head in heads_in(backend.as_ref(), name, slot, &scope).await {
+                    if best.as_ref().is_none_or(|b| better(&head, b).is_lt()) {
+                        best = Some(head);
+                    }
+                }
+            }
+            if best.is_some() {
+                return best;
+            }
+        }
+        None
+    }
+
+    /// Fetch a head's snapshot and unpack it into `dir`.
+    pub async fn scratch_pull(&self, head: &RemoteHead, dir: &Path) -> anyhow::Result<u64> {
+        let backends = self.remote_caches().readable_backends().await;
+        let (_, backend) = backends
+            .iter()
+            .find(|(n, _)| *n == head.cache)
+            .ok_or_else(|| anyhow::anyhow!("remote cache `{}` is gone", head.cache))?;
+
+        let key = format!("{}.tar.gz", head.stem);
+        let mut reader = backend
+            .open_read(&key)
+            .await
+            .with_context(|| format!("read scratch snapshot {key}"))?
+            .ok_or_else(|| anyhow::anyhow!("scratch snapshot {key} vanished"))?;
+
+        let mut bytes = Vec::new();
+        tokio::io::AsyncReadExt::read_to_end(&mut reader, &mut bytes)
+            .await
+            .with_context(|| format!("download scratch snapshot {key}"))?;
+
+        let dir = dir.to_path_buf();
+        let n = bytes.len() as u64;
+        hcore::blocking::run(move || unpack(&bytes, &dir).map_err(std::io::Error::other))
+            .await
+            .context("unpack scratch snapshot")?;
+        Ok(n)
+    }
+
+    /// Publish `dir` as the next generation of `scope`'s lineage.
+    ///
+    /// Writes into `scope` and **never** into a fallback, even the one the
+    /// directory was seeded from. That is the isolation: a PR job cannot advance
+    /// the lineage its base builds from.
+    pub async fn scratch_push(
+        &self,
+        slot: &str,
+        scope: &str,
+        dir: &Path,
+        parent: Option<&SnapshotMeta>,
+        producer: &str,
+    ) -> anyhow::Result<(u64, u64)> {
+        let backends = self.remote_caches().writable_backends();
+        if backends.is_empty() {
+            anyhow::bail!("no writable remote cache is configured");
+        }
+
+        let d = dir.to_path_buf();
+        let (blob, bytes) =
+            hcore::blocking::run(move || pack(&d).map_err(std::io::Error::other)).await?;
+
+        // `parent + 1` within this scope. A first publish — or one whose parent
+        // came from another lineage — starts this scope at 0, because a
+        // generation only means anything relative to the lineage it is in.
+        let generation = match parent {
+            Some(p) if p.scope == scope => p.generation + 1,
+            _ => 0,
+        };
+        let meta = SnapshotMeta {
+            format: SNAPSHOT_FORMAT,
+            scope: scope.to_string(),
+            generation,
+            parent_scope: parent.map(|p| p.scope.clone()).unwrap_or_default(),
+            parent_generation: parent.map(|p| p.generation).unwrap_or(0),
+            bytes,
+            heph_version: hcore::version::current().to_string(),
+            producer: producer.to_string(),
+            content_hash: String::new(),
+            produced_at: dir.to_string_lossy().into_owned(),
+        };
+
+        let hash = format!("{:016x}", xxhash_rust::xxh3::xxh3_64(&blob));
+        // Nothing to publish: this lineage already holds exactly these bytes.
+        // Skipping keeps a no-op CI run from adding a generation that says
+        // nothing, which would otherwise make the chain grow with every build.
+        if parent.is_some_and(|p| p.content_hash == hash && p.scope == scope) {
+            return Ok((parent.map(|p| p.generation).unwrap_or(0), 0));
+        }
+        let stem = format!("{}{:016x}.{hash}", scope_prefix(slot, scope), generation);
+        let meta = SnapshotMeta {
+            content_hash: hash.clone(),
+            ..meta
+        };
+        let meta_bytes = borsh::to_vec(&meta).context("encode scratch snapshot meta")?;
+
+        for (name, backend) in &backends {
+            // Payload first, meta last. A reader only ever discovers an entry via
+            // its meta, so a half-finished publish is invisible rather than a
+            // head pointing at bytes that are not there yet.
+            write_all(backend.as_ref(), &format!("{stem}.tar.gz"), &blob)
+                .await
+                .with_context(|| format!("upload scratch snapshot to `{name}`"))?;
+            write_all(backend.as_ref(), &format!("{stem}.meta"), &meta_bytes)
+                .await
+                .with_context(|| format!("upload scratch meta to `{name}`"))?;
+        }
+        // Recorded locally so the next publish knows its parent, and so an
+        // unchanged re-publish is recognized above.
+        write_local_meta(&self.home, slot, scope, &meta);
+        Ok((generation, blob.len() as u64))
+    }
+}
+
+async fn write_all(
+    backend: &dyn RemoteCacheBackend,
+    key: &str,
+    bytes: &[u8],
+) -> anyhow::Result<()> {
+    let mut w = backend.open_write(key).await?;
+    tokio::io::AsyncWriteExt::write_all(&mut w, bytes).await?;
+    tokio::io::AsyncWriteExt::shutdown(&mut w).await?;
+    Ok(())
+}
+
+/// Every readable head in one lineage of one cache.
+///
+/// A meta that will not decode, or one from a format this build does not know, is
+/// skipped rather than failing the listing: it is a cache, and one bad entry must
+/// not make the rest unreachable.
+async fn heads_in(
+    backend: &dyn RemoteCacheBackend,
+    cache: &str,
+    slot: &str,
+    scope: &str,
+) -> Vec<RemoteHead> {
+    let prefix = scope_prefix(slot, scope);
+    let Ok(names) = backend.list_names(&prefix).await else {
+        return Vec::new();
+    };
+    let mut out = Vec::new();
+    for name in names {
+        let Some(stem) = name.strip_suffix(".meta") else {
+            continue;
+        };
+        // `list_names` may return a bare name or a full key depending on backend;
+        // normalize to a full key so `open_read` finds it either way.
+        let stem = if stem.starts_with(KEY_PREFIX) {
+            stem.to_string()
+        } else {
+            format!("{prefix}{stem}")
+        };
+        let Ok(Some(mut r)) = backend.open_read(&format!("{stem}.meta")).await else {
+            continue;
+        };
+        let mut buf = Vec::new();
+        if tokio::io::AsyncReadExt::read_to_end(&mut r, &mut buf)
+            .await
+            .is_err()
+        {
+            continue;
+        }
+        let Ok(meta) = SnapshotMeta::try_from_slice(&buf) else {
+            continue;
+        };
+        if meta.format != SNAPSHOT_FORMAT {
+            continue;
+        }
+        out.push(RemoteHead {
+            cache: cache.to_string(),
+            stem,
+            meta,
+        });
+    }
+    out
+}
+
+/// The directory a lineage's contents live in. Re-exported here so the CLI has
+/// one place to ask for scratch paths.
+pub fn scope_head_dir(home: &Path, slot: &str, scope: &str) -> PathBuf {
+    crate::engine::scratch::scope_dir(home, slot, scope)
+}
+
+/// Where a slot's local lineage state is recorded.
+pub fn local_meta_path(home: &Path, slot: &str, scope: &str) -> PathBuf {
+    store_root(home)
+        .join(slot)
+        .join(crate::engine::config::sanitize_scope(scope))
+        .join("head.meta")
+}
+
+/// Read the snapshot a local lineage was last seeded from or published as.
+pub fn read_local_meta(home: &Path, slot: &str, scope: &str) -> Option<SnapshotMeta> {
+    let bytes = std::fs::read(local_meta_path(home, slot, scope)).ok()?;
+    let meta = SnapshotMeta::try_from_slice(&bytes).ok()?;
+    (meta.format == SNAPSHOT_FORMAT).then_some(meta)
+}
+
+/// Record what a local lineage descends from. Best-effort: losing it costs a
+/// generation reset, never a wrong build.
+pub fn write_local_meta(home: &Path, slot: &str, scope: &str, meta: &SnapshotMeta) {
+    let path = local_meta_path(home, slot, scope);
+    let write = || -> anyhow::Result<()> {
+        if let Some(parent) = path.parent() {
+            std::fs::create_dir_all(parent)?;
+        }
+        std::fs::write(&path, borsh::to_vec(meta)?)?;
+        Ok(())
+    };
+    if let Err(err) = write() {
+        tracing::debug!(slot, scope, error = %err, "recording scratch lineage meta");
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn meta(scope: &str, generation: u64, bytes: u64) -> SnapshotMeta {
+        SnapshotMeta {
+            format: SNAPSHOT_FORMAT,
+            scope: scope.to_string(),
+            generation,
+            parent_scope: scope.to_string(),
+            parent_generation: generation.saturating_sub(1),
+            bytes,
+            heph_version: "test".to_string(),
+            producer: String::new(),
+            content_hash: format!("h{generation}"),
+            produced_at: "/tmp".to_string(),
+        }
+    }
+
+    fn head(stem: &str, m: SnapshotMeta) -> RemoteHead {
+        RemoteHead {
+            cache: "c".to_string(),
+            stem: stem.to_string(),
+            meta: m,
+        }
+    }
+
+    #[test]
+    fn a_higher_generation_always_wins() {
+        let a = head("a", meta("m", 12, 1));
+        let b = head("b", meta("m", 11, 999_999));
+        assert!(better(&a, &b).is_lt(), "generation beats size");
+    }
+
+    /// A same-generation fork — two runners both publishing `parent + 1` — is
+    /// expected, not an error. The tie-break only has to be deterministic so every
+    /// reader converges; preferring the fuller cache makes it a useful choice too.
+    #[test]
+    fn a_same_generation_fork_prefers_the_fuller_cache() {
+        let a = head("a", meta("m", 12, 900));
+        let b = head("b", meta("m", 12, 100));
+        assert!(better(&a, &b).is_lt());
+    }
+
+    #[test]
+    fn the_order_is_total_so_readers_converge() {
+        let a = head("aaa", meta("m", 12, 100));
+        let b = head("bbb", meta("m", 12, 100));
+        assert!(better(&a, &b).is_lt());
+        assert!(better(&b, &a).is_gt());
+    }
+
+    /// Zero-padded generation in the key means lexicographic order *is* generation
+    /// order, so a listing can be sorted without fetching anything.
+    #[test]
+    fn keys_sort_by_generation_across_the_padding_width() {
+        let p = scope_prefix("slot", "master");
+        let k = |g: u64| format!("{p}{g:016x}.hash");
+        assert!(k(9) < k(10));
+        assert!(k(255) < k(256));
+        assert!(k(u32::MAX as u64) < k(u32::MAX as u64 + 1));
+    }
+
+    /// A branch name is one key component, or two branches collide the moment one
+    /// is a path prefix of another.
+    #[test]
+    fn a_branch_name_stays_one_key_component() {
+        let p = scope_prefix("slot", "feature/x");
+        assert_eq!(p, "scratch/v1/slot/feature_x/");
+        // The point: `feature/x` must not become two components, or it would
+        // collide with a branch literally called `x` under `feature`, and a
+        // prefix list for one would sweep up the other.
+        assert!(!p.contains("feature/x"), "{p}");
+        assert_eq!(
+            scope_prefix("slot", "feature/x").matches('/').count(),
+            scope_prefix("slot", "featurex").matches('/').count(),
+            "a slash in a branch name must not add a level"
+        );
+    }
+
+    #[test]
+    fn pack_and_unpack_round_trip_including_symlinks() {
+        let tmp = tempfile::tempdir().expect("tempdir");
+        let (src, dst) = (tmp.path().join("s"), tmp.path().join("d"));
+        std::fs::create_dir_all(src.join("sub")).expect("mkdir");
+        std::fs::write(src.join("sub").join("f"), b"contents").expect("write");
+        std::os::unix::fs::symlink("elsewhere", src.join("link")).expect("symlink");
+
+        let (blob, bytes) = pack(&src).expect("pack");
+        assert_eq!(bytes, 8);
+        unpack(&blob, &dst).expect("unpack");
+
+        assert_eq!(
+            std::fs::read(dst.join("sub").join("f")).expect("read"),
+            b"contents"
+        );
+        // A link must arrive as a link — following it on the way out would publish
+        // whatever it points at to every machine that picks the snapshot up.
+        let md = std::fs::symlink_metadata(dst.join("link")).expect("stat");
+        assert!(md.file_type().is_symlink());
+        assert_eq!(
+            std::fs::read_link(dst.join("link")).expect("readlink"),
+            Path::new("elsewhere")
+        );
+    }
+
+    #[test]
+    fn local_meta_round_trips_and_rejects_a_foreign_format() {
+        let tmp = tempfile::tempdir().expect("tempdir");
+        write_local_meta(tmp.path(), "s", "master", &meta("master", 3, 10));
+        assert_eq!(
+            read_local_meta(tmp.path(), "s", "master"),
+            Some(meta("master", 3, 10))
+        );
+
+        let mut future = meta("master", 4, 10);
+        future.format = SNAPSHOT_FORMAT + 1;
+        let p = local_meta_path(tmp.path(), "s", "master");
+        std::fs::write(&p, borsh::to_vec(&future).expect("ser")).expect("write");
+        assert_eq!(read_local_meta(tmp.path(), "s", "master"), None);
+    }
+
+    #[test]
+    fn an_absent_local_meta_is_none_rather_than_an_error() {
+        let tmp = tempfile::tempdir().expect("tempdir");
+        assert_eq!(read_local_meta(tmp.path(), "nope", "master"), None);
+    }
+}

--- a/src/commands/tool/scratch.rs
+++ b/src/commands/tool/scratch.rs
@@ -38,6 +38,45 @@ pub enum ScratchCommands {
         /// Address of the `scratch` target, e.g. `//build:gocache`.
         addr: String,
     },
+    /// Publish scratch caches to the remote
+    ///
+    /// The command CI runs as its last step. Publishing is **never** a side
+    /// effect of building: it is expensive, it mutates shared state, and whether
+    /// a given job's cache state deserves to become the branch's published head
+    /// is a CI-policy question — one answered far better by an `if:` condition in
+    /// a workflow than by a heuristic inside heph.
+    ///
+    /// Writes into the current branch's lineage and never into a fallback, even
+    /// the one the cache was seeded from. That isolation is what makes this safe
+    /// to enable on untrusted PR CI at all.
+    ///
+    /// Example: `heph tool scratch push --all --producer "$GITHUB_RUN_ID"`
+    Push {
+        /// Address of the `scratch` target to publish.
+        addr: Option<String>,
+        /// Publish every cache declared `remote = True`.
+        #[arg(long)]
+        all: bool,
+        /// Publish even when the contents are identical to what is already there.
+        #[arg(long)]
+        force: bool,
+        /// Free-form producer id recorded with the snapshot, e.g. a CI run id.
+        #[arg(long, default_value = "")]
+        producer: String,
+    },
+    /// Fetch scratch caches from the remote without building
+    ///
+    /// Builds do this on their own when a cache is cold, so this is for warming a
+    /// machine ahead of time, or recovering after a local cache went bad.
+    ///
+    /// Example: `heph tool scratch pull --all`
+    Pull {
+        /// Address of the `scratch` target to fetch.
+        addr: Option<String>,
+        /// Fetch every cache declared `remote = True`.
+        #[arg(long)]
+        all: bool,
+    },
     /// Delete scratch cache directories
     ///
     /// The remedy when a cache has gone bad: the next build starts cold and
@@ -65,6 +104,15 @@ impl ScratchArgs {
             ScratchCommands::Ls => bootstrap::block_on(ls())?,
             ScratchCommands::Path { addr } => bootstrap::block_on(path(addr))?,
             ScratchCommands::Rm { addr, all } => bootstrap::block_on(rm(addr.as_deref(), *all))?,
+            ScratchCommands::Push {
+                addr,
+                all,
+                force,
+                producer,
+            } => bootstrap::block_on(push(addr.as_deref(), *all, *force, producer.clone()))?,
+            ScratchCommands::Pull { addr, all } => {
+                bootstrap::block_on(pull(addr.as_deref(), *all))?
+            }
         }
     }
 }
@@ -179,6 +227,121 @@ async fn rm(addr: Option<&str>, all: bool) -> anyhow::Result<()> {
     Ok(())
 }
 
+/// Pick the slots a `push`/`pull` selection names.
+///
+/// A slot with no readable meta is never selected: it cannot be named, and it
+/// cannot say whether it is `remote` either, so publishing it would be a guess.
+fn select(
+    slots: Vec<crate::engine::scratch_store::SlotEntry>,
+    addr: Option<&str>,
+    all: bool,
+) -> anyhow::Result<Vec<crate::engine::scratch_store::SlotEntry>> {
+    if all == addr.is_some() {
+        anyhow::bail!("pass either an address or --all, not both or neither");
+    }
+    Ok(slots
+        .into_iter()
+        .filter(|s| match (&s.meta, addr) {
+            (Some(m), Some(want)) => m.addr == want,
+            // `--all` means every cache that opted into travelling, not every
+            // cache: a local-only one has nowhere to go.
+            (Some(m), None) => m.remote,
+            (None, _) => false,
+        })
+        .collect())
+}
+
+async fn push(addr: Option<&str>, all: bool, force: bool, producer: String) -> anyhow::Result<()> {
+    let (engine, _shutdown) = bootstrap::new_engine()?;
+    let selected = select(engine.scratch_slots()?, addr, all)?;
+    if selected.is_empty() {
+        println!("Nothing to publish.");
+        return Ok(());
+    }
+
+    let scope = engine.scratch_scope().to_string();
+    let mut failed = 0usize;
+    for slot in &selected {
+        let name = slot
+            .meta
+            .as_ref()
+            .map(|m| m.addr.clone())
+            .unwrap_or_else(|| slot.slot.clone());
+        let dir = crate::engine::scratch_remote::scope_head_dir(&engine.home, &slot.slot, &scope);
+        if !dir.is_dir() {
+            println!("{name}: nothing built in this lineage, skipped");
+            continue;
+        }
+        let parent =
+            crate::engine::scratch_remote::read_local_meta(&engine.home, &slot.slot, &scope);
+        let parent = if force { None } else { parent };
+        match engine
+            .scratch_push(&slot.slot, &scope, &dir, parent.as_ref(), &producer)
+            .await
+        {
+            Ok((_, 0)) => println!("{name}: unchanged, skipped"),
+            Ok((generation, bytes)) => {
+                println!("{name}: published generation {generation} ({bytes} bytes)")
+            }
+            Err(err) => {
+                // Reported per slot and counted, rather than aborting: one
+                // unpublishable cache should not silently drop the rest.
+                println!("{name}: FAILED — {err:#}");
+                failed += 1;
+            }
+        }
+    }
+    if failed > 0 {
+        anyhow::bail!("{failed} scratch cache(s) failed to publish");
+    }
+    Ok(())
+}
+
+async fn pull(addr: Option<&str>, all: bool) -> anyhow::Result<()> {
+    let (engine, _shutdown) = bootstrap::new_engine()?;
+    let selected = select(engine.scratch_slots()?, addr, all)?;
+    if selected.is_empty() {
+        println!(
+            "Nothing to fetch. A cache must have been built at least once, and declared `remote = True`."
+        );
+        return Ok(());
+    }
+
+    let scope = engine.scratch_scope().to_string();
+    let fallbacks = engine.scratch_restore_scopes().to_vec();
+    for slot in &selected {
+        let name = slot
+            .meta
+            .as_ref()
+            .map(|m| m.addr.clone())
+            .unwrap_or_else(|| slot.slot.clone());
+        let Some(head) = engine
+            .scratch_remote_head(&slot.slot, &scope, &fallbacks)
+            .await
+        else {
+            println!("{name}: nothing published for this branch");
+            continue;
+        };
+        let dir = crate::engine::scratch_remote::scope_head_dir(&engine.home, &slot.slot, &scope);
+        match engine.scratch_pull(&head, &dir).await {
+            Ok(bytes) => {
+                crate::engine::scratch_remote::write_local_meta(
+                    &engine.home,
+                    &slot.slot,
+                    &scope,
+                    &head.meta,
+                );
+                println!(
+                    "{name}: fetched generation {} from `{}` ({bytes} bytes)",
+                    head.meta.generation, head.meta.scope
+                );
+            }
+            Err(err) => println!("{name}: FAILED — {err:#}"),
+        }
+    }
+    Ok(())
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -238,6 +401,61 @@ mod tests {
         assert!(detail.contains("platform=any"), "{detail}");
         assert!(detail.contains("v=go1.23"), "{detail}");
         assert!(detail.contains("remote"), "{detail}");
+    }
+
+    fn slot(addr: &str, remote: bool) -> crate::engine::scratch_store::SlotEntry {
+        let mut m = meta();
+        m.addr = addr.to_string();
+        m.remote = remote;
+        crate::engine::scratch_store::SlotEntry {
+            slot: addr.replace(['/', ':'], "_"),
+            meta: Some(m),
+            scopes: vec!["_".to_string()],
+            bytes: 0,
+            last_used: None,
+        }
+    }
+
+    /// `--all` means every cache that opted into travelling, not every cache: a
+    /// local-only one has nowhere to go.
+    #[test]
+    fn select_all_takes_only_remote_slots() {
+        let slots = vec![slot("//a:remote", true), slot("//a:local", false)];
+        let got = select(slots, None, true).expect("select");
+        assert_eq!(got.len(), 1);
+        assert_eq!(got[0].meta.as_ref().expect("meta").addr, "//a:remote");
+    }
+
+    /// Naming a cache is an explicit instruction, so it is honoured even for one
+    /// that has not opted into `--all`.
+    #[test]
+    fn select_by_addr_finds_it_regardless_of_the_remote_flag() {
+        let slots = vec![slot("//a:local", false)];
+        assert_eq!(
+            select(slots, Some("//a:local"), false)
+                .expect("select")
+                .len(),
+            1
+        );
+    }
+
+    /// An unnameable slot cannot say whether it is `remote` either, so publishing
+    /// it would be a guess.
+    #[test]
+    fn select_never_picks_a_slot_with_no_meta() {
+        let slots = vec![entry(None)];
+        assert!(select(slots.clone(), None, true).expect("all").is_empty());
+        assert!(
+            select(slots, Some("//whatever:x"), false)
+                .expect("named")
+                .is_empty()
+        );
+    }
+
+    #[test]
+    fn select_refuses_an_ambiguous_selection() {
+        assert!(select(vec![], None, false).is_err(), "neither");
+        assert!(select(vec![], Some("//a:b"), true).is_err(), "both");
     }
 
     /// An orphan is occupying disk. Hiding it would make `ls` disagree with `du`


### PR DESCRIPTION
The point of the whole feature in CI, where every runner starts cold. A slot's
contents are published as immutable snapshots under
`scratch/v1/<slot>/<scope>/<gen>.<hash>.tar.gz`, and a cold runner picks up the
newest one for its branch — falling back to the branch it forked from.

    heph tool scratch push --all --producer "$GITHUB_RUN_ID"
    heph tool scratch pull --all      # builds do this on their own

## Pull is automatic, push is a command

A pull is read-only, costs one list plus one fetch, and every way it can fail —
no entry, remote down, corrupt meta, transfer dies halfway — degrades to a cold
build. So a build does it on its own.

A push is none of those. It is expensive, it mutates shared state, and whether a
given job's cache state deserves to become the branch's published head is a
CI-policy question — answered far better by an `if:` condition in a workflow than
by a heuristic inside heph. So it never happens as a side effect of building.

## Why "latest" is not a pointer

The tempting design is a mutable HEAD object naming the newest snapshot. It is
wrong twice over, and the structural reason is the one that matters: **one cache
serves many branches at once**. A remote holds a live lineage for master, one per
open PR, one per long-running branch, all advancing concurrently and all
legitimately different — there is no single "latest" for a pointer to name. A
pointer *per* branch models that and creates an unbounded set of mutable objects
with no way to relate the heads a cross-branch restore has to compare.

The store could not maintain one safely anyway: `RemoteCacheBackend` has
open_read/open_write/exists/list_names — no compare-and-swap and no delete. Even
for a single branch, two jobs finishing together race, and the loser can be the
one that finishes last, overwriting the pointer with older content.

So entries are immutable and ordering is carried in the key. Resolution is a
prefix list and a max: no mutation, no coordination, correct under concurrent
writers, and it extends to many branches by listing more than one prefix. The
generation is zero-padded hex and leads the key, so lexicographic order *is*
generation order and a listing sorts without fetching anything.

## Generations, not timestamps

A publish is `parent + 1` within its lineage. That is deliberately not a clock: a
slow runner that picked up generation 5 an hour ago and finishes now publishes 6,
which correctly loses to a chain that has since reached 12. A timestamp would
have that backwards, and clock skew across runners makes it worse.

A same-generation fork — two runners both publishing `parent + 1` — is expected,
not an error. The tie-break only has to be deterministic so every reader
converges; ordering by `(generation, bytes, key)` makes it a useful choice too,
preferring the fuller cache among two equally-derived ones.

Republishing identical contents is skipped. The archive is deterministic (entries
sorted), so unchanged contents hash identically, and without this a chain would
grow a generation on every no-op CI run.

## Isolation

Writes go to the current scope and never to a fallback, even the one the cache
was seeded from. A PR job picks up master's snapshot and publishes into its own
lineage, leaving master's head exactly where it was — asserted directly, since it
is what makes this safe to enable on untrusted PR CI.

Symlinks are archived as symlinks rather than followed, so a slot that acquired a
link out of the tree does not publish whatever it points at to every machine that
picks the snapshot up. A snapshot records the absolute path it was produced at,
because a cache whose entries embed paths restores fine elsewhere and is then
*inert* — present and useless, which looks exactly like a hit; the mismatch is
logged so it is diagnosable rather than mysterious.

Co-Authored-By: Claude Opus 5 (1M context) <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01FArWjycMDyWeSfHHtpgtoU

---

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>