### PR TITLE
fix(execrunner): PATH across the runner seam — carry the prefix out of band, and a tier for what heph supplies

### DIFF
--- a/crates/e2e/tests/oci_runner.rs
+++ b/crates/e2e/tests/oci_runner.rs
@@ -341,6 +341,64 @@ target(
     Ok(())
 }
 
+/// A tool the target declares must be findable inside the container, and the
+/// image's own directories must still be there behind it.
+///
+/// The regression this pins: a runner that carries the environment out of band
+/// — `oci` turns it into `docker exec -e KEY=VALUE` and hands back the *docker
+/// client's* environment — used to have the `PATH` prefix composed onto it
+/// after `prepare`, i.e. onto the client. The target inside the container got
+/// neither its declared tools nor heph's builtins, and silently: the container
+/// fell back to the image's own tools, so a recipe kept working with a
+/// different binary than its cache key names.
+#[tokio::test]
+async fn a_declared_tool_is_on_the_path_inside_the_container() -> anyhow::Result<()> {
+    skip_unless_docker!();
+    if !build_marker_image() {
+        eprintln!("skipping: could not build the fixture image");
+        return Ok(());
+    }
+
+    let ws = workspace();
+    ws.write_build_file(
+        "svc",
+        &format!(
+            r#"
+target(
+    name = "runner",
+    driver = "oci_runner",
+    image = "{MARKER_IMAGE}",
+)
+target(
+    name = "tool",
+    driver = "bash",
+    run = "printf '#!/bin/sh\necho from-the-declared-tool\n' > $OUT && chmod +x $OUT",
+    out = "heph-e2e-tool",
+)
+target(
+    name = "inside",
+    driver = "bash",
+    runner = ":runner",
+    tools = [":tool"],
+    run = "{{ heph-e2e-tool; command -v cat; }} > $OUT",
+    out = "where.txt",
+)
+"#
+        ),
+    );
+
+    let got = common::artifact_string(&*ws.run("//svc:inside").await?);
+    assert!(
+        got.contains("from-the-declared-tool"),
+        "a declared tool must be on PATH inside the container; got {got:?}"
+    );
+    assert!(
+        got.contains("/bin/cat"),
+        "the image's own directories must still be on PATH behind the target's; got {got:?}"
+    );
+    Ok(())
+}
+
 /// An image the daemon has never seen must fail by name, pointing at the
 /// `oci_load` that would put it there — not fail somewhere later with a digest
 /// nobody can explain.

