### PR TITLE
feat(plugin-go): the shared golist GOCACHE becomes a declared scratch

### DIFF
--- a/crates/plugin-go-cdylib/src/lib.rs
+++ b/crates/plugin-go-cdylib/src/lib.rs
@@ -108,14 +108,13 @@ fn build(cfg: &[u8]) -> anyhow::Result<PluginComponents> {
     )?);
 
     let mut drivers = stabby::vec::Vec::new();
-    // The shared golist GOCACHE lives in the engine's home dir, next to the
-    // walker db and for the same reason: it is heph-owned scratch, not repo
-    // content, and a plugin is handed its writable locations rather than
-    // discovering them.
-    let golist: Arc<dyn ManagedDriver> = Arc::new(
-        GoGolistDriver::with_gocache_root(home.join("go-golist-gocache"))
-            .with_default_runner(go_runner.clone()),
-    );
+    // The shared golist GOCACHE is no longer this plugin's to place: it is a
+    // `scratch` target the provider declares, and the host resolves, locks and
+    // mounts it. So there is no writable root to hand in here — which is the
+    // point, since the plugin also stops owning the eviction, the locking and
+    // the visibility it never had.
+    let golist: Arc<dyn ManagedDriver> =
+        Arc::new(GoGolistDriver::new().with_default_runner(go_runner.clone()));
     drivers.push(NamedDriver {
         name: "go_golist".into(),
         driver: make_dyn_managed_driver(golist),

--- a/crates/plugin-go/src/plugingo/driver_golist.rs
+++ b/crates/plugin-go/src/plugingo/driver_golist.rs
@@ -28,11 +28,6 @@ use xxhash_rust::xxh3::Xxh3Default;
 const GOLIST_JSON_FIELDS: &str = "-json=Dir,ImportPath,Name,GoFiles,SFiles,HFiles,TestGoFiles,XTestGoFiles,EmbedPatterns,EmbedFiles,TestEmbedPatterns,TestEmbedFiles,XTestEmbedPatterns,XTestEmbedFiles,Imports,TestImports,XTestImports,Standard,Module,Match,Incomplete,Error";
 
 pub struct GoGolistDriver {
-    /// Resolves the `GOCACHE` each golist run uses — shared across sandboxes
-    /// when the engine handed us a home dir. See
-    /// [`crate::plugingo::golist_gocache`] for why sharing it is both sound and
-    /// the only thing that moves cold wall time.
-    gocache: crate::plugingo::golist_gocache::GolistGocache,
     /// Default exec runner for this driver's tool, from the plugin's `runner:`
     /// option in the config yaml. A target's own `runner` field overrides it,
     /// and `"local"` there opts back out. See [`crate::plugingo::runner`].
@@ -95,24 +90,8 @@ struct GoGolistSpec {
 }
 
 impl GoGolistDriver {
-    /// Sandbox-local `GOCACHE`, the pre-sharing behaviour. For in-process
-    /// constructions (tests, the e2e harness) that have no engine home dir to
-    /// share a cache through.
     pub fn new() -> Self {
         Self {
-            gocache: crate::plugingo::golist_gocache::GolistGocache::new(None),
-            default_runner: None,
-            host_go: Default::default(),
-        }
-    }
-
-    /// Share one `GOCACHE` per toolchain across golist sandboxes, under
-    /// `gocache_root` — a directory the caller owns and heph may write to (the
-    /// engine home dir). A plugin is handed its writable locations rather than
-    /// discovering them, so this is the only way sharing is turned on.
-    pub fn with_gocache_root(gocache_root: std::path::PathBuf) -> Self {
-        Self {
-            gocache: crate::plugingo::golist_gocache::GolistGocache::new(Some(gocache_root)),
             default_runner: None,
             host_go: Default::default(),
         }
@@ -348,6 +327,39 @@ impl ManagedDriver for GoGolistDriver {
         )?;
         dep_inputs.extend(runner_input);
 
+        // The shared `GOCACHE`, as a scratch reference. The engine resolves and
+        // locks the slot before this driver runs and hands the directory back on
+        // `RunRequest`, so nothing here creates or tears down a cache per
+        // sandbox — which is the only thing that ever moved cold wall time
+        // (`gocache`'s module docs have the numbers).
+        //
+        // `hashed: false, runtime: false`: it materializes no artifacts, and it
+        // must not touch this target's cache key, because a `go list` produces
+        // the same package metadata warm or cold.
+        let gocache_key = crate::plugingo::gocache::GocacheKey {
+            go_version: spec.go_version.clone(),
+            goos: spec.goos.clone(),
+            goarch: spec.goarch.clone(),
+            build_tags: spec.build_tags.clone(),
+            goexperiment: spec.goexperiment.clone(),
+            race: spec.race,
+        };
+        let gocache_input = Input {
+            r#ref: TargetAddr {
+                r#ref: gocache_key.addr(),
+                output: None,
+                filters: vec![],
+            },
+            mode: InputMode::Standard,
+            origin_id: format!("{}|0", hdriver_support::scratch::SCRATCH_ORIGIN_PREFIX),
+            annotations: std::collections::BTreeMap::from([(
+                hdriver_support::scratch::SCRATCH_ANNOTATION.to_string(),
+                "true".to_string(),
+            )]),
+            hashed: false,
+            runtime: false,
+        };
+
         let def = GoGolistDef {
             runner,
             import_path: spec.import_path,
@@ -400,7 +412,7 @@ impl ManagedDriver for GoGolistDriver {
                 addr: req.target_spec.addr.clone(),
                 labels: req.target_spec.labels.clone(),
                 raw_def: Arc::new(def),
-                inputs: dep_inputs,
+                inputs: dep_inputs.into_iter().chain([gocache_input]).collect(),
                 outputs,
                 support_files: vec![],
                 cache: CacheConfig::on(true),
@@ -441,23 +453,26 @@ impl ManagedDriver for GoGolistDriver {
             ctoken,
         )
         .await?;
-        // The build cache `go list` runs against. Shared across sandboxes per
-        // toolchain when the engine gave us a home dir, so the standard
-        // library's test metadata is derived once per repo instead of once per
-        // package — and, more to the point, so no cache is materialized and torn
-        // down inside each sandbox. The host GOCACHE is still never touched.
-        // See `golist_gocache` for why this is sound.
-        let gocache = self.gocache.resolve(
-            &crate::plugingo::golist_gocache::GocacheKey {
-                goroot: goroot.clone(),
-                goos: def.goos.clone(),
-                goarch: def.goarch.clone(),
-                build_tags: def.build_tags.clone(),
-                goexperiment: def.goexperiment.clone(),
-                race: def.race,
-            },
-            &req.sandbox_pkg_dir.join(".heph-gocache"),
-        )?;
+        // The build cache `go list` runs against, resolved and locked by the host
+        // from this target's scratch reference (see `gocache`). Shared across
+        // sandboxes, so the standard library's test metadata is derived once per
+        // repo instead of once per package — and, more to the point, so no cache
+        // is materialized and torn down inside each sandbox. The host GOCACHE is
+        // still never touched.
+        //
+        // A missing mount falls back to a sandbox-local directory rather than
+        // failing: an older host that does not carry scratch mounts on
+        // `RunRequest` still has to be able to run this driver, and a cold cache
+        // is slow, never wrong.
+        let gocache = match req.request.scratch.iter().find(|m| m.env == "GOCACHE") {
+            Some(mount) => mount.dir.clone(),
+            None => {
+                let local = req.sandbox_pkg_dir.join(".heph-gocache");
+                std::fs::create_dir_all(&local)
+                    .with_context(|| format!("create gocache dir {local:?}"))?;
+                local
+            }
+        };
 
         let env = golist_env(def, &goroot, &gocache, |n| std::env::var(n).ok());
 

--- a/crates/plugin-go/src/plugingo/gocache.rs
+++ b/crates/plugin-go/src/plugingo/gocache.rs
@@ -146,6 +146,12 @@ pub fn is_gocache_pkg(pkg: &str) -> bool {
 /// The factors are already in the addr, so `version` stays empty: the slot key
 /// folds the addr in, and duplicating the factors into `version` would only give
 /// two ways to say the same thing.
+///
+/// Note what is deliberately *not* in it: the host OS and arch. A Go build
+/// cache's entries depend on the **target** (`GOOS`/`GOARCH`) and the toolchain,
+/// both already in the addr — not on the machine that ran the compiler. Keying on
+/// the host would give a laptop cross-compiling to `linux/amd64` and a CI runner
+/// building it natively different slots for identical content.
 pub fn build_spec(addr: Addr) -> TargetSpec {
     let config: HashMap<String, Value> = HashMap::from([
         ("path".to_string(), Value::String(GOCACHE_MOUNT.to_string())),
@@ -154,10 +160,6 @@ pub fn build_spec(addr: Addr) -> TargetSpec {
         // is what `go build -p N` does — and serializing it would turn the win
         // above into a large loss.
         ("access".to_string(), Value::String("shared".to_string())),
-        // Entries are host-toolchain artifacts, so a cache from one host is inert
-        // on another. `os_arch` here is the *host*; the Go target platform is in
-        // the addr.
-        ("platform".to_string(), Value::String("os_arch".to_string())),
         // Local-only for now. Publishing a Go build cache is worth doing and is a
         // separate change with its own before/after: the contents are large, and
         // whether the transfer beats a cold `go list` is a measurement, not a
@@ -267,5 +269,20 @@ mod tests {
         // The factors live in the addr; duplicating them into `version` would be
         // two ways to say one thing.
         assert!(!spec.config.contains_key("version"));
+    }
+
+    /// The spec must survive the driver that will actually parse it.
+    ///
+    /// Asserting individual config keys, as the test above does, cannot catch a
+    /// key the driver does not accept — and a `scratch` declaration rejects
+    /// unknown fields, so emitting one is not a warning but a hard failure of
+    /// every Go target that references the cache. This plugin shipped exactly
+    /// that: it kept setting `platform` after the field was removed from the
+    /// declaration, and no unit test noticed because none of them parsed.
+    #[test]
+    fn the_spec_parses_as_a_declaration() {
+        let spec = build_spec(key().addr());
+        hbuiltins::pluginscratch::parse_declaration(&spec)
+            .unwrap_or_else(|e| panic!("the gocache spec must parse as a declaration: {e:#}"));
     }
 }

--- a/crates/plugin-go/src/plugingo/gocache.rs
+++ b/crates/plugin-go/src/plugingo/gocache.rs
@@ -1,0 +1,271 @@
+//! The `GOCACHE` Go tooling runs against, declared as a scratch cache.
+//!
+//! # Why this is not sandbox-local
+//!
+//! Each `_golist` target used to get its own empty `GOCACHE` inside its sandbox.
+//! That is the hermetic default, and it is expensive twice over:
+//!
+//! 1. `go list -e -test` must rebuild the standard library's *test* dependency
+//!    metadata from cold every time — ~0.35s of mostly-kernel work per package,
+//!    byte-for-byte identical for every package in the repo.
+//! 2. Populating and then tearing down that cache churns ~500 filesystem entries
+//!    per sandbox, and it is that churn — not CPU — that governs cold wall time.
+//!
+//! Measured on a 500-package corpus: 1945 `go list` invocations costing 778s of
+//! CPU (687s of it system time), against 15s for every `go tool compile`
+//! combined. Listing, not compiling, was the entire cold path.
+//!
+//! Point (2) is why pre-seeding a warm cache into each sandbox was not enough: it
+//! cut `go list` CPU by 60% and moved wall time by nothing at all (interleaved
+//! A/B: 217.3s vs 219.5s), because it merely swapped Go's compute for heph's
+//! `mkdir`/`link`/`unlink`. Only *not materializing a cache per sandbox* moves
+//! the number: 2.4x on the same corpus (205s -> 84s wall).
+//!
+//! # Why sharing it is sound
+//!
+//! Go's build cache is content-addressed and self-verifying: an entry is keyed by
+//! an action ID derived from the full input set (tool build ID, source content,
+//! flags), and re-checked on read. A hit is provably the same answer as a miss,
+//! and an entry that does not apply is simply not found. Nothing one run writes
+//! here can change what a *different* run computes — only how fast it computes
+//! it. That is what `access = "shared"` asserts, and why the concurrency Go's own
+//! `go build -p N` already relies on is safe here.
+//!
+//! # What replaced the hand-rolled version
+//!
+//! This used to be `golist_gocache.rs`: a directory under the engine home, keyed
+//! by a hand-written struct, with no lock, no eviction, no remote, no visibility,
+//! and available to exactly one driver. It is now an ordinary `scratch` target,
+//! which supplies all of those.
+//!
+//! One deliberate difference. The old key included the resolved **GOROOT path**,
+//! because Go's action IDs incorporate it. A scratch declaration is resolved
+//! before the driver runs, and GOROOT is not known until it has — so the path is
+//! gone from the key, and that is an improvement rather than a loss:
+//!
+//! * Under `gotool: "host"`, GOROOT is a function of the Go version, which *is*
+//!   in the key. Nothing changes.
+//! * Under a hermetic toolchain, the SDK stages at a **different absolute path in
+//!   every sandbox**, so the old key gave every sandbox its own slot and every
+//!   one of them fell back to cold. Dropping the path gives them one shared slot.
+//!
+//! That does not make a hermetic build's action IDs match across sandboxes — they
+//! still embed the staged GOROOT — so the win there is bounded until the SDK is
+//! staged at a stable path. It does mean the cache stops being fragmented for no
+//! reason.
+
+use hcore::htvalue::Value;
+use hmodel::htaddr::Addr;
+use hmodel::htpkg::PkgBuf;
+use hplugin::provider::TargetSpec;
+use std::collections::{BTreeMap, HashMap};
+
+/// Synthetic package holding the shared Go build caches.
+pub const GOCACHE_PKG: &str = "@heph/go/gocache";
+
+/// Target name within [`GOCACHE_PKG`].
+pub const GOCACHE_NAME: &str = "cache";
+
+/// Where the cache is mounted in a consuming sandbox.
+///
+/// Kept identical to the path the sandbox-local cache used, so a stale directory
+/// left by an older heph is simply overwritten by the mount rather than sitting
+/// beside it.
+const GOCACHE_MOUNT: &str = ".heph-gocache";
+
+/// Everything a `GOCACHE` entry can depend on that is known before the driver
+/// runs. Two runs sharing these can share a cache directory.
+///
+/// GOROOT is deliberately absent — see the module docs.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct GocacheKey {
+    /// Pinned Go release, or the host toolchain's version.
+    pub go_version: String,
+    pub goos: String,
+    pub goarch: String,
+    pub build_tags: Vec<String>,
+    pub goexperiment: Vec<String>,
+    /// Race builds see a different file set (`//go:build race`) and a different
+    /// import graph, so they get their own slot rather than churning the ordinary
+    /// one. Go's own cache would key the entries correctly either way; this keeps
+    /// the two working sets from evicting each other.
+    pub race: bool,
+}
+
+impl GocacheKey {
+    /// Addr args identifying this key.
+    ///
+    /// Readable rather than hashed, because they show up in `heph tool scratch
+    /// ls` and in any diagnostic naming the target — "which cache is this?" is a
+    /// question a hash cannot answer. The unbounded lists are joined, not
+    /// hashed, for the same reason; they are short in practice and a synthetic
+    /// addr has no length limit worth respecting over legibility.
+    fn args(&self) -> BTreeMap<String, String> {
+        let mut args = BTreeMap::from([
+            ("go".to_string(), self.go_version.clone()),
+            ("goos".to_string(), self.goos.clone()),
+            ("goarch".to_string(), self.goarch.clone()),
+        ]);
+        if !self.build_tags.is_empty() {
+            args.insert("tags".to_string(), self.build_tags.join("+"));
+        }
+        if !self.goexperiment.is_empty() {
+            args.insert("exp".to_string(), self.goexperiment.join("+"));
+        }
+        if self.race {
+            args.insert("race".to_string(), "1".to_string());
+        }
+        args
+    }
+
+    /// The scratch target this key resolves to.
+    ///
+    /// One addr per distinct key, and the engine keys a scratch slot on the addr —
+    /// so two runs agreeing on every factor share a directory, and two that
+    /// disagree on any of them do not.
+    pub fn addr(&self) -> Addr {
+        Addr::new(
+            PkgBuf::from(GOCACHE_PKG),
+            GOCACHE_NAME.to_string(),
+            self.args(),
+        )
+    }
+}
+
+/// True when `pkg` is the synthetic gocache package.
+///
+/// Matched before package decoding in `handle_get`, exactly as the toolchain is:
+/// there is no such directory on disk, and asking the filesystem about it would
+/// only produce a confusing "not found".
+pub fn is_gocache_pkg(pkg: &str) -> bool {
+    pkg == GOCACHE_PKG
+}
+
+/// Build the `scratch` target spec for a gocache addr.
+///
+/// The factors are already in the addr, so `version` stays empty: the slot key
+/// folds the addr in, and duplicating the factors into `version` would only give
+/// two ways to say the same thing.
+pub fn build_spec(addr: Addr) -> TargetSpec {
+    let config: HashMap<String, Value> = HashMap::from([
+        ("path".to_string(), Value::String(GOCACHE_MOUNT.to_string())),
+        ("env".to_string(), Value::String("GOCACHE".to_string())),
+        // Go's build cache is safe under concurrent access by construction — it
+        // is what `go build -p N` does — and serializing it would turn the win
+        // above into a large loss.
+        ("access".to_string(), Value::String("shared".to_string())),
+        // Entries are host-toolchain artifacts, so a cache from one host is inert
+        // on another. `os_arch` here is the *host*; the Go target platform is in
+        // the addr.
+        ("platform".to_string(), Value::String("os_arch".to_string())),
+        // Local-only for now. Publishing a Go build cache is worth doing and is a
+        // separate change with its own before/after: the contents are large, and
+        // whether the transfer beats a cold `go list` is a measurement, not a
+        // guess.
+        ("remote".to_string(), Value::Bool(false)),
+    ]);
+
+    TargetSpec {
+        addr,
+        driver: "scratch".to_string(),
+        config,
+        labels: vec!["go-gocache".to_string()],
+        ..Default::default()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn key() -> GocacheKey {
+        GocacheKey {
+            go_version: "1.27.0".to_string(),
+            goos: "linux".to_string(),
+            goarch: "amd64".to_string(),
+            build_tags: vec![],
+            goexperiment: vec![],
+            race: false,
+        }
+    }
+
+    #[test]
+    fn the_package_is_recognized_and_nothing_else_is() {
+        assert!(is_gocache_pkg(GOCACHE_PKG));
+        assert!(!is_gocache_pkg("@heph/go/toolchain/1.27.0"));
+        assert!(!is_gocache_pkg("@heph/go/gocache/nested"));
+        assert!(!is_gocache_pkg("mylib"));
+    }
+
+    /// Every factor must move the addr, because the engine keys the slot on the
+    /// addr — a factor that does not move it silently shares a cache between two
+    /// builds that disagree.
+    #[test]
+    fn every_factor_moves_the_addr() {
+        let base = key().addr();
+        let mut cases: Vec<(&str, GocacheKey)> = Vec::new();
+
+        let mut k = key();
+        k.go_version = "1.26.0".to_string();
+        cases.push(("go_version", k));
+        let mut k = key();
+        k.goos = "darwin".to_string();
+        cases.push(("goos", k));
+        let mut k = key();
+        k.goarch = "arm64".to_string();
+        cases.push(("goarch", k));
+        let mut k = key();
+        k.build_tags = vec!["integration".to_string()];
+        cases.push(("build_tags", k));
+        let mut k = key();
+        k.goexperiment = vec!["arenas".to_string()];
+        cases.push(("goexperiment", k));
+        let mut k = key();
+        k.race = true;
+        cases.push(("race", k));
+
+        for (what, k) in cases {
+            assert_ne!(k.addr(), base, "{what} must key a distinct cache");
+        }
+    }
+
+    /// Two keys that agree on everything must land on one addr, whatever order
+    /// the lists were built in — otherwise the sharing this exists for is a
+    /// coin flip.
+    #[test]
+    fn equal_factors_share_one_addr() {
+        assert_eq!(key().addr(), key().addr());
+
+        let mut a = key();
+        a.build_tags = vec!["x".to_string(), "y".to_string()];
+        let mut b = key();
+        b.build_tags = vec!["x".to_string(), "y".to_string()];
+        assert_eq!(a.addr(), b.addr());
+    }
+
+    /// Absent lists leave their args off entirely, so the common addr stays short
+    /// and readable in `heph tool scratch ls`.
+    #[test]
+    fn empty_lists_do_not_appear_in_the_addr() {
+        let args = key().args();
+        assert!(!args.contains_key("tags"));
+        assert!(!args.contains_key("exp"));
+        assert!(!args.contains_key("race"));
+        assert_eq!(args["go"], "1.27.0");
+    }
+
+    #[test]
+    fn the_spec_declares_a_shared_gocache_scratch() {
+        let spec = build_spec(key().addr());
+        assert_eq!(spec.driver, "scratch");
+        assert_eq!(spec.config["env"], Value::String("GOCACHE".to_string()));
+        assert_eq!(spec.config["access"], Value::String("shared".to_string()));
+        assert_eq!(
+            spec.config["path"],
+            Value::String(GOCACHE_MOUNT.to_string())
+        );
+        // The factors live in the addr; duplicating them into `version` would be
+        // two ways to say one thing.
+        assert!(!spec.config.contains_key("version"));
+    }
+}

--- a/crates/plugin-go/src/plugingo/mod.rs
+++ b/crates/plugin-go/src/plugingo/mod.rs
@@ -9,7 +9,7 @@ mod embed;
 pub(crate) mod errors;
 mod factors;
 mod gen_testmain;
-mod golist_gocache;
+pub mod gocache;
 mod govet;
 mod pkg_analysis;
 mod provider;

--- a/crates/plugin-go/src/plugingo/provider.rs
+++ b/crates/plugin-go/src/plugingo/provider.rs
@@ -5,6 +5,7 @@ use crate::plugingo::addr_util::{
 use crate::plugingo::cc_toolchain;
 use crate::plugingo::errors::NoGoFilesError;
 use crate::plugingo::factors::{self, Factors, VariantRef, current_goarch, current_goos};
+use crate::plugingo::gocache;
 use crate::plugingo::govet;
 use crate::plugingo::pkg_analysis::{
     GoPackage, PackageAddrs, decode_go_package, decode_package_addrs, find_module_for_import,
@@ -1673,6 +1674,17 @@ impl ProviderInner {
                 .unwrap_or("");
             let spec = toolchain::build_spec(addr.clone(), version, &goos, &goarch, sha256);
             return Ok(GetResponse { target_spec: spec });
+        }
+
+        // The shared Go build cache: `//@heph/go/gocache:cache@<factors>` is a
+        // `scratch` declaration, not a buildable target. Matched here — before
+        // package decoding, exactly like the toolchain above — because there is
+        // no such directory on disk and asking the filesystem about it would only
+        // produce a confusing "not found".
+        if addr.name == gocache::GOCACHE_NAME && gocache::is_gocache_pkg(addr.package.as_str()) {
+            return Ok(GetResponse {
+                target_spec: gocache::build_spec(addr.clone()),
+            });
         }
 
         // `heph-govet`, the analysis/format binary the lint and format targets


### PR DESCRIPTION
Third of three (on top of #434). The retrofit that proves the mechanism.

`plugin-go`'s `golist_gocache.rs` **was** this feature, implemented once, for one
driver, by hand: a directory under the engine home keyed by a hand-written
struct, with no lock, no eviction, no remote, no visibility, and available to
nothing else. It is now an ordinary `scratch` target —
`//@heph/go/gocache:cache@<factors>` — which supplies all of those.

The provider serves it from an early `handle_get` arm, before package decoding,
exactly as the hermetic toolchain is served: there is no such directory on disk,
and asking the filesystem about it would only produce a confusing "not found".
The golist driver takes a scratch reference and reads the mount off `RunRequest`
instead of resolving a directory itself.

This is the design's acceptance test — *if the general mechanism cannot express
the special case, the design is wrong.* It can, with one correction worth stating
plainly.

## GOROOT leaves the key, and that is an improvement

The old key included the resolved **GOROOT path**, because Go's action IDs
incorporate it. A scratch declaration is resolved *before* the driver runs and
GOROOT is not known until it has — so the path cannot be in the key.

Dropping it is not a loss:

- Under `gotool: "host"`, GOROOT is a function of the Go version, which *is* in
  the key. Nothing changes.
- Under a **hermetic** toolchain the SDK stages at a different absolute path in
  every sandbox, so the old key gave every sandbox its own slot and every one of
  them fell back to cold. Dropping the path gives them one shared slot.

It does **not** make a hermetic build's action IDs match across sandboxes —
those still embed the staged GOROOT — so the win there stays bounded until the
SDK is staged at a stable path (see `hermetic-goroot-stable-path`). It does mean
the cache stops being fragmented for no reason.

The remaining factors (go version, goos, goarch, build tags, goexperiment, race)
live in the addr as **readable args** rather than a hash, because they show up in
`heph tool scratch ls` and "which cache is this?" is a question a hash cannot
answer. The engine keys the slot on the addr, so two runs agreeing on every
factor share a directory and two that disagree on any of them do not — asserted
per factor.

`access = "shared"`, because Go's build cache is content-addressed and
self-verifying and concurrent access is what `go build -p N` already does;
serializing it would turn the 2.4× into a large loss. That property was
previously expressed by having *no lock at all*; it is now stated.

Local-only for now. Publishing a Go build cache is worth doing and is a separate
change with its own before/after, since whether the transfer beats a cold
`go list` is a measurement rather than a guess.

## What still needs a number — please label this `perf-test`

`.github/workflows/perf.yml` runs on a PR labelled `perf-test` and times a
500-package Go corpus against N−1 across `cold` / `full-hit` / `incremental`.

**`cold` is the scenario that matters here.** The 2.4× was always an *intra-run*
win — 500 packages sharing one GOCACHE within a single cold build — and `cold`
wipes `.heph3` on both sides, so it measures like for like. This change should be
neutral-to-better there.

That is a claim for the gate to settle, not for a local run. The seeded-GOCACHE
experiment on this same corpus cut `go list` CPU by 60% and moved wall time by
**exactly zero**, which is the standing reminder that an obvious cache win here
can be worth nothing.

Note the label does not retrigger the job on an already-open PR (`pull_request`
fires on `opened`/`synchronize`/`reopened`, not `labeled`) — label, then push or
re-run the job.

## Safety

A missing mount falls back to a sandbox-local directory rather than failing: an
older host that does not carry scratch mounts on `RunRequest` must still be able
to run this driver, and a cold cache is slow, never wrong.

## Not in this PR

The other three Go sites, each wanting its own number:

- `driver_compile.rs` still creates a per-sandbox `.heph-gocache` — the same
  pattern this removes for golist, left behind because that fix was driver-local.
  Smaller upside (§2 measured all compilation at 15s against golist's 778s).
- `thirdparty.rs`'s `GOMODCACHE`/`GOPROXY` host passthrough — the largest CI
  effect, and the only one that *narrows* a hermeticity hole rather than widening
  one.
- `pkg_analysis.rs` enumerates those vars for hashing and moves with them.
