### PR TITLE
feat(exec): drop the host directories from a target's PATH

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -92,7 +92,8 @@ in one direction and a permanent full-miss in the other.
 heph ships 40 POSIX utilities inside the binary (`crates/coreutils`) and can put
 them on every target's `PATH`, so `cp`/`install`/`sha256sum` behave the same on
 Linux and macOS. On by default; `coreutils: false` on the `exec`/`bash` driver
-opts out.
+opts out. The host's directories are **not** on a target's `PATH` — it sees its
+own tools plus the builtins, and nothing else.
 
 Read `docs/COREUTILS.md` before touching it. The one thing to know going in:
 `COREUTILS_VERSION` is folded into every exec target's def hash when the toolbox

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5022,6 +5022,7 @@ dependencies = [
  "tokio",
  "tracing",
  "tracing-subscriber",
+ "which",
  "xxhash-rust",
 ]
 

--- a/crates/bench/src/inprocess.rs
+++ b/crates/bench/src/inprocess.rs
@@ -63,9 +63,9 @@ fn build_engine(root: &Path) -> Result<Arc<Engine>> {
         ))
     })
     .context("register pluginbuildfile provider")?;
-    e.register_managed_driver(|_| Box::new(heph::pluginexec::Driver::new_exec()))
+    e.register_managed_driver(|_| Box::new(heph::pluginexec::Driver::new_exec().with_host_path()))
         .context("register exec driver")?;
-    e.register_managed_driver(|_| Box::new(heph::pluginexec::Driver::new_bash()))
+    e.register_managed_driver(|_| Box::new(heph::pluginexec::Driver::new_bash().with_host_path()))
         .context("register bash driver")?;
     Ok(Arc::new(e))
 }

--- a/crates/e2e/tests/cache_load.rs
+++ b/crates/e2e/tests/cache_load.rs
@@ -124,7 +124,7 @@ fn build_engine(root: &Path, remote_uri: &str, parallelism: Option<usize>) -> Ar
         ))
     })
     .expect("register buildfile provider");
-    e.register_managed_driver(|_| Box::new(pluginexec::Driver::new_bash()))
+    e.register_managed_driver(|_| Box::new(pluginexec::Driver::new_bash().with_host_path()))
         .expect("register bash driver");
     Arc::new(e)
 }

--- a/crates/e2e/tests/common/mod.rs
+++ b/crates/e2e/tests/common/mod.rs
@@ -61,8 +61,8 @@ impl Workspace {
                     init.runtime.clone(),
                 ))
             })
-            .with_managed_driver(Box::new(pluginexec::Driver::new_exec()))
-            .with_managed_driver(Box::new(pluginexec::Driver::new_bash()))
+            .with_managed_driver(Box::new(pluginexec::Driver::new_exec().with_host_path()))
+            .with_managed_driver(Box::new(pluginexec::Driver::new_bash().with_host_path()))
             .with_managed_driver(Box::new(pluginhttp::Driver));
         let builder = if let Some(p) = p {
             builder.with_parallelism(p)
@@ -121,10 +121,10 @@ impl Workspace {
             })
             .context("reopen: register buildfile provider")?;
         engine
-            .register_managed_driver(|_| Box::new(pluginexec::Driver::new_exec()))
+            .register_managed_driver(|_| Box::new(pluginexec::Driver::new_exec().with_host_path()))
             .context("reopen: register exec driver")?;
         engine
-            .register_managed_driver(|_| Box::new(pluginexec::Driver::new_bash()))
+            .register_managed_driver(|_| Box::new(pluginexec::Driver::new_bash().with_host_path()))
             .context("reopen: register bash driver")?;
         engine
             .register_managed_driver(|_| Box::new(pluginhttp::Driver))
@@ -138,8 +138,8 @@ impl Workspace {
         let provider = pluginstatictarget::Provider::new(targets)?;
         let ws = WorkspaceBuilder::new()?
             .with_provider(move |_| Box::new(provider))
-            .with_managed_driver(Box::new(pluginexec::Driver::new_exec()))
-            .with_managed_driver(Box::new(pluginexec::Driver::new_bash()))
+            .with_managed_driver(Box::new(pluginexec::Driver::new_exec().with_host_path()))
+            .with_managed_driver(Box::new(pluginexec::Driver::new_bash().with_host_path()))
             .build()?;
         Ok(Self {
             inner: ws,

--- a/crates/e2e/tests/devenv_runner.rs
+++ b/crates/e2e/tests/devenv_runner.rs
@@ -84,7 +84,9 @@ fn workspace() -> htestkit::Workspace {
                 init.runtime.clone(),
             ))
         })
-        .with_managed_driver(Box::new(heph::pluginexec::Driver::new_bash()))
+        .with_managed_driver(Box::new(
+            heph::pluginexec::Driver::new_bash().with_host_path(),
+        ))
         .with_managed_driver(Box::new(plugindevenv::Driver::new()))
         .build()
         .expect("build workspace")

--- a/crates/e2e/tests/execrunner.rs
+++ b/crates/e2e/tests/execrunner.rs
@@ -74,7 +74,14 @@ async fn runner_json_never_enters_the_sandbox() -> anyhow::Result<()> {
     let ws = Workspace::new();
     let mut build = runner_target(
         "runner",
-        r#"{"version": 1, "fingerprint": "fp-1", "runner": "wrap", "config": {}}"#,
+        // The runner supplies the environment its targets run in, `PATH`
+        // included. The driver's own search path is deliberately not injected
+        // under a runner — putting the host's directories in front of the
+        // environment would let a host tool shadow the one the target asked to
+        // run beside — so a runner that names no `PATH` gives its targets only
+        // their declared tools.
+        r#"{"version": 1, "fingerprint": "fp-1", "runner": "wrap",
+ "config": {"env": {"PATH": "/usr/local/bin:/usr/bin:/bin"}}}"#,
     );
     build.push_str(
         r#"

--- a/crates/e2e/tests/oci.rs
+++ b/crates/e2e/tests/oci.rs
@@ -104,7 +104,9 @@ fn workspace_with_fake(fake: &Fake) -> htestkit::Workspace {
                 init.runtime.clone(),
             ))
         })