--- a/crates/execrunner/src/lib.rs
+++ b/crates/execrunner/src/lib.rs
@@ -392,6 +392,23 @@ async fn prepare(
     // side could equally be either.
     let declared = get_env(&spec.env, "PATH");
 
+    // The prefix has to be on the environment the runner *carries*, not only on
+    // the one this process ends up spawning. A runner may move the target's
+    // environment out of band — `oci` turns it into `docker exec -e KEY=VALUE`
+    // arguments and hands back the *client's* environment — and anything
+    // composed after `prepare` then decorates the docker client while the
+    // target inside the container gets neither its declared tools nor heph's
+    // builtins. Silently: the container falls back to the image's own tools, so
+    // the recipe keeps working with a different binary than its cache key names.
+    //
+    // Composing here puts the prefix on the wire the runner already carries.
+    // The composition after `prepare` still runs, and still orders the runner's
+    // own `PATH` behind the prefix for every runner that leaves the environment
+    // in place; `join_path` dedupes, so doing both is idempotent.
+    if let Some(carried) = carried_path(path, declared.as_ref()) {
+        set_path(&mut spec.env, carried);
+    }
+
     let outcome = host
         .prepare(runner.request_id, addr, SpecRewrite::split(spec), ctoken)
         .await?;
@@ -440,6 +457,16 @@ fn compose_path(
     if let Some(p) = composed {
         set_path(env, p);
     }
+}
+
+/// The `PATH` handed to the runner: the target's prefix ahead of what it
+/// declared.
+///
+/// Separate from the composition that follows `prepare` because a runner may
+/// carry the environment out of band, and then this is the only copy the target
+/// ever sees. See [`PathPolicy`].
+fn carried_path(path: &PathPolicy, declared: Option<&OsString>) -> Option<OsString> {
+    join_path(path.prefix.iter().cloned().chain(declared.cloned()))
 }
 
 fn set_path(env: &mut Vec<(OsString, OsString)>, value: OsString) {
@@ -652,6 +679,40 @@ mod tests {
             path_of(&spec.env).as_deref(),
             Some("/sandbox/bin:/usr/local/bin:/usr/bin")
         );
+    }
+
+    /// A runner may carry the target's environment **out of band**: `oci` turns
+    /// it into `docker exec -e KEY=VALUE` arguments and hands back the *docker
+    /// client's* environment. So the prefix — the target's declared tools, and
+    /// heph's builtin utilities — has to be on the environment handed *to* the
+    /// runner, because for such a runner that is the only copy the target ever
+    /// sees.
+    ///
+    /// Composing only after `prepare` decorated the docker client instead, and
+    /// the target inside the container got neither. Silently: the container
+    /// falls back to the image's own tools, so the recipe keeps working with a
+    /// different binary than its cache key names.
+    #[test]
+    fn the_path_handed_to_a_runner_leads_with_the_targets_prefix() {
+        let carried = carried_path(
+            &policy(&["/sandbox/bin", "/heph/coreutils/bin"], Some("/fallback")),
+            Some(&os("/declared")),
+        );
+        assert_eq!(
+            carried.as_deref(),
+            Some(std::ffi::OsStr::new(
+                "/sandbox/bin:/heph/coreutils/bin:/declared"
+            )),
+            "the target's tools and heph's builtins must lead the PATH the runner carries"
+        );
+    }
+
+    /// The fallback is the driver's sandbox `PATH`, and it is not part of what a
+    /// runner carries: reinstating it out of band would put `/usr/bin` inside
+    /// the environment the target asked to run in.
+    #[test]
+    fn nothing_is_carried_to_a_runner_when_there_is_no_prefix_and_no_declaration() {
+        assert_eq!(carried_path(&policy(&[], Some("/usr/bin")), None), None);
     }
 
     #[test]

--- a/crates/execrunner/src/lib.rs
+++ b/crates/execrunner/src/lib.rs
@@ -140,6 +140,20 @@ pub struct PathPolicy {
     /// Used only when nothing else provides a `PATH`, and never under a runner
     /// that supplies an environment of its own.
     pub fallback: Option<OsString>,
+    /// Entries that come **last**, behind everything the environment provides.
+    ///
+    /// For tools heph supplies rather than the target: they should fill a gap
+    /// the environment leaves, and never shadow a binary that environment
+    /// deliberately ships. `prefix` is the opposite — what the target declared,
+    /// which wins over everything.
+    ///
+    /// It is composed into the environment *this process* spawns, and so it
+    /// deliberately does not reach a runner that carries the environment out of
+    /// band: those entries are host paths, and a container's filesystem is not
+    /// this one. A runner that relocates the environment gets the prefix (which
+    /// is the target's own, and lives on paths the runner is responsible for
+    /// making visible) and not the suffix.
+    pub suffix: Vec<OsString>,
 }
 
 /// The `PATH` key, as an `OsStr` comparison target.
@@ -362,6 +376,7 @@ async fn prepare(
         // local spawn, unchanged.
         let declared = get_env(&spec.env, "PATH");
         compose_path(&mut spec.env, path, declared, true);
+        append_path(&mut spec.env, path.suffix.iter().cloned());
         return Ok(());
     };
 
@@ -429,11 +444,13 @@ async fn prepare(
         !supplies_environment,
     );
     if let Some(provided) = provided {
-        let so_far = get_env(&spec.env, "PATH");
-        if let Some(joined) = join_path(so_far.into_iter().chain(std::iter::once(provided))) {
-            set_path(&mut spec.env, joined);
-        }
+        append_path(&mut spec.env, std::iter::once(provided));
     }
+    // Last, behind the environment the target asked to run in. Only for a
+    // runner that left the environment in `spec.env`: one that carried it out
+    // of band is holding a copy this never touches, which is the intended
+    // outcome — see [`PathPolicy::suffix`].
+    append_path(&mut spec.env, path.suffix.iter().cloned());
     Ok(())
 }
 
