### PR TITLE
fix(cli): make `heph query`'s documented examples runnable

### DIFF
--- a/src/commands/gendocs.rs
+++ b/src/commands/gendocs.rs
@@ -192,6 +192,139 @@ mod tests {
         );
     }
 
+    /// Split a documented command line into argv, honouring the single quotes the
+    /// examples use around query expressions (`-e '//... && !//vendor/...'`).
+    fn argv(example: &str) -> Vec<String> {
+        let mut out = Vec::new();
+        let mut cur = String::new();
+        let mut started = false;
+        let mut quoted = false;
+        for c in example.chars() {
+            match c {
+                '\'' => {
+                    quoted = !quoted;
+                    started = true;
+                }
+                c if c.is_whitespace() && !quoted => {
+                    if started {
+                        out.push(std::mem::take(&mut cur));
+                        started = false;
+                    }
+                }
+                c => {
+                    cur.push(c);
+                    started = true;
+                }
+            }
+        }
+        if started {
+            out.push(cur);
+        }
+        out
+    }
+
+    /// Every `heph …` command line documented in `text`, from both the backticked
+    /// form the doc comments use and the bare form of the after-help reference
+    /// block. Lines carrying a `<PLACEHOLDER>` describe a form rather than name a
+    /// runnable command, so they are left out.
+    fn examples_in(text: &str) -> Vec<String> {
+        let mut out = Vec::new();
+        for line in text.lines() {
+            let mut found: Vec<&str> = line
+                .split('`')
+                .skip(1)
+                .step_by(2)
+                .filter(|span| span.starts_with("heph "))
+                .collect();
+            // Bare `heph …` line in the after-help block, with prose aligned two
+            // or more spaces to its right.
+            let bare = line.trim_start();
+            if found.is_empty()
+                && bare.starts_with("heph ")
+                && let Some(cmd) = bare.split("  ").next()
+            {
+                found.push(cmd);
+            }
+            out.extend(
+                found
+                    .into_iter()
+                    .map(str::trim)
+                    .filter(|e| !e.contains('<'))
+                    .map(str::to_string),
+            );
+        }
+        out
+    }
+
+    fn collect_examples(cmd: &clap::Command, out: &mut Vec<String>) {
+        for text in [
+            cmd.get_long_about().or_else(|| cmd.get_about()),
+            cmd.get_after_long_help().or_else(|| cmd.get_after_help()),
+        ]
+        .into_iter()
+        .flatten()
+        {
+            out.extend(examples_in(&text.to_string()));
+        }
+        for child in cmd.get_subcommands() {
+            collect_examples(child, out);
+        }
+    }
+
+    /// Every command line the help advertises must be one the CLI accepts.
+    ///
+    /// `heph query //...` shipped in the `query` help while the single-positional
+    /// form parses its argument as an *address*, so the advertised command could
+    /// not run at all — the whole-workspace selection needs `-e '//...'`. Copying
+    /// an example out of `--help` is the first thing anyone does, so an example
+    /// that does not parse is a bug in the CLI, not just in its prose.
+    #[test]
+    fn documented_examples_are_accepted() {
+        use crate::commands::utils::resolve_matcher;
+        use crate::htpkg::PkgBuf;
+
+        let root = cli_command();
+        let mut examples = Vec::new();
+        collect_examples(&root, &mut examples);
+        assert!(
+            examples.len() > 20,
+            "example extraction found almost nothing ({examples:?}) — the scan is broken, \
+             not the help"
+        );
+
+        for example in &examples {
+            let matches = root
+                .clone()
+                .try_get_matches_from(argv(example))
+                .unwrap_or_else(|e| panic!("`{example}` is not accepted by the CLI:\n{e}"));
+
+            // Walk to the leaf subcommand; the selection args only exist there.
+            let mut leaf = (String::from("heph"), &matches);
+            while let Some((name, sub)) = leaf.1.subcommand() {
+                leaf = (format!("{} {name}", leaf.0), sub);
+            }
+            let (path, m) = leaf;
+
+            // `run`/`query`/`tool clean` share the selection form, and clap
+            // accepting the string says nothing about whether it resolves.
+            let ids: Vec<_> = m.ids().map(|i| i.as_str()).collect();
+            if !ids.contains(&"arg1") && !ids.contains(&"expr") {
+                continue;
+            }
+            let get = |id| m.try_get_one::<String>(id).ok().flatten().cloned();
+            // `run` is the one selection that rejects the `all` label.
+            let allow_all = path != "heph run";
+            resolve_matcher(
+                &get("expr"),
+                &get("arg1"),
+                &get("arg2"),
+                &PkgBuf::from(""),
+                allow_all,
+            )
+            .unwrap_or_else(|e| panic!("`{example}` parses but selects nothing: {e:#}"));
+        }
+    }
+
     #[test]
     fn hidden_command_is_omitted() {
         let md = render_markdown(&cli_command());

--- a/src/commands/mod.rs
+++ b/src/commands/mod.rs
@@ -66,9 +66,11 @@ pub enum Commands {
     ///
     /// Examples:
     ///
-    /// `heph query //...`
+    /// `heph query //cmd/server:bin` — resolve a single address
     ///
-    /// `heph query test //cmd/...`
+    /// `heph query test //cmd/...` — every target labelled `test`
+    ///
+    /// `heph query -e '//...'` — every target in the workspace
     ///
     /// `heph query -e '//... && !//vendor/...'` — select with exclusion
     ///

--- a/src/commands/utils.rs
+++ b/src/commands/utils.rs
@@ -83,20 +83,44 @@ pub fn matcher_from_args(
                 anyhow::bail!("label `all` not allowed")
             }
 
-            htpkg::parse(package_matcher, &engine::get_cwp()?)
+            htpkg::parse(package_matcher, base_pkg)
         } else {
             validate_positional_label(label)?;
             Ok(Matcher::And(vec![
                 Matcher::Label(label.into()),
-                htpkg::parse(package_matcher, &engine::get_cwp()?)?,
+                htpkg::parse(package_matcher, base_pkg)?,
             ]))
         }
     } else {
         let addr_str = arg1;
         let addr = htaddr::parse_addr_with_base(addr_str, base_pkg)
+            .map_err(|err| annotate_lone_package_matcher(err, addr_str, base_pkg))
             .with_context(|| format!("parse {}", addr_str))?;
         Ok(Matcher::Addr(addr))
     }