-        .with_managed_driver(Box::new(heph::pluginexec::Driver::new_bash()))
+        .with_managed_driver(Box::new(
+            heph::pluginexec::Driver::new_bash().with_host_path(),
+        ))
         .with_managed_driver(Box::new(pluginoci::docker_build::Driver::with_binary(
             bin.clone(),
         )))
@@ -487,7 +489,9 @@ async fn test_docker_build_build_failure_surfaces_the_builder_error() -> anyhow:
                 init.runtime.clone(),
             ))
         })
-        .with_managed_driver(Box::new(heph::pluginexec::Driver::new_bash()))
+        .with_managed_driver(Box::new(
+            heph::pluginexec::Driver::new_bash().with_host_path(),
+        ))
         .with_managed_driver(Box::new(pluginoci::docker_build::Driver::with_binary(
             bin.to_string_lossy().into_owned(),
         )))

--- a/crates/e2e/tests/oci_docker.rs
+++ b/crates/e2e/tests/oci_docker.rs
@@ -196,7 +196,9 @@ fn workspace() -> htestkit::Workspace {
                 init.runtime.clone(),
             ))
         })
-        .with_managed_driver(Box::new(heph::pluginexec::Driver::new_bash()))
+        .with_managed_driver(Box::new(
+            heph::pluginexec::Driver::new_bash().with_host_path(),
+        ))
         .with_managed_driver(Box::new(pluginoci::docker_build::Driver::new()))
         .with_provider(|_| Box::new(pluginoci::platform::Provider))
         .with_managed_driver(Box::new(pluginoci::platform::Driver::new()))

--- a/crates/e2e/tests/oci_image.rs
+++ b/crates/e2e/tests/oci_image.rs
@@ -34,7 +34,9 @@ fn workspace() -> htestkit::Workspace {
                 init.runtime.clone(),
             ))
         })
-        .with_managed_driver(Box::new(heph::pluginexec::Driver::new_bash()))
+        .with_managed_driver(Box::new(
+            heph::pluginexec::Driver::new_bash().with_host_path(),
+        ))
         .with_managed_driver(Box::new(pluginoci::image::Driver::new()))
         .with_managed_driver(Box::new(pluginoci::layer::Driver::new()))
         .with_managed_driver(Box::new(pluginoci::index::Driver::new()))

--- a/crates/e2e/tests/oci_runner.rs
+++ b/crates/e2e/tests/oci_runner.rs
@@ -140,7 +140,9 @@ fn workspace() -> htestkit::Workspace {
                 init.runtime.clone(),
             ))
         })
-        .with_managed_driver(Box::new(heph::pluginexec::Driver::new_bash()))
+        .with_managed_driver(Box::new(
+            heph::pluginexec::Driver::new_bash().with_host_path(),
+        ))
         .with_managed_driver(Box::new(pluginoci::runner::Driver::new()))
         // What the cdylib hands the host through `NamedRunner`; an in-process
         // harness registers it directly.

--- a/crates/e2e/tests/remote_cache.rs
+++ b/crates/e2e/tests/remote_cache.rs
@@ -46,7 +46,7 @@ fn build_engine(root: &Path, remote_uri: &str) -> Arc<Engine> {
         ))
     })
     .expect("register buildfile provider");
-    e.register_managed_driver(|_| Box::new(pluginexec::Driver::new_bash()))
+    e.register_managed_driver(|_| Box::new(pluginexec::Driver::new_bash().with_host_path()))
         .expect("register bash driver");
     Arc::new(e)
 }
@@ -277,7 +277,7 @@ async fn output_is_nondeterministic_without_cache() {
             ))
         })
         .expect("provider");
-        e.register_managed_driver(|_| Box::new(pluginexec::Driver::new_bash()))
+        e.register_managed_driver(|_| Box::new(pluginexec::Driver::new_bash().with_host_path()))
             .expect("driver");
         Arc::new(e)
     };

--- a/crates/engine/src/engine/deppath.rs
+++ b/crates/engine/src/engine/deppath.rs
@@ -211,8 +211,9 @@ mod tests {
             parallelism: None,
             ..Default::default()
         })?;
-        engine
-            .register_managed_driver(|_| Box::new(hplugin_exec::pluginexec::Driver::new_exec()))?;
+        engine.register_managed_driver(|_| {
+            Box::new(hplugin_exec::pluginexec::Driver::new_exec().with_host_path())
+        })?;
         let provider = pluginstatictarget::Provider::new(targets)?;
         engine.register_provider(move |_| Box::new(provider))?;
         Ok((Arc::new(engine), root))

--- a/crates/engine/src/engine/expand.rs
+++ b/crates/engine/src/engine/expand.rs
@@ -408,8 +408,9 @@ mod tests {
         // group + fs are registered by Engine::new; only the exec driver needs
         // adding here. The fs provider/driver resolves the synthesized `@heph/fs`
         // inputs produced by introspect-outputs expansion.
-        engine
-            .register_managed_driver(|_| Box::new(hplugin_exec::pluginexec::Driver::new_exec()))?;
+        engine.register_managed_driver(|_| {
+            Box::new(hplugin_exec::pluginexec::Driver::new_exec().with_host_path())
+        })?;
         engine.register_provider(move |_| Box::new(CannedProvider { specs }))?;
         Ok((Arc::new(engine), root))
     }