@@ -467,6 +484,14 @@ fn compose_path(
 /// ever sees. See [`PathPolicy`].
 fn carried_path(path: &PathPolicy, declared: Option<&OsString>) -> Option<OsString> {
     join_path(path.prefix.iter().cloned().chain(declared.cloned()))
+}
+
+/// Append `items` behind whatever `PATH` the environment already has.
+fn append_path(env: &mut Vec<(OsString, OsString)>, items: impl IntoIterator<Item = OsString>) {
+    let so_far = get_env(env, "PATH");
+    if let Some(joined) = join_path(so_far.into_iter().chain(items)) {
+        set_path(env, joined);
+    }
 }
 
 fn set_path(env: &mut Vec<(OsString, OsString)>, value: OsString) {
@@ -613,6 +638,15 @@ mod tests {
         PathPolicy {
             prefix: prefix.iter().map(|p| os(p)).collect(),
             fallback: fallback.map(os),
+            suffix: vec![],
+        }
+    }
+
+    fn policy_with_suffix(prefix: &[&str], suffix: &[&str]) -> PathPolicy {
+        PathPolicy {
+            prefix: prefix.iter().map(|p| os(p)).collect(),
+            fallback: None,
+            suffix: suffix.iter().map(|p| os(p)).collect(),
         }
     }
 
@@ -704,6 +738,45 @@ mod tests {
                 "/sandbox/bin:/heph/coreutils/bin:/declared"
             )),
             "the target's tools and heph's builtins must lead the PATH the runner carries"
+        );
+    }
+
+    /// The suffix is for tools *heph* supplies rather than the target: they fill
+    /// a gap the environment leaves and never shadow what it deliberately
+    /// ships. So it composes behind everything — the target's tools lead, what
+    /// the target declared follows, then the environment, then these.
+    #[tokio::test]
+    async fn what_heph_supplies_composes_behind_the_environment() {
+        let mut spec = spec("/bin/true");
+        spec.env.push((os("PATH"), os("/declared")));
+        let ctoken = StdCancellationToken::new();
+        let policy = policy_with_suffix(&["/sandbox/bin"], &["/heph/coreutils/bin"]);
+        prepare(RunnerRef::local(), &mut spec, &policy, &ctoken)
+            .await
+            .expect("local prepare");
+        assert_eq!(
+            path_of(&spec.env).as_deref(),
+            Some("/sandbox/bin:/declared:/heph/coreutils/bin")
+        );
+    }
+
+    /// The suffix is not part of what a runner carries. Those entries are host
+    /// paths, and the whole point of naming a runner is that the filesystem may
+    /// not be this one — a container would get a directory of symlinks into a
+    /// binary built for the wrong platform.
+    ///
+    /// The prefix still is carried: it is the target's own, on paths the runner
+    /// is responsible for making visible.
+    #[test]
+    fn what_heph_supplies_is_not_carried_to_a_runner() {
+        let carried = carried_path(
+            &policy_with_suffix(&["/sandbox/bin"], &["/heph/coreutils/bin"]),
+            Some(&os("/declared")),
+        );
+        assert_eq!(
+            carried.as_deref(),
+            Some(std::ffi::OsStr::new("/sandbox/bin:/declared")),
+            "a runner carries the target's own PATH, not heph's host-path builtins"
         );
     }
 

--- a/crates/plugin-exec/src/pluginexec/mod.rs
+++ b/crates/plugin-exec/src/pluginexec/mod.rs
@@ -1520,6 +1520,9 @@ impl Driver {
                 .into_iter()
                 .collect(),
             fallback: Some(std::ffi::OsString::from(self.sandbox_path_display())),
+            // Nothing heph supplies behind the environment yet; the builtin
+            // toolbox is what this tier exists for.
+            suffix: vec![],
         };
 
         let output_log_path = req.sandbox_dir.join("log.txt");

--- a/crates/plugin-oci/src/pluginoci/exec_runner.rs
+++ b/crates/plugin-oci/src/pluginoci/exec_runner.rs
@@ -40,7 +40,8 @@ use hexecrunner::SpecRewrite;
 use hexecrunner::registry::{ExecRunner, RunnerCtx};
 use serde::Deserialize;
 use std::collections::HashMap;