+}
+
+/// Turn the address parse error for a lone `//pkg/...` into a pointer at `-e`.
+///
+/// A single positional argument is an *address*, so `heph query //...` — the
+/// obvious way to ask for the whole workspace, and what the `query` help itself
+/// used to show — failed with a raw parser error about a missing `:name`, with
+/// nothing to suggest that the selection belongs behind `-e`. Only annotate
+/// when the argument really is a well-formed package matcher; a genuine typo in
+/// an address keeps its own error.
+fn annotate_lone_package_matcher(
+    err: anyhow::Error,
+    input: &str,
+    base_pkg: &PkgBuf,
+) -> anyhow::Error {
+    if htpkg::parse(input, base_pkg).is_err() {
+        return err;
+    }
+    err.context(format!(
+        "`{input}` is a package matcher, not a target address — the single-argument \
+         form takes one address (`//pkg:name`); to select a package use `-e '{input}'`, \
+         or name a label first, e.g. `test {input}`"
+    ))
 }
 
 /// Check the positional `<LABEL> <PACKAGE_MATCHER>` form's first argument
@@ -316,6 +340,44 @@ mod tests {
         assert!(
             !chain.contains("query expression"),
             "no operators typed, so no -e hint: {chain}"
+        );
+    }
+
+    #[test]
+    fn lone_package_matcher_points_at_the_query_flag() {
+        // `heph query //...` — what the query help itself used to advertise. It
+        // is a package matcher in the address slot, so it cannot resolve; the
+        // error has to say where that selection belongs.
+        let pkg = PkgBuf::from("");
+        for input in ["//...", "//cmd/...", "//cmd/server", "./sub/..."] {
+            let err = matcher_from_args(input, &None, &pkg, true)
+                .err()
+                .unwrap_or_else(|| panic!("{input:?} unexpectedly resolved as an address"));
+            let chain = format!("{err:#}");
+            assert!(
+                chain.contains("package matcher, not a target address"),
+                "{input:?}: {chain}"
+            );
+            assert!(
+                chain.contains(&format!("-e '{input}'")),
+                "{input:?} should be quoted back behind -e: {chain}"
+            );
+        }
+    }
+
+    #[test]
+    fn malformed_address_keeps_its_own_error() {
+        // Not a valid package matcher either, so there is no `-e` form to
+        // suggest — the address parse error is the useful one.
+        let pkg = PkgBuf::from("");
+        let err = matcher_from_args("cmd/server:bin", &None, &pkg, true)
+            .err()
+            .expect("expected parse error");
+        let chain = format!("{err:#}");
+        assert!(chain.contains("parse cmd/server:bin"), "{chain}");
+        assert!(
+            !chain.contains("package matcher"),
+            "no package matcher hint for a malformed address: {chain}"
         );
     }
 


### PR DESCRIPTION
## The bug

`heph query --help` advertised this:

```
heph query //...
```

which the CLI rejects. A single positional argument is parsed as a **target address**, and `//...` is a package matcher — so the first example anyone copies out of the help fails, and fails with the parser's internals:

```
parse //...: invalid address "//...": Parsing Error: Error { input: "", code: Char }
```

The whole-workspace selection is `-e '//...'`. (`heph query test //cmd/...`, the other positional example, is fine — that's the `<LABEL> <PACKAGE_MATCHER>` form.)

## The fix

- **The examples**, now all runnable: a real address, the label+matcher form, and `-e '//...'` for the workspace.
- **The error**, at the point of failure. A lone positional argument that parses as a package matcher now names the two forms that do work instead of leaking nom:
  ```
  `//...` is a package matcher, not a target address — the single-argument form takes
  one address (`//pkg:name`); to select a package use `-e '//...'`, or name a label
  first, e.g. `test //...`
  ```
  It only fires when there really is a well-formed package matcher in the address slot; a malformed address (`cmd/server:bin`) keeps its own error, which is the useful one there.
- **`matcher_from_args` takes its base package from the argument it is already given**, rather than the ambient `get_cwp()` that the label branch alone was reaching for. Identical at all three call sites (`run`, `query`, `tool clean` all pass `get_cwp()`), and it makes the function testable without a workspace.

## Test

Rather than fixing one line of prose, `documented_examples_are_accepted` walks the **whole** clap tree: every `heph …` command line documented in any command's long help or after-help must parse with clap, and — for the `run`/`query`/`tool clean` selection form — must resolve to a matcher. 63 examples across `run`, `query`, `inspect`, and `tool` are covered, and it fails on the example this PR removes:

```
`heph query //...` parses but selects nothing: parse //...: `//...` is a package
matcher, not a target address — …
```

Plus unit tests for the new hint and for the malformed-address case that must not get it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013quWtzsLDC8Ajgre2cpKTb