### PR TITLE
feat(credential): credentials as targets

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -74,6 +74,20 @@ It builds `--release`, so it is slow and disk-hungry on a cold tree. Don't run i
 
 `tst` excludes `bin-e2e` deliberately: those tests need staged artifacts and hard-fail without `HEPH_E2E_DIST`, so a suite that never ran can't read as a suite that passed. See `.claude/testing.md` for what belongs there versus `crates/e2e`.
 
+### Credentials
+
+`docs/CREDENTIALS.md`. A credential is a target (`driver = "credential"`)
+declaring an identity, an ordered chain of ways to obtain it, and the shape it is
+presented in; a consumer names it with `credentials = [...]`.
+
+Read the doc before touching any of it. The two things to know going in: the
+reference is an `Input` with `hashed: false, runtime: false`, so **nothing about
+a credential can reach a cache key** and that exclusion is structural rather than
+conventional — and the other half of the contract, that a presentation carries
+material and handles but never anything that *selects content*, is a
+**convention** the parser cannot check. A target whose output depends on which
+identity ran it is not cacheable and says so with `cache = False`.
+
 ### Exec runners
 
 Every subprocess heph spawns goes through `crates/execrunner`, never

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1502,6 +1502,7 @@ version = "0.1.0"
 dependencies = [
  "anyhow",
  "core",
+ "futures",
  "heph",
  "plugin-devenv",
  "plugin-oci",
@@ -4124,6 +4125,7 @@ dependencies = [
  "execrunner",
  "glob",
  "libc",
+ "memchr",
  "minijinja",
  "model",
  "plugin",

--- a/crates/bin-e2e/tests/auth_helper.rs
+++ b/crates/bin-e2e/tests/auth_helper.rs
@@ -1,0 +1,308 @@
+//! `heph __auth-helper` as a **process**.
+//!
+//! This is here rather than in `crates/e2e` because none of it has an in-process
+//! form. The helper is dispatched *before* the argument parser, from `argv_os`,
+//! so nothing that goes through clap can exercise it; it is invoked by a foreign
+//! tool that owns its argv and its stdin; and its whole contract is about the
+//! process — stdout is somebody else's document, stderr is the diagnostic, and
+//! the exit status is what the calling SDK branches on.
+//!
+//! It is also the only way to reach the real callback at all: the config heph
+//! writes names `std::env::current_exe()`, which inside an in-process test is the
+//! test harness rather than `heph`.
+
+mod common;
+
+use common::{Dist, Workspace, describe};
+use std::io::Write as _;
+use std::process::Stdio;
+
+/// A credential presented through the git helper, plus a target that copies the
+/// pin heph wrote out to a path the test can read afterwards.
+///
+/// The chain is a `printf`: no network, no vendor CLI, and material that is the
+/// same on every host. The pin's own path is the tail of the `GIT_CONFIG_VALUE_0`
+/// heph injected, which is how the fixture finds it without heph needing a
+/// command that prints one.
+fn fixture(dest: &std::path::Path) -> String {
+    format!(
+        r#"
+target(
+    name    = "cred",
+    driver  = "credential",
+    sources = [heph.auth.exec(
+        ["sh", "-c", "printf '{{\"token\":\"bin-e2e-material\",\"username\":\"u\",\"expires_in\":3600}}'"],
+        fields  = {{"token": "token", "username": "username"}},
+        expires = "expires_in",
+    )],
+    present = heph.auth.git(["git.example"]),
+)
+
+target(
+    name        = "copy-pin",
+    driver      = "bash",
+    credentials = ["//auth:cred"],
+    cache       = False,
+    out         = [],
+    run         = ["cp \"${{GIT_CONFIG_VALUE_0##*--pin }}\" {dest}"],
+)
+"#,
+        dest = dest.display()
+    )
+}
+
+/// Run the fixture and return a durable copy of the pin.
+///
+/// The pin itself lives inside that run's sandbox and is deleted when the target
+/// finishes — that lifetime *is* the design, a presented credential is destroyed
+/// with its run — so the fixture copies it out rather than the test weakening it.
+fn staged_pin(ws: &Workspace, dist: &Dist) -> std::path::PathBuf {
+    let dest = ws.root().join("pin-copy.json");
+    ws.write("auth/BUILD", &fixture(&dest))
+        .expect("write BUILD");
+    let out = ws.run(dist, &["run", "//auth:copy-pin"]).expect("run");
+    assert!(out.status.success(), "{}", describe(&out));
+    assert!(
+        dest.is_file(),
+        "the run did not produce a pin: {}",
+        describe(&out)
+    );
+    dest
+}
+
+/// The git dialect, end to end as a process: heph's own argv, the calling tool's
+/// stdin, and `key=value` framing on stdout.
+#[test]
+fn the_git_helper_answers_the_protocol_as_a_process() {
+    let dist = Dist::locate();
+    let ws = Workspace::new().expect("workspace");
+    let pin = staged_pin(&ws, &dist);
+
+    let mut child = ws
+        .cmd(
+            &dist,
+            &[
+                "__auth-helper",
+                "git",
+                "--pin",
+                &pin.to_string_lossy(),
+                "get",
+            ],
+        )
+        .stdin(Stdio::piped())
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped())
+        .spawn()
+        .expect("spawn the helper");
+    child
+        .stdin
+        .as_mut()
+        .expect("stdin")
+        .write_all(b"protocol=https\nhost=git.example\n\n")
+        .expect("write the git request");
+    let out = child.wait_with_output().expect("wait");
+    assert!(out.status.success(), "{}", describe(&out));
+
+    let stdout = String::from_utf8_lossy(&out.stdout).into_owned();
+    assert!(stdout.contains("password=bin-e2e-material"), "{stdout}");
+    assert!(stdout.contains("username=u"), "{stdout}");
+    assert!(stdout.contains("password_expiry_utc="), "{stdout}");
+    // git reads until a blank line.
+    assert!(stdout.ends_with("\n\n"), "{stdout:?}");
+    // Nothing but the protocol on stdout, and no noise on stderr — a helper's
+    // stdout is parsed by somebody else's implementation.
+    assert!(
+        String::from_utf8_lossy(&out.stderr).trim().is_empty(),
+        "{}",
+        describe(&out)
+    );
+}
+
+/// The write half of the protocol succeeds and does nothing. A tool must not be
+/// able to substitute an identity into heph's store.
+#[test]
+fn store_and_erase_are_accepted_and_change_nothing() {
+    let dist = Dist::locate();
+    let ws = Workspace::new().expect("workspace");
+    for op in ["store", "erase"] {
+        // Deliberately a path that does not exist: these must return before
+        // reading the pin at all.
+        let out = ws
+            .run(
+                &dist,
+                &["__auth-helper", "git", "--pin", "/nonexistent/pin.json", op],
+            )
+            .expect("run");
+        assert!(out.status.success(), "{op}: {}", describe(&out));
+        assert!(out.stdout.is_empty(), "{op}: {}", describe(&out));
+    }
+}
+
+/// A helper invoked after its run has finished — the pin is gone with the
+/// sandbox — fails with a diagnostic on **stderr** and a non-zero status, not
+/// with half a document on stdout.
+#[test]
+fn a_missing_pin_fails_on_stderr_and_writes_nothing_to_stdout() {
+    let dist = Dist::locate();
+    let ws = Workspace::new().expect("workspace");
+    let out = ws
+        .run(
+            &dist,
+            &["__auth-helper", "aws", "--pin", "/nonexistent/pin.json"],
+        )
+        .expect("run");
+    assert!(!out.status.success(), "{}", describe(&out));
+    assert!(
+        out.stdout.is_empty(),
+        "stdout is the tool's document: {}",
+        describe(&out)
+    );
+    let stderr = String::from_utf8_lossy(&out.stderr).into_owned();
+    assert!(stderr.contains("credential pin"), "{stderr}");
+}
+
+/// The dispatch happens before the argument parser, so `__auth-helper` is not a
+/// clap subcommand and cannot be shadowed by one.
+#[test]
+fn the_helper_is_not_a_visible_subcommand() {
+    let dist = Dist::locate();
+    let ws = Workspace::new().expect("workspace");
+    let out = ws.run(&dist, &["--help"]).expect("run");
+    assert!(out.status.success(), "{}", describe(&out));
+    let help = String::from_utf8_lossy(&out.stdout).into_owned();
+    assert!(
+        !help.contains("__auth-helper"),
+        "a hidden subcommand must not be advertised: {help}"
+    );
+    assert!(help.contains("auth"), "but `heph auth` is: {help}");
+}
+
+// ---------------------------------------------------------------------------
+// `heph auth` as a command — the exit status is the contract
+// ---------------------------------------------------------------------------
+
+/// The preflight's whole point: a caller branches on the **exit status** and only
+/// then parses to learn what to run. That is an exit code, so it is only
+/// observable here.
+#[test]
+fn auth_status_exits_non_zero_when_a_credential_is_unavailable() {
+    let dist = Dist::locate();
+    let ws = Workspace::new().expect("workspace");
+    ws.write(
+        "auth/BUILD",
+        r#"
+target(name = "ok", driver = "credential",
+       sources = [heph.auth.exec(["sh", "-c", "printf 'v'"])],
+       present = {"env": {"OK": "${value}"}})
+target(name = "missing", driver = "credential",
+       sources = [heph.auth.env(["HEPH_BIN_E2E_SURELY_UNSET"])],
+       present = {"env": {"M": "${heph_bin_e2e_surely_unset}"}})
+"#,
+    )
+    .expect("write BUILD");
+
+    let out = ws
+        .run(&dist, &["auth", "status", "//auth/...", "--json"])
+        .expect("run");
+    assert!(
+        !out.status.success(),
+        "one unavailable credential must fail the preflight: {}",
+        describe(&out)
+    );
+    // …and the JSON is still on stdout, so the same invocation answers both
+    // "is everything fine?" and "what do I do about it?".
+    let stdout = String::from_utf8_lossy(&out.stdout).into_owned();
+    let rows: serde_json::Value = serde_json::from_str(&stdout)
+        .unwrap_or_else(|e| panic!("--json must be parseable ({e}): {}", describe(&out)));
+    let rows = rows.as_array().expect("an array of rows");
+    assert_eq!(rows.len(), 2, "{stdout}");
+    let missing = rows
+        .iter()
+        .find(|r| r["addr"] == "//auth:missing")
+        .expect("the unavailable row");
+    assert_eq!(missing["state"], "unavailable", "{stdout}");
+    let ok = rows
+        .iter()
+        .find(|r| r["addr"] == "//auth:ok")
+        .expect("the available row");
+    assert_eq!(ok["state"], "ok", "{stdout}");
+}
+
+/// Every row available means exit 0, so `heph auth status && heph run …` is a
+/// usable shape.
+#[test]
+fn auth_status_exits_zero_when_every_credential_applies() {
+    let dist = Dist::locate();
+    let ws = Workspace::new().expect("workspace");
+    ws.write(
+        "auth/BUILD",
+        r#"target(name = "ok", driver = "credential",
+       sources = [heph.auth.exec(["sh", "-c", "printf 'v'"])],
+       present = {"env": {"OK": "${value}"}})"#,
+    )
+    .expect("write BUILD");
+    let out = ws
+        .run(&dist, &["auth", "status", "//auth/..."])
+        .expect("run");
+    assert!(out.status.success(), "{}", describe(&out));
+}
+
+/// A workspace with no credentials is not a failure — there is nothing
+/// unavailable — and it says so rather than printing an empty table.
+#[test]
+fn auth_status_on_a_workspace_with_no_credentials_succeeds() {
+    let dist = Dist::locate();
+    let ws = Workspace::new().expect("workspace");
+    ws.write(
+        "app/BUILD",
+        r#"target(name = "a", driver = "bash", run = "true", out = [])"#,
+    )
+    .expect("write BUILD");
+    let out = ws.run(&dist, &["auth", "status"]).expect("run");
+    assert!(out.status.success(), "{}", describe(&out));
+    assert!(
+        String::from_utf8_lossy(&out.stdout).contains("no `credential` targets"),
+        "{}",
+        describe(&out)
+    );
+}
+
+/// `explain` prints the walk and fails when nothing applies — the same structure
+/// the build failure prints, so the diagnostic and the failure cannot drift.
+#[test]
+fn auth_explain_prints_the_walk_and_fails_when_nothing_applies() {
+    let dist = Dist::locate();
+    let ws = Workspace::new().expect("workspace");
+    ws.write(
+        "auth/BUILD",
+        r#"target(name = "t", driver = "credential",
+       sources = [
+           heph.auth.oidc("github_actions", audience = "x"),
+           heph.auth.env(["HEPH_BIN_E2E_SURELY_UNSET"]),
+       ],
+       present = {"env": {"T": "${id_token}"}})"#,
+    )
+    .expect("write BUILD");
+    let out = ws
+        .run(&dist, &["auth", "explain", "//auth:t"])
+        .expect("run");
+    assert!(!out.status.success(), "{}", describe(&out));
+    let stdout = String::from_utf8_lossy(&out.stdout).into_owned();
+    assert!(stdout.contains("oidc(github_actions)"), "{stdout}");
+    assert!(stdout.contains("skipped:"), "{stdout}");
+    assert!(
+        stdout.contains("id-token: write"),
+        "the fix rides on the line that failed: {stdout}"
+    );
+}
+
+/// `logout` on a store that was never written is a no-op, not an error.
+#[test]
+fn auth_logout_is_idempotent() {
+    let dist = Dist::locate();
+    let ws = Workspace::new().expect("workspace");
+    for _ in 0..2 {
+        let out = ws.run(&dist, &["auth", "logout"]).expect("run");
+        assert!(out.status.success(), "{}", describe(&out));
+    }
+}

--- a/crates/builtins/Cargo.toml
+++ b/crates/builtins/Cargo.toml
@@ -13,6 +13,7 @@ hwalk = { package = "walk", path = "../walk" }
 hplugin = { package = "plugin", path = "../plugin" }
 anyhow = "1.0.102"
 serde = { version = "1", features = ["derive"] }
+serde_json = "1.0"
 async-trait = "0.1.89"
 futures = "0.3.32"
 glob = "0.3"
@@ -27,6 +28,5 @@ itertools = "0.15.0"
 tokio = { version = "1.52.3", features = ["rt", "rt-multi-thread", "io-util", "macros", "sync", "fs", "process"] }
 
 [dev-dependencies]
-serde_json = "1.0"
 serde_yaml = "0.9"
 tempfile = "3"

--- a/crates/builtins/src/lib.rs
+++ b/crates/builtins/src/lib.rs
@@ -4,11 +4,14 @@
 //!
 //! - `pluginfs` — the `fs` provider + driver (filesystem targets).
 //! - `plugingroup` — the `group` driver (aggregate targets).
+//! - `plugincredential` — the `credential` driver (identity declarations) and the
+//!   `auth` provider that exposes the `heph.auth.*` constructors.
 //! - `pluginscratch` — the `scratch` driver (persistent cache-directory declarations).
 //! - `pluginstatictarget` — in-memory static target provider (tests/wiring).
 //! - `plugintextfile` — the `textfile` driver.
 //! - `pluginhostbin` — the host-binary provider + driver.
 
+pub mod plugincredential;
 pub mod pluginfs;
 pub mod plugingroup;
 pub mod pluginhostbin;

--- a/crates/builtins/src/plugincredential/functions.rs
+++ b/crates/builtins/src/plugincredential/functions.rs
@@ -112,7 +112,7 @@ impl EProvider for Provider {
 // Signature helpers
 // ---------------------------------------------------------------------------
 
-fn strs() -> ParamType {
+pub(crate) fn strs() -> ParamType {
     ParamType::union(vec![ParamType::String, ParamType::list(ParamType::String)])
 }
 
@@ -126,7 +126,7 @@ fn str_map() -> ParamType {
 /// checked: a preset returning something a `present =` cannot accept would
 /// otherwise fail one layer down, in the credential driver's parser, with no
 /// mention of the preset that produced it.
-fn presentation_ty() -> ParamType {
+pub(crate) fn presentation_ty() -> ParamType {
     ParamType::strukt(vec![
         ("env", str_map()),
         ("files", str_map()),
@@ -148,7 +148,7 @@ fn presentation_ty() -> ParamType {
 
 /// The shape a source constructor returns: one struct covering every inline
 /// kind's fields, which is what the driver's own schema says too.
-fn source_ty() -> ParamType {
+pub(crate) fn source_ty() -> ParamType {
     ParamType::strukt(vec![
         ("kind", ParamType::String),
         ("when", ParamType::String),

--- a/crates/builtins/src/plugincredential/functions.rs
+++ b/crates/builtins/src/plugincredential/functions.rs
@@ -1,0 +1,979 @@
+//! `heph.auth.*` — the ergonomic layer over the credential vocabulary.
+//!
+//! Every function here is a plain function returning a plain dict a BUILD file
+//! could have written by hand. None of them is privileged, and that is the
+//! property that keeps this from becoming a place behaviour hides: there is
+//! nothing a preset can express that the primitives cannot.
+//!
+//! What they buy is real all the same. A wrong argument fails at BUILD
+//! evaluation instead of at run time, which a magic string like
+//! `present = "aws"` can never do; the LSP completes and documents them; and
+//! `heph inspect functions` lists them. Above all, the *presentation* presets
+//! encode third-party wire formats with exactly one correct spelling — the AWS
+//! web-identity variables, Google's `external_account` document, the Docker
+//! credHelpers map — and hand-rolling those is how you get a subtly wrong one.
+//!
+//! # Why there are no source presets
+//!
+//! There is no `heph.auth.vault()`, no `heph.auth.op()`, no `heph.auth.aws_sso()`,
+//! and this is a rule rather than a gap. That list has no end — every secret
+//! manager, every cloud CLI, every internal tool at every company — and each entry
+//! would be a workflow frozen into a plugin, ageing badly, for no gain over four
+//! lines of [`exec`](super::source::SourceKind::Exec) with a field map. A source is
+//! `exec` with a field map, or it is a target.
+//!
+//! A *presentation* preset is the opposite case: the format is fixed by a vendor,
+//! the set is small and known, and a hand-typed one fails silently inside somebody
+//! else's SDK. That asymmetry is the whole rule.
+
+use async_trait::async_trait;
+use hcore::htvalue::Value;
+use hcore::htvalue::signature::{FnSignature, Param, ParamType};
+use hplugin::provider::{
+    ConfigRequest, ConfigResponse, FnArgs, FnCallContext, GetError, GetRequest, GetResponse,
+    ListPackageResponse, ListPackagesRequest, ListRequest, ListResponse, ProbeRequest,
+    ProbeResponse, Provider as EProvider, ProviderFn, ProviderFunctionDef,
+};
+use std::collections::HashMap;
+use std::sync::Arc;
+
+/// The provider namespace these functions live under: `heph.auth.<fn>`.
+pub const PROVIDER_NAME: &str = "auth";
+
+/// A provider that serves no targets and exists only to carry the `heph.auth.*`
+/// functions into BUILD files.
+///
+/// The same shape `query` already uses. Functions reach BUILD files through
+/// `Provider::functions()`, and a provider is the only thing that has one — so a
+/// namespace with no targets behind it is an inert provider, not a new concept.
+pub struct Provider;
+
+impl EProvider for Provider {
+    fn config(&self, _req: ConfigRequest) -> anyhow::Result<ConfigResponse> {
+        Ok(ConfigResponse {
+            name: PROVIDER_NAME.to_string(),
+        })
+    }
+
+    fn list<'a>(
+        &'a self,
+        _req: ListRequest,
+        _ctoken: &'a (dyn hcore::hasync::Cancellable + Send + Sync),
+    ) -> futures::future::BoxFuture<
+        'a,
+        anyhow::Result<Box<dyn Iterator<Item = anyhow::Result<ListResponse>> + Send>>,
+    > {
+        Box::pin(async {
+            Ok(Box::new(std::iter::empty())
+                as Box<
+                    dyn Iterator<Item = anyhow::Result<ListResponse>> + Send,
+                >)
+        })
+    }
+
+    fn list_packages<'a>(
+        &'a self,
+        _req: ListPackagesRequest,
+        _ctoken: &'a (dyn hcore::hasync::Cancellable + Send + Sync),
+    ) -> futures::future::BoxFuture<
+        'a,
+        anyhow::Result<Box<dyn Iterator<Item = anyhow::Result<ListPackageResponse>> + Send>>,
+    > {
+        Box::pin(async {
+            Ok(Box::new(std::iter::empty())
+                as Box<
+                    dyn Iterator<Item = anyhow::Result<ListPackageResponse>> + Send,
+                >)
+        })
+    }
+
+    fn get<'a>(
+        &'a self,
+        _req: GetRequest,
+        _ctoken: &'a (dyn hcore::hasync::Cancellable + Send + Sync),
+    ) -> futures::future::BoxFuture<'a, Result<GetResponse, GetError>> {
+        Box::pin(async { Err(GetError::NotFound) })
+    }
+
+    fn probe<'a>(
+        &'a self,
+        _req: ProbeRequest,
+        _ctoken: &'a (dyn hcore::hasync::Cancellable + Send + Sync),
+    ) -> futures::future::BoxFuture<'a, anyhow::Result<ProbeResponse>> {
+        Box::pin(async { Ok(ProbeResponse { states: vec![] }) })
+    }
+
+    fn functions(&self) -> Vec<ProviderFunctionDef> {
+        definitions()
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Signature helpers
+// ---------------------------------------------------------------------------
+
+fn strs() -> ParamType {
+    ParamType::union(vec![ParamType::String, ParamType::list(ParamType::String)])
+}
+
+fn str_map() -> ParamType {
+    ParamType::map(ParamType::String)
+}
+
+/// The shape a presentation preset returns.
+///
+/// Written out rather than left as "some map", because the return value **is**
+/// checked: a preset returning something a `present =` cannot accept would
+/// otherwise fail one layer down, in the credential driver's parser, with no
+/// mention of the preset that produced it.
+fn presentation_ty() -> ParamType {
+    ParamType::strukt(vec![
+        ("env", str_map()),
+        ("files", str_map()),
+        (
+            "helper",
+            ParamType::union(vec![
+                ParamType::String,
+                ParamType::strukt(vec![
+                    ("dialect", ParamType::String),
+                    ("registries", ParamType::list(ParamType::String)),
+                    ("hosts", ParamType::list(ParamType::String)),
+                    ("audience", ParamType::String),
+                    ("impersonate", ParamType::String),
+                ]),
+            ]),
+        ),
+    ])
+}
+
+/// The shape a source constructor returns: one struct covering every inline
+/// kind's fields, which is what the driver's own schema says too.
+fn source_ty() -> ParamType {
+    ParamType::strukt(vec![
+        ("kind", ParamType::String),
+        ("when", ParamType::String),
+        ("credentials", strs()),
+        ("present", presentation_ty()),
+        ("hint", ParamType::String),
+        ("names", ParamType::list(ParamType::String)),
+        ("path", ParamType::String),
+        ("run", ParamType::list(ParamType::String)),
+        ("fields", str_map()),
+        ("expires", ParamType::String),
+        ("login", ParamType::list(ParamType::list(ParamType::String))),
+        ("runner", ParamType::String),
+        ("paths", str_map()),
+        ("provider", ParamType::String),
+        ("audience", ParamType::String),
+    ])
+}
+
+/// The four fields every source constructor accepts, appended to its own named
+/// params so they are not repeated per row.
+fn common_source_params() -> Vec<Param> {
+    vec![
+        Param::optional("when", ParamType::String, Value::Null()),
+        Param::optional("credentials", strs(), Value::Null()),
+        Param::optional("present", presentation_ty(), Value::Null()),
+        Param::optional("hint", ParamType::String, Value::Null()),
+    ]
+}
+
+/// Apply the common source fields onto a constructed source dict.
+fn apply_common(out: &mut HashMap<String, Value>, args: &FnArgs) {
+    for key in ["when", "credentials", "present", "hint"] {
+        if let Some(v) = args.named.get(key)
+            && !matches!(v, Value::Null())
+        {
+            out.insert(key.to_string(), v.clone());
+        }
+    }
+}
+
+fn map(pairs: Vec<(&str, Value)>) -> Value {
+    Value::Map(pairs.into_iter().map(|(k, v)| (k.to_string(), v)).collect())
+}
+
+fn s(v: impl Into<String>) -> Value {
+    Value::String(v.into())
+}
+
+/// A named argument that must be present and a string.
+fn req_str(args: &FnArgs, name: &str, func: &str) -> anyhow::Result<String> {
+    match args.named.get(name) {
+        Some(Value::String(v)) if !v.is_empty() => Ok(v.clone()),
+        Some(Value::String(_)) | None | Some(Value::Null()) => {
+            anyhow::bail!("heph.auth.{func}: `{name}` is required and must be a non-empty string")
+        }
+        Some(other) => anyhow::bail!("heph.auth.{func}: `{name}` must be a string, got {other:?}"),
+    }
+}
+
+fn opt_str(args: &FnArgs, name: &str) -> Option<String> {
+    match args.named.get(name) {
+        Some(Value::String(v)) if !v.is_empty() => Some(v.clone()),
+        _ => None,
+    }
+}
+
+/// The first positional, as a list of strings.
+fn positional_strings(args: &FnArgs, func: &str, what: &str) -> anyhow::Result<Vec<String>> {
+    let Some(v) = args.positional.first() else {
+        anyhow::bail!("heph.auth.{func}: {what} is required")
+    };
+    let out = super::present::strings(v, what)?;
+    if out.is_empty() {
+        anyhow::bail!("heph.auth.{func}: {what} must not be empty");
+    }
+    Ok(out)
+}
+
+/// A `ProviderFn` implemented by a plain closure over `FnArgs`.
+///
+/// Every function here is pure — it reads no filesystem, resolves no target, and
+/// never touches the network. That is deliberate and load-bearing: a preset that
+/// could *look something up* would be a place where a credential's behaviour
+/// depends on where the BUILD file was evaluated, which is precisely what the
+/// chain exists to make explicit.
+struct PureFn(fn(&FnArgs) -> anyhow::Result<Value>);
+
+#[async_trait]
+impl ProviderFn for PureFn {
+    async fn call(&self, _ctx: &FnCallContext<'_>, args: FnArgs) -> anyhow::Result<Value> {
+        (self.0)(&args)
+    }
+}
+
+fn def(
+    name: &str,
+    positional: Vec<Param>,
+    mut named: Vec<Param>,
+    returns: ParamType,
+    doc: &str,
+    f: fn(&FnArgs) -> anyhow::Result<Value>,
+) -> ProviderFunctionDef {
+    named.sort_by_key(|p| p.name);
+    ProviderFunctionDef {
+        name: name.to_string(),
+        signature: FnSignature {
+            positional,
+            named,
+            variadic: None,
+            returns,
+        },
+        doc: doc.to_string(),
+        func: Arc::new(PureFn(f)),
+    }
+}
+
+fn source_def(
+    name: &str,
+    positional: Vec<Param>,
+    own: Vec<Param>,
+    doc: &str,
+    f: fn(&FnArgs) -> anyhow::Result<Value>,
+) -> ProviderFunctionDef {
+    let mut named = own;
+    named.extend(common_source_params());
+    def(name, positional, named, source_ty(), doc, f)
+}
+
+/// A presentation preset.
+fn present_def(
+    name: &str,
+    positional: Vec<Param>,
+    named: Vec<Param>,
+    doc: &str,
+    f: fn(&FnArgs) -> anyhow::Result<Value>,
+) -> ProviderFunctionDef {
+    def(name, positional, named, presentation_ty(), doc, f)
+}
+
+// ---------------------------------------------------------------------------
+// The functions
+// ---------------------------------------------------------------------------
+
+pub fn definitions() -> Vec<ProviderFunctionDef> {
+    vec![
+        // ---- source constructors ----
+        source_def(
+            "env",
+            vec![Param::required("names", strs())],
+            vec![],
+            "A source reading host environment variables. Probes that each is set. \
+             Yields one material field per name, lowercased: `env([\"GITHUB_TOKEN\"])` \
+             yields `${github_token}`.",
+            |args| {
+                let names = positional_strings(args, "env", "`names`")?;
+                let mut out = HashMap::from([
+                    ("kind".to_string(), s("env")),
+                    (
+                        "names".to_string(),
+                        Value::List(names.into_iter().map(Value::String).collect()),
+                    ),
+                ]);
+                apply_common(&mut out, args);
+                Ok(Value::Map(out))
+            },
+        ),
+        source_def(
+            "file",
+            vec![Param::required("path", ParamType::String)],
+            vec![
+                Param::optional("fields", str_map(), Value::Null()),
+                Param::optional("expires", ParamType::String, Value::Null()),
+            ],
+            "A source reading a file on the host. Probes that the path exists. With \
+             `fields` the file is parsed as JSON and each field is picked out by a \
+             (possibly dotted) key; without it the whole file becomes `${value}`. \
+             `expires` names the JSON key carrying the expiry — an absolute timestamp \
+             or a duration in seconds, told apart by type, since vendors do both.",
+            |args| {
+                let path = match args.positional.first() {
+                    Some(Value::String(p)) if !p.is_empty() => p.clone(),
+                    _ => anyhow::bail!("heph.auth.file: `path` is required"),
+                };
+                let mut out = HashMap::from([
+                    ("kind".to_string(), s("file")),
+                    ("path".to_string(), s(path)),
+                ]);
+                for k in ["fields", "expires"] {
+                    if let Some(v) = args.named.get(k)
+                        && !matches!(v, Value::Null())
+                    {
+                        out.insert(k.to_string(), v.clone());
+                    }
+                }
+                apply_common(&mut out, args);
+                Ok(Value::Map(out))
+            },
+        ),
+        source_def(
+            "exec",
+            vec![Param::required("run", strs())],
+            vec![
+                Param::optional("fields", str_map(), Value::Null()),
+                Param::optional("expires", ParamType::String, Value::Null()),
+                Param::optional("login", ParamType::list(strs()), Value::Null()),
+                Param::optional("runner", ParamType::String, Value::Null()),
+            ],
+            "A source running one command whose **stdout** is the credential. Probes \
+             that `run[0]` resolves inside `runner`, then runs it there. Stdout is JSON \
+             and `fields` maps material field → JSON key (keys may be dotted paths). \
+             `login` is a *list* of argvs, because some tools keep more than one login \
+             store; `heph auth login` runs whichever the probe found stale. A command \
+             that writes files is a target, not a source — there is deliberately no \
+             way to name output files here.",
+            |args| {
+                let run = positional_strings(args, "exec", "`run`")?;
+                let mut out = HashMap::from([
+                    ("kind".to_string(), s("exec")),
+                    (
+                        "run".to_string(),
+                        Value::List(run.into_iter().map(Value::String).collect()),
+                    ),
+                ]);
+                for k in ["fields", "expires", "login", "runner"] {
+                    if let Some(v) = args.named.get(k)
+                        && !matches!(v, Value::Null())
+                    {
+                        out.insert(k.to_string(), v.clone());
+                    }
+                }
+                apply_common(&mut out, args);
+                Ok(Value::Map(out))
+            },
+        ),
+        source_def(
+            "passthrough",
+            vec![],
+            vec![
+                Param::optional("paths", str_map(), Value::Null()),
+                Param::optional("env", str_map(), Value::Null()),
+                Param::optional("login", ParamType::list(strs()), Value::Null()),
+            ],
+            "A source exposing host files or directories **in place** — nothing is \
+             copied into the credential store. Probes that every path exists. Each is \
+             reachable as `${file:<name>}`. `env` is a shorthand for the presentation, \
+             which is what a passthrough almost always needs: \
+             `passthrough(paths = {\"config\": \"~/.config/gcloud\"}, env = \
+             {\"CLOUDSDK_CONFIG\": \"${file:config}\"})`. No product names: the author \
+             says which path.",
+            |args| {
+                let Some(paths) = args
+                    .named
+                    .get("paths")
+                    .filter(|v| !matches!(v, Value::Null()))
+                else {
+                    anyhow::bail!(
+                        "heph.auth.passthrough: `paths` is required — heph exposes the host files \
+                         you name and takes no view about which product wrote them"
+                    )
+                };
+                let mut out = HashMap::from([
+                    ("kind".to_string(), s("passthrough")),
+                    ("paths".to_string(), paths.clone()),
+                ]);
+                if let Some(v) = args.named.get("login")
+                    && !matches!(v, Value::Null())
+                {
+                    out.insert("login".to_string(), v.clone());
+                }
+                apply_common(&mut out, args);
+                // `env =` folds into the presentation, and must not silently
+                // overwrite an explicit `present =`.
+                if let Some(env) = args
+                    .named
+                    .get("env")
+                    .filter(|v| !matches!(v, Value::Null()))
+                {
+                    if out.contains_key("present") {
+                        anyhow::bail!(
+                            "heph.auth.passthrough: pass either `env` (the shorthand) or \
+                             `present` (the full presentation), not both"
+                        );
+                    }
+                    out.insert("present".to_string(), map(vec![("env", env.clone())]));
+                }
+                Ok(Value::Map(out))
+            },
+        ),
+        source_def(
+            "oidc",
+            vec![Param::optional(
+                "provider",
+                ParamType::String,
+                s("github_actions"),
+            )],
+            vec![Param::optional(
+                "audience",
+                ParamType::String,
+                Value::Null(),
+            )],
+            "A source minting a workload-identity token from the CI provider heph \
+             detects. Probes that the provider is present — on a laptop that probe \
+             fails cleanly, which is what lets this sit above the vendor-CLI source in \
+             a chain that serves both. Yields `${id_token}`. `provider` is \
+             `github_actions` or `generic`.",
+            |args| {
+                let provider = match args.positional.first() {
+                    Some(Value::String(p)) if !p.is_empty() => p.clone(),
+                    _ => "github_actions".to_string(),
+                };
+                let mut out = HashMap::from([
+                    ("kind".to_string(), s("oidc")),
+                    ("provider".to_string(), s(provider)),
+                ]);
+                if let Some(a) = opt_str(args, "audience") {
+                    out.insert("audience".to_string(), s(a));
+                }
+                apply_common(&mut out, args);
+                Ok(Value::Map(out))
+            },
+        ),
+        // ---- presentation presets ----
+        present_def(
+            "aws_process",
+            vec![],
+            vec![],
+            "Present the credential as an AWS **credential process**: heph writes a \
+             config file naming `heph __auth-helper aws <addr>` as the profile's \
+             `credential_process`, and points `AWS_CONFIG_FILE` at it. The only AWS \
+             shape that survives expiry mid-run, because the SDK re-invokes the helper \
+             whenever it needs a fresh credential.",
+            |_args| Ok(map(vec![("helper", map(vec![("dialect", s("aws"))]))])),
+        ),
+        present_def(
+            "aws_web_identity",
+            vec![],
+            vec![
+                Param::required("role", ParamType::String),
+                Param::optional("session_name", ParamType::String, s("heph")),
+            ],
+            "Present an OIDC token as an AWS web identity: a `0600` token file plus \
+             `AWS_WEB_IDENTITY_TOKEN_FILE`, `AWS_ROLE_ARN` and \
+             `AWS_ROLE_SESSION_NAME`. heph performs **no token exchange** — the AWS \
+             SDK does it, and re-reads the token file on every refresh, so a long \
+             build is fine as long as something keeps the file current. \
+             Expands to exactly `{\"files\": {\"token\": \"${id_token}\"}, \"env\": \
+             {...three variables...}}`.",
+            |args| {
+                let role = req_str(args, "role", "aws_web_identity")?;
+                let session = opt_str(args, "session_name").unwrap_or_else(|| "heph".to_string());
+                Ok(map(vec![
+                    ("files", map(vec![("token", s("${id_token}"))])),
+                    (
+                        "env",
+                        map(vec![
+                            ("AWS_WEB_IDENTITY_TOKEN_FILE", s("${file:token}")),
+                            ("AWS_ROLE_ARN", s(role)),
+                            ("AWS_ROLE_SESSION_NAME", s(session)),
+                        ]),
+                    ),
+                ]))
+            },
+        ),
+        present_def(
+            "gcp",
+            vec![],
+            vec![
+                Param::required("audience", ParamType::String),
+                Param::optional("impersonate", ParamType::String, Value::Null()),
+            ],
+            "Present an OIDC token as Google **workload identity federation**: a \
+             `0600` token file plus the `external_account` document ADC consumers know \
+             how to use, pointed at by both `GOOGLE_APPLICATION_CREDENTIALS` and \
+             `CLOUDSDK_AUTH_CREDENTIAL_FILE_OVERRIDE`. Setting the override as well as \
+             the ADC variable is what collapses gcloud's two independent logins into \
+             one credential. `audience` is the full pool-provider audience \
+             (`//iam.googleapis.com/projects/…`); pass `impersonate` when the service \
+             does not accept a federated identity directly — Cloud Run, kubectl from \
+             inside GKE and HCP Terraform all require it.",
+            |args| {
+                let audience = req_str(args, "audience", "gcp")?;
+                let impersonate = opt_str(args, "impersonate");
+                Ok(map(vec![
+                    (
+                        "files",
+                        map(vec![
+                            ("token", s("${id_token}")),
+                            (
+                                "adc",
+                                s(gcp_external_account(&audience, impersonate.as_deref())),
+                            ),
+                        ]),
+                    ),
+                    (
+                        "env",
+                        map(vec![
+                            ("GOOGLE_APPLICATION_CREDENTIALS", s("${file:adc}")),
+                            ("CLOUDSDK_AUTH_CREDENTIAL_FILE_OVERRIDE", s("${file:adc}")),
+                        ]),
+                    ),
+                ]))
+            },
+        ),
+        present_def(
+            "azure_workload",
+            vec![],
+            vec![
+                Param::required("client_id", ParamType::String),
+                Param::required("tenant_id", ParamType::String),
+            ],
+            "Present an OIDC token as an Azure **federated credential**: a `0600` \
+             token file plus `AZURE_FEDERATED_TOKEN_FILE`, `AZURE_CLIENT_ID` and \
+             `AZURE_TENANT_ID`. Azure has no generic token-process credential, so this \
+             is the only file-shaped door — the SDKs re-read the file on a timer but \
+             never re-mint, which is why a build outliving the token needs heph to \
+             rotate it.",
+            |args| {
+                let client_id = req_str(args, "client_id", "azure_workload")?;
+                let tenant_id = req_str(args, "tenant_id", "azure_workload")?;
+                Ok(map(vec![
+                    ("files", map(vec![("token", s("${id_token}"))])),
+                    (
+                        "env",
+                        map(vec![
+                            ("AZURE_FEDERATED_TOKEN_FILE", s("${file:token}")),
+                            ("AZURE_CLIENT_ID", s(client_id)),
+                            ("AZURE_TENANT_ID", s(tenant_id)),
+                        ]),
+                    ),
+                ]))
+            },
+        ),
+        present_def(
+            "github",
+            vec![],
+            vec![Param::optional("hosts", strs(), s("github.com"))],
+            "Present a GitHub token as both `GH_TOKEN` and a git credential helper, so \
+             `gh`, `git` and `go mod download` over HTTPS all authenticate without any \
+             further wiring. The git half is what gives private Go modules a credential \
+             path at all.",
+            |args| {
+                let hosts = match args.named.get("hosts") {
+                    Some(v) if !matches!(v, Value::Null()) => super::present::strings(v, "hosts")?,
+                    _ => vec!["github.com".to_string()],
+                };
+                Ok(map(vec![
+                    ("env", map(vec![("GH_TOKEN", s("${token}"))])),
+                    (
+                        "helper",
+                        map(vec![
+                            ("dialect", s("git")),
+                            (
+                                "hosts",
+                                Value::List(hosts.into_iter().map(Value::String).collect()),
+                            ),
+                        ]),
+                    ),
+                ]))
+            },
+        ),
+        present_def(
+            "docker",
+            vec![Param::required("registries", strs())],
+            vec![],
+            "Present the credential through the **Docker credential-helper** protocol: \
+             heph writes a `DOCKER_CONFIG` directory whose `credHelpers` names each \
+             registry, and prepends the directory holding a `docker-credential-heph` \
+             shim to `PATH`. This is the only presentation that touches `PATH`, because \
+             Docker resolves a helper by executable name.",
+            |args| {
+                let registries = positional_strings(args, "docker", "`registries`")?;
+                Ok(map(vec![(
+                    "helper",
+                    map(vec![
+                        ("dialect", s("docker")),
+                        (
+                            "registries",
+                            Value::List(registries.into_iter().map(Value::String).collect()),
+                        ),
+                    ]),
+                )]))
+            },
+        ),
+        present_def(
+            "git",
+            vec![Param::required("hosts", strs())],
+            vec![],
+            "Present the credential through the **git credential-helper** protocol, \
+             injected via `GIT_CONFIG_COUNT` / `GIT_CONFIG_KEY_n` / \
+             `GIT_CONFIG_VALUE_n`. No gitconfig is written and the developer's own is \
+             never touched.",
+            |args| {
+                let hosts = positional_strings(args, "git", "`hosts`")?;
+                Ok(map(vec![(
+                    "helper",
+                    map(vec![
+                        ("dialect", s("git")),
+                        (
+                            "hosts",
+                            Value::List(hosts.into_iter().map(Value::String).collect()),
+                        ),
+                    ]),
+                )]))
+            },
+        ),
+        present_def(
+            "netrc",
+            vec![Param::required("machines", strs())],
+            vec![
+                Param::optional("login", ParamType::String, s("${username}")),
+                Param::optional("password", ParamType::String, s("${token}")),
+            ],
+            "Present the credential as a `0600` netrc file plus `NETRC` pointing at \
+             it. The fallback of last resort: no callback and no expiry field, so it is \
+             a snapshot. It is here because Go's module fetch over HTTPS honours it, \
+             and private Go modules otherwise have no credential path at all.",
+            |args| {
+                let machines = positional_strings(args, "netrc", "`machines`")?;
+                let login = opt_str(args, "login").unwrap_or_else(|| "${username}".to_string());
+                let password = opt_str(args, "password").unwrap_or_else(|| "${token}".to_string());
+                let body = machines
+                    .iter()
+                    .map(|m| format!("machine {m} login {login} password {password}\n"))
+                    .collect::<String>();
+                Ok(map(vec![
+                    ("files", map(vec![("netrc", s(body))])),
+                    ("env", map(vec![("NETRC", s("${file:netrc}"))])),
+                ]))
+            },
+        ),
+    ]
+}
+
+/// The `external_account` document `heph.auth.gcp` generates.
+///
+/// The file-sourced form, rather than the URL-sourced one Google's own Action
+/// writes: heph already holds the token and does not need to hand a caller a live
+/// minting endpoint plus its bearer token.
+///
+/// Written out as a function with a test rather than inline, because it is the one
+/// preset expansion most likely to be wrong if hand-typed and the failure is a
+/// message from inside Google's SDK.
+fn gcp_external_account(audience: &str, impersonate: Option<&str>) -> String {
+    let mut doc = serde_json::json!({
+        "type": "external_account",
+        "audience": audience,
+        "subject_token_type": "urn:ietf:params:oauth:token-type:jwt",
+        "token_url": "https://sts.googleapis.com/v1/token",
+        "credential_source": { "file": "${file:token}" },
+    });
+    if let Some(sa) = impersonate
+        && let Some(obj) = doc.as_object_mut()
+    {
+        obj.insert(
+            "service_account_impersonation_url".to_string(),
+            serde_json::Value::String(format!(
+                "https://iamcredentials.googleapis.com/v1/projects/-/serviceAccounts/{sa}:generateAccessToken"
+            )),
+        );
+    }
+    doc.to_string()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::plugincredential::present::Presentation;
+    use crate::plugincredential::source::SourceDecl;
+
+    /// One case: the function name, its positionals, and its named arguments.
+    type Case = (&'static str, Vec<Value>, Vec<(&'static str, Value)>);
+
+    fn call(name: &str, positional: Vec<Value>, named: &[(&str, Value)]) -> anyhow::Result<Value> {
+        let defs = definitions();
+        let d = defs
+            .iter()
+            .find(|d| d.name == name)
+            .ok_or_else(|| anyhow::anyhow!("no such function {name}"))?;
+        let args = FnArgs {
+            positional,
+            named: named
+                .iter()
+                .map(|(k, v)| (k.to_string(), v.clone()))
+                .collect(),
+        };
+        let f = d.func.clone();
+        futures::executor::block_on(async move {
+            f.call(
+                &FnCallContext {
+                    pkg: "auth",
+                    root: std::path::Path::new("/ws"),
+                },
+                args,
+            )
+            .await
+        })
+    }
+
+    fn s(v: &str) -> Value {
+        Value::String(v.to_string())
+    }
+    fn list(vs: &[&str]) -> Value {
+        Value::List(vs.iter().map(|v| s(v)).collect())
+    }
+
+    /// The claim worth being able to check: a preset returns a dict the author
+    /// could have written, so every one of them must parse as the primitive it
+    /// stands for.
+    #[test]
+    fn every_source_preset_parses_as_a_source() {
+        let cases: Vec<Case> = vec![
+            (
+                "env",
+                vec![list(&["GITHUB_TOKEN"])],
+                vec![("when", s("ci"))],
+            ),
+            (
+                "file",
+                vec![s("~/.config/svc/creds.json")],
+                vec![
+                    (
+                        "fields",
+                        Value::Map(
+                            [("token".to_string(), s("access_token"))]
+                                .into_iter()
+                                .collect(),
+                        ),
+                    ),
+                    ("expires", s("expires_at")),
+                ],
+            ),
+            (
+                "exec",
+                vec![list(&["vault", "read", "-format=json", "secret/cf"])],
+                vec![
+                    ("login", Value::List(vec![list(&["vault", "login"])])),
+                    ("runner", s("//tools/devenv:runner")),
+                    ("credentials", s("//auth:vault")),
+                ],
+            ),
+            (
+                "passthrough",
+                vec![],
+                vec![
+                    (
+                        "paths",
+                        Value::Map(
+                            [("config".to_string(), s("~/.config/gcloud"))]
+                                .into_iter()
+                                .collect(),
+                        ),
+                    ),
+                    (
+                        "env",
+                        Value::Map(
+                            [("CLOUDSDK_CONFIG".to_string(), s("${file:config}"))]
+                                .into_iter()
+                                .collect(),
+                        ),
+                    ),
+                ],
+            ),
+            (
+                "oidc",
+                vec![s("github_actions")],
+                vec![("audience", s("sts.amazonaws.com"))],
+            ),
+        ];
+        for (name, positional, named) in cases {
+            let v = call(name, positional, &named).unwrap_or_else(|e| panic!("{name}: {e:#}"));
+            SourceDecl::parse(&v).unwrap_or_else(|e| panic!("{name} does not parse: {e:#}"));
+        }
+    }
+
+    #[test]
+    fn every_presentation_preset_parses_as_a_presentation() {
+        let cases: Vec<Case> = vec![
+            ("aws_process", vec![], vec![]),
+            (
+                "aws_web_identity",
+                vec![],
+                vec![("role", s("arn:aws:iam::123:role/deployer"))],
+            ),
+            (
+                "gcp",
+                vec![],
+                vec![
+                    ("audience", s("//iam.googleapis.com/projects/1/x")),
+                    ("impersonate", s("d@p.iam.gserviceaccount.com")),
+                ],
+            ),
+            (
+                "azure_workload",
+                vec![],
+                vec![("client_id", s("c")), ("tenant_id", s("t"))],
+            ),
+            ("github", vec![], vec![]),
+            ("docker", vec![list(&["ghcr.io"])], vec![]),
+            ("git", vec![list(&["git.corp.example"])], vec![]),
+            ("netrc", vec![list(&["artifacts.corp"])], vec![]),
+        ];
+        for (name, positional, named) in cases {
+            let v = call(name, positional, &named).unwrap_or_else(|e| panic!("{name}: {e:#}"));
+            Presentation::parse(&v).unwrap_or_else(|e| panic!("{name} does not parse: {e:#}"));
+        }
+    }
+
+    #[test]
+    fn aws_web_identity_is_a_token_file_and_three_variables() {
+        let v = call(
+            "aws_web_identity",
+            vec![],
+            &[("role", s("arn:aws:iam::123:role/deployer"))],
+        )
+        .expect("call");
+        let p = Presentation::parse(&v).expect("parse");
+        assert_eq!(
+            p.files.get("token").map(String::as_str),
+            Some("${id_token}")
+        );
+        assert_eq!(
+            p.env.get("AWS_WEB_IDENTITY_TOKEN_FILE").map(String::as_str),
+            Some("${file:token}")
+        );
+        assert_eq!(
+            p.env.get("AWS_ROLE_ARN").map(String::as_str),
+            Some("arn:aws:iam::123:role/deployer")
+        );
+        assert_eq!(
+            p.env.get("AWS_ROLE_SESSION_NAME").map(String::as_str),
+            Some("heph")
+        );
+        assert!(p.helper.is_none(), "web identity is not a callback");
+    }
+
+    #[test]
+    fn the_gcp_document_is_the_file_sourced_external_account_form() {
+        let doc: serde_json::Value =
+            serde_json::from_str(&gcp_external_account("//iam.googleapis.com/x", None))
+                .expect("valid json");
+        assert_eq!(doc["type"], "external_account");
+        assert_eq!(doc["audience"], "//iam.googleapis.com/x");
+        assert_eq!(doc["credential_source"]["file"], "${file:token}");
+        // Absent without `impersonate`: adding it unconditionally would change
+        // which identity the credential ends up being.
+        assert!(doc.get("service_account_impersonation_url").is_none());
+
+        let imp: serde_json::Value =
+            serde_json::from_str(&gcp_external_account("//a", Some("sa@p.iam"))).expect("json");
+        assert_eq!(
+            imp["service_account_impersonation_url"],
+            "https://iamcredentials.googleapis.com/v1/projects/-/serviceAccounts/sa@p.iam:generateAccessToken"
+        );
+    }
+
+    #[test]
+    fn the_netrc_body_is_one_line_per_machine() {
+        let v = call("netrc", vec![list(&["a.corp", "b.corp"])], &[]).expect("call");
+        let p = Presentation::parse(&v).expect("parse");
+        assert_eq!(
+            p.files.get("netrc").map(String::as_str),
+            Some(
+                "machine a.corp login ${username} password ${token}\nmachine b.corp login ${username} password ${token}\n"
+            )
+        );
+    }
+
+    #[test]
+    fn a_missing_required_argument_fails_at_build_evaluation() {
+        let err = call("aws_web_identity", vec![], &[]).expect_err("must fail");
+        assert!(format!("{err:#}").contains("`role` is required"), "{err:#}");
+    }
+
+    #[test]
+    fn passthrough_refuses_both_shorthand_and_full_presentation() {
+        let err = call(
+            "passthrough",
+            vec![],
+            &[
+                (
+                    "paths",
+                    Value::Map([("c".to_string(), s("~/.aws"))].into_iter().collect()),
+                ),
+                (
+                    "env",
+                    Value::Map([("A".to_string(), s("${file:c}"))].into_iter().collect()),
+                ),
+                (
+                    "present",
+                    Value::Map(
+                        [(
+                            "env".to_string(),
+                            Value::Map([("B".to_string(), s("${file:c}"))].into_iter().collect()),
+                        )]
+                        .into_iter()
+                        .collect(),
+                    ),
+                ),
+            ],
+        )
+        .expect_err("must fail");
+        assert!(format!("{err:#}").contains("not both"), "{err:#}");
+    }
+
+    #[test]
+    fn there_is_no_source_preset_for_any_product() {
+        let names: Vec<&str> = definitions()
+            .iter()
+            .map(|d| d.name.clone())
+            .map(|n| Box::leak(n.into_boxed_str()) as &str)
+            .collect();
+        for banned in ["vault", "op", "onepassword", "aws_sso", "gcloud", "az"] {
+            assert!(
+                !names.contains(&banned),
+                "`heph.auth.{banned}` must not exist: a source preset is a workflow frozen into a \
+                 plugin, and the list has no end"
+            );
+        }
+    }
+
+    #[test]
+    fn every_function_is_documented() {
+        for d in definitions() {
+            assert!(!d.doc.is_empty(), "heph.auth.{} has no doc", d.name);
+        }
+    }
+}

--- a/crates/builtins/src/plugincredential/mod.rs
+++ b/crates/builtins/src/plugincredential/mod.rs
@@ -1,0 +1,508 @@
+//! The `credential` driver: declares what identity is needed, how it may be
+//! obtained, and the shape it is presented in.
+//!
+//! A credential is a target for the same reasons a `scratch` is. Settings live in
+//! exactly one place, so two consumers cannot disagree about which role to
+//! assume; the address gives packages, visibility and `heph query revdeps` for
+//! free; and `heph auth status` has something to enumerate. Inline credential
+//! config on each consumer would make "which credentials does this workspace
+//! need?" an unanswerable question.
+//!
+//! The contract everything here follows from:
+//!
+//! > A credential grants **access**; it is not an **input**. A target's outputs
+//! > must be identical whichever identity satisfied its credential requirement.
+//!
+//! This driver is only the **declaration**. It has no inputs, no outputs, never
+//! executes, and is never cached as a target — `parse` returns a def and `run` is
+//! inert. The chain walk, the acquisition, the store and the presentation all
+//! live in the engine, on behalf of the targets that reference it.
+//!
+//! # Why the parsing lives here rather than in the engine
+//!
+//! Same reason as `scratch`: the engine reads a declaration from its *spec
+//! config* (a `raw_def` is opaque to the host by contract), so host and driver
+//! must agree about what a declaration means. Reading it through the same
+//! function both call is what makes that agreement structural.
+
+pub mod functions;
+pub mod present;
+pub mod source;
+
+use anyhow::Context as _;
+use async_trait::async_trait;
+use hcore::hasync::Cancellable;
+use hcore::htvalue::Value;
+use hcore::htvalue::signature::ParamType;
+use hplugin::driver::{
+    ApplyTransitiveRequest, ApplyTransitiveResponse, ConfigRequest, ConfigResponse, DriverField,
+    DriverSchema, ParseRequest, ParseResponse, RunRequest, RunResponse,
+    targetdef::{CacheConfig, TargetDef},
+};
+use std::sync::Arc;
+use std::time::Duration;
+use xxhash_rust::xxh3::Xxh3;
+
+pub use present::{Dialect, Helper, Presentation};
+pub use source::{SourceDecl, SourceKind, When};
+
+pub const DRIVER_NAME: &str = "credential";
+
+/// A parsed credential declaration.
+///
+/// Public because the engine reads these settings when a consumer references the
+/// target — but note it reads them from the *spec config*, not from here.
+#[derive(Debug, Clone, PartialEq, Eq, serde::Serialize)]
+pub struct CredentialDef {
+    /// The ordered chain. The first applicable source is the source.
+    pub sources: Vec<SourceDecl>,
+    /// The presentation used by any source that does not override it.
+    pub present: Option<Presentation>,
+    /// A declared lifetime, for material whose source reports none.
+    ///
+    /// Set it *under* the true lifetime, never at it. Without one, material with
+    /// no expiry is never written to the disk cache — a one-hour session token
+    /// cached for an hour is a convenience; a long-lived API token written to
+    /// `<home>/auth/` is a durable secret at rest that nothing will ever clean up.
+    #[serde(serialize_with = "ser_ttl")]
+    pub ttl: Option<Duration>,
+}
+
+fn ser_ttl<S: serde::Serializer>(v: &Option<Duration>, s: S) -> Result<S::Ok, S::Error> {
+    match v {
+        Some(d) => s.serialize_some(&d.as_secs()),
+        None => s.serialize_none(),
+    }
+}
+
+impl CredentialDef {
+    /// The presentation a given source uses: its own override, or the
+    /// credential's.
+    ///
+    /// A source's override exists because a token file and a key pair are
+    /// genuinely different shapes — which is forced by the domain rather than
+    /// chosen. When the sources agree, `present` on the credential says so once.
+    pub fn presentation_for<'a>(
+        &'a self,
+        source: &'a SourceDecl,
+    ) -> anyhow::Result<&'a Presentation> {
+        source
+            .present
+            .as_ref()
+            .or(self.present.as_ref())
+            .ok_or_else(|| {
+                anyhow::anyhow!(
+                    "the {} source has no presentation, and the credential declares none — add \
+                     `present = …` to the credential, or to this source if its material has a \
+                     different shape from the others",
+                    source.label()
+                )
+            })
+    }
+}
+
+/// Config for a `credential` target.
+///
+/// Hand-parsed rather than `#[derive(Spec)]`d: `sources` is a heterogeneous list
+/// (an address *or* an inline dict) and `present` is a nested document, neither of
+/// which the derive's field shapes describe. The schema below is written out for
+/// the same reason.
+fn schema() -> DriverSchema {
+    let strs = || ParamType::union(vec![ParamType::String, ParamType::list(ParamType::String)]);
+    let present_ty = || {
+        ParamType::strukt(vec![
+            ("env", ParamType::map(ParamType::String)),
+            ("files", ParamType::map(ParamType::String)),
+            (
+                "helper",
+                ParamType::union(vec![
+                    ParamType::String,
+                    ParamType::strukt(vec![
+                        ("dialect", ParamType::String),
+                        ("registries", strs()),
+                        ("hosts", strs()),
+                        ("audience", ParamType::String),
+                        ("impersonate", ParamType::String),
+                    ]),
+                ]),
+            ),
+        ])
+    };
+    // An address, or one of the five inline kinds. Written out rather than
+    // derived because the union is genuinely heterogeneous — which is also why
+    // authors write `heph.auth.exec(...)` and get the fields checked by a
+    // function signature instead.
+    let source_ty = ParamType::union(vec![
+        ParamType::String,
+        ParamType::strukt(vec![
+            ("kind", ParamType::String),
+            ("when", ParamType::String),
+            ("credentials", strs()),
+            ("present", present_ty()),
+            ("hint", ParamType::String),
+            ("names", strs()),
+            ("path", ParamType::String),
+            ("run", strs()),
+            ("fields", ParamType::map(ParamType::String)),
+            ("expires", ParamType::String),
+            ("login", ParamType::list(strs())),
+            ("runner", ParamType::String),
+            ("paths", ParamType::map(ParamType::String)),
+            ("provider", ParamType::String),
+            ("audience", ParamType::String),
+        ]),
+    ]);
+    DriverSchema {
+        fields: vec![
+            DriverField {
+                name: "sources".to_string(),
+                ty: ParamType::list(source_ty),
+                doc: "Ordered ways to obtain this credential. Each is a target address or a \
+                      `heph.auth.*` constructor. The first *applicable* source is the source: an \
+                      acquire failure is terminal, not a fallthrough, so a misconfigured role in \
+                      CI cannot silently fall back to an ambient identity."
+                    .to_string(),
+                required: true,
+            },
+            DriverField {
+                name: "present".to_string(),
+                ty: present_ty(),
+                doc: "How the material reaches a consumer: `env` (name → template), `files` \
+                      (name → content template, written 0600 and deleted at run end) and/or \
+                      `helper` (a callback protocol — aws, gcp, docker, git, kubernetes). May \
+                      instead be set per source, which is required when two sources yield \
+                      different material shapes. A presentation carries material and handles \
+                      only: anything that selects content (a region, an account, a project) is an \
+                      ordinary hashed input on the consumer."
+                    .to_string(),
+                required: false,
+            },
+            DriverField {
+                name: "ttl".to_string(),
+                ty: ParamType::String,
+                doc: "A declared lifetime (`55m`, `6h`) for material whose source reports none. \
+                      Set it under the true lifetime, never at it. Without it, material with no \
+                      expiry is never written to the disk cache."
+                    .to_string(),
+                required: false,
+            },
+        ],
+    }
+}
+
+/// Parse and validate a credential declaration straight from a target spec.
+///
+/// The engine calls this when a consumer references a credential. Reading the
+/// spec config — which *is* host-visible — through the same function the driver
+/// uses keeps one implementation of the parsing and validation rules.
+pub fn parse_declaration(spec: &hplugin::provider::TargetSpec) -> anyhow::Result<CredentialDef> {
+    let mut sources: Vec<SourceDecl> = Vec::new();
+    let mut present: Option<Presentation> = None;
+    let mut ttl: Option<Duration> = None;
+
+    for (k, v) in &spec.config {
+        match k.as_str() {
+            "sources" => {
+                let Value::List(items) = v else {
+                    anyhow::bail!(
+                        "credential `sources` must be a list of sources, got {v:?} — the list is \
+                         ordered, and the order is the whole point"
+                    );
+                };
+                sources = items
+                    .iter()
+                    .enumerate()
+                    .map(|(i, item)| {
+                        SourceDecl::parse(item).with_context(|| format!("sources[{i}]"))
+                    })
+                    .collect::<anyhow::Result<_>>()?;
+            }
+            "present" => present = Some(Presentation::parse(v)?),
+            "ttl" => {
+                let raw = present::string(v, "ttl")?;
+                ttl = Some(hcore::units::parse_duration(&raw).context("credential `ttl`")?);
+            }
+            other => anyhow::bail!(
+                "unknown key {other:?} on a `credential` target — it takes `sources`, `present` \
+                 and `ttl`"
+            ),
+        }
+    }
+
+    if sources.is_empty() {
+        anyhow::bail!(
+            "a `credential` target needs at least one entry in `sources` — a credential with an \
+             empty chain can never be acquired anywhere"
+        );
+    }
+
+    // A source that overrides nothing and a credential that presents nothing
+    // between them leave a consumer with no identity. Caught here so the failure
+    // names the declaration rather than surfacing as a 403 from a tool.
+    let def = CredentialDef {
+        sources,
+        present,
+        ttl,
+    };
+    for (i, s) in def.sources.iter().enumerate() {
+        def.presentation_for(s)
+            .with_context(|| format!("sources[{i}]"))?;
+    }
+    Ok(def)
+}
+
+pub struct Driver;
+
+#[async_trait]
+impl hplugin::driver::Driver for Driver {
+    fn config(&self, _req: ConfigRequest) -> anyhow::Result<ConfigResponse> {
+        Ok(ConfigResponse {
+            name: DRIVER_NAME.to_string(),
+        })
+    }
+
+    fn schema(&self) -> DriverSchema {
+        schema()
+    }
+
+    async fn parse(
+        &self,
+        req: ParseRequest,
+        _ctoken: &(dyn Cancellable + Send + Sync),
+    ) -> anyhow::Result<ParseResponse> {
+        let def = parse_declaration(&req.target_spec)
+            .with_context(|| format!("credential {}", req.target_spec.addr))?;
+
+        // The def hash covers the declaration so the graph sees a target that
+        // changes when its config does. It does NOT reach any consumer's
+        // `hashin`: a credential is referenced with `hashed: false`, precisely
+        // because a target's outputs must be identical whichever identity
+        // satisfied its requirement.
+        //
+        // Serialized rather than field-by-field because the declaration is a
+        // tree, and a hand-written walk of it would be one more place for the
+        // hash and the type to drift apart. Nothing secret is in it: a
+        // declaration says how to obtain material, never what the material is.
+        let mut h = Xxh3::new();
+        h.update(req.target_spec.addr.format().as_bytes());
+        h.update(
+            serde_json::to_vec(&def)
+                .context("hash credential declaration")?
+                .as_slice(),
+        );
+        let hash = format!("{:016x}", h.digest()).into_bytes();
+
+        Ok(ParseResponse {
+            target_def: TargetDef {
+                addr: req.target_spec.addr.clone(),
+                labels: req.target_spec.labels.clone(),
+                raw_def: Arc::new(def),
+                inputs: vec![],
+                outputs: vec![],
+                support_files: vec![],
+                // Never cached as a target. Material has a lifetime of its own,
+                // managed by the credential store, which is a different thing.
+                cache: CacheConfig::off(),
+                pty: false,
+                hash,
+                transparent: false,
+            },
+        })
+    }
+
+    async fn apply_transitive(
+        &self,
+        req: ApplyTransitiveRequest,
+        _ctoken: &(dyn Cancellable + Send + Sync),
+    ) -> anyhow::Result<ApplyTransitiveResponse> {
+        Ok(ApplyTransitiveResponse {
+            target_def: req.target_def,
+        })
+    }
+
+    async fn run<'a, 'io>(
+        &self,
+        _req: RunRequest<'a, 'io>,
+        _ctoken: &(dyn Cancellable + Send + Sync),
+    ) -> anyhow::Result<RunResponse> {
+        // Reachable and not an error, exactly as for `scratch`: resolving a
+        // declaration directly (`heph run //auth:aws`) executes it like any other
+        // target, and a declaration is inert by construction. Acquiring material
+        // here would be wrong twice over — it would put a secret behind an
+        // ordinary `run`, and it would make a build sign someone in.
+        Ok(RunResponse::default())
+    }
+
+    async fn run_shell<'a, 'io>(
+        &self,
+        req: RunRequest<'a, 'io>,
+        ctoken: &(dyn Cancellable + Send + Sync),
+    ) -> anyhow::Result<RunResponse> {
+        self.run(req, ctoken).await
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use hmodel::htaddr::Addr;
+    use hmodel::htpkg::PkgBuf;
+    use std::collections::{BTreeMap, HashMap};
+
+    fn s(v: &str) -> Value {
+        Value::String(v.to_string())
+    }
+    fn map(pairs: &[(&str, Value)]) -> Value {
+        Value::Map(
+            pairs
+                .iter()
+                .map(|(k, v)| (k.to_string(), v.clone()))
+                .collect(),
+        )
+    }
+    fn list(vs: Vec<Value>) -> Value {
+        Value::List(vs)
+    }
+
+    fn spec(config: &[(&str, Value)]) -> hplugin::provider::TargetSpec {
+        hplugin::provider::TargetSpec {
+            addr: Addr::new(PkgBuf::from("auth"), "aws".to_string(), BTreeMap::new()),
+            driver: DRIVER_NAME.to_string(),
+            config: config
+                .iter()
+                .map(|(k, v)| (k.to_string(), v.clone()))
+                .collect::<HashMap<_, _>>(),
+            ..Default::default()
+        }
+    }
+
+    #[test]
+    fn the_acceptance_declaration_parses() {
+        let def = parse_declaration(&spec(&[(
+            "sources",
+            list(vec![
+                map(&[
+                    ("kind", s("oidc")),
+                    ("provider", s("github_actions")),
+                    ("audience", s("sts.amazonaws.com")),
+                    (
+                        "present",
+                        map(&[
+                            ("files", map(&[("token", s("${id_token}"))])),
+                            (
+                                "env",
+                                map(&[
+                                    ("AWS_WEB_IDENTITY_TOKEN_FILE", s("${file:token}")),
+                                    ("AWS_ROLE_ARN", s("arn:aws:iam::1:role/deployer")),
+                                ]),
+                            ),
+                        ]),
+                    ),
+                ]),
+                map(&[
+                    ("kind", s("exec")),
+                    (
+                        "run",
+                        list(vec![s("aws"), s("configure"), s("export-credentials")]),
+                    ),
+                    ("present", map(&[("helper", s("aws"))])),
+                ]),
+            ]),
+        )]))
+        .expect("parse");
+        assert_eq!(def.sources.len(), 2);
+        assert_eq!(def.sources[0].label(), "oidc(github_actions)");
+        assert_eq!(def.sources[1].label(), "exec(aws)");
+    }
+
+    #[test]
+    fn an_empty_chain_is_rejected() {
+        let err = parse_declaration(&spec(&[("sources", list(vec![]))])).expect_err("must fail");
+        assert!(format!("{err:#}").contains("at least one"), "{err:#}");
+    }
+
+    #[test]
+    fn a_source_with_no_presentation_anywhere_is_rejected_at_the_declaration() {
+        let err = parse_declaration(&spec(&[(
+            "sources",
+            list(vec![map(&[("kind", s("env")), ("names", s("TOKEN"))])]),
+        )]))
+        .expect_err("must fail");
+        assert!(format!("{err:#}").contains("no presentation"), "{err:#}");
+    }
+
+    #[test]
+    fn a_credential_level_presentation_covers_every_source() {
+        let def = parse_declaration(&spec(&[
+            (
+                "sources",
+                list(vec![
+                    map(&[("kind", s("env")), ("names", s("TOKEN"))]),
+                    s("//auth:other"),
+                ]),
+            ),
+            ("present", map(&[("env", map(&[("T", s("${token}"))]))])),
+            ("ttl", s("55m")),
+        ]))
+        .expect("parse");
+        assert_eq!(def.ttl, Some(Duration::from_secs(3300)));
+        for src in &def.sources {
+            def.presentation_for(src)
+                .expect("every source is covered by the credential's presentation");
+        }
+    }
+
+    #[tokio::test]
+    async fn the_def_hash_moves_with_the_declaration_and_never_holds_material() {
+        use hplugin::driver::Driver as _;
+        let ctoken = hcore::hasync::StdCancellationToken::new();
+        let parse = async |ttl: &str| {
+            Driver
+                .parse(
+                    ParseRequest {
+                        request_id: "r".to_string(),
+                        target_spec: Arc::new(spec(&[
+                            (
+                                "sources",
+                                list(vec![map(&[("kind", s("env")), ("names", s("TOKEN"))])]),
+                            ),
+                            ("present", map(&[("env", map(&[("T", s("${token}"))]))])),
+                            ("ttl", s(ttl)),
+                        ])),
+                    },
+                    &ctoken,
+                )
+                .await
+                .expect("parse")
+                .target_def
+                .hash
+        };
+        assert_ne!(parse("55m").await, parse("6h").await);
+    }
+
+    #[tokio::test]
+    async fn a_declaration_declares_and_does_not_execute() {
+        use hplugin::driver::Driver as _;
+        let ctoken = hcore::hasync::StdCancellationToken::new();
+        let res = Driver
+            .parse(
+                ParseRequest {
+                    request_id: "r".to_string(),
+                    target_spec: Arc::new(spec(&[
+                        (
+                            "sources",
+                            list(vec![map(&[("kind", s("env")), ("names", s("TOKEN"))])]),
+                        ),
+                        ("present", map(&[("env", map(&[("T", s("${token}"))]))])),
+                    ])),
+                },
+                &ctoken,
+            )
+            .await
+            .expect("parse")
+            .target_def;
+        assert!(res.inputs.is_empty(), "a declaration has no inputs");
+        assert!(res.outputs.is_empty(), "a declaration has no outputs");
+        assert!(!res.cache.enabled, "material is not a build artifact");
+    }
+}

--- a/crates/builtins/src/plugincredential/mod.rs
+++ b/crates/builtins/src/plugincredential/mod.rs
@@ -35,8 +35,8 @@ use hcore::hasync::Cancellable;
 use hcore::htvalue::Value;
 use hcore::htvalue::signature::ParamType;
 use hplugin::driver::{
-    ApplyTransitiveRequest, ApplyTransitiveResponse, ConfigRequest, ConfigResponse, DriverField,
-    DriverSchema, ParseRequest, ParseResponse, RunRequest, RunResponse,
+    ApplyTransitiveRequest, ApplyTransitiveResponse, ConfigRequest, ConfigResponse, DriverSchema,
+    ParseRequest, ParseResponse, RunRequest, RunResponse,
     targetdef::{CacheConfig, TargetDef},
 };
 use std::sync::Arc;
@@ -101,133 +101,81 @@ impl CredentialDef {
     }
 }
 
-/// Config for a `credential` target.
-///
-/// Hand-parsed rather than `#[derive(Spec)]`d: `sources` is a heterogeneous list
-/// (an address *or* an inline dict) and `present` is a nested document, neither of
-/// which the derive's field shapes describe. The schema below is written out for
-/// the same reason.
-fn schema() -> DriverSchema {
-    let strs = || ParamType::union(vec![ParamType::String, ParamType::list(ParamType::String)]);
-    let present_ty = || {
-        ParamType::strukt(vec![
-            ("env", ParamType::map(ParamType::String)),
-            ("files", ParamType::map(ParamType::String)),
-            (
-                "helper",
-                ParamType::union(vec![
-                    ParamType::String,
-                    ParamType::strukt(vec![
-                        ("dialect", ParamType::String),
-                        ("registries", strs()),
-                        ("hosts", strs()),
-                        ("audience", ParamType::String),
-                        ("impersonate", ParamType::String),
-                    ]),
-                ]),
-            ),
-        ])
-    };
-    // An address, or one of the five inline kinds. Written out rather than
-    // derived because the union is genuinely heterogeneous — which is also why
-    // authors write `heph.auth.exec(...)` and get the fields checked by a
-    // function signature instead.
-    let source_ty = ParamType::union(vec![
-        ParamType::String,
-        ParamType::strukt(vec![
-            ("kind", ParamType::String),
-            ("when", ParamType::String),
-            ("credentials", strs()),
-            ("present", present_ty()),
-            ("hint", ParamType::String),
-            ("names", strs()),
-            ("path", ParamType::String),
-            ("run", strs()),
-            ("fields", ParamType::map(ParamType::String)),
-            ("expires", ParamType::String),
-            ("login", ParamType::list(strs())),
-            ("runner", ParamType::String),
-            ("paths", ParamType::map(ParamType::String)),
-            ("provider", ParamType::String),
-            ("audience", ParamType::String),
-        ]),
-    ]);
-    DriverSchema {
-        fields: vec![
-            DriverField {
-                name: "sources".to_string(),
-                ty: ParamType::list(source_ty),
-                doc: "Ordered ways to obtain this credential. Each is a target address or a \
-                      `heph.auth.*` constructor. The first *applicable* source is the source: an \
-                      acquire failure is terminal, not a fallthrough, so a misconfigured role in \
-                      CI cannot silently fall back to an ambient identity."
-                    .to_string(),
-                required: true,
-            },
-            DriverField {
-                name: "present".to_string(),
-                ty: present_ty(),
-                doc: "How the material reaches a consumer: `env` (name → template), `files` \
-                      (name → content template, written 0600 and deleted at run end) and/or \
-                      `helper` (a callback protocol — aws, gcp, docker, git, kubernetes). May \
-                      instead be set per source, which is required when two sources yield \
-                      different material shapes. A presentation carries material and handles \
-                      only: anything that selects content (a region, an account, a project) is an \
-                      ordinary hashed input on the consumer."
-                    .to_string(),
-                required: false,
-            },
-            DriverField {
-                name: "ttl".to_string(),
-                ty: ParamType::String,
-                doc: "A declared lifetime (`55m`, `6h`) for material whose source reports none. \
-                      Set it under the true lifetime, never at it. Without it, material with no \
-                      expiry is never written to the disk cache."
-                    .to_string(),
-                required: false,
-            },
-        ],
-    }
-}
-
 /// Parse and validate a credential declaration straight from a target spec.
 ///
 /// The engine calls this when a consumer references a credential. Reading the
 /// spec config — which *is* host-visible — through the same function the driver
 /// uses keeps one implementation of the parsing and validation rules.
-pub fn parse_declaration(spec: &hplugin::provider::TargetSpec) -> anyhow::Result<CredentialDef> {
-    let mut sources: Vec<SourceDecl> = Vec::new();
-    let mut present: Option<Presentation> = None;
-    let mut ttl: Option<Duration> = None;
+/// The `credential` driver's config, as the author writes it.
+///
+/// `#[derive(Spec)]` owns the key set, the per-field decoding, the unknown-key
+/// refusal and the LSP schema — so the parser and the schema are one thing, and
+/// the doc comments below are what `heph inspect schema` prints. Only the two
+/// fields whose *shape* the derive cannot express carry a `parse` function:
+/// `sources` is an ordered heterogeneous list, and `ttl` is a duration grammar.
+#[derive(hplugin::htspec::Spec)]
+struct CredentialSpec {
+    /// Ordered ways to obtain this credential. Each is a target address or a
+    /// `heph.auth.*` constructor. The first *applicable* source is the source:
+    /// an acquire failure is terminal, not a fallthrough, so a misconfigured
+    /// role in CI cannot silently fall back to an ambient identity.
+    #[spec(required, parse = parse_sources, ty = ParamType::list(functions::source_ty()))]
+    sources: Vec<SourceDecl>,
+    /// How the material reaches a consumer: `env` (name → template), `files`
+    /// (name → content template, written 0600 and deleted at run end) and/or
+    /// `helper` (a callback protocol — aws, gcp, docker, git, kubernetes). May
+    /// instead be set per source, which is required when two sources yield
+    /// different material shapes. A presentation carries material and handles
+    /// only: anything that selects content (a region, an account, a project) is
+    /// an ordinary hashed input on the consumer.
+    #[spec(parse = parse_present, ty = functions::presentation_ty())]
+    present: Option<Presentation>,
+    /// A declared lifetime (`55m`, `6h`) for material whose source reports none.
+    /// Set it under the true lifetime, never at it. Without it, material with no
+    /// expiry is never written to the disk cache.
+    #[spec(parse = parse_ttl, ty = ParamType::String)]
+    ttl: Option<Duration>,
+}
 
-    for (k, v) in &spec.config {
-        match k.as_str() {
-            "sources" => {
-                let Value::List(items) = v else {
-                    anyhow::bail!(
-                        "credential `sources` must be a list of sources, got {v:?} — the list is \
-                         ordered, and the order is the whole point"
-                    );
-                };
-                sources = items
-                    .iter()
-                    .enumerate()
-                    .map(|(i, item)| {
-                        SourceDecl::parse(item).with_context(|| format!("sources[{i}]"))
-                    })
-                    .collect::<anyhow::Result<_>>()?;
-            }
-            "present" => present = Some(Presentation::parse(v)?),
-            "ttl" => {
-                let raw = present::string(v, "ttl")?;
-                ttl = Some(hcore::units::parse_duration(&raw).context("credential `ttl`")?);
-            }
-            other => anyhow::bail!(
-                "unknown key {other:?} on a `credential` target — it takes `sources`, `present` \
-                 and `ttl`"
-            ),
-        }
+/// An ordered, heterogeneous list: each entry is a bare address or a
+/// `heph.auth.*` dict, and the index is part of every diagnostic.
+fn parse_sources(v: &Value) -> anyhow::Result<Vec<SourceDecl>> {
+    let Value::List(items) = v else {
+        anyhow::bail!(
+            "credential `sources` must be a list of sources, got {v:?} — the list is ordered, \
+             and the order is the whole point"
+        );
+    };
+    items
+        .iter()
+        .enumerate()
+        .map(|(i, item)| SourceDecl::parse(item).with_context(|| format!("sources[{i}]")))
+        .collect()
+}
+
+fn parse_present(v: &Value) -> anyhow::Result<Option<Presentation>> {
+    match v {
+        Value::Null() => Ok(None),
+        other => Presentation::parse(other).map(Some),
     }
+}
+
+fn parse_ttl(v: &Value) -> anyhow::Result<Option<Duration>> {
+    let Some(raw) = <Option<String> as hplugin::htspec::FromSpecValue>::from_spec_value(v)? else {
+        return Ok(None);
+    };
+    Ok(Some(
+        hcore::units::parse_duration(&raw).context("credential `ttl`")?,
+    ))
+}
+
+pub fn parse_declaration(spec: &hplugin::provider::TargetSpec) -> anyhow::Result<CredentialDef> {
+    let CredentialSpec {
+        sources,
+        present,
+        ttl,
+    } = CredentialSpec::from(&spec.config)
+        .context("a `credential` target takes `sources`, `present` and `ttl`")?;
 
     if sources.is_empty() {
         anyhow::bail!(
@@ -262,7 +210,7 @@ impl hplugin::driver::Driver for Driver {
     }
 
     fn schema(&self) -> DriverSchema {
-        schema()
+        CredentialSpec::schema()
     }
 
     async fn parse(

--- a/crates/builtins/src/plugincredential/present.rs
+++ b/crates/builtins/src/plugincredential/present.rs
@@ -1,0 +1,438 @@
+//! How material reaches a consumer.
+//!
+//! A presentation is the *shape* a credential arrives in, and nothing else. The
+//! rule it exists to enforce is the sharpest one in the design:
+//!
+//! > A presentation may carry only **material** and the handles needed to use it
+//! > — keys, tokens, a token-file path, a helper argv. Anything that **selects
+//! > content** (a region, an account, a project, a profile) is an ordinary hashed
+//! > input on the consumer.
+//!
+//! heph cannot check that rule mechanically, and it is worth being precise about
+//! how far the vocabulary gets. Three keys, a closed set of helper dialects and a
+//! four-token template grammar mean a *key* like `region` is rejected outright —
+//! there is nowhere to put it. A content-selecting **value** is not caught:
+//! `{"env": {"AWS_REGION": "eu-west-1"}}` parses, because it is the same shape
+//! `heph.auth.aws_web_identity` uses to carry a role ARN, which is a handle
+//! rather than a selector. Nothing from the outside tells those apart.
+//!
+//! What keeps that sound is the contract rather than the parser: a target whose
+//! *output* depends on which identity ran it is not cacheable and says so with
+//! `cache = False`. That is a deliberate, recorded decision — making it
+//! structural would cost CI its remote sharing on every private fetch — and the
+//! audit it owes in exchange is `heph auth explain` plus a documented rule, not a
+//! check. See `docs/CREDENTIALS.md`, "The rule that is easiest to get wrong".
+
+use hcore::htvalue::Value;
+use std::collections::BTreeMap;
+
+/// A callback protocol heph speaks on a tool's behalf.
+///
+/// Each of these is a **third-party wire format with exactly one correct
+/// encoding**, which is the whole reason they are presets rather than something
+/// an author hand-rolls: getting a field name wrong is a silent failure inside
+/// somebody else's SDK. The set is closed because the number of such formats is
+/// small and known.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, serde::Serialize)]
+pub enum Dialect {
+    /// The AWS credential-process contract: a config file naming
+    /// `heph __auth-helper aws <addr>` as a profile's `credential_process`.
+    Aws,
+    /// GCP executable-sourced external-account credentials.
+    Gcp,
+    /// The Docker credential-helper protocol, via a `docker-credential-heph`
+    /// shim and a generated `DOCKER_CONFIG` directory.
+    Docker,
+    /// The git credential-helper protocol, injected through `GIT_CONFIG_*` so no
+    /// gitconfig is written and the developer's own is never touched.
+    Git,
+    /// The client-go `ExecCredential` object. Unlike the others heph writes no
+    /// document: the author templates the kubeconfig and places the argv with
+    /// `${helper:command}` and `${helper:args}`.
+    Kubernetes,
+}
+
+impl Dialect {
+    pub fn parse(s: &str) -> anyhow::Result<Self> {
+        Ok(match s {
+            "aws" => Self::Aws,
+            "gcp" => Self::Gcp,
+            "docker" => Self::Docker,
+            "git" => Self::Git,
+            "kubernetes" => Self::Kubernetes,
+            other => anyhow::bail!(
+                "unknown credential helper dialect {other:?} — expected one of aws, gcp, docker, \
+                 git, kubernetes. A helper is a protocol heph speaks on a tool's behalf; for a \
+                 tool that speaks none, use `env` or `files`"
+            ),
+        })
+    }
+
+    pub fn as_str(self) -> &'static str {
+        match self {
+            Self::Aws => "aws",
+            Self::Gcp => "gcp",
+            Self::Docker => "docker",
+            Self::Git => "git",
+            Self::Kubernetes => "kubernetes",
+        }
+    }
+
+    /// Whether heph generates the tool's configuration document itself.
+    ///
+    /// False only for [`Kubernetes`](Self::Kubernetes): a kubeconfig is not
+    /// purely a credential format — it also carries the cluster, which is the
+    /// author's — so heph supplies only the callback argv.
+    pub fn writes_a_document(self) -> bool {
+        !matches!(self, Self::Kubernetes)
+    }
+}
+
+/// A helper presentation: which dialect, and the handles that dialect needs.
+///
+/// Every field here is a *handle* — which registries this credential covers,
+/// which git hosts, which workload-identity audience to present it as. None of
+/// them selects content, which is the test §2 of the design applies to
+/// everything on this side of the line.
+#[derive(Debug, Clone, PartialEq, Eq, serde::Serialize, Default)]
+pub struct Helper {
+    pub dialect: Option<Dialect>,
+    /// Docker: registries this credential authenticates. Empty is an error —
+    /// a credHelpers map with no entries authenticates nothing.
+    pub registries: Vec<String>,
+    /// Git: hosts this credential authenticates.
+    pub hosts: Vec<String>,
+    /// GCP: the workload-identity-pool audience the token is presented for.
+    pub audience: Option<String>,
+    /// GCP: a service account to impersonate. Some Google services do not accept
+    /// a federated identity directly, which is why this exists at all.
+    pub impersonate: Option<String>,
+}
+
+impl Helper {
+    pub fn dialect(&self) -> anyhow::Result<Dialect> {
+        self.dialect
+            .ok_or_else(|| anyhow::anyhow!("credential `helper` needs a `dialect`"))
+    }
+}
+
+/// How material reaches the sandbox.
+///
+/// Three shapes, in preference order, and they compose: a kubernetes helper is a
+/// `files` kubeconfig plus an `env` pointing at it plus the callback argv.
+#[derive(Debug, Clone, PartialEq, Eq, serde::Serialize, Default)]
+pub struct Presentation {
+    /// Name → template. Injected as **runtime** environment — never `env`, never
+    /// `pass_env` — so it cannot reach a def hash by construction.
+    pub env: BTreeMap<String, String>,
+    /// Name → content template. Written by the host at `0600` under the sandbox
+    /// root, beside the workspace directory and never inside it, and deleted at
+    /// run end whatever the outcome. Reachable as `${file:<name>}`.
+    pub files: BTreeMap<String, String>,
+    /// A callback protocol. The only presentation that survives expiry.
+    pub helper: Option<Helper>,
+}
+
+impl Presentation {
+    pub fn is_empty(&self) -> bool {
+        self.env.is_empty() && self.files.is_empty() && self.helper.is_none()
+    }
+
+    /// Parse a presentation from its BUILD-file value.
+    ///
+    /// Accepts the map form written by hand and the dicts the `heph.auth.*`
+    /// presets return — which are the same thing, deliberately: a preset is a
+    /// function returning a value the author could have typed.
+    pub fn parse(v: &Value) -> anyhow::Result<Self> {
+        let m = match v {
+            Value::Map(m) => m,
+            other => anyhow::bail!(
+                "credential `present` must be a dict with `env`, `files` and/or `helper` keys, \
+                 got {other:?}"
+            ),
+        };
+        let mut out = Self::default();
+        for (k, v) in m {
+            match k.as_str() {
+                "env" => out.env = str_map(v, "present.env")?,
+                "files" => out.files = str_map(v, "present.files")?,
+                "helper" => out.helper = Some(parse_helper(v)?),
+                other => anyhow::bail!(
+                    "unknown key {other:?} in credential `present` — expected `env`, `files` or \
+                     `helper`. Configuration that selects content (a region, an account, a \
+                     project) is a hashed input on the consumer, not part of a presentation"
+                ),
+            }
+        }
+        if out.is_empty() {
+            anyhow::bail!(
+                "credential `present` is empty — a credential that presents nothing hands its \
+                 consumer no identity"
+            );
+        }
+        out.validate()?;
+        Ok(out)
+    }
+
+    /// Reject a template referring to a kind that does not exist here.
+    ///
+    /// Done on the declaration so a typo is reported once, at the source, rather
+    /// than once per consumer at acquisition time — and long before any material
+    /// has been fetched, which is the point at which a mistake is cheapest.
+    fn validate(&self) -> anyhow::Result<()> {
+        // A presented file's name becomes one path component under the run's
+        // credential directory. Anything else escapes it — and the teardown that
+        // deletes those files only removes that directory, so an escaped `0600`
+        // token would be left behind with nothing to collect it. Checked on the
+        // declaration, where the author can see it.
+        for name in self.files.keys() {
+            validate_file_name(name)?;
+        }
+        for (name, tmpl) in self.env.iter().chain(self.files.iter()) {
+            for piece in hcore::template::parse(tmpl).with_context_name(name)?.iter() {
+                let hcore::template::Piece::Ref(r) = piece else {
+                    continue;
+                };
+                match r.kind {
+                    // A bare `${name}` is a material field. Which fields exist
+                    // depends on which source wins, so it can only be checked at
+                    // acquisition — where the error names the credential, the
+                    // field and the source that produced the material.
+                    None => {}
+                    Some("file") => {}
+                    Some("helper") => match r.arg {
+                        "command" | "args" => {}
+                        other => anyhow::bail!(
+                            "unknown template token `${{helper:{other}}}` in `{name}` — expected \
+                             `${{helper:command}}` (the heph binary) or `${{helper:args}}` (the \
+                             argv tail that selects a dialect and this credential)"
+                        ),
+                    },
+                    Some(other) => anyhow::bail!(
+                        "unknown template kind {other:?} in `{name}` — a presentation understands \
+                         `${{<field>}}`, `${{file:<name>}}`, `${{helper:command}}` and \
+                         `${{helper:args}}`. Write a literal `$` as `$$`"
+                    ),
+                }
+            }
+        }
+        if let Some(h) = &self.helper {
+            let dialect = h.dialect()?;
+            match dialect {
+                Dialect::Docker if h.registries.is_empty() => anyhow::bail!(
+                    "the docker credential helper needs at least one entry in `registries` — a \
+                     credHelpers map with no entries authenticates nothing"
+                ),
+                Dialect::Git if h.hosts.is_empty() => anyhow::bail!(
+                    "the git credential helper needs at least one entry in `hosts` — a credential \
+                     config with no host matches no fetch"
+                ),
+                Dialect::Gcp if h.audience.is_none() => anyhow::bail!(
+                    "the gcp credential helper needs an `audience` — the workload-identity pool \
+                     provider this token is presented for"
+                ),
+                _ => {}
+            }
+            // The one dialect that writes no document is also the one that
+            // cannot be reached without the author placing the callback: a
+            // kubernetes helper with no `${helper:command}` anywhere is inert.
+            if !dialect.writes_a_document()
+                && !self
+                    .files
+                    .values()
+                    .chain(self.env.values())
+                    .any(|t| t.contains("${helper:command}"))
+            {
+                anyhow::bail!(
+                    "a `kubernetes` helper writes no document of its own, so nothing calls back \
+                     into heph unless the kubeconfig you present places it — put \
+                     `${{helper:command}}` and `${{helper:args}}` in the `exec` stanza of the \
+                     user you present"
+                );
+            }
+        }
+        Ok(())
+    }
+}
+
+/// `anyhow::Context` for a template parse, naming the field it came from.
+trait ContextName<T> {
+    fn with_context_name(self, name: &str) -> anyhow::Result<T>;
+}
+
+impl<T> ContextName<T> for anyhow::Result<T> {
+    fn with_context_name(self, name: &str) -> anyhow::Result<T> {
+        use anyhow::Context as _;
+        self.with_context(|| format!("in `{name}`"))
+    }
+}
+
+/// A presented file's name must be a single plain path component.
+pub fn validate_file_name(name: &str) -> anyhow::Result<()> {
+    let mut comps = std::path::Path::new(name).components();
+    let plain =
+        matches!(comps.next(), Some(std::path::Component::Normal(_))) && comps.next().is_none();
+    if !plain {
+        anyhow::bail!(
+            "credential file name {name:?} must be a plain name with no `/` and no `..` — it \
+             becomes one path component under the run's credential directory, and that directory \
+             is what gets deleted at run end"
+        );
+    }
+    Ok(())
+}
+
+fn parse_helper(v: &Value) -> anyhow::Result<Helper> {
+    match v {
+        // `helper = "kubernetes"` — the shorthand for a dialect that needs no
+        // options.
+        Value::String(s) => Ok(Helper {
+            dialect: Some(Dialect::parse(s)?),
+            ..Helper::default()
+        }),
+        Value::Map(m) => {
+            let mut h = Helper::default();
+            for (k, v) in m {
+                match k.as_str() {
+                    "dialect" => h.dialect = Some(Dialect::parse(&string(v, "dialect")?)?),
+                    "registries" => h.registries = strings(v, "registries")?,
+                    "hosts" => h.hosts = strings(v, "hosts")?,
+                    "audience" => h.audience = Some(string(v, "audience")?),
+                    "impersonate" => h.impersonate = Some(string(v, "impersonate")?),
+                    other => anyhow::bail!(
+                        "unknown key {other:?} in credential `present.helper` — expected \
+                         `dialect`, `registries`, `hosts`, `audience` or `impersonate`"
+                    ),
+                }
+            }
+            h.dialect()?;
+            Ok(h)
+        }
+        other => anyhow::bail!(
+            "credential `present.helper` must be a dialect name or a dict, got {other:?}"
+        ),
+    }
+}
+
+pub(crate) fn string(v: &Value, what: &str) -> anyhow::Result<String> {
+    match v {
+        Value::String(s) => Ok(s.clone()),
+        other => anyhow::bail!("credential `{what}` must be a string, got {other:?}"),
+    }
+}
+
+pub(crate) fn strings(v: &Value, what: &str) -> anyhow::Result<Vec<String>> {
+    match v {
+        Value::String(s) => Ok(vec![s.clone()]),
+        Value::List(l) => l.iter().map(|v| string(v, what)).collect(),
+        other => anyhow::bail!("credential `{what}` must be a string or a list, got {other:?}"),
+    }
+}
+
+pub(crate) fn str_map(v: &Value, what: &str) -> anyhow::Result<BTreeMap<String, String>> {
+    match v {
+        Value::Map(m) => m
+            .iter()
+            .map(|(k, v)| Ok((k.clone(), string(v, what)?)))
+            .collect(),
+        other => anyhow::bail!("credential `{what}` must be a dict, got {other:?}"),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn map(pairs: &[(&str, Value)]) -> Value {
+        Value::Map(
+            pairs
+                .iter()
+                .map(|(k, v)| (k.to_string(), v.clone()))
+                .collect(),
+        )
+    }
+
+    fn s(v: &str) -> Value {
+        Value::String(v.to_string())
+    }
+
+    #[test]
+    fn an_env_presentation_parses() {
+        let p = Presentation::parse(&map(&[(
+            "env",
+            map(&[("CLOUDFLARE_API_TOKEN", s("${token}"))]),
+        )]))
+        .expect("parse");
+        assert_eq!(
+            p.env.get("CLOUDFLARE_API_TOKEN").map(String::as_str),
+            Some("${token}")
+        );
+    }
+
+    #[test]
+    fn a_region_has_nowhere_to_go() {
+        // The design's sharpest rule, enforced by the vocabulary rather than by
+        // a check: there is no key a region fits in.
+        let err = Presentation::parse(&map(&[("region", s("eu-west-1"))])).expect_err("must fail");
+        let msg = format!("{err:#}");
+        assert!(msg.contains("unknown key"), "{msg}");
+        assert!(msg.contains("hashed input on the consumer"), "{msg}");
+    }
+
+    #[test]
+    fn an_unknown_template_kind_is_rejected_at_the_declaration() {
+        let err = Presentation::parse(&map(&[("env", map(&[("A", s("${secret:x}"))]))]))
+            .expect_err("must fail");
+        assert!(
+            format!("{err:#}").contains("unknown template kind"),
+            "{err:#}"
+        );
+    }
+
+    #[test]
+    fn a_bare_field_reference_is_accepted_because_only_a_source_knows_its_fields() {
+        Presentation::parse(&map(&[("env", map(&[("A", s("${anything}"))]))])).expect("parse");
+    }
+
+    #[test]
+    fn the_helper_shorthand_is_a_dialect_name() {
+        let p = Presentation::parse(&map(&[
+            ("helper", s("kubernetes")),
+            (
+                "files",
+                map(&[("kubeconfig", s("command: ${helper:command}"))]),
+            ),
+        ]))
+        .expect("parse");
+        assert_eq!(p.helper.and_then(|h| h.dialect), Some(Dialect::Kubernetes));
+    }
+
+    #[test]
+    fn a_kubernetes_helper_that_places_no_callback_is_inert_and_says_so() {
+        let err = Presentation::parse(&map(&[("helper", s("kubernetes"))])).expect_err("must fail");
+        assert!(format!("{err:#}").contains("${helper:command}"), "{err:#}");
+    }
+
+    #[test]
+    fn a_docker_helper_with_no_registries_authenticates_nothing() {
+        let err = Presentation::parse(&map(&[("helper", map(&[("dialect", s("docker"))]))]))
+            .expect_err("must fail");
+        assert!(format!("{err:#}").contains("registries"), "{err:#}");
+    }
+
+    #[test]
+    fn a_file_name_that_escapes_the_credential_directory_is_rejected() {
+        for bad in ["../leak", "a/b", "/tmp/leak", "..", "."] {
+            let err = Presentation::parse(&map(&[("files", map(&[(bad, s("${token}"))]))]))
+                .expect_err("must reject");
+            assert!(format!("{err:#}").contains("plain name"), "{bad}: {err:#}");
+        }
+        Presentation::parse(&map(&[("files", map(&[("token", s("${token}"))]))])).expect("parse");
+    }
+
+    #[test]
+    fn an_empty_presentation_is_rejected() {
+        let err = Presentation::parse(&Value::Map(Default::default())).expect_err("must fail");
+        assert!(format!("{err:#}").contains("presents nothing"), "{err:#}");
+    }
+}

--- a/crates/builtins/src/plugincredential/present.rs
+++ b/crates/builtins/src/plugincredential/present.rs
@@ -24,6 +24,8 @@
 //! check. See `docs/CREDENTIALS.md`, "The rule that is easiest to get wrong".
 
 use hcore::htvalue::Value;
+use hcore::htvalue::signature::ParamType;
+use hplugin::htspec::{FromSpecValue, SpecStruct};
 use std::collections::BTreeMap;
 
 /// A callback protocol heph speaks on a tool's behalf.
@@ -50,6 +52,19 @@ pub enum Dialect {
     /// document: the author templates the kubeconfig and places the argv with
     /// `${helper:command}` and `${helper:args}`.
     Kubernetes,
+}
+
+/// Decoded through [`Dialect::parse`] rather than `#[derive(SpecEnum)]`, so the
+/// name table and its message exist once: the same string is also parsed out of
+/// `heph __auth-helper <dialect>`'s argv, where there is no `Value` to decode.
+impl FromSpecValue for Dialect {
+    fn from_spec_value(v: &Value) -> anyhow::Result<Self> {
+        Self::parse(&String::from_spec_value(v)?)
+    }
+
+    fn spec_param_type() -> ParamType {
+        ParamType::String
+    }
 }
 
 impl Dialect {
@@ -94,8 +109,9 @@ impl Dialect {
 /// which git hosts, which workload-identity audience to present it as. None of
 /// them selects content, which is the test §2 of the design applies to
 /// everything on this side of the line.
-#[derive(Debug, Clone, PartialEq, Eq, serde::Serialize, Default)]
+#[derive(Debug, Clone, PartialEq, Eq, serde::Serialize, Default, SpecStruct)]
 pub struct Helper {
+    /// Which callback protocol heph speaks.
     pub dialect: Option<Dialect>,
     /// Docker: registries this credential authenticates. Empty is an error —
     /// a credHelpers map with no entries authenticates nothing.
@@ -120,7 +136,7 @@ impl Helper {
 ///
 /// Three shapes, in preference order, and they compose: a kubernetes helper is a
 /// `files` kubeconfig plus an `env` pointing at it plus the callback argv.
-#[derive(Debug, Clone, PartialEq, Eq, serde::Serialize, Default)]
+#[derive(Debug, Clone, PartialEq, Eq, serde::Serialize, Default, SpecStruct)]
 pub struct Presentation {
     /// Name → template. Injected as **runtime** environment — never `env`, never
     /// `pass_env` — so it cannot reach a def hash by construction.
@@ -130,6 +146,7 @@ pub struct Presentation {
     /// run end whatever the outcome. Reachable as `${file:<name>}`.
     pub files: BTreeMap<String, String>,
     /// A callback protocol. The only presentation that survives expiry.
+    #[spec(parse = parse_helper)]
     pub helper: Option<Helper>,
 }
 
@@ -138,32 +155,24 @@ impl Presentation {
         self.env.is_empty() && self.files.is_empty() && self.helper.is_none()
     }
 
-    /// Parse a presentation from its BUILD-file value.
+    /// Parse a presentation from its BUILD-file value, then check it.
     ///
     /// Accepts the map form written by hand and the dicts the `heph.auth.*`
     /// presets return — which are the same thing, deliberately: a preset is a
     /// function returning a value the author could have typed.
+    ///
+    /// The parse is `#[derive(SpecStruct)]`: the key set, the per-field decoding
+    /// and the unknown-key refusal all come from the field list, so the parser
+    /// and the schema cannot drift. What stays here is the part that is not
+    /// parsing — the emptiness rule and [`validate`](Self::validate).
     pub fn parse(v: &Value) -> anyhow::Result<Self> {
-        let m = match v {
-            Value::Map(m) => m,
-            other => anyhow::bail!(
-                "credential `present` must be a dict with `env`, `files` and/or `helper` keys, \
-                 got {other:?}"
-            ),
-        };
-        let mut out = Self::default();
-        for (k, v) in m {
-            match k.as_str() {
-                "env" => out.env = str_map(v, "present.env")?,
-                "files" => out.files = str_map(v, "present.files")?,
-                "helper" => out.helper = Some(parse_helper(v)?),
-                other => anyhow::bail!(
-                    "unknown key {other:?} in credential `present` — expected `env`, `files` or \
-                     `helper`. Configuration that selects content (a region, an account, a \
-                     project) is a hashed input on the consumer, not part of a presentation"
-                ),
-            }
-        }
+        use anyhow::Context as _;
+        let out = Self::from_spec_value(v).context(
+            "credential `present` takes `env` (name → template), `files` (name → content \
+             template) and/or `helper` (a callback protocol). Configuration that selects content \
+             (a region, an account, a project) is a hashed input on the consumer, not part of a \
+             presentation",
+        )?;
         if out.is_empty() {
             anyhow::bail!(
                 "credential `present` is empty — a credential that presents nothing hands its \
@@ -282,61 +291,50 @@ pub fn validate_file_name(name: &str) -> anyhow::Result<()> {
     Ok(())
 }
 
-fn parse_helper(v: &Value) -> anyhow::Result<Helper> {
-    match v {
-        // `helper = "kubernetes"` — the shorthand for a dialect that needs no
-        // options.
-        Value::String(s) => Ok(Helper {
+/// `helper = "kubernetes"` — the shorthand for a dialect that needs no options —
+/// or the full dict, whose keys [`Helper`]'s derive owns.
+///
+/// Shape dispatch rather than a union, for the reason `TargetSpecCache` gives:
+/// a map *commits* to the dict arm, so an unknown key inside it reports itself
+/// rather than being masked by a generic "expected string | map".
+fn parse_helper(v: &Value) -> anyhow::Result<Option<Helper>> {
+    let h = match v {
+        Value::Null() => return Ok(None),
+        Value::String(s) => Helper {
             dialect: Some(Dialect::parse(s)?),
             ..Helper::default()
-        }),
-        Value::Map(m) => {
-            let mut h = Helper::default();
-            for (k, v) in m {
-                match k.as_str() {
-                    "dialect" => h.dialect = Some(Dialect::parse(&string(v, "dialect")?)?),
-                    "registries" => h.registries = strings(v, "registries")?,
-                    "hosts" => h.hosts = strings(v, "hosts")?,
-                    "audience" => h.audience = Some(string(v, "audience")?),
-                    "impersonate" => h.impersonate = Some(string(v, "impersonate")?),
-                    other => anyhow::bail!(
-                        "unknown key {other:?} in credential `present.helper` — expected \
-                         `dialect`, `registries`, `hosts`, `audience` or `impersonate`"
-                    ),
-                }
-            }
-            h.dialect()?;
-            Ok(h)
-        }
-        other => anyhow::bail!(
-            "credential `present.helper` must be a dialect name or a dict, got {other:?}"
-        ),
-    }
+        },
+        other => Helper::from_spec_value(other)
+            .map_err(|e| anyhow::anyhow!("{e:#}"))
+            .map_err(|e| {
+                anyhow::anyhow!("credential `present.helper` must be a dialect name or a dict: {e}")
+            })?,
+    };
+    // A helper with no dialect is inert — nothing to speak.
+    h.dialect()?;
+    Ok(Some(h))
 }
 
+// `sources` is an ordered, heterogeneous list — a bare address or one of five
+// inline kinds, discriminated by `kind` — which is the one shape the derive's
+// field types cannot describe, so [`SourceDecl::parse`] dispatches by hand. The
+// three helpers below exist only to carry the field name into the message; the
+// decoding itself is the shared `FromSpecValue` every other driver uses, so
+// "what is a string here" has exactly one answer workspace-wide.
+
 pub(crate) fn string(v: &Value, what: &str) -> anyhow::Result<String> {
-    match v {
-        Value::String(s) => Ok(s.clone()),
-        other => anyhow::bail!("credential `{what}` must be a string, got {other:?}"),
-    }
+    use anyhow::Context as _;
+    String::from_spec_value(v).with_context(|| format!("credential `{what}`"))
 }
 
 pub(crate) fn strings(v: &Value, what: &str) -> anyhow::Result<Vec<String>> {
-    match v {
-        Value::String(s) => Ok(vec![s.clone()]),
-        Value::List(l) => l.iter().map(|v| string(v, what)).collect(),
-        other => anyhow::bail!("credential `{what}` must be a string or a list, got {other:?}"),
-    }
+    use anyhow::Context as _;
+    Vec::<String>::from_spec_value(v).with_context(|| format!("credential `{what}`"))
 }
 
 pub(crate) fn str_map(v: &Value, what: &str) -> anyhow::Result<BTreeMap<String, String>> {
-    match v {
-        Value::Map(m) => m
-            .iter()
-            .map(|(k, v)| Ok((k.clone(), string(v, what)?)))
-            .collect(),
-        other => anyhow::bail!("credential `{what}` must be a dict, got {other:?}"),
-    }
+    use anyhow::Context as _;
+    BTreeMap::<String, String>::from_spec_value(v).with_context(|| format!("credential `{what}`"))
 }
 
 #[cfg(test)]
@@ -375,7 +373,9 @@ mod tests {
         // a check: there is no key a region fits in.
         let err = Presentation::parse(&map(&[("region", s("eu-west-1"))])).expect_err("must fail");
         let msg = format!("{err:#}");
-        assert!(msg.contains("unknown key"), "{msg}");
+        // The derive names the offending key; the context says where a region
+        // does belong.
+        assert!(msg.contains("region"), "{msg}");
         assert!(msg.contains("hashed input on the consumer"), "{msg}");
     }
 

--- a/crates/builtins/src/plugincredential/source.rs
+++ b/crates/builtins/src/plugincredential/source.rs
@@ -1,0 +1,652 @@
+//! The chain: ordered ways to obtain material, and the rule that orders them.
+//!
+//! > A probe answers **"is this source applicable here?"**, not **"will it
+//! > succeed?"**. The first applicable source *is* the source; an acquire failure
+//! > is terminal, not a fallthrough.
+//!
+//! Every reader's first instinct is the opposite, which is why it is written at
+//! the top of the module that implements it. It is what makes the ordering
+//! meaningful — `oidc` sits above `exec` because on a laptop its probe fails
+//! cleanly and on a runner it wins — and it is why `exec`'s probe being merely
+//! "the program exists" is sufficient. If a chain fell through on failure, a
+//! misconfigured role in CI would silently fall back to whatever ambient identity
+//! the runner happened to have, which is precisely the class of accident this
+//! feature exists to prevent.
+
+use super::present::{Presentation, str_map, string, strings};
+use hcore::htvalue::Value;
+use std::collections::BTreeMap;
+
+/// The fixed `when` vocabulary.
+///
+/// Policy, not logic, and deliberately not an expression language: the moment it
+/// becomes one, BUILD files start containing credential-selection programs that
+/// nobody can audit.
+#[derive(Debug, Clone, PartialEq, Eq, serde::Serialize)]
+pub enum When {
+    /// Any CI provider heph can detect.
+    Ci,
+    /// One named CI provider (`ci:github_actions`).
+    CiProvider(String),
+    /// A terminal is attached, so a human could answer a prompt.
+    Interactive,
+    /// A named host environment variable is set and non-empty.
+    Env(String),
+    /// `os:linux` / `os:darwin`.
+    Os(String),
+}
+
+impl When {
+    pub fn parse(s: &str) -> anyhow::Result<Self> {
+        Ok(match s.split_once(':') {
+            None => match s {
+                "ci" => Self::Ci,
+                "interactive" => Self::Interactive,
+                other => anyhow::bail!(
+                    "unknown `when` value {other:?} — the vocabulary is `ci`, `ci:<provider>`, \
+                     `interactive`, `env:NAME`, `os:linux`, `os:darwin`. It is deliberately a \
+                     fixed list rather than an expression language"
+                ),
+            },
+            Some(("ci", p)) => Self::CiProvider(p.to_string()),
+            Some(("env", n)) if !n.is_empty() => Self::Env(n.to_string()),
+            Some(("os", o @ ("linux" | "darwin"))) => Self::Os(o.to_string()),
+            Some(("os", other)) => {
+                anyhow::bail!("unknown `when = \"os:{other}\"` — heph supports linux and darwin")
+            }
+            Some(_) => anyhow::bail!(
+                "unknown `when` value {s:?} — the vocabulary is `ci`, `ci:<provider>`, \
+                 `interactive`, `env:NAME`, `os:linux`, `os:darwin`"
+            ),
+        })
+    }
+
+    pub fn as_str(&self) -> String {
+        match self {
+            Self::Ci => "ci".to_string(),
+            Self::CiProvider(p) => format!("ci:{p}"),
+            Self::Interactive => "interactive".to_string(),
+            Self::Env(n) => format!("env:{n}"),
+            Self::Os(o) => format!("os:{o}"),
+        }
+    }
+}
+
+/// Which CI provider a `when` names, and how heph recognizes it.
+///
+/// Detection is by the provider's own marker variable, never by a generic `CI`
+/// alone: `CI=true` is set by a dozen things including a developer's shell
+/// profile, and picking a source on it would be exactly the kind of accidental
+/// identity selection the chain exists to prevent.
+pub fn detected_ci_provider(env: &dyn Fn(&str) -> Option<String>) -> Option<&'static str> {
+    const MARKERS: &[(&str, &str)] = &[
+        ("github_actions", "GITHUB_ACTIONS"),
+        ("gitlab_ci", "GITLAB_CI"),
+        ("buildkite", "BUILDKITE"),
+        ("circleci", "CIRCLECI"),
+        ("jenkins", "JENKINS_URL"),
+    ];
+    MARKERS
+        .iter()
+        .find(|(_, marker)| env(marker).is_some_and(|v| !v.is_empty()))
+        .map(|(name, _)| *name)
+}
+
+/// One way to obtain material.
+#[derive(Debug, Clone, PartialEq, Eq, serde::Serialize)]
+pub enum SourceKind {
+    /// Host environment variables. Probes that each is set.
+    Env { names: Vec<String> },
+    /// A file on the host, read raw or picked apart as JSON.
+    File {
+        path: String,
+        fields: BTreeMap<String, String>,
+        expires: Option<String>,
+    },
+    /// One command whose **stdout** is the credential.
+    ///
+    /// There is no way to name files this command wrote, because a command that
+    /// writes files is a target — see [`SourceKind::Target`].
+    Exec {
+        run: Vec<String>,
+        fields: BTreeMap<String, String>,
+        expires: Option<String>,
+        /// A *list* of argvs: some tools keep more than one login store, and
+        /// `heph auth login` runs whichever the probe found stale.
+        login: Vec<Vec<String>>,
+        /// Where the probe and the command run. Both, necessarily: probing the
+        /// host for a program that lives in a devenv shell answers the wrong
+        /// question.
+        runner: Option<String>,
+    },
+    /// Host paths and variables exposed in place — `~/.aws`, `~/.config/gcloud`.
+    /// Nothing is copied into the credential store.
+    Passthrough {
+        paths: BTreeMap<String, String>,
+        login: Vec<Vec<String>>,
+    },
+    /// A CI provider's OIDC endpoint. Yields `${id_token}`.
+    Oidc { provider: String, audience: String },
+    /// A target address.
+    ///
+    /// The driver of the referenced target decides what this means, so it needs
+    /// no syntax of its own: a `credential` target is a delegation, anything else
+    /// is a producer whose outputs become material.
+    Target { addr: String },
+}
+
+impl SourceKind {
+    pub fn kind_name(&self) -> &'static str {
+        match self {
+            Self::Env { .. } => "env",
+            Self::File { .. } => "file",
+            Self::Exec { .. } => "exec",
+            Self::Passthrough { .. } => "passthrough",
+            Self::Oidc { .. } => "oidc",
+            Self::Target { .. } => "target",
+        }
+    }
+}
+
+/// One entry in a credential's chain.
+#[derive(Debug, Clone, PartialEq, Eq, serde::Serialize)]
+pub struct SourceDecl {
+    pub kind: SourceKind,
+    pub when: Option<When>,
+    /// Credentials presented to this source's own acquire subprocess, exactly as
+    /// they would be to a consumer. A source that shells out to a secret manager
+    /// has to authenticate to the secret manager; this is that, and it costs
+    /// nothing new to implement because the acquire subprocess is just another
+    /// consumer of the presentation machinery.
+    pub credentials: Vec<String>,
+    /// Overrides the credential's presentation, for this source only. Required
+    /// when two sources yield genuinely different material shapes — a token file
+    /// and a key pair are not the same thing.
+    pub present: Option<Presentation>,
+    /// Shown when this source's probe fails. Every kind ships a default.
+    pub hint: Option<String>,
+}
+
+impl SourceDecl {
+    /// A one-line label for `heph auth status` / `heph auth explain`.
+    pub fn label(&self) -> String {
+        match &self.kind {
+            SourceKind::Env { names } => format!("env({})", names.join(",")),
+            SourceKind::File { path, .. } => format!("file({path})"),
+            SourceKind::Exec { run, .. } => {
+                format!("exec({})", run.first().map(String::as_str).unwrap_or(""))
+            }
+            SourceKind::Passthrough { paths, .. } => {
+                let mut names: Vec<&str> = paths.keys().map(String::as_str).collect();
+                names.sort_unstable();
+                format!("passthrough({})", names.join(","))
+            }
+            SourceKind::Oidc { provider, .. } => format!("oidc({provider})"),
+            SourceKind::Target { addr } => format!("target({addr})"),
+        }
+    }
+
+    /// What to tell a human when this source's probe fails.
+    ///
+    /// Every kind ships a default so a chain that applies nowhere is never a bare
+    /// "no source applies": the fix is attached to the line that failed. An
+    /// author who knows better overrides it with `hint`.
+    pub fn default_hint(&self) -> String {
+        match &self.kind {
+            SourceKind::Env { names } => format!(
+                "set {} in this environment, or add it to the job's secrets",
+                names.join(", ")
+            ),
+            SourceKind::File { path, .. } => {
+                format!("create {path}, or sign in with the tool that writes it")
+            }
+            SourceKind::Exec { run, login, .. } => {
+                let program = run.first().map(String::as_str).unwrap_or("the command");
+                if login.is_empty() {
+                    format!("install {program}, or add it to the target's tools")
+                } else {
+                    format!(
+                        "install {program}, or add it to the target's tools; then run \
+                         `heph auth login`"
+                    )
+                }
+            }
+            SourceKind::Passthrough { paths, .. } => {
+                let mut ps: Vec<&str> = paths.values().map(String::as_str).collect();
+                ps.sort_unstable();
+                format!("sign in with the tool that writes {}", ps.join(", "))
+            }
+            SourceKind::Oidc { provider, .. } if provider == "github_actions" => {
+                "add `permissions: { id-token: write }` to the job".to_string()
+            }
+            SourceKind::Oidc { provider, .. } => {
+                format!("no {provider} OIDC endpoint is present in this environment")
+            }
+            SourceKind::Target { .. } => {
+                "this source is selected by `when`, and no `when` matched here".to_string()
+            }
+        }
+    }
+
+    /// Parse one chain entry.
+    ///
+    /// A bare string is an address; a dict is an inline source. There is no `ref`
+    /// kind to learn, because an address already is one.
+    pub fn parse(v: &Value) -> anyhow::Result<Self> {
+        match v {
+            Value::String(addr) => Ok(Self {
+                kind: SourceKind::Target { addr: addr.clone() },
+                when: None,
+                credentials: vec![],
+                present: None,
+                hint: None,
+            }),
+            Value::Map(m) => Self::parse_inline(m),
+            other => anyhow::bail!(
+                "a credential source must be a target address or a dict (normally written with a \
+                 `heph.auth.*` constructor), got {other:?}"
+            ),
+        }
+    }
+
+    fn parse_inline(m: &std::collections::HashMap<String, Value>) -> anyhow::Result<Self> {
+        let kind_name = m
+            .get("kind")
+            .ok_or_else(|| {
+                anyhow::anyhow!(
+                    "an inline credential source needs a `kind` — one of env, file, exec, \
+                     passthrough, oidc. Normally you write `heph.auth.exec([...])` rather than \
+                     the dict"
+                )
+            })
+            .and_then(|v| string(v, "kind"))?;
+
+        // Shared fields, taken off first so the per-kind match sees only its own.
+        let when = m.get("when").map(|v| string(v, "when")).transpose()?;
+        let when = when.as_deref().map(When::parse).transpose()?;
+        let credentials = m
+            .get("credentials")
+            .map(|v| strings(v, "credentials"))
+            .transpose()?
+            .unwrap_or_default();
+        let present = m.get("present").map(Presentation::parse).transpose()?;
+        let hint = m.get("hint").map(|v| string(v, "hint")).transpose()?;
+
+        let fields = m
+            .get("fields")
+            .map(|v| str_map(v, "fields"))
+            .transpose()?
+            .unwrap_or_default();
+        let expires = m.get("expires").map(|v| string(v, "expires")).transpose()?;
+        let login = m
+            .get("login")
+            .map(parse_login)
+            .transpose()?
+            .unwrap_or_default();
+
+        let kind = match kind_name.as_str() {
+            "env" => {
+                let names = strings(
+                    m.get("names").ok_or_else(|| {
+                        anyhow::anyhow!("an `env` credential source needs `names`")
+                    })?,
+                    "names",
+                )?;
+                if names.is_empty() {
+                    anyhow::bail!("an `env` credential source needs at least one name");
+                }
+                reject(
+                    m,
+                    &["kind", "when", "credentials", "present", "hint", "names"],
+                    "env",
+                )?;
+                SourceKind::Env { names }
+            }
+            "file" => {
+                let path = string(
+                    m.get("path").ok_or_else(|| {
+                        anyhow::anyhow!("a `file` credential source needs a `path`")
+                    })?,
+                    "path",
+                )?;
+                reject(
+                    m,
+                    &[
+                        "kind",
+                        "when",
+                        "credentials",
+                        "present",
+                        "hint",
+                        "path",
+                        "fields",
+                        "expires",
+                    ],
+                    "file",
+                )?;
+                SourceKind::File {
+                    path,
+                    fields,
+                    expires,
+                }
+            }
+            "exec" => {
+                let run = strings(
+                    m.get("run").ok_or_else(|| {
+                        anyhow::anyhow!("an `exec` credential source needs `run`")
+                    })?,
+                    "run",
+                )?;
+                if run.is_empty() {
+                    anyhow::bail!("an `exec` credential source needs a non-empty `run` argv");
+                }
+                let runner = m.get("runner").map(|v| string(v, "runner")).transpose()?;
+                reject(
+                    m,
+                    &[
+                        "kind",
+                        "when",
+                        "credentials",
+                        "present",
+                        "hint",
+                        "run",
+                        "fields",
+                        "expires",
+                        "login",
+                        "runner",
+                    ],
+                    "exec",
+                )?;
+                SourceKind::Exec {
+                    run,
+                    fields,
+                    expires,
+                    login,
+                    // `"local"` is the spelling for "this host" everywhere else
+                    // in heph (the exec driver's `runner`), so it means the same
+                    // here rather than naming a target called `local`.
+                    runner: runner.filter(|r| r != "local"),
+                }
+            }
+            "passthrough" => {
+                let paths = m
+                    .get("paths")
+                    .map(|v| str_map(v, "paths"))
+                    .transpose()?
+                    .unwrap_or_default();
+                if paths.is_empty() {
+                    anyhow::bail!(
+                        "a `passthrough` credential source needs `paths` — heph exposes the host \
+                         files you name, and takes no view about which product wrote them"
+                    );
+                }
+                reject(
+                    m,
+                    &[
+                        "kind",
+                        "when",
+                        "credentials",
+                        "present",
+                        "hint",
+                        "paths",
+                        "login",
+                    ],
+                    "passthrough",
+                )?;
+                SourceKind::Passthrough { paths, login }
+            }
+            "oidc" => {
+                let provider = m
+                    .get("provider")
+                    .map(|v| string(v, "provider"))
+                    .transpose()?
+                    .unwrap_or_else(|| "github_actions".to_string());
+                if provider != "github_actions" && provider != "generic" {
+                    anyhow::bail!(
+                        "unknown oidc `provider` {provider:?} — heph knows `github_actions` and \
+                         `generic` (a token named by variable or file)"
+                    );
+                }
+                let audience = m
+                    .get("audience")
+                    .map(|v| string(v, "audience"))
+                    .transpose()?
+                    .unwrap_or_default();
+                reject(
+                    m,
+                    &[
+                        "kind",
+                        "when",
+                        "credentials",
+                        "present",
+                        "hint",
+                        "provider",
+                        "audience",
+                    ],
+                    "oidc",
+                )?;
+                SourceKind::Oidc { provider, audience }
+            }
+            other => anyhow::bail!(
+                "unknown credential source kind {other:?} — core knows env, file, exec, \
+                 passthrough and oidc, and nothing else. There is deliberately no per-product \
+                 source: a secret manager is `exec` with a field map, or a target when its tool \
+                 lives in an environment"
+            ),
+        };
+
+        Ok(Self {
+            kind,
+            when,
+            credentials,
+            present,
+            hint,
+        })
+    }
+}
+
+/// `login` is a list of argvs, but one argv is by far the common case, so a
+/// single flat list of strings is accepted and read as one command.
+fn parse_login(v: &Value) -> anyhow::Result<Vec<Vec<String>>> {
+    match v {
+        Value::List(items) => {
+            if items.iter().all(|i| matches!(i, Value::String(_))) {
+                let argv = strings(v, "login")?;
+                return Ok(if argv.is_empty() { vec![] } else { vec![argv] });
+            }
+            items.iter().map(|i| strings(i, "login")).collect()
+        }
+        other => anyhow::bail!(
+            "credential `login` must be an argv or a list of argvs, got {other:?} — a list, \
+             because some tools keep more than one login store"
+        ),
+    }
+}
+
+/// Reject a key that means nothing for this kind.
+///
+/// A silently-ignored `login` on an `oidc` source is a workflow the author
+/// believes exists and does not, which surfaces much later as an expiry nobody
+/// can repair.
+fn reject(
+    m: &std::collections::HashMap<String, Value>,
+    allowed: &[&str],
+    kind: &str,
+) -> anyhow::Result<()> {
+    let mut unknown: Vec<&str> = m
+        .keys()
+        .map(String::as_str)
+        .filter(|k| !allowed.contains(k))
+        .collect();
+    if unknown.is_empty() {
+        return Ok(());
+    }
+    unknown.sort_unstable();
+    anyhow::bail!(
+        "a `{kind}` credential source does not take {} — it accepts {}",
+        unknown
+            .iter()
+            .map(|k| format!("`{k}`"))
+            .collect::<Vec<_>>()
+            .join(", "),
+        allowed
+            .iter()
+            .map(|k| format!("`{k}`"))
+            .collect::<Vec<_>>()
+            .join(", ")
+    )
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::collections::HashMap;
+
+    fn map(pairs: &[(&str, Value)]) -> Value {
+        Value::Map(
+            pairs
+                .iter()
+                .map(|(k, v)| (k.to_string(), v.clone()))
+                .collect(),
+        )
+    }
+    fn s(v: &str) -> Value {
+        Value::String(v.to_string())
+    }
+    fn list(vs: &[&str]) -> Value {
+        Value::List(vs.iter().map(|v| s(v)).collect())
+    }
+
+    #[test]
+    fn a_bare_address_is_a_source_with_no_syntax_of_its_own() {
+        let d = SourceDecl::parse(&s("//auth:vault")).expect("parse");
+        assert!(matches!(d.kind, SourceKind::Target { .. }));
+    }
+
+    #[test]
+    fn an_exec_source_carries_its_argv_and_field_map() {
+        let d = SourceDecl::parse(&map(&[
+            ("kind", s("exec")),
+            ("run", list(&["vault", "read", "-format=json", "secret/cf"])),
+            ("fields", map(&[("token", s("data.token"))])),
+            ("expires", s("lease_duration")),
+            ("credentials", s("//auth:vault")),
+        ]))
+        .expect("parse");
+        let SourceKind::Exec { run, fields, .. } = &d.kind else {
+            panic!("expected exec")
+        };
+        assert_eq!(run.first().map(String::as_str), Some("vault"));
+        assert_eq!(fields.get("token").map(String::as_str), Some("data.token"));
+        assert_eq!(d.credentials, vec!["//auth:vault".to_string()]);
+    }
+
+    #[test]
+    fn login_accepts_one_argv_and_a_list_of_them() {
+        let one = parse_login(&list(&["gcloud", "auth", "login"])).expect("parse");
+        assert_eq!(one.len(), 1);
+        let two = parse_login(&Value::List(vec![
+            list(&["gcloud", "auth", "login"]),
+            list(&["gcloud", "auth", "application-default", "login"]),
+        ]))
+        .expect("parse");
+        assert_eq!(two.len(), 2);
+    }
+
+    #[test]
+    fn there_is_no_produces_on_an_inline_exec_source() {
+        // A command that writes files is a target, so naming files here has to
+        // fail loudly rather than be quietly ignored.
+        let err = SourceDecl::parse(&map(&[
+            ("kind", s("exec")),
+            ("run", list(&["x"])),
+            ("produces", map(&[("cred", s("c.json"))])),
+        ]))
+        .expect_err("must fail");
+        assert!(format!("{err:#}").contains("`produces`"), "{err:#}");
+    }
+
+    #[test]
+    fn a_product_named_source_kind_is_refused_with_the_reason() {
+        let err = SourceDecl::parse(&map(&[("kind", s("vault"))])).expect_err("must fail");
+        assert!(format!("{err:#}").contains("field map"), "{err:#}");
+    }
+
+    #[test]
+    fn the_when_vocabulary_is_closed() {
+        assert_eq!(When::parse("ci").expect("parse"), When::Ci);
+        assert_eq!(
+            When::parse("ci:github_actions").expect("parse"),
+            When::CiProvider("github_actions".to_string())
+        );
+        assert_eq!(
+            When::parse("env:CI_JOB").expect("parse"),
+            When::Env("CI_JOB".to_string())
+        );
+        assert_eq!(
+            When::parse("os:darwin").expect("parse"),
+            When::Os("darwin".to_string())
+        );
+        // Not an expression language.
+        drop(When::parse("ci && !os:darwin").expect_err("not an expression language"));
+        drop(When::parse("os:windows").expect_err("not a supported target"));
+    }
+
+    #[test]
+    fn ci_detection_needs_a_providers_own_marker() {
+        let none = |_n: &str| None;
+        assert_eq!(detected_ci_provider(&none), None);
+        // A bare `CI=true` is not a provider: a shell profile sets it.
+        let generic = |n: &str| (n == "CI").then(|| "true".to_string());
+        assert_eq!(detected_ci_provider(&generic), None);
+        let gha = |n: &str| (n == "GITHUB_ACTIONS").then(|| "true".to_string());
+        assert_eq!(detected_ci_provider(&gha), Some("github_actions"));
+    }
+
+    #[test]
+    fn every_kind_ships_a_hint() {
+        let kinds = [
+            SourceKind::Env {
+                names: vec!["A".to_string()],
+            },
+            SourceKind::File {
+                path: "~/x".to_string(),
+                fields: BTreeMap::new(),
+                expires: None,
+            },
+            SourceKind::Exec {
+                run: vec!["aws".to_string()],
+                fields: BTreeMap::new(),
+                expires: None,
+                login: vec![],
+                runner: None,
+            },
+            SourceKind::Passthrough {
+                paths: BTreeMap::from([("c".to_string(), "~/.aws".to_string())]),
+                login: vec![],
+            },
+            SourceKind::Oidc {
+                provider: "github_actions".to_string(),
+                audience: "a".to_string(),
+            },
+            SourceKind::Target {
+                addr: "//a:b".to_string(),
+            },
+        ];
+        for kind in kinds {
+            let d = SourceDecl {
+                kind,
+                when: None,
+                credentials: vec![],
+                present: None,
+                hint: None,
+            };
+            assert!(!d.default_hint().is_empty(), "{} has no hint", d.label());
+        }
+    }
+
+    #[test]
+    fn an_inline_source_needs_a_kind() {
+        let err = SourceDecl::parse(&Value::Map(HashMap::new())).expect_err("must fail");
+        assert!(format!("{err:#}").contains("needs a `kind`"), "{err:#}");
+    }
+}

--- a/crates/builtins/src/pluginfs/mod.rs
+++ b/crates/builtins/src/pluginfs/mod.rs
@@ -1534,6 +1534,7 @@ mod tests {
             stderr: None,
             sandbox_dir: root,
             scratch: vec![],
+            credentials: vec![],
         }
     }
 

--- a/crates/builtins/src/plugingroup/mod.rs
+++ b/crates/builtins/src/plugingroup/mod.rs
@@ -728,6 +728,7 @@ mod tests {
                     stderr: None,
                     sandbox_dir: Default::default(),
                     scratch: vec![],
+                    credentials: vec![],
                 },
                 &ctoken(),
             )

--- a/crates/builtins/src/pluginhostbin/mod.rs
+++ b/crates/builtins/src/pluginhostbin/mod.rs
@@ -326,6 +326,7 @@ mod tests {
             stderr: None,
             sandbox_dir: sandbox_dir.to_path_buf(),
             scratch: vec![],
+            credentials: vec![],
         }
     }
 

--- a/crates/builtins/src/pluginscratch/mod.rs
+++ b/crates/builtins/src/pluginscratch/mod.rs
@@ -650,6 +650,7 @@ mod tests {
             stderr: None,
             sandbox_dir: std::path::PathBuf::from("/tmp"),
             scratch: vec![],
+            credentials: vec![],
         };
         let res = Driver
             .run(req, &ctoken())

--- a/crates/builtins/src/plugintextfile/mod.rs
+++ b/crates/builtins/src/plugintextfile/mod.rs
@@ -201,6 +201,7 @@ mod tests {
             stderr: None,
             sandbox_dir: sandbox_dir.to_path_buf(),
             scratch: vec![],
+            credentials: vec![],
         }
     }
 

--- a/crates/core/src/lib.rs
+++ b/crates/core/src/lib.rs
@@ -27,5 +27,6 @@ pub mod htplatform;
 pub mod htvalue;
 pub mod paths;
 pub mod shutdown;
+pub mod template;
 pub mod units;
 pub mod version;

--- a/crates/core/src/template.rs
+++ b/crates/core/src/template.rs
@@ -1,0 +1,243 @@
+//! The one `${…}` tokenizer.
+//!
+//! heph grows several places where a string carries a reference to something the
+//! author did not write inline — a credential's presentation templates today,
+//! driver-option references next. Left alone those become separate parsers with
+//! different escapes and overlapping kind names, so that `${env:NAME}` means one
+//! thing in one file and another thing two files away.
+//!
+//! This module is deliberately only the *tokenizer*. It says what the pieces of a
+//! string are; it has no opinion about which kinds exist, because that genuinely
+//! differs per site — `file`, `field` and `helper` are meaningful only inside a
+//! credential presentation, and rejecting them elsewhere is the caller's job. One
+//! grammar, one escape, many vocabularies.
+//!
+//! ```text
+//! $$          a literal `$`
+//! ${name}     a reference with no kind
+//! ${kind:arg} a reference with a kind (split at the FIRST colon)
+//! $           anything else after a `$` is a literal `$`
+//! ```
+//!
+//! Substitution is **single-pass** by construction: [`parse`] returns pieces of
+//! the *input*, so a replacement value containing `${` is never re-scanned. That
+//! matters most where the values are credential material, which an attacker-shaped
+//! token could otherwise use to reach a second field.
+
+/// One piece of a parsed template.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum Piece<'a> {
+    /// Verbatim text. `$$` arrives here as a one-character `"$"`, which is why
+    /// this is a `Cow`-shaped borrow-or-static rather than a plain `&str` slice.
+    Text(&'a str),
+    /// A `${…}` reference.
+    Ref(Ref<'a>),
+}
+
+/// A parsed `${…}` reference.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct Ref<'a> {
+    /// The part before the first `:`, or `None` when there is no colon.
+    pub kind: Option<&'a str>,
+    /// Everything after the first `:`, or the whole body when there is no colon.
+    pub arg: &'a str,
+    /// The original text including the `${` and `}`, so a caller that does not
+    /// recognize `kind` can emit the reference back unchanged rather than having
+    /// to reconstruct (and risk normalizing) it.
+    pub raw: &'a str,
+}
+
+/// A `$$` escape, already unescaped.
+const DOLLAR: &str = "$";
+
+/// Split `s` into literal and reference pieces.
+///
+/// Fails only on an unterminated `${`, which is always a typo: silently treating
+/// it as literal text would put the reference into whatever the string configures,
+/// and the author would find out from the tool rather than from heph.
+pub fn parse(s: &str) -> anyhow::Result<Vec<Piece<'_>>> {
+    let mut out: Vec<Piece<'_>> = Vec::new();
+    let bytes = s.as_bytes();
+    let mut i = 0usize;
+    let mut lit_start = 0usize;
+    while i < bytes.len() {
+        if bytes.get(i) != Some(&b'$') {
+            i += 1;
+            continue;
+        }
+        match bytes.get(i + 1) {
+            Some(&b'$') => {
+                push_text(&mut out, s.get(lit_start..i));
+                out.push(Piece::Text(DOLLAR));
+                i += 2;
+                lit_start = i;
+            }
+            Some(&b'{') => {
+                let Some(close) = s.get(i + 2..).and_then(|rest| rest.find('}')) else {
+                    anyhow::bail!(
+                        "unterminated `${{` in template {s:?} — every `${{` needs a closing `}}`, \
+                         and a literal `$` is written `$$`"
+                    );
+                };
+                let end = i + 2 + close + 1;
+                push_text(&mut out, s.get(lit_start..i));
+                let body = s.get(i + 2..end - 1).unwrap_or_default();
+                let raw = s.get(i..end).unwrap_or_default();
+                let (kind, arg) = match body.split_once(':') {
+                    Some((k, a)) => (Some(k), a),
+                    None => (None, body),
+                };
+                out.push(Piece::Ref(Ref { kind, arg, raw }));
+                i = end;
+                lit_start = i;
+            }
+            // A bare `$` is ordinary text — `$HOME` in a netrc line, a price in a
+            // label. Only `$$` and `${` mean anything.
+            _ => i += 1,
+        }
+    }
+    push_text(&mut out, s.get(lit_start..));
+    Ok(out)
+}
+
+fn push_text<'a>(out: &mut Vec<Piece<'a>>, t: Option<&'a str>) {
+    if let Some(t) = t
+        && !t.is_empty()
+    {
+        out.push(Piece::Text(t));
+    }
+}
+
+/// True when `s` contains at least one `${…}` reference.
+///
+/// Cheap enough to call per string on a parse path: it is a single `memchr`-shaped
+/// scan and returns on the first hit, so the overwhelmingly common "no references
+/// anywhere" case never allocates.
+pub fn has_ref(s: &str) -> bool {
+    let bytes = s.as_bytes();
+    let mut i = 0usize;
+    while let Some(pos) = s.get(i..).and_then(|r| r.find('$')) {
+        let at = i + pos;
+        match bytes.get(at + 1) {
+            // `$$` escapes the dollar, so the `{` after it (if any) is literal.
+            Some(&b'$') => i = at + 2,
+            Some(&b'{') => return true,
+            _ => i = at + 1,
+        }
+    }
+    false
+}
+
+/// Substitute every reference through `resolve`, concatenating the result.
+///
+/// `resolve` returns the replacement text for a reference, or an error naming
+/// what it did not recognize. Returning an error rather than the original text is
+/// the right default for a *closed* vocabulary like a credential presentation; a
+/// caller with an open one passes back [`Ref::raw`].
+pub fn render(
+    s: &str,
+    mut resolve: impl FnMut(&Ref<'_>) -> anyhow::Result<String>,
+) -> anyhow::Result<String> {
+    let pieces = parse(s)?;
+    // The common case is a template with no references at all.
+    if pieces.len() == 1
+        && let Some(Piece::Text(t)) = pieces.first()
+        && std::ptr::eq(*t, s)
+    {
+        return Ok(s.to_string());
+    }
+    let mut out = String::with_capacity(s.len());
+    for p in &pieces {
+        match p {
+            Piece::Text(t) => out.push_str(t),
+            Piece::Ref(r) => out.push_str(&resolve(r)?),
+        }
+    }
+    Ok(out)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn refs(s: &str) -> Vec<(Option<String>, String)> {
+        parse(s)
+            .expect("parse")
+            .into_iter()
+            .filter_map(|p| match p {
+                Piece::Ref(r) => Some((r.kind.map(str::to_string), r.arg.to_string())),
+                Piece::Text(_) => None,
+            })
+            .collect()
+    }
+
+    #[test]
+    fn a_bare_name_has_no_kind() {
+        assert_eq!(refs("${token}"), vec![(None, "token".to_string())]);
+    }
+
+    #[test]
+    fn the_first_colon_splits_kind_from_arg() {
+        // A URL as the arg is the case that makes "first colon" load-bearing:
+        // `${file:https://x}` must not split at the scheme's colon.
+        assert_eq!(
+            refs("${file:https://x}"),
+            vec![(Some("file".to_string()), "https://x".to_string())]
+        );
+    }
+
+    #[test]
+    fn dollar_dollar_is_a_literal_dollar_and_does_not_open_a_reference() {
+        let out = render("$${token}", |_r| panic!("must not resolve")).expect("render");
+        assert_eq!(out, "${token}");
+    }
+
+    #[test]
+    fn a_bare_dollar_is_literal() {
+        assert_eq!(refs("costs $5 and $HOME"), vec![]);
+        let out = render("costs $5", |r| {
+            anyhow::bail!("a bare `$` opened a reference: {}", r.raw)
+        })
+        .expect("render");
+        assert_eq!(out, "costs $5");
+    }
+
+    #[test]
+    fn an_unterminated_reference_is_an_error() {
+        let err = parse("a ${token").expect_err("must fail");
+        assert!(format!("{err:#}").contains("unterminated"), "{err:#}");
+    }
+
+    #[test]
+    fn substitution_is_single_pass() {
+        // The property that matters when the values are secrets: material that
+        // happens to contain `${…}` is never re-interpreted.
+        let out = render("${a}", |_r| Ok("${b}".to_string())).expect("render");
+        assert_eq!(out, "${b}");
+    }
+
+    #[test]
+    fn render_interleaves_text_and_references() {
+        let out = render("machine ${host} login ${user}\n", |r| {
+            Ok(match r.arg {
+                "host" => "h".to_string(),
+                "user" => "u".to_string(),
+                other => panic!("unexpected {other}"),
+            })
+        })
+        .expect("render");
+        assert_eq!(out, "machine h login u\n");
+    }
+
+    #[test]
+    fn has_ref_agrees_with_parse() {
+        for s in [
+            "", "plain", "$", "$$", "$${x}", "${x}", "a${x}b", "$$${x}", "$ {x}",
+        ] {
+            let parsed = parse(s)
+                .map(|ps| ps.iter().any(|p| matches!(p, Piece::Ref(_))))
+                .unwrap_or(true);
+            assert_eq!(has_ref(s), parsed, "disagreed on {s:?}");
+        }
+    }
+}

--- a/crates/core/src/units.rs
+++ b/crates/core/src/units.rs
@@ -127,3 +127,105 @@ mod tests {
         assert!(parse_size("99999999999999999999TiB").is_err());
     }
 }
+
+/// Parse a human duration (`55m`, `6h`, `90s`, `1h30m`) into a [`Duration`].
+///
+/// Same shape as [`parse_size`] and for the same reason: a credential's `ttl` and
+/// a config timeout must not come to mean two things depending on which surface
+/// they were typed into.
+///
+/// A bare number is **seconds**, matching every vendor API that reports a lease
+/// in them (`lease_duration`, `expires_in`). Fractions are deliberately not
+/// accepted: a credential lifetime measured to the millisecond is a false
+/// precision, and rejecting `1.5h` is cheaper than deciding what it rounds to.
+///
+/// [`Duration`]: std::time::Duration
+pub fn parse_duration(s: &str) -> anyhow::Result<std::time::Duration> {
+    let t = s.trim();
+    if t.is_empty() {
+        anyhow::bail!("empty duration; try 30s, 55m, 6h, 1h30m");
+    }
+    let mut total = 0u64;
+    let mut rest = t;
+    let mut any = false;
+    while !rest.is_empty() {
+        let digits = rest
+            .find(|c: char| !c.is_ascii_digit())
+            .unwrap_or(rest.len());
+        if digits == 0 {
+            anyhow::bail!("{s:?} is not a duration; try 30s, 55m, 6h, 1h30m");
+        }
+        let (num, tail) = rest.split_at(digits);
+        let n: u64 = num
+            .parse()
+            .with_context(|| format!("{s:?} is not a duration"))?;
+        let unit_len = tail
+            .find(|c: char| c.is_ascii_digit())
+            .unwrap_or(tail.len());
+        let (unit, next) = tail.split_at(unit_len);
+        let mult = match unit.trim().to_ascii_lowercase().as_str() {
+            // Bare number => seconds. See the doc comment.
+            "" | "s" | "sec" | "secs" => 1,
+            "m" | "min" | "mins" => 60,
+            "h" | "hr" | "hrs" => 3600,
+            "d" => 86400,
+            other => anyhow::bail!("unknown duration unit {other:?} in {s:?}; try 30s, 55m, 6h"),
+        };
+        total = total
+            .checked_add(n.saturating_mul(mult))
+            .ok_or_else(|| anyhow::anyhow!("duration {s:?} overflows"))?;
+        any = true;
+        rest = next;
+    }
+    if !any {
+        anyhow::bail!("{s:?} is not a duration; try 30s, 55m, 6h, 1h30m");
+    }
+    Ok(std::time::Duration::from_secs(total))
+}
+
+#[cfg(test)]
+mod duration_tests {
+    use super::parse_duration;
+    use std::time::Duration;
+
+    #[test]
+    fn a_bare_number_is_seconds() {
+        // Every vendor lease field reports seconds, so this is the form that
+        // arrives from an API rather than from a person.
+        assert_eq!(
+            parse_duration("3600").expect("parse"),
+            Duration::from_secs(3600)
+        );
+    }
+
+    #[test]
+    fn units_and_compounds() {
+        assert_eq!(
+            parse_duration("55m").expect("parse"),
+            Duration::from_secs(3300)
+        );
+        assert_eq!(
+            parse_duration("6h").expect("parse"),
+            Duration::from_secs(21600)
+        );
+        assert_eq!(
+            parse_duration("1h30m").expect("parse"),
+            Duration::from_secs(5400)
+        );
+        assert_eq!(
+            parse_duration(" 2d ").expect("parse"),
+            Duration::from_secs(172800)
+        );
+    }
+
+    #[test]
+    fn a_fraction_is_rejected_rather_than_rounded() {
+        assert!(parse_duration("1.5h").is_err());
+    }
+
+    #[test]
+    fn an_unknown_unit_names_itself() {
+        let err = parse_duration("5y").expect_err("must fail");
+        assert!(format!("{err:#}").contains("\"y\""), "{err:#}");
+    }
+}

--- a/crates/driver-bridge/src/bridge.rs
+++ b/crates/driver-bridge/src/bridge.rs
@@ -348,6 +348,7 @@ mod shell_fallback_tests {
             stderr: None,
             sandbox_dir: sandbox.clone(),
             scratch: vec![],
+            credentials: vec![],
         };
 
         bridge.run_shell(req, &ctoken).await?;

--- a/crates/driver-support/src/credential.rs
+++ b/crates/driver-support/src/credential.rs
@@ -1,0 +1,77 @@
+//! The producer→host channel for credential references.
+//!
+//! A target referencing a credential records it as an ordinary [`Input`] with
+//! `hashed: false, runtime: false` — a graph edge that materializes nothing
+//! through the normal input path and contributes nothing to the parent's key —
+//! marked with the annotation below.
+//!
+//! This is the same channel [`scratch`](crate::scratch) uses, and for the same
+//! reason: annotations are how a driver already tells the *host* something about
+//! a dependency edge, so a credential reference needs no new `TargetDef` field
+//! and no change to the shape of an `Input`.
+//!
+//! What is *not* the same is what happens afterwards. A scratch reaches the
+//! sandbox as a symlink the driver places; a credential reaches it as a
+//! [`CredentialMount`](hplugin::driver::CredentialMount) the host resolved,
+//! acquired and materialized — because the material is the host's and must never
+//! be visible to the graph. The edge exists so `heph query revdeps` and
+//! `heph inspect deps` can see it, and so the engine knows which credentials a
+//! target is allowed to receive.
+//!
+//! The *settings* never travel this way. They live on the referenced `credential`
+//! target's spec config, which the host reads directly — so there is exactly one
+//! copy of them and two consumers cannot disagree about which identity to use.
+//!
+//! [`Input`]: hplugin::driver::targetdef::Input
+
+/// Input annotation marking a dep edge as a credential reference. Value must be
+/// the string `"true"`.
+///
+/// Set by a driver whose target declared the reference (pluginexec's
+/// `credentials` attribute); read by the engine, which resolves the referenced
+/// declaration, walks its source chain and presents the material. An input
+/// without it is an ordinary dependency.
+pub const CREDENTIAL_ANNOTATION: &str = "credential";
+
+/// `origin_id` prefix for credential inputs, matching the `dep|<group>|<i>` shape
+/// the other input kinds use.
+///
+/// Distinct from the dep prefixes so a credential can never collide with a dep
+/// group literally named `credential`, and so the id reads as what it is in
+/// `heph inspect`.
+pub const CREDENTIAL_ORIGIN_PREFIX: &str = "credential";
+
+/// True when `annotations` marks an input as a credential reference.
+pub fn is_credential(annotations: &std::collections::BTreeMap<String, String>) -> bool {
+    annotations.get(CREDENTIAL_ANNOTATION).map(String::as_str) == Some("true")
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::collections::BTreeMap;
+
+    fn ann(pairs: &[(&str, &str)]) -> BTreeMap<String, String> {
+        pairs
+            .iter()
+            .map(|(k, v)| (k.to_string(), v.to_string()))
+            .collect()
+    }
+
+    #[test]
+    fn only_the_exact_true_marker_counts() {
+        assert!(is_credential(&ann(&[("credential", "true")])));
+        assert!(!is_credential(&ann(&[])));
+        assert!(!is_credential(&ann(&[("credential", "false")])));
+        // Not truthy-parsed: an annotation is a string channel, and accepting
+        // near-misses would make a typo silently mean "yes" — which here would
+        // route an ordinary dependency through the credential path.
+        assert!(!is_credential(&ann(&[("credential", "1")])));
+        assert!(!is_credential(&ann(&[("credential", "True")])));
+    }
+
+    #[test]
+    fn a_scratch_annotation_does_not_mark_a_credential() {
+        assert!(!is_credential(&ann(&[("scratch", "true")])));
+    }
+}

--- a/crates/driver-support/src/driver_managed.rs
+++ b/crates/driver-support/src/driver_managed.rs
@@ -243,6 +243,7 @@ async fn run_shell_fallback<'a, 'io>(
         stderr,
         sandbox_dir: req_sandbox_dir,
         scratch,
+        credentials,
     } = request;
 
     let mut synthetic = (*shell_fallback.spec_template).clone();
@@ -278,6 +279,7 @@ async fn run_shell_fallback<'a, 'io>(
         stderr,
         sandbox_dir: req_sandbox_dir,
         scratch,
+        credentials,
     };
     let new_mreq = ManagedRunRequest {
         request: new_req,

--- a/crates/driver-support/src/lib.rs
+++ b/crates/driver-support/src/lib.rs
@@ -5,6 +5,7 @@
 //! `ManagedDriver` don't link `fuser`/libfuse. The FUSE backend and the
 //! `ManagedDriverBridge` that routes between OS and FUSE live in
 //! `heph-driver-bridge`, which the engine wires via `Engine::new_managed_driver`.
+pub mod credential;
 pub mod driver_managed;
 pub mod driver_managed_os;
 pub mod scratch;

--- a/crates/e2e/Cargo.toml
+++ b/crates/e2e/Cargo.toml
@@ -13,7 +13,8 @@ htestkit = { package = "testkit", path = "../testkit" }
 hplugin-oci = { package = "plugin-oci", path = "../plugin-oci" }
 hplugin-devenv = { package = "plugin-devenv", path = "../plugin-devenv" }
 hcore = { package = "core", path = "../core" }
-tokio = { version = "1", features = ["rt", "rt-multi-thread", "macros"] }
+tokio = { version = "1", features = ["rt", "rt-multi-thread", "macros", "time"] }
+futures = "0.3"
 anyhow = "1"
 tempfile = "3"
 tar = "0.4"

--- a/crates/e2e/tests/credential.rs
+++ b/crates/e2e/tests/credential.rs
@@ -1,0 +1,1593 @@
+#![expect(
+    clippy::panic_in_result_fn,
+    clippy::panic,
+    reason = "restriction/style lints scoped to production code; tests are exempt"
+)]
+
+//! End-to-end coverage for credentials as targets.
+//!
+//! These go through the real `Engine` — provider, BUILD-file evaluation, driver
+//! registry, `get_def`, `execute` — rather than calling the driver directly,
+//! because what is being tested is the *wiring*: that a declaration resolves,
+//! that a reference is an edge the cache key cannot see, that the chosen source's
+//! material reaches the target's environment, and that a mistake fails where a
+//! BUILD author will see it.
+//!
+//! The chain is exercised through the `env` and `file` source kinds, which need
+//! no network and no vendor CLI. `oidc` is covered by its probe (there is no
+//! endpoint here) and `exec` by a command the test writes itself.
+
+mod common;
+
+use common::Workspace;
+use std::sync::Arc;
+
+/// `EResult` has no `Debug`, so `expect_err` will not compile. Unwrap the error
+/// side explicitly instead.
+fn expect_err<T>(r: anyhow::Result<T>, what: &str) -> anyhow::Error {
+    match r {
+        Ok(_) => panic!("{what}"),
+        Err(e) => e,
+    }
+}
+
+/// Set a host variable for the duration of one test.
+///
+/// The chain reads the *process* environment, which is what makes an `env` source
+/// mean anything — so a test that exercises one has to touch it. Restored on drop
+/// so a failure does not leak into another test.
+struct EnvVar(&'static str);
+
+impl EnvVar {
+    fn set(name: &'static str, value: &str) -> Self {
+        // SAFETY: these tests run on their own variables, and each guard restores
+        // its own on drop.
+        unsafe { std::env::set_var(name, value) };
+        Self(name)
+    }
+}
+
+impl Drop for EnvVar {
+    fn drop(&mut self) {
+        // SAFETY: see `set`.
+        unsafe { std::env::remove_var(self.0) };
+    }
+}
+
+async fn def_hash(engine: &Arc<heph::engine::Engine>, addr: &str) -> anyhow::Result<Vec<u8>> {
+    let addr = heph::htaddr::parse_addr(addr)?;
+    let def = Arc::clone(engine)
+        .get_def(engine.new_state(), &addr)
+        .await?;
+    Ok(def.target_def.hash.clone())
+}
+
+async fn hashin(engine: &Arc<heph::engine::Engine>, addr: &str) -> anyhow::Result<String> {
+    let addr = heph::htaddr::parse_addr(addr)?;
+    Ok(Arc::clone(engine)
+        .meta(engine.new_state(), &addr)
+        .await?
+        .hashin)
+}
+
+// ---------------------------------------------------------------------------
+// The declaration
+// ---------------------------------------------------------------------------
+
+/// The driver is registered and a declaration resolves. Without this, everything
+/// downstream fails with "driver not found" and no test says why.
+#[tokio::test]
+async fn a_credential_declaration_resolves_through_the_engine() -> anyhow::Result<()> {
+    let ws = Workspace::new();
+    ws.write_build_file(
+        "auth",
+        r#"
+target(
+    name    = "token",
+    driver  = "credential",
+    sources = [heph.auth.env(["MY_TOKEN"])],
+    present = {"env": {"MY_TOKEN": "${my_token}"}},
+)
+"#,
+    );
+    let spec = ws.get_spec("//auth:token").await?;
+    assert_eq!(spec.driver, "credential");
+    heph::plugincredential::parse_declaration(&spec)?;
+    Ok(())
+}
+
+/// A declaration produces no artifacts, so resolving one directly yields an empty
+/// result rather than an error — and, critically, acquires nothing. Running
+/// `heph run //auth:aws` must not sign anyone in.
+#[tokio::test]
+async fn resolving_a_declaration_directly_acquires_nothing() -> anyhow::Result<()> {
+    let ws = Workspace::new();
+    ws.write_build_file(
+        "auth",
+        r#"target(name = "t", driver = "credential",
+       sources = [heph.auth.env(["ABSENT_EVERYWHERE"])],
+       present = {"env": {"T": "${absent_everywhere}"}})"#,
+    );
+    // The chain cannot be satisfied here, and that is precisely the point: a
+    // declaration is inert, so this succeeds anyway.
+    let result = ws.run("//auth:t").await?;
+    assert!(result.artifacts.is_empty());
+    Ok(())
+}
+
+/// An empty chain can never be acquired anywhere, so it fails at the declaration
+/// rather than at the first consumer.
+#[tokio::test]
+async fn an_empty_chain_fails_at_the_declaration() -> anyhow::Result<()> {
+    let ws = Workspace::new();
+    ws.write_build_file(
+        "auth",
+        r#"target(name = "t", driver = "credential", sources = [])"#,
+    );
+    let err = expect_err(ws.run("//auth:t").await, "an empty chain must not resolve");
+    assert!(format!("{err:#}").contains("at least one"), "{err:#}");
+    Ok(())
+}
+
+/// The sharpest rule in the design, enforced by the vocabulary rather than by a
+/// check: a presentation carries material and handles only, so a region — which
+/// *selects bytes* — has nowhere to go.
+#[tokio::test]
+async fn configuration_has_nowhere_to_hide_in_a_presentation() -> anyhow::Result<()> {
+    let ws = Workspace::new();
+    ws.write_build_file(
+        "auth",
+        r#"target(name = "t", driver = "credential",
+       sources = [heph.auth.env(["T"])],
+       present = {"env": {"T": "${t}"}, "region": "eu-west-1"})"#,
+    );
+    let err = expect_err(
+        ws.run("//auth:t").await,
+        "a region must not be a presentation",
+    );
+    let msg = format!("{err:#}");
+    assert!(msg.contains("unknown key"), "{msg}");
+    assert!(
+        msg.contains("hashed input on the consumer"),
+        "the message must say where it does belong: {msg}"
+    );
+    Ok(())
+}
+
+/// **The limit of the structural guard, pinned deliberately.**
+///
+/// The vocabulary stops a *key* like `region` (the test above). It does not stop
+/// a content-selecting *value* — `present = {"env": {"AWS_REGION": "eu-west-1"}}`
+/// is accepted, and by design: the same shape is how `heph.auth.aws_web_identity`
+/// carries a role ARN, which is a handle rather than a selector, and heph cannot
+/// tell those apart from the outside.
+///
+/// What keeps that sound is the contract, not the parser: a target whose *output*
+/// depends on which identity ran it is not cacheable and says so with
+/// `cache = False`. This test exists so the boundary between "enforced" and
+/// "conventional" is written down where someone reading the parser will find it,
+/// rather than implied by a doc sentence.
+#[tokio::test]
+async fn a_literal_value_in_a_presentation_is_accepted_and_is_a_convention_not_a_check()
+-> anyhow::Result<()> {
+    let _guard = EnvVar::set("HEPH_E2E_CONV_TOKEN", "v");
+    let ws = Workspace::new();
+    ws.write_build_file(
+        "auth",
+        r#"target(name = "t", driver = "credential",
+       sources = [heph.auth.env(["HEPH_E2E_CONV_TOKEN"])],
+       present = {"env": {"TOKEN": "${heph_e2e_conv_token}",
+                          "AWS_ROLE_ARN": "arn:aws:iam::123456789012:role/deployer"}})"#,
+    );
+    ws.write_build_file(
+        "app",
+        r#"target(name = "a", driver = "bash", out = "o.txt", cache = False,
+       credentials = ["//auth:t"], run = ["printf '%s' \"$AWS_ROLE_ARN\" > o.txt"])"#,
+    );
+    assert_eq!(
+        common::artifact_string(&*ws.run("//app:a").await?),
+        "arn:aws:iam::123456789012:role/deployer"
+    );
+    Ok(())
+}
+
+/// A reference to something that is not a credential is a BUILD-file mistake that
+/// would otherwise surface much later as a target with no identity. Name both
+/// ends.
+#[tokio::test]
+async fn referencing_a_non_credential_target_names_both_ends() -> anyhow::Result<()> {
+    let ws = Workspace::new();
+    ws.write_build_file(
+        "app",
+        r#"
+target(name = "notacred", driver = "bash", run = "true", out = [])
+target(name = "a", driver = "bash", run = "true", credentials = ["//app:notacred"], out = [])
+"#,
+    );
+    let err = expect_err(
+        ws.run("//app:a").await,
+        "referencing a bash target as a credential must fail",
+    );
+    let msg = format!("{err:#}");
+    assert!(msg.contains("//app:notacred"), "{msg}");
+    assert!(msg.contains("`deps`"), "must suggest the fix: {msg}");
+    Ok(())
+}
+
+/// A BUILD-file mistake surfaces at `get_def`, so `heph query` and
+/// `heph inspect def` report it — where the author is still looking at the file
+/// — rather than only when something eventually executes.
+#[tokio::test]
+async fn a_bad_reference_is_caught_without_executing_anything() -> anyhow::Result<()> {
+    let ws = Workspace::new();
+    ws.write_build_file(
+        "app",
+        r#"
+target(name = "notacred", driver = "bash", run = "true", out = [])
+target(name = "a", driver = "bash", run = "true", credentials = ["//app:notacred"], out = [])
+"#,
+    );
+    let addr = heph::htaddr::parse_addr("//app:a")?;
+    let err = expect_err(
+        Arc::clone(&ws.engine)
+            .get_def(ws.engine.new_state(), &addr)
+            .await,
+        "resolution must fail at get_def",
+    );
+    assert!(format!("{err:#}").contains("//app:notacred"), "{err:#}");
+    Ok(())
+}
+
+// ---------------------------------------------------------------------------
+// The cache-key boundary — the load-bearing claim
+// ---------------------------------------------------------------------------
+
+/// **Nothing about a credential enters the consumer's key.** Not the reference,
+/// not the declaration, not the names of the variables it presents.
+///
+/// Structural rather than conventional: `hashin` is computed over `hashed: true`
+/// inputs, and a credential reference sets both flags false. This is the test a
+/// reviewer should attack first.
+#[tokio::test]
+async fn referencing_a_credential_does_not_change_the_consumer_hash() -> anyhow::Result<()> {
+    let ws = Workspace::new();
+    ws.write_build_file(
+        "auth",
+        r#"target(name = "t", driver = "credential",
+       sources = [heph.auth.env(["MY_TOKEN"])],
+       present = {"env": {"MY_TOKEN": "${my_token}"}})"#,
+    );
+    ws.write_build_file(
+        "app",
+        r#"target(name = "a", driver = "bash", run = "true", out = [])"#,
+    );
+    let before_def = def_hash(&ws.engine, "//app:a").await?;
+    let before_hashin = hashin(&ws.engine, "//app:a").await?;
+
+    ws.write_build_file(
+        "app",
+        r#"target(name = "a", driver = "bash", run = "true", out = [],
+       credentials = ["//auth:t"])"#,
+    );
+    let engine = ws.reopen()?;
+    let after_def = def_hash(&engine, "//app:a").await?;
+    let after_hashin = hashin(&engine, "//app:a").await?;
+
+    assert_eq!(
+        before_def, after_def,
+        "a credential reference must not move the def hash"
+    );
+    assert_eq!(
+        before_hashin, after_hashin,
+        "a credential reference must not move the input hash — this is the whole contract"
+    );
+    Ok(())
+}
+
+/// The declaration's *contents* are equally invisible. Changing which variable a
+/// credential presents, or which sources it has, must not rebuild its consumers:
+/// a target's outputs are required to be identical whichever identity satisfied
+/// its requirement.
+#[tokio::test]
+async fn changing_the_declaration_does_not_rebuild_consumers() -> anyhow::Result<()> {
+    let ws = Workspace::new();
+    ws.write_build_file(
+        "auth",
+        r#"target(name = "t", driver = "credential",
+       sources = [heph.auth.env(["A"])],
+       present = {"env": {"A": "${a}"}})"#,
+    );
+    ws.write_build_file(
+        "app",
+        r#"target(name = "a", driver = "bash", run = "true", out = [],
+       credentials = ["//auth:t"])"#,
+    );
+    let before = hashin(&ws.engine, "//app:a").await?;
+
+    ws.write_build_file(
+        "auth",
+        r#"target(name = "t", driver = "credential",
+       sources = [heph.auth.env(["B"]), heph.auth.env(["C"])],
+       ttl     = "10m",
+       present = {"env": {"TOTALLY_DIFFERENT": "${b}"}})"#,
+    );
+    let engine = ws.reopen()?;
+    let after = hashin(&engine, "//app:a").await?;
+    assert_eq!(
+        before, after,
+        "a declaration change must not reach a consumer"
+    );
+    Ok(())
+}
+
+/// The edge exists even though it is invisible to the key — which is what makes
+/// `heph query revdeps` answer "who needs this identity?" and turns a bad addr
+/// into an ordinary resolution failure rather than a 403 much later.
+#[tokio::test]
+async fn a_credential_reference_is_an_edge_the_graph_can_see() -> anyhow::Result<()> {
+    let ws = Workspace::new();
+    ws.write_build_file(
+        "auth",
+        r#"target(name = "t", driver = "credential",
+       sources = [heph.auth.env(["A"])], present = {"env": {"A": "${a}"}})"#,
+    );
+    ws.write_build_file(
+        "app",
+        r#"target(name = "a", driver = "bash", run = "true", out = [],
+       credentials = ["//auth:t"])"#,
+    );
+    let addr = heph::htaddr::parse_addr("//app:a")?;
+    let def = Arc::clone(&ws.engine)
+        .get_def(ws.engine.new_state(), &addr)
+        .await?;
+    let input = def
+        .target_def
+        .inputs
+        .iter()
+        .find(|i| i.origin_id.starts_with("credential|"))
+        .expect("the reference is an input");
+    assert!(
+        !input.hashed,
+        "a credential must not feed the consumer's key"
+    );
+    assert!(
+        !input.runtime,
+        "a credential materializes nothing through the input path"
+    );
+    assert_eq!(input.r#ref.r#ref.format(), "//auth:t");
+    Ok(())
+}
+
+/// A duplicate reference presents one set of variables twice, which does nothing.
+/// Naming it beats quietly collapsing it.
+#[tokio::test]
+async fn a_duplicate_reference_is_rejected() -> anyhow::Result<()> {
+    let ws = Workspace::new();
+    ws.write_build_file(
+        "auth",
+        r#"target(name = "t", driver = "credential",
+       sources = [heph.auth.env(["A"])], present = {"env": {"A": "${a}"}})"#,
+    );
+    ws.write_build_file(
+        "app",
+        r#"target(name = "a", driver = "bash", run = "true", out = [],
+       credentials = ["//auth:t", "//auth:t"])"#,
+    );
+    let err = expect_err(ws.run("//app:a").await, "a duplicate must not resolve");
+    assert!(format!("{err:#}").contains("twice"), "{err:#}");
+    Ok(())
+}
+
+/// Two credentials on one target claiming one variable leaves one of them
+/// inoperative with nothing to see. Refuse rather than resolve.
+#[tokio::test]
+async fn two_credentials_claiming_one_variable_are_refused() -> anyhow::Result<()> {
+    let ws = Workspace::new();
+    ws.write_build_file(
+        "auth",
+        r#"
+target(name = "a", driver = "credential",
+       sources = [heph.auth.env(["A"])], present = {"env": {"TOKEN": "${a}"}})
+target(name = "b", driver = "credential",
+       sources = [heph.auth.env(["B"])], present = {"env": {"TOKEN": "${b}"}})
+"#,
+    );
+    ws.write_build_file(
+        "app",
+        r#"target(name = "x", driver = "bash", run = "true", out = [],
+       credentials = ["//auth:a", "//auth:b"])"#,
+    );
+    let err = expect_err(ws.run("//app:x").await, "a collision must not resolve");
+    let msg = format!("{err:#}");
+    assert!(msg.contains("TOKEN"), "{msg}");
+    assert!(msg.contains("shadow"), "{msg}");
+    Ok(())
+}
+
+// ---------------------------------------------------------------------------
+// The chain, and what reaches the target
+// ---------------------------------------------------------------------------
+
+/// The acceptance scenario, minus the clouds: a chain whose first source does not
+/// apply here and whose second does, presenting material the target can read.
+#[tokio::test]
+async fn the_first_applicable_source_wins_and_its_material_reaches_the_target() -> anyhow::Result<()>
+{
+    let _guard = EnvVar::set("HEPH_E2E_CRED_TOKEN", "sekrit-token-value");
+    let ws = Workspace::new();
+    ws.write_build_file(
+        "auth",
+        r#"
+target(
+    name    = "t",
+    driver  = "credential",
+    sources = [
+        # Not here: there is no OIDC endpoint in a test process.
+        heph.auth.oidc("github_actions", audience = "x",
+                       present = {"env": {"TOKEN": "${id_token}"}}),
+        # Here.
+        heph.auth.env(["HEPH_E2E_CRED_TOKEN"]),
+    ],
+    present = {"env": {"TOKEN": "${heph_e2e_cred_token}"}},
+)
+"#,
+    );
+    ws.write_build_file(
+        "app",
+        r#"target(name = "a", driver = "bash", out = "o.txt", cache = False,
+       credentials = ["//auth:t"], run = ["printf '%s' \"$TOKEN\" > o.txt"])"#,
+    );
+    let out = common::artifact_string(&*ws.run("//app:a").await?);
+    assert_eq!(out, "sekrit-token-value");
+    Ok(())
+}
+
+/// The commonest failure in CI, and today an unreadable one. The error prints the
+/// walk, with the fix attached to the line that failed.
+#[tokio::test]
+async fn a_chain_that_applies_nowhere_prints_the_walk_and_the_fix() -> anyhow::Result<()> {
+    let ws = Workspace::new();
+    ws.write_build_file(
+        "auth",
+        r#"
+target(
+    name    = "t",
+    driver  = "credential",
+    sources = [
+        heph.auth.oidc("github_actions", audience = "sts.amazonaws.com",
+                       present = {"env": {"T": "${id_token}"}}),
+        heph.auth.env(["HEPH_E2E_SURELY_UNSET"]),
+    ],
+    present = {"env": {"T": "${heph_e2e_surely_unset}"}},
+)
+"#,
+    );
+    ws.write_build_file(
+        "app",
+        r#"target(name = "a", driver = "bash", run = "true", out = [], cache = False,
+       credentials = ["//auth:t"])"#,
+    );
+    let err = expect_err(ws.run("//app:a").await, "no source applies");
+    let msg = format!("{err:#}");
+    assert!(msg.contains("no source applies here"), "{msg}");
+    // Every source, in order, with why it was skipped …
+    assert!(msg.contains("oidc(github_actions)"), "{msg}");
+    assert!(msg.contains("ACTIONS_ID_TOKEN_REQUEST_URL"), "{msg}");
+    assert!(msg.contains("HEPH_E2E_SURELY_UNSET"), "{msg}");
+    // … and the fix, on the line that failed.
+    assert!(
+        msg.contains("id-token: write"),
+        "the hint must be there: {msg}"
+    );
+    Ok(())
+}
+
+/// An acquire failure is **terminal, not a fallthrough**. If a chain fell through
+/// on failure, a misconfigured role in CI would silently fall back to whatever
+/// ambient identity the runner happened to have — precisely the accident this
+/// feature exists to prevent.
+#[tokio::test]
+async fn an_acquire_failure_does_not_fall_through_to_the_next_source() -> anyhow::Result<()> {
+    let _fallback = EnvVar::set("HEPH_E2E_FALLBACK_TOKEN", "the-wrong-identity");
+    let ws = Workspace::new();
+    // A `file` source whose path exists — so it is applicable — but whose
+    // contents are not the JSON its `fields` map promises. The probe passes, the
+    // acquire fails, and the chain must stop.
+    ws.write_file("secrets/creds.json", "this is not json");
+    let root = ws.dir.path().display().to_string();
+    ws.write_build_file(
+        "auth",
+        &format!(
+            r#"
+target(
+    name    = "t",
+    driver  = "credential",
+    sources = [
+        heph.auth.file("{root}/secrets/creds.json", fields = {{"token": "access_token"}}),
+        heph.auth.env(["HEPH_E2E_FALLBACK_TOKEN"]),
+    ],
+    present = {{"env": {{"T": "${{token}}"}}}},
+)
+"#
+        ),
+    );
+    ws.write_build_file(
+        "app",
+        r#"target(name = "a", driver = "bash", out = "o.txt", cache = False,
+       credentials = ["//auth:t"], run = ["printf '%s' \"$T\" > o.txt"])"#,
+    );
+    let err = expect_err(ws.run("//app:a").await, "an acquire failure is terminal");
+    let msg = format!("{err:#}");
+    assert!(msg.contains("not JSON"), "{msg}");
+    assert!(
+        !msg.contains("the-wrong-identity"),
+        "the chain must not have reached the next source"
+    );
+    Ok(())
+}
+
+/// `when` is policy, not logic: a fixed vocabulary heph evaluates. A source whose
+/// `when` does not hold here is skipped before its probe runs.
+#[tokio::test]
+async fn when_selects_a_source_before_any_probe() -> anyhow::Result<()> {
+    let _guard = EnvVar::set("HEPH_E2E_LAPTOP_TOKEN", "laptop");
+    let other_os = if cfg!(target_os = "macos") {
+        "linux"
+    } else {
+        "darwin"
+    };
+    let ws = Workspace::new();
+    ws.write_build_file(
+        "auth",
+        &format!(
+            r#"
+target(
+    name    = "t",
+    driver  = "credential",
+    sources = [
+        heph.auth.env(["HEPH_E2E_LAPTOP_TOKEN"], when = "os:{other_os}",
+                      present = {{"env": {{"T": "never"}}}}),
+        heph.auth.env(["HEPH_E2E_LAPTOP_TOKEN"]),
+    ],
+    present = {{"env": {{"T": "${{heph_e2e_laptop_token}}"}}}},
+)
+"#
+        ),
+    );
+    ws.write_build_file(
+        "app",
+        r#"target(name = "a", driver = "bash", out = "o.txt", cache = False,
+       credentials = ["//auth:t"], run = ["printf '%s' \"$T\" > o.txt"])"#,
+    );
+    assert_eq!(
+        common::artifact_string(&*ws.run("//app:a").await?),
+        "laptop"
+    );
+    Ok(())
+}
+
+/// A `files` presentation lands **beside** the workspace directory, never inside
+/// it — because output collection is rooted at the workspace directory and packs
+/// every regular file it walks. A token file inside it would land in the local
+/// cache and be pushed to the shared remote automatically.
+#[tokio::test]
+async fn a_presented_file_is_never_collected_as_an_output() -> anyhow::Result<()> {
+    let _guard = EnvVar::set("HEPH_E2E_FILE_TOKEN", "file-material");
+    let ws = Workspace::new();
+    ws.write_build_file(
+        "auth",
+        r#"target(name = "t", driver = "credential",
+       sources = [heph.auth.env(["HEPH_E2E_FILE_TOKEN"])],
+       present = {"files": {"tok": "${heph_e2e_file_token}"},
+                  "env":   {"TOKFILE": "${file:tok}"}})"#,
+    );
+    // A `**/*` output glob: the greediest collection there is. If the presented
+    // file were inside the workspace directory, this is what would pack it.
+    ws.write_build_file(
+        "app",
+        r#"target(name = "a", driver = "bash", out = "**/*", cache = False,
+       credentials = ["//auth:t"],
+       run = ["cat \"$TOKFILE\" > seen.txt"])"#,
+    );
+    let result = ws.run("//app:a").await?;
+    let paths = common::artifact_paths(&result);
+    // The target really did read the file …
+    let seen = paths
+        .iter()
+        .any(|p| p.to_string_lossy().ends_with("seen.txt"));
+    assert!(
+        seen,
+        "the target must have read the presented file: {paths:?}"
+    );
+    // … and no artifact is the token file itself.
+    for p in &paths {
+        let s = p.to_string_lossy();
+        assert!(
+            !s.contains(".heph/auth"),
+            "a presented credential file must never be collected: {s}"
+        );
+        assert!(!s.ends_with("/tok"), "{s}");
+    }
+    Ok(())
+}
+
+/// Material never reaches `log.txt`, the TUI, the failure event or the cache —
+/// because it is scrubbed at the tee, before any of them.
+///
+/// Asserted on a **failing** target deliberately. That is the case where the
+/// captured log matters most (it is lifted into the failure event, the JSON
+/// output and the CI report) and it is also the one where the sandbox survives,
+/// so `log.txt` can be read back.
+#[tokio::test]
+async fn credential_material_is_scrubbed_from_a_targets_output() -> anyhow::Result<()> {
+    let _guard = EnvVar::set("HEPH_E2E_LOUD_TOKEN", "extremely-secret-value");
+    let ws = Workspace::new();
+    ws.write_build_file(
+        "auth",
+        r#"target(name = "t", driver = "credential",
+       sources = [heph.auth.env(["HEPH_E2E_LOUD_TOKEN"])],
+       present = {"env": {"TOKEN": "${heph_e2e_loud_token}"}})"#,
+    );
+    // A build step that echoes its own credential — the motivating accident —
+    // and then fails, which is when the log is lifted into an event.
+    ws.write_build_file(
+        "app",
+        r#"target(name = "a", driver = "bash", out = [], cache = False,
+       credentials = ["//auth:t"],
+       run = ["echo \"using $TOKEN\"", "exit 3"])"#,
+    );
+    let err = expect_err(ws.run("//app:a").await, "the target exits 3");
+    let msg = format!("{err:#}");
+    assert!(
+        !msg.contains("extremely-secret-value"),
+        "a token echoed by a build step must not reach the failure: {msg}"
+    );
+
+    let mut found = false;
+    for entry in walkdir(&ws.dir.path().join(".heph3").join("sandbox")) {
+        if entry.file_name().is_some_and(|n| n == "log.txt") {
+            let body = std::fs::read_to_string(&entry).unwrap_or_default();
+            if !body.contains("using") {
+                continue;
+            }
+            assert!(
+                !body.contains("extremely-secret-value"),
+                "a token echoed by a build step must not reach log.txt: {body}"
+            );
+            assert!(
+                body.contains("[redacted]"),
+                "the log must show that something was scrubbed: {body}"
+            );
+            found = true;
+        }
+    }
+    assert!(found, "no log.txt was written, so nothing was asserted");
+    Ok(())
+}
+
+/// The floor is a stated limit, not a hidden one: material shorter than
+/// `REDACT_MIN_LEN` is **not** scrubbed, because a substring replacement over a
+/// byte stream cannot remove `"1"` without corrupting every number a build
+/// prints.
+#[tokio::test]
+async fn a_secret_below_the_length_floor_is_documented_as_not_scrubbed() -> anyhow::Result<()> {
+    let _guard = EnvVar::set("HEPH_E2E_TINY_TOKEN", "abc");
+    let ws = Workspace::new();
+    ws.write_build_file(
+        "auth",
+        r#"target(name = "t", driver = "credential",
+       sources = [heph.auth.env(["HEPH_E2E_TINY_TOKEN"])],
+       present = {"env": {"TOKEN": "${heph_e2e_tiny_token}"}})"#,
+    );
+    ws.write_build_file(
+        "app",
+        r#"target(name = "a", driver = "bash", out = "o.txt", cache = False,
+       credentials = ["//auth:t"], run = ["printf '%s' \"$TOKEN\" > o.txt"])"#,
+    );
+    // The material still reaches the target — only the scrubbing declines.
+    assert_eq!(common::artifact_string(&*ws.run("//app:a").await?), "abc");
+    assert_eq!(heph::engine::driver::REDACT_MIN_LEN, 8);
+    Ok(())
+}
+
+fn walkdir(root: &std::path::Path) -> Vec<std::path::PathBuf> {
+    let mut out = Vec::new();
+    let mut stack = vec![root.to_path_buf()];
+    while let Some(dir) = stack.pop() {
+        let Ok(rd) = std::fs::read_dir(&dir) else {
+            continue;
+        };
+        for e in rd.flatten() {
+            let p = e.path();
+            if p.is_dir() {
+                stack.push(p);
+            } else {
+                out.push(p);
+            }
+        }
+    }
+    out
+}
+
+/// A presented file may name another presented file — Google's
+/// `external_account` document points at the token file beside it — so the
+/// rendering pass retries until it makes no progress.
+#[tokio::test]
+async fn a_presented_file_can_name_another_presented_file() -> anyhow::Result<()> {
+    let _guard = EnvVar::set("HEPH_E2E_CHAIN_TOKEN", "chained");
+    let ws = Workspace::new();
+    // `adc` sorts before `token`, so a single pass in map order would fail.
+    ws.write_build_file(
+        "auth",
+        r#"target(name = "t", driver = "credential",
+       sources = [heph.auth.env(["HEPH_E2E_CHAIN_TOKEN"])],
+       present = {"files": {"adc": "points at ${file:token}",
+                            "token": "${heph_e2e_chain_token}"},
+                  "env":   {"ADC": "${file:adc}"}})"#,
+    );
+    ws.write_build_file(
+        "app",
+        r#"target(name = "a", driver = "bash", out = "o.txt", cache = False,
+       credentials = ["//auth:t"], run = ["cat \"$ADC\" > o.txt"])"#,
+    );
+    let out = common::artifact_string(&*ws.run("//app:a").await?);
+    assert!(out.starts_with("points at /"), "{out:?}");
+    assert!(out.trim().ends_with("/token"), "{out:?}");
+    Ok(())
+}
+
+/// A typo in a presented file's template reports *that*, not a generic "does not
+/// resolve" — the retry loop must carry the real error out.
+#[tokio::test]
+async fn a_bad_field_in_a_presented_file_names_the_field() -> anyhow::Result<()> {
+    let _guard = EnvVar::set("HEPH_E2E_TYPO_TOKEN", "v");
+    let ws = Workspace::new();
+    ws.write_build_file(
+        "auth",
+        r#"target(name = "t", driver = "credential",
+       sources = [heph.auth.env(["HEPH_E2E_TYPO_TOKEN"])],
+       present = {"files": {"f": "${heph_e2e_typo_tokn}"},
+                  "env":   {"F": "${file:f}"}})"#,
+    );
+    ws.write_build_file(
+        "app",
+        r#"target(name = "a", driver = "bash", run = "true", out = [], cache = False,
+       credentials = ["//auth:t"])"#,
+    );
+    let err = expect_err(ws.run("//app:a").await, "a typo must fail");
+    let msg = format!("{err:#}");
+    assert!(msg.contains("heph_e2e_typo_tokn"), "{msg}");
+    assert!(
+        msg.contains("heph_e2e_typo_token"),
+        "must name what the source did yield: {msg}"
+    );
+    Ok(())
+}
+
+// ---------------------------------------------------------------------------
+// The chain refuses to eat itself
+// ---------------------------------------------------------------------------
+
+/// A credential that names itself must **fail**, not hang.
+///
+/// The guard has to run before anything takes the per-address cell, or the
+/// recursion parks on a lock it is itself holding — a one-line BUILD typo turning
+/// into a wedged build with no diagnostic and no timeout. The `timeout` here is
+/// what makes a regression fail rather than hang the whole suite.
+#[tokio::test]
+async fn a_credential_that_is_its_own_source_fails_rather_than_hanging() -> anyhow::Result<()> {
+    let ws = Workspace::new();
+    ws.write_build_file(
+        "auth",
+        r#"target(name = "t", driver = "credential", sources = ["//auth:t"],
+       present = {"env": {"T": "${token}"}})"#,
+    );
+    ws.write_build_file(
+        "app",
+        r#"target(name = "a", driver = "bash", run = "true", out = [], cache = False,
+       credentials = ["//auth:t"])"#,
+    );
+    let res = tokio::time::timeout(std::time::Duration::from_secs(20), ws.run("//app:a"))
+        .await
+        .expect("a self-referencing credential must fail, not hang");
+    let err = expect_err(res, "a cycle must fail");
+    let msg = format!("{err:#}");
+    assert!(msg.contains("its own source"), "{msg}");
+    assert!(
+        msg.contains("//auth:t → //auth:t"),
+        "must name the loop: {msg}"
+    );
+    Ok(())
+}
+
+/// The same, one hop further out: `a → b → a`.
+#[tokio::test]
+async fn a_two_credential_cycle_is_named_not_hung() -> anyhow::Result<()> {
+    let ws = Workspace::new();
+    ws.write_build_file(
+        "auth",
+        r#"
+target(name = "a", driver = "credential", sources = ["//auth:b"],
+       present = {"env": {"A": "${token}"}})
+target(name = "b", driver = "credential", sources = ["//auth:a"],
+       present = {"env": {"B": "${token}"}})
+"#,
+    );
+    ws.write_build_file(
+        "app",
+        r#"target(name = "x", driver = "bash", run = "true", out = [], cache = False,
+       credentials = ["//auth:a"])"#,
+    );
+    let res = tokio::time::timeout(std::time::Duration::from_secs(20), ws.run("//app:x"))
+        .await
+        .expect("a two-credential cycle must fail, not hang");
+    let err = expect_err(res, "a cycle must fail");
+    assert!(
+        format!("{err:#}").contains("//auth:a → //auth:b → //auth:a"),
+        "{err:#}"
+    );
+    Ok(())
+}
+
+// ---------------------------------------------------------------------------
+// The rest of the source vocabulary
+// ---------------------------------------------------------------------------
+
+/// `passthrough` exposes host files **in place** — nothing is copied into the
+/// credential store — and the presentation points a variable at the path.
+#[tokio::test]
+async fn a_passthrough_source_exposes_a_host_path_in_place() -> anyhow::Result<()> {
+    let host = tempfile::tempdir().expect("tempdir");
+    let cfg = host.path().join("config");
+    std::fs::write(&cfg, "vendor session state").expect("write");
+
+    let ws = Workspace::new();
+    ws.write_build_file(
+        "auth",
+        &format!(
+            r#"target(name = "t", driver = "credential",
+       sources = [heph.auth.passthrough(
+           paths = {{"config": "{}"}},
+           env   = {{"VENDOR_CONFIG": "${{file:config}}"}})],
+       present = {{"env": {{"UNUSED": "${{file:config}}"}}}})"#,
+            cfg.display()
+        ),
+    );
+    ws.write_build_file(
+        "app",
+        r#"target(name = "a", driver = "bash", out = "o.txt", cache = False,
+       credentials = ["//auth:t"], run = ["cat \"$VENDOR_CONFIG\" > o.txt"])"#,
+    );
+    assert_eq!(
+        common::artifact_string(&*ws.run("//app:a").await?),
+        "vendor session state"
+    );
+    // Exposed, not copied: the host file is still the one the target read.
+    assert!(cfg.exists());
+    Ok(())
+}
+
+/// A `passthrough` whose path is absent is skipped, not failed — that is what
+/// makes it usable as the laptop half of a chain whose other half is CI.
+#[tokio::test]
+async fn a_passthrough_with_a_missing_path_is_skipped() -> anyhow::Result<()> {
+    let _guard = EnvVar::set("HEPH_E2E_PT_FALLBACK", "fallback");
+    let ws = Workspace::new();
+    ws.write_build_file(
+        "auth",
+        r#"target(name = "t", driver = "credential",
+       sources = [
+           heph.auth.passthrough(paths = {"c": "/nonexistent/heph/e2e"},
+                                 env = {"T": "never"}),
+           heph.auth.env(["HEPH_E2E_PT_FALLBACK"]),
+       ],
+       present = {"env": {"T": "${heph_e2e_pt_fallback}"}})"#,
+    );
+    ws.write_build_file(
+        "app",
+        r#"target(name = "a", driver = "bash", out = "o.txt", cache = False,
+       credentials = ["//auth:t"], run = ["printf '%s' \"$T\" > o.txt"])"#,
+    );
+    assert_eq!(
+        common::artifact_string(&*ws.run("//app:a").await?),
+        "fallback"
+    );
+    Ok(())
+}
+
+/// The `generic` OIDC provider: a token some other CI system already put where
+/// heph can find it. Deliberately generic — a provider list has no end.
+#[tokio::test]
+async fn a_generic_oidc_token_is_read_from_its_file_and_trimmed() -> anyhow::Result<()> {
+    let dir = tempfile::tempdir().expect("tempdir");
+    let token = dir.path().join("token");
+    // A trailing newline is what every CI system writes.
+    std::fs::write(&token, "jwt-value\n").expect("write");
+    let _guard = EnvVar::set("HEPH_OIDC_TOKEN_FILE", &token.to_string_lossy());
+
+    let ws = Workspace::new();
+    ws.write_build_file(
+        "auth",
+        r#"target(name = "t", driver = "credential",
+       sources = [heph.auth.oidc("generic")],
+       present = {"env": {"TOK": "${id_token}"}})"#,
+    );
+    ws.write_build_file(
+        "app",
+        r#"target(name = "a", driver = "bash", out = "o.txt", cache = False,
+       credentials = ["//auth:t"], run = ["printf '%s' \"$TOK\" > o.txt"])"#,
+    );
+    assert_eq!(
+        common::artifact_string(&*ws.run("//app:a").await?),
+        "jwt-value"
+    );
+    Ok(())
+}
+
+// ---------------------------------------------------------------------------
+// The helper presentations
+// ---------------------------------------------------------------------------
+
+/// Read a file the credential presented, from inside the target, by copying it
+/// to an output. The sandbox is gone by the time a test could look.
+fn cat_target(var: &str) -> String {
+    format!(
+        r#"target(name = "a", driver = "bash", out = "o.txt", cache = False,
+       credentials = ["//auth:t"], run = ["cat \"${var}\" > o.txt"])"#
+    )
+}
+
+/// The AWS credential-process presentation writes a config file naming the helper
+/// and points `AWS_CONFIG_FILE` at it.
+#[tokio::test]
+async fn the_aws_helper_writes_a_config_naming_the_callback() -> anyhow::Result<()> {
+    let _guard = EnvVar::set("HEPH_E2E_AWS_TOKEN", "aws-material");
+    let ws = Workspace::new();
+    ws.write_build_file(
+        "auth",
+        r#"target(name = "t", driver = "credential",
+       sources = [heph.auth.env(["HEPH_E2E_AWS_TOKEN"])],
+       present = heph.auth.aws_process())"#,
+    );
+    ws.write_build_file("app", &cat_target("AWS_CONFIG_FILE"));
+    let cfg = common::artifact_string(&*ws.run("//app:a").await?);
+    assert!(cfg.contains("[default]"), "{cfg}");
+    assert!(cfg.contains("credential_process = "), "{cfg}");
+    assert!(cfg.contains("__auth-helper aws"), "{cfg}");
+    assert!(cfg.contains("--pin "), "the callback must be pinned: {cfg}");
+    Ok(())
+}
+
+/// The GCP helper writes an `external_account` document whose
+/// `credential_source.executable` names the callback — and sets the opt-in
+/// without which no Google SDK will run an executable credential source at all.
+#[tokio::test]
+async fn the_gcp_helper_writes_an_executable_sourced_external_account() -> anyhow::Result<()> {
+    let _guard = EnvVar::set("HEPH_E2E_GCP_TOKEN", "gcp-material");
+    let ws = Workspace::new();
+    ws.write_build_file(
+        "auth",
+        r#"target(name = "t", driver = "credential",
+       sources = [heph.auth.env(["HEPH_E2E_GCP_TOKEN"])],
+       present = {"helper": {"dialect": "gcp",
+                             "audience": "//iam.googleapis.com/projects/1/x",
+                             "impersonate": "d@p.iam.gserviceaccount.com"}})"#,
+    );
+    ws.write_build_file(
+        "app",
+        r#"target(name = "a", driver = "bash", out = "o.txt", cache = False,
+       credentials = ["//auth:t"],
+       run = ["cat \"$GOOGLE_APPLICATION_CREDENTIALS\" > o.txt",
+              "test \"$GOOGLE_EXTERNAL_ACCOUNT_ALLOW_EXECUTABLES\" = 1",
+              "test -n \"$CLOUDSDK_AUTH_CREDENTIAL_FILE_OVERRIDE\""])"#,
+    );
+    let doc: serde_json::Value =
+        serde_json::from_str(&common::artifact_string(&*ws.run("//app:a").await?))
+            .expect("valid json");
+    assert_eq!(doc["type"], "external_account");
+    assert_eq!(doc["audience"], "//iam.googleapis.com/projects/1/x");
+    let cmd = doc["credential_source"]["executable"]["command"]
+        .as_str()
+        .expect("a command");
+    assert!(cmd.contains("__auth-helper gcp"), "{cmd}");
+    assert!(
+        doc["service_account_impersonation_url"]
+            .as_str()
+            .is_some_and(|u| u.contains("d@p.iam.gserviceaccount.com")),
+        "{doc}"
+    );
+    Ok(())
+}
+
+/// The Docker helper writes a `credHelpers` config, a `docker-credential-heph`
+/// shim, and puts the shim's directory on `PATH` — which is the only presentation
+/// that touches `PATH`, because Docker resolves a helper by executable name.
+#[tokio::test]
+async fn the_docker_helper_writes_a_shim_and_puts_it_on_path() -> anyhow::Result<()> {
+    let _guard = EnvVar::set("HEPH_E2E_REG_TOKEN", "registry-material");
+    let ws = Workspace::new();
+    ws.write_build_file(
+        "auth",
+        r#"target(name = "t", driver = "credential",
+       sources = [heph.auth.env(["HEPH_E2E_REG_TOKEN"])],
+       present = heph.auth.docker(["ghcr.io"]))"#,
+    );
+    ws.write_build_file(
+        "app",
+        r#"target(name = "a", driver = "bash", out = "o.txt", cache = False,
+       credentials = ["//auth:t"],
+       run = ["cat \"$DOCKER_CONFIG/config.json\" > o.txt",
+              # resolvable by name, and executable
+              "command -v docker-credential-heph > /dev/null",
+              "test -x \"$(command -v docker-credential-heph)\""])"#,
+    );
+    let doc: serde_json::Value =
+        serde_json::from_str(&common::artifact_string(&*ws.run("//app:a").await?))
+            .expect("valid json");
+    assert_eq!(doc["credHelpers"]["ghcr.io"], "heph");
+    Ok(())
+}
+
+/// The git helper is injected entirely through `GIT_CONFIG_*`, so no gitconfig is
+/// written and the developer's own is never touched.
+#[tokio::test]
+async fn the_git_helper_is_environment_only() -> anyhow::Result<()> {
+    let _guard = EnvVar::set("HEPH_E2E_GIT_TOKEN", "git-material");
+    let ws = Workspace::new();
+    ws.write_build_file(
+        "auth",
+        r#"target(name = "t", driver = "credential",
+       sources = [heph.auth.env(["HEPH_E2E_GIT_TOKEN"])],
+       present = heph.auth.git(["git.corp.example"]))"#,
+    );
+    ws.write_build_file(
+        "app",
+        r#"target(name = "a", driver = "bash", out = "o.txt", cache = False,
+       credentials = ["//auth:t"],
+       run = ["printf '%s|%s|%s' \"$GIT_CONFIG_COUNT\" \"$GIT_CONFIG_KEY_0\" \"$GIT_CONFIG_VALUE_0\" > o.txt"])"#,
+    );
+    let out = common::artifact_string(&*ws.run("//app:a").await?);
+    let parts: Vec<&str> = out.split('|').collect();
+    assert_eq!(parts.first().copied(), Some("1"), "{out}");
+    assert_eq!(
+        parts.get(1).copied(),
+        Some("credential.https://git.corp.example.helper"),
+        "{out}"
+    );
+    let value = parts.get(2).copied().unwrap_or_default();
+    assert!(
+        value.starts_with('!'),
+        "a git helper argv is `!<cmd>`: {out}"
+    );
+    assert!(value.contains("__auth-helper git"), "{out}");
+    Ok(())
+}
+
+/// The kubernetes dialect writes no document of its own: the author templates the
+/// kubeconfig and places the callback with `${helper:command}` / `${helper:args}`.
+#[tokio::test]
+async fn the_kubernetes_helper_places_the_callback_in_the_authors_document() -> anyhow::Result<()> {
+    let _guard = EnvVar::set("HEPH_E2E_K8S_TOKEN", "k8s-material");
+    let ws = Workspace::new();
+    ws.write_build_file(
+        "auth",
+        r#"target(name = "t", driver = "credential",
+       sources = [heph.auth.env(["HEPH_E2E_K8S_TOKEN"])],
+       present = {"helper": "kubernetes",
+                  "files":  {"kubeconfig": "command: ${helper:command}\nargs: ${helper:args}\n"},
+                  "env":    {"KUBECONFIG": "${file:kubeconfig}"}})"#,
+    );
+    ws.write_build_file("app", &cat_target("KUBECONFIG"));
+    let out = common::artifact_string(&*ws.run("//app:a").await?);
+    assert!(out.starts_with("command: /"), "an absolute path: {out}");
+    assert!(out.contains("__auth-helper"), "{out}");
+    assert!(out.contains("kubernetes"), "{out}");
+    assert!(out.contains("--pin"), "{out}");
+    Ok(())
+}
+
+/// A credential whose material has no expiry and no `ttl` is never written to
+/// disk: a long-lived API token under `<home>/auth/` is a durable secret at rest
+/// that nothing will ever clean up.
+#[tokio::test]
+async fn material_with_no_expiry_is_never_left_at_rest() -> anyhow::Result<()> {
+    let _guard = EnvVar::set("HEPH_E2E_UNBOUNDED", "no-expiry-token");
+    let ws = Workspace::new();
+    ws.write_build_file(
+        "auth",
+        r#"target(name = "t", driver = "credential",
+       sources = [heph.auth.env(["HEPH_E2E_UNBOUNDED"])],
+       present = {"env": {"T": "${heph_e2e_unbounded}"}})"#,
+    );
+    ws.write_build_file(
+        "app",
+        r#"target(name = "a", driver = "bash", out = "o.txt", cache = False,
+       credentials = ["//auth:t"], run = ["printf '%s' \"$T\" > o.txt"])"#,
+    );
+    assert_eq!(
+        common::artifact_string(&*ws.run("//app:a").await?),
+        "no-expiry-token"
+    );
+
+    let auth_dir = ws.dir.path().join(".heph3").join("auth");
+    for f in walkdir(&auth_dir) {
+        let body = std::fs::read(&f).unwrap_or_default();
+        assert!(
+            !String::from_utf8_lossy(&body).contains("no-expiry-token"),
+            "unbounded material must not be written to {}",
+            f.display()
+        );
+    }
+    Ok(())
+}
+
+/// A target used as a credential source must be `cache = False`: its outputs are
+/// material, and a cacheable target's outputs are written to the local cache and
+/// pushed to the shared remote automatically. Enforced at resolution rather than
+/// documented.
+#[tokio::test]
+async fn a_cacheable_producer_is_refused_as_a_credential_source() -> anyhow::Result<()> {
+    let ws = Workspace::new();
+    ws.write_build_file(
+        "auth",
+        r#"
+target(name = "fetch", driver = "bash", out = {"credential": "cred.json"},
+       run = ["printf '{\"token\":\"abc\"}' > cred.json"])
+target(name = "t", driver = "credential", sources = ["//auth:fetch"],
+       present = {"env": {"T": "${token}"}})
+"#,
+    );
+    ws.write_build_file(
+        "app",
+        r#"target(name = "a", driver = "bash", out = "o.txt", cache = False,
+       credentials = ["//auth:t"], run = ["printf '%s' \"$T\" > o.txt"])"#,
+    );
+    let err = expect_err(
+        ws.run("//app:a").await,
+        "a cacheable credential source must be refused",
+    );
+    let msg = format!("{err:#}");
+    assert!(msg.contains("cache = False"), "{msg}");
+    assert!(msg.contains("shared remote"), "must say why: {msg}");
+    Ok(())
+}
+
+/// A source can be a target, and everything about how and where it runs is the
+/// exec driver's existing surface. Its `credential` output group is read as JSON
+/// into fields — one convention, not configuration.
+#[tokio::test]
+async fn a_target_source_yields_its_credential_group_as_fields() -> anyhow::Result<()> {
+    let ws = Workspace::new();
+    ws.write_build_file(
+        "auth",
+        r#"
+target(name = "fetch", driver = "bash", cache = False,
+       out = {"credential": "cred.json"},
+       run = ["printf '{\"token\":\"from-a-target\",\"expires_in\":600}' > cred.json"])
+target(name = "t", driver = "credential", sources = ["//auth:fetch"],
+       present = {"env": {"T": "${token}"}})
+"#,
+    );
+    ws.write_build_file(
+        "app",
+        r#"target(name = "a", driver = "bash", out = "o.txt", cache = False,
+       credentials = ["//auth:t"], run = ["printf '%s' \"$T\" > o.txt"])"#,
+    );
+    assert_eq!(
+        common::artifact_string(&*ws.run("//app:a").await?),
+        "from-a-target"
+    );
+    Ok(())
+}
+
+/// A credential naming another credential is a delegation: take that one's
+/// material, apply this one's presentation. No syntax of its own — the driver of
+/// the referenced target decides.
+#[tokio::test]
+async fn a_credential_can_delegate_to_another() -> anyhow::Result<()> {
+    let _guard = EnvVar::set("HEPH_E2E_ROOT_TOKEN", "root-material");
+    let ws = Workspace::new();
+    ws.write_build_file(
+        "auth",
+        r#"
+target(name = "root", driver = "credential",
+       sources = [heph.auth.env(["HEPH_E2E_ROOT_TOKEN"])],
+       present = {"env": {"ROOT": "${heph_e2e_root_token}"}})
+target(name = "derived", driver = "credential", sources = ["//auth:root"],
+       present = {"env": {"DERIVED": "${heph_e2e_root_token}"}})
+"#,
+    );
+    ws.write_build_file(
+        "app",
+        r#"target(name = "a", driver = "bash", out = "o.txt", cache = False,
+       credentials = ["//auth:derived"],
+       run = ["printf '%s|%s' \"$DERIVED\" \"${ROOT:-unset}\" > o.txt"])"#,
+    );
+    // The consumer gets the *derived* presentation and only that: delegation
+    // takes the material, not the parent's variable names.
+    assert_eq!(
+        common::artifact_string(&*ws.run("//app:a").await?),
+        "root-material|unset"
+    );
+    Ok(())
+}
+
+/// A source that shells out to a secret manager has to authenticate to the secret
+/// manager. That is not a second, private notion of "how the credential tool logs
+/// in" — it is the same presentation machinery, with the acquire subprocess as
+/// just another consumer.
+#[tokio::test]
+async fn a_source_can_declare_its_own_credentials() -> anyhow::Result<()> {
+    let _guard = EnvVar::set("HEPH_E2E_VAULT_TOKEN", "vault-login");
+    let ws = Workspace::new();
+    ws.write_build_file(
+        "auth",
+        r#"
+target(name = "vault", driver = "credential",
+       sources = [heph.auth.env(["HEPH_E2E_VAULT_TOKEN"])],
+       present = {"env": {"VAULT_TOKEN": "${heph_e2e_vault_token}"}})
+
+# The acquire command prints whatever identity it was handed, which is exactly
+# what a real `vault read` does with the token it was given.
+target(name = "cf", driver = "credential",
+       sources = [heph.auth.exec(
+           ["sh", "-c", "printf '{\"token\":\"scoped-for-%s\"}' \"$VAULT_TOKEN\""],
+           fields = {"token": "token"},
+           credentials = ["//auth:vault"])],
+       present = {"env": {"CF": "${token}"}})
+"#,
+    );
+    ws.write_build_file(
+        "app",
+        r#"target(name = "a", driver = "bash", out = "o.txt", cache = False,
+       credentials = ["//auth:cf"], run = ["printf '%s' \"$CF\" > o.txt"])"#,
+    );
+    assert_eq!(
+        common::artifact_string(&*ws.run("//app:a").await?),
+        "scoped-for-vault-login"
+    );
+    Ok(())
+}
+
+/// One acquisition serves every **concurrent** consumer. This is a
+/// single-flighting property, not a memoization one — running the consumers one
+/// after another would prove only that the second read a cache the first filled,
+/// which is the easy half.
+///
+/// The command sleeps, so without single-flighting all five would be in flight at
+/// once and the counter would show five.
+#[tokio::test]
+async fn one_acquisition_serves_every_concurrent_consumer() -> anyhow::Result<()> {
+    let ws = Workspace::new();
+    let counter = ws.dir.path().join("concurrent-acquisitions");
+    ws.write_build_file(
+        "auth",
+        &format!(
+            r#"
+target(name = "t", driver = "credential",
+       sources = [heph.auth.exec(["sh", "-c",
+           "sleep 0.3; echo x >> {c}; printf '{{\"token\":\"once\"}}'"],
+           fields = {{"token": "token"}})],
+       present = {{"env": {{"T": "${{token}}"}}}})
+"#,
+            c = counter.display()
+        ),
+    );
+    let consumers: String = (0..5)
+        .map(|i| {
+            format!(
+                r#"target(name = "c{i}", driver = "bash", out = "o.txt", cache = False,
+       credentials = ["//auth:t"], run = ["printf '%s' \"$T\" > o.txt"])
+"#
+            )
+        })
+        .collect();
+    ws.write_build_file("app", &consumers);
+
+    let runs = (0..5).map(|i| {
+        let ws = &ws;
+        async move { ws.run(&format!("//app:c{i}")).await }
+    });
+    for r in futures::future::try_join_all(runs).await? {
+        assert_eq!(common::artifact_string(&r), "once");
+    }
+    let acquisitions = std::fs::read_to_string(&counter).unwrap_or_default();
+    assert_eq!(
+        acquisitions.lines().count(),
+        1,
+        "five concurrent consumers must cause one acquisition, got {acquisitions:?}"
+    );
+    Ok(())
+}
+
+/// Material that has lapsed is re-acquired rather than handed on.
+///
+/// This is the whole reason the process cache is not the engine's `Memoizer`: a
+/// memoized cell is computed once and kept forever, so a long build with a
+/// short-lived token would hand a target starting later material that expired
+/// before it did.
+#[tokio::test]
+async fn lapsed_material_is_re_acquired_rather_than_handed_on() -> anyhow::Result<()> {
+    let ws = Workspace::new();
+    let counter = ws.dir.path().join("refreshes");
+    // A one-second lifetime. `usable_at`'s margin is `min(60s, lifetime/2)`, so
+    // this is usable for about half a second and then is not.
+    ws.write_build_file(
+        "auth",
+        &format!(
+            r#"
+target(name = "t", driver = "credential",
+       sources = [heph.auth.exec(["sh", "-c",
+           "echo x >> {c}; printf '{{\"token\":\"v\",\"expires_in\":1}}'"],
+           fields = {{"token": "token"}}, expires = "expires_in")],
+       present = {{"env": {{"T": "${{token}}"}}}})
+"#,
+            c = counter.display()
+        ),
+    );
+    ws.write_build_file(
+        "app",
+        r#"
+target(name = "first", driver = "bash", out = "o.txt", cache = False,
+       credentials = ["//auth:t"], run = ["printf '%s' \"$T\" > o.txt"])
+target(name = "second", driver = "bash", out = "o.txt", cache = False,
+       credentials = ["//auth:t"], run = ["printf '%s' \"$T\" > o.txt"])
+"#,
+    );
+    ws.run("//app:first").await?;
+    assert_eq!(
+        std::fs::read_to_string(&counter)
+            .unwrap_or_default()
+            .lines()
+            .count(),
+        1
+    );
+    tokio::time::sleep(std::time::Duration::from_millis(1200)).await;
+    ws.run("//app:second").await?;
+    assert_eq!(
+        std::fs::read_to_string(&counter)
+            .unwrap_or_default()
+            .lines()
+            .count(),
+        2,
+        "a target starting after the material lapsed must not be handed it"
+    );
+    Ok(())
+}
+
+/// A second `heph` process reuses the first's material rather than re-acquiring
+/// it — which is what "sign in once a day" actually means.
+#[tokio::test]
+async fn a_second_process_reuses_the_disk_tier() -> anyhow::Result<()> {
+    let ws = Workspace::new();
+    let counter = ws.dir.path().join("cross-process");
+    ws.write_build_file(
+        "auth",
+        &format!(
+            r#"
+target(name = "t", driver = "credential",
+       sources = [heph.auth.exec(["sh", "-c",
+           "echo x >> {c}; printf '{{\"token\":\"v\",\"expires_in\":3600}}'"],
+           fields = {{"token": "token"}}, expires = "expires_in")],
+       present = {{"env": {{"T": "${{token}}"}}}})
+"#,
+            c = counter.display()
+        ),
+    );
+    ws.write_build_file(
+        "app",
+        r#"target(name = "a", driver = "bash", out = "o.txt", cache = False,
+       credentials = ["//auth:t"], run = ["printf '%s' \"$T\" > o.txt"])"#,
+    );
+    ws.run("//app:a").await?;
+
+    // A second engine over the same on-disk store: what the next `heph`
+    // invocation sees. Its process tier starts empty, so a hit here can only
+    // have come from disk.
+    let engine = ws.reopen()?;
+    let addr = heph::htaddr::parse_addr("//app:a")?;
+    Arc::clone(&engine)
+        .result_addr(
+            engine.new_state(),
+            &addr,
+            heph::engine::OutputMatcher::All,
+            &heph::engine::ResultOptions::default(),
+        )
+        .await?;
+    let acquisitions = std::fs::read_to_string(&counter).unwrap_or_default();
+    assert_eq!(
+        acquisitions.lines().count(),
+        1,
+        "a second process must reuse the disk tier, got {acquisitions:?}"
+    );
+    Ok(())
+}
+
+/// A producer's non-`credential` output groups are material too, so the
+/// no-expiry-at-rest rule covers them.
+#[tokio::test]
+async fn a_producers_files_are_not_left_at_rest_without_an_expiry() -> anyhow::Result<()> {
+    let ws = Workspace::new();
+    ws.write_build_file(
+        "auth",
+        r#"
+target(name = "mint", driver = "bash", cache = False,
+       out = {"kubeconfig": "kc.yaml"},
+       run = ["printf 'token: unbounded-producer-secret' > kc.yaml"])
+target(name = "t", driver = "credential", sources = ["//auth:mint"],
+       present = {"env": {"KUBECONFIG": "${file:kubeconfig}"}})
+"#,
+    );
+    ws.write_build_file(
+        "app",
+        r#"target(name = "a", driver = "bash", out = "o.txt", cache = False,
+       credentials = ["//auth:t"], run = ["cat \"$KUBECONFIG\" > o.txt"])"#,
+    );
+    // The material still reaches the target …
+    assert_eq!(
+        common::artifact_string(&*ws.run("//app:a").await?),
+        "token: unbounded-producer-secret"
+    );
+    // … and the only copy at rest is the per-process staging directory, which
+    // the next `heph` sweeps. Nothing sits in the durable half of the store.
+    let auth = ws.dir.path().join(".heph3").join("auth");
+    let live = auth.join("files").join("live");
+    let mut staged = 0usize;
+    for f in walkdir(&auth) {
+        let body = String::from_utf8_lossy(&std::fs::read(&f).unwrap_or_default()).into_owned();
+        if !body.contains("unbounded-producer-secret") {
+            continue;
+        }
+        assert!(
+            f.starts_with(&live),
+            "unbounded material must not be promoted out of staging: {}",
+            f.display()
+        );
+        staged += 1;
+    }
+    assert_eq!(staged, 1, "the staged copy should exist exactly once");
+    Ok(())
+}
+
+/// The same producer with a `ttl` **is** kept: a declared lifetime is what makes
+/// material cacheable at all, and is the difference between the two halves of the
+/// store.
+#[tokio::test]
+async fn a_producers_files_are_kept_once_a_ttl_gives_them_a_lifetime() -> anyhow::Result<()> {
+    let ws = Workspace::new();
+    ws.write_build_file(
+        "auth",
+        r#"
+target(name = "mint", driver = "bash", cache = False,
+       out = {"kubeconfig": "kc.yaml"},
+       run = ["printf 'token: bounded-producer-secret' > kc.yaml"])
+target(name = "t", driver = "credential", sources = ["//auth:mint"],
+       ttl = "6h",
+       present = {"env": {"KUBECONFIG": "${file:kubeconfig}"}})
+"#,
+    );
+    ws.write_build_file(
+        "app",
+        r#"target(name = "a", driver = "bash", out = "o.txt", cache = False,
+       credentials = ["//auth:t"], run = ["cat \"$KUBECONFIG\" > o.txt"])"#,
+    );
+    assert_eq!(
+        common::artifact_string(&*ws.run("//app:a").await?),
+        "token: bounded-producer-secret"
+    );
+    let live = ws
+        .dir
+        .path()
+        .join(".heph3")
+        .join("auth")
+        .join("files")
+        .join("live");
+    let durable = walkdir(&ws.dir.path().join(".heph3").join("auth"))
+        .into_iter()
+        .filter(|f| !f.starts_with(&live))
+        .any(|f| {
+            String::from_utf8_lossy(&std::fs::read(&f).unwrap_or_default())
+                .contains("bounded-producer-secret")
+        });
+    assert!(durable, "material with a declared lifetime is kept");
+    Ok(())
+}
+
+/// One acquisition serves every consumer in a run. An `exec` source shelling out
+/// to a vendor CLI costs the better part of a second, and two hundred consumers
+/// must not pay it two hundred times.
+#[tokio::test]
+async fn one_acquisition_serves_every_consumer() -> anyhow::Result<()> {
+    let ws = Workspace::new();
+    // The command appends to a counter file, so the number of acquisitions is
+    // observable from outside.
+    let counter = ws.dir.path().join("acquisitions");
+    ws.write_build_file(
+        "auth",
+        &format!(
+            r#"
+target(name = "t", driver = "credential",
+       sources = [heph.auth.exec(["sh", "-c",
+           "echo x >> {c}; printf '{{\"token\":\"once\"}}'"],
+           fields = {{"token": "token"}})],
+       present = {{"env": {{"T": "${{token}}"}}}})
+"#,
+            c = counter.display()
+        ),
+    );
+    let consumers: String = (0..5)
+        .map(|i| {
+            format!(
+                r#"target(name = "a{i}", driver = "bash", out = "o.txt", cache = False,
+       credentials = ["//auth:t"], run = ["printf '%s' \"$T\" > o.txt"])
+"#
+            )
+        })
+        .collect();
+    ws.write_build_file("app", &consumers);
+
+    for i in 0..5 {
+        assert_eq!(
+            common::artifact_string(&*ws.run(&format!("//app:a{i}")).await?),
+            "once"
+        );
+    }
+    let runs = std::fs::read_to_string(&counter).unwrap_or_default();
+    assert_eq!(
+        runs.lines().count(),
+        1,
+        "five consumers must cause one acquisition, got {runs:?}"
+    );
+    Ok(())
+}
+
+/// A cache hit acquires nothing. That placement is what makes the "zero cost on a
+/// hit" claim structural rather than aspirational: a fully cached build never
+/// reaches the acquisition step at all.
+#[tokio::test]
+async fn a_cache_hit_acquires_nothing() -> anyhow::Result<()> {
+    let ws = Workspace::new();
+    let counter = ws.dir.path().join("acquisitions");
+    ws.write_build_file(
+        "auth",
+        &format!(
+            r#"
+target(name = "t", driver = "credential",
+       sources = [heph.auth.exec(["sh", "-c",
+           "echo x >> {c}; printf '{{\"token\":\"v\"}}'"],
+           fields = {{"token": "token"}})],
+       present = {{"env": {{"T": "${{token}}"}}}})
+"#,
+            c = counter.display()
+        ),
+    );
+    // Cacheable, deliberately: the output does not depend on the identity.
+    ws.write_build_file(
+        "app",
+        r#"target(name = "a", driver = "bash", out = "o.txt",
+       credentials = ["//auth:t"], run = ["printf 'constant' > o.txt"])"#,
+    );
+
+    ws.run("//app:a").await?;
+    let after_first = std::fs::read_to_string(&counter).unwrap_or_default();
+    assert_eq!(after_first.lines().count(), 1);
+
+    // A second engine over the same on-disk cache: the next `heph` invocation.
+    let engine = ws.reopen()?;
+    let addr = heph::htaddr::parse_addr("//app:a")?;
+    Arc::clone(&engine)
+        .result_addr(
+            engine.new_state(),
+            &addr,
+            heph::engine::OutputMatcher::All,
+            &heph::engine::ResultOptions::default(),
+        )
+        .await?;
+    let after_second = std::fs::read_to_string(&counter).unwrap_or_default();
+    assert_eq!(
+        after_second.lines().count(),
+        1,
+        "a cache hit must not acquire, got {after_second:?}"
+    );
+    Ok(())
+}

--- a/crates/e2e/tests/credential.rs
+++ b/crates/e2e/tests/credential.rs
@@ -146,7 +146,9 @@ async fn configuration_has_nowhere_to_hide_in_a_presentation() -> anyhow::Result
         "a region must not be a presentation",
     );
     let msg = format!("{err:#}");
-    assert!(msg.contains("unknown key"), "{msg}");
+    // The `SpecStruct` derive names the offending key; the context says where
+    // configuration does belong.
+    assert!(msg.contains("region"), "{msg}");
     assert!(
         msg.contains("hashed input on the consumer"),
         "the message must say where it does belong: {msg}"

--- a/crates/engine/src/engine/credential.rs
+++ b/crates/engine/src/engine/credential.rs
@@ -1,0 +1,2264 @@
+//! Host-side handling of credential references: the chain walk, acquisition, and
+//! presentation.
+//!
+//! A credential is declared as a target (`driver = "credential"`) and referenced
+//! by addr from the targets that use it. The reference arrives as an [`Input`]
+//! with `hashed: false, runtime: false`, marked by
+//! [`CREDENTIAL_ANNOTATION`](hdriver_support::credential::CREDENTIAL_ANNOTATION).
+//!
+//! # The load-bearing claim
+//!
+//! **Nothing about a credential enters `hashin`** — not the material, not the
+//! chosen source, not the declaration, not even the names of the variables it
+//! presents. That is structural rather than conventional: `hashin` is computed
+//! over `hashed: true` inputs only, so an edge with both flags false has no path
+//! to it. The test that proves it is the same shape as scratch's.
+//!
+//! **A credential is acquired only on a miss.** Everything in this module hangs
+//! off `execute`, which a cache hit never reaches. A fully cached build probes
+//! nothing, spawns nothing and prompts nobody.
+//!
+//! # Where a run's credential files live, and why the path is load-bearing
+//!
+//! Presentation files are written at `<sandbox_dir>/.heph/auth/<addr>/<name>` — a
+//! sibling of the workspace directory, **never inside it**. This is not tidiness.
+//! Output collection is rooted at the workspace directory and packs every regular
+//! file it walks, and unlike a scratch mount (a symlink to an absolute path, which
+//! the artifact packer refuses) a token file is an ordinary file that would pack
+//! silently, land in the local cache, and be pushed to the shared remote
+//! automatically.
+//!
+//! Two more rules fall out of the same reasoning. The directory is named by the
+//! full sanitized *address* rather than the target name, so two credentials called
+//! `aws` in different packages cannot collide. And it is deleted at run end
+//! regardless of outcome — a failed target's sandbox is deliberately kept for
+//! diagnostics, and the log tail is what makes it useful, not the token.
+
+use crate::engine::Engine;
+use crate::engine::driver::targetdef::Input;
+use crate::engine::request_state::RequestState;
+use anyhow::Context as _;
+use hbuiltins::plugincredential::{
+    CredentialDef, DRIVER_NAME, Dialect, Presentation, SourceDecl, SourceKind, When,
+    parse_declaration, source::detected_ci_provider,
+};
+use hcore::template::Ref;
+use hdriver_support::credential::is_credential;
+use hmodel::htaddr::Addr;
+use hplugin::driver::{CREDENTIAL_ENV_MAX_BYTES, CredentialMount};
+use std::collections::BTreeMap;
+use std::path::{Path, PathBuf};
+use std::sync::Arc;
+use std::time::SystemTime;
+
+pub use crate::engine::credential_store::{CredentialStore, Material};
+
+/// A reference resolved against its declaration.
+#[derive(Debug, Clone)]
+pub struct ResolvedCredential {
+    pub addr: Addr,
+    pub def: CredentialDef,
+}
+
+/// What led to a credential: the addresses already being acquired, and the
+/// resolution keys of the parents whose identity this one is derived under.
+///
+/// The two halves are deliberately separate because they answer different
+/// questions. `visited` is the **recursion guard** — a credential that names
+/// itself, directly or through another, must fail rather than deadlock, and it
+/// has to be checked in address space. `keys` is the **identity** — material
+/// minted under one root must never be served to a run holding another, which is
+/// checked in key space, both in the process cache and in the disk store.
+///
+/// Conflating them is how the guard came to compare a 16-hex resolution key
+/// against `"//auth:x"` and therefore never fire.
+#[derive(Debug, Clone, Default)]
+pub struct Chain {
+    visited: Vec<Addr>,
+    keys: Vec<String>,
+}
+
+impl Chain {
+    /// The empty chain: a credential a consumer named directly.
+    pub fn root() -> Self {
+        Self::default()
+    }
+
+    /// `Err` when `addr` is already being acquired further up, naming the loop.
+    fn enter(&self, addr: &Addr) -> anyhow::Result<()> {
+        if !self.visited.iter().any(|a| a == addr) {
+            return Ok(());
+        }
+        let mut path: Vec<String> = self.visited.iter().map(Addr::format).collect();
+        path.push(addr.format());
+        anyhow::bail!(
+            "credential {addr} is its own source, directly or through another credential: {}. A chain \
+             cannot depend on itself — the fix is usually a second, bootstrap credential \
+             that reads no state of its own",
+            path.join(" → ")
+        )
+    }
+
+    /// The chain as seen by the sources *of* `addr`.
+    fn descend(&self, addr: &Addr) -> Self {
+        let mut visited = self.visited.clone();
+        visited.push(addr.clone());
+        Self {
+            visited,
+            keys: self.keys.clone(),
+        }
+    }
+
+    fn with_key(&self, key: String) -> Self {
+        let mut keys = self.keys.clone();
+        keys.push(key);
+        Self {
+            visited: self.visited.clone(),
+            keys,
+        }
+    }
+
+    fn keys(&self) -> &[String] {
+        &self.keys
+    }
+}
+
+/// Material plus everything a human needs to know about how it got here.
+#[derive(Debug, Clone)]
+pub struct Acquired {
+    pub material: Material,
+    /// The winning source's label, e.g. `exec(aws)`.
+    pub source: String,
+    /// Index of the winning source in the chain.
+    pub source_index: usize,
+    pub acquired_at: SystemTime,
+    /// The store key this was cached under. A child credential folds its
+    /// parents' keys into its own.
+    pub key: String,
+    /// Whether it came from the disk tier rather than being freshly acquired.
+    pub from_disk: bool,
+}
+
+/// One line of a chain walk: a source, and what happened to it.
+#[derive(Debug, Clone)]
+pub struct WalkStep {
+    pub index: usize,
+    pub label: String,
+    /// `None` when this source was chosen.
+    pub skipped: Option<String>,
+    /// What to tell a human, when this source was skipped.
+    pub hint: String,
+}
+
+/// Every source was skipped. The commonest failure in CI, and today an
+/// unreadable one — so the error prints the walk, with the fix attached to the
+/// line that failed.
+#[derive(Debug)]
+pub struct NoApplicableSourceError {
+    pub addr: Addr,
+    pub walk: Vec<WalkStep>,
+}
+
+impl std::fmt::Display for NoApplicableSourceError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        writeln!(f, "credential {} — no source applies here", self.addr)?;
+        for step in &self.walk {
+            let reason = step.skipped.as_deref().unwrap_or("skipped");
+            writeln!(
+                f,
+                "  {}. {:<24} skipped: {reason}",
+                step.index + 1,
+                step.label
+            )?;
+            writeln!(f, "{:28}→ {}", "", step.hint)?;
+        }
+        Ok(())
+    }
+}
+
+impl std::error::Error for NoApplicableSourceError {}
+
+/// A credential exists here but needs a human to sign in.
+///
+/// A build never signs anyone in: it fails with the exact command to run, and a
+/// human runs it. The `login` argvs travel as structured data rather than as
+/// prose so `--json` consumers and the TUI render the same instruction.
+#[derive(Debug)]
+pub struct AuthRequiredError {
+    pub addr: Addr,
+    pub source: String,
+    pub login: Vec<Vec<String>>,
+}
+
+impl std::fmt::Display for AuthRequiredError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(
+            f,
+            "credential {} needs a sign-in ({}) — run: heph auth login {}",
+            self.addr, self.source, self.addr
+        )
+    }
+}
+
+impl std::error::Error for AuthRequiredError {}
+
+impl AuthRequiredError {
+    /// This error, with the chain walk that produced it as its cause.
+    ///
+    /// Both, deliberately: the walk says *why nothing applied*, and this says
+    /// *what to run about it*. A `--json` consumer downcasts to this; a human
+    /// reads both paragraphs.
+    fn context(self, walk: NoApplicableSourceError) -> anyhow::Error {
+        anyhow::Error::new(walk).context(self)
+    }
+}
+
+/// The sign-in commands a source declares, if any.
+///
+/// Only `exec` and `passthrough` have one: nothing a human can run repairs a
+/// missing OIDC endpoint or an unset environment variable.
+pub fn source_login(src: &SourceDecl) -> &[Vec<String>] {
+    match &src.kind {
+        SourceKind::Exec { login, .. } | SourceKind::Passthrough { login, .. } => login,
+        _ => &[],
+    }
+}
+
+/// True when this input is a credential reference rather than an ordinary dep.
+///
+/// Both flags false *and* the annotation. The flags alone are the scratch shape
+/// too, so the annotation is what tells them apart.
+pub(crate) fn is_credential_input(i: &Input) -> bool {
+    !i.hashed && !i.runtime && is_credential(&i.annotations)
+}
+
+/// The per-process acquisition cache.
+///
+/// Not the engine's [`Memoizer`](hcore::hmemoizer::Memoizer): a memoized cell is
+/// computed once and kept forever, and material expires. A three-hour build with
+/// a one-hour token would otherwise hand a target starting at hour two material
+/// that lapsed an hour earlier. So each key gets an async mutex holding an
+/// `Option`, which gives single-flighting *and* re-acquisition on expiry from the
+/// same structure.
+#[derive(Default)]
+pub struct CredentialCache {
+    cells: parking_lot::Mutex<
+        std::collections::HashMap<String, Arc<tokio::sync::Mutex<Option<Acquired>>>>,
+    >,
+}
+
+impl CredentialCache {
+    /// The cell for one credential *under one root identity*.
+    ///
+    /// Keyed on the address **and** the parents' resolution keys, not the address
+    /// alone. That is the same invariant the disk store's key enforces, and
+    /// dropping it here would reintroduce one tier up exactly what the disk key
+    /// exists to prevent: a derived credential is reachable both directly from a
+    /// consumer and as a source-credential under some parent, and whichever
+    /// material landed in the cell first would then serve both for the rest of
+    /// the process.
+    fn cell(&self, addr: &str, parents: &[String]) -> Arc<tokio::sync::Mutex<Option<Acquired>>> {
+        let mut key = String::with_capacity(addr.len() + parents.len() * 17);
+        key.push_str(addr);
+        for p in parents {
+            key.push('\u{1f}');
+            key.push_str(p);
+        }
+        Arc::clone(
+            self.cells
+                .lock()
+                .entry(key)
+                .or_insert_with(|| Arc::new(tokio::sync::Mutex::new(None))),
+        )
+    }
+
+    fn clear(&self) {
+        self.cells.lock().clear();
+    }
+}
+
+impl Engine {
+    /// Resolve every credential reference on a def against its declaration, and
+    /// reject an incoherent set.
+    ///
+    /// Done on the finalized def, like `resolve_scratch`, so every driver gets the
+    /// checks and a BUILD-file mistake surfaces at `get_def` — where the author is
+    /// still looking at the file — rather than as an identity that quietly does
+    /// nothing much later.
+    ///
+    /// Returns immediately for a target with no references, which is nearly all
+    /// of them.
+    pub(crate) async fn resolve_credentials(
+        self: &Arc<Self>,
+        rs: &Arc<RequestState>,
+        consumer: &Addr,
+        inputs: &[Input],
+    ) -> anyhow::Result<Vec<ResolvedCredential>> {
+        let refs: Vec<&Input> = inputs.iter().filter(|i| is_credential_input(i)).collect();
+        if refs.is_empty() {
+            return Ok(Vec::new());
+        }
+
+        let mut resolved = Vec::with_capacity(refs.len());
+        for input in refs {
+            let addr = input.r#ref.r#ref.clone();
+            let spec = Arc::clone(self)
+                .get_spec(rs.clone(), &addr)
+                .await
+                .with_context(|| {
+                    format!("{consumer} references credential {addr}, which does not resolve")
+                })?;
+
+            if spec.driver != DRIVER_NAME {
+                anyhow::bail!(
+                    "{consumer} lists {addr} under `credentials`, but {addr} is a `{}` target — \
+                     `credentials` takes addresses of `{DRIVER_NAME}` targets. Did you mean to \
+                     put it in `deps`?",
+                    spec.driver
+                );
+            }
+
+            let def = parse_declaration(&spec)
+                .with_context(|| format!("{consumer} references credential {addr}"))?;
+            resolved.push(ResolvedCredential { addr, def });
+        }
+
+        check_env_collisions(consumer, &resolved)?;
+        Ok(resolved)
+    }
+
+    /// Acquire a credential's material, or return the material already held.
+    ///
+    /// Single-flighted per address across the process, expiry-aware, and backed by
+    /// the disk tier. `parents` carries the store keys of the credentials that
+    /// *led* here, so a derived credential minted under one root identity is never
+    /// served to a run holding another; it is also the recursion guard.
+    #[async_recursion::async_recursion]
+    pub async fn acquire_credential<'a>(
+        self: &'a Arc<Self>,
+        rs: &'a Arc<RequestState>,
+        addr: &'a Addr,
+        chain: &'a Chain,
+    ) -> anyhow::Result<Acquired> {
+        // Before anything takes a lock. A credential that names itself would
+        // otherwise park on its own cell forever — a one-line BUILD typo turning
+        // into a wedged build with no diagnostic, no timeout and no error.
+        chain.enter(addr)?;
+        let spec = Arc::clone(self).get_spec(rs.clone(), addr).await?;
+        if spec.driver != DRIVER_NAME {
+            anyhow::bail!("{addr} is a `{}` target, not a credential", spec.driver);
+        }
+        let def = parse_declaration(&spec).with_context(|| format!("credential {addr}"))?;
+        self.acquire_declared(rs, addr, &def, chain).await
+    }
+
+    async fn acquire_declared(
+        self: &Arc<Self>,
+        rs: &Arc<RequestState>,
+        addr: &Addr,
+        def: &CredentialDef,
+        chain: &Chain,
+    ) -> anyhow::Result<Acquired> {
+        let addr_s = addr.format();
+        let cell = self.credential_cache.cell(&addr_s, chain.keys());
+        let mut held = cell.lock().await;
+        let now = SystemTime::now();
+
+        if let Some(a) = held.as_ref()
+            && a.material.usable_at(now, a.acquired_at)
+        {
+            return Ok(a.clone());
+        }
+
+        let acquired = self
+            .walk_and_acquire(rs, addr, def, chain)
+            .await
+            .with_context(|| format!("acquire credential {addr}"))?;
+        *held = Some(acquired.clone());
+        Ok(acquired)
+    }
+
+    /// Walk the chain and acquire from the first applicable source.
+    ///
+    /// > A probe answers "is this source applicable here?", not "will it
+    /// > succeed?". The first applicable source *is* the source; an acquire
+    /// > failure is terminal, not a fallthrough.
+    ///
+    /// If a chain fell through on failure, a misconfigured role in CI would
+    /// silently fall back to whatever ambient identity the runner happened to
+    /// have — which is precisely the class of accident this feature prevents.
+    async fn walk_and_acquire(
+        self: &Arc<Self>,
+        rs: &Arc<RequestState>,
+        addr: &Addr,
+        def: &CredentialDef,
+        chain: &Chain,
+    ) -> anyhow::Result<Acquired> {
+        let walk = self.walk_chain(rs, addr, def).await;
+        let Some(step) = walk.iter().find(|s| s.skipped.is_none()) else {
+            // A chain that applies nowhere but *could* be repaired by signing in
+            // is a different failure from one that could not, and the difference
+            // is the whole value of the message: one is a command to run, the
+            // other is a configuration bug. The login argvs travel as structured
+            // data so `--json` consumers and the terminal render the same
+            // instruction.
+            let repairable: Vec<Vec<String>> = walk
+                .iter()
+                .filter_map(|s| def.sources.get(s.index))
+                .flat_map(source_login)
+                .cloned()
+                .collect();
+            if !repairable.is_empty() {
+                return Err(AuthRequiredError {
+                    addr: addr.clone(),
+                    source: walk.first().map(|s| s.label.clone()).unwrap_or_default(),
+                    login: repairable,
+                }
+                .context(NoApplicableSourceError {
+                    addr: addr.clone(),
+                    walk,
+                }));
+            }
+            return Err(NoApplicableSourceError {
+                addr: addr.clone(),
+                walk,
+            }
+            .into());
+        };
+        let index = step.index;
+        let source = def
+            .sources
+            .get(index)
+            .ok_or_else(|| anyhow::anyhow!("chain walk named a source that is not in the chain"))?;
+
+        // The parents this source itself needs, acquired first — their keys are
+        // what makes this credential's key identity-specific. `descend` is what
+        // arms the recursion guard for everything below.
+        let mut inner = chain.descend(addr);
+        for cred in &source.credentials {
+            let cred_addr = self.parse_credential_addr(cred, addr)?;
+            let got = self
+                .acquire_credential(rs, &cred_addr, &inner)
+                .await
+                .with_context(|| format!("{addr} source {} needs {cred_addr}", step.label))?;
+            inner = inner.with_key(got.key);
+        }
+
+        let key = crate::engine::credential_store::resolution_key(
+            &addr.format(),
+            &source_config_key(source),
+            inner.keys(),
+        );
+
+        let store = self.credential_store();
+        let now = SystemTime::now();
+        // The entry's own acquisition time rides back with it. Substituting `now`
+        // would shrink the skew margin — which is `min(60s, lifetime/2)` — for
+        // exactly the entries that have been sitting longest, so a one-hour token
+        // read with seventy seconds left would be handed out with a 35-second
+        // margin instead of the sixty it was written to have.
+        if let Some(hit) = store.get(&key, now) {
+            return Ok(Acquired {
+                material: hit.material,
+                source: hit.source,
+                source_index: index,
+                acquired_at: hit.acquired_at,
+                key,
+                from_disk: true,
+            });
+        }
+
+        // Cross-process lock, so two concurrent `heph` invocations do not both
+        // drive an interactive vendor CLI for the same credential.
+        let _guard = self.credential_lock_guard(&key).await?;
+        // Re-check under the lock: the process we waited for may have just
+        // written the entry.
+        if let Some(hit) = store.get(&key, SystemTime::now()) {
+            return Ok(Acquired {
+                material: hit.material,
+                source: hit.source,
+                source_index: index,
+                acquired_at: hit.acquired_at,
+                key,
+                from_disk: true,
+            });
+        }
+
+        let acquired_at = SystemTime::now();
+        let mut material = self
+            .acquire_from(rs, addr, source, &key, &inner)
+            .await
+            .with_context(|| format!("credential {addr} via {}", step.label))?;
+
+        // A declared `ttl` fills in for material whose source reports no expiry —
+        // and is also what makes such material cacheable at all.
+        if material.expires_at.is_none()
+            && let Some(ttl) = def.ttl
+        {
+            material.expires_at = Some(
+                acquired_at
+                    .checked_add(ttl)
+                    .and_then(|t| t.duration_since(SystemTime::UNIX_EPOCH).ok())
+                    .map(|d| d.as_secs())
+                    .unwrap_or_default(),
+            );
+        }
+
+        // The no-expiry rule covers *files* too, and it cannot be applied inside
+        // `put`: a producer's outputs are written before anything knows whether
+        // the material has an expiry. So they are staged under a per-process
+        // directory — swept of dead pids by the next `heph` — and promoted into
+        // their durable home only once the material has earned the right to
+        // outlive this process. An unbounded producer credential still works for
+        // the whole run; what it does not do is leave a `0600` secret behind
+        // that only `heph auth logout` would ever collect.
+        let staged = !material.files.is_empty()
+            && material
+                .files
+                .values()
+                .any(|p| p.starts_with(store.staged_files_dir(&key)));
+        if material.expires_at.is_some() && staged {
+            let durable = store
+                .promote_staged(&key)
+                .with_context(|| format!("keep credential {addr}'s files"))?;
+            for path in material.files.values_mut() {
+                if let Some(name) = path.file_name() {
+                    *path = durable.join(name);
+                }
+            }
+        }
+        store
+            .put(&key, &addr.format(), &step.label, &material, acquired_at)
+            .with_context(|| format!("cache credential {addr}"))?;
+
+        Ok(Acquired {
+            material,
+            source: step.label.clone(),
+            source_index: index,
+            acquired_at,
+            key,
+            from_disk: false,
+        })
+    }
+
+    /// Re-acquire from **one named source**, for a helper callback whose pinned
+    /// material has lapsed.
+    ///
+    /// Deliberately not a chain walk. The host already chose; a callback running
+    /// in a sandbox must not be able to choose differently, so this either
+    /// acquires from that source or fails saying why it cannot — never silently
+    /// from another. It is also why the failure message names the environment: a
+    /// refresh inside a sandbox has no `HOME`, no vendor session and no OIDC
+    /// endpoint, so an `exec`-sourced credential genuinely cannot refresh there,
+    /// and saying so beats a vendor SDK's own error.
+    pub async fn refresh_credential_source(
+        self: &Arc<Self>,
+        rs: &Arc<RequestState>,
+        addr: &Addr,
+        source_index: usize,
+    ) -> anyhow::Result<Material> {
+        let spec = Arc::clone(self).get_spec(rs.clone(), addr).await?;
+        let def = parse_declaration(&spec).with_context(|| format!("credential {addr}"))?;
+        let source = def.sources.get(source_index).ok_or_else(|| {
+            anyhow::anyhow!(
+                "credential {addr} no longer has a source at position {source_index} — the \
+                 declaration changed while a target was running"
+            )
+        })?;
+        if let Some(reason) = self
+            .probe_source(rs, addr, source)
+            .await
+            .unwrap_or_else(|e| Some(format!("{e:#}")))
+        {
+            anyhow::bail!(
+                "credential {addr} expired and its source {} cannot be re-run here: {reason}. A \
+                 credential helper is called back from inside the target's sandbox, which has no \
+                 HOME, no vendor session and no CI OIDC endpoint — so a source that needs any of \
+                 those can refresh only between builds, not during one. Shorten the target, or \
+                 declare a source that can",
+                source.label()
+            );
+        }
+        let key = crate::engine::credential_store::resolution_key(
+            &addr.format(),
+            &source_config_key(source),
+            &[],
+        );
+        self.acquire_from(rs, addr, source, &key, &Chain::root())
+            .await
+            .with_context(|| format!("refresh credential {addr} via {}", source.label()))
+    }
+
+    /// Run one sign-in command, in the environment its source runs in.
+    ///
+    /// Through `hexecrunner`, not `std::process::Command`, and for the same reason
+    /// the *probe* goes through it: if a source names a runner because its tool
+    /// lives in a devenv shell, then the login for that tool lives there too. A
+    /// probe that correctly asks the runner, followed by a login that runs on the
+    /// bare host, is two halves of one feature disagreeing about where the tool
+    /// is — and the user is left being told to run a command that cannot work.
+    ///
+    /// Stdio is **inherited**, deliberately. A browser flow needs the terminal
+    /// when there is one, and an agent needs to *see* the URL and code on its own
+    /// output when there is not; capturing would strand the second case with no
+    /// path forward.
+    pub async fn run_login(
+        self: &Arc<Self>,
+        rs: &Arc<RequestState>,
+        addr: &Addr,
+        source: &SourceDecl,
+        argv: &[String],
+    ) -> anyhow::Result<std::process::ExitStatus> {
+        let (program, args) = argv
+            .split_first()
+            .ok_or_else(|| anyhow::anyhow!("empty login command"))?;
+        let runner_addr = match &source.kind {
+            SourceKind::Exec { runner, .. } => runner
+                .as_deref()
+                .map(|r| self.parse_credential_addr(r, addr))
+                .transpose()?,
+            _ => None,
+        };
+        let program_path = match runner_addr {
+            None => which::which(program).unwrap_or_else(|_e| PathBuf::from(program)),
+            Some(_) => PathBuf::from(program),
+        };
+        let spec = hproc::proc_exec::Spec {
+            program: program_path,
+            args: args.iter().map(std::ffi::OsString::from).collect(),
+            // A login is interactive and belongs to the user, not to a build, so
+            // it gets the user's own environment rather than the acquire
+            // allowlist: a browser flow reads `BROWSER`, `DISPLAY`, proxy
+            // settings and whatever else the vendor CLI needs to open a page.
+            env: std::env::vars_os().collect(),
+            cwd: self.cfg.root.clone(),
+            stdin: hproc::proc_exec::StdioSpec::Inherit,
+            stdout: hproc::proc_exec::StdioSpec::Inherit,
+            stderr: hproc::proc_exec::StdioSpec::Inherit,
+            setsid: false,
+            ctty: false,
+        };
+        let runner_ref = match &runner_addr {
+            Some(a) => hexecrunner::RunnerRef::target(rs.request_id(), a),
+            None => hexecrunner::RunnerRef::local(),
+        };
+        let handle = hexecrunner::spawn(runner_ref, spec, rs.ctoken())
+            .await
+            .with_context(|| format!("run {program}"))?;
+        // `spawn_wait` rather than a bare await: waiting parks its worker for the
+        // child's whole lifetime, which for a browser sign-in is however long the
+        // human takes.
+        handle
+            .spawn_wait(Arc::new(hcore::hasync::StdCancellationToken::new()))
+            .await
+            .context("the sign-in task panicked")?
+            .with_context(|| format!("wait for {program}"))
+    }
+
+    /// Probe every source in order, recording why each was skipped.
+    ///
+    /// The whole walk is computed rather than stopping at the winner, because
+    /// `heph auth explain` and the "no source applies" error print the same
+    /// structure — so the diagnostic and the failure can never drift apart.
+    pub async fn walk_chain(
+        self: &Arc<Self>,
+        rs: &Arc<RequestState>,
+        addr: &Addr,
+        def: &CredentialDef,
+    ) -> Vec<WalkStep> {
+        let mut out = Vec::with_capacity(def.sources.len());
+        let mut chosen = false;
+        for (index, source) in def.sources.iter().enumerate() {
+            let hint = source.hint.clone().unwrap_or_else(|| source.default_hint());
+            if chosen {
+                out.push(WalkStep {
+                    index,
+                    label: source.label(),
+                    skipped: Some("not reached: an earlier source applied".to_string()),
+                    hint,
+                });
+                continue;
+            }
+            let skipped = match self.probe_source(rs, addr, source).await {
+                Ok(None) => None,
+                Ok(Some(reason)) => Some(reason),
+                // A probe that *errors* is a skip with the error as the reason:
+                // it answers "not applicable here" just as well as a clean miss,
+                // and turning it into a build failure would make an unrelated
+                // broken tool on PATH fatal to a chain that has a working
+                // alternative below it.
+                Err(e) => Some(format!("{e:#}")),
+            };
+            chosen |= skipped.is_none();
+            out.push(WalkStep {
+                index,
+                label: source.label(),
+                skipped,
+                hint,
+            });
+        }
+        out
+    }
+
+    /// `Ok(None)` = applicable. `Ok(Some(reason))` = skipped, with the reason.
+    async fn probe_source(
+        self: &Arc<Self>,
+        rs: &Arc<RequestState>,
+        addr: &Addr,
+        source: &SourceDecl,
+    ) -> anyhow::Result<Option<String>> {
+        if let Some(when) = &source.when
+            && let Some(reason) = when_unmet(when)
+        {
+            return Ok(Some(reason));
+        }
+        Ok(match &source.kind {
+            SourceKind::Env { names } => names
+                .iter()
+                .find(|n| host_env(n).is_none())
+                .map(|n| format!("{n} unset")),
+            SourceKind::File { path, .. } => {
+                let p = expand_home(path);
+                (!p.exists()).then(|| format!("{} does not exist", p.display()))
+            }
+            SourceKind::Exec { run, runner, .. } => {
+                let program = run.first().map(String::as_str).unwrap_or_default();
+                self.probe_program(rs, addr, program, runner.as_deref())
+                    .await?
+            }
+            SourceKind::Passthrough { paths, .. } => paths
+                .values()
+                .map(|p| expand_home(p))
+                .find(|p| !p.exists())
+                .map(|p| format!("{} does not exist", p.display())),
+            SourceKind::Oidc { provider, .. } => oidc_unavailable(provider),
+            // A target has no cheap probe — you cannot ask "is this applicable
+            // here?" of a target without running it — so it is selected by `when`
+            // alone, which is exactly right for the case it serves: "am I in CI"
+            // is a `when`, "is the AWS CLI installed" is a probe.
+            SourceKind::Target { .. } => None,
+        })
+    }
+
+    /// Whether `program` resolves where this source would run it.
+    ///
+    /// Under a runner the question is about the *runner's* environment, not this
+    /// host's: probing the host for a program that lives in a devenv shell answers
+    /// the wrong question, and answering it wrongly is how a chain silently picks
+    /// the next source down.
+    async fn probe_program(
+        self: &Arc<Self>,
+        rs: &Arc<RequestState>,
+        addr: &Addr,
+        program: &str,
+        runner: Option<&str>,
+    ) -> anyhow::Result<Option<String>> {
+        let Some(runner) = runner else {
+            return Ok(which::which(program)
+                .is_err()
+                .then(|| format!("`{program}` not found on PATH")));
+        };
+        let runner_addr = self.parse_credential_addr(runner, addr)?;
+        // `command -v` through a POSIX shell is the portable "does this resolve
+        // here" question, and it is the only one that can be asked *inside*
+        // another environment without running the tool itself.
+        let spec = hproc::proc_exec::Spec {
+            program: PathBuf::from("sh"),
+            args: vec![
+                std::ffi::OsString::from("-c"),
+                std::ffi::OsString::from("command -v -- \"$1\" >/dev/null"),
+                std::ffi::OsString::from("sh"),
+                std::ffi::OsString::from(program),
+            ],
+            env: vec![],
+            cwd: self.cfg.root.clone(),
+            stdin: hproc::proc_exec::StdioSpec::Null,
+            stdout: hproc::proc_exec::StdioSpec::Piped,
+            stderr: hproc::proc_exec::StdioSpec::Piped,
+            setsid: false,
+            ctty: false,
+        };
+        let out = hexecrunner::output(
+            hexecrunner::RunnerRef::target(rs.request_id(), &runner_addr),
+            spec,
+            rs.ctoken(),
+        )
+        .await
+        .with_context(|| format!("probe `{program}` under runner {runner_addr}"))?;
+        Ok((!out.status.success()).then(|| format!("`{program}` not found in {runner_addr}")))
+    }
+
+    async fn acquire_from(
+        self: &Arc<Self>,
+        rs: &Arc<RequestState>,
+        addr: &Addr,
+        source: &SourceDecl,
+        key: &str,
+        chain: &Chain,
+    ) -> anyhow::Result<Material> {
+        match &source.kind {
+            SourceKind::Env { names } => {
+                let mut fields = BTreeMap::new();
+                for n in names {
+                    let v = host_env(n).ok_or_else(|| {
+                        anyhow::anyhow!("{n} is unset — the probe said it was set")
+                    })?;
+                    fields.insert(env_field_name(n), v);
+                }
+                Ok(Material {
+                    fields,
+                    ..Material::default()
+                })
+            }
+            SourceKind::File {
+                path,
+                fields,
+                expires,
+            } => {
+                let p = expand_home(path);
+                let body =
+                    std::fs::read_to_string(&p).with_context(|| format!("read {}", p.display()))?;
+                material_from_text(&body, fields, expires.as_deref())
+            }
+            SourceKind::Exec {
+                run,
+                fields,
+                expires,
+                runner,
+                ..
+            } => {
+                let stdout = self
+                    .run_acquire_command(rs, addr, source, run, runner.as_deref(), chain)
+                    .await?;
+                material_from_text(&stdout, fields, expires.as_deref())
+            }
+            SourceKind::Passthrough { paths, .. } => {
+                let mut files = BTreeMap::new();
+                for (name, path) in paths {
+                    let p = expand_home(path);
+                    if !p.exists() {
+                        anyhow::bail!("{} does not exist", p.display());
+                    }
+                    files.insert(name.clone(), p);
+                }
+                Ok(Material {
+                    files,
+                    ..Material::default()
+                })
+            }
+            SourceKind::Oidc { provider, audience } => {
+                let token = self.mint_oidc_token(provider, audience).await?;
+                Ok(Material {
+                    fields: BTreeMap::from([("id_token".to_string(), token)]),
+                    ..Material::default()
+                })
+            }
+            SourceKind::Target { addr: target } => {
+                let target_addr = self.parse_credential_addr(target, addr)?;
+                self.material_from_target(rs, &target_addr, key, chain)
+                    .await
+            }
+        }
+    }
+
+    /// Resolve an address written in a credential declaration.
+    ///
+    /// Relative to the *declaring credential's* package, not the consumer's:
+    /// a chain is written once and read from everywhere, so what `:vault` means
+    /// must not depend on who asked.
+    fn parse_credential_addr(&self, raw: &str, from: &Addr) -> anyhow::Result<Addr> {
+        hmodel::htaddr::parse_addr_with_base(raw, &from.package)
+            .with_context(|| format!("credential {from} names {raw:?}"))
+    }
+
+    /// A source that is a target: either another credential (a delegation) or a
+    /// producer whose outputs are the material.
+    ///
+    /// The driver of the referenced target decides which, so this needs no syntax
+    /// of its own.
+    async fn material_from_target(
+        self: &Arc<Self>,
+        rs: &Arc<RequestState>,
+        target: &Addr,
+        key: &str,
+        chain: &Chain,
+    ) -> anyhow::Result<Material> {
+        let spec = Arc::clone(self).get_spec(rs.clone(), target).await?;
+        if spec.driver == DRIVER_NAME {
+            // Delegation: take that credential's material, apply this
+            // credential's presentation. `chain` already includes the delegating
+            // credential, so `a → a` and `a → b → a` are caught rather than
+            // parking on a held cell.
+            return Ok(self.acquire_credential(rs, target, chain).await?.material);
+        }
+        self.material_from_producer(rs, target, key).await
+    }
+
+    /// Run a producer target and take its outputs into the credential store.
+    ///
+    /// **This is the interception the design prices as the one piece of real
+    /// engine work.** A target's outputs normally land in the artifact store, and
+    /// material in the build cache is the invariant this whole feature exists to
+    /// preserve. So a producer is run through `execute` directly and its output
+    /// bytes are copied into the credential store at `0600`; `cache_locally` is
+    /// never reached and no artifact for it ever exists.
+    ///
+    /// `cache = False` is required and enforced here rather than documented,
+    /// because a cacheable producer would be pushed to the shared remote before
+    /// anything here could intervene.
+    async fn material_from_producer(
+        self: &Arc<Self>,
+        rs: &Arc<RequestState>,
+        target: &Addr,
+        key: &str,
+    ) -> anyhow::Result<Material> {
+        let spec = Arc::clone(self).get_spec(rs.clone(), target).await?;
+        let def = Arc::clone(self).get_def(rs.clone(), target).await?;
+        if def.target_def.cache.enabled {
+            anyhow::bail!(
+                "{target} is used as a credential source, so it must set `cache = False` — its \
+                 outputs are material, and a cacheable target's outputs are written to the local \
+                 cache and pushed to the shared remote automatically"
+            );
+        }
+        let linked = Arc::clone(self)
+            .link(rs.clone(), Arc::clone(&def.target_def))
+            .await
+            .with_context(|| format!("link credential source {target}"))?;
+        let meta = Arc::clone(self).meta(rs.clone(), target).await?;
+        self.gate_approval(rs, &spec, &linked)
+            .await
+            .with_context(|| format!("approval {target}"))?;
+
+        // The per-addr execute lock, taken by hand because this path deliberately
+        // sidesteps `result_addr`. Without it two runs of one producer — this one
+        // and an ordinary `heph run` of the same target — both claim
+        // `<home>/sandbox/<pkg>/__target_<name>`, and the second claim's
+        // `remove_stale` deletes the first's live tree. `credential_lock` does not
+        // cover this: it is keyed on a resolution key, not on an address.
+        let _w = self
+            .acquire_with_notice(rs, target, self.result_lock().write(target, rs.ctoken()))
+            .await?;
+
+        let run = Arc::clone(self)
+            .execute(
+                rs.clone(),
+                target,
+                &spec,
+                &linked,
+                &meta.hashin,
+                None,
+                false,
+                false,
+                // The outputs are material: a failure must not leave them in a
+                // sandbox kept for diagnostics.
+                true,
+            )
+            .await;
+
+        let (artifacts, teardown, guards) = match run {
+            Ok(v) => v,
+            Err(e) => {
+                return Err(e).with_context(|| format!("run credential source {target}"));
+            }
+        };
+
+        let material = read_producer_outputs(&artifacts, self.credential_store(), key)
+            .with_context(|| format!("read credential material from {target}"));
+
+        drop(guards);
+        teardown.complete(target.format());
+        material
+    }
+
+    /// Run an inline `exec` source's command and return its stdout.
+    ///
+    /// Goes through `hexecrunner` like every other subprocess heph spawns, so a
+    /// source can name a runner and its command runs inside that environment —
+    /// and so a source that shells out to a secret manager can be handed the
+    /// credentials it needs, presented exactly as they would be to a consumer.
+    async fn run_acquire_command(
+        self: &Arc<Self>,
+        rs: &Arc<RequestState>,
+        addr: &Addr,
+        source: &SourceDecl,
+        run: &[String],
+        runner: Option<&str>,
+        chain: &Chain,
+    ) -> anyhow::Result<String> {
+        let (program, args) = run
+            .split_first()
+            .ok_or_else(|| anyhow::anyhow!("empty credential command"))?;
+
+        // The source's own credentials, presented to its subprocess. The machinery
+        // is the consumer's, unchanged: an acquire subprocess is just another
+        // consumer of a presentation.
+        //
+        // The presented files ride an RAII guard rather than a deferred cleanup
+        // list: this function can leave by `?` (a second credential's
+        // presentation fails) or by being dropped (cancellation), and both used to
+        // leave a 0600 token on disk with nothing to collect it.
+        let mut env: Vec<(std::ffi::OsString, std::ffi::OsString)> = acquire_base_env();
+        let mut presented = CredentialTeardown::none();
+        for cred in &source.credentials {
+            let cred_addr = self.parse_credential_addr(cred, addr)?;
+            let cred_spec = Arc::clone(self).get_spec(rs.clone(), &cred_addr).await?;
+            let cred_def = parse_declaration(&cred_spec)?;
+            let acquired = self.acquire_credential(rs, &cred_addr, chain).await?;
+            let source_decl = cred_def.sources.get(acquired.source_index);
+            let present = match source_decl {
+                Some(sd) => cred_def.presentation_for(sd)?,
+                None => anyhow::bail!("credential {cred_addr} chose a source that vanished"),
+            };
+            // Unique per acquisition, not per resolution key: two credentials
+            // naming one source-credential resolve to the same key, and a shared
+            // directory means one acquisition's teardown deletes the other's
+            // files while its subprocess is still reading them.
+            let dir = presented.add_under(self.credential_store().root())?;
+            let mount = self
+                .present_material(&cred_addr, present, &acquired, &dir)
+                .with_context(|| format!("present {cred_addr} to a credential command"))?;
+            env.extend(
+                mount
+                    .env
+                    .into_iter()
+                    .map(|(k, v)| (std::ffi::OsString::from(k), std::ffi::OsString::from(v))),
+            );
+        }
+
+        let runner_addr = runner
+            .map(|r| self.parse_credential_addr(r, addr))
+            .transpose()?;
+        // The probe answered with `which::which` against *this* PATH, so the
+        // spawn has to ask the same question or the two disagree: a bare program
+        // name spawned into a cleared environment resolves against `confstr(_CS_PATH)`,
+        // which is `/usr/bin:/bin` — where neither `aws` nor `gcloud` nor `vault`
+        // is installed on any supported target. Under a runner the runner supplies
+        // the PATH and resolves the name itself, so leave it alone there.
+        let program_path = match runner_addr {
+            None => which::which(program).unwrap_or_else(|_e| PathBuf::from(program)),
+            Some(_) => PathBuf::from(program),
+        };
+        let spec = hproc::proc_exec::Spec {
+            program: program_path,
+            args: args.iter().map(std::ffi::OsString::from).collect(),
+            env,
+            cwd: self.cfg.root.clone(),
+            stdin: hproc::proc_exec::StdioSpec::Null,
+            stdout: hproc::proc_exec::StdioSpec::Piped,
+            stderr: hproc::proc_exec::StdioSpec::Piped,
+            setsid: false,
+            ctty: false,
+        };
+        let runner_ref = match &runner_addr {
+            Some(a) => hexecrunner::RunnerRef::target(rs.request_id(), a),
+            None => hexecrunner::RunnerRef::local(),
+        };
+        let out = hexecrunner::output(runner_ref, spec, rs.ctoken())
+            .await
+            .with_context(|| format!("run {program}"))?;
+        drop(presented);
+        if !out.status.success() {
+            // stderr, never stdout: stdout is the credential.
+            anyhow::bail!(
+                "{program} exited with {}: {}",
+                out.status,
+                String::from_utf8_lossy(&out.stderr).trim()
+            );
+        }
+        String::from_utf8(out.stdout)
+            .with_context(|| format!("{program} printed something that is not UTF-8"))
+    }
+
+    /// Mint a workload-identity token from the CI provider's own endpoint.
+    async fn mint_oidc_token(
+        self: &Arc<Self>,
+        provider: &str,
+        audience: &str,
+    ) -> anyhow::Result<String> {
+        match provider {
+            "github_actions" => {
+                let url = host_env(GHA_OIDC_URL).ok_or_else(|| {
+                    anyhow::anyhow!(
+                        "{GHA_OIDC_URL} is unset — add `permissions: {{ id-token: write }}` to the \
+                         job"
+                    )
+                })?;
+                let token = host_env(GHA_OIDC_TOKEN).ok_or_else(|| {
+                    anyhow::anyhow!("{GHA_OIDC_TOKEN} is unset — the OIDC endpoint needs it")
+                })?;
+                let url = if audience.is_empty() {
+                    url
+                } else {
+                    format!(
+                        "{url}{}audience={}",
+                        if url.contains('?') { "&" } else { "?" },
+                        urlencode(audience)
+                    )
+                };
+                let body: String = hcore::blocking::run(move || {
+                    let resp = reqwest::blocking::Client::new()
+                        .get(&url)
+                        .bearer_auth(&token)
+                        .send()
+                        .context("call the OIDC endpoint")?;
+                    let status = resp.status();
+                    let text = resp.text().context("read the OIDC response")?;
+                    if !status.is_success() {
+                        anyhow::bail!("the OIDC endpoint answered {status}");
+                    }
+                    anyhow::Ok(text)
+                })
+                .await?;
+                let doc: serde_json::Value = serde_json::from_str(&body)
+                    .context("the OIDC endpoint did not answer with JSON")?;
+                doc.get("value")
+                    .and_then(|v| v.as_str())
+                    .map(str::to_string)
+                    .ok_or_else(|| anyhow::anyhow!("the OIDC response carried no `value`"))
+            }
+            // A token some other CI provider already put where heph can find it.
+            // Deliberately generic: the alternative is a provider list with no end.
+            "generic" => {
+                if let Some(t) = host_env(GENERIC_OIDC_TOKEN) {
+                    return Ok(t);
+                }
+                let path = host_env(GENERIC_OIDC_TOKEN_FILE).ok_or_else(|| {
+                    anyhow::anyhow!(
+                        "neither {GENERIC_OIDC_TOKEN} nor {GENERIC_OIDC_TOKEN_FILE} is set"
+                    )
+                })?;
+                std::fs::read_to_string(&path)
+                    .map(|s| s.trim().to_string())
+                    .with_context(|| format!("read {path}"))
+            }
+            other => anyhow::bail!("unknown oidc provider {other:?}"),
+        }
+    }
+
+    /// Acquire and present every credential a target declared.
+    ///
+    /// Returns the mounts the driver applies, plus a teardown that deletes the
+    /// presented files. Runs strictly *downstream* of runner preparation, which is
+    /// the rule that keeps the devenv `wrap` runner's environment capture — a
+    /// cached, remotely-shippable `runner.json` — from ever seeing material.
+    pub(crate) async fn acquire_and_present(
+        self: &Arc<Self>,
+        rs: &Arc<RequestState>,
+        consumer: &Addr,
+        sandbox_dir: &Path,
+        resolved: &[ResolvedCredential],
+    ) -> anyhow::Result<(Vec<CredentialMount>, CredentialTeardown)> {
+        if resolved.is_empty() {
+            return Ok((Vec::new(), CredentialTeardown::none()));
+        }
+        let root = credential_dir(sandbox_dir);
+        let mut mounts = Vec::with_capacity(resolved.len());
+        for rc in resolved {
+            let acquired = self
+                .acquire_declared(rs, &rc.addr, &rc.def, &Chain::root())
+                .await
+                .with_context(|| format!("{consumer} needs credential {}", rc.addr))?;
+            let source = rc.def.sources.get(acquired.source_index).ok_or_else(|| {
+                anyhow::anyhow!("credential {} chose a source that vanished", rc.addr)
+            })?;
+            let present = rc.def.presentation_for(source)?;
+            let dir = root.join(sanitize_addr(&rc.addr));
+            let mount = self
+                .present_material(&rc.addr, present, &acquired, &dir)
+                .with_context(|| format!("present credential {} to {consumer}", rc.addr))?;
+            mounts.push(mount);
+        }
+        Ok((mounts, CredentialTeardown::at(root)))
+    }
+
+    /// Turn material plus a presentation into a mount, writing any files.
+    pub(crate) fn present_material(
+        self: &Arc<Self>,
+        addr: &Addr,
+        present: &Presentation,
+        acquired: &Acquired,
+        dir: &Path,
+    ) -> anyhow::Result<CredentialMount> {
+        let material = &acquired.material;
+        let helper_command = helper_command()?;
+
+        // Written before anything that might name it, because every helper
+        // document's argv points at it. Only for a helper presentation: nothing
+        // else calls back, so nothing else needs the material on disk.
+        let pin_path = dir.join(HELPER_PIN_FILE);
+        if present.helper.is_some() {
+            let pin = HelperPin {
+                addr: addr.format(),
+                root: self.cfg.root.clone(),
+                source_index: acquired.source_index,
+                acquired_at: acquired
+                    .acquired_at
+                    .duration_since(SystemTime::UNIX_EPOCH)
+                    .unwrap_or_default()
+                    .as_secs(),
+                material: material.clone(),
+            };
+            crate::engine::credential_store::write_private_file(
+                &pin_path,
+                &serde_json::to_vec(&pin).context("serialize the credential helper pin")?,
+            )
+            .with_context(|| format!("write the credential helper pin for {addr}"))?;
+        }
+        let helper_args = |dialect: Dialect| {
+            vec![
+                crate::engine::credential::AUTH_HELPER_SUBCOMMAND.to_string(),
+                dialect.as_str().to_string(),
+                "--pin".to_string(),
+                pin_path.to_string_lossy().into_owned(),
+            ]
+        };
+
+        // Files first: an `env` template may point at one, and a helper document
+        // may be one.
+        let mut files: BTreeMap<String, PathBuf> = material.files.clone();
+        let mut path_prefix: Vec<PathBuf> = Vec::new();
+        let mut env: BTreeMap<String, String> = BTreeMap::new();
+
+        // A file's *content* may name another presented file — `heph.auth.gcp`'s
+        // `external_account` document points at `${file:token}` — so one pass in
+        // map order is not enough. Retry until a round makes no progress, then
+        // report the error from the file that is still stuck.
+        //
+        // Progress-bounded rather than depth-bounded: it terminates because every
+        // round either resolves at least one file or stops, and it does not
+        // silently cap how deep a legitimate chain may be. Refusing to iterate
+        // further than that is what keeps this from becoming a template language.
+        let dialect = present.helper.as_ref().map(|h| h.dialect()).transpose()?;
+        let mut pending: Vec<(&String, &String)> = present.files.iter().collect();
+        let mut stuck: Option<(String, anyhow::Error)> = None;
+        while !pending.is_empty() {
+            let before = pending.len();
+            let mut deferred = Vec::with_capacity(before);
+            stuck = None;
+            for (name, tmpl) in pending {
+                match render(
+                    tmpl,
+                    material,
+                    &files,
+                    dialect,
+                    &helper_command,
+                    &helper_args,
+                ) {
+                    Ok(body) => {
+                        let path = dir.join(name);
+                        crate::engine::credential_store::write_private_file(&path, body.as_bytes())
+                            .with_context(|| format!("write presented file `{name}`"))?;
+                        files.insert(name.clone(), path);
+                    }
+                    Err(e) => {
+                        // Keep the first round's real error — "no material field
+                        // `tokn`" is the message the author needs, not a generic
+                        // "does not resolve".
+                        if stuck.is_none() {
+                            stuck = Some((name.clone(), e));
+                        }
+                        deferred.push((name, tmpl));
+                    }
+                }
+            }
+            // No file resolved this round, so none ever will.
+            if deferred.len() == before {
+                break;
+            }
+            pending = deferred;
+        }
+        if let Some((name, err)) = stuck {
+            return Err(err.context(format!("credential {addr}: presented file `{name}`")));
+        }
+
+        // Helper documents, which are files heph writes rather than the author.
+        if let Some(helper) = &present.helper {
+            let dialect = helper.dialect()?;
+            match dialect {
+                Dialect::Aws => {
+                    let body = format!(
+                        "[default]\ncredential_process = {}\n",
+                        shell_join(&helper_command, &helper_args(dialect))
+                    );
+                    let path = dir.join("aws-config");
+                    crate::engine::credential_store::write_private_file(&path, body.as_bytes())?;
+                    env.insert(
+                        "AWS_CONFIG_FILE".to_string(),
+                        path.to_string_lossy().into_owned(),
+                    );
+                    env.insert("AWS_PROFILE".to_string(), "default".to_string());
+                }
+                Dialect::Gcp => {
+                    let audience = helper.audience.clone().unwrap_or_default();
+                    let mut doc = serde_json::json!({
+                        "type": "external_account",
+                        "audience": audience,
+                        "subject_token_type": "urn:ietf:params:oauth:token-type:jwt",
+                        "token_url": "https://sts.googleapis.com/v1/token",
+                        "credential_source": {
+                            "executable": {
+                                "command": shell_join(&helper_command, &helper_args(dialect)),
+                                "timeout_millis": 30_000,
+                            }
+                        },
+                    });
+                    if let Some(sa) = &helper.impersonate
+                        && let Some(obj) = doc.as_object_mut()
+                    {
+                        obj.insert(
+                            "service_account_impersonation_url".to_string(),
+                            serde_json::Value::String(format!(
+                                "https://iamcredentials.googleapis.com/v1/projects/-/serviceAccounts/{sa}:generateAccessToken"
+                            )),
+                        );
+                    }
+                    let path = dir.join("gcp-adc.json");
+                    crate::engine::credential_store::write_private_file(
+                        &path,
+                        doc.to_string().as_bytes(),
+                    )?;
+                    let p = path.to_string_lossy().into_owned();
+                    env.insert("GOOGLE_APPLICATION_CREDENTIALS".to_string(), p.clone());
+                    env.insert("CLOUDSDK_AUTH_CREDENTIAL_FILE_OVERRIDE".to_string(), p);
+                    // No Google SDK will run an executable credential source
+                    // unless this is set, and forgetting it by hand produces an
+                    // error from inside the SDK rather than from heph.
+                    env.insert(
+                        "GOOGLE_EXTERNAL_ACCOUNT_ALLOW_EXECUTABLES".to_string(),
+                        "1".to_string(),
+                    );
+                }
+                Dialect::Docker => {
+                    let cred_helpers: serde_json::Map<String, serde_json::Value> = helper
+                        .registries
+                        .iter()
+                        .map(|r| (r.clone(), serde_json::Value::String("heph".to_string())))
+                        .collect();
+                    let doc = serde_json::json!({ "credHelpers": cred_helpers });
+                    let cfg_dir = dir.join("docker");
+                    crate::engine::credential_store::write_private_file(
+                        &cfg_dir.join("config.json"),
+                        doc.to_string().as_bytes(),
+                    )?;
+                    // Docker resolves a helper by executable name, so the shim
+                    // has to exist under that exact name somewhere on PATH.
+                    let bin = dir.join("bin");
+                    let shim = bin.join("docker-credential-heph");
+                    let script = format!(
+                        "#!/bin/sh\nexec {} \"$@\"\n",
+                        shell_join(&helper_command, &helper_args(dialect))
+                    );
+                    crate::engine::credential_store::write_private_file(&shim, script.as_bytes())?;
+                    make_executable(&shim)?;
+                    env.insert(
+                        "DOCKER_CONFIG".to_string(),
+                        cfg_dir.to_string_lossy().into_owned(),
+                    );
+                    path_prefix.push(bin);
+                }
+                Dialect::Git => {
+                    // Through the environment rather than a gitconfig: it avoids
+                    // generating a file, avoids any chance of touching the
+                    // developer's real one, and the settings vanish with the
+                    // process.
+                    let helper_value =
+                        format!("!{}", shell_join(&helper_command, &helper_args(dialect)));
+                    env.insert(
+                        "GIT_CONFIG_COUNT".to_string(),
+                        helper.hosts.len().to_string(),
+                    );
+                    for (i, host) in helper.hosts.iter().enumerate() {
+                        env.insert(
+                            format!("GIT_CONFIG_KEY_{i}"),
+                            format!("credential.https://{host}.helper"),
+                        );
+                        env.insert(format!("GIT_CONFIG_VALUE_{i}"), helper_value.clone());
+                    }
+                }
+                // The one dialect where heph writes no document: a kubeconfig is
+                // not purely a credential format, so the author templates it and
+                // places the callback with `${helper:command}` / `${helper:args}`.
+                Dialect::Kubernetes => {}
+            }
+        }
+
+        let dialect = present.helper.as_ref().map(|h| h.dialect()).transpose()?;
+        for (name, tmpl) in &present.env {
+            let value = render(
+                tmpl,
+                material,
+                &files,
+                dialect,
+                &helper_command,
+                &helper_args,
+            )
+            .with_context(|| format!("credential {addr}: environment variable `{name}`"))?;
+            if value.len() > CREDENTIAL_ENV_MAX_BYTES {
+                anyhow::bail!(
+                    "credential {addr}: `{name}` is {} bytes, over the {CREDENTIAL_ENV_MAX_BYTES}-byte \
+                     limit for a presented environment value. Something that large is a document, \
+                     not a token — present it as a `files` entry and point a variable at the path",
+                    value.len()
+                );
+            }
+            // A helper document already claimed some names; an author's own
+            // template must not silently lose to one, or win over one.
+            if let Some(existing) = env.get(name)
+                && existing != &value
+            {
+                anyhow::bail!(
+                    "credential {addr}: `{name}` is set both by the `{}` helper and by this \
+                     presentation's `env`. One would shadow the other — drop it from `env`, or \
+                     use a different variable",
+                    dialect.map(Dialect::as_str).unwrap_or("?")
+                );
+            }
+            env.insert(name.clone(), value);
+        }
+
+        Ok(CredentialMount {
+            addr: addr.clone(),
+            env,
+            path_prefix,
+            // Every material *field*, whether or not this presentation uses it —
+            // so a credential that presents only `${access_key_id}` still scrubs
+            // its session token, which is the value a build step is most likely
+            // to echo.
+            //
+            // File-backed material is deliberately **not** here. A path is not a
+            // secret and redacting it would mangle ordinary output; what is in
+            // the file is the file's problem, and files are `0600` inside a
+            // sandbox that is deleted at run end. The stated consequence is that
+            // a target which `cat`s its own kubeconfig puts that token in
+            // `log.txt` — see `docs/CREDENTIALS.md`, "Redaction".
+            //
+            // The floor is applied here so a driver receives only what it can
+            // safely scrub.
+            redact: material
+                .secrets()
+                .filter(|s| s.len() >= hplugin::driver::REDACT_MIN_LEN)
+                .map(str::to_string)
+                .collect(),
+        })
+    }
+
+    /// Drop every credential this process has acquired. `heph auth logout`.
+    pub fn forget_credentials(&self) {
+        self.credential_cache.clear();
+    }
+
+    fn credential_store(&self) -> CredentialStore {
+        CredentialStore::new(&self.home)
+    }
+
+    /// The cross-process acquisition lock for one resolution key.
+    ///
+    /// Two concurrent `heph` invocations must not both drive an interactive
+    /// vendor CLI for the same credential — that is two browser windows and two
+    /// sessions where the user asked for one.
+    async fn credential_lock_guard(
+        self: &Arc<Self>,
+        key: &str,
+    ) -> anyhow::Result<Box<dyn std::any::Any + Send>> {
+        self.credential_lock.write(key).await
+    }
+}
+
+/// The cross-process acquisition lock, keyed by resolution key.
+///
+/// A [`KeyedRWLock`](hlock::hlock::KeyedRWLock) taken only for write: acquisition
+/// is never a shared operation, so the read half would buy nothing. Its whole job
+/// is to stop two concurrent `heph` invocations both driving an interactive vendor
+/// CLI for the same credential — which is two browser windows and two sessions
+/// where the user asked for one.
+pub enum CredentialLock {
+    /// `flock(2)` files under `<home>/lock/auth/`.
+    Fs(hlock::hlock::KeyedRWLock<String, hlock::hlock::FRWLock>),
+    /// In-process only. Tests, and anything that has opted out of file locking.
+    Mem(hlock::hlock::KeyedRWLock<String, hlock::hlock::MemRWLock>),
+}
+
+impl CredentialLock {
+    pub fn new(backend: crate::engine::result_lock::LockBackend, dir: PathBuf) -> Self {
+        match backend {
+            crate::engine::result_lock::LockBackend::Fs => {
+                Self::Fs(hlock::hlock::KeyedRWLock::new(move |key: &String| {
+                    hlock::hlock::FRWLock::new(dir.join(format!("{key}.auth.lock")))
+                }))
+            }
+            crate::engine::result_lock::LockBackend::Mem => {
+                Self::Mem(hlock::hlock::KeyedRWLock::new(|_k| {
+                    hlock::hlock::MemRWLock::default()
+                }))
+            }
+        }
+    }
+
+    /// Take the exclusive guard for `key`. Type-erased: this code only ever holds
+    /// and drops it.
+    pub async fn write(&self, key: &str) -> anyhow::Result<Box<dyn std::any::Any + Send>> {
+        // Deliberately not cancellable-scoped: an acquisition already in flight
+        // in another process is what this waits on, and abandoning the wait would
+        // just start a second one.
+        let ct = hcore::hasync::StdCancellationToken::new();
+        Ok(match self {
+            Self::Fs(l) => {
+                Box::new(l.write(key.to_string(), &ct).await?) as Box<dyn std::any::Any + Send>
+            }
+            Self::Mem(l) => {
+                Box::new(l.write(key.to_string(), &ct).await?) as Box<dyn std::any::Any + Send>
+            }
+        })
+    }
+}
+
+/// What the host hands a helper callback, so the callback does not have to
+/// rediscover it.
+///
+/// **This is the fix for the sharpest hole a callback presentation has.** A
+/// helper runs inside the *target's* sandbox, where the environment is cleared,
+/// `PATH` is the sandbox's, and there is no `HOME` — so a helper that re-walked
+/// the chain would probe a different environment and could pick a *different
+/// source*, silently acquiring a different identity than the one the host chose.
+/// On a GitHub Actions runner that is concretely: the host wins on
+/// `oidc(github_actions)`, the callback finds no OIDC endpoint in the sandbox,
+/// falls to `exec(aws)`, and the build runs against whatever ambient identity the
+/// runner happened to have — the exact accident the chain exists to prevent.
+///
+/// So the resolution is pinned. The document carries the material itself (the
+/// common case answers from it with no engine, no probe and no environment
+/// dependency at all) and, for the refresh case, the *index of the winning
+/// source*, so a re-acquisition can only ever use the source the host chose.
+///
+/// It lives at `0600` beside the presented files, inside the sandbox, and is
+/// deleted with them at run end.
+#[derive(serde::Serialize, serde::Deserialize)]
+pub struct HelperPin {
+    /// The credential, for diagnostics and for a refresh.
+    pub addr: String,
+    /// The workspace, because a sandbox has its own cwd.
+    pub root: PathBuf,
+    /// Which source the host chose. A refresh may use this one and no other.
+    pub source_index: usize,
+    /// Unix seconds, so `Material::usable_at` means the same thing here.
+    pub acquired_at: u64,
+    pub material: Material,
+}
+
+/// The file a [`HelperPin`] is written to, beside the presented files.
+pub const HELPER_PIN_FILE: &str = "pin.json";
+
+/// `heph __auth-helper` — the hidden subcommand a tool calls back into.
+///
+/// Parsed before the argument parser, since its argv and stdin belong to the
+/// calling tool rather than to heph.
+pub const AUTH_HELPER_SUBCOMMAND: &str = "__auth-helper";
+
+const GHA_OIDC_URL: &str = "ACTIONS_ID_TOKEN_REQUEST_URL";
+const GHA_OIDC_TOKEN: &str = "ACTIONS_ID_TOKEN_REQUEST_TOKEN";
+const GENERIC_OIDC_TOKEN: &str = "HEPH_OIDC_TOKEN";
+const GENERIC_OIDC_TOKEN_FILE: &str = "HEPH_OIDC_TOKEN_FILE";
+
+/// Deletes a run's presented credential files.
+///
+/// Fires whatever the outcome. A failed target's sandbox is deliberately kept for
+/// diagnostics — the failure paragraph reads its log tail lazily — and the log
+/// tail is what makes that useful, not the token.
+pub struct CredentialTeardown {
+    dirs: Vec<PathBuf>,
+}
+
+impl CredentialTeardown {
+    fn none() -> Self {
+        Self { dirs: Vec::new() }
+    }
+
+    fn at(dir: PathBuf) -> Self {
+        Self { dirs: vec![dir] }
+    }
+
+    /// Claim a fresh, uniquely-named private directory under `root`, owned by
+    /// this guard.
+    ///
+    /// Unique per call rather than keyed on anything: two acquisitions of the
+    /// same credential resolve to the same key, and a shared directory means one
+    /// teardown deletes files another subprocess is still reading.
+    fn add_under(&mut self, root: &Path) -> anyhow::Result<PathBuf> {
+        use std::sync::atomic::{AtomicU64, Ordering};
+        static SEQ: AtomicU64 = AtomicU64::new(0);
+        let dir = root.join("acquire").join(format!(
+            "{}-{}",
+            std::process::id(),
+            SEQ.fetch_add(1, Ordering::Relaxed)
+        ));
+        crate::engine::credential_store::ensure_private_dir(&dir)?;
+        self.dirs.push(dir.clone());
+        Ok(dir)
+    }
+}
+
+impl Drop for CredentialTeardown {
+    fn drop(&mut self) {
+        for dir in self.dirs.drain(..) {
+            drop(std::fs::remove_dir_all(dir));
+        }
+    }
+}
+
+/// The host variables an acquire subprocess is handed, and nothing else.
+///
+/// An explicit allowlist rather than an empty environment or the whole host's.
+/// Empty is what the first version did, and it does not work: `execve` with a
+/// cleared environ resolves a bare program name against `confstr(_CS_PATH)`, and
+/// every vendor CLI worth acquiring from (`aws`, `gcloud`, `az`, `vault`) reads
+/// `$HOME` to find the session cache the probe just decided was there. Passing
+/// the whole host environment is the other extreme, and is how a source quietly
+/// picks up an ambient identity the declaration never mentioned — the accident
+/// the chain exists to prevent.
+///
+/// So: enough to *find and run* a tool, and nothing that names an identity. A
+/// source that needs more says so with `credentials`, which is presented on top
+/// of this.
+fn acquire_base_env() -> Vec<(std::ffi::OsString, std::ffi::OsString)> {
+    // `PATH` so the program can be found at all and can find its own libraries;
+    // `HOME` because every vendor CLI keeps its session under it, which is what
+    // the probe just decided was there; `TMPDIR` because some refuse to start
+    // without one; `LANG`/`LC_ALL` so a CLI that formats its output formats it
+    // the same way twice; `TERM` because one that finds none behaves better than
+    // one that guesses.
+    const ALLOWED: &[&str] = &["PATH", "HOME", "TMPDIR", "LANG", "LC_ALL", "TERM"];
+    ALLOWED
+        .iter()
+        .filter_map(|k| std::env::var_os(k).map(|v| (std::ffi::OsString::from(*k), v)))
+        .collect()
+}
+
+/// The part of a source declaration that decides which material it yields.
+///
+/// The **whole** declaration, not just its `kind`. Two `exec` sources running one
+/// command under different `when`s serialize their kinds identically, and keying
+/// on that alone would let a build under `when = "env:STAGING"` be served the
+/// entry a build under `when = "env:PROD"` wrote — which is a build acting as the
+/// wrong principal, the one thing this key exists to prevent.
+fn source_config_key(source: &SourceDecl) -> String {
+    serde_json::to_string(source).unwrap_or_default()
+}
+
+/// Where a run's presented credential files go: beside the workspace directory,
+/// never inside it. See the module docs — output collection walks the workspace
+/// directory and packs every regular file it finds.
+pub fn credential_dir(sandbox_dir: &Path) -> PathBuf {
+    sandbox_dir.join(".heph").join("auth")
+}
+
+/// One path component per credential, from its *full* address.
+///
+/// The address rather than the name, so two credentials called `aws` in different
+/// packages cannot collide.
+fn sanitize_addr(addr: &Addr) -> String {
+    addr.format()
+        .chars()
+        .map(|c| {
+            if c.is_ascii_alphanumeric() || c == '.' || c == '-' || c == '_' {
+                c
+            } else {
+                '_'
+            }
+        })
+        .collect()
+}
+
+/// The material field name an `env` source yields for a variable: the name,
+/// lowercased. `GITHUB_TOKEN` → `${github_token}`.
+fn env_field_name(name: &str) -> String {
+    name.to_ascii_lowercase()
+}
+
+/// Read a host environment variable, treating empty as unset.
+///
+/// Empty-as-unset because CI systems routinely export a variable with no value
+/// for a secret that was not configured, and treating that as "present" makes a
+/// probe pick a source that cannot possibly work.
+fn host_env(name: &str) -> Option<String> {
+    std::env::var(name).ok().filter(|v| !v.is_empty())
+}
+
+/// `~` expansion, because every vendor CLI writes under it and a declaration that
+/// had to spell out `/Users/x` would not be portable between a laptop and CI.
+fn expand_home(path: &str) -> PathBuf {
+    if let Some(rest) = path.strip_prefix("~/")
+        && let Some(home) = std::env::var_os("HOME")
+    {
+        return PathBuf::from(home).join(rest);
+    }
+    PathBuf::from(path)
+}
+
+/// `Some(reason)` when this `when` does not hold here.
+fn when_unmet(when: &When) -> Option<String> {
+    match when {
+        When::Ci => (detected_ci_provider(&|n| host_env(n)).is_none())
+            .then(|| "not running in a CI provider heph recognizes".to_string()),
+        When::CiProvider(p) => {
+            let got = detected_ci_provider(&|n| host_env(n));
+            (got != Some(p.as_str())).then(|| match got {
+                Some(other) => format!("running in {other}, not {p}"),
+                None => format!("not running in {p}"),
+            })
+        }
+        When::Interactive => (!std::io::IsTerminal::is_terminal(&std::io::stderr()))
+            .then(|| "no terminal is attached".to_string()),
+        When::Env(n) => host_env(n).is_none().then(|| format!("{n} unset")),
+        When::Os(o) => {
+            let here = if cfg!(target_os = "macos") {
+                "darwin"
+            } else {
+                "linux"
+            };
+            (here != o).then(|| format!("running on {here}, not {o}"))
+        }
+    }
+}
+
+/// `Some(reason)` when this OIDC provider is not present here.
+fn oidc_unavailable(provider: &str) -> Option<String> {
+    match provider {
+        "github_actions" => host_env(GHA_OIDC_URL)
+            .is_none()
+            .then(|| format!("{GHA_OIDC_URL} unset")),
+        "generic" => (host_env(GENERIC_OIDC_TOKEN).is_none()
+            && host_env(GENERIC_OIDC_TOKEN_FILE).is_none())
+        .then(|| format!("neither {GENERIC_OIDC_TOKEN} nor {GENERIC_OIDC_TOKEN_FILE} is set")),
+        other => Some(format!("unknown oidc provider {other:?}")),
+    }
+}
+
+/// Build material from a source's stdout or a file's contents.
+///
+/// With no field map the whole text is `${value}` — which is what a command
+/// printing a bare token needs, and it is deliberately the *only* thing heph
+/// guesses about a vendor's output.
+pub(crate) fn material_from_text(
+    text: &str,
+    fields: &BTreeMap<String, String>,
+    expires: Option<&str>,
+) -> anyhow::Result<Material> {
+    if fields.is_empty() && expires.is_none() {
+        return Ok(Material {
+            fields: BTreeMap::from([("value".to_string(), text.trim().to_string())]),
+            ..Material::default()
+        });
+    }
+    let doc: serde_json::Value = serde_json::from_str(text.trim()).context(
+        "the source printed something that is not JSON, but `fields`/`expires` name JSON keys",
+    )?;
+    let mut out = BTreeMap::new();
+    for (field, key) in fields {
+        let v = json_path(&doc, key)
+            .ok_or_else(|| anyhow::anyhow!("the source's JSON has no `{key}`"))?;
+        let s = match v {
+            serde_json::Value::String(s) => s.clone(),
+            serde_json::Value::Number(n) => n.to_string(),
+            serde_json::Value::Bool(b) => b.to_string(),
+            other => anyhow::bail!("`{key}` is {other}, which is not a credential field"),
+        };
+        out.insert(field.clone(), s);
+    }
+    let expires_at = expires
+        .and_then(|key| json_path(&doc, key))
+        .map(parse_expiry)
+        .transpose()?;
+    Ok(Material {
+        fields: out,
+        files: BTreeMap::new(),
+        expires_at,
+    })
+}
+
+/// A dotted path into a JSON document: `data.token`.
+fn json_path<'a>(doc: &'a serde_json::Value, key: &str) -> Option<&'a serde_json::Value> {
+    key.split('.').try_fold(doc, |d, part| d.get(part))
+}
+
+/// An expiry, as vendors actually report them.
+///
+/// A number is a **duration in seconds** (Vault's `lease_duration`, OAuth's
+/// `expires_in`); a string is an absolute RFC 3339 timestamp (AWS's `Expiration`).
+/// Told apart by type, because vendors do both and a declaration should not have
+/// to say which.
+fn parse_expiry(v: &serde_json::Value) -> anyhow::Result<u64> {
+    let now = SystemTime::now()
+        .duration_since(SystemTime::UNIX_EPOCH)
+        .unwrap_or_default()
+        .as_secs();
+    match v {
+        serde_json::Value::Number(n) => {
+            let secs = n
+                .as_u64()
+                .ok_or_else(|| anyhow::anyhow!("expiry {n} is not a whole number of seconds"))?;
+            Ok(now.saturating_add(secs))
+        }
+        serde_json::Value::String(s) => {
+            // A string that is all digits is a Unix timestamp, which some tools
+            // emit; anything else must be RFC 3339.
+            if let Ok(secs) = s.parse::<u64>() {
+                return Ok(secs);
+            }
+            let ts = chrono::DateTime::parse_from_rfc3339(s)
+                .with_context(|| format!("expiry {s:?} is not an RFC 3339 timestamp"))?;
+            Ok(ts.timestamp().max(0).cast_unsigned())
+        }
+        other => anyhow::bail!("expiry {other} is neither a duration nor a timestamp"),
+    }
+}
+
+/// Substitute a presentation template.
+///
+/// Single-pass by construction (see [`hcore::template`]): material containing
+/// `${` is never re-interpreted.
+fn render(
+    tmpl: &str,
+    material: &Material,
+    files: &BTreeMap<String, PathBuf>,
+    dialect: Option<Dialect>,
+    helper_command: &Path,
+    helper_args: &dyn Fn(Dialect) -> Vec<String>,
+) -> anyhow::Result<String> {
+    hcore::template::render(tmpl, |r: &Ref<'_>| match r.kind {
+        None => material.fields.get(r.arg).cloned().ok_or_else(|| {
+            anyhow::anyhow!(
+                "no material field `{}` — this source yields {}",
+                r.arg,
+                render_names(material.fields.keys())
+            )
+        }),
+        Some("file") => files
+            .get(r.arg)
+            .map(|p| p.to_string_lossy().into_owned())
+            .ok_or_else(|| {
+                anyhow::anyhow!(
+                    "no presented file `{}` — this credential presents {}",
+                    r.arg,
+                    render_names(files.keys())
+                )
+            }),
+        Some("helper") => {
+            let dialect = dialect.ok_or_else(|| {
+                anyhow::anyhow!(
+                    "`${{helper:{}}}` needs a `helper` dialect on this presentation",
+                    r.arg
+                )
+            })?;
+            match r.arg {
+                "command" => Ok(helper_command.to_string_lossy().into_owned()),
+                "args" => Ok(serde_json::to_string(&helper_args(dialect))
+                    .unwrap_or_else(|_e| "[]".to_string())),
+                other => anyhow::bail!("unknown `${{helper:{other}}}`"),
+            }
+        }
+        Some(other) => anyhow::bail!("unknown template kind `{other}`"),
+    })
+}
+
+fn render_names<'a>(names: impl Iterator<Item = &'a String>) -> String {
+    let v: Vec<&str> = names.map(String::as_str).collect();
+    if v.is_empty() {
+        "nothing".to_string()
+    } else {
+        v.join(", ")
+    }
+}
+
+/// The absolute path of this heph binary, for a config document that calls back.
+fn helper_command() -> anyhow::Result<PathBuf> {
+    std::env::current_exe()
+        .context("cannot determine this heph binary's path, which a credential helper has to name")
+}
+
+/// Render an argv the way a config file that is parsed by a shell expects it.
+fn shell_join(program: &Path, args: &[String]) -> String {
+    std::iter::once(program.to_string_lossy().into_owned())
+        .chain(args.iter().cloned())
+        .map(|a| {
+            if a.chars()
+                .all(|c| c.is_ascii_alphanumeric() || "-_./:=@".contains(c))
+            {
+                a
+            } else {
+                format!("'{}'", a.replace('\'', r"'\''"))
+            }
+        })
+        .collect::<Vec<_>>()
+        .join(" ")
+}
+
+fn make_executable(path: &Path) -> anyhow::Result<()> {
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::PermissionsExt as _;
+        std::fs::set_permissions(path, std::fs::Permissions::from_mode(0o700))
+            .with_context(|| format!("chmod 0700 {}", path.display()))?;
+    }
+    Ok(())
+}
+
+/// Percent-encode an audience for the OIDC endpoint's query string.
+fn urlencode(s: &str) -> String {
+    let mut out = String::with_capacity(s.len());
+    for b in s.bytes() {
+        match b {
+            b'A'..=b'Z' | b'a'..=b'z' | b'0'..=b'9' | b'-' | b'_' | b'.' | b'~' => {
+                out.push(b as char)
+            }
+            _ => out.push_str(&format!("%{b:02X}")),
+        }
+    }
+    out
+}
+
+/// Take a producer target's outputs into the credential store.
+///
+/// One convention, not configuration: an output group named `credential` is read
+/// as JSON and its top-level keys become fields; every other group becomes a named
+/// file. An inline `exec` source needs a `fields` map instead, and the asymmetry is
+/// deliberate — a target's `run` can pipe through `jq` and shape its own output,
+/// so it does not need one; a vendor's stdout is whatever the vendor decided, so
+/// it does.
+fn read_producer_outputs(
+    artifacts: &[crate::engine::driver::outputartifact::OutputArtifact],
+    store: CredentialStore,
+    key: &str,
+) -> anyhow::Result<Material> {
+    use crate::engine::driver::outputartifact::Type;
+    use hcore::hartifactcontent::{Content as _, WalkEntryKind};
+
+    // Staged, not durable: whether these bytes may outlive this process is not
+    // known until the material's expiry is, which is only after every group has
+    // been read.
+    store.sweep_dead_staged();
+    let dir = store.staged_files_dir(key);
+    drop(std::fs::remove_dir_all(&dir));
+    let mut fields = BTreeMap::new();
+    let mut files = BTreeMap::new();
+    let mut expires_at = None;
+
+    for artifact in artifacts
+        .iter()
+        .filter(|a| matches!(a.r#type, Type::Output))
+    {
+        let mut body = Vec::new();
+        for entry in artifact.walk()? {
+            let entry = entry?;
+            if let WalkEntryKind::File { mut data, .. } = entry.kind {
+                std::io::copy(&mut data, &mut body)
+                    .with_context(|| format!("read credential output `{}`", artifact.group))?;
+            }
+        }
+        // Same escape as a presented file name, and the same fix: the group name
+        // becomes one path component under the credential store.
+        hbuiltins::plugincredential::present::validate_file_name(&artifact.group)
+            .with_context(|| format!("credential source output group `{}`", artifact.group))?;
+        if artifact.group == CREDENTIAL_OUTPUT_GROUP {
+            let text = String::from_utf8(body).context(
+                "the `credential` output group is read as JSON, and this is not valid UTF-8",
+            )?;
+            let m = material_from_json_object(&text)?;
+            fields.extend(m.fields);
+            expires_at = expires_at.or(m.expires_at);
+        } else {
+            let path = dir.join(&artifact.group);
+            crate::engine::credential_store::write_private_file(&path, &body)?;
+            files.insert(artifact.group.clone(), path);
+        }
+    }
+
+    if fields.is_empty() && files.is_empty() {
+        anyhow::bail!(
+            "the target produced no outputs, so there is no material — a credential source names \
+             its material in `out`, with the group `{CREDENTIAL_OUTPUT_GROUP}` read as JSON"
+        );
+    }
+    Ok(Material {
+        fields,
+        files,
+        expires_at,
+    })
+}
+
+/// The reserved output-group name whose contents are read as JSON fields.
+pub const CREDENTIAL_OUTPUT_GROUP: &str = "credential";
+
+/// Every top-level key of a JSON object becomes a field.
+fn material_from_json_object(text: &str) -> anyhow::Result<Material> {
+    let doc: serde_json::Value = serde_json::from_str(text.trim()).context(
+        "the `credential` output group is read as JSON — pipe the tool's output through `jq` if \
+         it prints something else",
+    )?;
+    let obj = doc.as_object().ok_or_else(|| {
+        anyhow::anyhow!("the `credential` output group must be a JSON object of fields")
+    })?;
+    let mut fields = BTreeMap::new();
+    for (k, v) in obj {
+        // Expiry, by whichever of the two names the tool used. Not a field: it is
+        // metadata about the material rather than part of it.
+        if k == "expires_at" || k == "expires_in" {
+            continue;
+        }
+        let s = match v {
+            serde_json::Value::String(s) => s.clone(),
+            serde_json::Value::Number(n) => n.to_string(),
+            serde_json::Value::Bool(b) => b.to_string(),
+            // Nested structure is not a credential field. Silently flattening or
+            // JSON-encoding it would hand a tool something that looks like a
+            // token and is not.
+            _ => continue,
+        };
+        fields.insert(k.clone(), s);
+    }
+    let expires_at = obj
+        .get("expires_at")
+        .or_else(|| obj.get("expires_in"))
+        .map(parse_expiry)
+        .transpose()?;
+    Ok(Material {
+        fields,
+        files: BTreeMap::new(),
+        expires_at,
+    })
+}
+
+/// Two credentials on one target claiming the same environment variable.
+///
+/// Rejected rather than resolved: silently winning either way leaves one of the
+/// two identities inoperative with nothing to see, and "which credential am I
+/// actually using?" is the question this whole feature exists to answer.
+fn check_env_collisions(consumer: &Addr, resolved: &[ResolvedCredential]) -> anyhow::Result<()> {
+    let mut seen: BTreeMap<&str, &Addr> = BTreeMap::new();
+    for rc in resolved {
+        // Every presentation this credential could use, since which one wins is
+        // not known until acquisition — and a collision that only appears on a
+        // laptop is worse than one that appears everywhere.
+        let presentations = rc
+            .def
+            .sources
+            .iter()
+            .filter_map(|s| s.present.as_ref())
+            .chain(rc.def.present.as_ref());
+        for present in presentations {
+            for name in present.env.keys() {
+                if let Some(other) = seen.insert(name, &rc.addr)
+                    && other != &rc.addr
+                {
+                    anyhow::bail!(
+                        "{consumer} declares both {other} and {}, and both present `{name}`. One \
+                         would shadow the other — drop one of them, or change the variable on its \
+                         presentation",
+                        rc.addr
+                    );
+                }
+            }
+        }
+    }
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn a_presented_file_lands_beside_the_workspace_and_never_inside_it() {
+        // The whole reason for this path: output collection is rooted at the
+        // workspace directory and packs every regular file it walks.
+        let sandbox = Path::new("/s/__target_x");
+        let dir = credential_dir(sandbox);
+        assert_eq!(dir, Path::new("/s/__target_x/.heph/auth"));
+        assert!(!dir.starts_with(sandbox.join("ws")));
+    }
+
+    #[test]
+    fn a_credential_directory_is_named_by_its_full_address() {
+        let a = Addr::new(
+            hmodel::htpkg::PkgBuf::from("infra/auth"),
+            "aws".to_string(),
+            Default::default(),
+        );
+        let b = Addr::new(
+            hmodel::htpkg::PkgBuf::from("svc/auth"),
+            "aws".to_string(),
+            Default::default(),
+        );
+        assert_ne!(
+            sanitize_addr(&a),
+            sanitize_addr(&b),
+            "two credentials called `aws` in different packages must not collide"
+        );
+        assert!(!sanitize_addr(&a).contains('/'));
+    }
+
+    #[test]
+    fn no_field_map_means_the_whole_text_is_one_field() {
+        let m = material_from_text("  tok-123\n", &BTreeMap::new(), None).expect("parse");
+        assert_eq!(m.fields.get("value").map(String::as_str), Some("tok-123"));
+    }
+
+    #[test]
+    fn a_field_map_picks_dotted_json_paths() {
+        let m = material_from_text(
+            r#"{"data":{"token":"t"},"lease_duration":3600}"#,
+            &BTreeMap::from([("token".to_string(), "data.token".to_string())]),
+            Some("lease_duration"),
+        )
+        .expect("parse");
+        assert_eq!(m.fields.get("token").map(String::as_str), Some("t"));
+        let now = SystemTime::now()
+            .duration_since(SystemTime::UNIX_EPOCH)
+            .expect("epoch")
+            .as_secs();
+        let at = m.expires_at.expect("expiry");
+        assert!(at > now + 3500 && at <= now + 3600, "got {at}");
+    }
+
+    #[test]
+    fn a_number_is_a_duration_and_a_string_is_a_timestamp() {
+        // Vendors do both, so the type is what tells them apart.
+        let abs = parse_expiry(&serde_json::json!("2030-01-01T00:00:00Z")).expect("rfc3339");
+        assert_eq!(abs, 1_893_456_000);
+        let now = SystemTime::now()
+            .duration_since(SystemTime::UNIX_EPOCH)
+            .expect("epoch")
+            .as_secs();
+        let rel = parse_expiry(&serde_json::json!(60)).expect("duration");
+        assert!(rel >= now + 59 && rel <= now + 61);
+    }
+
+    #[test]
+    fn a_missing_field_names_what_the_source_did_yield() {
+        let err = material_from_text(
+            r#"{"AccessKeyId":"a"}"#,
+            &BTreeMap::from([("secret".to_string(), "SecretAccessKey".to_string())]),
+            None,
+        )
+        .expect_err("must fail");
+        assert!(format!("{err:#}").contains("SecretAccessKey"), "{err:#}");
+    }
+
+    #[test]
+    fn the_credential_output_group_becomes_fields_and_expiry() {
+        let m = material_from_json_object(r#"{"token":"t","expires_in":120,"nested":{"a":1}}"#)
+            .expect("parse");
+        assert_eq!(m.fields.get("token").map(String::as_str), Some("t"));
+        assert!(
+            !m.fields.contains_key("expires_in"),
+            "expiry is metadata about the material, not part of it"
+        );
+        assert!(
+            !m.fields.contains_key("nested"),
+            "nested structure is not a credential field"
+        );
+        assert!(m.expires_at.is_some());
+    }
+
+    #[test]
+    fn template_rendering_resolves_fields_files_and_the_helper_argv() {
+        let material = Material {
+            fields: BTreeMap::from([("token".to_string(), "tok".to_string())]),
+            files: BTreeMap::new(),
+            expires_at: None,
+        };
+        let files = BTreeMap::from([("kc".to_string(), PathBuf::from("/s/.heph/auth/a/kc"))]);
+        let args = |d: Dialect| vec!["__auth-helper".to_string(), d.as_str().to_string()];
+        let cmd = PathBuf::from("/usr/local/bin/heph");
+        assert_eq!(
+            render("Bearer ${token}", &material, &files, None, &cmd, &args).expect("render"),
+            "Bearer tok"
+        );
+        assert_eq!(
+            render("${file:kc}", &material, &files, None, &cmd, &args).expect("render"),
+            "/s/.heph/auth/a/kc"
+        );
+        assert_eq!(
+            render(
+                "${helper:command}",
+                &material,
+                &files,
+                Some(Dialect::Kubernetes),
+                &cmd,
+                &args
+            )
+            .expect("render"),
+            "/usr/local/bin/heph"
+        );
+        // An unknown field names what the source did yield, rather than
+        // substituting an empty string.
+        let err = render("${nope}", &material, &files, None, &cmd, &args).expect_err("must fail");
+        assert!(format!("{err:#}").contains("token"), "{err:#}");
+    }
+
+    #[test]
+    fn shell_join_quotes_what_a_shell_would_otherwise_split() {
+        assert_eq!(
+            shell_join(Path::new("/usr/bin/heph"), &["a".to_string()]),
+            "/usr/bin/heph a"
+        );
+        assert_eq!(
+            shell_join(
+                Path::new("/Applications/My Tools/heph"),
+                &["//auth:aws".to_string()]
+            ),
+            "'/Applications/My Tools/heph' //auth:aws"
+        );
+    }
+
+    #[test]
+    fn a_when_is_evaluated_against_this_host() {
+        assert!(when_unmet(&When::Os("linux".to_string())).is_none() == cfg!(target_os = "linux"));
+        assert!(when_unmet(&When::Env("HEPH_SURELY_UNSET_XYZ".to_string())).is_some());
+    }
+
+    #[test]
+    fn two_credentials_claiming_one_variable_are_refused() {
+        use hbuiltins::plugincredential::Presentation;
+        let mk = |name: &str, var: &str| ResolvedCredential {
+            addr: Addr::new(
+                hmodel::htpkg::PkgBuf::from("auth"),
+                name.to_string(),
+                Default::default(),
+            ),
+            def: CredentialDef {
+                sources: vec![],
+                present: Some(Presentation {
+                    env: BTreeMap::from([(var.to_string(), "${token}".to_string())]),
+                    ..Presentation::default()
+                }),
+                ttl: None,
+            },
+        };
+        let consumer = Addr::new(
+            hmodel::htpkg::PkgBuf::from("svc"),
+            "deploy".to_string(),
+            Default::default(),
+        );
+        assert!(check_env_collisions(&consumer, &[mk("a", "TOKEN"), mk("b", "OTHER")]).is_ok());
+        let err = check_env_collisions(&consumer, &[mk("a", "TOKEN"), mk("b", "TOKEN")])
+            .expect_err("must fail");
+        assert!(format!("{err:#}").contains("shadow"), "{err:#}");
+    }
+
+    #[test]
+    fn an_env_variable_becomes_a_lowercase_field() {
+        assert_eq!(env_field_name("GITHUB_TOKEN"), "github_token");
+    }
+
+    #[test]
+    fn an_empty_variable_reads_as_unset() {
+        // CI systems export an empty variable for a secret that was not
+        // configured; treating that as present picks a source that cannot work.
+        // SAFETY: single-threaded test, and the variable is unique to it.
+        unsafe { std::env::set_var("HEPH_TEST_EMPTY_CRED", "") };
+        assert!(host_env("HEPH_TEST_EMPTY_CRED").is_none());
+        // SAFETY: as above.
+        unsafe { std::env::remove_var("HEPH_TEST_EMPTY_CRED") };
+    }
+}

--- a/crates/engine/src/engine/credential_store.rs
+++ b/crates/engine/src/engine/credential_store.rs
@@ -1,0 +1,541 @@
+//! Where acquired material lives, and for how long.
+//!
+//! Two tiers, both keyed on a *resolution key* rather than on the address alone:
+//!
+//! - **Per process**, so two hundred consumers of one credential cause one
+//!   acquisition. This matters: an `exec` source shelling out to a vendor CLI
+//!   costs the better part of a second.
+//! - **Across processes**, under `<home>/auth/` at mode `0700` with entries at
+//!   `0600`, so signing in once a day means signing in once a day. This is what
+//!   `~/.aws/cli/cache` already is — heph is not inventing a mechanism, only
+//!   owning one.
+//!
+//! No daemon. Same reasoning as the local build cache: a disk store plus the
+//! vendor CLIs' own caches already deliver the property people want.
+//!
+//! # Two rules about what is written
+//!
+//! **Material with no expiry is never written to disk.** A one-hour session token
+//! cached for an hour is a convenience; a long-lived API token written to
+//! `<home>/auth/` is a durable secret at rest that nothing will ever clean up.
+//! The rule falls out anyway from a separate fact — material with no expiry has no
+//! defined cache lifetime — and the two reasons agree.
+//!
+//! **The key covers the chosen source and the identity that acquired it**, not
+//! just the address. Two sources of one credential yield different material, and
+//! a derived credential minted under one root identity must not be served to a
+//! run holding another.
+
+use anyhow::Context as _;
+use std::collections::BTreeMap;
+use std::path::{Path, PathBuf};
+use std::time::{Duration, SystemTime, UNIX_EPOCH};
+
+/// On-disk layout version. Bumping it orphans old entries rather than
+/// misreading them.
+const STORE_FORMAT: u32 = 1;
+
+/// How much of a credential's remaining life must be left for it to be handed to
+/// a target.
+///
+/// Covers clock skew between the issuer and this host, plus the gap between
+/// handing material to a target and the target actually using it. A minute is
+/// generous for both and cheap: it costs at most one extra acquisition per
+/// credential lifetime.
+///
+/// A credential whose *whole* life is shorter than this is still usable — see
+/// [`Material::usable_at`] — because refusing to use a 30-second token would make
+/// the feature unusable for exactly the case (Vault's Kubernetes secrets engine)
+/// that most needs a callback presentation.
+pub const SKEW_MARGIN: Duration = Duration::from_secs(60);
+
+/// Acquired credential material.
+///
+/// The one type in heph that holds a secret. It is never hashed, never packed
+/// into an artifact, never put on the event stream, never printed by `inspect`,
+/// and its `Debug` deliberately shows only field *names*.
+#[derive(Clone, Default, serde::Serialize, serde::Deserialize)]
+pub struct Material {
+    /// Named string values, reachable from a presentation as `${<name>}`.
+    pub fields: BTreeMap<String, String>,
+    /// Named files, reachable as `${file:<name>}`. Either a host path a
+    /// `passthrough` source exposed in place, or a file this store owns.
+    pub files: BTreeMap<String, PathBuf>,
+    /// Absolute expiry, in Unix seconds. `None` means the source reported none
+    /// and the declaration set no `ttl`.
+    pub expires_at: Option<u64>,
+}
+
+/// Names only. A `{material:?}` in a log line, a span field or a panic message
+/// must never be the thing that leaks a token, and the only way to guarantee that
+/// is for the formatting not to have the value in it.
+impl std::fmt::Debug for Material {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("Material")
+            .field("fields", &self.fields.keys().collect::<Vec<_>>())
+            .field("files", &self.files.keys().collect::<Vec<_>>())
+            .field("expires_at", &self.expires_at)
+            .finish()
+    }
+}
+
+impl Material {
+    /// Whether this material may still be handed to a target at `now`.
+    ///
+    /// Material with no expiry is always usable — that is what "no expiry" means
+    /// — and separately is never written to disk, so an unbounded credential is
+    /// re-acquired once per process rather than trusted forever.
+    ///
+    /// The margin shrinks for genuinely short-lived material: a token whose total
+    /// life is under a minute would otherwise be born unusable, and those are
+    /// exactly the credentials a callback presentation exists to serve.
+    pub fn usable_at(&self, now: SystemTime, acquired_at: SystemTime) -> bool {
+        let Some(expires_at) = self.expires_at else {
+            return true;
+        };
+        let expiry = UNIX_EPOCH + Duration::from_secs(expires_at);
+        let lifetime = expiry.duration_since(acquired_at).unwrap_or(Duration::ZERO);
+        let margin = SKEW_MARGIN.min(lifetime / 2);
+        expiry
+            .checked_sub(margin)
+            .is_some_and(|usable_until| now < usable_until)
+    }
+
+    /// Every secret string in this material, for the log redactor.
+    ///
+    /// Field values only: a file *path* is not a secret and redacting it would
+    /// mangle ordinary output. What is in the file is the file's problem, and
+    /// files are `0600` inside a sandbox that is deleted at run end.
+    pub fn secrets(&self) -> impl Iterator<Item = &str> {
+        self.fields.values().map(String::as_str)
+    }
+}
+
+/// A hit on the disk tier.
+///
+/// Carries the entry's **own** acquisition time, not the read time: the skew
+/// margin is a fraction of the material's lifetime, so substituting "now" would
+/// silently shrink it for exactly the entries that have been on disk longest.
+#[derive(Debug)]
+pub struct Hit {
+    pub material: Material,
+    /// The winning source's label, for `heph auth explain`.
+    pub source: String,
+    pub acquired_at: SystemTime,
+}
+
+/// A credential's entry as it sits on disk.
+#[derive(serde::Serialize, serde::Deserialize)]
+struct Entry {
+    format: u32,
+    /// The address, for `heph auth status` and for a human reading the directory.
+    addr: String,
+    /// Which source produced this, for `heph auth explain`.
+    source: String,
+    /// Unix seconds.
+    acquired_at: u64,
+    material: Material,
+}
+
+/// The resolution key an entry is stored under.
+///
+/// Covers the address, the chosen source's configuration, and the keys of every
+/// credential that source itself needed. That last part is what stops a derived
+/// credential minted under one root identity from being served to a run holding
+/// another — the failure it prevents is a build silently acting as the wrong
+/// principal, which no amount of later auditing recovers from.
+pub fn resolution_key(addr: &str, source_config: &str, parents: &[String]) -> String {
+    use std::hash::{Hash as _, Hasher as _};
+    let mut h = xxhash_rust::xxh3::Xxh3Default::new();
+    STORE_FORMAT.hash(&mut h);
+    addr.hash(&mut h);
+    source_config.hash(&mut h);
+    for p in parents {
+        p.hash(&mut h);
+    }
+    format!("{:016x}", h.finish())
+}
+
+/// `<home>/auth`, the root of the on-disk tier.
+pub fn store_root(home: &Path) -> PathBuf {
+    home.join("auth")
+}
+
+/// The disk tier.
+///
+/// A plain directory of `0600` JSON files under a `0700` directory. Deliberately
+/// **not** a keychain: there is no consent dialog to block an unattended agent, no
+/// dependency on a session bus a CI container does not have, and no re-prompt
+/// every time a locally built binary changes its code signature. It is also what
+/// the AWS, gcloud and Azure CLIs all do — and it is the choice that removes a
+/// per-platform divergence rather than creating one.
+pub struct CredentialStore {
+    root: PathBuf,
+}
+
+impl CredentialStore {
+    pub fn new(home: &Path) -> Self {
+        Self {
+            root: store_root(home),
+        }
+    }
+
+    pub fn root(&self) -> &Path {
+        &self.root
+    }
+
+    fn entry_path(&self, key: &str) -> PathBuf {
+        self.root.join(format!("{key}.json"))
+    }
+
+    /// Where a key's **durable** files live: a producer target's outputs, for
+    /// material that carries an expiry and may therefore be reused across
+    /// processes.
+    pub fn files_dir(&self, key: &str) -> PathBuf {
+        self.root.join("files").join(key)
+    }
+
+    /// Where a key's files live until it is known whether they may be kept.
+    ///
+    /// Named by pid, and swept of dead pids by the next `heph` that touches the
+    /// store — the same shape the scratch audit directories use. That is what
+    /// lets unbounded producer material exist at all without breaking the
+    /// no-expiry rule: the rule is against a durable secret at rest that nothing
+    /// will ever clean up, and this has a defined end.
+    pub fn staged_files_dir(&self, key: &str) -> PathBuf {
+        self.root
+            .join("files")
+            .join("live")
+            .join(std::process::id().to_string())
+            .join(key)
+    }
+
+    /// Remove staged files belonging to processes that are gone.
+    ///
+    /// Best-effort and cheap: one `read_dir` plus a `kill(pid, 0)` per entry,
+    /// run once per process on the first staging.
+    pub fn sweep_dead_staged(&self) {
+        let live = self.root.join("files").join("live");
+        let Ok(entries) = std::fs::read_dir(&live) else {
+            return;
+        };
+        for entry in entries.flatten() {
+            let name = entry.file_name();
+            let Ok(pid) = name.to_string_lossy().parse::<i32>() else {
+                continue;
+            };
+            if pid == std::process::id() as i32 {
+                continue;
+            }
+            // SAFETY: `kill` with signal 0 performs the permission check and
+            // returns, sending nothing. It takes a plain `pid_t` and touches no
+            // memory we own. ESRCH means no such process; EPERM means it exists
+            // and belongs to someone else, which still counts as alive.
+            let alive = unsafe { libc::kill(pid, 0) } == 0
+                || std::io::Error::last_os_error().raw_os_error() == Some(libc::EPERM);
+            if !alive {
+                drop(std::fs::remove_dir_all(entry.path()));
+            }
+        }
+    }
+
+    /// Move a key's staged files into their durable home.
+    ///
+    /// Called only once the material is known to carry an expiry — which is the
+    /// point at which it is allowed to outlive this process.
+    pub fn promote_staged(&self, key: &str) -> anyhow::Result<PathBuf> {
+        let from = self.staged_files_dir(key);
+        let to = self.files_dir(key);
+        drop(std::fs::remove_dir_all(&to));
+        if let Some(parent) = to.parent() {
+            ensure_private_dir(parent)?;
+        }
+        std::fs::rename(&from, &to)
+            .with_context(|| format!("promote {} to {}", from.display(), to.display()))?;
+        Ok(to)
+    }
+
+    /// Create the store root at `0700`, tightening it if it already exists with
+    /// looser permissions.
+    ///
+    /// Tightening rather than trusting: a directory created by an older heph, or
+    /// by a `mkdir -p` in someone's setup script, would otherwise be world-readable
+    /// and nothing would ever say so.
+    pub fn ensure_root(&self) -> anyhow::Result<()> {
+        ensure_private_dir(&self.root)
+    }
+
+    /// Read a cached entry, if one exists and is still usable.
+    ///
+    /// A malformed or unreadable entry is treated as absent, not as an error: the
+    /// worst case is one extra acquisition, and failing a build because a cache
+    /// file got truncated would be a poor trade.
+    pub fn get(&self, key: &str, now: SystemTime) -> Option<Hit> {
+        let path = self.entry_path(key);
+        let raw = std::fs::read(&path).ok()?;
+        let entry: Entry = serde_json::from_slice(&raw).ok()?;
+        if entry.format != STORE_FORMAT {
+            return None;
+        }
+        let acquired_at = UNIX_EPOCH + Duration::from_secs(entry.acquired_at);
+        // An entry with no expiry should not be here at all (see `put`), but if
+        // one is — an older heph, a hand-written file — do not honour it: the rule
+        // is that unbounded material is not trusted across processes.
+        if entry.material.expires_at.is_none() {
+            drop(std::fs::remove_file(&path));
+            return None;
+        }
+        if !entry.material.usable_at(now, acquired_at) {
+            drop(std::fs::remove_file(&path));
+            // The entry's files go with it: they are the same material, and
+            // leaving them is exactly the durable-secret-at-rest this store's
+            // rules are written against.
+            drop(std::fs::remove_dir_all(self.files_dir(key)));
+            return None;
+        }
+        Some(Hit {
+            material: entry.material,
+            source: entry.source,
+            acquired_at,
+        })
+    }
+
+    /// Write an entry, if it may be written at all.
+    ///
+    /// Returns whether it was persisted, so a caller can say so in
+    /// `heph auth explain` rather than leaving "why is this re-acquired every
+    /// time?" unanswerable.
+    pub fn put(
+        &self,
+        key: &str,
+        addr: &str,
+        source: &str,
+        material: &Material,
+        acquired_at: SystemTime,
+    ) -> anyhow::Result<bool> {
+        if material.expires_at.is_none() {
+            return Ok(false);
+        }
+        self.ensure_root()?;
+        let entry = Entry {
+            format: STORE_FORMAT,
+            addr: addr.to_string(),
+            source: source.to_string(),
+            acquired_at: unix_secs(acquired_at),
+            material: material.clone(),
+        };
+        let body = serde_json::to_vec(&entry).context("serialize credential entry")?;
+        write_private_file(&self.entry_path(key), &body)?;
+        Ok(true)
+    }
+
+    /// Drop every cached entry. `heph auth logout`.
+    pub fn clear(&self) -> anyhow::Result<()> {
+        match std::fs::remove_dir_all(&self.root) {
+            Ok(()) => Ok(()),
+            Err(e) if e.kind() == std::io::ErrorKind::NotFound => Ok(()),
+            Err(e) => Err(e).with_context(|| format!("clear {}", self.root.display())),
+        }
+    }
+}
+
+fn unix_secs(t: SystemTime) -> u64 {
+    t.duration_since(UNIX_EPOCH)
+        .unwrap_or(Duration::ZERO)
+        .as_secs()
+}
+
+/// Create (or tighten) a directory to `0700`.
+pub fn ensure_private_dir(dir: &Path) -> anyhow::Result<()> {
+    std::fs::create_dir_all(dir).with_context(|| format!("create {}", dir.display()))?;
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::PermissionsExt as _;
+        std::fs::set_permissions(dir, std::fs::Permissions::from_mode(0o700))
+            .with_context(|| format!("chmod 0700 {}", dir.display()))?;
+    }
+    Ok(())
+}
+
+/// Write a file at `0600`, creating it with those permissions rather than
+/// widening then narrowing.
+///
+/// The order matters: `write` then `chmod` leaves a window in which the file
+/// exists at the umask's permissions with the secret already in it. `OpenOptions`
+/// with `mode` closes it, because the mode is applied by `open(2)` itself.
+pub fn write_private_file(path: &Path, body: &[u8]) -> anyhow::Result<()> {
+    use std::io::Write as _;
+    if let Some(parent) = path.parent() {
+        ensure_private_dir(parent)?;
+    }
+    // Truncate through a fresh create so a shorter secret cannot leave a tail of
+    // a longer previous one behind.
+    drop(std::fs::remove_file(path));
+    let mut opts = std::fs::OpenOptions::new();
+    opts.write(true).create_new(true);
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::OpenOptionsExt as _;
+        opts.mode(0o600);
+    }
+    let mut f = opts
+        .open(path)
+        .with_context(|| format!("create {}", path.display()))?;
+    f.write_all(body)
+        .with_context(|| format!("write {}", path.display()))?;
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn material(expires_in: Option<u64>, now: SystemTime) -> Material {
+        Material {
+            fields: BTreeMap::from([("token".to_string(), "s3cr3t".to_string())]),
+            files: BTreeMap::new(),
+            expires_at: expires_in.map(|d| unix_secs(now) + d),
+        }
+    }
+
+    #[test]
+    fn debug_shows_names_and_never_values() {
+        let m = material(Some(3600), SystemTime::now());
+        let rendered = format!("{m:?}");
+        assert!(rendered.contains("token"), "{rendered}");
+        assert!(
+            !rendered.contains("s3cr3t"),
+            "a Debug impl must not be the thing that leaks a token: {rendered}"
+        );
+    }
+
+    #[test]
+    fn material_is_not_handed_out_inside_the_skew_margin() {
+        let now = SystemTime::now();
+        let acquired = now - Duration::from_secs(3000);
+        // 3600s lifetime, 3000 elapsed: 600 left, well past the margin.
+        let m = Material {
+            expires_at: Some(unix_secs(acquired) + 3600),
+            ..material(None, now)
+        };
+        assert!(m.usable_at(now, acquired));
+        // 30 seconds left is inside the one-minute margin.
+        let late = acquired + Duration::from_secs(3570);
+        assert!(!m.usable_at(late, acquired));
+    }
+
+    #[test]
+    fn a_very_short_lived_token_is_still_usable_when_fresh() {
+        // Vault's Kubernetes engine leases tokens that live for minutes; a flat
+        // margin would make them born unusable, which would rule out exactly the
+        // case the callback presentation exists for.
+        let now = SystemTime::now();
+        let m = Material {
+            expires_at: Some(unix_secs(now) + 40),
+            ..material(None, now)
+        };
+        assert!(m.usable_at(now, now));
+        assert!(!m.usable_at(now + Duration::from_secs(25), now));
+    }
+
+    #[test]
+    fn material_with_no_expiry_is_never_written_to_disk() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let store = CredentialStore::new(dir.path());
+        let now = SystemTime::now();
+        let wrote = store
+            .put("k", "//auth:a", "env(T)", &material(None, now), now)
+            .expect("put");
+        assert!(!wrote, "an unbounded secret must not be left at rest");
+        assert!(store.get("k", now).is_none());
+    }
+
+    #[test]
+    fn a_bounded_entry_round_trips_and_is_dropped_once_expired() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let store = CredentialStore::new(dir.path());
+        let now = SystemTime::now();
+        assert!(
+            store
+                .put(
+                    "k",
+                    "//auth:a",
+                    "exec(aws)",
+                    &material(Some(3600), now),
+                    now
+                )
+                .expect("put")
+        );
+        let hit = store.get("k", now).expect("hit");
+        assert_eq!(
+            hit.material.fields.get("token").map(String::as_str),
+            Some("s3cr3t")
+        );
+        assert_eq!(hit.source, "exec(aws)");
+        // The entry's own time, not the read time.
+        assert!(hit.acquired_at <= now);
+        // Past its expiry, the entry is both a miss and gone.
+        assert!(store.get("k", now + Duration::from_secs(3601)).is_none());
+        assert!(store.get("k", now).is_none(), "an expired entry is removed");
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn the_store_is_private_on_disk() {
+        use std::os::unix::fs::PermissionsExt as _;
+        let dir = tempfile::tempdir().expect("tempdir");
+        let store = CredentialStore::new(dir.path());
+        let now = SystemTime::now();
+        store
+            .put("k", "//auth:a", "env(T)", &material(Some(60), now), now)
+            .expect("put");
+        let dmode = std::fs::metadata(store.root())
+            .expect("stat root")
+            .permissions()
+            .mode()
+            & 0o777;
+        assert_eq!(dmode, 0o700, "store root must be 0700");
+        let fmode = std::fs::metadata(store.root().join("k.json"))
+            .expect("stat entry")
+            .permissions()
+            .mode()
+            & 0o777;
+        assert_eq!(fmode, 0o600, "entries must be 0600");
+    }
+
+    #[test]
+    fn a_key_separates_sources_and_root_identities() {
+        let a = resolution_key("//auth:aws", "exec(aws)", &[]);
+        let b = resolution_key("//auth:aws", "oidc(github_actions)", &[]);
+        let c = resolution_key("//auth:aws", "exec(aws)", &["parent-1".to_string()]);
+        assert_ne!(a, b, "two sources yield different material");
+        assert_ne!(
+            a, c,
+            "material minted under one root identity must not be served to another"
+        );
+    }
+
+    #[test]
+    fn a_truncated_entry_reads_as_absent_rather_than_failing_the_build() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let store = CredentialStore::new(dir.path());
+        store.ensure_root().expect("root");
+        std::fs::write(store.root().join("k.json"), b"{not json").expect("write");
+        assert!(store.get("k", SystemTime::now()).is_none());
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn a_pre_existing_loose_directory_is_tightened() {
+        use std::os::unix::fs::PermissionsExt as _;
+        let dir = tempfile::tempdir().expect("tempdir");
+        let root = store_root(dir.path());
+        std::fs::create_dir_all(&root).expect("mkdir");
+        std::fs::set_permissions(&root, std::fs::Permissions::from_mode(0o755)).expect("chmod");
+        CredentialStore::new(dir.path())
+            .ensure_root()
+            .expect("ensure");
+        let mode = std::fs::metadata(&root).expect("stat").permissions().mode() & 0o777;
+        assert_eq!(mode, 0o700);
+    }
+}

--- a/crates/engine/src/engine/engine.rs
+++ b/crates/engine/src/engine/engine.rs
@@ -125,6 +125,15 @@ pub struct Engine {
     pub(crate) result_lock: ResultLock,
     pub(crate) scratch_lock: crate::engine::scratch::ScratchLock,
 
+    /// Acquired credential material, per process. Not a `Memoizer`: material
+    /// expires, and a memoized cell is computed once and kept forever. See
+    /// [`CredentialCache`](crate::engine::credential::CredentialCache).
+    pub(crate) credential_cache: crate::engine::credential::CredentialCache,
+    /// Serializes acquisition across processes, per resolution key. Two
+    /// concurrent `heph` invocations must not both drive an interactive vendor
+    /// CLI for the same credential.
+    pub(crate) credential_lock: crate::engine::credential::CredentialLock,
+
     /// Ordered set of remote (shared) caches fronting the local cache. Empty
     /// (a cheap no-op on every path) unless `caches:` is configured.
     pub(crate) remote_caches: Arc<crate::engine::RemoteCacheSet>,
@@ -452,6 +461,13 @@ impl Engine {
             .with_context(|| format!("create scratch lock dir {scratch_lock_dir:?}"))?;
         let scratch_lock =
             crate::engine::scratch::ScratchLock::new(cfg.lock_backend, scratch_lock_dir);
+        // Third namespace, third directory: a credential is keyed by its
+        // resolution key, which is neither an addr nor a slot id.
+        let credential_lock_dir = lock_dir.join("auth");
+        std::fs::create_dir_all(&credential_lock_dir)
+            .with_context(|| format!("create credential lock dir {credential_lock_dir:?}"))?;
+        let credential_lock =
+            crate::engine::credential::CredentialLock::new(cfg.lock_backend, credential_lock_dir);
 
         // Remote caches: backends are constructed synchronously here (no
         // network); latency ordering is measured lazily on first use.
@@ -522,6 +538,8 @@ impl Engine {
             fuse,
             result_lock,
             scratch_lock,
+            credential_cache: Default::default(),
+            credential_lock,
             remote_caches,
             provider_functions_wired: std::sync::Once::new(),
             remote_tmp_ready: tokio::sync::OnceCell::new(),
@@ -529,6 +547,9 @@ impl Engine {
         };
         engine.register_driver(|_| Box::new(hbuiltins::plugingroup::Driver))?;
         engine.register_driver(|_| Box::new(hbuiltins::pluginscratch::Driver))?;
+        engine.register_driver(|_| Box::new(hbuiltins::plugincredential::Driver))?;
+        // Serves no targets; it exists to carry `heph.auth.*` into BUILD files.
+        engine.register_provider(|_| Box::new(hbuiltins::plugincredential::functions::Provider))?;
         engine.register_provider(|_| Box::new(hplugin_query::pluginquery::Provider))?;
 
         // The `fs` provider + driver are always-on built-ins. Each builds its

--- a/crates/engine/src/engine/execute.rs
+++ b/crates/engine/src/engine/execute.rs
@@ -28,6 +28,9 @@ impl Engine {
         exec_wrapper: Option<InteractiveWrapper>,
         shell: bool,
         no_scratch: bool,
+        // `outputs_are_material`: this target's outputs are credential material.
+        // The one thing it changes is the failure path — see the `Err` arm below.
+        outputs_are_material: bool,
     ) -> anyhow::Result<(
         Vec<OutputArtifact>,
         crate::engine::sandbox_cleaner::SandboxTeardown,
@@ -61,6 +64,27 @@ impl Engine {
             .acquire_scratch(&rs, addr, &resolved_scratch, no_scratch)
             .await
             .with_context(|| format!("acquire scratch for {addr}"))?;
+
+        // Credentials, after scratch and after every dep has resolved.
+        //
+        // The ordering is load-bearing in two directions. **After the cache
+        // decision**, because a cache hit never reaches `execute` at all — which
+        // is what makes "zero cost on a hit" structural rather than aspirational:
+        // a fully cached build probes nothing, spawns nothing and prompts nobody.
+        // And **strictly downstream of runner preparation**, because the devenv
+        // `wrap` runner captures its entire resolved environment into a
+        // `runner.json` that is a cached, remotely-shippable artifact; a runner
+        // capture must never see material.
+        //
+        // Resolution (which declaration does this reference name, and is the set
+        // coherent?) already happened at `get_def`. What happens here is the part
+        // that costs something: walking the chain, acquiring, and writing the
+        // presented files into this run's sandbox.
+        hcore::hmemoizer::set_phase("execute:credential_acquire");
+        let resolved_credentials = self
+            .resolve_credentials(&rs, addr, &def.target.inputs)
+            .await
+            .with_context(|| format!("resolve credentials for {addr}"))?;
 
         // Acquire semaphore AFTER dep resolution so no permit is held while waiting for
         // deps — prevents the classic diamond deadlock where mid-nodes hold permits while
@@ -165,6 +189,16 @@ impl Engine {
                         format!("remove stale sandbox dir {}", sandbox_dir.display())
                     })?;
 
+                    // Presented *inside* the sandbox claim, so the files land
+                    // under a directory this run owns and the teardown below
+                    // deletes them whatever the outcome — including the failure
+                    // path, which deliberately keeps the rest of the sandbox for
+                    // diagnostics. The log tail is what makes that useful, not
+                    // the token.
+                    let (credential_mounts, _credential_teardown) = self
+                        .acquire_and_present(&rs, addr, &sandbox_dir, &resolved_credentials)
+                        .await
+                        .with_context(|| format!("credentials for {addr}"))?;
                     let exec_wrapper: InteractiveWrapper = exec_wrapper.unwrap_or_else(|| {
                         Arc::new(|inner: InteractiveInner| {
                             Box::pin(async move { inner(None, None, None).await })
@@ -176,7 +210,7 @@ impl Engine {
                     let hashin = hashin.to_owned();
 
                     let inner: InteractiveInner = Box::new(enclose!(
-                        (driver, def, rs, self => engine, sandbox_dir, scratch_mounts)
+                        (driver, def, rs, self => engine, sandbox_dir, scratch_mounts, credential_mounts)
                         move |stdin, stdout, stderr| {
                             Box::pin(async move {
                                 let req = RunRequest {
@@ -190,6 +224,7 @@ impl Engine {
                                     stderr,
                                     sandbox_dir,
                                     scratch: scratch_mounts,
+                                    credentials: credential_mounts,
                                 };
                                 let res = if shell {
                                     driver.driver.run_shell(req, rs.ctoken()).await?
@@ -221,7 +256,15 @@ impl Engine {
                         // cleanup and a failing target reports an exit status
                         // with no output. The tree survives until this target's
                         // next run, whose `remove_stale` reclaims it.
-                        sandbox_teardown.leave_for_diagnostics();
+                        //
+                        // Unless the outputs are material, in which case the
+                        // diagnostic is not worth the secret it would leave on
+                        // disk.
+                        if outputs_are_material {
+                            sandbox_teardown.complete(addr.format());
+                        } else {
+                            sandbox_teardown.leave_for_diagnostics();
+                        }
                         return Err(err);
                     }
                 };

--- a/crates/engine/src/engine/mod.rs
+++ b/crates/engine/src/engine/mod.rs
@@ -25,8 +25,12 @@ pub mod approval;
 pub mod diag;
 pub mod execrunner_host;
 pub use approval::{ApprovalHandler, ApprovalNotice, ApprovalRequest};
+pub mod credential;
+pub mod credential_store;
 mod cwd;
 mod result;
+pub use credential::{Acquired, CredentialTeardown, ResolvedCredential, WalkStep};
+pub use credential_store::{CredentialStore, Material};
 pub use cwd::get_cwp;
 // The plugin contract (driver/provider/error + targetdef/eresult/htspec) now
 // lives in the `heph-plugin` crate; re-export at the original engine paths so

--- a/crates/engine/src/engine/result.rs
+++ b/crates/engine/src/engine/result.rs
@@ -3082,7 +3082,7 @@ impl Engine {
                     hcore::hmemoizer::set_phase("execute_cache:engine_execute");
                     let (artifacts, sandbox_teardown, sandbox_guards) = engine
                         .clone()
-                        .execute(rs.clone(), &addr, &spec, &def, &hashin, interactive, shell, no_scratch)
+                        .execute(rs.clone(), &addr, &spec, &def, &hashin, interactive, shell, no_scratch, false)
                         .await
                         .with_context(|| format!("execute {addr}"))?;
 
@@ -3696,6 +3696,15 @@ impl Engine {
         // Returns immediately for a target with no references, which is nearly
         // all of them.
         self.resolve_scratch(&rs, addr, &def.inputs).await?;
+
+        // Credential references: same seam, same reasoning. Resolving here means
+        // a reference to the wrong kind of target, or two credentials claiming
+        // one environment variable, is reported by `heph query` and
+        // `heph inspect def` — where the author is still looking at the BUILD
+        // file — rather than only when something eventually executes. It
+        // acquires nothing: the chain walk and the material live behind
+        // `execute`, which a cache hit never reaches.
+        self.resolve_credentials(&rs, addr, &def.inputs).await?;
 
         // Validate approval notices against the finalized input set at definition
         // time — before any result resolution or execution — so a notice naming a

--- a/crates/plugin-abi/src/convert.rs
+++ b/crates/plugin-abi/src/convert.rs
@@ -717,6 +717,50 @@ pub fn scratch_mount_from_pb(m: pb::ScratchMount) -> Option<hplugin::driver::Scr
     })
 }
 
+/// Credential mounts, host -> plugin.
+///
+/// One-way like a scratch mount, and for a sharper reason: nothing about an
+/// identity travels back, because a driver is never told which one it got.
+pub fn credential_mount_to_pb(m: &hplugin::driver::CredentialMount) -> pb::CredentialMount {
+    pb::CredentialMount {
+        addr: Some(addr_to_pb(&m.addr)),
+        env: m.env.iter().map(|(k, v)| (k.clone(), v.clone())).collect(),
+        path_prefix: m
+            .path_prefix
+            .iter()
+            .map(|p| p.to_string_lossy().into_owned())
+            .collect(),
+        redact: m.redact.clone(),
+    }
+}
+
+/// Credential mounts, as seen by a plugin.
+///
+/// **Fallible, and never lossy** — the opposite of [`scratch_mount_from_pb`],
+/// which drops a mount whose addr did not survive. A scratch that silently does
+/// not mount costs a cold cache; a credential that silently does not mount leaves
+/// the target with no identity, which either fails much later somewhere else with
+/// a message from someone else's SDK, or — worse — succeeds against whatever
+/// ambient identity the host happened to have. So a malformed mount stops the run
+/// here, where the reason is still legible.
+pub fn credential_mount_from_pb(
+    m: pb::CredentialMount,
+) -> anyhow::Result<hplugin::driver::CredentialMount> {
+    let addr = m
+        .addr
+        .ok_or_else(|| anyhow::anyhow!("credential mount carries no address"))?;
+    Ok(hplugin::driver::CredentialMount {
+        addr: addr_from_pb(addr),
+        env: m.env.into_iter().collect(),
+        path_prefix: m
+            .path_prefix
+            .into_iter()
+            .map(std::path::PathBuf::from)
+            .collect(),
+        redact: m.redact,
+    })
+}
+
 pub fn target_def_to_pb(td: &TargetDef) -> anyhow::Result<pb::TargetDef> {
     Ok(pb::TargetDef {
         addr: Some(addr_to_pb(&td.addr)),

--- a/crates/plugin-abi/src/lib.rs
+++ b/crates/plugin-abi/src/lib.rs
@@ -21,6 +21,24 @@ pub use hproto_gen::heph::plugin::v1 as pb;
 /// bookkeeping: `scripts/abi-check.sh` fails CI if the ABI surface changed
 /// without a bump, so the version history documents *why* a break happened.
 ///
+/// 0.9.0: `RunRequest`/`ManagedRunRequest` gained `repeated CredentialMount
+/// credentials` — identities the host resolved, acquired and materialized for the
+/// run, which the driver applies as runtime environment, a PATH prefix, and a
+/// redaction set for its output tee. Additive and cold-path (a prost wire field,
+/// not a vtable change), so an old plugin still loads.
+///
+/// Minor, but with a sharper consequence than 0.8.0's if a plugin is *not*
+/// rebuilt: an old driver drops the mounts and runs its target with no identity,
+/// which either fails much later with a message from someone else's SDK or —
+/// worse — succeeds against whatever ambient identity the host happened to have.
+/// Nothing is silently wrong in the *cache*, because a credential contributes
+/// nothing to any hash in either direction; what is lost is the identity itself.
+/// Two things bound the exposure: a reference can only enter a definition through
+/// the plugin's own parser, and a plugin old enough to drop the field rejects the
+/// `credentials` attribute outright. Decoding on the plugin side is fallible and
+/// never lossy for the same reason — unlike a scratch mount, a credential that
+/// fails to decode is an error rather than a dropped mount.
+///
 /// 0.8.0: `RunRequest`/`ManagedRunRequest` gained `repeated ScratchMount
 /// scratch` — persistent cache directories the host resolved, locked and created
 /// for the run, which the driver symlinks into the sandbox and announces through
@@ -46,7 +64,7 @@ pub use hproto_gen::heph::plugin::v1 as pb;
 /// 0.3.0: `PluginComponents` gained a `hooks` field (a layout change to the
 /// create-entry struct) for the Hook plugin kind — a hard break, so every plugin
 /// must be rebuilt against this ABI.
-pub const ABI_SEMVER: &str = "0.8.0";
+pub const ABI_SEMVER: &str = "0.9.0";
 
 #[cfg(feature = "convert")]
 pub mod convert;

--- a/crates/plugin-buildfile/src/pluginbuildfile/run_file.rs
+++ b/crates/plugin-buildfile/src/pluginbuildfile/run_file.rs
@@ -396,8 +396,20 @@ impl<'v> starlark::values::StarlarkValue<'v> for ProviderNativeFn {
         // fixed cap and let the signature validator enforce the real arity. Eight
         // is far beyond any provider function (the widest takes one positional);
         // more than that trips Starlark's own too-many-args error first.
-        let (_, optional) =
-            starlark::__derive_refs::parse_args::parse_positional::<0, 8>(args, eval.heap())?;
+        //
+        // The `_kwargs` variant, deliberately: the plain `parse_positional`
+        // begins with `no_named_args()`, which rejects **every** keyword argument
+        // before the declared signature is ever consulted. That made a
+        // `FnSignature`'s `named` params unreachable — `heph.go.gocache_addr(goos
+        // = …)` and every `heph.auth.*` constructor — with a Starlark-level
+        // "extra named parameter" rather than anything naming the function's own
+        // parameter list. Named args are read from `names_map` below and checked
+        // by `validate_args`, which is where an unknown keyword genuinely belongs.
+        let (_, optional, _kwargs) =
+            starlark::__derive_refs::parse_args::parse_positional_kwargs_alloc::<0, 8>(
+                args,
+                eval.heap(),
+            )?;
         let positional: Vec<htvalue::Value> = optional
             .iter()
             .flatten()
@@ -3990,6 +4002,121 @@ target(name = "t_in_app", driver = SHARED)
             Some(htvalue::Value::String(s)) => assert_eq!(s, "mypkg:hi"),
             other => panic!("expected echoed string, got {other:?}"),
         }
+    }
+
+    /// A provider function's declared **named** parameters must actually be
+    /// callable.
+    ///
+    /// They were not: the dispatch began with Starlark's `no_named_args()`, which
+    /// rejects every keyword argument before the function's own signature is
+    /// consulted — so `heph.go.gocache_addr(goos = "linux")` and every
+    /// `heph.auth.*` constructor failed with a Starlark-level "extra named
+    /// parameter" naming nothing useful, and a `FnSignature`'s `named` list was
+    /// unreachable surface.
+    #[test]
+    fn a_provider_function_accepts_its_declared_named_arguments() {
+        struct SuffixFn;
+        #[async_trait::async_trait]
+        impl ProviderFn for SuffixFn {
+            async fn call(
+                &self,
+                _ctx: &FnCallContext<'_>,
+                args: FnArgs,
+            ) -> anyhow::Result<htvalue::Value> {
+                let base = match args.positional.first() {
+                    Some(htvalue::Value::String(s)) => s.clone(),
+                    _ => anyhow::bail!("expected a string"),
+                };
+                let suffix = match args.named.get("suffix") {
+                    Some(htvalue::Value::String(s)) => s.clone(),
+                    _ => String::new(),
+                };
+                Ok(htvalue::Value::String(format!("{base}{suffix}")))
+            }
+        }
+
+        let tmp_dir = tempdir().unwrap();
+        let pkg = tmp_dir.path().join("mypkg");
+        fs::create_dir_all(&pkg).unwrap();
+        fs::write(
+            pkg.join("BUILD"),
+            r#"target(name = "t", driver = "d", v = heph.myprov.tag("a", suffix = "-b"))"#,
+        )
+        .unwrap();
+
+        let provider = Provider {
+            root: tmp_dir.path().to_path_buf(),
+            ..Provider::default()
+        };
+        let mut reg = ProviderFunctionRegistry::default();
+        reg.insert_provider(
+            "myprov",
+            vec![hplugin::provider::ProviderFunctionDef {
+                name: "tag".to_string(),
+                signature: FnSignature {
+                    positional: vec![Param::required("base", ParamType::String)],
+                    named: vec![Param::optional(
+                        "suffix",
+                        ParamType::String,
+                        htvalue::Value::String(String::new()),
+                    )],
+                    variadic: None,
+                    returns: ParamType::String,
+                },
+                doc: String::new(),
+                func: Arc::new(SuffixFn),
+            }],
+        );
+        assert!(provider.function_registry.set(Arc::new(reg)).is_ok());
+
+        let result = run_pkg_blocking(&provider, "mypkg").unwrap();
+        match result.targets[0].config.get("v") {
+            Some(htvalue::Value::String(s)) => assert_eq!(s, "a-b"),
+            other => panic!("expected the named argument to be applied, got {other:?}"),
+        }
+    }
+
+    /// …and an *undeclared* keyword is still rejected — now by the function's own
+    /// signature, which can name what it does accept, rather than by Starlark
+    /// before it ever looked.
+    #[test]
+    fn an_undeclared_keyword_argument_is_rejected_by_the_functions_own_signature() {
+        let tmp_dir = tempdir().unwrap();
+        let pkg = tmp_dir.path().join("mypkg");
+        fs::create_dir_all(&pkg).unwrap();
+        fs::write(
+            pkg.join("BUILD"),
+            r#"target(name = "t", driver = "d", v = heph.myprov.echo("hi", nope = 1))"#,
+        )
+        .unwrap();
+
+        let provider = Provider {
+            root: tmp_dir.path().to_path_buf(),
+            ..Provider::default()
+        };
+        let mut reg = ProviderFunctionRegistry::default();
+        reg.insert_provider(
+            "myprov",
+            vec![hplugin::provider::ProviderFunctionDef {
+                name: "echo".to_string(),
+                signature: FnSignature {
+                    positional: vec![Param::required("v", ParamType::String)],
+                    named: vec![],
+                    variadic: None,
+                    returns: ParamType::String,
+                },
+                doc: String::new(),
+                func: Arc::new(EchoFn),
+            }],
+        );
+        assert!(provider.function_registry.set(Arc::new(reg)).is_ok());
+
+        let err = run_pkg_blocking(&provider, "mypkg").unwrap_err();
+        let msg = format!("{err:#}");
+        assert!(
+            msg.contains("unknown keyword argument `nope`"),
+            "the function's own validator must be the one that answers: {msg}"
+        );
     }
 
     #[test]

--- a/crates/plugin-exec/Cargo.toml
+++ b/crates/plugin-exec/Cargo.toml
@@ -7,6 +7,10 @@ edition = "2024"
 workspace = true
 
 [dependencies]
+# Substring search for the credential-output scrubber: a needle there is a whole
+# session token, so the naive scan it replaced cost ~1000 byte-comparisons per
+# output byte on every credentialed target.
+memchr = "2.8"
 hcore = { package = "core", path = "../core" }
 hmodel = { package = "model", path = "../model" }
 hplugin = { package = "plugin", path = "../plugin" }

--- a/crates/plugin-exec/src/pluginexec/filterenv.rs
+++ b/crates/plugin-exec/src/pluginexec/filterenv.rs
@@ -6,6 +6,7 @@
 //
 // See https://www.in-ulm.de/~mascheck/various/argmax/
 
+use std::collections::BTreeSet;
 use std::ffi::OsString;
 use std::sync::OnceLock;
 
@@ -43,10 +44,13 @@ fn env_byte_length(env: &[(String, String)]) -> i64 {
     l
 }
 
-fn remove_longest(env: &mut Vec<(String, String)>) -> bool {
+/// Evict the longest *evictable* entry. Returns false when only protected
+/// entries are left.
+fn remove_longest(env: &mut Vec<(String, String)>, protected: &BTreeSet<String>) -> bool {
     let Some((i, _)) = env
         .iter()
         .enumerate()
+        .filter(|(_, (k, _))| !protected.contains(k))
         .max_by_key(|(_, (k, v))| entry_len(k, v))
     else {
         return false;
@@ -55,24 +59,74 @@ fn remove_longest(env: &mut Vec<(String, String)>) -> bool {
     true
 }
 
-fn filter_impl(env: &mut Vec<(String, String)>, args_len: i64, maxl: i64) {
-    env.retain(|(k, v)| entry_len(k, v) <= MAX_ARG_STRLEN);
-    while env_byte_length(env) + args_len >= maxl && remove_longest(env) {}
+fn filter_impl(
+    env: &mut Vec<(String, String)>,
+    args_len: i64,
+    maxl: i64,
+    protected: &BTreeSet<String>,
+) -> anyhow::Result<()> {
+    env.retain(|(k, v)| entry_len(k, v) <= MAX_ARG_STRLEN || protected.contains(k));
+    while env_byte_length(env) + args_len >= maxl && remove_longest(env, protected) {}
+    let mut names: Vec<&str> = env
+        .iter()
+        .filter(|(k, _)| protected.contains(k))
+        .map(|(k, _)| k.as_str())
+        .collect();
+    // Only a *credential* that cannot fit is worth failing for. With nothing
+    // protected left, the pre-existing behaviour stands: evict everything and let
+    // `execve` decide, which is what a target with a huge argv has always got.
+    if !names.is_empty() && env_byte_length(env) + args_len >= maxl {
+        names.sort_unstable();
+        anyhow::bail!(
+            "this target's command line plus its credentials ({}) is larger than this system's \
+             ARG_MAX ({maxl} bytes). Dropping a credential to make room would run the target \
+             unauthenticated — or worse, against whatever ambient identity the host has — so the \
+             target fails instead. Present the largest values as `files` rather than `env`",
+            names.join(", ")
+        );
+    }
+    Ok(())
 }
 
-pub fn filter_long_env(mut env: Vec<(String, String)>, args: &[OsString]) -> Vec<(String, String)> {
-    let Some(maxl) = max_args() else { return env };
+/// Fit `env` under this system's `ARG_MAX`, evicting the longest entries first.
+///
+/// `protected` names entries the limiter may **never** evict: credential values.
+/// Without that exemption the eviction order — longest first — picks precisely a
+/// session token, and because `ARG_MAX` differs by operating system the same
+/// BUILD file would keep the credential on Linux and drop it on macOS, then run
+/// unauthenticated or against whatever ambient identity the host had. That is a
+/// silent per-platform divergence in *who the build acts as*, which is the one
+/// class of difference this must never produce.
+///
+/// If the protected set alone does not fit, the target fails rather than
+/// spawning.
+pub fn filter_long_env(
+    mut env: Vec<(String, String)>,
+    args: &[OsString],
+    protected: &BTreeSet<String>,
+) -> anyhow::Result<Vec<(String, String)>> {
+    let Some(maxl) = max_args() else {
+        return Ok(env);
+    };
     if maxl <= 0 {
-        return env;
+        return Ok(env);
     }
     let args_len: i64 = args.iter().map(|a| a.len() as i64).sum();
-    filter_impl(&mut env, args_len, maxl);
-    env
+    filter_impl(&mut env, args_len, maxl, protected)?;
+    Ok(env)
 }
 
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    fn none() -> BTreeSet<String> {
+        BTreeSet::new()
+    }
+
+    fn protect(names: &[&str]) -> BTreeSet<String> {
+        names.iter().map(|n| n.to_string()).collect()
+    }
 
     #[test]
     fn drops_overlong_entry() {
@@ -81,7 +135,7 @@ mod tests {
             ("KEEP".to_string(), "value".to_string()),
             ("BIG".to_string(), huge),
         ];
-        filter_impl(&mut env, 0, i64::MAX);
+        filter_impl(&mut env, 0, i64::MAX, &none()).expect("fits");
         assert_eq!(env.len(), 1);
         assert_eq!(env[0].0, "KEEP");
     }
@@ -94,7 +148,7 @@ mod tests {
             ("C".to_string(), "x".repeat(200)),
         ];
         // 2860 with all three; 2356 after removing B.
-        filter_impl(&mut env, 0, 2500);
+        filter_impl(&mut env, 0, 2500, &none()).expect("fits");
         let keys: Vec<&str> = env.iter().map(|(k, _)| k.as_str()).collect();
         assert_eq!(keys, vec!["A", "C"]);
     }
@@ -103,10 +157,55 @@ mod tests {
     fn args_length_counted() {
         let mut env = vec![("A".to_string(), "x".repeat(100))];
         let baseline = env_byte_length(&env);
-        filter_impl(&mut env, 0, baseline + 10);
+        filter_impl(&mut env, 0, baseline + 10, &none()).expect("fits");
         assert_eq!(env.len(), 1);
 
-        filter_impl(&mut env, 10_000, baseline + 10);
+        filter_impl(&mut env, 10_000, baseline + 10, &none()).expect("fits");
+        assert!(env.is_empty());
+    }
+
+    /// The eviction order is longest-first, which is precisely a session token.
+    #[test]
+    fn a_credential_is_never_the_entry_that_gets_evicted() {
+        let mut env = vec![
+            ("AWS_SESSION_TOKEN".to_string(), "x".repeat(500)),
+            ("BULK".to_string(), "x".repeat(200)),
+        ];
+        filter_impl(&mut env, 0, 2600, &protect(&["AWS_SESSION_TOKEN"])).expect("fits");
+        let keys: Vec<&str> = env.iter().map(|(k, _)| k.as_str()).collect();
+        assert_eq!(keys, vec!["AWS_SESSION_TOKEN"]);
+    }
+
+    /// If only the protected set is left and it still does not fit, spawning
+    /// would run the target unauthenticated. Fail instead.
+    #[test]
+    fn a_credential_that_cannot_fit_fails_the_target_rather_than_being_dropped() {
+        let mut env = vec![("AWS_SESSION_TOKEN".to_string(), "x".repeat(500))];
+        let err =
+            filter_impl(&mut env, 0, 100, &protect(&["AWS_SESSION_TOKEN"])).expect_err("must fail");
+        let msg = format!("{err:#}");
+        assert!(msg.contains("AWS_SESSION_TOKEN"), "{msg}");
+        assert!(msg.contains("unauthenticated"), "{msg}");
+    }
+
+    /// `MAX_ARG_STRLEN` is a per-entry cap, and dropping a protected entry for it
+    /// would be the same silent de-authentication by another route. Keeping it
+    /// makes `execve` fail with `E2BIG`, which is a visible failure rather than a
+    /// build that quietly ran as nobody.
+    #[test]
+    fn an_overlong_credential_is_kept_so_the_spawn_fails_visibly() {
+        let mut env = vec![("TOKEN".to_string(), "x".repeat(MAX_ARG_STRLEN + 10))];
+        filter_impl(&mut env, 0, i64::MAX, &protect(&["TOKEN"])).expect("no total-size failure");
+        assert_eq!(env.len(), 1, "a credential is never silently dropped");
+    }
+
+    /// The pre-credential behaviour is untouched: a target whose argv alone
+    /// blows past ARG_MAX still gets an empty env and a spawn attempt, not a new
+    /// hard failure.
+    #[test]
+    fn a_target_with_no_credentials_still_just_gets_everything_evicted() {
+        let mut env = vec![("A".to_string(), "x".repeat(100))];
+        filter_impl(&mut env, 10_000, 2500, &none()).expect("no failure without credentials");
         assert!(env.is_empty());
     }
 }

--- a/crates/plugin-exec/src/pluginexec/mod.rs
+++ b/crates/plugin-exec/src/pluginexec/mod.rs
@@ -1,5 +1,6 @@
 mod filterenv;
 mod pty;
+pub mod redact;
 mod spec;
 
 use anyhow::Context;
@@ -372,14 +373,23 @@ async fn tee_stream(
     addr: &str,
     stream: &str,
     bytes_read: &std::sync::atomic::AtomicUsize,
+    // `None` for every target that declares no credentials, which is nearly all
+    // of them — so the scrubbing path costs one null check.
+    needles: Option<Arc<redact::Needles>>,
 ) {
     use tokio::io::{AsyncReadExt, AsyncWriteExt};
     let Some(mut source) = source else { return };
     let mut buf = vec![0u8; 8192];
     let mut lost = SinkLoss::default();
+    let mut redactor = needles.map(redact::Redactor::new);
     loop {
         match source.read(&mut buf).await {
-            Ok(0) => break,
+            Ok(0) => {
+                // Flush whatever the redactor held back across the last read
+                // boundary, or the tail of the output disappears.
+                flush_redacted(&mut redactor, &log, &mut sink, &mut lost).await;
+                break;
+            }
             Err(error) => {
                 tracing::warn!(
                     addr,
@@ -388,6 +398,9 @@ async fn tee_stream(
                     bytes_read = bytes_read.load(std::sync::atomic::Ordering::Relaxed),
                     "pluginexec: error draining child output; log tail may be truncated"
                 );
+                // Flush before leaving, or a read error costs the log the
+                // redactor's held-back tail on top of whatever the read lost.
+                flush_redacted(&mut redactor, &log, &mut sink, &mut lost).await;
                 break;
             }
             Ok(n) => {
@@ -397,6 +410,14 @@ async fn tee_stream(
                     reason = "n guaranteed <= buf.len() by AsyncRead contract"
                 )]
                 let slice = &buf[..n];
+                // Scrubbed BEFORE the log write, not after: `log.txt` is packed
+                // into the cache as an artifact and lifted into the failure
+                // event, so a token that reaches it has already escaped.
+                let scrubbed = redactor.as_mut().map(|r| r.push(slice));
+                let slice: &[u8] = scrubbed.as_deref().unwrap_or(slice);
+                if slice.is_empty() {
+                    continue;
+                }
                 if let Ok(mut g) = log.lock() {
                     drop(g.write_all(slice));
                 }
@@ -410,13 +431,43 @@ async fn tee_stream(
                     // surfaces at the flush rather than at `write_all` — take
                     // whichever failed.
                     if let Err(e) = wrote.and(flushed) {
-                        lost.record(n, e);
+                        lost.record(slice.len(), e);
                     }
                 }
             }
         }
     }
     lost.finish(addr, stream);
+}
+
+/// Write a redactor's held-back tail to the log and the sink.
+///
+/// Shared by every exit from a tee loop — EOF *and* a read error — because a tail
+/// that is not flushed is output that silently disappears, which is the failure
+/// [`SinkLoss`] exists to make visible.
+async fn flush_redacted(
+    redactor: &mut Option<redact::Redactor>,
+    log: &Arc<std::sync::Mutex<std::fs::File>>,
+    sink: &mut Option<&mut (dyn tokio::io::AsyncWrite + Send + Sync + Unpin)>,
+    lost: &mut SinkLoss,
+) {
+    use std::io::Write as _;
+    use tokio::io::AsyncWriteExt as _;
+    let Some(r) = redactor.as_mut() else { return };
+    let tail = r.finish();
+    if tail.is_empty() {
+        return;
+    }
+    if let Ok(mut g) = log.lock() {
+        drop(g.write_all(&tail));
+    }
+    if let Some(out) = sink {
+        let wrote = out.write_all(&tail).await;
+        let flushed = out.flush().await;
+        if let Err(e) = wrote.and(flushed) {
+            lost.record(tail.len(), e);
+        }
+    }
 }
 
 /// Output the sink refused, and why.
@@ -493,6 +544,10 @@ impl SinkLoss {
 /// `stdout_bytes`/`stderr_bytes` mirror `tee_stream`'s `bytes_read`: a
 /// post-wait drain timeout reports how much of each stream it actually got
 /// before giving up, rather than just "it timed out".
+#[expect(
+    clippy::too_many_arguments,
+    reason = "one tee over both streams: two sinks, two counters, and redaction"
+)]
 async fn tee_output<'io>(
     reader: Option<proc_exec::OutputReader>,
     log: Arc<std::sync::Mutex<std::fs::File>>,
@@ -503,15 +558,31 @@ async fn tee_output<'io>(
     addr: &str,
     stdout_bytes: &std::sync::atomic::AtomicUsize,
     stderr_bytes: &std::sync::atomic::AtomicUsize,
+    needles: Option<Arc<redact::Needles>>,
 ) {
     use tokio::io::AsyncWriteExt;
     let Some(mut reader) = reader else { return };
     let mut absorbed = SinkCost::default();
     let (mut lost_stdout, mut lost_stderr) = (SinkLoss::default(), SinkLoss::default());
+    // One redactor per stream, never one shared. The held-back tail is a
+    // property of *this* byte sequence; running both streams through one buffer
+    // would splice them together.
+    let (mut red_out, mut red_err) = (
+        needles.clone().map(redact::Redactor::new),
+        needles.map(redact::Redactor::new),
+    );
     loop {
         let (stream, chunk) = match reader.recv().await {
             Ok(Some(c)) => c,
-            Ok(None) => break,
+            Ok(None) => {
+                // Flush both redactors' held-back tails, or the last bytes of a
+                // target's output disappear. A refused write is recorded rather
+                // than dropped, for the same reason every other sink write here
+                // is — see [`SinkLoss`].
+                flush_redacted(&mut red_out, &log, &mut stdout, &mut lost_stdout).await;
+                flush_redacted(&mut red_err, &log, &mut stderr, &mut lost_stderr).await;
+                break;
+            }
             // One reader now carries both streams, so treating a read error as
             // EOF would stop teeing the *other* stream too — `log.txt` would
             // truncate with no note, and dropping the reader would SIGPIPE the
@@ -533,15 +604,25 @@ async fn tee_output<'io>(
             proc_exec::StreamId::Stderr => stderr_bytes,
         };
         bytes_counter.fetch_add(chunk.len(), std::sync::atomic::Ordering::Relaxed);
+        // Scrubbed before the log write — see `tee_stream`.
+        let redactor = match stream {
+            proc_exec::StreamId::Stdout => red_out.as_mut(),
+            proc_exec::StreamId::Stderr => red_err.as_mut(),
+        };
+        let scrubbed = redactor.map(|r| r.push(&chunk));
+        let chunk: &[u8] = scrubbed.as_deref().unwrap_or(&chunk);
+        if chunk.is_empty() {
+            continue;
+        }
         if let Ok(mut g) = log.lock() {
-            drop(g.write_all(&chunk));
+            drop(g.write_all(chunk));
         }
         let sink = match stream {
             proc_exec::StreamId::Stdout => stdout.as_mut(),
             proc_exec::StreamId::Stderr => stderr.as_mut(),
         };
         if let Some(out) = sink {
-            let wrote = out.write_all(&chunk).await;
+            let wrote = out.write_all(chunk).await;
             // Flush immediately so an interactive consumer sees each chunk
             // as it appears rather than at process exit.
             let flushed = out.flush().await;
@@ -888,6 +969,46 @@ impl hdriver_support::driver_managed::ManagedDriver for Driver {
             });
         }
 
+        // Credential references. The same `hashed: false, runtime: false` edge a
+        // scratch uses, told apart by its annotation — and for a sharper reason
+        // than scratch's. Both flags false is not an optimization here, it is the
+        // contract: nothing about a credential may enter `hashin`, not the
+        // material, not the chosen source, not the declaration, not even the
+        // names of the variables it presents. Because the exclusion is
+        // structural, adding a credential to a target cannot move its cache key.
+        //
+        // What the edge *does* buy is the graph: `heph query revdeps` answers
+        // "who needs this identity?", `heph inspect deps` shows it, and a bad
+        // addr is an ordinary `TargetNotFoundError` rather than a 403 much later.
+        let mut seen_credential: BTreeMap<String, usize> = BTreeMap::new();
+        let mut credential_inputs: Vec<Input> = Vec::with_capacity(spec.credentials.len());
+        for (i, raw) in spec.credentials.iter().enumerate() {
+            let r#ref = TargetAddr::parse(raw, &pkg)?;
+            let key = r#ref.to_string();
+            if let Some(first) = seen_credential.insert(key.clone(), i) {
+                anyhow::bail!(
+                    "credential {key} is referenced twice (positions {first} and {i}) — a \
+                     credential presents one set of variables and files, so referencing it again \
+                     does nothing; drop the duplicate"
+                );
+            }
+            credential_inputs.push(Input {
+                r#ref,
+                mode: InputMode::Standard,
+                origin_id: format!(
+                    "{}|{}",
+                    hdriver_support::credential::CREDENTIAL_ORIGIN_PREFIX,
+                    i
+                ),
+                annotations: BTreeMap::from([(
+                    hdriver_support::credential::CREDENTIAL_ANNOTATION.to_string(),
+                    "true".to_string(),
+                )]),
+                hashed: false,
+                runtime: false,
+            });
+        }
+
         let tool_inputs = sorted_by_group(spec.tools)
             .into_iter()
             .flat_map(|(k, v)| {
@@ -1052,6 +1173,7 @@ impl hdriver_support::driver_managed::ManagedDriver for Driver {
                     .chain(tool_inputs.into_iter().map(|(_, v)| v))
                     .chain(runner_input)
                     .chain(scratch_inputs)
+                    .chain(credential_inputs)
                     .collect(),
                 outputs,
                 support_files,
@@ -1509,15 +1631,58 @@ impl Driver {
             env.insert(m.env.clone(), dir.to_string());
         }
 
+        // Credentials. The host already walked the chain, acquired the material
+        // and wrote every presented file into this run's sandbox at 0600; what is
+        // left is what a driver can actually do — set some environment, and
+        // prepend a directory to PATH for the one protocol (Docker's) that
+        // resolves a helper by executable name.
+        //
+        // Set last so a credential is never shadowed by the target's own `env`:
+        // the point of naming a credential is to get that identity, and a target
+        // that also sets the variable has written a conflict rather than an
+        // override. A collision is refused rather than resolved, exactly as for
+        // scratch — silently winning either way leaves one of the two
+        // inoperative with nothing to see.
+        let mut credential_env_names: std::collections::BTreeSet<String> =
+            std::collections::BTreeSet::new();
+        let mut credential_path_prefix: Vec<OsString> = Vec::new();
+        for m in &rreq.credentials {
+            for (k, v) in &m.env {
+                if let Some(existing) = env.get(k)
+                    && existing != v
+                {
+                    anyhow::bail!(
+                        "credential {} presents `{k}`, but this target already sets it. One would \
+                         shadow the other — drop it from this target's `env`, or change the \
+                         variable on the credential's presentation",
+                        m.addr
+                    );
+                }
+                env.insert(k.clone(), v.clone());
+                credential_env_names.insert(k.clone());
+            }
+            credential_path_prefix
+                .extend(m.path_prefix.iter().map(|p| p.as_os_str().to_os_string()));
+        }
+
+        // Values this target's output must be scrubbed of, before any byte of it
+        // reaches `log.txt` — which is packed into the cache as an artifact and
+        // lifted into the failure event. `None` for every target that declares no
+        // credentials.
+        let needles = redact::Needles::new(rreq.credentials.iter().flat_map(|m| m.redact.iter()));
+
         // The target's own tools lead, wherever it ends up running — composed by
         // `hexecrunner` rather than spliced into the string here, because under
         // a runner the rest of `PATH` is not known until the runner (or its
         // agent) has had its say.
+        //
+        // A credential helper shim goes ahead of even the target's tools: it is
+        // named `docker-credential-heph`, which nothing else in the tree provides,
+        // so leading costs nothing and guarantees Docker finds it.
         let path_policy = hexecrunner::PathPolicy {
-            prefix: tool_bin_dir
-                .as_ref()
-                .map(|d| d.as_os_str().to_os_string())
+            prefix: credential_path_prefix
                 .into_iter()
+                .chain(tool_bin_dir.as_ref().map(|d| d.as_os_str().to_os_string()))
                 .collect(),
             fallback: Some(std::ffi::OsString::from(self.sandbox_path_display())),
         };
@@ -1555,7 +1720,12 @@ impl Driver {
         let mut argv_for_filter: Vec<OsString> = Vec::with_capacity(1 + args_os.len());
         argv_for_filter.push(OsString::from(&program));
         argv_for_filter.extend(args_os.iter().cloned());
-        let env_vec = filterenv::filter_long_env(env_vec, &argv_for_filter);
+        // Credential names are protected from the size limiter: its eviction
+        // order is longest-first, which is precisely a session token, and
+        // `ARG_MAX` differs by operating system — so without this the same BUILD
+        // file would keep the credential on Linux and drop it on macOS, then run
+        // unauthenticated or against whatever ambient identity the host had.
+        let env_vec = filterenv::filter_long_env(env_vec, &argv_for_filter, &credential_env_names)?;
         let env_pairs: Vec<(OsString, OsString)> = env_vec
             .into_iter()
             .map(|(k, v)| (OsString::from(k), OsString::from(v)))
@@ -1728,6 +1898,7 @@ impl Driver {
                 &addr_str,
                 "pty",
                 &stdout_bytes,
+                needles.clone(),
             ));
 
             let stdin_fut: std::pin::Pin<Box<dyn std::future::Future<Output = ()> + Send + '_>> =
@@ -1753,6 +1924,7 @@ impl Driver {
                 &addr_str,
                 &stdout_bytes,
                 &stderr_bytes,
+                needles.clone(),
             ));
             let stdin_fut: std::pin::Pin<Box<dyn std::future::Future<Output = ()> + Send + '_>> =
                 match (rreq.stdin, stdin_pump) {
@@ -2044,6 +2216,7 @@ mod tests {
             "//pkg:target",
             "pty",
             &bytes_read,
+            None,
         )
         .await;
         drop(guard);
@@ -2079,6 +2252,7 @@ mod tests {
             "//pkg:target",
             "stdout",
             &bytes_read,
+            None,
         )
         .await;
         drop(guard);
@@ -2197,6 +2371,7 @@ mod tests {
             stderr: None,
             sandbox_dir: tmp.path().to_path_buf(),
             scratch: vec![],
+            credentials: vec![],
         };
 
         let res = tokio::time::timeout(
@@ -2522,6 +2697,7 @@ mod tests {
             stderr: None,
             sandbox_dir: tmp.path().to_path_buf(),
             scratch: vec![],
+            credentials: vec![],
         };
 
         let _res = driver.run(make_req(req), &ctoken).await?;
@@ -2581,6 +2757,7 @@ mod tests {
             stderr: None,
             sandbox_dir: tmp.path().to_path_buf(),
             scratch: vec![],
+            credentials: vec![],
         };
 
         let res = driver.run(make_req(req), &ctoken).await;
@@ -2653,6 +2830,7 @@ mod tests {
             stderr: None,
             sandbox_dir: tmp.path().to_path_buf(),
             scratch: vec![],
+            credentials: vec![],
         };
 
         // Use a timeout to detect the hang
@@ -2715,6 +2893,7 @@ mod tests {
             stderr: None,
             sandbox_dir: tmp.path().to_path_buf(),
             scratch: vec![],
+            credentials: vec![],
         };
 
         let run_fut = driver.run(make_req(req), &ctoken);
@@ -2784,6 +2963,7 @@ mod tests {
             stderr: None,
             sandbox_dir: tmp.path().to_path_buf(),
             scratch: vec![],
+            credentials: vec![],
         };
 
         let run_fut = driver.run(make_req(req), &ctoken);
@@ -2852,6 +3032,7 @@ mod tests {
             stderr: None,
             sandbox_dir: tmp.path().to_path_buf(),
             scratch: vec![],
+            credentials: vec![],
         };
 
         let res = tokio::time::timeout(
@@ -3029,6 +3210,7 @@ mod tests {
             stderr: Some(&mut err_handle),
             sandbox_dir: tmp.path().to_path_buf(),
             scratch: vec![],
+            credentials: vec![],
         };
 
         tokio::time::timeout(MIDDLE * 10, driver.run(make_req(req), &ctoken))
@@ -3111,6 +3293,7 @@ mod tests {
             stderr: None,
             sandbox_dir: tmp.path().to_path_buf(),
             scratch: vec![],
+            credentials: vec![],
         };
 
         driver.run(make_req(req), &ctoken).await?;
@@ -3186,6 +3369,7 @@ mod tests {
             stderr: Some(&mut stderr),
             sandbox_dir: tmp.path().to_path_buf(),
             scratch: vec![],
+            credentials: vec![],
         };
 
         tokio::time::timeout(
@@ -3343,6 +3527,7 @@ mod tests {
             stderr: None,
             sandbox_dir: tmp.path().to_path_buf(),
             scratch: vec![],
+            credentials: vec![],
         };
 
         tokio::time::timeout(
@@ -3442,6 +3627,7 @@ mod tests {
             stderr: None,
             sandbox_dir: tmp.path().to_path_buf(),
             scratch: vec![],
+            credentials: vec![],
         };
         driver.run(make_req(req), &ctoken).await?;
         Ok(String::from_utf8(stdout)?.trim().to_string())
@@ -4474,6 +4660,7 @@ mod tests {
             stderr: None,
             sandbox_dir: tmp.path().to_path_buf(),
             scratch: vec![],
+            credentials: vec![],
         };
         driver
             .run(
@@ -4521,6 +4708,7 @@ mod tests {
             stderr: None,
             sandbox_dir: tmp.path().to_path_buf(),
             scratch: vec![],
+            credentials: vec![],
         };
         driver
             .run(
@@ -4601,6 +4789,7 @@ mod tests {
             stderr: None,
             sandbox_dir: tmp.path().to_path_buf(),
             scratch: vec![],
+            credentials: vec![],
         };
         driver
             .run(
@@ -4758,6 +4947,7 @@ mod tests {
             stderr: None,
             sandbox_dir: sandbox.clone(),
             scratch: vec![],
+            credentials: vec![],
         };
 
         os.run_inner(req, &ctoken, false).await?;
@@ -4855,6 +5045,7 @@ mod tests {
             stderr: None,
             sandbox_dir: tmp.path().to_path_buf(),
             scratch: vec![],
+            credentials: vec![],
         };
         driver
             .run(
@@ -4930,6 +5121,7 @@ mod tests {
             stderr: None,
             sandbox_dir: tmp.path().to_path_buf(),
             scratch: vec![],
+            credentials: vec![],
         };
         driver.run(make_req(req), &ctoken).await?;
 
@@ -5017,6 +5209,7 @@ mod tests {
             stderr: None,
             sandbox_dir: tmp.path().to_path_buf(),
             scratch: vec![],
+            credentials: vec![],
         };
         driver
             .run(
@@ -5120,6 +5313,7 @@ mod tests {
             stderr: None,
             sandbox_dir: tmp.path().to_path_buf(),
             scratch: vec![],
+            credentials: vec![],
         };
         driver
             .run(
@@ -5210,6 +5404,7 @@ mod tests {
             stderr: None,
             sandbox_dir: tmp.path().to_path_buf(),
             scratch: vec![],
+            credentials: vec![],
         };
 
         driver.run(make_req(req), &ctoken).await?;

--- a/crates/plugin-exec/src/pluginexec/redact.rs
+++ b/crates/plugin-exec/src/pluginexec/redact.rs
@@ -1,0 +1,304 @@
+//! Scrubbing credential material out of a target's output, at the tee.
+//!
+//! # Why here and not at render
+//!
+//! Redacting where output is *displayed* misses everything that matters. The
+//! captured log is packed into the cache as an artifact, lifted into the failure
+//! event, and printed in the JSON output and the CI report — so by the time a
+//! renderer sees it, the token is already on disk and on its way to a shared
+//! remote. The tee is the one point every one of those paths passes through, and
+//! it is upstream of all of them.
+//!
+//! # Why it holds bytes back
+//!
+//! A read boundary lands wherever the kernel put it, so a token can arrive split
+//! across two chunks with nothing wrong with either half. Scanning per chunk would
+//! let exactly that one through, and it would do so *intermittently*, which is
+//! the worst possible failure shape for a secret. So the last `len(longest
+//! secret) - 1` bytes of every chunk are held back and rescanned with the next
+//! one.
+//!
+//! # What it does not do
+//!
+//! Redaction is **best-effort by construction**, and that is documented rather
+//! than hidden. It is a substring replacement over a byte stream, so a short
+//! secret cannot be scrubbed without corrupting output that merely happens to
+//! contain those bytes — see [`REDACT_MIN_LEN`]. It also cannot see a secret the
+//! target transformed: base64, a URL-encoding, or a token split across two lines
+//! by the tool that printed it all pass through.
+
+use hplugin::driver::REDACT_MIN_LEN;
+use std::sync::Arc;
+
+/// What a redacted run of bytes is replaced with.
+///
+/// Fixed-width and obviously not a value, so a log that has been scrubbed reads
+/// as scrubbed rather than as a build that printed something odd.
+const MARKER: &[u8] = b"[redacted]";
+
+/// The secrets to scrub, shared by every stream of one run.
+///
+/// Built once per target and `None` when there is nothing to scrub — which is
+/// every target that declares no credentials, so the hot path pays a null check.
+pub struct Needles {
+    /// Longest first, so a secret that contains another is replaced whole rather
+    /// than leaving a scrubbed fragment inside a longer one.
+    ///
+    /// Each carries a prebuilt substring searcher. The naive
+    /// `windows(n).position(…)` this replaced is `O(hay × needle)`, and a needle
+    /// here is a whole session token — around a kilobyte — so a target printing a
+    /// few megabytes of ordinary build output paid on the order of a thousand
+    /// byte-comparisons per output byte, on the tee, in the middle of the run.
+    needles: Vec<(Vec<u8>, memchr::memmem::Finder<'static>)>,
+}
+
+impl Needles {
+    /// `None` when nothing needs scrubbing.
+    pub fn new<I, S>(values: I) -> Option<Arc<Self>>
+    where
+        I: IntoIterator<Item = S>,
+        S: AsRef<str>,
+    {
+        let mut raw: Vec<Vec<u8>> = values
+            .into_iter()
+            // The floor, applied here as well as at the host so a driver that is
+            // handed a short value by an older host still refuses to corrupt
+            // ordinary output with it.
+            .filter(|v| v.as_ref().len() >= REDACT_MIN_LEN)
+            .map(|v| v.as_ref().as_bytes().to_vec())
+            .collect();
+        if raw.is_empty() {
+            return None;
+        }
+        raw.sort_by(|a, b| b.len().cmp(&a.len()).then_with(|| a.cmp(b)));
+        raw.dedup();
+        let needles = raw
+            .into_iter()
+            .map(|n| {
+                let finder = memchr::memmem::Finder::new(&n).into_owned();
+                (n, finder)
+            })
+            .collect();
+        Some(Arc::new(Self { needles }))
+    }
+}
+
+/// Per-stream redaction state.
+///
+/// One per stream, never shared: the held-back tail is a property of *this*
+/// byte sequence, and interleaving two streams through one buffer would splice
+/// them together.
+pub struct Redactor {
+    needles: Arc<Needles>,
+    /// Bytes seen but not yet emitted.
+    buf: Vec<u8>,
+}
+
+impl Redactor {
+    pub fn new(needles: Arc<Needles>) -> Self {
+        Self {
+            needles,
+            buf: Vec::new(),
+        }
+    }
+
+    /// Feed a chunk; returns the bytes that are now safe to emit.
+    ///
+    /// Every returned byte is past every possible secret boundary: replacement
+    /// happens *before* the emit split, and the split leaves behind exactly the
+    /// tail that could still be the beginning of a secret.
+    pub fn push(&mut self, chunk: &[u8]) -> Vec<u8> {
+        self.buf.extend_from_slice(chunk);
+        self.scrub();
+        let keep = self.partial_tail();
+        let emit_len = self.buf.len() - keep;
+        let rest = self.buf.split_off(emit_len);
+        std::mem::replace(&mut self.buf, rest)
+    }
+
+    /// Flush at end of stream. Nothing is held back after this.
+    pub fn finish(&mut self) -> Vec<u8> {
+        self.scrub();
+        std::mem::take(&mut self.buf)
+    }
+
+    /// How many trailing bytes could still turn out to be the start of a secret.
+    ///
+    /// **This is what keeps an interactive session alive.** Holding back a flat
+    /// `len(longest secret) - 1` bytes — the obvious implementation — blanks a
+    /// `--shell` prompt and makes a streaming `terraform apply` look stalled,
+    /// because a session token is around a kilobyte and a prompt is twenty bytes.
+    /// Holding back only a genuine partial match means ordinary output keeps
+    /// nothing back at all: the answer is `0` unless the chunk really did end
+    /// mid-token.
+    ///
+    /// Cost is bounded by the longest needle and paid only on the tail: for each
+    /// needle, the candidate split points are the positions of its first byte in
+    /// the last `len(needle) - 1` bytes, which `memchr` finds without scanning
+    /// byte by byte.
+    fn partial_tail(&self) -> usize {
+        let mut keep = 0usize;
+        for (needle, _) in &self.needles.needles {
+            let window = (needle.len().saturating_sub(1)).min(self.buf.len());
+            if window <= keep {
+                // Longest-first ordering means no shorter needle can beat a
+                // longer partial match already found.
+                continue;
+            }
+            let start = self.buf.len() - window;
+            let tail = self.buf.get(start..).unwrap_or_default();
+            let Some(first) = needle.first().copied() else {
+                continue;
+            };
+            for pos in memchr::memchr_iter(first, tail) {
+                let k = tail.len() - pos;
+                if k <= keep {
+                    break;
+                }
+                let candidate = tail.get(pos..).unwrap_or_default();
+                if needle.get(..candidate.len()) == Some(candidate) {
+                    keep = k;
+                    break;
+                }
+            }
+        }
+        keep.min(self.buf.len())
+    }
+
+    /// Replace every occurrence of every needle in the pending buffer.
+    ///
+    /// Longest-first, so a secret that is a substring of another does not leave a
+    /// `[redacted]` embedded in the longer one — which would both look wrong and
+    /// reveal the longer secret's shape.
+    fn scrub(&mut self) {
+        for (needle, finder) in &self.needles.needles {
+            if needle.is_empty() {
+                continue;
+            }
+            let mut from = 0usize;
+            while let Some(pos) = finder.find(self.buf.get(from..).unwrap_or_default()) {
+                let at = from + pos;
+                self.buf
+                    .splice(at..at + needle.len(), MARKER.iter().copied());
+                from = at + MARKER.len();
+            }
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn needles(vs: &[&str]) -> Arc<Needles> {
+        Needles::new(vs.iter().copied()).expect("some needles")
+    }
+
+    fn run(r: &mut Redactor, chunks: &[&[u8]]) -> Vec<u8> {
+        let mut out = Vec::new();
+        for c in chunks {
+            out.extend(r.push(c));
+        }
+        out.extend(r.finish());
+        out
+    }
+
+    #[test]
+    fn a_secret_in_one_chunk_is_replaced() {
+        let mut r = Redactor::new(needles(&["s3cr3t-value"]));
+        let out = run(&mut r, &[b"token=s3cr3t-value done\n"]);
+        assert_eq!(out, b"token=[redacted] done\n");
+    }
+
+    /// The failure this exists to prevent: a read boundary lands wherever the
+    /// kernel put it, so per-chunk scanning lets a split secret through — and
+    /// does it intermittently.
+    #[test]
+    fn a_secret_split_across_a_read_boundary_is_still_caught() {
+        let mut r = Redactor::new(needles(&["s3cr3t-value"]));
+        let out = run(&mut r, &[b"token=s3cr", b"3t-value done\n"]);
+        assert_eq!(out, b"token=[redacted] done\n");
+    }
+
+    #[test]
+    fn a_secret_split_one_byte_at_a_time_is_still_caught() {
+        let mut r = Redactor::new(needles(&["s3cr3t-value"]));
+        let input = b"a s3cr3t-value b";
+        let chunks: Vec<&[u8]> = input.chunks(1).collect();
+        assert_eq!(run(&mut r, &chunks), b"a [redacted] b");
+    }
+
+    #[test]
+    fn every_occurrence_is_replaced() {
+        let mut r = Redactor::new(needles(&["abcdefgh"]));
+        assert_eq!(
+            run(&mut r, &[b"abcdefgh abcdefgh"]),
+            b"[redacted] [redacted]"
+        );
+    }
+
+    #[test]
+    fn ordinary_output_is_untouched_byte_for_byte() {
+        let mut r = Redactor::new(needles(&["s3cr3t-value"]));
+        let text = b"compiling 42 files in 3.1s\n" as &[u8];
+        assert_eq!(run(&mut r, &[text]), text);
+    }
+
+    /// A secret that contains another must not end up with a `[redacted]`
+    /// embedded in it — that both looks wrong and reveals the longer one's shape.
+    #[test]
+    fn the_longest_secret_wins() {
+        let mut r = Redactor::new(needles(&["abcdefgh", "abcdefghijkl"]));
+        assert_eq!(run(&mut r, &[b"x abcdefghijkl y"]), b"x [redacted] y");
+    }
+
+    /// The stated limit. A short secret cannot be scrubbed without corrupting
+    /// output that merely happens to contain those bytes.
+    #[test]
+    fn a_secret_shorter_than_the_floor_is_not_scrubbed_and_that_is_documented() {
+        assert!(Needles::new(["abc"]).is_none());
+        assert_eq!(REDACT_MIN_LEN, 8);
+    }
+
+    #[test]
+    fn no_secrets_means_no_redactor_at_all() {
+        assert!(Needles::new(Vec::<String>::new()).is_none());
+    }
+
+    /// The property that keeps `--shell` usable and a streaming build legible:
+    /// ordinary output is emitted immediately, not held back by the length of the
+    /// longest secret.
+    #[test]
+    fn ordinary_output_is_not_held_back_at_all() {
+        let mut r = Redactor::new(needles(&["a-very-long-session-token-value"]));
+        // A shell prompt. A flat `len(longest) - 1` hold-back would show nothing
+        // until ~30 more bytes arrived.
+        assert_eq!(r.push(b"$ "), b"$ ");
+        assert_eq!(r.push(b"echo hi\n"), b"echo hi\n");
+    }
+
+    /// …and a chunk that really does end mid-secret holds back exactly that much.
+    #[test]
+    fn only_a_genuine_partial_match_is_held_back() {
+        let mut r = Redactor::new(needles(&["s3cr3t-value"]));
+        // Ends with `s3cr`, which is a prefix of the needle.
+        assert_eq!(r.push(b"tok=s3cr"), b"tok=");
+        assert_eq!(r.push(b"3t-value!"), b"[redacted]!");
+    }
+
+    /// A tail that looks like a prefix but is not must not be held back.
+    #[test]
+    fn a_near_miss_tail_is_emitted() {
+        let mut r = Redactor::new(needles(&["s3cr3t-value"]));
+        // `s3cx` is not a prefix of the needle, but shares its first byte.
+        assert_eq!(r.push(b"tok=s3cx"), b"tok=s3cx");
+    }
+
+    #[test]
+    fn nothing_is_held_back_after_finish() {
+        let mut r = Redactor::new(needles(&["s3cr3t-value"]));
+        let mut out = r.push(b"tail");
+        out.extend(r.finish());
+        assert_eq!(out, b"tail");
+    }
+}

--- a/crates/plugin-exec/src/pluginexec/spec.rs
+++ b/crates/plugin-exec/src/pluginexec/spec.rs
@@ -29,6 +29,18 @@ pub(crate) struct TargetSpec {
     /// `env` variable is set for the run. A scratch is not an input: it is never
     /// materialized from artifacts and never affects this target's cache key.
     pub scratch: Vec<String>,
+    /// Credentials this target needs, as a list of `credential` target addresses.
+    /// Each is acquired from whatever environment the build is running in and
+    /// presented in the shape its declaration names — environment variables,
+    /// `0600` files, or a callback helper.
+    ///
+    /// A credential is not an input: nothing about it reaches this target's cache
+    /// key, in either direction. The contract that makes that sound is that a
+    /// credential grants *access* and is not an *input* — this target's outputs
+    /// must be identical whichever identity satisfied the requirement. A target
+    /// whose output depends on *who* ran it is not cacheable, and says so with
+    /// `cache = False`.
+    pub credentials: Vec<String>,
     /// Build tools, grouped by name → list of target addresses; symlinked under `tools/`.
     pub tools: HashMap<String, Vec<String>>,
     /// Declared outputs, grouped by name → list of output paths the target writes.
@@ -93,6 +105,7 @@ mod tests {
             "runtime_pass_env",
             "runtime_env",
             "runner",
+            "credentials",
         ] {
             assert!(by_name.contains_key(key), "schema missing field `{key}`");
         }

--- a/crates/plugin-oci/src/pluginoci/mod.rs
+++ b/crates/plugin-oci/src/pluginoci/mod.rs
@@ -466,6 +466,7 @@ pub(crate) mod testfake {
                 stderr: None,
                 sandbox_dir: sandbox.dir.path().to_path_buf(),
                 scratch: vec![],
+                credentials: vec![],
             },
             sandbox_dir: sandbox.dir.path().to_path_buf(),
             sandbox_ws_dir: sandbox.ws.clone(),

--- a/crates/plugin-sdk/src/serve.rs
+++ b/crates/plugin-sdk/src/serve.rs
@@ -1250,6 +1250,18 @@ async fn run_once(
     let request_id = req.request_id;
     let hashin = req.hashin;
     let sandbox_dir = PathBuf::from(req.sandbox_dir);
+    // Fallible and never lossy: a credential dropped here would leave the target
+    // with no identity, which fails much later somewhere else — or succeeds
+    // against whatever ambient identity the host happened to have.
+    let credentials = match req
+        .credentials
+        .into_iter()
+        .map(convert::credential_mount_from_pb)
+        .collect::<anyhow::Result<Vec<_>>>()
+    {
+        Ok(c) => c,
+        Err(e) => return run_out_err(err_message(&e)),
+    };
     let run_inputs: Vec<RunInput> = req.inputs.iter().map(run_input_from_pb).collect();
     let managed_inputs: Vec<ManagedRunInput> =
         req.inputs.into_iter().map(managed_input_from_pb).collect();
@@ -1273,6 +1285,7 @@ async fn run_once(
             .into_iter()
             .filter_map(convert::scratch_mount_from_pb)
             .collect(),
+        credentials,
     };
     let mrr = ManagedRunRequest {
         request: rr,

--- a/crates/plugin-stabby/src/load_stable.rs
+++ b/crates/plugin-stabby/src/load_stable.rs
@@ -756,6 +756,12 @@ impl StableRemoteManagedDriver {
                 .iter()
                 .map(convert::scratch_mount_to_pb)
                 .collect(),
+            credentials: req
+                .request
+                .credentials
+                .iter()
+                .map(convert::credential_mount_to_pb)
+                .collect(),
         };
         // `run` is bidi: the request stream carries the run request (RunInFrame),
         // the response stream carries the result (RunOutFrame). `shell` rides pmrr.

--- a/crates/plugin/src/driver.rs
+++ b/crates/plugin/src/driver.rs
@@ -1038,6 +1038,71 @@ pub struct ScratchMount {
     pub dir: PathBuf,
 }
 
+/// The largest a single presented environment value may be.
+///
+/// Environment values *are* the material — a token a tool reads from its
+/// environment has nowhere else to live — so unlike a presentation file they
+/// cross inline. That makes them the one place a credential can push against
+/// `execve`'s `ARG_MAX`, so the bound is stated here rather than discovered as a
+/// spawn failure. Anything larger is a `files` presentation, which is also the
+/// right shape for it: a 32 KiB credential is a document, not a token.
+///
+/// Generous next to every real credential (a session token is a few kilobytes, a
+/// JWT rarely more) and small next to the smallest `ARG_MAX` on any supported
+/// target.
+pub const CREDENTIAL_ENV_MAX_BYTES: usize = 32 * 1024;
+
+/// A credential the host resolved, acquired and materialized for this run.
+///
+/// Deliberately the *smallest* thing that can carry an identity. The material
+/// itself, the chain that produced it, which source won and when it expires are
+/// all the host's and are not visible here — a driver's job is to hand its child
+/// an environment, not to understand an identity.
+///
+/// Presentation **files** are not in this type at all: the host wrote them under
+/// the run's `sandbox_dir` at `0600` and deletes them when the run ends whatever
+/// its outcome, and the `env` templates that point at them already carry their
+/// paths. So a driver that does nothing but apply `env` and `path_prefix` is a
+/// complete implementation.
+#[derive(Clone, Debug, Default, PartialEq, Eq)]
+pub struct CredentialMount {
+    /// The declaring target, for diagnostics.
+    pub addr: Addr,
+    /// Runtime environment for the target. Never hashed and never `pass_env`, so
+    /// it cannot reach a def hash by construction.
+    pub env: std::collections::BTreeMap<String, String>,
+    /// Directories to prepend to `PATH`, ahead of the target's own tools.
+    ///
+    /// Only the Docker credential-helper protocol needs this, because Docker
+    /// resolves a helper by executable name and nothing else will find a
+    /// `docker-credential-heph` shim.
+    pub path_prefix: Vec<std::path::PathBuf>,
+    /// Every material value this target's output must be scrubbed of.
+    ///
+    /// Redaction belongs at the **output tee**, before bytes reach disk — not at
+    /// render. The captured log is packed into the cache as an artifact and
+    /// lifted into the failure event, the JSON output and the CI report, so
+    /// redacting where it is displayed misses everything that matters.
+    ///
+    /// Best-effort by construction: a short secret cannot be scrubbed without
+    /// corrupting ordinary output, so [`REDACT_MIN_LEN`] is a floor and is
+    /// documented rather than hidden.
+    pub redact: Vec<String>,
+}
+
+/// The shortest material value worth scrubbing from a target's output.
+///
+/// Redaction is a substring replacement over a byte stream, so a short secret
+/// cannot be redacted without corrupting output that merely happens to contain
+/// those bytes — `"1"` would rewrite every number a build prints. Eight
+/// characters is short enough to cover every real token and long enough that a
+/// collision with ordinary output is vanishingly unlikely.
+///
+/// This is a stated limit, not a hidden one: a credential whose material is
+/// shorter than this is **not** redacted, and that must be said out loud rather
+/// than left for someone to discover in a log.
+pub const REDACT_MIN_LEN: usize = 8;
+
 pub struct RunRequest<'a, 'io> {
     pub request_id: &'a String,
     pub target: &'a targetdef::TargetDef,
@@ -1051,6 +1116,9 @@ pub struct RunRequest<'a, 'io> {
     /// Scratch caches to mount for this run, already locked and created by the
     /// host. Empty for the overwhelming majority of targets.
     pub scratch: Vec<ScratchMount>,
+    /// Credentials to present for this run, already acquired and materialized by
+    /// the host. Empty for the overwhelming majority of targets.
+    pub credentials: Vec<CredentialMount>,
 }
 /// Cleanup closure a driver returns for the engine to run after `cache_locally`.
 /// The FUSE/OS sandbox layers each supply their own teardown; the engine's

--- a/crates/plugin/src/htspec/mod.rs
+++ b/crates/plugin/src/htspec/mod.rs
@@ -87,13 +87,42 @@ impl FromSpecValue for String {
     }
 }
 
-impl FromSpecValue for Option<String> {
+/// Any decodable type becomes optional for free: absent or null is `None`.
+///
+/// Blanket rather than one impl per `Option<T>`, so a nested config struct can
+/// have an optional field without the leaf type having to know about it.
+impl<T: FromSpecValue> FromSpecValue for Option<T> {
     fn from_spec_value(v: &Value) -> anyhow::Result<Self> {
-        parse_string(v)
+        match v {
+            Value::Null() => Ok(None),
+            other => Ok(Some(T::from_spec_value(other)?)),
+        }
     }
 
     fn spec_param_type() -> ParamType {
-        ParamType::union(vec![ParamType::String, ParamType::Null])
+        ParamType::union(vec![T::spec_param_type(), ParamType::Null])
+    }
+}
+
+/// A `{name: value}` map that keeps its keys in order.
+///
+/// Strict where [`HashMap<String, String>`] is lenient: a bare string does not
+/// become `{"": s}`. The ordered form is used where the map *is* the document —
+/// a credential presentation's `env`, say — and a nameless entry has no meaning
+/// there.
+impl FromSpecValue for std::collections::BTreeMap<String, String> {
+    fn from_spec_value(v: &Value) -> anyhow::Result<Self> {
+        match v {
+            Value::Map(m) => m
+                .iter()
+                .map(|(k, v)| Ok((k.clone(), String::from_spec_value(v)?)))
+                .collect(),
+            other => anyhow::bail!("invalid: expected {{string: string}}, got: {other:?}"),
+        }
+    }
+
+    fn spec_param_type() -> ParamType {
+        ParamType::map(ParamType::String)
     }
 }
 

--- a/docs/CREDENTIALS.md
+++ b/docs/CREDENTIALS.md
@@ -1,0 +1,548 @@
+# Credentials
+
+A **credential** is a declared target naming an identity a build needs, how it
+may be obtained in whatever environment the build happens to be running in, and
+the shape it is presented in. The consumer says one word; it never knows which
+identity it got, and the cache key never knows there was one.
+
+Before this, heph had no concept of a credential, so eight places each invented a
+partial one: `pass_env` values hashed into a def, an OCI registry client silently
+degrading to anonymous, `docker_build` secrets wired to an `env=` source that
+resolves against a cleared environment, `http_fetch` with no auth at all, private
+Go modules with no credential path anywhere, and a devenv runner capturing its
+whole environment into a cached, remotely-shippable artifact.
+
+## The contract
+
+> A credential grants **access**; it is not an **input**. A target's outputs must
+> be identical whichever identity satisfied its credential requirement. A target
+> whose *output* depends on *who* ran it is not cacheable, and says so with
+> `cache = False`.
+
+Deliberately the same shape as the [scratch contract](SCRATCH.md), and for the
+same reason: it turns a fuzzy question ("does auth affect the build?") into a
+rule an author can check and a reviewer can enforce.
+
+- **Nothing about a credential enters `hashin`** — not the material, not the
+  chosen source, not the declaration, not even the names of the variables it
+  presents.
+- **A credential is acquired only on a miss.** A cache hit probes nothing, spawns
+  nothing and prompts nobody.
+- **The invariant is not checkable in general**, so the system owes an audit
+  rather than a proof: `heph auth explain` plus the `cache = False` convention.
+
+### The rule that is easiest to get wrong
+
+A presentation may carry only **material** and the handles needed to use it —
+keys, tokens, a token-file path, a helper argv. Anything that **selects content**
+is an input, and belongs on the consumer as ordinary hashed `env`.
+
+That is narrower than it first looks. A region, an account or project id, a
+subscription, an endpoint override, a profile name: every one of those selects
+bytes. A laptop resolving through one profile and a runner resolving through a
+federated role in another region would otherwise compute the same input hash and
+serve each other's artifacts.
+
+**How far the vocabulary enforces it.** A presentation accepts exactly three
+keys, so `present = {"region": …}` is rejected outright. A content-selecting
+*value* is not caught: `present = {"env": {"AWS_REGION": "eu-west-1"}}` parses,
+because it is the same shape `heph.auth.aws_web_identity` uses to carry a role
+ARN — and a role ARN is a handle, not a selector. Nothing from the outside tells
+those apart.
+
+So the second half is a **convention**, and deliberately so: the alternative —
+folding presentation text into every consumer's key — would cost CI its remote
+sharing on every private fetch, and would make a role rename rebuild a workspace
+that does not depend on the role. The residual risk, stated plainly: a
+credential-gated read of a *mutable* reference, on a **cacheable** target, pushed
+to a shared remote. All three have to hold, and when they do the contract already
+names the fix — a content-addressed reference, or `cache = False`. What the system
+owes in exchange is an audit rather than a proof: `heph auth explain`, and the
+rule written here.
+
+### Two more places the naive reading breaks
+
+**A gated fetch is cacheable only if the reference is content-addressed.** Pulling
+an image by digest or a file by checksum is fine. Pulling `corp/base:latest` is
+not: the tag resolves inside the server, against the caller's principal, and two
+tenants behind one tag produce one hash and two different artifacts.
+
+**Some outputs simply contain the identity.** A `terraform plan` naming the
+account; an output embedding a presigned URL. Those were never cacheable and must
+carry `cache = False` whether or not they use this feature.
+
+## Model
+
+| | |
+|---|---|
+| **credential** | a target with `driver = "credential"`. Declares what is needed and how it may be obtained. Builds nothing, executes nothing, is never cached. |
+| **source** | one way to obtain material. Has a *probe* (is this applicable here?) and an *acquire*; optionally a *login* and a *hint*. |
+| **chain** | the credential's ordered `sources`. The environment picks the winner, not the author. |
+| **material** | named string fields and files, plus an optional expiry. Never hashed, never in an artifact, never in an event, never in a def. |
+| **presentation** | how material reaches the sandbox: environment variables, files, or a callback helper. |
+| **reference** | `credentials = ["//auth:aws"]` on a consumer. An `Input` with `hashed: false, runtime: false` plus an annotation. |
+
+Why a target rather than a field on the consumer: identical reasoning to
+`scratch`. Settings live in exactly one place, so two consumers cannot disagree
+about which role to assume; the address gives packages, visibility and
+`heph query revdeps` for free; and `heph auth status` has something to enumerate.
+
+## What an author writes
+
+```python
+# //auth/BUILD
+aws = target(
+    name    = "aws",
+    driver  = "credential",
+    sources = [
+        # CI. Probe: the runner's OIDC endpoint is in the environment. heph mints
+        # the token and writes it to a file; the AWS SDK performs the exchange
+        # itself and re-reads that file on every refresh, so heph contains no AWS
+        # code at all — not even the exchange.
+        heph.auth.oidc("github_actions", audience = "sts.amazonaws.com",
+                       present = heph.auth.aws_web_identity(
+                           role = "arn:aws:iam::123456789012:role/deployer")),
+
+        # Laptop. Probe: `aws` is on PATH. Login: the vendor's own SSO flow,
+        # which is where Okta actually happens.
+        heph.auth.exec(["aws", "configure", "export-credentials",
+                        "--profile", "acme", "--format", "process"],
+                       fields  = {"access_key_id": "AccessKeyId",
+                                  "secret_access_key": "SecretAccessKey",
+                                  "session_token": "SessionToken"},
+                       expires = "Expiration",
+                       login   = [["aws", "sso", "login", "--profile", "acme"]],
+                       present = heph.auth.aws_process()),
+    ],
+)
+
+# //svc/BUILD
+target(
+    name        = "deploy",
+    driver      = "bash",
+    credentials = [aws],
+    tools       = [terraform],
+    env         = {"AWS_REGION": "eu-west-1"},   # configuration: hashed, on the consumer
+    run         = "terraform apply -auto-approve",
+    cache       = False,
+    approval    = True,
+)
+```
+
+Four things worth noticing, because they are the design decisions rather than the
+syntax:
+
+- **The consumer says one word.** No branching on CI, no wrapper script, no
+  environment names.
+- **The declaration is environment-independent; the chain is not.** The same two
+  entries serve a runner with workload federation and a laptop with an expired
+  SSO session.
+- **The region is on the consumer.** It selects bytes, so it is an ordinary
+  hashed input.
+- **heph does not reimplement Okta.** On the laptop it drives `aws sso login`,
+  whose browser hop already lands on the corporate identity provider.
+
+## The chain
+
+> A probe answers **"is this source applicable here?"**, not **"will it
+> succeed?"**. The first applicable source *is* the source; an acquire failure is
+> terminal, not a fallthrough.
+
+Every reader's first instinct is the opposite. It is what makes the ordering
+meaningful — `oidc` sits above `exec` because on a laptop its probe fails cleanly
+and on a runner it wins — and it is why `exec`'s probe being merely "the program
+exists" is sufficient. If a chain fell through on failure, a misconfigured role in
+CI would silently fall back to whatever ambient identity the runner happened to
+have, which is precisely the class of accident this feature exists to prevent.
+
+| Kind | Probe | Acquire | Login |
+|---|---|---|---|
+| `env` | named variables are set | read them | — |
+| `file` | path exists | read raw, or pick fields out of JSON | — |
+| `exec` | program resolves (inside `runner`) | run argv; parse stdout through a field map | a *list* of argvs |
+| `passthrough` | host paths exist | expose them in place | optional |
+| `oidc` | the named CI provider is detected | mint a token for `audience` | — |
+| *an address* | selected by `when` | build it, or delegate to it | delegates |
+
+A bare address in `sources` is a reference; there is no `ref` kind to learn. Every
+source additionally accepts `when`, `credentials`, `present` and `hint`.
+
+`when` is a **fixed vocabulary** evaluated by heph, deliberately not an expression
+language: `ci`, `ci:<provider>`, `interactive`, `env:NAME`, `os:linux`,
+`os:darwin`. The moment it becomes a language, BUILD files start containing
+credential-selection programs that nobody can audit.
+
+### Why `exec` has exactly one output format
+
+The temptation is `format = "aws_process" | "gcp_executable" | "az_token"`. That
+is cloud-specific parsing code living in the engine. One generic JSON field map
+expresses all three, and it is deliberately spellable — a tool heph has never
+heard of is a BUILD file away rather than a pull request away.
+
+### Which presets exist, and which deliberately do not
+
+**Presentation presets exist**, because a presentation is a third-party wire
+format with exactly one correct encoding — the AWS credential-process JSON, the
+client-go `ExecCredential`, the Docker helper's three keys. Hand-rolling those is
+how you get a subtly wrong one, and the set is closed because the number of such
+formats is small and known.
+
+**Source presets do not.** There is no `heph.auth.vault()`, no `heph.auth.op()`,
+no `heph.auth.aws_sso()`. That list has no end — every secret manager, every cloud
+CLI, every internal tool at every company — and each entry would be a workflow
+frozen into a plugin, ageing badly, for no gain over four lines of `exec` with a
+field map. **A source is `exec` with a field map, or it is a target.**
+
+## Sources with dependencies
+
+### A source can be a target
+
+A source may be a plain target reference. The target produces the material as its
+outputs; the credential presents them. Whether a referenced target is a producer
+or another credential to delegate to is decided by its driver, so this needs no
+syntax of its own.
+
+```python
+cf_fetch = target(
+    name        = "cf-token",
+    driver      = "bash",
+    credentials = ["//auth:vault"],          # the fetch needs its own identity
+    tools       = ["//tools:vault"],         # declared, not hoped for
+    runner      = "//tools/devenv:runner",   # and it lives in the devenv shell
+    cache       = False,                     # required of every credential source
+    out         = {"credential": "cred.json"},
+    run         = "vault kv get -format=json -field=data secret/cloudflare > $OUT",
+)
+
+cf_root = target(
+    name    = "cf-root",
+    driver  = "credential",
+    sources = [cf_fetch],
+    present = {"env": {"CLOUDFLARE_API_TOKEN": "${token}"}},
+)
+```
+
+Everything on that target comes free, because it is a target: the runner, tools,
+deps, output collection, the sandbox, cancellation, process supervision, and the
+project's rule that every subprocess goes through one exec seam.
+
+Two constraints the form carries:
+
+- **It has no cheap probe.** You cannot ask "is this applicable here?" of a target
+  without running it, so a target source is selected by `when` rather than by
+  probing. That sorts correctly: "am I in CI" is a `when`; "is the AWS CLI
+  installed" is a probe.
+- **Its outputs must not become cached artifacts.** A target used as a credential
+  source is required to be `cache = False`, enforced at resolution, and it is run
+  through `execute` directly with its output bytes taken into the credential store
+  at `0600` — `cache_locally` is never reached and no artifact for it ever exists.
+
+**How a target's output becomes material:** by one convention, not by
+configuration. An output group named `credential` is read as JSON and its
+top-level keys become fields; every other group becomes a named file reachable as
+`${file:<group>}`. Expiry comes from `expires_at`/`expires_in` in that same JSON,
+or from the credential's `ttl`.
+
+An inline `exec` source needs a `fields` map instead, and the asymmetry is
+deliberate: a target's `run` can pipe through `jq` and shape its own output, so it
+does not need one; a vendor's stdout is whatever the vendor decided, so it does.
+
+### A source can need a credential
+
+A source that shells out to a secret manager has to authenticate to the secret
+manager. The wrong answer is a second, private notion of "how the credential tool
+logs in". The right one is that a source declares `credentials`, presented to its
+subprocess exactly as they would be to any consumer.
+
+```python
+heph.auth.exec(["vault", "kv", "get", "-field=token", "secret/cloudflare"],
+               credentials = [vault_login])
+```
+
+Secret managers therefore need no source kind of their own and no preset: they are
+`exec` with a field map, or a target when the tool lives in an environment.
+
+### Does the produced file hold a secret?
+
+That question decides whether a credential is involved at all.
+
+- A file **with a secret in it** is material, and belongs to a credential —
+  presented at `0600`, kept out of the build cache, deleted at run end. A Rancher
+  kubeconfig, which embeds a bearer token, is this.
+- A file that merely **says how to obtain a secret** is an artifact, and belongs
+  to a target, with `transitive` carrying the credential it will need. A GKE or
+  EKS kubeconfig — an endpoint, a CA, and a stanza naming an auth plugin — is
+  this.
+
+## Presentation
+
+Three shapes, in preference order. What separates them is one thing: what happens
+when a token expires while a target is still running.
+
+| | Survives expiry | |
+|---|---|---|
+| `helper` | **yes** | heph writes a config file naming `heph __auth-helper` as the tool's own credential process. The tool calls back whenever it needs a fresh credential. No loopback server, no file rewriting, no background refresh task. |
+| `files` | sometimes | Written by the host at `0600`, destroyed at run end. `${file:name}` resolves to the absolute path. Whether it survives expiry depends on whether the consuming SDK re-reads the file on refresh. |
+| `env` | **no** | Static material handed over once. If it expires mid-target, the target fails. |
+
+### Where the files go, and why the path is load-bearing
+
+Presentation files live at `<sandbox_dir>/.heph/auth/<addr>/<name>` — a sibling of
+the workspace directory, **never inside it**. This is not tidiness. Output
+collection is rooted at the workspace directory and packs every regular file it
+walks, and unlike a scratch mount (a symlink to an absolute path, which the
+artifact packer refuses) a token file is an ordinary file that would pack
+silently, land in the local cache, and be pushed to the shared remote
+automatically.
+
+Two more rules fall out of the same reasoning. The directory is named by the full
+sanitized *address* rather than the target name, so two credentials called `aws`
+in different packages cannot collide. And it is deleted at run end regardless of
+outcome — a failed target's sandbox is deliberately kept for diagnostics, and the
+log tail is what makes it useful, not the token.
+
+### The callback is pinned, not re-derived
+
+A helper runs **inside the target's sandbox**, where the environment is cleared,
+`PATH` is the sandbox's, and there is no `HOME`. A callback that re-walked the
+chain would therefore probe a different environment and could pick a *different
+source* — on a GitHub Actions runner, concretely: the host wins on
+`oidc(github_actions)`, the callback finds no OIDC endpoint, falls through to
+`exec(aws)`, and the build runs against whatever ambient identity the runner
+happened to have. That is the exact accident the chain exists to prevent, arriving
+by the back door.
+
+So the host writes a **pin** next to the presented files — the material, the
+workspace, and the index of the source it chose — and every generated config
+points the callback at it:
+
+```
+heph __auth-helper <dialect> --pin <sandbox>/.heph/auth/<addr>/pin.json
+```
+
+Two things follow. The common path is a file read: no engine, no workspace parse,
+no probe, and nothing that depends on this process's environment — which matters
+because a tool re-invokes its helper on every refresh, every fetch, every registry
+operation. And a refresh, when the pinned material has genuinely lapsed, may use
+**only that source**; if it cannot run there, heph says so, naming the sandbox as
+the reason, rather than quietly acquiring something else.
+
+The pin is `0600`, lives inside the run's sandbox, and is deleted with it.
+
+### The dialects the helper speaks
+
+One hidden subcommand wearing five protocol hats. Each is a third-party grammar
+heph must produce byte-exactly, so each has a pinned conformance test.
+
+| Dialect | How it is presented | Wire shape |
+|---|---|---|
+| `aws` | a config file naming the helper as the profile's `credential_process`, plus `AWS_CONFIG_FILE` | JSON on stdout: `Version` (must be 1), `AccessKeyId`, `SecretAccessKey`, `SessionToken`, RFC 3339 `Expiration` |
+| `gcp` | an `external_account` file whose `credential_source.executable` names the helper, plus `GOOGLE_EXTERNAL_ACCOUNT_ALLOW_EXECUTABLES=1` | JSON on stdout: `version`, `success`, `token_type`, the token, `expiration_time` |
+| `docker` | a generated `DOCKER_CONFIG` directory pointing per-registry at a `docker-credential-heph` shim | the bare registry URL on stdin; `{"ServerURL","Username","Secret"}` on stdout, `Username` = `<token>` for an identity token |
+| `git` | `GIT_CONFIG_COUNT` + `GIT_CONFIG_KEY_n`/`GIT_CONFIG_VALUE_n`, so no gitconfig is written and the developer's own is never touched | `key=value` lines terminated by a blank line, including `password_expiry_utc` |
+| `kubernetes` | heph writes no document: the author templates the kubeconfig and places the argv with `${helper:command}` and `${helper:args}` | the client-go `ExecCredential` object |
+
+Two wrinkles worth knowing before they surprise someone: the **Docker** dialect is
+the only presentation that touches `PATH`, because Docker resolves a helper by
+executable name; and the **git** dialect deliberately writes no file.
+
+The `gcp` variable is not optional decoration — no Google SDK will run an
+executable credential source without it, and forgetting it by hand produces an
+error from inside the SDK rather than from heph.
+
+### Template vocabulary
+
+| Token | Resolves to |
+|---|---|
+| `${<field>}` | a material field, by name |
+| `${file:<name>}` | the absolute path of a presented file |
+| `${helper:command}` | absolute path of the heph binary |
+| `${helper:args}` | the argv tail selecting a dialect and this credential |
+| `$$` | a literal `$` |
+
+Substitution is single-pass, so material containing `${` is never re-interpreted.
+An unknown name is a loud error naming the credential and the field.
+
+## Where it enters a run
+
+```
+result(addr)
+  → cache probe            ← a HIT leaves the timeline here, having acquired nothing
+  → execute
+      → dep resolution
+      → scratch acquire
+      → credential resolve  (which declaration, is the set coherent?)
+      → sandbox claim
+      → credential acquire + present  ← files written 0600, beside the workspace dir
+      → driver run
+      → teardown            ← the auth directory is deleted whatever the outcome
+```
+
+Two orderings are load-bearing. **Acquisition is after the cache decision**, which
+is what makes "zero cost on a hit" structural rather than aspirational. And it is
+**strictly downstream of runner preparation**: the devenv `wrap` runner captures
+its entire resolved environment into a `runner.json`, which is a cached,
+remotely-shippable artifact, so a runner capture must never see material.
+
+## Caching acquired material
+
+- **Per process**, single-flighted per address and expiry-aware, so two hundred
+  consumers cause one acquisition. Not the engine's memoizer: a memoized cell is
+  computed once and kept forever, and material expires — a three-hour build with a
+  one-hour token would hand a target starting at hour two material that lapsed an
+  hour earlier.
+- **Across processes**, under `<home>/auth/` at mode `0700` with entries at
+  `0600`, keyed by a resolution key over the address, the chosen source's whole
+  declaration (`when` included), and the resolution keys of the credentials that
+  led there. Mechanically this is what `~/.aws/cli/cache` already is — heph is not
+  inventing a mechanism, only owning one — with one difference worth stating:
+  `<home>` is the *workspace's* `.heph3`, not a user-level directory, so
+  credentials are per checkout and `rm -rf .heph3` is a logout.
+- **No daemon.** Same reasoning as the local build cache.
+
+The key separates *declarations*, not identities. A parent's key is a function of
+what it declares, so material derived under two different tokens that arrived
+through the same `env` source shares a key. That is sound only because unbounded
+material is never persisted, which is the next rule.
+
+**Material with no expiry is never written to disk.** A one-hour session token
+cached for an hour is a convenience; a long-lived API token written to
+`<home>/auth/` is a durable secret at rest that nothing will ever clean up.
+Declare a `ttl` to make such material cacheable — set it *under* the true
+lifetime, never at it.
+
+That covers *files* too, which a producer target produces before anything knows
+whether they have an expiry. They are staged under `<home>/auth/files/live/<pid>/`
+— swept of dead pids by the next `heph` — and promoted into their durable home
+only once the material has earned the right to outlive the process. An unbounded
+producer credential works for the whole run; what it does not do is leave a
+`0600` secret behind that only `heph auth logout` would collect.
+
+## The CLI
+
+| Command | Does |
+|---|---|
+| `heph auth status` | one row per declared credential. Exits non-zero unless every row is `ok`. `--json` carries `addr`, `state`, `source`, `expires_at`, `login`. |
+| `heph auth explain <addr>` | the whole chain walk: every source, why each was skipped, which won. |
+| `heph auth login [addr]` | runs whichever login commands the probe found stale. Never requires a terminal. |
+| `heph auth logout` | clears the disk tier. |
+| `heph __auth-helper` | hidden. Speaks one callback dialect; parsed before the argument parser, since its argv and stdin belong to the calling tool. |
+
+**A build never signs anyone in.** It fails with the exact command to run, and a
+human runs `heph auth login`, where heph owns the terminal because it is the only
+thing using it. That removes a seam (nothing has to hand a child process the
+terminal mid-build) and an event (no login URL can reach the hook stream and end
+up in a pull-request comment).
+
+Even `login` does not require a tty. An agent's stderr is not a terminal; it runs
+the command, relays the URL and code a human needs, and the human finishes
+elsewhere.
+
+## Redaction
+
+Declared credential values are scrubbed from a target's output **at the tee**,
+before any byte reaches `log.txt`. Redacting at render would be too late: the
+captured log is packed into the cache as an artifact and lifted into the failure
+event, the JSON output and the CI report.
+
+The scrubber holds back `len(longest secret) - 1` bytes across every read
+boundary, because a token can arrive split across two chunks with nothing wrong
+with either half — and per-chunk scanning would let exactly that one through,
+*intermittently*.
+
+It is best-effort by construction, and that is stated rather than hidden:
+
+- Material shorter than **8 bytes** is not scrubbed. A substring replacement over
+  a byte stream cannot remove `"1"` without corrupting every number a build
+  prints.
+- A secret the target *transformed* — base64, URL-encoded, split across lines —
+  passes through.
+- Only material **fields** are scrubbed, not the contents of a presented *file*.
+  A path is not a secret and redacting it would mangle ordinary output. So a
+  target that `cat`s its own kubeconfig does put that token in `log.txt`; the
+  answer there is not to.
+
+Ordinary output is never held back: the scrubber retains only a tail that is
+genuinely a partial match, so a `--shell` prompt still appears immediately and a
+streaming `terraform apply` still streams.
+
+## The security boundary
+
+**What this does.** Material is never hashed, never in the build cache, never in a
+target definition, never in an event, never printed by `inspect`. Presented files
+are `0600` inside the sandbox and destroyed with it; environment values are set
+only on the declaring consumer. A credential reaches only the targets that named
+it, instead of every target that happens to run.
+
+**What it does not do.** It does not create an isolation boundary — heph's sandbox
+is a logical scope, not an OS one, and a BUILD file that wanted the whole
+environment could already ask for it. It does not protect against a malicious
+target in the same workspace. It does not remove long-lived secrets where a
+provider offers no alternative.
+
+Three limits worth naming, because each is a place someone will otherwise assume
+more than is true:
+
+- **Do not name a credential-source target in `deps`, and do not build it
+  directly.** The credential path runs it through `execute` and takes its bytes
+  into the store, so no artifact exists. The *ordinary* path does not: an
+  uncacheable target's outputs still transit the in-memory tmp store, which spills
+  to the durable local cache above its per-entry cap. `cache = False` keeps them
+  off the shared remote — the exposure that crosses machines — but not off this
+  disk. heph cannot detect the mistake.
+- **A helper refresh runs inside the target's sandbox.** The host pins which
+  source it chose, so a callback can never *silently* pick a different identity —
+  but a source that needs `$HOME`, a vendor session or a CI OIDC endpoint cannot
+  re-acquire there, and says so rather than guessing. A credential that must
+  survive expiry mid-run needs a source that can be re-run from nothing.
+- **An acquire subprocess gets a fixed environment**: `PATH`, `HOME`, `TMPDIR`,
+  `LANG`, `LC_ALL`, `TERM`, plus whatever its own `credentials` present. Not the
+  host's whole environment — that is how a source quietly picks up an identity
+  the declaration never mentioned — and not an empty one, which is how a vendor
+  CLI fails to find the session the probe just decided was there.
+
+This narrows exposure substantially and makes it auditable; it does not turn heph
+into a secrets manager.
+
+## The audit question
+
+`scratch` has `--no-scratch`, which withholds cache contents and proves outputs do
+not depend on them. There is no equivalent here, and there deliberately is no
+`--no-credentials`: withholding an identity produces a permission error, not an
+audit. The real audit is **two identities, one output hash** — run the target
+forced under each and compare — which is a short CI script rather than a flag.
+
+## Interactions to know about
+
+- **The argument-size limiter never evicts a credential.** Its eviction order is
+  longest-first, which is precisely a session token, and `ARG_MAX` differs by
+  operating system — so without the exemption the same BUILD file would keep the
+  credential on Linux and drop it on macOS, then run unauthenticated. If the
+  protected set alone does not fit, the target fails rather than spawning.
+
+  That trades a per-platform *identity* divergence for a per-platform *failure*
+  one: `ARG_MAX` is roughly 2 MiB on Linux and 256 KiB on macOS, so a very large
+  credential set could spawn on one and fail on the other. Failing loudly is the
+  better half of that trade, and the ceiling is far out of reach — each presented
+  value is capped at 32 KiB, so it needs eight to thirty maximum-size credentials
+  on one target.
+- **A credential's variables are set last**, and a collision with the target's own
+  `env` is refused rather than resolved.
+- **A duplicate reference** is refused: a credential presents one set of variables,
+  so referencing it twice does nothing.
+- **Two credentials claiming one variable** on the same consumer are refused, for
+  the same reason.
+
+## ABI
+
+`ABI_SEMVER` 0.8.0 → 0.9.0. `RunRequest`/`ManagedRunRequest` gained
+`repeated CredentialMount credentials` — additive and cold-path, so an old plugin
+still loads. It should nonetheless be rebuilt: an old driver drops the mounts and
+runs its target with no identity, which either fails much later with a message
+from someone else's SDK or succeeds against whatever ambient identity the host
+had. Nothing is silently wrong in the *cache* — a credential contributes nothing
+to any hash in either direction — what is lost is the identity itself.
+
+`example/credential/` is a worked package: a two-source chain, a credential whose
+source is a target, and a build step that leaks its own token so the redaction is
+visible.

--- a/example/credential/BUILD
+++ b/example/credential/BUILD
@@ -1,0 +1,155 @@
+# Credentials: an identity a target declares, and heph obtains.
+#
+# heph's sandbox clears the environment completely, so before this the only way a
+# target got a credential was `pass_env` — captured at parse and *hashed into the
+# def*, which puts a session token into a durable cache key.
+#
+# A credential is a target instead. It declares what identity is needed, an
+# ordered list of ways to obtain it, and the shape it is presented in. The
+# consumer says one word.
+#
+# The rule that makes it safe is one sentence: **a target's outputs must be
+# identical whichever identity satisfied its credential requirement.** A
+# credential grants *access*; it is not an *input*. Nothing about one — not the
+# material, not the chosen source, not the declaration, not even the names of the
+# variables it presents — reaches any cache key, in either direction.
+#
+# Everything here is runnable with no setup and no real secrets: the sources
+# below produce fake material from `printf`. Try:
+#
+#   heph auth status
+#   heph auth explain //example/credential:demo
+#   heph run //example/credential:uses-it
+
+# ── 1. the declaration ───────────────────────────────────────────────────────
+#
+# `sources` is an ordered chain, and the *environment* picks the winner, not the
+# author. The rule to internalise:
+#
+#   A probe answers "is this source applicable here?", not "will it succeed?".
+#   The first applicable source IS the source; an acquire failure is terminal,
+#   not a fallthrough.
+#
+# That is what makes the ordering meaningful. If a chain fell through on failure,
+# a misconfigured role in CI would silently fall back to whatever ambient
+# identity the runner happened to have — precisely the accident this prevents.
+demo = target(
+    name = "demo",
+    driver = "credential",
+    sources = [
+        # CI: mint the runner's OIDC token. On a laptop this probe fails cleanly
+        # (there is no OIDC endpoint), which is what lets one declaration serve
+        # both. `present` is per-source here because a federated token file and a
+        # key pair are genuinely different shapes.
+        heph.auth.oidc(
+            "github_actions",
+            audience = "example.heph.invalid",
+            present = {"env": {"DEMO_TOKEN": "${id_token}"}},
+        ),
+
+        # Anywhere: a command whose stdout is the credential. This is what a
+        # `vault read` or an `aws configure export-credentials` looks like —
+        # there is deliberately no per-product source kind, because that list has
+        # no end. A source is `exec` with a field map, or it is a target.
+        heph.auth.exec(
+            ["sh", "-c", 'printf \'{"token":"demo-not-a-real-secret","expires_in":600}\''],
+            fields = {"token": "token"},
+            expires = "expires_in",   # seconds; a string would be RFC 3339
+        ),
+    ],
+
+    # How the material reaches a consumer. Three keys and nothing else: `env`,
+    # `files`, `helper`. There is deliberately nowhere to put a region, an
+    # account or a profile — those *select bytes*, so they are ordinary hashed
+    # inputs on the consumer.
+    present = {"env": {"DEMO_TOKEN": "${token}"}},
+)
+
+# ── 2. the consumer ──────────────────────────────────────────────────────────
+#
+# One word. No branching on CI, no wrapper script, no environment names — and the
+# same file on a laptop and a runner.
+#
+# `cache = True` (the default) is correct here, and worth pausing on: the output
+# does not depend on *who* ran the target, only on that someone did. A target
+# whose output embeds the identity — a `terraform plan` naming the account, an
+# output holding a presigned URL — was never cacheable and says so with
+# `cache = False`.
+target(
+    name = "uses-it",
+    driver = "bash",
+    credentials = [demo],
+    out = "greeting.txt",
+    # The token is never printed: heph would scrub it from the log anyway (see 4)
+    # but a build step should not be reaching for it in the first place.
+    run = [
+        'if [ -n "$DEMO_TOKEN" ]; then',
+        '  echo "authenticated" > $OUT',
+        'else',
+        '  echo "no identity" > $OUT && exit 1',
+        'fi',
+    ],
+)
+
+# ── 3. a credential whose source is a target ─────────────────────────────────
+#
+# When the acquiring command needs tools, deps, an environment or more than one
+# step, it stops being an inline `exec` and becomes an ordinary target. Then
+# everything heph already does — the runner, declared tools, the sandbox, output
+# collection, process supervision — applies to acquisition for free.
+#
+# Two rules this form carries. It has no cheap probe (you cannot ask "is this
+# applicable?" of a target without running it), so it is selected by `when`. And
+# it MUST be `cache = False`: its outputs are material, and a cacheable target's
+# outputs are written to the local cache and pushed to the shared remote
+# automatically. heph enforces that rather than documenting it.
+mint = target(
+    name = "mint",
+    driver = "bash",
+    cache = False,                            # required of every credential source
+    out = {"credential": "cred.json"},        # the reserved group, read as JSON
+    # A named output group is `$OUT_<GROUP>`, exactly as anywhere else — a
+    # credential source is an ordinary target and gets no special vocabulary.
+    run = 'printf \'{"token":"minted-not-a-real-secret","expires_in":300}\' > $OUT_CREDENTIAL',
+)
+
+derived = target(
+    name = "derived",
+    driver = "credential",
+    sources = [mint],
+    present = {"env": {"DERIVED_TOKEN": "${token}"}},
+)
+
+target(
+    name = "uses-derived",
+    driver = "bash",
+    credentials = [derived],
+    cache = False,
+    out = "ok.txt",
+    run = 'test -n "$DERIVED_TOKEN" && echo ok > $OUT',
+)
+
+# ── 4. what heph does when a build step leaks one ────────────────────────────
+#
+# Declared credential values are scrubbed from a target's output at the tee,
+# before any byte reaches `log.txt` — which is packed into the cache as an
+# artifact and lifted into the failure event, so redacting at render would be too
+# late.
+#
+# Run this and look at the output: the token is `[redacted]`.
+#
+# It is best-effort by construction, and that is stated rather than hidden:
+# material shorter than 8 bytes is not scrubbed (a substring replacement cannot
+# remove "1" without corrupting every number a build prints), and a secret the
+# target transformed — base64, URL-encoded — passes through.
+target(
+    name = "leaks-it",
+    driver = "bash",
+    credentials = [demo],
+    cache = False,
+    out = "out.txt",
+    run = [
+        'echo "the token is $DEMO_TOKEN"',
+        'echo done > $OUT',
+    ],
+)

--- a/example/credential/README.md
+++ b/example/credential/README.md
@@ -1,0 +1,68 @@
+# Credentials
+
+Run it:
+
+```bash
+heph auth status                                # which identities apply here
+heph auth explain //credential:demo             # and why the chain picked what it picked
+heph run //credential:uses-it
+heph run //credential:leaks-it --no-tui         # the token comes out as [redacted]
+```
+
+Nothing here needs setup or a real secret: the sources produce fake material from
+`printf`.
+
+## What to read for
+
+**The consumer says one word.** `credentials = [demo]` is the entire integration
+— no branching on CI, no wrapper script, no environment names, and the same file
+on a laptop and a runner. Everything environment-shaped lives in the declaration
+above it, written once.
+
+**The chain is ordered, and the environment picks the winner.** Run
+`heph auth explain //credential:demo` and read the walk: the OIDC source is
+skipped here because there is no OIDC endpoint on a laptop, so the `exec` source
+wins. On a GitHub Actions runner the same two lines resolve the other way. The
+rule to internalise is that a probe answers *"is this applicable here?"*, not
+*"will it succeed?"* — the first applicable source **is** the source, and an
+acquire failure is terminal rather than a fallthrough. If a chain fell through on
+failure, a misconfigured role in CI would silently fall back to whatever ambient
+identity the runner happened to have.
+
+**The cache key never learns there was a credential.** Add `credentials = [demo]`
+to a target and its `heph inspect hashin` does not move — not for the reference,
+not for the declaration, not for the names of the variables it presents. That is
+structural: the reference is an input with `hashed: false, runtime: false`, so it
+has no path into `hashin` at all. It is also what makes the contract enforceable
+rather than aspirational:
+
+> A target's outputs must be identical whichever identity satisfied its
+> credential requirement.
+
+**A presentation has nowhere to put configuration.** Three keys — `env`, `files`,
+`helper` — and nothing else. A region, an account id, a project, a profile: every
+one of those *selects bytes*, so it is an ordinary hashed input on the consumer.
+Try adding `"region": "eu-west-1"` to a `present` block and heph will tell you
+where it belongs.
+
+**A leaked token is scrubbed before it reaches disk.** `//credential:leaks-it`
+echoes its own credential. The scrubbing happens at the output tee, upstream of
+`log.txt` — which matters because that log is packed into the cache as an
+artifact and lifted into the failure event, so redacting at render time would be
+too late.
+
+## What is deliberately absent
+
+- **No `heph.auth.vault()`, no `heph.auth.op()`, no `heph.auth.aws_sso()`.** That
+  list has no end, and each entry would be a workflow frozen into a plugin for no
+  gain over four lines. A source is `exec` with a field map, or it is a target.
+  The *presentation* presets exist for the opposite reason: those are third-party
+  wire formats with exactly one correct encoding.
+- **No command that prints material to a terminal.** It would become a shell
+  history entry, a screen share and a paste into a chat window. The two honest
+  uses it would serve are already served by `heph shell` and `heph auth explain`.
+- **No `--no-credentials`.** Withholding an identity produces a permission error,
+  not an audit. The real audit is two identities and one output hash.
+
+See `docs/CREDENTIALS.md` for the full model, the helper dialects, and the
+security boundary.

--- a/proto/plugin/v1/driver.proto
+++ b/proto/plugin/v1/driver.proto
@@ -65,6 +65,44 @@ message ScratchMount {
   string dir = 4;
 }
 
+// A credential the host resolved, acquired and materialized for this run.
+//
+// Deliberately the *smallest* thing that can carry an identity. Presentation
+// files were written by the host, under `RunRequest.sandbox_dir`, at 0600, and
+// are deleted when the run ends whatever its outcome — so they cross as nothing
+// at all and the driver never sees material it did not need. What is left is
+// what a driver genuinely has to do: set some environment, and (for the Docker
+// credential-helper protocol, which resolves a helper by executable name)
+// prepend a directory to PATH.
+//
+// `env` values ARE the material, so they cross inline; there is no other way to
+// hand a tool a token it reads from its environment. They carry a hard size
+// bound for that reason — see `CREDENTIAL_ENV_MAX_BYTES` — with anything larger
+// being a `files` presentation instead.
+//
+// Unlike a ScratchMount, a mount that fails to decode is an ERROR and never
+// dropped: a missing scratch costs a cold cache, whereas a missing credential
+// produces a run with no identity that either fails much later somewhere else,
+// or succeeds against whatever ambient identity the host happened to have.
+message CredentialMount {
+  Addr addr = 1;
+  // Runtime environment for the target. Never hashed, never `pass_env`.
+  map<string, string> env = 2;
+  // Directories to prepend to PATH, ahead of the target's own tools.
+  repeated string path_prefix = 3;
+  // Every material value the driver must scrub from this target's output before
+  // it reaches log.txt, the TUI, the failure event or the cache.
+  //
+  // These are secrets, and they cross even for material presented only as a file
+  // — which is the deliberate part. Redacting at render would be too late: the
+  // captured log is packed into the cache as an artifact and lifted into the
+  // failure event, the JSON output and the CI report, so the only place that
+  // covers all of them is the tee, before bytes reach disk. The driver already
+  // receives every env-presented value, so the marginal exposure is a file-only
+  // credential a build step chose to `cat`.
+  repeated string redact = 4;
+}
+
 message RunRequest {
   string request_id = 1;
   TargetDef target = 2;
@@ -80,6 +118,7 @@ message RunRequest {
   // true => run_shell, false => run
   bool shell = 10;
   repeated ScratchMount scratch = 11;
+  repeated CredentialMount credentials = 12;
 }
 
 // fuse_slot_guards and sandbox_cleanup are non-transferable host RAII,
@@ -124,6 +163,7 @@ message ManagedRunRequest {
   bool shell = 9;
   string driver = 10;
   repeated ScratchMount scratch = 11;
+  repeated CredentialMount credentials = 12;
 }
 
 message ManagedRunResponse {

--- a/src/commands/auth.rs
+++ b/src/commands/auth.rs
@@ -1,0 +1,494 @@
+//! `heph auth` — the preflight, and the one place a human signs in.
+//!
+//! # Why this is top-level and not `heph tool auth`
+//!
+//! It is a command a developer runs directly and often, which is the line the
+//! `tool` group is on the other side of, and it matches the shape of every vendor
+//! CLI a user already has muscle memory for. That also makes it frozen once
+//! shipped: moving it later would need a permanent alias.
+//!
+//! # A build never signs anyone in
+//!
+//! It fails with the exact command to run, and a human runs it here, in the
+//! foreground, where heph owns the terminal because it is the only thing using
+//! it. That removes a whole seam — nothing has to hand a child process the
+//! terminal mid-build — and it removes an event: with no prompt during a build,
+//! no login URL can reach the hook stream and end up in a pull-request comment.
+//!
+//! # And even `login` does not require a tty
+//!
+//! An agent's stderr is not a terminal. It runs the command, relays the URL and
+//! code a human needs, and the human finishes elsewhere. Demanding a terminal
+//! would strand the agent with no path forward.
+
+use crate::commands::GlobalOptions;
+use crate::commands::bootstrap;
+use crate::engine::credential::source_login;
+use crate::engine::{Engine, get_cwp};
+use crate::tui::LogSink;
+use anyhow::Context as _;
+use clap::{Args, Subcommand};
+use hbuiltins::plugincredential::{CredentialDef, DRIVER_NAME, parse_declaration};
+use hmodel::htaddr::Addr;
+use std::sync::Arc;
+
+#[derive(Args)]
+pub struct AuthArgs {
+    #[command(subcommand)]
+    pub command: AuthCommands,
+}
+
+#[derive(Subcommand)]
+pub enum AuthCommands {
+    /// One row per declared credential: is it available here, from where, and
+    /// until when
+    ///
+    /// The preflight. Exits non-zero unless every row is `ok`, so a caller can
+    /// branch without parsing and then parse to learn what to run.
+    ///
+    /// Probes each chain; it does not acquire anything, so it runs no vendor CLI
+    /// and signs nobody in.
+    ///
+    /// Examples:
+    ///
+    /// `heph auth status`
+    ///
+    /// `heph auth status //auth/... --json`
+    Status(StatusArgs),
+    /// The whole chain walk: every source, why each was skipped, which won
+    ///
+    /// What to run when `status` says something is unavailable and the reason is
+    /// not obvious. Prints the same structure the "no source applies" build
+    /// failure does, so the diagnostic and the failure can never drift apart.
+    ///
+    /// Example: `heph auth explain //auth:aws`
+    Explain(ExplainArgs),
+    /// Run whichever sign-in commands the probe found stale
+    ///
+    /// Never requires a terminal: it runs the vendor's own command with this
+    /// process's stdio attached, so a browser flow works interactively and an
+    /// agent sees the URL and code on its own output.
+    ///
+    /// Examples:
+    ///
+    /// `heph auth login` — everything that has gone stale
+    ///
+    /// `heph auth login //auth:aws` — one credential
+    Login(LoginArgs),
+    /// Forget every acquired credential, in this process and on disk
+    ///
+    /// Clears `<home>/auth`. The vendor CLIs' own sessions are untouched — heph
+    /// does not own those, and signing you out of `aws` because you asked heph to
+    /// forget a cache entry would be a surprise.
+    Logout,
+}
+
+#[derive(Args, Clone)]
+pub struct StatusArgs {
+    /// Package matcher limiting which credentials are listed. Defaults to the
+    /// whole workspace.
+    #[arg(value_name = "PACKAGE_MATCHER")]
+    pub matcher: Option<String>,
+    /// Machine-readable output: `addr`, `state`, `source`, `expires_at`, `login`.
+    #[arg(long)]
+    pub json: bool,
+}
+
+#[derive(Args, Clone)]
+pub struct ExplainArgs {
+    /// The credential to explain.
+    #[arg(value_name = "TARGET_ADDRESS")]
+    pub addr: String,
+    #[arg(long)]
+    pub json: bool,
+}
+
+#[derive(Args, Clone)]
+pub struct LoginArgs {
+    /// Credential to sign in to. Defaults to every one that has gone stale.
+    #[arg(value_name = "TARGET_ADDRESS")]
+    pub addr: Option<String>,
+}
+
+impl AuthArgs {
+    pub fn execute(&self, _sink: LogSink, global: &GlobalOptions) -> anyhow::Result<()> {
+        match &self.command {
+            AuthCommands::Status(a) => bootstrap::block_on(status(a.clone(), global.clone()))?,
+            AuthCommands::Explain(a) => bootstrap::block_on(explain(a.clone(), global.clone()))?,
+            AuthCommands::Login(a) => bootstrap::block_on(login(a.clone(), global.clone()))?,
+            AuthCommands::Logout => bootstrap::block_on(logout())?,
+        }
+    }
+}
+
+/// What `status` says about one credential.
+///
+/// Three states, and the distinction between the last two is the whole value of
+/// the command: "you need to run something" is actionable, "nothing here can
+/// work" is a configuration bug.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, serde::Serialize)]
+#[serde(rename_all = "snake_case")]
+enum State {
+    /// A source applies here.
+    Ok,
+    /// No source applies, but one of them has a sign-in command.
+    NeedsSignIn,
+    /// No source applies and none can be repaired by signing in.
+    Unavailable,
+}
+
+impl State {
+    fn label(self) -> &'static str {
+        match self {
+            Self::Ok => "ok",
+            Self::NeedsSignIn => "needs sign-in",
+            Self::Unavailable => "unavailable",
+        }
+    }
+}
+
+#[derive(serde::Serialize)]
+struct Row {
+    addr: String,
+    state: State,
+    /// The winning source, or the first one that could be repaired.
+    source: String,
+    /// Absolute, never a relative `expires_in` — which is only true at the moment
+    /// it was emitted, and a caller that stores the answer would be wrong by
+    /// however long it took to get there.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    expires_at: Option<String>,
+    /// The sign-in commands a human should run, as structured data rather than
+    /// prose, so `--json` consumers and the terminal render the same instruction.
+    #[serde(skip_serializing_if = "Vec::is_empty")]
+    login: Vec<Vec<String>>,
+}
+
+async fn status(args: StatusArgs, _global: GlobalOptions) -> anyhow::Result<()> {
+    let (engine, _shutdown) = bootstrap::new_engine()?;
+    let rs = engine.new_state();
+    let creds = find_credentials(&engine, &rs, args.matcher.as_deref()).await?;
+
+    let mut rows = Vec::with_capacity(creds.len());
+    for (addr, def) in &creds {
+        rows.push(row_for(&engine, &rs, addr, def).await);
+    }
+
+    if args.json {
+        println!(
+            "{}",
+            serde_json::to_string_pretty(&rows).context("render --json")?
+        );
+    } else if rows.is_empty() {
+        println!("no `credential` targets in this workspace");
+    } else {
+        let widest = rows.iter().map(|r| r.addr.len()).max().unwrap_or(0);
+        for r in &rows {
+            let tail = match (&r.expires_at, r.login.first()) {
+                (Some(at), _) => format!("expires {at}"),
+                (None, Some(_)) => format!("run: heph auth login {}", r.addr),
+                (None, None) => String::new(),
+            };
+            println!(
+                "{:<widest$}  {:<14} {:<24} {tail}",
+                r.addr,
+                r.state.label(),
+                r.source
+            );
+        }
+    }
+
+    // Non-zero unless every row is ok, so a caller can branch on the exit status
+    // and only then parse to learn what to run.
+    if rows.iter().any(|r| r.state != State::Ok) {
+        anyhow::bail!(
+            "{} of {} credentials are not available here — `heph auth explain <addr>` says why",
+            rows.iter().filter(|r| r.state != State::Ok).count(),
+            rows.len()
+        );
+    }
+    Ok(())
+}
+
+async fn row_for(
+    engine: &Arc<Engine>,
+    rs: &Arc<crate::engine::request_state::RequestState>,
+    addr: &Addr,
+    def: &CredentialDef,
+) -> Row {
+    let walk = engine.walk_chain(rs, addr, def).await;
+    let chosen = walk.iter().find(|s| s.skipped.is_none());
+    match chosen {
+        Some(step) => Row {
+            addr: addr.format(),
+            state: State::Ok,
+            source: step.label.clone(),
+            // Best-effort: the disk tier is keyed on the chosen source *and the
+            // identity that acquired it*, and status deliberately acquires
+            // nothing — so a credential whose source needs its own credentials
+            // reports no expiry rather than a guessed one.
+            expires_at: def
+                .sources
+                .get(step.index)
+                .and_then(|s| cached_expiry(engine, addr, s)),
+            login: Vec::new(),
+        },
+        None => {
+            let repairable = walk
+                .iter()
+                .filter_map(|s| def.sources.get(s.index).map(|src| (s, src)))
+                .find(|(_, src)| !source_login(src).is_empty());
+            match repairable {
+                Some((step, src)) => Row {
+                    addr: addr.format(),
+                    state: State::NeedsSignIn,
+                    source: step.label.clone(),
+                    expires_at: None,
+                    login: source_login(src).to_vec(),
+                },
+                None => Row {
+                    addr: addr.format(),
+                    state: State::Unavailable,
+                    source: walk
+                        .first()
+                        .map(|s| s.label.clone())
+                        .unwrap_or_else(|| "—".to_string()),
+                    expires_at: None,
+                    login: Vec::new(),
+                },
+            }
+        }
+    }
+}
+
+/// The expiry of a cached entry for this credential + source, when one exists.
+fn cached_expiry(
+    engine: &Arc<Engine>,
+    addr: &Addr,
+    source: &hbuiltins::plugincredential::SourceDecl,
+) -> Option<String> {
+    let store = crate::engine::CredentialStore::new(&engine.home);
+    let key = crate::engine::credential_store::resolution_key(
+        &addr.format(),
+        &serde_json::to_string(&source.kind).unwrap_or_default(),
+        &[],
+    );
+    let secs = store
+        .get(&key, std::time::SystemTime::now())?
+        .material
+        .expires_at?;
+    let at = chrono::DateTime::from_timestamp(secs as i64, 0)?;
+    Some(at.to_rfc3339())
+}
+
+#[derive(serde::Serialize)]
+struct ExplainStep {
+    index: usize,
+    source: String,
+    chosen: bool,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    skipped: Option<String>,
+    hint: String,
+}
+
+async fn explain(args: ExplainArgs, _global: GlobalOptions) -> anyhow::Result<()> {
+    let (engine, _shutdown) = bootstrap::new_engine()?;
+    let rs = engine.new_state();
+    let cwp = get_cwp()?;
+    let addr = hmodel::htaddr::parse_addr_with_base(&args.addr, &cwp)?;
+    let spec = Arc::clone(&engine).get_spec(rs.clone(), &addr).await?;
+    if spec.driver != DRIVER_NAME {
+        anyhow::bail!(
+            "{addr} is a `{}` target, not a credential — `heph auth explain` walks a credential's \
+             source chain",
+            spec.driver
+        );
+    }
+    let def = parse_declaration(&spec)?;
+    let walk = engine.walk_chain(&rs, &addr, &def).await;
+    let steps: Vec<ExplainStep> = walk
+        .iter()
+        .map(|s| ExplainStep {
+            index: s.index,
+            source: s.label.clone(),
+            chosen: s.skipped.is_none(),
+            skipped: s.skipped.clone(),
+            hint: s.hint.clone(),
+        })
+        .collect();
+
+    if args.json {
+        println!(
+            "{}",
+            serde_json::to_string_pretty(&serde_json::json!({
+                "addr": addr.format(),
+                "sources": steps,
+            }))
+            .context("render --json")?
+        );
+        return Ok(());
+    }
+
+    println!("{addr}");
+    for s in &steps {
+        match &s.skipped {
+            None => println!("  {}. {:<24} applies here", s.index + 1, s.source),
+            Some(reason) => {
+                println!("  {}. {:<24} skipped: {reason}", s.index + 1, s.source);
+                println!("{:28}→ {}", "", s.hint);
+            }
+        }
+    }
+    if !steps.iter().any(|s| s.chosen) {
+        anyhow::bail!("no source applies here");
+    }
+    Ok(())
+}
+
+async fn login(args: LoginArgs, _global: GlobalOptions) -> anyhow::Result<()> {
+    let (engine, _shutdown) = bootstrap::new_engine()?;
+    let rs = engine.new_state();
+    let creds = match &args.addr {
+        Some(raw) => {
+            let cwp = get_cwp()?;
+            let addr = hmodel::htaddr::parse_addr_with_base(raw, &cwp)?;
+            let spec = Arc::clone(&engine).get_spec(rs.clone(), &addr).await?;
+            if spec.driver != DRIVER_NAME {
+                anyhow::bail!("{addr} is a `{}` target, not a credential", spec.driver);
+            }
+            vec![(addr, parse_declaration(&spec)?)]
+        }
+        None => find_credentials(&engine, &rs, None).await?,
+    };
+
+    let mut ran = 0usize;
+    for (addr, def) in &creds {
+        let walk = engine.walk_chain(&rs, addr, def).await;
+        // Only sources the probe found *stale*. Running a login for a source
+        // that already works would re-open a browser for nothing — and gcloud's
+        // two independent logins are exactly why this is per-source rather than
+        // per-credential.
+        for step in walk.iter().filter(|s| s.skipped.is_some()) {
+            let Some(src) = def.sources.get(step.index) else {
+                continue;
+            };
+            for argv in source_login(src) {
+                if argv.is_empty() {
+                    continue;
+                }
+                println!("{addr}: {}", argv.join(" "));
+                // Through the engine's exec-runner seam, so a source whose tool
+                // lives in a devenv shell signs in *there* — the same place its
+                // probe looked. Stdio is inherited: a browser flow needs the
+                // terminal when there is one, and an agent needs to see the URL
+                // and code on its own output when there is not.
+                let status = engine.run_login(&rs, addr, src, argv).await?;
+                if !status.success() {
+                    anyhow::bail!("{addr}: `{}` exited with {status}", argv.join(" "));
+                }
+                ran += 1;
+            }
+        }
+    }
+    if ran == 0 {
+        println!("nothing to sign in to — every declared credential already applies here");
+    }
+    Ok(())
+}
+
+async fn logout() -> anyhow::Result<()> {
+    let (engine, _shutdown) = bootstrap::new_engine()?;
+    // Both tiers. The process one is empty in a fresh `heph auth logout`, but
+    // clearing only the disk would make this command mean something different
+    // depending on who called it.
+    engine.forget_credentials();
+    let store = crate::engine::CredentialStore::new(&engine.home);
+    store.clear()?;
+    println!("cleared {}", store.root().display());
+    Ok(())
+}
+
+/// Every `credential` target in the workspace (or under `matcher`).
+///
+/// Resolves each spec, which is what makes this a preflight rather than something
+/// on a build's path. There is no "by driver" matcher in the query language and
+/// adding one for this would be a lot of surface for one command.
+async fn find_credentials(
+    engine: &Arc<Engine>,
+    rs: &Arc<crate::engine::request_state::RequestState>,
+    matcher: Option<&str>,
+) -> anyhow::Result<Vec<(Addr, CredentialDef)>> {
+    use futures::TryStreamExt as _;
+    let cwp = get_cwp()?;
+    // Through the expression slot, not the positional one: the single-positional
+    // form takes an *address*, and the selection here is a package matcher.
+    let m = crate::commands::utils::resolve_matcher(
+        &Some(matcher.unwrap_or("//...").to_string()),
+        &None,
+        &None,
+        &cwp,
+        true,
+    )?;
+    let stream = Arc::clone(engine).query(rs.clone(), &m);
+    tokio::pin!(stream);
+    let mut out = Vec::new();
+    while let Some(addr) = stream.try_next().await? {
+        let spec = Arc::clone(engine).get_spec(rs.clone(), &addr).await?;
+        if spec.driver != DRIVER_NAME {
+            continue;
+        }
+        let def = parse_declaration(&spec).with_context(|| format!("credential {addr}"))?;
+        out.push((addr, def));
+    }
+    out.sort_by_key(|a| a.0.format());
+    Ok(out)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn a_status_row_serializes_the_fix_as_data_not_prose() {
+        let row = Row {
+            addr: "//auth:aws".to_string(),
+            state: State::NeedsSignIn,
+            source: "exec(aws)".to_string(),
+            expires_at: None,
+            login: vec![vec![
+                "aws".to_string(),
+                "sso".to_string(),
+                "login".to_string(),
+            ]],
+        };
+        let v: serde_json::Value = serde_json::to_value(&row).expect("serialize");
+        assert_eq!(v["state"], "needs_sign_in");
+        assert_eq!(v["login"][0][0], "aws");
+        // Absent rather than null: a consumer branches on presence.
+        assert!(v.get("expires_at").is_none());
+    }
+
+    #[test]
+    fn an_ok_row_carries_an_absolute_expiry() {
+        let row = Row {
+            addr: "//auth:aws".to_string(),
+            state: State::Ok,
+            source: "exec(aws)".to_string(),
+            expires_at: Some("2026-09-08T15:41:00+00:00".to_string()),
+            login: vec![],
+        };
+        let v: serde_json::Value = serde_json::to_value(&row).expect("serialize");
+        assert_eq!(v["expires_at"], "2026-09-08T15:41:00+00:00");
+        assert!(
+            v.get("login").is_none(),
+            "an available credential has nothing to run"
+        );
+    }
+
+    #[test]
+    fn the_three_states_read_the_way_the_terminal_prints_them() {
+        assert_eq!(State::Ok.label(), "ok");
+        assert_eq!(State::NeedsSignIn.label(), "needs sign-in");
+        assert_eq!(State::Unavailable.label(), "unavailable");
+    }
+}

--- a/src/commands/auth_helper.rs
+++ b/src/commands/auth_helper.rs
@@ -1,0 +1,500 @@
+//! `heph __auth-helper` — one hidden subcommand wearing five protocol hats.
+//!
+//! A tool that supports a *credential helper* asks for a credential whenever it
+//! needs one, instead of being handed a snapshot at spawn. That is the only
+//! presentation that survives an expiry mid-run, and it is why it is the preferred
+//! one: a three-hour `terraform apply` under a one-hour token simply works.
+//!
+//! Each hat is a **third-party grammar heph must produce byte-exactly**, and a
+//! wrong field name is a silent failure inside somebody else's SDK. They are not
+//! internal interfaces that can be adjusted later, so each one has a pinned
+//! conformance test below rather than a best effort.
+//!
+//! # Why it is parsed before the argument parser
+//!
+//! Its argv and its stdin belong to the *calling tool*. Docker appends `get`,
+//! git appends `get`/`store`/`erase`, and both write a request on stdin — none of
+//! which is heph's CLI grammar. Parsing it as flags would misread the caller's
+//! own protocol.
+
+use anyhow::Context as _;
+use std::io::Read as _;
+
+/// A parsed `__auth-helper` invocation.
+pub struct Invocation {
+    pub dialect: String,
+    /// The pin the host wrote beside the presented files. It carries the material,
+    /// the workspace, and which source the host chose.
+    pub pin: std::path::PathBuf,
+    /// Whatever the calling tool appended — `get`, `store`, `erase`.
+    pub operation: Option<String>,
+}
+
+/// Recognize `heph __auth-helper <dialect> --pin <path> [op]`.
+///
+/// A pure prefix match on `args_os`, like the exec-runner subcommands: nothing
+/// here may pull in logging, a runtime, clap or the TUI, because this process is
+/// a callback inside somebody else's tool and must stay small and predictable.
+pub fn parse(args: impl IntoIterator<Item = std::ffi::OsString>) -> Option<Invocation> {
+    let mut it = args.into_iter().skip(1);
+    if it.next()?.to_str()? != crate::engine::credential::AUTH_HELPER_SUBCOMMAND {
+        return None;
+    }
+    let dialect = it.next()?.to_str()?.to_string();
+    let mut pin = None;
+    let mut operation = None;
+    while let Some(a) = it.next() {
+        match a.to_str() {
+            Some("--pin") => pin = it.next().map(std::path::PathBuf::from),
+            Some(other) if !other.starts_with("--") => operation = Some(other.to_string()),
+            _ => {}
+        }
+    }
+    Some(Invocation {
+        dialect,
+        pin: pin?,
+        operation,
+    })
+}
+
+/// Answer the calling tool, then exit.
+///
+/// Never returns: a helper process does one thing.
+pub fn run(inv: Invocation) -> ! {
+    let code = match answer(&inv) {
+        Ok(out) => {
+            print!("{out}");
+            0
+        }
+        Err(e) => {
+            // stderr, always: stdout is the protocol. Every one of these dialects
+            // reads stdout as a document, so a diagnostic there is a parse error
+            // inside the calling tool rather than a message anyone sees.
+            eprintln!("heph auth helper ({}): {e:#}", inv.dialect);
+            1
+        }
+    };
+    std::process::exit(code)
+}
+
+fn answer(inv: &Invocation) -> anyhow::Result<String> {
+    // `store` and `erase` are the write half of the Docker and git protocols.
+    // heph's credential store is not a place a tool may write to — the material
+    // comes from a declared chain, and accepting a write would let a tool
+    // silently substitute an identity — so they succeed and do nothing, which is
+    // what the protocols specify for a read-only helper.
+    if matches!(inv.operation.as_deref(), Some("store" | "erase")) {
+        return Ok(String::new());
+    }
+
+    let material = material_for(inv)?;
+    match inv.dialect.as_str() {
+        "aws" => aws(&material),
+        "gcp" => gcp(&material),
+        "docker" => docker(&material, &read_stdin()?),
+        "git" => git(&material, &read_stdin()?),
+        "kubernetes" => kubernetes(&material),
+        other => anyhow::bail!("unknown credential helper dialect {other:?}"),
+    }
+}
+
+/// The material to answer with.
+///
+/// **The common path reads the pin and stops.** No engine, no workspace parse, no
+/// probe, and — critically — no dependence on this process's environment, which
+/// is the target's sandbox rather than the host's. A tool re-invokes its helper
+/// on every refresh, every fetch, every registry operation; each of those has to
+/// be a file read.
+///
+/// Only when the pinned material has actually lapsed does this reach for the
+/// engine, and then it re-acquires from **the source the host chose** and no
+/// other — see `Engine::refresh_credential_source`.
+fn material_for(inv: &Invocation) -> anyhow::Result<crate::engine::Material> {
+    let raw = std::fs::read(&inv.pin).with_context(|| {
+        format!(
+            "read the credential pin at {} — a helper is only ever invoked from a config heph \
+             wrote, and that file lives inside the run's sandbox, so this usually means the run \
+             has already finished",
+            inv.pin.display()
+        )
+    })?;
+    let pin: crate::engine::credential::HelperPin =
+        serde_json::from_slice(&raw).context("parse the credential pin")?;
+
+    let acquired_at = std::time::UNIX_EPOCH + std::time::Duration::from_secs(pin.acquired_at);
+    if pin
+        .material
+        .usable_at(std::time::SystemTime::now(), acquired_at)
+    {
+        return Ok(pin.material);
+    }
+
+    // The sandbox has its own cwd, so the workspace is named by the pin.
+    std::env::set_current_dir(&pin.root)
+        .with_context(|| format!("enter workspace {}", pin.root.display()))?;
+    crate::commands::bootstrap::block_on(refresh(&pin))?
+}
+
+async fn refresh(
+    pin: &crate::engine::credential::HelperPin,
+) -> anyhow::Result<crate::engine::Material> {
+    let (engine, _shutdown) = crate::commands::bootstrap::new_engine()?;
+    let rs = engine.new_state();
+    let addr = hmodel::htaddr::parse_addr(&pin.addr)?;
+    engine
+        .refresh_credential_source(&rs, &addr, pin.source_index)
+        .await
+}
+
+fn read_stdin() -> anyhow::Result<String> {
+    let mut s = String::new();
+    std::io::stdin()
+        .read_to_string(&mut s)
+        .context("read the calling tool's request from stdin")?;
+    Ok(s)
+}
+
+// ---------------------------------------------------------------------------
+// The dialects
+// ---------------------------------------------------------------------------
+
+/// The first field present under any of `names`.
+///
+/// Vendors disagree about spelling for the same value — `AccessKeyId` from the
+/// AWS CLI, `access_key_id` from a `fields` map an author wrote — and a
+/// presentation should not have to normalize by hand.
+fn field<'a>(m: &'a crate::engine::Material, names: &[&str]) -> Option<&'a str> {
+    names
+        .iter()
+        .find_map(|n| m.fields.get(*n))
+        .map(String::as_str)
+}
+
+fn require<'a>(
+    m: &'a crate::engine::Material,
+    names: &[&str],
+    what: &str,
+) -> anyhow::Result<&'a str> {
+    field(m, names).ok_or_else(|| {
+        anyhow::anyhow!(
+            "this credential has no {what} — the {} dialect needs a field named one of {}; this \
+             source yields {}",
+            what,
+            names.join(", "),
+            if m.fields.is_empty() {
+                "nothing".to_string()
+            } else {
+                m.fields.keys().cloned().collect::<Vec<_>>().join(", ")
+            }
+        )
+    })
+}
+
+fn rfc3339(secs: u64) -> Option<String> {
+    chrono::DateTime::from_timestamp(secs as i64, 0).map(|d| d.to_rfc3339())
+}
+
+/// The AWS credential-process contract.
+///
+/// `Version` must be `1` — the SDKs reject anything else outright — and
+/// `Expiration` is RFC 3339, which is what the SDK re-invokes against.
+fn aws(m: &crate::engine::Material) -> anyhow::Result<String> {
+    let mut doc = serde_json::json!({
+        "Version": 1,
+        "AccessKeyId": require(m, &["access_key_id", "AccessKeyId"], "access key id")?,
+        "SecretAccessKey": require(
+            m,
+            &["secret_access_key", "SecretAccessKey"],
+            "secret access key",
+        )?,
+    });
+    if let Some(t) = field(m, &["session_token", "SessionToken"])
+        && let Some(o) = doc.as_object_mut()
+    {
+        o.insert(
+            "SessionToken".to_string(),
+            serde_json::Value::String(t.to_string()),
+        );
+    }
+    if let Some(at) = m.expires_at.and_then(rfc3339)
+        && let Some(o) = doc.as_object_mut()
+    {
+        o.insert("Expiration".to_string(), serde_json::Value::String(at));
+    }
+    Ok(format!("{doc}\n"))
+}
+
+/// GCP executable-sourced external-account credentials.
+///
+/// `success` is a field rather than an exit status, and `expiration_time` is a
+/// Unix timestamp. A subject token is a JWT, which is what an OIDC source yields.
+fn gcp(m: &crate::engine::Material) -> anyhow::Result<String> {
+    let token = require(m, &["id_token", "token", "value"], "token")?;
+    let mut doc = serde_json::json!({
+        "version": 1,
+        "success": true,
+        "token_type": "urn:ietf:params:oauth:token-type:jwt",
+        "id_token": token,
+    });
+    if let Some(at) = m.expires_at
+        && let Some(o) = doc.as_object_mut()
+    {
+        o.insert("expiration_time".to_string(), serde_json::json!(at));
+    }
+    Ok(format!("{doc}\n"))
+}
+
+/// The Docker credential-helper protocol.
+///
+/// The bare registry URL arrives on stdin; the answer is three keys. `Username`
+/// is the literal `<token>` when the secret is an identity token rather than a
+/// password — that convention is what makes a registry accept a bearer token
+/// through a protocol that only speaks username/password.
+///
+/// The protocol carries no expiry field, so the tool re-asks only on its next
+/// registry interaction.
+fn docker(m: &crate::engine::Material, stdin: &str) -> anyhow::Result<String> {
+    let server = stdin.trim();
+    let secret = require(m, &["token", "password", "secret", "value"], "token")?;
+    let username = field(m, &["username", "user"]).unwrap_or("<token>");
+    let doc = serde_json::json!({
+        "ServerURL": server,
+        "Username": username,
+        "Secret": secret,
+    });
+    Ok(format!("{doc}\n"))
+}
+
+/// The git credential-helper protocol.
+///
+/// `key=value` lines terminated by a blank line, in both directions.
+/// `password_expiry_utc` is a Unix timestamp git honours by re-asking once it
+/// passes — which is what makes this dialect survive an expiry mid-fetch.
+fn git(m: &crate::engine::Material, stdin: &str) -> anyhow::Result<String> {
+    let password = require(m, &["token", "password", "value"], "token")?;
+    // Not `<token>` here: git sends the username as basic-auth, and GitHub (the
+    // dominant case) accepts any non-empty username with a token as the password.
+    let username = field(m, &["username", "user"]).unwrap_or("x-access-token");
+    let mut out = String::new();
+    // Echo back the protocol/host git asked about. Git tolerates their absence,
+    // but returning them is what lets a helper be scoped to one host in a config
+    // that also has others.
+    for line in stdin.lines() {
+        if let Some((k, _)) = line.split_once('=')
+            && matches!(k, "protocol" | "host")
+        {
+            out.push_str(line);
+            out.push('\n');
+        }
+    }
+    out.push_str(&format!("username={username}\n"));
+    out.push_str(&format!("password={password}\n"));
+    if let Some(at) = m.expires_at {
+        out.push_str(&format!("password_expiry_utc={at}\n"));
+    }
+    out.push('\n');
+    Ok(out)
+}
+
+/// The client-go `ExecCredential` object.
+///
+/// Pure format: heph knows nothing about Kubernetes beyond this shape and the
+/// kubeconfig stanza that names it, which is why it costs the engine almost
+/// nothing to speak. kubectl caches the token until `expirationTimestamp` and
+/// then calls again.
+fn kubernetes(m: &crate::engine::Material) -> anyhow::Result<String> {
+    let token = require(m, &["token", "id_token", "value"], "token")?;
+    let mut status = serde_json::json!({ "token": token });
+    if let Some(at) = m.expires_at.and_then(rfc3339)
+        && let Some(o) = status.as_object_mut()
+    {
+        o.insert(
+            "expirationTimestamp".to_string(),
+            serde_json::Value::String(at),
+        );
+    }
+    let doc = serde_json::json!({
+        "apiVersion": "client.authentication.k8s.io/v1beta1",
+        "kind": "ExecCredential",
+        "status": status,
+    });
+    Ok(format!("{doc}\n"))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::engine::Material;
+    use std::collections::BTreeMap;
+
+    fn material(pairs: &[(&str, &str)], expires_at: Option<u64>) -> Material {
+        Material {
+            fields: pairs
+                .iter()
+                .map(|(k, v)| (k.to_string(), v.to_string()))
+                .collect(),
+            files: BTreeMap::new(),
+            expires_at,
+        }
+    }
+
+    fn json(s: &str) -> serde_json::Value {
+        serde_json::from_str(s).expect("valid json")
+    }
+
+    #[test]
+    fn the_helper_is_recognized_before_the_argument_parser() {
+        let inv = parse(
+            [
+                "heph",
+                "__auth-helper",
+                "aws",
+                "--pin",
+                "/s/.heph/auth/a/pin.json",
+            ]
+            .into_iter()
+            .map(std::ffi::OsString::from),
+        )
+        .expect("parsed");
+        assert_eq!(inv.dialect, "aws");
+        assert_eq!(inv.pin, std::path::Path::new("/s/.heph/auth/a/pin.json"));
+        assert_eq!(inv.operation, None);
+        // An ordinary command is not one.
+        assert!(
+            parse(
+                ["heph", "run", "//a:b"]
+                    .into_iter()
+                    .map(std::ffi::OsString::from)
+            )
+            .is_none()
+        );
+    }
+
+    #[test]
+    fn a_trailing_operation_from_the_calling_tool_is_captured() {
+        let inv = parse(
+            ["heph", "__auth-helper", "docker", "--pin", "/p", "get"]
+                .into_iter()
+                .map(std::ffi::OsString::from),
+        )
+        .expect("parsed");
+        assert_eq!(inv.operation.as_deref(), Some("get"));
+    }
+
+    /// AWS rejects anything but `Version: 1`, and re-invokes against
+    /// `Expiration`.
+    #[test]
+    fn aws_speaks_the_credential_process_contract() {
+        let m = material(
+            &[
+                ("access_key_id", "AKIA"),
+                ("secret_access_key", "sec"),
+                ("session_token", "tok"),
+            ],
+            Some(1_893_456_000),
+        );
+        let doc = json(&aws(&m).expect("render"));
+        assert_eq!(doc["Version"], 1);
+        assert_eq!(doc["AccessKeyId"], "AKIA");
+        assert_eq!(doc["SecretAccessKey"], "sec");
+        assert_eq!(doc["SessionToken"], "tok");
+        assert_eq!(doc["Expiration"], "2030-01-01T00:00:00+00:00");
+    }
+
+    #[test]
+    fn aws_accepts_either_spelling_of_a_field() {
+        // The AWS CLI prints `AccessKeyId`; an author's own `fields` map is more
+        // likely to say `access_key_id`. Both must work.
+        let m = material(&[("AccessKeyId", "A"), ("SecretAccessKey", "S")], None);
+        let doc = json(&aws(&m).expect("render"));
+        assert_eq!(doc["AccessKeyId"], "A");
+        // No session token and no expiry: a long-lived key pair is a legal
+        // credential-process answer, and inventing an `Expiration` would make the
+        // SDK re-invoke forever.
+        assert!(doc.get("SessionToken").is_none());
+        assert!(doc.get("Expiration").is_none());
+    }
+
+    #[test]
+    fn aws_names_what_is_missing_rather_than_emitting_a_half_document() {
+        let err = aws(&material(&[("token", "t")], None)).expect_err("must fail");
+        let msg = format!("{err:#}");
+        assert!(msg.contains("access key id"), "{msg}");
+        assert!(
+            msg.contains("token"),
+            "must name what the source did yield: {msg}"
+        );
+    }
+
+    #[test]
+    fn gcp_speaks_the_executable_sourced_contract() {
+        let doc =
+            json(&gcp(&material(&[("id_token", "jwt")], Some(1_893_456_000))).expect("render"));
+        assert_eq!(doc["version"], 1);
+        assert_eq!(doc["success"], true);
+        assert_eq!(doc["token_type"], "urn:ietf:params:oauth:token-type:jwt");
+        assert_eq!(doc["id_token"], "jwt");
+        // A Unix timestamp here, unlike AWS's RFC 3339 — the two protocols
+        // genuinely differ and getting it wrong fails inside the SDK.
+        assert_eq!(doc["expiration_time"], 1_893_456_000u64);
+    }
+
+    #[test]
+    fn docker_answers_the_registry_it_was_asked_about() {
+        let out = docker(&material(&[("token", "t")], None), "ghcr.io\n").expect("render");
+        let doc = json(&out);
+        assert_eq!(doc["ServerURL"], "ghcr.io");
+        assert_eq!(doc["Secret"], "t");
+        // The identity-token convention: a registry accepts a bearer token
+        // through a username/password protocol only under this literal username.
+        assert_eq!(doc["Username"], "<token>");
+    }
+
+    #[test]
+    fn git_frames_key_values_and_echoes_the_hosts_it_was_asked_about() {
+        let out = git(
+            &material(&[("token", "t")], Some(1_893_456_000)),
+            "protocol=https\nhost=github.com\n\n",
+        )
+        .expect("render");
+        assert_eq!(
+            out,
+            "protocol=https\nhost=github.com\nusername=x-access-token\npassword=t\npassword_expiry_utc=1893456000\n\n"
+        );
+    }
+
+    #[test]
+    fn git_output_always_ends_with_the_blank_line_that_terminates_it() {
+        let out = git(&material(&[("token", "t")], None), "").expect("render");
+        assert!(out.ends_with("\n\n"), "{out:?}");
+    }
+
+    #[test]
+    fn kubernetes_speaks_the_exec_credential_object() {
+        let doc =
+            json(&kubernetes(&material(&[("token", "t")], Some(1_893_456_000))).expect("render"));
+        assert_eq!(doc["apiVersion"], "client.authentication.k8s.io/v1beta1");
+        assert_eq!(doc["kind"], "ExecCredential");
+        assert_eq!(doc["status"]["token"], "t");
+        assert_eq!(
+            doc["status"]["expirationTimestamp"],
+            "2030-01-01T00:00:00+00:00"
+        );
+    }
+
+    /// A tool asking heph to *write* a credential must not be able to substitute
+    /// an identity. Both protocols specify a no-op for a read-only helper.
+    #[test]
+    fn store_and_erase_succeed_and_change_nothing() {
+        for op in ["store", "erase"] {
+            let inv = Invocation {
+                dialect: "git".to_string(),
+                pin: std::path::PathBuf::from("/nonexistent"),
+                operation: Some(op.to_string()),
+            };
+            // Returns before touching the pin, which is why a bogus path is
+            // harmless here.
+            assert_eq!(answer(&inv).expect("no-op"), "");
+        }
+    }
+}

--- a/src/commands/mod.rs
+++ b/src/commands/mod.rs
@@ -1,4 +1,6 @@
 pub mod approval;
+pub mod auth;
+pub mod auth_helper;
 pub mod bootstrap;
 pub mod completion;
 pub mod errors;
@@ -84,6 +86,23 @@ pub enum Commands {
     ///
     /// Prints the heph version string and exits.
     Version(version::Args),
+    /// Sign in, and see which credentials are available here
+    ///
+    /// A credential is a target (`driver = "credential"`) declaring what identity
+    /// a build needs and how it may be obtained. This is the preflight over them:
+    /// which apply in this environment, from which source, and until when.
+    ///
+    /// A build never signs anyone in — it fails with the exact command to run,
+    /// and `heph auth login` is where a human runs it.
+    ///
+    /// Examples:
+    ///
+    /// `heph auth status` — one row per declared credential
+    ///
+    /// `heph auth explain //auth:aws` — why a chain picked what it picked
+    ///
+    /// `heph auth login` — run whichever sign-ins have gone stale
+    Auth(auth::AuthArgs),
     /// Developer tools
     ///
     /// Maintenance and housekeeping subcommands that operate on the workspace
@@ -102,6 +121,7 @@ impl Commands {
             Commands::Query(args) => query::execute(args, sink, global),
             Commands::Validate(args) => validate::execute(args, sink, global),
             Commands::Version(args) => version::execute(args),
+            Commands::Auth(args) => args.execute(sink, global),
             Commands::Tool(args) => args.execute(sink, global),
             Commands::GenDocs(args) => gendocs::execute(args),
         }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -20,7 +20,8 @@ extern crate core;
 // module paths so `crate::hasync::…` etc. keep resolving unchanged across the
 // monolith.
 pub use hbuiltins::{
-    pluginfs, plugingroup, pluginhostbin, pluginscratch, pluginstatictarget, plugintextfile,
+    plugincredential, pluginfs, plugingroup, pluginhostbin, pluginscratch, pluginstatictarget,
+    plugintextfile,
 };
 pub use hcore::{
     debug_hash, defer, hartifactcontent, hasync, hmemoizer, htplatform, htvalue, version,

--- a/src/main.rs
+++ b/src/main.rs
@@ -45,6 +45,17 @@ fn main() -> ExitCode {
         None => {}
     }
 
+    // The credential helper, dispatched here for the same reason as the runner
+    // subcommands: its argv and its stdin belong to the *calling tool* — Docker
+    // appends `get`, git appends `get`/`store`/`erase`, and both write a request
+    // on stdin — so parsing it as flags would misread somebody else's protocol.
+    // It also must not pull in logging or the TUI: it is a callback running
+    // inside another tool, and anything it writes to stdout is that tool's
+    // document.
+    if let Some(inv) = commands::auth_helper::parse(std::env::args_os()) {
+        commands::auth_helper::run(inv);
+    }
+
     // Dynamic shell completion. A no-op unless the `COMPLETE` env var is set
     // (a tab press or `heph tool completions` registration), in which case it
     // emits candidates / the registration script and exits the process. Runs


### PR DESCRIPTION
Implements the [Credentials as Targets](https://claude.ai/code/artifact/9afdf412-2dca-47d4-bf38-88be8034b870) design, Phase 1.

A credential becomes a declared target — an identity a build needs, an ordered chain of ways to obtain it in whatever environment the build happens to be running in, and the shape it is presented in. The consumer says one word. It never knows which identity it got, and the cache key never knows there was one.

```python
aws = target(
    name = "aws",
    driver = "credential",
    sources = [
        heph.auth.oidc("github_actions", audience = WIF,
                       present = heph.auth.aws_web_identity(role = ROLE)),
        heph.auth.exec(["aws", "configure", "export-credentials", "--format", "process"]),
    ],
    present = heph.auth.aws_env(),
)

target(name = "deploy", driver = "bash", credentials = [aws], run = "terraform apply")
```

Before this heph had no concept of a credential, so eight places each invented a partial one: `pass_env` values hashed into a def (a session token in a durable cache key, printed by `inspect def`), an OCI registry client silently degrading to anonymous, `docker_build` secrets wired to an `env=` source that resolves against a cleared environment, `http_fetch` with no auth at all, private Go modules with no credential path anywhere, and a devenv runner capturing its whole environment into a cached, remotely-shippable artifact.

## The contract

> A credential grants **access**; it is not an **input**. A target's outputs must be identical whichever identity satisfied its credential requirement. A target whose output depends on *who* ran it is not cacheable, and says so with `cache = False`.

The half heph can enforce, it enforces structurally: a reference is an `Input` with `hashed: false, runtime: false`, and `hashin` is computed over `hashed` inputs only — so nothing about a credential has a path into a cache key in either direction. The half it cannot — that a presentation carries material and handles but never anything that *selects content* — is a stated convention, backed by `heph auth explain` and by `cache = False`, not by the parser.

A probe answers *"is this source applicable here?"*, not *"will it succeed?"*. The first applicable source **is** the source; an acquire failure is terminal, not a fallthrough — otherwise a misconfigured role in CI silently falls back to whatever ambient identity the runner happened to have.

## What ships

- The **`credential` driver**: `sources`, `present`, `ttl`. Declares, never executes, never cached — the `scratch` shape, pointed at identity.
- **Five inline source kinds** (`env`, `file`, `exec`, `passthrough`, `oidc`) plus a bare address, which is a producer target or a delegation depending on its driver. No per-product source kind and no source preset: that list has no end, and a secret manager is `exec` with a field map, or a target.
- **Three presentations** — `env`, `files`, and a `helper` speaking the AWS credential-process, GCP executable-sourced, Docker, git and Kubernetes ExecCredential protocols. Each is a third-party grammar heph must produce byte-exactly, so each has a pinned conformance test.
- `heph.auth.*` presentation presets from a builtin `auth` provider, returning plain dicts an author could have written.
- Per-process (single-flighted, expiry-aware) and cross-process (`<home>/auth`, 0700/0600) acquisition caches, with a cross-process lock so two invocations do not both open a browser.
- **Redaction at the output tee**, before any byte reaches `log.txt` — which is packed into the cache and lifted into the failure event, so redacting at render is too late. Best-effort by construction, and stated rather than hidden: material under 8 bytes is not scrubbed, and a secret the target transformed passes through.
- `heph auth status | explain | login | logout`, and a hidden `heph __auth-helper` the callback protocols invoke.

Two orderings are load-bearing and asserted rather than described: acquisition sits **after** the cache decision (a hit acquires nothing), and strictly **downstream of runner preparation** (the devenv `wrap` runner's environment capture is a cached, remotely-shippable artifact).

`example/credential/` is runnable with no setup and no real secrets — a two-source chain, a credential whose source is a target, and a build step that leaks its own token so the redaction is visible. `docs/CREDENTIALS.md` has the full design.

## Review board

**hermeticity — NOT HERMETIC on two.** One fixed: a helper callback runs inside the target's sandbox and re-walked the chain there, so it could silently pick a different source — and therefore a different identity — than the host chose. The host now writes a pin (material, workspace, winning source index) beside the presented files; the common path is a file read, and a refresh may use only the pinned source.

The other is **overruled, deliberately**: a literal `present.env` value can carry something that selects content (`AWS_REGION`), and nothing folds it into a consumer's key. This is the residual risk the design settled as the user's call — making it structural would cost CI its remote sharing on every private fetch, and rebuild a workspace on a role rename. It needs a cacheable target whose output depends on the identity, which the contract already forbids. The overstated "nowhere to put a region" claim is corrected in the docs and in the parser, and the accepted behaviour is pinned by a test.

**code-quality and feature-quality — BLOCKED, all fixed**, including: the recursion guard compared resolution keys against addresses, so a self-referencing credential deadlocked instead of failing; the process cache was keyed on the address alone, dropping the root identity the disk key is careful to include; the redactor held back `len(longest secret) - 1` bytes unconditionally, which blanks an interactive `--shell` prompt; the acquire subprocess got an empty environment, so the documented `aws` source could not resolve on any supported target; `heph auth login` bypassed the exec-runner seam its own probe uses; and a producer's output files were written before anything knew whether the material had an expiry.

**compatibility — COMPATIBLE AFTER BUMP.** `ABI_SEMVER` 0.8.0 → 0.9.0.

**Per-platform note.** The argument-size limiter now fails a target rather than evicting a credential, and `ARG_MAX` differs by OS, so a very large credential set could spawn on Linux and fail on macOS. Failing loudly beats running unauthenticated, and the ceiling is far out of reach (each presented value is capped at 32 KiB).

## Second commit: parse the declaration with the derive

The first draft of this driver hand-parsed its whole config — `Presentation::parse`, `parse_helper`, and private `string`/`strings`/`str_map` helpers — and hand-wrote an 80-line `DriverSchema` to match. Every one of those already existed: `String::from_spec_value`, `Vec<String>::from_spec_value`, `#[derive(SpecStruct)]` for a nested object, `#[derive(Spec)]` for the driver's own config, and the derive's own unknown-key refusal.

The justification in the code was circular — `string()`'s doc comment said the credential driver hand-parses, *so* the shared spec decoder never runs for it, *so* it reimplemented the decoder privately. Two copies of `source_ty` had already appeared.

- `Helper` and `Presentation` derive `SpecStruct`; `CredentialSpec` derives `Spec`. The key set, the per-field decoding, the unknown-key refusal and the LSP schema now come from the field list, so the parser and the schema cannot drift, and the doc comments *are* the schema docs.
- Only the two fields whose *shape* the derive cannot express keep a `parse` function: `sources` (an ordered heterogeneous list discriminated by `kind`) and `ttl` (a duration grammar).
- `Dialect` gets a `FromSpecValue` delegating to the existing `Dialect::parse`, so the name table and its message exist once — the same string is also parsed out of `heph __auth-helper <dialect>`'s argv, where there is no `Value`.
- The three private helpers become one-line delegations, keeping only what they were for: carrying the field name into the message as `anyhow` context.

Two additions any driver can now use: a blanket `FromSpecValue for Option<T>` (so an optional field inherits `T`'s gate rather than needing its own), and one for `BTreeMap<String, String>` — strict where the `HashMap` form is lenient, since a bare string becoming `{"": s}` is meaningless where the map *is* the document.

Net −51 lines in the driver. Behaviour is unchanged except two error messages, which now name the offending key the way every other driver does.

## Tests

43 engine e2e tests (`crates/e2e/tests/credential.rs`), 13 binary e2e tests for the helper protocols (`crates/bin-e2e/tests/auth_helper.rs`), plus unit tests across the driver, the store, the redactor and the templates. Full `tst` passes; the only failure is the pre-existing `test_real_docker_default_builder_without_exporters_is_diagnosable`, which needs a running Docker daemon.

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Jr413rT5LPhzVYo6QFckDm

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>

