### PR TITLE
feat(coreutils): the toolbox is on by default

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -91,7 +91,8 @@ in one direction and a permanent full-miss in the other.
 
 heph ships 40 POSIX utilities inside the binary (`crates/coreutils`) and can put
 them on every target's `PATH`, so `cp`/`install`/`sha256sum` behave the same on
-Linux and macOS. Off by default (`coreutils: true` on the `exec`/`bash` driver).
+Linux and macOS. On by default; `coreutils: false` on the `exec`/`bash` driver
+opts out.
 
 Read `docs/COREUTILS.md` before touching it. The one thing to know going in:
 `COREUTILS_VERSION` is folded into every exec target's def hash when the toolbox

--- a/crates/plugin-exec/src/pluginexec/mod.rs
+++ b/crates/plugin-exec/src/pluginexec/mod.rs
@@ -52,8 +52,10 @@ pub struct Driver {
     /// unchanged when it was switched on.
     default_runner: Option<String>,
     /// Whether this driver puts heph's builtin utilities on its targets' PATH,
-    /// from the `coreutils:` option. Off by default: turning it on changes what
-    /// every recipe's `cp` resolves to, and it moves every exec cache key.
+    /// from the `coreutils:` option. On by default — the whole point is that a
+    /// recipe behaves the same on both hosts without opting in. A driver built
+    /// directly rather than from options starts off, because only a host that
+    /// knows the heph home can supply the shims.
     coreutils_enabled: bool,
     /// The toolbox version to hash, and how to get its shim directory —
     /// supplied by the host, which is the thing that knows the heph home.
@@ -431,13 +433,15 @@ fn decode_path(opts: &hplugin::config::Options) -> anyhow::Result<Vec<String>> {
     Ok(hplugin::config::decode_opt(opts, "exec/bash/sh driver", "path")?.unwrap_or_default())
 }
 
-/// `coreutils: true` puts heph's builtin utilities on every target's PATH.
+/// `coreutils:` puts heph's builtin utilities on every target's PATH.
 ///
-/// Off by default. Turning it on is a behaviour change to every recipe — the
-/// `cp` a target runs stops being the host's — and it moves every exec target's
-/// cache key, so it stays opt-in until a release makes it the default.
+/// **On by default.** The point of shipping them is that a recipe behaves the
+/// same on Linux and macOS without anyone opting in; a toolbox nobody enables
+/// fixes nothing. `coreutils: false` is the escape hatch for a workspace that
+/// genuinely wants the host's tools, and opting out is itself folded into the
+/// def hash, so it is a cache-visible decision rather than a silent one.
 fn decode_coreutils(opts: &hplugin::config::Options) -> anyhow::Result<bool> {
-    Ok(hplugin::config::decode_opt(opts, "exec/bash/sh driver", "coreutils")?.unwrap_or(false))
+    Ok(hplugin::config::decode_opt(opts, "exec/bash/sh driver", "coreutils")?.unwrap_or(true))
 }
 
 /// The workspace-wide default runner, from `options.runner`.
@@ -2661,6 +2665,13 @@ mod tests {
         opts.insert(
             "path".to_string(),
             serde_yaml::from_str("[/nonexistent-test-search-dir]").expect("yaml"),
+        );
+        // The toolbox is on by default, and this test is about the spawn
+        // diagnostic rather than about `PATH` composition — so it opts out
+        // rather than standing up a shim directory it would never look at.
+        opts.insert(
+            "coreutils".to_string(),
+            serde_yaml::from_str("false").expect("yaml"),
         );
         let driver = Driver::from_options_exec(&opts)?;
         let ctoken = StdCancellationToken::new();
@@ -5382,10 +5393,24 @@ mod tests {
     }
 
     #[test]
-    fn coreutils_is_off_unless_asked_for() {
-        // The default must stay off: turning it on changes what every recipe's
-        // `cp` resolves to and moves every exec cache key.
-        let d = Driver::from_options_exec(&hplugin::config::Options::new()).expect("from_options");
+    fn coreutils_is_on_unless_turned_off() {
+        // The default is on: a toolbox nobody enables fixes nothing.
+        let on = Driver::from_options_exec(&hplugin::config::Options::new()).expect("from_options");
+        assert!(on.coreutils_enabled, "the toolbox must be on by default");
+
+        // And `coreutils: false` must still turn it off, since that is the
+        // escape hatch for a workspace that wants the host's tools.
+        let off = Driver::from_options_exec(&coreutils_opts(false)).expect("from_options");
+        assert!(!off.coreutils_enabled);
+        assert!(off.coreutils_version().is_none());
+    }
+
+    #[test]
+    fn a_driver_built_without_options_starts_off() {
+        // `new_exec` is what test harnesses and the shell fallback use. They
+        // have no heph home to materialize shims under, so the toolbox must not
+        // switch itself on there and then assert about missing shims.
+        let d = Driver::new_exec();
         assert!(!d.coreutils_enabled);
         assert!(d.coreutils_version().is_none());
     }

--- a/docs/COREUTILS.md
+++ b/docs/COREUTILS.md
@@ -34,18 +34,26 @@ those outputs undeclared and host-defined.
 
 ## Using it
 
-Off by default. Turning it on changes what every recipe's `cp` resolves to, and
-it moves every exec target's cache key.
+**On by default.** There is nothing to configure: a recipe that runs `cp`
+behaves the same on Linux and macOS because the toolbox is already on its
+`PATH`. A toolbox nobody enables fixes nothing.
+
+The escape hatch is per driver, for a workspace that genuinely wants the host's
+tools:
 
 ```yaml
 plugins:
   - builtin: exec
     options:
-      coreutils: true
+      coreutils: false
   - builtin: bash
     options:
-      coreutils: true
+      coreutils: false
 ```
+
+Opting out is folded into the def hash too, so it is a cache-visible decision
+rather than a silent one — turning it off invalidates the targets it affects,
+which is what you want, because their outputs may change.
 
 `heph tool coreutils list` prints the set. `heph tool coreutils which cp` says
 whether heph ships that name and what the host would supply instead — the two
@@ -120,8 +128,8 @@ deliberate:
 
 Bump it on any observable behaviour change: an applet added or removed, an
 upstream upgrade that changes output, a fix to a hand-written part. Nothing is
-hashed at all while the toolbox is off, so a workspace that never turns it on
-keeps the keys it has today.
+hashed at all while the toolbox is off, so a workspace that opts out keeps the
+keys it would have had without this feature.
 
 Resolving the shim directory is fallible on purpose. Degrading to "no builtins"
 would run the target against the host's utilities while its cache key claims

--- a/src/commands/tool/coreutils.rs
+++ b/src/commands/tool/coreutils.rs
@@ -148,8 +148,9 @@ fn which(args: &WhichArgs) -> anyhow::Result<()> {
     if builtin {
         writeln!(
             out,
-            "A target gets the builtin when the exec/bash driver has `coreutils: true`,\n\
-             unless it declares a tool of the same name — a target's own tools always win."
+            "A target gets the builtin unless it declares a tool of the same name — a\n\
+             target's own tools always win — or the exec/bash driver is configured with\n\
+             `coreutils: false`."
         )?;
     } else {
         writeln!(


### PR DESCRIPTION
`coreutils: true` becomes the default on the `exec`/`bash` driver. Fifty-five lines, and the decision the whole stack exists for.

A toolbox nobody enables fixes nothing: the point of shipping these utilities is that a recipe behaves the same on Linux and macOS *without anyone opting in*. Leaving it off by default would mean the divergences in #438 keep biting everyone who hasn't heard of the flag.

## What this changes

Every `exec`/`bash` target gets heph's `cp`, `install`, `sed`, `sha256sum` and the rest on its `PATH` — **behind** everything the environment provides, so a declared tool and a runner's environment both still win. Where the target's `PATH` previously resolved to a host binary that heph now supplies, it resolves to heph's.

`coreutils: false` is the escape hatch, and opting out is itself folded into the def hash — a cache-visible decision rather than a silent one.

## Why it is its own PR

It has its own revert line. If the flip proves too disruptive it can go back without losing the toolbox, and #446 can be reverted without losing the flip. Bundling either pair would force an all-or-nothing rollback of a change this broad.

---

### The stack

Merge bottom-up, and `gh stack sync` after each one lands — `master` is squash-only, so the rebase will conflict and the [resolution rule in CLAUDE.md](https://github.com/hephbuild/heph/blob/master/CLAUDE.md) applies.

| | PR | What |
|---|---|---|
| 6 | #446 | drop the host directories from a target's `PATH` — **breaking** |
| 5 | #445 | the toolbox on by default |
| 4 | #440 | the `template` rule and the `tmpl` applet |
| 3 | #453 | grep, find, xargs, sed, tar, gzip, zstd |
| 2 | #438 | the crate, the entry points, the shim directory |
| 1 | #451 | the runner `PATH` seam ← **base, targets `master`** |

Only #451 builds automatically: since #449 a stacked PR is skipped unless it carries `ci/force-ci`. Every layer was checked locally on its own — `cargo build --workspace --all-targets`, `cargo clippy --workspace --all-targets`, and its unit tests — not just at the top of the stack.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0181d7hhbYWXT42Z1KQPM29Q