--- a/crates/engine/src/engine/gitignore.rs
+++ b/crates/engine/src/engine/gitignore.rs
@@ -627,8 +627,9 @@ mod tests {
             parallelism: None,
             ..Default::default()
         })?;
-        engine
-            .register_managed_driver(|_| Box::new(hplugin_exec::pluginexec::Driver::new_exec()))?;
+        engine.register_managed_driver(|_| {
+            Box::new(hplugin_exec::pluginexec::Driver::new_exec().with_host_path())
+        })?;
         // Declared in an order that does not match the sorted pattern order, so a
         // stable result cannot come from insertion order alone.
         let provider = hbuiltins::pluginstatictarget::Provider::new(vec![

--- a/crates/engine/src/engine/result.rs
+++ b/crates/engine/src/engine/result.rs
@@ -5194,8 +5194,9 @@ mod tests {
             parallelism: None,
             ..Default::default()
         })?;
-        engine
-            .register_managed_driver(|_| Box::new(hplugin_exec::pluginexec::Driver::new_exec()))?;
+        engine.register_managed_driver(|_| {
+            Box::new(hplugin_exec::pluginexec::Driver::new_exec().with_host_path())
+        })?;
         let provider = pluginstatictarget::Provider::new(targets)?;
         engine.register_provider(move |_| Box::new(provider))?;
         Ok(Arc::new(engine))
@@ -5225,8 +5226,9 @@ mod tests {
             }],
             ..Default::default()
         })?;
-        engine
-            .register_managed_driver(|_| Box::new(hplugin_exec::pluginexec::Driver::new_exec()))?;
+        engine.register_managed_driver(|_| {
+            Box::new(hplugin_exec::pluginexec::Driver::new_exec().with_host_path())
+        })?;
         let provider = pluginstatictarget::Provider::new(targets)?;
         engine.register_provider(move |_| Box::new(provider))?;
         Ok((Arc::new(engine), root))
@@ -5449,8 +5451,9 @@ mod tests {
             }],
             ..Default::default()
         })?;
-        engine
-            .register_managed_driver(|_| Box::new(hplugin_exec::pluginexec::Driver::new_bash()))?;
+        engine.register_managed_driver(|_| {
+            Box::new(hplugin_exec::pluginexec::Driver::new_bash().with_host_path())
+        })?;
         let provider = pluginstatictarget::Provider::new(targets)?;
         engine.register_provider(move |_| Box::new(provider))?;
         Ok((Arc::new(engine), root))
@@ -6203,8 +6206,9 @@ mod tests {
             parallelism: None,
             ..Default::default()
         })?;
-        engine
-            .register_managed_driver(|_| Box::new(hplugin_exec::pluginexec::Driver::new_exec()))?;
+        engine.register_managed_driver(|_| {
+            Box::new(hplugin_exec::pluginexec::Driver::new_exec().with_host_path())
+        })?;
         // Cycling provider FIRST, so `get_spec` hits it before the static one.
         let cycles_for = cycles_for.to_string();
         engine.register_provider(move |_| {
@@ -6672,8 +6676,9 @@ mod tests {
             SArc::new(AtomicUsize::new(0)),
         );
         let gate = SArc::new(tokio::sync::Semaphore::new(0));
-        engine
-            .register_managed_driver(|_| Box::new(hplugin_exec::pluginexec::Driver::new_exec()))?;
+        engine.register_managed_driver(|_| {
+            Box::new(hplugin_exec::pluginexec::Driver::new_exec().with_host_path())
+        })?;
         let provider = AdmissionGate {
             inner: pluginstatictarget::Provider::new(targets)?,
             entered: SArc::clone(&entered),
@@ -7007,8 +7012,9 @@ mod tests {
             parallelism: None,
             ..Default::default()
         })?;
-        engine
-            .register_managed_driver(|_| Box::new(hplugin_exec::pluginexec::Driver::new_exec()))?;
+        engine.register_managed_driver(|_| {
+            Box::new(hplugin_exec::pluginexec::Driver::new_exec().with_host_path())
+        })?;
         let targets = vec![
             static_target("//pkg:a", &[], &[]),
             static_target("//pkg:b", &[], &[]),
@@ -8237,8 +8243,9 @@ mod tests {
             parallelism: Some(parallelism),
             ..Default::default()
         })?;
-        engine
-            .register_managed_driver(|_| Box::new(hplugin_exec::pluginexec::Driver::new_exec()))?;
+        engine.register_managed_driver(|_| {
+            Box::new(hplugin_exec::pluginexec::Driver::new_exec().with_host_path())
+        })?;
         let provider = pluginstatictarget::Provider::new(targets(engine.max_workers))?;
         engine.register_provider(move |_| Box::new(provider))?;
         Ok((Arc::new(engine), root))
@@ -8257,8 +8264,9 @@ mod tests {
             parallelism: None,
             ..Default::default()
         })?;
-        engine
-            .register_managed_driver(|_| Box::new(hplugin_exec::pluginexec::Driver::new_exec()))?;
+        engine.register_managed_driver(|_| {
+            Box::new(hplugin_exec::pluginexec::Driver::new_exec().with_host_path())
+        })?;
         let provider = pluginstatictarget::Provider::new(targets)?;
         engine.register_provider(move |_| Box::new(provider))?;
         Ok((Arc::new(engine), root))
@@ -9564,8 +9572,9 @@ mod tests {
         // so codegen targets can run real shell. The `@heph/fs` provider+driver
         // (auto-registered by `Engine::new`) resolves the synthesized
         // introspect-outputs inputs.
-        engine
-            .register_managed_driver(|_| Box::new(hplugin_exec::pluginexec::Driver::new_bash()))?;
+        engine.register_managed_driver(|_| {
+            Box::new(hplugin_exec::pluginexec::Driver::new_bash().with_host_path())
+        })?;
         let provider = pluginstatictarget::Provider::new(targets)?;
         engine.register_provider(move |_| Box::new(provider))?;
         Ok((Arc::new(engine), root))
@@ -9722,8 +9731,9 @@ mod tests {
             parallelism: None,
             ..Default::default()
         })?;
-        engine
-            .register_managed_driver(|_| Box::new(hplugin_exec::pluginexec::Driver::new_exec()))?;
+        engine.register_managed_driver(|_| {
+            Box::new(hplugin_exec::pluginexec::Driver::new_exec().with_host_path())
+        })?;
         // A dep is what makes the probe run at all: `meta` hashes a target from
         // its inputs, so it resolves `//pkg:dep` for its `hashout` — and that
         // resolution is what probes the cache under the hash-only request.

--- a/crates/engine/src/engine/revdeps.rs
+++ b/crates/engine/src/engine/revdeps.rs
@@ -116,8 +116,9 @@ mod tests {
             parallelism: None,
             ..Default::default()
         })?;