-use std::ffi::OsString;
+use std::ffi::{OsStr, OsString};
+use std::path::PathBuf;
 use std::sync::Mutex;
 
 /// The name a `runner.json` selects this by.
@@ -120,6 +121,13 @@ fn resolve_docker(bin: &str) -> anyhow::Result<std::path::PathBuf> {
 struct Live {
     id: String,
     docker: String,
+    /// The image's own `PATH`, read once from the container's config.
+    ///
+    /// A target's `PATH` reaches the container as an explicit `-e PATH=…`,
+    /// which *replaces* the image's rather than extending it. Without the
+    /// image's own value behind it, entering a container would strip `/usr/bin`
+    /// from every target that declares a tool.
+    path: Option<OsString>,
 }
 
 pub struct OciRunner {
@@ -149,14 +157,18 @@ impl OciRunner {
     /// container is a *place to exec into*, so its own entrypoint is irrelevant
     /// and must not be whatever the image happens to declare — an image whose
     /// entrypoint exits immediately would otherwise leave nothing to exec into.
-    fn container(&self, ctx: &RunnerCtx<'_>, cfg: &OciConfig) -> anyhow::Result<String> {
+    fn container(
+        &self,
+        ctx: &RunnerCtx<'_>,
+        cfg: &OciConfig,
+    ) -> anyhow::Result<(String, Option<OsString>)> {
         let key = (ctx.addr.to_string(), ctx.fingerprint.to_string());
         let mut live = self
             .live
             .lock()
             .map_err(|_poisoned| anyhow::anyhow!("oci runner container table poisoned"))?;
         if let Some(c) = live.get(&key) {
-            return Ok(c.id.clone());
+            return Ok((c.id.clone(), c.path.clone()));
         }
 
         let mut args: Vec<String> = vec!["run".into(), "-d".into(), "--rm".into()];
@@ -195,15 +207,106 @@ impl OciRunner {
                 cfg.docker
             );
         }
+        let path = image_path(&cfg.docker, &id);
         live.insert(
             key,
             Live {
                 id: id.clone(),
                 docker: cfg.docker.clone(),
+                path: path.clone(),
             },
         );
-        Ok(id)
+        Ok((id, path))
     }
+}
+
+/// The `docker exec` argv for one target.
+///
+/// Separate from [`OciRunner::prepare`] so the argv can be asserted without a
+/// daemon: everything above it needs a running container, and this is the part
+/// that decides what the target actually sees.
+fn exec_args(id: &str, image_path: Option<&OsStr>, rewrite: SpecRewrite) -> Vec<OsString> {
+    let mut args: Vec<OsString> = vec!["exec".into()];
+    args.push("-w".into());
+    args.push(rewrite.cwd.into_os_string());
+    for (k, v) in &rewrite.env {
+        args.push("-e".into());
+        // `-e KEY=VALUE` as one argument, so a value containing `=` or
+        // whitespace survives — docker splits on the first `=` only.
+        let mut kv = k.clone();
+        kv.push("=");
+        if k == "PATH" {
+            // `-e PATH` replaces the image's rather than extending it, so the
+            // image's own value has to be restored *behind* what the target
+            // carries: its declared tools and heph's builtins lead, the image's
+            // directories follow. Without this, entering a container would
+            // strip `/usr/bin` from every target that declares a tool.
+            kv.push(join_path_values(v, image_path));
+        } else {
+            kv.push(v);
+        }
+        args.push(kv);
+    }
+    args.push(OsString::from(id));
+    args.push(rewrite.program.into_os_string());
+    args.extend(rewrite.args);
+    args
+}
+
+/// `carried`, then whatever of `image` is not already in it.
+///
+/// Deduplicated because the two genuinely overlap — a target whose tools live
+/// under a mounted host path and an image that ships the same directory — and a
+/// `PATH` that grows a duplicate per exec is a real cost on every `execvp` the
+/// target makes.
+fn join_path_values(carried: &OsStr, image: Option<&OsStr>) -> OsString {
+    let Some(image) = image else {
+        return carried.to_os_string();
+    };
+    let mut seen: Vec<PathBuf> = std::env::split_paths(carried).collect();
+    let mut out = carried.to_os_string();
+    for entry in std::env::split_paths(image) {
+        if entry.as_os_str().is_empty() || seen.contains(&entry) {
+            continue;
+        }
+        if !out.is_empty() {
+            out.push(":");
+        }
+        out.push(&entry);
+        seen.push(entry);
+    }
+    out
+}
+
+/// The image's `PATH`, read from the running container's config.
+///
+/// Asked of the daemon rather than of the image, because `docker run` arguments
+/// (`--env`) can override it. Best-effort: an unreadable value costs the image's
+/// own directories on the target's `PATH`, which is a degraded environment but
+/// not a wrong one, and failing the build over it would be worse.
+fn image_path(docker: &str, id: &str) -> Option<OsString> {
+    let out = std::process::Command::new(docker)
+        .args([
+            "inspect",
+            "--format",
+            "{{range .Config.Env}}{{println .}}{{end}}",
+            id,
+        ])
+        .output()
+        .ok()?;
+    if !out.status.success() {
+        tracing::debug!(
+            container = id,
+            "could not inspect the container for its PATH; the image's own \
+             directories will not be on the target's PATH"
+        );
+        return None;
+    }
+    String::from_utf8_lossy(&out.stdout)
+        .lines()
+        .find_map(|l| l.strip_prefix("PATH="))
+        .filter(|v| !v.is_empty())
+        .map(OsString::from)
 }
 
 #[async_trait::async_trait]
@@ -225,26 +328,12 @@ impl ExecRunner for OciRunner {
     ) -> anyhow::Result<SpecRewrite> {
         let cfg: OciConfig = serde_json::from_value(ctx.config.clone())
             .map_err(|e| anyhow::anyhow!("oci runner {}: parse config: {e}", ctx.addr))?;
-        let id = self.container(ctx, &cfg)?;
+        let (id, image_path) = self.container(ctx, &cfg)?;
 
         // `docker exec` rather than a fresh `docker run`: the cwd and the
         // environment are per-exec, and a container that is already up costs
         // nothing to enter.
-        let mut args: Vec<OsString> = vec!["exec".into()];
-        args.push("-w".into());
-        args.push(rewrite.cwd.clone().into_os_string());
-        for (k, v) in &rewrite.env {
-            args.push("-e".into());
-            // `-e KEY=VALUE` as one argument, so a value containing `=` or
-            // whitespace survives — docker splits on the first `=` only.
-            let mut kv = k.clone();
-            kv.push("=");
-            kv.push(v);
-            args.push(kv);
-        }
-        args.push(OsString::from(&id));
-        args.push(rewrite.program.into_os_string());
-        args.extend(rewrite.args);
+        let args = exec_args(&id, image_path.as_deref(), rewrite);
 
         Ok(SpecRewrite {
             program: resolve_docker(&cfg.docker)?,
@@ -281,6 +370,70 @@ mod tests {
 
     fn ctx_config(json: serde_json::Value) -> OciConfig {
         serde_json::from_value(json).expect("parse")
+    }
+
+    /// The end of the whole chain: what the target inside the container is
+    /// actually handed. Its declared tools and heph's builtins lead, and the
+    /// image's own directories are still there behind them.
+    #[test]
+    fn the_exec_argv_carries_the_targets_path_ahead_of_the_images() {
+        let args = exec_args(
+            "deadbeef",
+            Some(OsStr::new("/usr/bin:/bin")),
+            SpecRewrite {
+                program: PathBuf::from("bash"),
+                args: vec![OsString::from("-c"), OsString::from("make")],
+                env: vec![(
+                    OsString::from("PATH"),
+                    OsString::from("/sandbox/bin:/heph/coreutils/bin"),
+                )],
+                cwd: PathBuf::from("/ws/pkg"),
+            },
+        );
+        let path = args
+            .iter()
+            .find_map(|a| a.to_str()?.strip_prefix("PATH="))
+            .expect("the target's PATH must reach the container");
+        assert_eq!(path, "/sandbox/bin:/heph/coreutils/bin:/usr/bin:/bin");
+        // The container id must still separate the docker flags from the
+        // target's own command.
+        let id_at = args.iter().position(|a| a == "deadbeef").expect("id");
+        assert_eq!(args[id_at + 1], OsString::from("bash"));
+    }
+
+    /// `-e PATH` replaces the image's, so the image's own directories have to be
+    /// restored behind what the target carries — otherwise entering a container
+    /// strips `/usr/bin` from every target that declares a tool.
+    #[test]
+    fn the_image_path_follows_what_the_target_carries() {
+        let joined = join_path_values(
+            OsStr::new("/sandbox/bin:/heph/coreutils/bin"),
+            Some(OsStr::new("/usr/local/bin:/usr/bin:/bin")),
+        );
+        assert_eq!(
+            joined,
+            OsString::from("/sandbox/bin:/heph/coreutils/bin:/usr/local/bin:/usr/bin:/bin")
+        );
+    }
+
+    /// The two overlap in practice — the workspace is mounted at the same path
+    /// inside, so a tool directory can appear in both — and a duplicate costs a
+    /// wasted `stat` on every `execvp` the target makes.
+    #[test]
+    fn a_directory_in_both_is_not_repeated() {
+        let joined = join_path_values(
+            OsStr::new("/sandbox/bin:/usr/bin"),
+            Some(OsStr::new("/usr/bin:/bin")),
+        );
+        assert_eq!(joined, OsString::from("/sandbox/bin:/usr/bin:/bin"));
+    }
+
+    /// An image whose `PATH` could not be read leaves the target with exactly
+    /// what it carried, rather than failing the build.
+    #[test]
+    fn an_unreadable_image_path_leaves_the_carried_one_alone() {
+        let joined = join_path_values(OsStr::new("/sandbox/bin"), None);
+        assert_eq!(joined, OsString::from("/sandbox/bin"));
     }
 
     #[test]

--- a/docs/EXEC_RUNNERS.md
+++ b/docs/EXEC_RUNNERS.md
@@ -150,6 +150,7 @@ contribute:
 
 ```text
 PATH = the target's tools  ++  what the target declared  ++  the runner's PATH
+                                                          ++  what heph supplies
 ```
 
 Tools lead, so a target that declares a tool gets that one even when the
@@ -165,6 +166,14 @@ to the image's own tools: the recipe keeps working, with a different binary than
 its cache key names. A runner that replaces `PATH` outright is then responsible
 for putting its own environment's back *behind* what it was handed — which is
 why the oci runner reads the image's `PATH` from the container config.
+
+The last tier is the opposite of the first. `prefix` is what the *target*
+declared, so it leads and wins over everything; `suffix` is what *heph* supplies
+— the builtin utilities — so it trails, filling a gap the environment leaves
+without ever shadowing a binary that environment deliberately ships. It is
+composed into the environment this process spawns, and therefore deliberately
+does not reach a runner carrying the environment out of band: those are host
+paths, and a container's filesystem is not this one.
 
 What is **not** in there is the exec driver's own sandbox `PATH`
 (`/usr/local/bin:/usr/bin:/bin`, or its `path:` option). Under a runner the

--- a/docs/EXEC_RUNNERS.md
+++ b/docs/EXEC_RUNNERS.md
@@ -155,6 +155,17 @@ PATH = the target's tools  ++  what the target declared  ++  the runner's PATH
 Tools lead, so a target that declares a tool gets that one even when the
 environment ships another by the same name.
 
+The prefix is composed onto the target's environment **before** the runner is
+asked to prepare, not after. A runner may carry that environment out of band —
+`oci` turns it into `docker exec -e KEY=VALUE` arguments and hands back the
+*docker client's* environment — and a prefix applied afterwards would decorate
+the client while the target inside the container got neither its declared tools
+nor heph's builtins. It would do so silently, because the container falls back
+to the image's own tools: the recipe keeps working, with a different binary than
+its cache key names. A runner that replaces `PATH` outright is then responsible
+for putting its own environment's back *behind* what it was handed — which is
+why the oci runner reads the image's `PATH` from the container config.
+
 What is **not** in there is the exec driver's own sandbox `PATH`
 (`/usr/local/bin:/usr/bin:/bin`, or its `path:` option). Under a runner the
 driver does not inject it at all: it is a fallback for a local spawn, and


### PR DESCRIPTION
Two commits, both about how `PATH` composes across the runner seam. Found while regrounding the builtin-coreutils stack (#438 and up) against the runner model; the defect is on `master` and independent of that stack, so it lives here rather than folded into it.

## 1 · A runner carrying the environment out of band still gets the prefix

`PathPolicy.prefix` — a target's declared tools — was composed onto `spec.env` only **after** the runner's `prepare`.

That is right for a runner that leaves the environment where it found it: `wrap` puts its own `PATH` into `spec.env`, and `session` hands `spec.env` to the client, which forwards it to the agent.

It is wrong for a runner that carries the environment **out of band**. `OciRunner::prepare` turns the target's environment into `docker exec -e KEY=VALUE` arguments and returns the *docker client's* environment in its place. The composition then decorated the docker client, and the target inside the container never got its declared tools.

It failed **silently**, which is the part that matters: the container falls back to the image's own tools, so a recipe that reaches for a declared tool keeps working — with a different binary than its cache key names.

The fix composes the prefix onto the environment handed *to* the runner as well, so it rides whatever wire that runner already uses. Nothing changes for a runner that leaves the environment in place: the composition after `prepare` still orders the runner's own `PATH` behind the prefix, and `join_path` dedupes, so doing both is idempotent.

A runner that replaces `PATH` outright then owes its own environment's value *behind* what it was handed — `-e PATH` replaces the image's rather than extending it. So the oci runner now reads the image's `PATH` from the container config and restores it behind the target's. Without that, entering a container would strip `/usr/bin` from every target that declares a tool. Best-effort: an unreadable value costs the image's directories, a degraded environment rather than a wrong one.

## 2 · `PathPolicy.suffix` — a tier for what heph supplies

`prefix` is what the *target* declared, so it leads and wins over everything. There was no counterpart for what *heph* supplies, which wants the opposite ordering: fill a gap the environment leaves, never shadow a binary that environment deliberately ships. A workspace that names a devenv or nix runner pinned those tools on purpose, and heph's `sed` arriving in front of them is not a service.

```text
PATH = the target's tools ++ what it declared ++ the runner's PATH ++ what heph supplies
```

It is composed into the environment *this process* spawns, so it deliberately does not reach a runner carrying the environment out of band. That is the wanted behaviour, not a gap: those entries are host paths, and a container's filesystem is not this one — a shim directory of symlinks into a host-platform binary is worse inside an image than absent.

**Inert in this PR** — nothing populates it. The builtin-coreutils stack is the caller.

## Tests

Both halves of (1) are asserted **without a daemon**, since the failure is in what gets handed over, not in docker:

- `the_path_handed_to_a_runner_leads_with_the_targets_prefix`
- `the_exec_argv_carries_the_targets_path_ahead_of_the_images`
- `the_image_path_follows_what_the_target_carries`, `a_directory_in_both_is_not_repeated`, `an_unreadable_image_path_leaves_the_carried_one_alone`

For (2): `what_heph_supplies_composes_behind_the_environment` and `what_heph_supplies_is_not_carried_to_a_runner`.

A docker-gated e2e pins the real thing: `a_declared_tool_is_on_the_path_inside_the_container` runs a declared tool inside the container and checks `cat` still resolves from the image.

> The e2e is **unverified locally** — no docker daemon on this machine, so it skipped. CI is what exercises it. The three existing seam tests (`wrap`, agent, local) pass unchanged.

---

### The stack

Merge bottom-up, and `gh stack sync` after each one lands — `master` is squash-only, so the rebase will conflict and the [resolution rule in CLAUDE.md](https://github.com/hephbuild/heph/blob/master/CLAUDE.md) applies.

| | PR | What |
|---|---|---|
| 6 | #446 | drop the host directories from a target's `PATH` — **breaking** |
| 5 | #445 | the toolbox on by default |
| 4 | #440 | the `template` rule and the `tmpl` applet |
| 3 | #453 | grep, find, xargs, sed, tar, gzip, zstd |
| 2 | #438 | the crate, the entry points, the shim directory |
| 1 | #451 | the runner `PATH` seam ← **base, targets `master`** |

Only #451 builds automatically: since #449 a stacked PR is skipped unless it carries `ci/force-ci`. Every layer was checked locally on its own — `cargo build --workspace --all-targets`, `cargo clippy --workspace --all-targets`, and its unit tests — not just at the top of the stack.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0181d7hhbYWXT42Z1KQPM29Q