-        engine
-            .register_managed_driver(|_| Box::new(hplugin_exec::pluginexec::Driver::new_exec()))?;
+        engine.register_managed_driver(|_| {
+            Box::new(hplugin_exec::pluginexec::Driver::new_exec().with_host_path())
+        })?;
         let provider = pluginstatictarget::Provider::new(targets)?;
         engine.register_provider(move |_| Box::new(provider))?;
         Ok((Arc::new(engine), root))

--- a/crates/engine/src/engine/validate.rs
+++ b/crates/engine/src/engine/validate.rs
@@ -196,8 +196,9 @@ mod tests {
         // exec driver parses specs into defs (with codegen-stamped outputs); the
         // fs provider/driver resolves any synthesized inputs; the static provider
         // supplies the specs and the `list_packages` query needs.
-        engine
-            .register_managed_driver(|_| Box::new(hplugin_exec::pluginexec::Driver::new_exec()))?;
+        engine.register_managed_driver(|_| {
+            Box::new(hplugin_exec::pluginexec::Driver::new_exec().with_host_path())
+        })?;
         let provider = pluginstatictarget::Provider::new(targets)?;
         engine.register_provider(move |_| Box::new(provider))?;
         Ok((Arc::new(engine), root))

--- a/crates/plugin-exec/Cargo.toml
+++ b/crates/plugin-exec/Cargo.toml
@@ -20,6 +20,7 @@ async-trait = "0.1.89"
 glob = "0.3"
 tar = "0.4"
 libc = "0.2"
+which = "8.0.3"
 xxhash-rust = { version = "0.8.15", features = ["xxh3", "std"] }
 minijinja = "2"
 tracing = "0.1"

--- a/crates/plugin-exec/src/pluginexec/mod.rs
+++ b/crates/plugin-exec/src/pluginexec/mod.rs
@@ -63,6 +63,12 @@ pub struct Driver {
     coreutils: Option<(u32, CoreutilsShims)>,
     /// Resolved on first use and reused: the steady-state cost is one `stat`.
     coreutils_dir: std::sync::OnceLock<PathBuf>,
+    /// True when this driver wraps the target's command in a shell, so `argv[0]`
+    /// is *ours* rather than the target's. Only then may it be resolved on the
+    /// ambient PATH — see [`Driver::resolve_shell`].
+    wraps_in_shell: bool,
+    /// The absolute shell, resolved once on first use.
+    shell_path: std::sync::OnceLock<PathBuf>,
     wrap_run: fn(&std::path::Path, &[String]) -> anyhow::Result<Vec<String>>,
     wrap_run_shell: fn(&std::path::Path, &[String]) -> anyhow::Result<Vec<String>>,
 }
@@ -278,6 +284,8 @@ impl Driver {
         Self {
             default_runner: None,
             name: "exec".to_string(),
+            wraps_in_shell: false,
+            shell_path: std::sync::OnceLock::new(),
             coreutils_enabled: false,
             coreutils: None,
             coreutils_dir: std::sync::OnceLock::new(),
@@ -304,7 +312,13 @@ impl Driver {
             std::collections::HashMap::new();
         config.insert("run".to_string(), hcore::htvalue::Value::List(vec![]));
         std::sync::Arc::new(hdriver_support::driver_managed::ShellFallback {
-            driver: std::sync::Arc::new(Driver::new_exec()),
+            // The host's directories, deliberately, unlike a build target. This
+            // is the interactive shell a human gets from `--shell` on a driver
+            // that has no shell mode of its own — its entire purpose is poking
+            // around, and a session with no `ls` on `PATH` would be useless. It
+            // builds nothing and reaches no cache key, so the argument for
+            // keeping the host out does not apply to it.
+            driver: std::sync::Arc::new(Driver::new_exec().with_host_path()),
             spec_template: std::sync::Arc::new(hplugin::provider::TargetSpec {
                 addr: Default::default(),
                 driver: "exec".to_string(),
@@ -318,6 +332,8 @@ impl Driver {
         Self {
             default_runner: None,
             name: "bash".to_string(),
+            wraps_in_shell: true,
+            shell_path: std::sync::OnceLock::new(),
             coreutils_enabled: false,
             coreutils: None,
             coreutils_dir: std::sync::OnceLock::new(),
@@ -393,6 +409,68 @@ impl Driver {
         }
         let dir = shims().context("materialize the builtin-utility shim directory")?;
         Ok(Some(self.coreutils_dir.get_or_init(|| dir).as_path()))
+    }
+
+    /// Name the directories a target's `PATH` should end with.
+    ///
+    /// The equivalent of the driver's `path:` option, for an embedder that
+    /// builds the driver directly rather than from config. A driver with none
+    /// gives its targets only their declared tools and heph's builtins — see
+    /// `docs/COREUTILS.md`.
+    #[must_use]
+    pub fn with_search_path(mut self, dirs: impl IntoIterator<Item = impl Into<String>>) -> Self {
+        self.search_path = dirs.into_iter().map(Into::into).collect();
+        self
+    }
+
+    /// The host's directories on the target's `PATH`.
+    ///
+    /// For a test harness that needs a real `cat`/`sleep`/`printf` because it
+    /// is exercising the engine or process plumbing rather than `PATH` policy.
+    /// Spelled out per harness rather than defaulted, so anything depending on
+    /// the host says so.
+    #[must_use]
+    pub fn with_host_path(self) -> Self {
+        self.with_search_path(["/usr/local/bin", "/usr/bin", "/bin"])
+    }
+
+    /// The absolute path of the shell this driver wraps commands in.
+    ///
+    /// Resolved on the **ambient** `PATH` — the environment heph itself was
+    /// launched in — and spawned by absolute path, so the shell starts even
+    /// though the target's own `PATH` has no host directories on it. The two
+    /// are deliberately different things: the shell is the driver's
+    /// implementation detail, while everything the recipe runs *inside* it must
+    /// come from a declared tool or a builtin.
+    ///
+    /// Two things this must never extend to. The `exec` driver's `argv[0]` is
+    /// the target's own command, and resolving that ambiently would hand back
+    /// the entire hole this change closes. And a target under a *runner* runs
+    /// somewhere else entirely — a container has its own filesystem, where a
+    /// path resolved from heph's `PATH` does not exist — so the caller only
+    /// reaches here for a local spawn.
+    fn resolve_shell(&self, run: Vec<String>) -> anyhow::Result<Vec<String>> {
+        let Some((program, rest)) = run.split_first() else {
+            return Ok(run);
+        };
+        if program.contains('/') {
+            return Ok(run);
+        }
+        if let Some(found) = self.shell_path.get() {
+            let mut out = vec![found.to_string_lossy().into_owned()];
+            out.extend_from_slice(rest);
+            return Ok(out);
+        }
+        let found = which::which(program).with_context(|| {
+            format!(
+                "the {} driver needs `{program}` and could not find it on the PATH heph was                  launched with. A target's own PATH deliberately has no host directories on it,                  so the shell is resolved here instead.",
+                self.name,
+            )
+        })?;
+        let found = self.shell_path.get_or_init(|| found);
+        let mut out = vec![found.to_string_lossy().into_owned()];
+        out.extend_from_slice(rest);
+        Ok(out)
     }
 
     /// The toolbox identity that reaches a target's cache key, or `None` when it
@@ -1297,7 +1375,7 @@ impl Driver {
     /// a hardcoded default.
     fn sandbox_path_display(&self) -> String {
         if self.search_path.is_empty() {
-            ["/usr/local/bin", "/usr/bin", "/bin"].join(":")
+            "the target's tools and heph's builtin utilities".to_string()
         } else {
             self.search_path.join(":")
         }
@@ -1314,10 +1392,25 @@ impl Driver {
         let def = rreq.target.def::<TargetDef>();
 
         let run = {
-            if shell {
+            let wrapped = if shell {
                 (self.wrap_run_shell)(&rreq.sandbox_dir, &def.run)?
             } else {
                 (self.wrap_run)(&rreq.sandbox_dir, &def.run)?
+            };
+            // `argv[0]` is ours whenever we wrapped the command in a shell —
+            // either because this is the bash driver, or because shell mode
+            // wrapped an exec target.
+            //
+            // Only for a *local* spawn, though. Under a runner the environment
+            // is the runner's, and an absolute path resolved from heph's own
+            // PATH is meaningless there: a container has its own filesystem,
+            // and `/nix/store/…/bash` does not exist inside it. The shell has
+            // to come from the environment the target actually runs in, which
+            // is exactly what naming a runner asks for.
+            if def.runner.is_none() && (self.wraps_in_shell || shell) {
+                self.resolve_shell(wrapped)?
+            } else {
+                wrapped
             }
         };
 
@@ -1329,14 +1422,13 @@ impl Driver {
         if shell && let Ok(term) = std::env::var("TERM") {
             env.insert("TERM".to_string(), term);
         }
-        // Only when nothing else supplies an environment. Under a runner the
-        // environment is the runner's, and injecting `/usr/local/bin:/usr/bin:/bin`
-        // here would put the host's copy of a tool ahead of the one the target
-        // asked to run beside — silently, and inside a cache key that claims the
-        // runner's environment. It travels as `PathPolicy::fallback` instead, so
-        // a local spawn still gets it and an agent decides for itself.
-        if def.runner.is_none() {
-            env.insert("PATH".to_string(), self.sandbox_path_display());
+        // The host directories are deliberately absent. A target sees its own
+        // tools and heph's builtins, and nothing else: a recipe that reaches for
+        // an undeclared host binary is reaching outside its cache key, and the
+        // failure should say so rather than silently succeed on one machine.
+        // `path:` names directories back for a workspace that needs them.
+        if def.runner.is_none() && !self.search_path.is_empty() {
+            env.insert("PATH".to_string(), self.search_path.join(":"));
         }
         env.insert(
             "WORKSPACE_ROOT".to_string(),
@@ -1642,7 +1734,9 @@ impl Driver {
                 .map(|d| d.as_os_str().to_os_string())
                 .into_iter()
                 .collect(),
-            fallback: Some(std::ffi::OsString::from(self.sandbox_path_display())),
+            // No fallback. It carried `/usr/local/bin:/usr/bin:/bin` to the seam
+            // for a local spawn, which is precisely what this change removes.
+            fallback: None,
             suffix: coreutils_dir
                 .map(|d| d.as_os_str().to_os_string())
                 .into_iter()
@@ -1779,7 +1873,7 @@ impl Driver {
             };
             if e.kind() == std::io::ErrorKind::NotFound {
                 anyhow::anyhow!(
-                    "spawn child process {program:?}{via}: {e} — not found in the driver's sandbox PATH ({path}). This PATH is set by the driver's `path` option in .hephconfig and is independent of the invoking shell's PATH — a program on your interactive PATH can still be missing here. Also check that the working directory {cwd:?} exists.",
+                    "spawn child process {program:?}{via}: {e} — not found on the target's PATH ({path}). A target sees only what it declares as a tool plus heph's builtin utilities; the host's directories are deliberately not there, so a program on your interactive PATH is still missing here. Declare it as a tool, call it by absolute path, or name the directories back with the driver's `path` option in .hephconfig. Also check that the working directory {cwd:?} exists.",
                     path = self.sandbox_path_display(),
                     cwd = req.sandbox_pkg_dir,
                 )
@@ -2875,7 +2969,7 @@ mod tests {
     /// Runs on the `multi_thread` flavor — the runtime shape that panicked.
     #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
     async fn cancel_grace_escalates_without_panicking_timer() -> anyhow::Result<()> {
-        let driver = Driver::new_bash();
+        let driver = Driver::new_bash().with_host_path();
         let ctoken = StdCancellationToken::new();
 
         let target_def = EngineTargetDef {
@@ -2941,7 +3035,7 @@ mod tests {
     /// draining; without that, the child blocks on `write` and never exits.
     #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
     async fn test_run_large_output_does_not_deadlock_multi_thread() -> anyhow::Result<()> {
-        let driver = Driver::new_bash();
+        let driver = Driver::new_bash().with_host_path();
         let ctoken = StdCancellationToken::new();
         // 256 KiB — bigger than macOS pipe buffers (16-64 KiB), so without
         // a draining stdout pump the child would block on write forever.
@@ -3115,7 +3209,7 @@ mod tests {
         /// while a starved stream (delta ~0) stays unambiguously red.
         const EARLY_BY: std::time::Duration = std::time::Duration::from_millis(500);
 
-        let driver = Driver::new_bash();
+        let driver = Driver::new_bash().with_host_path();
         let ctoken = StdCancellationToken::new();
         let target_def = EngineTargetDef {
             addr: Addr::default(),
@@ -3202,7 +3296,7 @@ mod tests {
     /// sleeps make the true order unambiguous, so this is not a race.
     #[tokio::test(flavor = "multi_thread", worker_threads = 4)]
     async fn test_run_log_records_both_streams_in_arrival_order() -> anyhow::Result<()> {
-        let driver = Driver::new_bash();
+        let driver = Driver::new_bash().with_host_path();
         let ctoken = StdCancellationToken::new();
         let target_def = EngineTargetDef {
             addr: Addr::default(),
@@ -3270,7 +3364,7 @@ mod tests {
     async fn test_run_output_far_beyond_drain_bound_does_not_deadlock() -> anyhow::Result<()> {
         const PER_STREAM: usize = 4 * 1024 * 1024;
 
-        let driver = Driver::new_bash();
+        let driver = Driver::new_bash().with_host_path();
         let ctoken = StdCancellationToken::new();
         let target_def = EngineTargetDef {
             addr: Addr::default(),
@@ -3425,7 +3519,7 @@ mod tests {
         // the overlap deterministic rather than a race).
         const SINK_DELAY: std::time::Duration = std::time::Duration::from_millis(5);
 
-        let driver = Driver::new_bash();
+        let driver = Driver::new_bash().with_host_path();
         let ctoken = StdCancellationToken::new();
         let target_def = EngineTargetDef {
             addr: Addr::default(),
@@ -3536,7 +3630,7 @@ mod tests {
         runtime_pass_env: Vec<String>,
         runtime_env: HashMap<String, String>,
     ) -> anyhow::Result<String> {
-        let driver = Driver::new_bash();
+        let driver = Driver::new_bash().with_host_path();
         let ctoken = StdCancellationToken::new();
         let target_def = EngineTargetDef {
             addr: Addr::default(),
@@ -4919,7 +5013,7 @@ mod tests {
     /// correct given that already-merged state).
     #[tokio::test]
     async fn test_multi_output_tool_symlinks_all_binaries() -> anyhow::Result<()> {
-        let driver = Driver::new_exec();
+        let driver = Driver::new_exec().with_host_path();
         let ctoken = StdCancellationToken::new();
         let tmp = tempfile::tempdir()?;
 
@@ -5080,7 +5174,7 @@ mod tests {
     /// upstream by `Sandbox::merge_sandbox`; here we just avoid EEXIST.
     #[tokio::test]
     async fn overlapping_tool_filenames_dedupe_silently() -> anyhow::Result<()> {
-        let driver = Driver::new_exec();
+        let driver = Driver::new_exec().with_host_path();
         let ctoken = StdCancellationToken::new();
         let tmp = tempfile::tempdir()?;
 
@@ -5177,7 +5271,7 @@ mod tests {
     /// destination once and continue.
     #[tokio::test]
     async fn same_source_tool_filename_dedupes_silently() -> anyhow::Result<()> {
-        let driver = Driver::new_exec();
+        let driver = Driver::new_exec().with_host_path();
         let ctoken = StdCancellationToken::new();
         let tmp = tempfile::tempdir()?;
 
@@ -5486,6 +5580,115 @@ mod tests {
         )
         .await?;
         assert_eq!(base.hash, off_again.hash);
+        Ok(())
+    }
+
+    #[test]
+    fn the_shell_is_not_resolved_for_a_target_under_a_runner() {
+        // A runner's environment is somewhere else — a container has its own
+        // filesystem, and an absolute path resolved from heph's PATH does not
+        // exist inside it. Rewriting `argv[0]` here would hand the runner a
+        // program that cannot run.
+        let driver = Driver::new_bash();
+        let argv = vec!["bash".to_string(), "-c".to_string(), "true".to_string()];
+        let resolved = driver.resolve_shell(argv.clone()).expect("resolve");
+        assert_ne!(
+            resolved, argv,
+            "a local spawn does resolve the shell to an absolute path"
+        );
+        assert!(
+            resolved.first().is_some_and(|p| p.contains('/')),
+            "and that path is absolute; got {resolved:?}"
+        );
+        // The runner case is decided by the caller in `run_inner`, which is
+        // covered end to end by `crates/e2e/tests/oci_runner.rs` — a container
+        // target whose `argv[0]` was rewritten to a host path cannot start.
+    }
+
+    #[tokio::test]
+    async fn a_target_that_declares_nothing_gets_no_host_directories() -> anyhow::Result<()> {
+        // The point of dropping the host `PATH`: a recipe that reaches for an
+        // undeclared binary is reaching outside its own cache key, and must
+        // fail rather than silently succeed on whichever machine has it.
+        let home = tempfile::tempdir()?;
+        let driver = Driver::new_bash()
+            .with_coreutils_enabled_for_test()
+            .with_coreutils(1, fake_shims(home.path()));
+        let ctoken = StdCancellationToken::new();
+        let tmp = tempfile::tempdir()?;
+
+        let target_def = EngineTargetDef {
+            addr: Addr::default(),
+            labels: vec![],
+            raw_def: Arc::new(TargetDef {
+                runner: None,
+                run: vec!["echo $PATH".to_string()],
+                dep_group_inputs: BTreeMap::new(),
+                runtime_dep_group_inputs: BTreeMap::new(),
+                env: BTreeMap::new(),
+                tool_group_inputs: BTreeMap::new(),
+                pass_env: BTreeMap::new(),
+                runtime_pass_env: vec![],
+                runtime_env: HashMap::new(),
+                outputs: BTreeMap::new(),
+                support_files: vec![],
+            }),
+            inputs: vec![],
+            outputs: vec![],
+            support_files: vec![],
+            cache: CacheConfig::on(true),
+            pty: true,
+            hash: vec![],
+            transparent: false,
+        };
+        let mut stdout = Vec::new();
+        let request_id = "test".to_string();
+        let req = RunRequest {
+            request_id: &request_id,
+            target: &target_def,
+            tree_root_path: "".to_string().into(),
+            inputs: vec![],
+            hashin: "",
+            stdin: None,
+            stdout: Some(&mut stdout),
+            stderr: None,
+            sandbox_dir: tmp.path().to_path_buf(),
+            scratch: vec![],
+        };
+        driver
+            .run(
+                ManagedRunRequest {
+                    sandbox_dir: tmp.path().to_path_buf(),
+                    sandbox_ws_dir: tmp.path().to_path_buf(),
+                    sandbox_pkg_dir: tmp.path().to_path_buf(),
+                    request: req,
+                    inputs: vec![],
+                },
+                &ctoken,
+            )
+            .await?;
+
+        let path_out = String::from_utf8(stdout)?;
+        let path_out = path_out.trim();
+        for host in ["/usr/local/bin", "/usr/bin", "/bin"] {
+            assert!(
+                !path_out.split(':').any(|e| e == host),
+                "{host} must not be on a target's PATH; got: {path_out}"
+            );
+        }
+        // What is left is exactly the builtins — and the shell still started,
+        // which is the other half of the change: it is resolved on the ambient
+        // PATH and spawned by absolute path, so it runs even though the
+        // target's own PATH could never have found it.
+        let shims = driver
+            .coreutils_dir()?
+            .expect("enabled")
+            .to_string_lossy()
+            .into_owned();
+        assert_eq!(
+            path_out, shims,
+            "a target that declares nothing sees only the builtins"
+        );
         Ok(())
     }
 

--- a/crates/plugingo-e2e/tests/common/mod.rs
+++ b/crates/plugingo-e2e/tests/common/mod.rs
@@ -470,8 +470,8 @@ fn make_workspace_ordered_runner(
     }
 
     let r = || runner.clone();
-    b.with_managed_driver(Box::new(pluginexec::Driver::new_bash()))
-        .with_managed_driver(Box::new(pluginexec::Driver::new_exec()))
+    b.with_managed_driver(Box::new(pluginexec::Driver::new_bash().with_host_path()))
+        .with_managed_driver(Box::new(pluginexec::Driver::new_exec().with_host_path()))
         .with_managed_driver(Box::new(hplugin_devenv::plugindevenv::Driver::new()))
         .with_managed_driver(Box::new(
             plugingo::GoGolistDriver::new().with_default_runner(r()),

--- a/docs/COREUTILS.md
+++ b/docs/COREUTILS.md
@@ -70,6 +70,44 @@ environment provides:
 PATH = the target's tools  ++  what the target declared  ++  the runner's PATH  ++  heph coreutils
 ```
 
+**The host's directories are not on that list.** A target sees what it declares
+plus heph's builtins, and nothing else: a recipe that reaches for an undeclared
+host binary is reaching outside its own cache key, and it now fails with
+`command not found` rather than succeeding on whichever machine happens to have
+it. `path:` on the driver names directories back for a workspace that needs
+them.
+
+The shell is the exception, and deliberately so. `bash` is the *driver's*
+implementation detail, not something the target declared, so **for a local
+spawn** it is resolved on the **ambient** `PATH` — the environment heph itself
+was launched in — and spawned by absolute path. Under a runner it is left
+alone: a container has its own filesystem, and an absolute path resolved from
+heph's `PATH` does not exist inside it, so the shell has to come from the
+environment the target actually runs in — which is what naming a runner asks
+for. An absolute program spawns fine regardless of the
+child's `PATH`, so the shell starts and the recipe inside it still cannot reach
+an undeclared host binary. That must never extend to the `exec` driver's
+`argv[0]`, which *is* the target's command: resolving that ambiently would hand
+back the whole hole this closes.
+
+The interactive shell from `--shell`, on a driver with no shell mode of its
+own, is the other exception: it gets the host's directories. Its entire purpose
+is poking around, a session with no `ls` on `PATH` would be useless, and it
+builds nothing and reaches no cache key — so the argument for keeping the host
+out does not apply to it.
+
+A runner supplies the environment its targets run in, `PATH` included — the
+driver's search path is not injected under one, for the same reason the host's
+directories are not injected locally. A `wrap` runner that names no `PATH` gives
+its targets only their declared tools and, where the shim directory is
+reachable, the builtins.
+
+The shell stays out of the cache key. It is unhashed, and folding the resolved
+path in would split the remote cache between every machine whose `bash` lives
+somewhere different. A provisioned shell would close that properly; until then
+it is an acknowledged hole, and macOS's bash 3.2 remains the largest cross-OS
+divergence left.
+
 **A target's own tools always win.** A recipe that provisions its own `sed` gets
 that `sed`; the builtins never override a deliberately declared tool.
 

--- a/docs/EXEC_RUNNERS.md
+++ b/docs/EXEC_RUNNERS.md
@@ -175,12 +175,12 @@ composed into the environment this process spawns, and therefore deliberately
 does not reach a runner carrying the environment out of band: those are host
 paths, and a container's filesystem is not this one.
 
-What is **not** in there is the exec driver's own sandbox `PATH`
-(`/usr/local/bin:/usr/bin:/bin`, or its `path:` option). Under a runner the
-driver does not inject it at all: it is a fallback for a local spawn, and
-putting it in front of the environment would let a host-installed tool silently
-shadow the one the target asked to run beside — inside a cache key that claims
-the runner's environment.
+What is **not** in there is the host's directories. They are not injected under
+a runner — putting them in front of the environment would let a host-installed
+tool silently shadow the one the target asked to run beside, inside a cache key
+that claims the runner's environment — and, since heph ships its own utilities,
+they are not injected for a local spawn either. See `COREUTILS.md`. The driver's
+`path:` option names directories back for a workspace that needs them.
 
 ## The fingerprint, and why it exists
 


### PR DESCRIPTION
The host directories — `/usr/local/bin:/usr/bin:/bin` — come off every target's `PATH`. **Breaking, deliberately.**

This is what makes the toolbox worth more than convenience. It turns the sandbox from *isolated files, ambient tools* into *isolated files, declared tools*, and closes the largest remaining under-hashing hole in the cache key: the version of every host binary a recipe ever invoked was never in it.

A target's `PATH` becomes exactly `[its tools] : [what it declared] : [heph's builtins]`. Nothing else.

## This removes discovery, not visibility

The sandbox already exposes the host filesystem; dropping the entries only stops *bare-name* resolution. `/usr/bin/foo` still runs. `foo` stops resolving. The failure is always "not found on PATH" with the program and the searched path named — never a silent behaviour change.

## What stops resolving

Worth being blunt: this is larger than shadowing `cp`. Shadowing changes *which* `cp` runs; this changes *whether* `cc` runs at all.

- `#!/usr/bin/env python3` — `env` is exec'd by absolute path, then searches `PATH` and does not find the interpreter. Declare it.
- `cc`/`clang`/`ld`/`pkg-config` — any recipe shelling out to a toolchain it never declared. The largest migration cost in practice.
- `git`, `xcrun`, `codesign` — usually undeclared and usually already non-hermetic.

The driver's `path:` option names directories back for a workspace that needs them.

## Two different PATHs, and that is the trick

Resolving *the driver's own program* and *what the recipe sees* are separate things:

- **The shell resolves on the ambient `PATH`** — the environment heph itself was launched in — to an absolute path, once. Only for a local spawn: under a runner the shell has to come from the environment the target actually runs in.
- **The child's `PATH`** is the sandbox one above. Nothing ambient.

An absolute program path spawns regardless of the child's `PATH`, so the shell starts and the recipe inside it still cannot reach an undeclared host binary.

## Known cost

Which `bash` you get now depends on how heph was launched, where it used to be a hardcoded list. More convenient, less deterministic; the shell stays out of the cache key, because folding the resolved path in would split the remote cache across every machine whose `bash` lives elsewhere. An acknowledged hole that a provisioned shell would close properly.

---

### The stack

Merge bottom-up, and `gh stack sync` after each one lands — `master` is squash-only, so the rebase will conflict and the [resolution rule in CLAUDE.md](https://github.com/hephbuild/heph/blob/master/CLAUDE.md) applies.

| | PR | What |
|---|---|---|
| 6 | #446 | drop the host directories from a target's `PATH` — **breaking** |
| 5 | #445 | the toolbox on by default |
| 4 | #440 | the `template` rule and the `tmpl` applet |
| 3 | #453 | grep, find, xargs, sed, tar, gzip, zstd |
| 2 | #438 | the crate, the entry points, the shim directory |
| 1 | #451 | the runner `PATH` seam ← **base, targets `master`** |

Only #451 builds automatically: since #449 a stacked PR is skipped unless it carries `ci/force-ci`. Every layer was checked locally on its own — `cargo build --workspace --all-targets`, `cargo clippy --workspace --all-targets`, and its unit tests — not just at the top of the stack.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0181d7hhbYWXT42Z1KQPM29Q
